### PR TITLE
feat: add optional `abortSignal` parameters to sandbox command execution

### DIFF
--- a/.changeset/great-panthers-greet.md
+++ b/.changeset/great-panthers-greet.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/anthropic": patch
+---
+
+feat: add optional `abortSignal` parameters to sandbox command execution

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -150,12 +150,12 @@ const agent = new ToolLoopAgent({
         command: z.string(),
         workingDirectory: z.string().optional(),
       }),
-      execute: async ({ command, workingDirectory }, { sandbox }) => {
+      execute: async ({ command, workingDirectory }, { abortSignal, sandbox }) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return sandbox.executeCommand({ command, workingDirectory });
+        return sandbox.executeCommand({ command, workingDirectory, abortSignal });
       },
     }),
   },

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -150,12 +150,19 @@ const agent = new ToolLoopAgent({
         command: z.string(),
         workingDirectory: z.string().optional(),
       }),
-      execute: async ({ command, workingDirectory }, { abortSignal, sandbox }) => {
+      execute: async (
+        { command, workingDirectory },
+        { abortSignal, sandbox },
+      ) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return sandbox.executeCommand({ command, workingDirectory, abortSignal });
+        return sandbox.executeCommand({
+          command,
+          workingDirectory,
+          abortSignal,
+        });
       },
     }),
   },

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -861,12 +861,12 @@ const result = await generateText({
         command: z.string(),
         workingDirectory: z.string().optional(),
       }),
-      execute: async ({ command, workingDirectory }, { sandbox }) => {
+      execute: async ({ command, workingDirectory }, { abortSignal, sandbox }) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return sandbox.executeCommand({ command, workingDirectory });
+        return sandbox.executeCommand({ command, workingDirectory, abortSignal });
       },
     }),
   },
@@ -880,9 +880,11 @@ model should know about details such as the root directory, exposed ports, or
 public hostname, include `sandbox.description` in your system prompt,
 instructions, or user-visible context.
 
-`executeCommand` also accepts an optional `workingDirectory`. Use it when a tool
-needs to run a command from a directory other than the sandbox implementation's
-default working directory.
+`executeCommand` also accepts an optional `workingDirectory` and `abortSignal`.
+Use `workingDirectory` when a tool needs to run a command from a directory other
+than the sandbox implementation's default working directory. Forward
+`abortSignal` from the tool execution options so the sandbox can cancel the
+command if the overall operation is aborted or times out.
 
 The AI SDK forwards your sandbox object but does not create or isolate one for
 you.

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -861,12 +861,19 @@ const result = await generateText({
         command: z.string(),
         workingDirectory: z.string().optional(),
       }),
-      execute: async ({ command, workingDirectory }, { abortSignal, sandbox }) => {
+      execute: async (
+        { command, workingDirectory },
+        { abortSignal, sandbox },
+      ) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return sandbox.executeCommand({ command, workingDirectory, abortSignal });
+        return sandbox.executeCommand({
+          command,
+          workingDirectory,
+          abortSignal,
+        });
       },
     }),
   },

--- a/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
@@ -25,6 +25,7 @@ type Sandbox = {
   readonly executeCommand: (options: {
     command: string;
     workingDirectory?: string;
+    abortSignal?: AbortSignal;
   }) => PromiseLike<{
     exitCode: number;
     stdout: string;
@@ -45,7 +46,7 @@ type Sandbox = {
     },
     {
       name: 'executeCommand',
-      type: '(options: { command: string; workingDirectory?: string }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
+      type: '(options: { command: string; workingDirectory?: string; abortSignal?: AbortSignal }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
       description:
         'Executes a command in the sandbox and resolves with the command exit code, standard output, and standard error.',
       properties: [
@@ -62,6 +63,12 @@ type Sandbox = {
               type: 'string | undefined',
               description:
                 'Optional working directory to execute the command in. If omitted, the sandbox implementation uses its default working directory.',
+            },
+            {
+              name: 'abortSignal',
+              type: 'AbortSignal | undefined',
+              description:
+                'Optional abort signal that the sandbox implementation can use to cancel the command.',
             },
           ],
         },
@@ -89,12 +96,12 @@ const shell = tool({
     command: z.string(),
     workingDirectory: z.string().optional(),
   }),
-  execute: async ({ command, workingDirectory }, { sandbox }) => {
+  execute: async ({ command, workingDirectory }, { abortSignal, sandbox }) => {
     if (!sandbox) {
       throw new Error('Sandbox is not available');
     }
 
-    return sandbox.executeCommand({ command, workingDirectory });
+    return sandbox.executeCommand({ command, workingDirectory, abortSignal });
   },
 });
 ```

--- a/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
+++ b/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
@@ -26,21 +26,37 @@ export class VercelSandbox implements AISandbox {
   async executeCommand({
     command,
     workingDirectory,
+    abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    abortSignal?: AbortSignal;
   }) {
-    const result = await this.sandbox.runCommand({
+    const sandboxCommand = await this.sandbox.runCommand({
       cmd: 'bash',
       args: ['-c', command],
       cwd: workingDirectory ?? rootDirectory,
+      detached: true,
     });
 
-    return {
-      exitCode: result.exitCode,
-      stdout: await result.stdout(),
-      stderr: await result.stderr(),
-    };
+    const abortCommand = () => void sandboxCommand.kill('SIGTERM');
+    if (abortSignal?.aborted) {
+      abortCommand();
+    } else {
+      abortSignal?.addEventListener('abort', abortCommand, { once: true });
+    }
+
+    try {
+      const result = await sandboxCommand.wait();
+
+      return {
+        exitCode: result.exitCode,
+        stdout: await result.stdout(),
+        stderr: await result.stderr(),
+      };
+    } finally {
+      abortSignal?.removeEventListener('abort', abortCommand);
+    }
   }
 
   async stop() {

--- a/examples/ai-e2e-next/tool/sandbox-shell-tool.ts
+++ b/examples/ai-e2e-next/tool/sandbox-shell-tool.ts
@@ -9,12 +9,15 @@ export function sandboxShellTool() {
       workingDirectory: z.string().optional(),
     }),
 
-    execute: async ({ command, workingDirectory }, { sandbox }) => {
+    execute: async (
+      { command, workingDirectory },
+      { abortSignal, sandbox },
+    ) => {
       // TODO figure out type inference to turn the runtime error into a type error
       if (!sandbox) {
         throw new Error('Sandbox is not available');
       }
-      return sandbox.executeCommand({ command, workingDirectory });
+      return sandbox.executeCommand({ command, workingDirectory, abortSignal });
     },
   });
 }

--- a/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
@@ -7,10 +7,14 @@ export class JustBashSandbox implements Sandbox {
   async executeCommand({
     command,
     workingDirectory,
+    abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    abortSignal?: AbortSignal;
   }) {
+    abortSignal?.throwIfAborted();
+
     const result = await this.bash.exec(command, { cwd: workingDirectory });
 
     return {

--- a/examples/ai-functions/src/sandbox/local-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/local-sandbox.ts
@@ -27,15 +27,18 @@ export class LocalSandbox implements Sandbox {
   async executeCommand({
     command,
     workingDirectory,
+    abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    abortSignal?: AbortSignal;
   }) {
     try {
       const { stdout, stderr } = await execAsync(command, {
         cwd: workingDirectory ?? this.rootDirectory,
         timeout: 60_000,
         maxBuffer: 10 * 1024 * 1024,
+        signal: abortSignal,
       });
 
       return {

--- a/examples/ai-functions/src/sandbox/vercel-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/vercel-sandbox.ts
@@ -13,21 +13,37 @@ export class VercelSandbox implements AISandbox {
   async executeCommand({
     command,
     workingDirectory,
+    abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    abortSignal?: AbortSignal;
   }) {
-    const result = await this.sandbox.runCommand({
+    const sandboxCommand = await this.sandbox.runCommand({
       cmd: 'bash',
       args: ['-c', command],
       cwd: workingDirectory ?? rootDirectory,
+      detached: true,
     });
 
-    return {
-      exitCode: result.exitCode,
-      stdout: await result.stdout(),
-      stderr: await result.stderr(),
-    };
+    const abortCommand = () => void sandboxCommand.kill('SIGTERM');
+    if (abortSignal?.aborted) {
+      abortCommand();
+    } else {
+      abortSignal?.addEventListener('abort', abortCommand, { once: true });
+    }
+
+    try {
+      const result = await sandboxCommand.wait();
+
+      return {
+        exitCode: result.exitCode,
+        stdout: await result.stdout(),
+        stderr: await result.stderr(),
+      };
+    } finally {
+      abortSignal?.removeEventListener('abort', abortCommand);
+    }
   }
 
   async stop() {

--- a/examples/ai-functions/src/tools/sandbox-shell-tool.ts
+++ b/examples/ai-functions/src/tools/sandbox-shell-tool.ts
@@ -9,12 +9,15 @@ export function sandboxShellTool() {
       workingDirectory: z.string().optional(),
     }),
 
-    execute: async ({ command, workingDirectory }, { sandbox }) => {
+    execute: async (
+      { command, workingDirectory },
+      { abortSignal, sandbox },
+    ) => {
       // TODO figure out type inference to turn the runtime error into a type error
       if (!sandbox) {
         throw new Error('Sandbox is not available');
       }
-      return sandbox.executeCommand({ command, workingDirectory });
+      return sandbox.executeCommand({ command, workingDirectory, abortSignal });
     },
   });
 }

--- a/packages/anthropic/src/tool/bash_20241022.test.ts
+++ b/packages/anthropic/src/tool/bash_20241022.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { bash_20241022 } from './bash_20241022';
+
+describe('bash_20241022 tool', () => {
+  it('passes abort signal to sandbox command execution', async () => {
+    const abortController = new AbortController();
+    let receivedAbortSignal: AbortSignal | undefined;
+    const bashTool = bash_20241022();
+
+    await bashTool.execute?.(
+      { command: 'ls' },
+      {
+        toolCallId: 'tool-call-id',
+        messages: [],
+        abortSignal: abortController.signal,
+        context: {},
+        sandbox: {
+          description: 'test sandbox',
+          executeCommand: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+
+            return {
+              exitCode: 0,
+              stdout: '',
+              stderr: '',
+            };
+          },
+        },
+      },
+    );
+
+    expect(receivedAbortSignal).toBe(abortController.signal);
+  });
+});

--- a/packages/anthropic/src/tool/bash_20241022.ts
+++ b/packages/anthropic/src/tool/bash_20241022.ts
@@ -79,12 +79,12 @@ export function bash_20241022<OUTPUT>(
   if (execute === undefined) {
     return bash_20241022_internal({
       ...rest,
-      execute: async ({ command }, { sandbox }) => {
+      execute: async ({ command }, { abortSignal, sandbox }) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return await sandbox.executeCommand({ command });
+        return await sandbox.executeCommand({ command, abortSignal });
       },
     } as Bash20241022Options<Bash20241022DefaultOutput>) as ReturnType<
       typeof bash_20241022_internal<OUTPUT>

--- a/packages/anthropic/src/tool/bash_20250124.test.ts
+++ b/packages/anthropic/src/tool/bash_20250124.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { bash_20250124 } from './bash_20250124';
+
+describe('bash_20250124 tool', () => {
+  it('passes abort signal to sandbox command execution', async () => {
+    const abortController = new AbortController();
+    let receivedAbortSignal: AbortSignal | undefined;
+    const bashTool = bash_20250124();
+
+    await bashTool.execute?.(
+      { command: 'ls' },
+      {
+        toolCallId: 'tool-call-id',
+        messages: [],
+        abortSignal: abortController.signal,
+        context: {},
+        sandbox: {
+          description: 'test sandbox',
+          executeCommand: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+
+            return {
+              exitCode: 0,
+              stdout: '',
+              stderr: '',
+            };
+          },
+        },
+      },
+    );
+
+    expect(receivedAbortSignal).toBe(abortController.signal);
+  });
+});

--- a/packages/anthropic/src/tool/bash_20250124.ts
+++ b/packages/anthropic/src/tool/bash_20250124.ts
@@ -79,12 +79,12 @@ export function bash_20250124<OUTPUT>(
   if (execute === undefined) {
     return bash_20250124_internal({
       ...rest,
-      execute: async ({ command }, { sandbox }) => {
+      execute: async ({ command }, { abortSignal, sandbox }) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return await sandbox.executeCommand({ command });
+        return await sandbox.executeCommand({ command, abortSignal });
       },
     } as Bash20250124Options<Bash20250124DefaultOutput>) as ReturnType<
       typeof bash_20250124_internal<OUTPUT>

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -22,6 +22,11 @@ export type Sandbox = {
      * Working directory to execute the command in.
      */
     workingDirectory?: string;
+
+    /**
+     * Signal that can be used to abort the command.
+     */
+    abortSignal?: AbortSignal;
   }) => PromiseLike<{
     /**
      * Exit code returned by the command.

--- a/packages/provider-utils/src/types/tool-execute-function.test-d.ts
+++ b/packages/provider-utils/src/types/tool-execute-function.test-d.ts
@@ -18,6 +18,14 @@ describe('tool execute function types', () => {
     }>();
   });
 
+  it('should include abort signal in sandbox command options', () => {
+    expectTypeOf<Parameters<Sandbox['executeCommand']>[0]>().toEqualTypeOf<{
+      command: string;
+      workingDirectory?: string;
+      abortSignal?: AbortSignal;
+    }>();
+  });
+
   it('should type the input, output, and execution options', () => {
     expectTypeOf<
       ToolExecuteFunction<{ city: string }, { temperature: number }, Context>


### PR DESCRIPTION
## Background
We introduced a Sandbox abstraction for bash execution in #14949

## Summary
Add `abortSignal` option to `executeCommand`

## Related Issues
Builds on #14949