### PR TITLE
fix(ai): correct off-by-one in array form of mock model helpers

### DIFF
--- a/.changeset/mock-model-array-off-by-one.md
+++ b/.changeset/mock-model-array-off-by-one.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Fix off-by-one in array form of `MockLanguageModelV3` / `V4` and `MockEmbeddingModelV3` / `V4`. The first scripted call now returns the first array entry instead of the second; subsequent calls advance correctly.

--- a/packages/ai/src/test/mock-embedding-model-v3.test.ts
+++ b/packages/ai/src/test/mock-embedding-model-v3.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { MockEmbeddingModelV3 } from './mock-embedding-model-v3';
+
+describe('MockEmbeddingModelV3', () => {
+  describe('doEmbed array form', () => {
+    it('should return entries in order starting from the first', async () => {
+      const model = new MockEmbeddingModelV3({
+        doEmbed: [{ embeddings: [[1]] } as any, { embeddings: [[2]] } as any],
+      });
+
+      const r1 = await model.doEmbed({} as any);
+      const r2 = await model.doEmbed({} as any);
+
+      expect(r1.embeddings).toEqual([[1]]);
+      expect(r2.embeddings).toEqual([[2]]);
+    });
+  });
+});

--- a/packages/ai/src/test/mock-embedding-model-v3.ts
+++ b/packages/ai/src/test/mock-embedding-model-v3.ts
@@ -39,7 +39,7 @@ export class MockEmbeddingModelV3 implements EmbeddingModelV3 {
       if (typeof doEmbed === 'function') {
         return doEmbed(options);
       } else if (Array.isArray(doEmbed)) {
-        return doEmbed[this.doEmbedCalls.length];
+        return doEmbed[this.doEmbedCalls.length - 1];
       } else {
         return doEmbed;
       }

--- a/packages/ai/src/test/mock-embedding-model-v4.test.ts
+++ b/packages/ai/src/test/mock-embedding-model-v4.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { MockEmbeddingModelV4 } from './mock-embedding-model-v4';
+
+describe('MockEmbeddingModelV4', () => {
+  describe('doEmbed array form', () => {
+    it('should return entries in order starting from the first', async () => {
+      const model = new MockEmbeddingModelV4({
+        doEmbed: [{ embeddings: [[1]] } as any, { embeddings: [[2]] } as any],
+      });
+
+      const r1 = await model.doEmbed({} as any);
+      const r2 = await model.doEmbed({} as any);
+
+      expect(r1.embeddings).toEqual([[1]]);
+      expect(r2.embeddings).toEqual([[2]]);
+    });
+  });
+});

--- a/packages/ai/src/test/mock-embedding-model-v4.ts
+++ b/packages/ai/src/test/mock-embedding-model-v4.ts
@@ -39,7 +39,7 @@ export class MockEmbeddingModelV4 implements EmbeddingModelV4 {
       if (typeof doEmbed === 'function') {
         return doEmbed(options);
       } else if (Array.isArray(doEmbed)) {
-        return doEmbed[this.doEmbedCalls.length];
+        return doEmbed[this.doEmbedCalls.length - 1];
       } else {
         return doEmbed;
       }

--- a/packages/ai/src/test/mock-language-model-v3.test.ts
+++ b/packages/ai/src/test/mock-language-model-v3.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { MockLanguageModelV3 } from './mock-language-model-v3';
+
+const generateResult = (text: string) =>
+  ({
+    content: [{ type: 'text', text }],
+    finishReason: { unified: 'stop', raw: 'stop' },
+    usage: {
+      inputTokens: {
+        total: 1,
+        noCache: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      outputTokens: { total: 1, text: 1, reasoning: 0 },
+    },
+    warnings: [],
+  }) as any;
+
+describe('MockLanguageModelV3', () => {
+  describe('doGenerate array form', () => {
+    it('should return entries in order starting from the first', async () => {
+      const model = new MockLanguageModelV3({
+        doGenerate: [generateResult('FIRST'), generateResult('SECOND')],
+      });
+
+      const r1 = await model.doGenerate({} as any);
+      const r2 = await model.doGenerate({} as any);
+
+      expect((r1.content[0] as { text: string }).text).toBe('FIRST');
+      expect((r2.content[0] as { text: string }).text).toBe('SECOND');
+    });
+  });
+
+  describe('doStream array form', () => {
+    it('should return entries in order starting from the first', async () => {
+      const model = new MockLanguageModelV3({
+        doStream: [
+          { stream: new ReadableStream(), request: { tag: 'first' } } as any,
+          { stream: new ReadableStream(), request: { tag: 'second' } } as any,
+        ],
+      });
+
+      const r1 = await model.doStream({} as any);
+      const r2 = await model.doStream({} as any);
+
+      expect((r1.request as { tag: string }).tag).toBe('first');
+      expect((r2.request as { tag: string }).tag).toBe('second');
+    });
+  });
+});

--- a/packages/ai/src/test/mock-language-model-v3.ts
+++ b/packages/ai/src/test/mock-language-model-v3.ts
@@ -49,7 +49,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -60,7 +60,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-language-model-v4.test.ts
+++ b/packages/ai/src/test/mock-language-model-v4.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { MockLanguageModelV4 } from './mock-language-model-v4';
+
+const generateResult = (text: string) =>
+  ({
+    content: [{ type: 'text', text }],
+    finishReason: { unified: 'stop', raw: 'stop' },
+    usage: {
+      inputTokens: {
+        total: 1,
+        noCache: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      outputTokens: { total: 1, text: 1, reasoning: 0 },
+    },
+    warnings: [],
+  }) as any;
+
+describe('MockLanguageModelV4', () => {
+  describe('doGenerate array form', () => {
+    it('should return entries in order starting from the first', async () => {
+      const model = new MockLanguageModelV4({
+        doGenerate: [generateResult('FIRST'), generateResult('SECOND')],
+      });
+
+      const r1 = await model.doGenerate({} as any);
+      const r2 = await model.doGenerate({} as any);
+
+      expect((r1.content[0] as { text: string }).text).toBe('FIRST');
+      expect((r2.content[0] as { text: string }).text).toBe('SECOND');
+    });
+  });
+
+  describe('doStream array form', () => {
+    it('should return entries in order starting from the first', async () => {
+      const model = new MockLanguageModelV4({
+        doStream: [
+          { stream: new ReadableStream(), request: { tag: 'first' } } as any,
+          { stream: new ReadableStream(), request: { tag: 'second' } } as any,
+        ],
+      });
+
+      const r1 = await model.doStream({} as any);
+      const r2 = await model.doStream({} as any);
+
+      expect((r1.request as { tag: string }).tag).toBe('first');
+      expect((r2.request as { tag: string }).tag).toBe('second');
+    });
+  });
+});

--- a/packages/ai/src/test/mock-language-model-v4.ts
+++ b/packages/ai/src/test/mock-language-model-v4.ts
@@ -49,7 +49,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -60,7 +60,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }


### PR DESCRIPTION
## Problem

`MockLanguageModelV3` / `MockLanguageModelV4` and `MockEmbeddingModelV3` / `MockEmbeddingModelV4` accept an array of results to script multi-call test scenarios (e.g. tool-call → tool-result → final text for `ToolLoopAgent`). The array form silently misbehaved: the first call returned the **second** entry, and the last call returned `undefined`.

The cause is the indexer running after the call has already been pushed onto the call list:

```ts
this.doGenerate = async (options) => {
  this.doGenerateCalls.push(options);          // length is incremented…
  if (Array.isArray(doGenerate)) {
    return doGenerate[this.doGenerateCalls.length]; // …then used as the index
  }
  ...
};
```

The same off-by-one is in `doStream` for both V3 and V4 and in `doEmbed` for both embedding mocks.

Fixes #15141.

## Solution

Index with `length - 1` after the push so the n-th call returns the n-th array entry, matching the obvious user expectation.

## Testing

Added `mock-language-model-v3.test.ts`, `mock-language-model-v4.test.ts`, `mock-embedding-model-v3.test.ts`, `mock-embedding-model-v4.test.ts` covering both `doGenerate` / `doStream` / `doEmbed` array forms. Verified the new tests fail against `main` and pass with the fix. Existing `wrap-language-model` and `wrap-embedding-model` tests continue to pass (they use empty arrays, so behavior is unchanged for that path).