### PR TITLE
fix(ai): correct off-by-one in mock model array indexing

### DIFF
--- a/.changeset/green-dodos-notice.md
+++ b/.changeset/green-dodos-notice.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): correct off-by-one array indexing in mock test models

--- a/packages/ai/src/test/mock-embedding-model-v3.ts
+++ b/packages/ai/src/test/mock-embedding-model-v3.ts
@@ -39,7 +39,7 @@ export class MockEmbeddingModelV3 implements EmbeddingModelV3 {
       if (typeof doEmbed === 'function') {
         return doEmbed(options);
       } else if (Array.isArray(doEmbed)) {
-        return doEmbed[this.doEmbedCalls.length];
+        return doEmbed[this.doEmbedCalls.length - 1];
       } else {
         return doEmbed;
       }

--- a/packages/ai/src/test/mock-embedding-model-v4.ts
+++ b/packages/ai/src/test/mock-embedding-model-v4.ts
@@ -39,7 +39,7 @@ export class MockEmbeddingModelV4 implements EmbeddingModelV4 {
       if (typeof doEmbed === 'function') {
         return doEmbed(options);
       } else if (Array.isArray(doEmbed)) {
-        return doEmbed[this.doEmbedCalls.length];
+        return doEmbed[this.doEmbedCalls.length - 1];
       } else {
         return doEmbed;
       }

--- a/packages/ai/src/test/mock-language-model-v3.ts
+++ b/packages/ai/src/test/mock-language-model-v3.ts
@@ -49,7 +49,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -60,7 +60,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-language-model-v4.ts
+++ b/packages/ai/src/test/mock-language-model-v4.ts
@@ -49,7 +49,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -60,7 +60,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-model-array-indexing.test.ts
+++ b/packages/ai/src/test/mock-model-array-indexing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { MockEmbeddingModelV3 } from './mock-embedding-model-v3';
+import { MockEmbeddingModelV4 } from './mock-embedding-model-v4';
+import { MockLanguageModelV3 } from './mock-language-model-v3';
+import { MockLanguageModelV4 } from './mock-language-model-v4';
+
+describe('mock model array indexing', () => {
+  it('returns array entries in call order for MockLanguageModelV3', async () => {
+    const generateResult1 = { text: 'generate-1' } as any;
+    const generateResult2 = { text: 'generate-2' } as any;
+    const streamResult1 = { stream: 'stream-1' } as any;
+    const streamResult2 = { stream: 'stream-2' } as any;
+    const model = new MockLanguageModelV3({
+      doGenerate: [generateResult1, generateResult2],
+      doStream: [streamResult1, streamResult2],
+    });
+
+    expect(await model.doGenerate({} as any)).toBe(generateResult1);
+    expect(await model.doGenerate({} as any)).toBe(generateResult2);
+    expect(await model.doStream({} as any)).toBe(streamResult1);
+    expect(await model.doStream({} as any)).toBe(streamResult2);
+  });
+
+  it('returns array entries in call order for MockLanguageModelV4', async () => {
+    const generateResult1 = { text: 'generate-1' } as any;
+    const generateResult2 = { text: 'generate-2' } as any;
+    const streamResult1 = { stream: 'stream-1' } as any;
+    const streamResult2 = { stream: 'stream-2' } as any;
+    const model = new MockLanguageModelV4({
+      doGenerate: [generateResult1, generateResult2],
+      doStream: [streamResult1, streamResult2],
+    });
+
+    expect(await model.doGenerate({} as any)).toBe(generateResult1);
+    expect(await model.doGenerate({} as any)).toBe(generateResult2);
+    expect(await model.doStream({} as any)).toBe(streamResult1);
+    expect(await model.doStream({} as any)).toBe(streamResult2);
+  });
+
+  it('returns array entries in call order for MockEmbeddingModelV3', async () => {
+    const embedResult1 = { embeddings: [[1]], usage: { tokens: 1 } } as any;
+    const embedResult2 = { embeddings: [[2]], usage: { tokens: 2 } } as any;
+    const model = new MockEmbeddingModelV3({
+      doEmbed: [embedResult1, embedResult2],
+    });
+
+    expect(await model.doEmbed({} as any)).toBe(embedResult1);
+    expect(await model.doEmbed({} as any)).toBe(embedResult2);
+  });
+
+  it('returns array entries in call order for MockEmbeddingModelV4', async () => {
+    const embedResult1 = { embeddings: [[1]], usage: { tokens: 1 } } as any;
+    const embedResult2 = { embeddings: [[2]], usage: { tokens: 2 } } as any;
+    const model = new MockEmbeddingModelV4({
+      doEmbed: [embedResult1, embedResult2],
+    });
+
+    expect(await model.doEmbed({} as any)).toBe(embedResult1);
+    expect(await model.doEmbed({} as any)).toBe(embedResult2);
+  });
+});


### PR DESCRIPTION
Fixes #15141

## Summary
After .push(), the array length is already incremented, so using .length as an index skips the first element. Changed to .length - 1 in all 4 mock model files.

## Affected files
- mock-language-model-v3.ts
- mock-language-model-v4.ts
- mock-embedding-model-v3.ts
- mock-embedding-model-v4.ts