### PR TITLE
feat(examples): add next-vc-deal-flow-mcp example

### DIFF
--- a/examples/next-vc-deal-flow-mcp/README.md
+++ b/examples/next-vc-deal-flow-mcp/README.md
@@ -1,0 +1,68 @@
+# Next.js + AI SDK + MCP — VC Deal Flow Research
+
+A minimal Next.js example that streams a chat response from `streamText` while
+calling tools on a remote, public MCP server over Streamable HTTP.
+
+The example uses the [GitDealFlow Signal](https://signals.gitdealflow.com)
+public MCP endpoint, which exposes read-only tools for looking up GitHub-derived
+engineering momentum signals on venture-backed startups. The endpoint is
+no-auth and rate-limited, so the example is runnable end-to-end without
+additional API keys (other than the model provider).
+
+## What it shows
+
+- `createMCPClient` from `@ai-sdk/mcp` with a `StreamableHTTPClientTransport`
+  pointed at a remote MCP server URL
+- `mcpClient.tools()` auto-discovers tools and turns them into AI SDK tools
+- Wiring those tools into `streamText` and returning a UI message stream via
+  `toUIMessageStreamResponse`
+- Closing the MCP client in `onFinish` / `onError`
+
+## Running
+
+1. Add an Anthropic API key:
+
+   ```sh
+   echo 'ANTHROPIC_API_KEY="sk-ant-..."' > .env.local
+   ```
+
+2. From the AI SDK repo root:
+
+   ```sh
+   pnpm install
+   pnpm build
+   ```
+
+3. From this directory:
+
+   ```sh
+   pnpm dev
+   ```
+
+4. Open http://localhost:3000 and try one of the starter prompts.
+
+## Swap in another MCP server
+
+Edit `app/api/research/route.ts` and change `MCP_URL` to any HTTP MCP endpoint:
+
+```ts
+const MCP_URL = 'https://your-server.example.com/mcp';
+```
+
+If the server requires auth, pass headers to the transport:
+
+```ts
+const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+  requestInit: { headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` } },
+});
+```
+
+## Swap in another model
+
+Replace the Anthropic provider with any other AI SDK provider, e.g.:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+// ...
+model: openai('gpt-4o'),
+```

--- a/examples/next-vc-deal-flow-mcp/app/api/research/route.ts
+++ b/examples/next-vc-deal-flow-mcp/app/api/research/route.ts
@@ -1,0 +1,38 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { createMCPClient } from '@ai-sdk/mcp';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { convertToModelMessages, streamText, type UIMessage } from 'ai';
+
+// GitDealFlow Signal — public, no-auth MCP server.
+// Tools: get_trending_startups, search_startups_by_sector, get_startup_signal,
+//        get_deep_signal, get_signals_summary, get_methodology, get_scout_receipts.
+const MCP_URL = 'https://signals.gitdealflow.com/api/mcp/rpc';
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL));
+  const mcpClient = await createMCPClient({ transport });
+
+  const tools = await mcpClient.tools();
+
+  const result = streamText({
+    model: anthropic('claude-opus-4-7'),
+    system:
+      'You are a venture research assistant. Use the provided MCP tools to ' +
+      'answer questions about engineering momentum at venture-backed startups. ' +
+      'Cite the tools you used and the period the signals cover.',
+    messages: await convertToModelMessages(messages),
+    tools,
+    onFinish: async () => {
+      await mcpClient.close();
+    },
+    onError: async () => {
+      await mcpClient.close();
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/next-vc-deal-flow-mcp/app/globals.css
+++ b/examples/next-vc-deal-flow-mcp/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/examples/next-vc-deal-flow-mcp/app/layout.tsx
+++ b/examples/next-vc-deal-flow-mcp/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'AI SDK + MCP — VC Deal Flow Research',
+  description:
+    'Streaming chat agent that calls a public MCP server to research engineering momentum at venture-backed startups.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/next-vc-deal-flow-mcp/app/page.tsx
+++ b/examples/next-vc-deal-flow-mcp/app/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { useState } from 'react';
+
+const STARTER_PROMPTS = [
+  'Which AI/ML startups had the strongest engineering momentum this week?',
+  'Compare engineering activity at Anthropic, OpenAI, and Cohere.',
+  'Find dark-horse fintech startups with breakout commit-velocity but no major press.',
+];
+
+export default function Page() {
+  const { messages, sendMessage, status } = useChat();
+  const [input, setInput] = useState('');
+
+  return (
+    <main className="flex flex-col py-12 mx-auto w-full max-w-2xl px-4">
+      <h1 className="text-2xl font-semibold mb-1">VC Deal Flow Research</h1>
+      <p className="text-sm text-gray-600 mb-6">
+        Streaming agent that calls a public, no-auth MCP server to surface
+        engineering momentum at venture-backed startups.
+      </p>
+
+      {messages.length === 0 && (
+        <div className="flex flex-col gap-2 mb-6">
+          {STARTER_PROMPTS.map(p => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => sendMessage({ text: p })}
+              className="text-left text-sm border border-gray-300 rounded p-3 hover:bg-gray-50"
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4">
+        {messages.map(message => (
+          <div key={message.id} className="whitespace-pre-wrap">
+            <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+              {message.role}
+            </div>
+            {message.parts.map((part, index) => {
+              switch (part.type) {
+                case 'text':
+                  return <div key={index}>{part.text}</div>;
+                case 'step-start':
+                  return index > 0 ? (
+                    <hr key={index} className="my-2 border-gray-200" />
+                  ) : null;
+                default:
+                  if (part.type.startsWith('tool-')) {
+                    return (
+                      <pre
+                        key={index}
+                        className="text-xs bg-gray-50 border border-gray-200 rounded p-2 my-2 overflow-x-auto"
+                      >
+                        {part.type}
+                        {'state' in part ? ` (${(part as any).state})` : ''}
+                      </pre>
+                    );
+                  }
+                  return null;
+              }
+            })}
+          </div>
+        ))}
+      </div>
+
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          if (input.trim() === '') return;
+          sendMessage({ text: input });
+          setInput('');
+        }}
+        className="mt-6"
+      >
+        <input
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder="Ask about a startup, sector, or trend..."
+          disabled={status !== 'ready'}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+        />
+      </form>
+    </main>
+  );
+}

--- a/examples/next-vc-deal-flow-mcp/next-env.d.ts
+++ b/examples/next-vc-deal-flow-mcp/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/next-vc-deal-flow-mcp/next.config.js
+++ b/examples/next-vc-deal-flow-mcp/next.config.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  outputFileTracingRoot: path.join(__dirname, '../../'),
+};
+
+module.exports = nextConfig;

--- a/examples/next-vc-deal-flow-mcp/package.json
+++ b/examples/next-vc-deal-flow-mcp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@example/next-vc-deal-flow-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "4.0.0-canary.50",
+    "@ai-sdk/mcp": "workspace:*",
+    "@ai-sdk/react": "4.0.0-canary.131",
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "ai": "7.0.0-canary.130",
+    "next": "^15.5.9",
+    "react": "^18",
+    "react-dom": "^18",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.15",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/next-vc-deal-flow-mcp/postcss.config.js
+++ b/examples/next-vc-deal-flow-mcp/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/examples/next-vc-deal-flow-mcp/tailwind.config.js
+++ b/examples/next-vc-deal-flow-mcp/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/examples/next-vc-deal-flow-mcp/tsconfig.json
+++ b/examples/next-vc-deal-flow-mcp/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "composite": true,
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/anthropic"
+    },
+    {
+      "path": "../../packages/mcp"
+    },
+    {
+      "path": "../../packages/react"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1221,6 +1221,58 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/next-vc-deal-flow-mcp:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 4.0.0-canary.50
+        version: link:../../packages/anthropic
+      '@ai-sdk/mcp':
+        specifier: workspace:*
+        version: link:../../packages/mcp
+      '@ai-sdk/react':
+        specifier: 4.0.0-canary.131
+        version: link:../../packages/react
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      ai:
+        specifier: 7.0.0-canary.130
+        version: link:../../packages/ai
+      next:
+        specifier: ^15.5.9
+        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      react:
+        specifier: ^18
+        version: 18.3.1
+      react-dom:
+        specifier: ^18
+        version: 18.3.1(react@18.3.1)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      autoprefixer:
+        specifier: ^10.4.14
+        version: 10.4.27(postcss@8.5.9)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.9
+      tailwindcss:
+        specifier: ^3.4.15
+        version: 3.4.19(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@20.17.24)(typescript@5.8.3))
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/next-workflow:
     dependencies:
       '@ai-sdk/anthropic':
@@ -10873,6 +10925,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/dom@1.11.11':
     resolution: {integrity: sha512-4YwziCH5CmjvUzSGdZ4Klj6BqhLSTNZooA9kt47yDxj4Qw9uHqVnXwWWupYsVdIYPNsw1tR2AkHveg82y1Fn3A==}
@@ -19880,6 +19933,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -19892,10 +19946,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -20829,7 +20885,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.8.4))(yaml@2.8.4)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -20843,13 +20899,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
-      css-loader: 7.1.2(webpack@5.105.0)
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
+      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -20857,22 +20913,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
-      license-webpack-plugin: 4.0.2(webpack@5.105.0)
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0)
+      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -20882,7 +20938,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -20912,7 +20968,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -25900,7 +25956,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -31301,7 +31357,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -32171,7 +32227,7 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -32278,7 +32334,7 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  css-loader@7.1.2(webpack@5.105.0):
+  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.9)
       postcss: 8.5.9
@@ -35939,7 +35995,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -35967,7 +36023,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0):
+  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -37072,7 +37128,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -38700,7 +38756,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.4
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -39785,7 +39841,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -40259,7 +40315,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0):
+  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -42667,7 +42723,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)

--- a/tsconfig.with-examples.json
+++ b/tsconfig.with-examples.json
@@ -58,6 +58,9 @@
       "path": "examples/next-openai-upstash-rate-limits"
     },
     {
+      "path": "examples/next-vc-deal-flow-mcp"
+    },
+    {
       "path": "examples/node-http-server"
     },
     {


### PR DESCRIPTION
## Summary

Adds a Next.js example that streams a chat response from `streamText` while calling tools on a public, no-auth MCP server over Streamable HTTP.

The example uses the [GitDealFlow Signal](https://signals.gitdealflow.com) MCP endpoint, which exposes read-only tools for looking up GitHub-derived engineering momentum signals on venture-backed startups. The endpoint requires no API key, so the example is runnable end-to-end with only the model provider's key.

## What it demonstrates

- `createMCPClient` from `@ai-sdk/mcp` with `StreamableHTTPClientTransport` pointed at a remote MCP server URL
- `mcpClient.tools()` auto-discovers tools and turns them into AI SDK tools
- Wiring those tools into `streamText` and returning a UI message stream via `toUIMessageStreamResponse`
- Closing the MCP client in `onFinish` / `onError` callbacks
- Using `useChat` from `@ai-sdk/react` to render streaming output and tool invocations

## Why this example

The existing `examples/mcp/` directory shows MCP transport mechanics with a local Express server. The existing `examples/next-agent/` shows a Next.js chat UI with a hand-defined tool. This example fills the gap: a Next.js app that calls a remote, public MCP server end-to-end. Useful as a reference for users who want to consume third-party MCP servers from their AI SDK apps.

## Files

- `examples/next-vc-deal-flow-mcp/app/api/research/route.ts` — route handler with `streamText` + MCP transport (~40 lines)
- `examples/next-vc-deal-flow-mcp/app/page.tsx` — chat UI with `useChat`
- Standard Next.js scaffolding (`layout.tsx`, `globals.css`, `tailwind.config.js`, etc.) mirroring the existing `next-agent` example
- `tsconfig.with-examples.json` updated to include the new example

## Verification

`pnpm turbo build --filter='@example/next-vc-deal-flow-mcp...'` passes locally.

## Test plan

- [ ] Reviewer adds an `ANTHROPIC_API_KEY` to `.env.local`
- [ ] `pnpm install && pnpm build` from the repo root
- [ ] `pnpm dev` from `examples/next-vc-deal-flow-mcp`
- [ ] Open `http://localhost:3000` and click a starter prompt; expect streaming output with tool invocations rendered

## Notes

- Per `CONTRIBUTING.md`, examples are not released, so no changeset is included.
- The MCP server is rate-limited but otherwise public and stable; if it goes down, swapping `MCP_URL` to any other HTTP MCP endpoint (or a local one from `examples/mcp/src/http/`) keeps the example working.