### PR TITLE
docs: add prompt injection detection middleware example

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -451,6 +451,49 @@ export const yourGuardrailMiddleware: LanguageModelV4Middleware = {
 };
 ```
 
+### Prompt Injection Detection
+
+This example shows how to add a fast pre-flight regex check on incoming prompts using `transformParams`. Pattern-based detection runs in microseconds before the model call, complementing slower model-based moderation. The patterns below are inspired by published prompt-injection corpora (instruction overrides, role hijacks, system-prompt extraction, jailbreak frames) and can be extended or replaced with rules from an open detection standard such as Agent Threat Rules at https://github.com/Agent-Threat-Rule/agent-threat-rules (Apache-2.0).
+
+```ts
+import type { LanguageModelV4Middleware } from '@ai-sdk/provider';
+
+const INJECTION_PATTERNS: { id: string; pattern: RegExp }[] = [
+  { id: 'instruction-override', pattern: /\b(ignore|disregard|forget)\b[^.]{0,40}\b(previous|prior|above|all)\b[^.]{0,40}\b(instructions?|prompts?|rules?)\b/i },
+  { id: 'role-hijack', pattern: /\byou\s+are\s+now\b[^.]{0,60}\b(?:dan|jailbroken|developer\s+mode|admin|root)\b/i },
+  { id: 'system-prompt-extraction', pattern: /\b(repeat|print|reveal|show|output)\b[^.]{0,40}\b(system\s+prompt|initial\s+prompt|original\s+instructions)\b/i },
+  { id: 'jailbreak-frame', pattern: /\b(developer\s+mode|do\s+anything\s+now|unrestricted\s+mode)\s+(enabled|on|activated)\b/i },
+  { id: 'delimiter-injection', pattern: /<\|im_(start|end)\|>|<\/?(system|assistant|user)>|\[\/?INST\]/i },
+  { id: 'tool-exfil', pattern: /\b(send|post|fetch|exfiltrate)\b[^.]{0,60}\b(api[_-]?key|secret|token|credential)s?\b/i },
+];
+
+export class PromptInjectionDetectedError extends Error {
+  constructor(public ruleId: string, public excerpt: string) {
+    super(`Prompt injection detected (${ruleId})`);
+  }
+}
+
+export const promptInjectionMiddleware: LanguageModelV4Middleware = {
+  transformParams: async ({ params }) => {
+    for (const part of params.prompt) {
+      if (part.role !== 'user') continue;
+      const text = typeof part.content === 'string'
+        ? part.content
+        : part.content.map(p => (p.type === 'text' ? p.text : '')).join(' ');
+      for (const rule of INJECTION_PATTERNS) {
+        const match = text.match(rule.pattern);
+        if (match) {
+          throw new PromptInjectionDetectedError(rule.id, match[0]);
+        }
+      }
+    }
+    return params;
+  },
+};
+```
+
+To audit suspicious input without blocking, log the rule id via `providerMetadata` instead of throwing. Combine pattern detection with a model-based moderation layer for defense in depth.
+
 ## Configuring Per Request Custom Metadata
 
 To send and access custom metadata in Middleware, you can use `providerOptions`. This is useful when building logging middleware where you want to pass additional context like user IDs, timestamps, or other contextual data that can help with tracking and debugging.


### PR DESCRIPTION
This PR adds a prompt injection detection example to the middleware documentation, alongside the existing Guardrails section. The example demonstrates how transformParams can short-circuit suspicious user input before the model call using deterministic regex patterns.

The patterns cover six classic prompt injection categories: instruction overrides, role hijacks, system-prompt extraction, jailbreak frames, delimiter injection, and credential exfiltration attempts. They are inspired by published prompt-injection corpora and can be replaced with rules from an open detection standard such as Agent Threat Rules at https://github.com/Agent-Threat-Rule/agent-threat-rules (Apache-2.0, 330 rules).

Pattern-based pre-flight detection complements the existing model-based moderation example. It runs in microseconds and acts as a cheap first filter before more expensive detection layers.

The example is self-contained, around 35 lines of TypeScript, and uses only the existing LanguageModelV4Middleware interface. No new dependencies. The doc note suggests combining pattern detection with model-based moderation for defense in depth.

The repository this contribution comes from has been adopted in production at Cisco AI Defense and Microsoft agent-governance-toolkit; this example is purely a docs addition with no runtime impact on the AI SDK itself.