### PR TITLE
feat(openai): add opt-in pass-through for unsupported file media types

### DIFF
--- a/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
@@ -228,6 +228,54 @@ describe('convertToOpenResponsesInput', () => {
         },
       ]);
     });
+
+    it('should pass through non-image file parts when explicitly enabled', async () => {
+      const result = await convertToOpenResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: { type: 'data' as const, data: 'aGVsbG8=' },
+                mediaType: 'text/plain',
+                filename: 'notes.txt',
+              },
+              {
+                type: 'file',
+                data: {
+                  type: 'url' as const,
+                  url: new URL('https://example.com/data.csv'),
+                },
+                mediaType: 'text/csv',
+              },
+            ],
+          },
+        ],
+        passThroughUnsupportedFiles: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "file_data": "data:text/plain;base64,aGVsbG8=",
+                "filename": "notes.txt",
+                "type": "input_file",
+              },
+              {
+                "file_url": "https://example.com/data.csv",
+                "type": "input_file",
+              },
+            ],
+            "role": "user",
+            "type": "message",
+          },
+        ]
+      `);
+      expect(result.warnings).toEqual([]);
+    });
   });
 
   describe('assistant messages', () => {

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -21,8 +21,10 @@ import type {
 
 export async function convertToOpenResponsesInput({
   prompt,
+  passThroughUnsupportedFiles = false,
 }: {
   prompt: LanguageModelV4Prompt;
+  passThroughUnsupportedFiles?: boolean;
 }): Promise<{
   input: OpenResponsesRequestBody['input'];
   instructions: string | undefined;
@@ -65,6 +67,19 @@ export async function convertToOpenResponsesInput({
                 case 'url':
                 case 'data': {
                   if (getTopLevelMediaType(part.mediaType) !== 'image') {
+                    if (passThroughUnsupportedFiles) {
+                      userContent.push({
+                        type: 'input_file',
+                        ...(part.data.type === 'url'
+                          ? { file_url: part.data.url.toString() }
+                          : {
+                              filename: part.filename,
+                              file_data: `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
+                            }),
+                      });
+                      break;
+                    }
+
                     warnings.push({
                       type: 'other',
                       message: `unsupported file content type: ${part.mediaType}`,

--- a/packages/open-responses/src/responses/open-responses-language-model-options.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model-options.ts
@@ -13,6 +13,14 @@ export const openResponsesLanguageModelOptions = lazySchema(() =>
        * Valid values: 'concise', 'detailed', 'auto'.
        */
       reasoningSummary: z.enum(['concise', 'detailed', 'auto']).nullish(),
+
+      /**
+       * Forward unsupported non-image file media types as `input_file` parts
+       * instead of dropping them in the SDK conversion layer.
+       *
+       * Defaults to `false`, preserving the existing image-only behavior.
+       */
+      passThroughUnsupportedFiles: z.boolean().nullish(),
     }),
   ),
 );

--- a/packages/open-responses/src/responses/open-responses-language-model.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.ts
@@ -105,12 +105,20 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
       warnings.push({ type: 'unsupported', feature: 'seed' });
     }
 
+    const openResponsesOptions = await parseProviderOptions({
+      provider: this.config.providerOptionsName,
+      providerOptions,
+      schema: openResponsesLanguageModelOptions,
+    });
+
     const {
       input,
       instructions,
       warnings: inputWarnings,
     } = await convertToOpenResponsesInput({
       prompt,
+      passThroughUnsupportedFiles:
+        openResponsesOptions?.passThroughUnsupportedFiles ?? undefined,
     });
 
     warnings.push(...inputWarnings);
@@ -148,12 +156,6 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
               : {}),
           }
         : undefined;
-
-    const openResponsesOptions = await parseProviderOptions({
-      provider: this.config.providerOptionsName,
-      providerOptions,
-      schema: openResponsesLanguageModelOptions,
-    });
 
     const resolvedReasoningEffort = isCustomReasoning(reasoning)
       ? reasoning === 'none'

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -592,6 +592,82 @@ describe('convertToOpenAIResponsesInput', () => {
       ).rejects.toThrow('file part media type text/plain');
     });
 
+    it('should pass through unsupported file types when explicitly enabled', async () => {
+      const base64Data = Buffer.from('hello').toString('base64');
+
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: { type: 'data' as const, data: base64Data },
+                filename: 'notes.txt',
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        passThroughUnsupportedFiles: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              filename: 'notes.txt',
+              file_data: 'data:text/plain;base64,aGVsbG8=',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should pass through arbitrary unsupported file types when explicitly enabled', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/json',
+                data: {
+                  type: 'data' as const,
+                  data: Buffer.from('{}').toString('base64'),
+                },
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        passThroughUnsupportedFiles: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              filename: 'part-0',
+              file_data: 'data:application/json;base64,e30=',
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should convert PDF file parts with URL to input_file with file_url', async () => {
       const result = await convertToOpenAIResponsesInput({
         prompt: [

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -64,6 +64,7 @@ export async function convertToOpenAIResponsesInput({
   hasShellTool = false,
   hasApplyPatchTool = false,
   customProviderToolNames,
+  passThroughUnsupportedFiles = false,
 }: {
   prompt: LanguageModelV4Prompt;
   toolNameMapping: ToolNameMapping;
@@ -77,6 +78,7 @@ export async function convertToOpenAIResponsesInput({
   hasShellTool?: boolean;
   hasApplyPatchTool?: boolean;
   customProviderToolNames?: Set<string>;
+  passThroughUnsupportedFiles?: boolean;
 }): Promise<{
   input: OpenAIResponsesInput;
   warnings: Array<SharedV4Warning>;
@@ -178,7 +180,10 @@ export async function convertToOpenAIResponsesInput({
                       }
 
                       const fullMediaType = resolveFullMediaType({ part });
-                      if (fullMediaType !== 'application/pdf') {
+                      if (
+                        fullMediaType !== 'application/pdf' &&
+                        !passThroughUnsupportedFiles
+                      ) {
                         throw new UnsupportedFunctionalityError({
                           functionality: `file part media type ${fullMediaType}`,
                         });
@@ -190,8 +195,12 @@ export async function convertToOpenAIResponsesInput({
                         isFileId(part.data.data, fileIdPrefixes)
                           ? { file_id: part.data.data }
                           : {
-                              filename: part.filename ?? `part-${index}.pdf`,
-                              file_data: `data:application/pdf;base64,${convertToBase64(part.data.data)}`,
+                              filename:
+                                part.filename ??
+                                (fullMediaType === 'application/pdf'
+                                  ? `part-${index}.pdf`
+                                  : `part-${index}`),
+                              file_data: `data:${fullMediaType};base64,${convertToBase64(part.data.data)}`,
                             }),
                       };
                     }

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -206,6 +206,15 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
       metadata: z.any().nullish(),
 
       /**
+       * Forward unsupported non-image file media types as `input_file` parts
+       * instead of rejecting them in the SDK conversion layer.
+       *
+       * Defaults to `false`, preserving the existing `application/pdf`-only
+       * validation for non-image inline files.
+       */
+      passThroughUnsupportedFiles: z.boolean().nullish(),
+
+      /**
        * Whether to use parallel tool calls. Defaults to `true`.
        */
       parallelToolCalls: z.boolean().nullish(),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -411,6 +411,47 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should pass through unsupported files when enabled through provider options', async () => {
+        await createModel('gpt-4o').doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  mediaType: 'text/plain',
+                  data: {
+                    type: 'data',
+                    data: Buffer.from('hello').toString('base64'),
+                  },
+                  filename: 'notes.txt',
+                },
+              ],
+            },
+          ],
+          providerOptions: {
+            openai: {
+              passThroughUnsupportedFiles: true,
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          input: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'input_file',
+                  filename: 'notes.txt',
+                  file_data: 'data:text/plain;base64,aGVsbG8=',
+                },
+              ],
+            },
+          ],
+        });
+      });
+
       it('should keep temperature and topP for gpt-5.1 models when reasoning effort is none', async () => {
         const { warnings } = await createModel('gpt-5.1').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -258,6 +258,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
           customProviderToolNames.size > 0
             ? customProviderToolNames
             : undefined,
+        passThroughUnsupportedFiles:
+          openaiOptions?.passThroughUnsupportedFiles ?? undefined,
       });
 
     warnings.push(...inputWarnings);


### PR DESCRIPTION
Closes #14747
## Background

Some providers support broader inline file handling than the SDK currently allows.  
Currently, unsupported non-image inline files are rejected or dropped unless they are PDFs.

This PR adds an explicit opt-in escape hatch for advanced users while preserving existing strict defaults and backward compatibility.

## Summary

Adds an opt-in `passThroughUnsupportedFiles` provider option for OpenAI/OpenResponses file-part conversion.

Default behavior is unchanged:
- non-image inline files still reject/drop unless they are `application/pdf`

When enabled:
- unsupported media types are forwarded to the provider as `input_file` parts instead of being rejected/dropped

## Manual Verification

Verified with targeted vitest runs:

- `convert-to-open-responses-input.test.ts`
- `convert-to-openai-responses-input.test.ts`
- `openai-responses-language-model.test.ts`

Also verified:
- existing default validation behavior remains unchanged
- unsupported files pass through only when explicitly enabled
- request payloads serialize correctly as `input_file`

## Checklist

- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [ ] A patch changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Future Work

Potential future improvements:
- document provider compatibility expectations
- consider a more granular allowlist-based configuration
- extend behavior consistently across additional providers