### PR TITLE
fix(ai): correct mock array result indexing

### DIFF
--- a/.changeset/slow-mocks-learn.md
+++ b/.changeset/slow-mocks-learn.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix test mocks to return the first array-backed result on the first call

--- a/packages/ai/src/test/mock-embedding-model-v3.ts
+++ b/packages/ai/src/test/mock-embedding-model-v3.ts
@@ -39,7 +39,7 @@ export class MockEmbeddingModelV3 implements EmbeddingModelV3 {
       if (typeof doEmbed === 'function') {
         return doEmbed(options);
       } else if (Array.isArray(doEmbed)) {
-        return doEmbed[this.doEmbedCalls.length];
+        return doEmbed[this.doEmbedCalls.length - 1];
       } else {
         return doEmbed;
       }

--- a/packages/ai/src/test/mock-embedding-model-v4.ts
+++ b/packages/ai/src/test/mock-embedding-model-v4.ts
@@ -39,7 +39,7 @@ export class MockEmbeddingModelV4 implements EmbeddingModelV4 {
       if (typeof doEmbed === 'function') {
         return doEmbed(options);
       } else if (Array.isArray(doEmbed)) {
-        return doEmbed[this.doEmbedCalls.length];
+        return doEmbed[this.doEmbedCalls.length - 1];
       } else {
         return doEmbed;
       }

--- a/packages/ai/src/test/mock-embedding-model.test.ts
+++ b/packages/ai/src/test/mock-embedding-model.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { MockEmbeddingModelV3 } from './mock-embedding-model-v3';
+import { MockEmbeddingModelV4 } from './mock-embedding-model-v4';
+
+function embeddingResult(value: number) {
+  return {
+    embeddings: [[value]],
+    warnings: [],
+  };
+}
+
+describe('MockEmbeddingModelV3', () => {
+  it('returns array-backed embed results from the first entry', async () => {
+    const model = new MockEmbeddingModelV3({
+      doEmbed: [embeddingResult(1), embeddingResult(2)],
+    });
+
+    await expect(model.doEmbed({ values: ['first'] })).resolves.toMatchObject({
+      embeddings: [[1]],
+    });
+    await expect(model.doEmbed({ values: ['second'] })).resolves.toMatchObject({
+      embeddings: [[2]],
+    });
+  });
+});
+
+describe('MockEmbeddingModelV4', () => {
+  it('returns array-backed embed results from the first entry', async () => {
+    const model = new MockEmbeddingModelV4({
+      doEmbed: [embeddingResult(1), embeddingResult(2)],
+    });
+
+    await expect(model.doEmbed({ values: ['first'] })).resolves.toMatchObject({
+      embeddings: [[1]],
+    });
+    await expect(model.doEmbed({ values: ['second'] })).resolves.toMatchObject({
+      embeddings: [[2]],
+    });
+  });
+});

--- a/packages/ai/src/test/mock-language-model-v2.ts
+++ b/packages/ai/src/test/mock-language-model-v2.ts
@@ -44,7 +44,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -55,7 +55,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-language-model-v3.ts
+++ b/packages/ai/src/test/mock-language-model-v3.ts
@@ -49,7 +49,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -60,7 +60,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-language-model-v4.ts
+++ b/packages/ai/src/test/mock-language-model-v4.ts
@@ -49,7 +49,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       if (typeof doGenerate === 'function') {
         return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -60,7 +60,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       if (typeof doStream === 'function') {
         return await doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-language-model.test.ts
+++ b/packages/ai/src/test/mock-language-model.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { MockLanguageModelV2 } from './mock-language-model-v2';
+import { MockLanguageModelV3 } from './mock-language-model-v3';
+import { MockLanguageModelV4 } from './mock-language-model-v4';
+
+const usageV2 = {
+  inputTokens: 1,
+  outputTokens: 1,
+  totalTokens: 2,
+};
+
+const usage = {
+  cachedInputTokens: undefined,
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 1,
+    text: 1,
+    reasoning: undefined,
+  },
+};
+
+function generateResult(text: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    finishReason: { unified: 'stop' as const, raw: 'stop' },
+    usage,
+    warnings: [],
+  };
+}
+
+function generateResultV2(text: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    finishReason: 'stop' as const,
+    usage: usageV2,
+    warnings: [],
+  };
+}
+
+function streamResult(text: string) {
+  return {
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'text-start', id: text });
+        controller.enqueue({ type: 'text-delta', id: text, delta: text });
+        controller.enqueue({ type: 'text-end', id: text });
+        controller.close();
+      },
+    }),
+  };
+}
+
+async function readStreamText(stream: ReadableStream) {
+  const reader = stream.getReader();
+  let text = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return text;
+    }
+    if (value.type === 'text-delta') {
+      text += value.delta;
+    }
+  }
+}
+
+describe('MockLanguageModelV2', () => {
+  it('returns array-backed generate results from the first entry', async () => {
+    const model = new MockLanguageModelV2({
+      doGenerate: [generateResultV2('first'), generateResultV2('second')],
+    });
+
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'first' }],
+    });
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'second' }],
+    });
+  });
+
+  it('returns array-backed stream results from the first entry', async () => {
+    const model = new MockLanguageModelV2({
+      doStream: [streamResult('first'), streamResult('second')],
+    });
+
+    await expect(
+      readStreamText((await model.doStream({} as never)).stream),
+    ).resolves.toBe('first');
+    await expect(
+      readStreamText((await model.doStream({} as never)).stream),
+    ).resolves.toBe('second');
+    expect(model.doStreamCalls).toHaveLength(2);
+  });
+});
+
+describe('MockLanguageModelV3', () => {
+  it('returns array-backed generate results from the first entry', async () => {
+    const model = new MockLanguageModelV3({
+      doGenerate: [generateResult('first'), generateResult('second')],
+    });
+
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'first' }],
+    });
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'second' }],
+    });
+  });
+
+  it('returns array-backed stream results from the first entry', async () => {
+    const model = new MockLanguageModelV3({
+      doStream: [streamResult('first'), streamResult('second')],
+    });
+
+    await expect(
+      readStreamText((await model.doStream({} as never)).stream),
+    ).resolves.toBe('first');
+    await expect(
+      readStreamText((await model.doStream({} as never)).stream),
+    ).resolves.toBe('second');
+    expect(model.doStreamCalls).toHaveLength(2);
+  });
+});
+
+describe('MockLanguageModelV4', () => {
+  it('returns array-backed generate results from the first entry', async () => {
+    const model = new MockLanguageModelV4({
+      doGenerate: [generateResult('first'), generateResult('second')],
+    });
+
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'first' }],
+    });
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'second' }],
+    });
+  });
+
+  it('returns array-backed stream results from the first entry', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: [streamResult('first'), streamResult('second')],
+    });
+
+    await expect(
+      readStreamText((await model.doStream({} as never)).stream),
+    ).resolves.toBe('first');
+    await expect(
+      readStreamText((await model.doStream({} as never)).stream),
+    ).resolves.toBe('second');
+    expect(model.doStreamCalls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #15141.

- corrects array-backed indexing in `MockLanguageModelV3` / `MockLanguageModelV4` for `doGenerate` and `doStream`
- corrects the same off-by-one in `MockEmbeddingModelV3` / `MockEmbeddingModelV4` for `doEmbed`
- adds focused tests that verify the first call returns the first scripted result and the second call returns the second scripted result
- adds a patch changeset for `ai`

## Verification

- `pnpm --filter ai exec vitest --config vitest.node.config.js --run src/test/mock-language-model.test.ts src/test/mock-embedding-model.test.ts`
- `pnpm --filter ai type-check`
- `pnpm type-check:full`
- `pnpm exec ultracite check packages/ai/src/test/mock-language-model.test.ts packages/ai/src/test/mock-embedding-model.test.ts packages/ai/src/test/mock-language-model-v3.ts packages/ai/src/test/mock-language-model-v4.ts packages/ai/src/test/mock-embedding-model-v3.ts packages/ai/src/test/mock-embedding-model-v4.ts .changeset/slow-mocks-learn.md`

Note: local verification ran on Node `v25.9.0`, so pnpm emitted the repo's unsupported-engine warning. The commands still passed.
