### PR TITLE
feat: flexible tool descriptions

### DIFF
--- a/.changeset/hot-fishes-tap.md
+++ b/.changeset/hot-fishes-tap.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/workflow": patch
+"ai": patch
+---
+
+feat: flexible tool descriptions

--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -23,7 +23,7 @@ and [`streamText`](/docs/reference/ai-sdk-core/stream-text) by passing one or mo
 
 A tool consists of three properties:
 
-- **`description`**: An optional description of the tool that can influence when the tool is picked.
+- **`description`**: An optional description of the tool that can influence when the tool is picked. Function and dynamic tools can use either a string or a function that derives the description from the tool's context and sandbox.
 - **`inputSchema`**: A [Zod schema](/docs/reference/ai-sdk-core/zod-schema) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input required for the tool to run. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
 - **`execute`**: An optional async function that is called with the arguments from the tool call.
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -8,7 +8,7 @@ description: Learn about tool calling and multi-step calls (using stopWhen) with
 As covered under Foundations, [tools](/docs/foundations/tools) are objects that can be called by the model to perform a specific task.
 Function tools and dynamic tools contain several core elements:
 
-- **`description`**: An optional description of the tool that can influence when the tool is picked.
+- **`description`**: An optional description of the tool that can influence when the tool is picked. It can be a string or a function that derives the description from the tool's context and sandbox.
 - **`inputSchema`**: A [Zod schema](/docs/foundations/tools#schemas) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input parameters. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
 - **`execute`**: An optional async function that is called with the inputs from the tool call. It produces a value of type `RESULT` (generic type). It is optional because you might want to forward tool calls to the client or to a queue instead of executing them in the same process.
 - **`strict`**: _(optional, boolean)_ Enables strict tool calling when supported by the provider
@@ -51,6 +51,55 @@ const result = await generateText({
 
 Tool calling is not restricted to only text generation.
 You can also use it to render user interfaces (Generative UI).
+
+## Dynamic Descriptions
+
+Tool descriptions can be fixed strings or functions. Use a function when the
+description sent to the model should depend on the current tool context or
+sandbox, such as a tenant, project, environment, or workspace.
+
+The description function is resolved before the tool definition is sent to the
+model for each generation step. It receives the matching tool `context` from
+`toolsContext` and the current `sandbox`, if one was provided. If `prepareStep`
+updates `toolsContext` or `sandbox`, the next step uses those updated values.
+
+```ts highlight="6-14,28-33"
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const shell = tool({
+  contextSchema: z.object({
+    projectName: z.string(),
+  }),
+  description: ({ context, sandbox }) =>
+    [
+      `Run shell commands for the ${context.projectName} project.`,
+      sandbox != null ? `Sandbox: ${sandbox.description}` : undefined,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  inputSchema: z.object({
+    command: z.string(),
+  }),
+  execute: async ({ command }, { sandbox }) => {
+    if (!sandbox) {
+      throw new Error('Sandbox is not available');
+    }
+
+    return sandbox.executeCommand({ command });
+  },
+});
+
+const result = await generateText({
+  model: __MODEL__,
+  tools: { shell },
+  toolsContext: {
+    shell: { projectName: 'web-app' },
+  },
+  sandbox,
+  prompt: 'List the project files.',
+});
+```
 
 ## Strict Mode
 
@@ -842,7 +891,8 @@ const result = await generateText({
 
 Pass `sandbox` to `generateText`, `streamText`, or a `ToolLoopAgent` call when a
 tool needs to run commands or code in an execution environment. The sandbox is
-available on the second parameter of the tool's `execute` function.
+available to tool description functions and on the second parameter of the
+tool's `execute` function.
 
 Passing a sandbox does not sandbox the tool itself. Tool code still runs wherever
 your application runs. Only the operations that your tool explicitly delegates to
@@ -885,7 +935,7 @@ const result = await generateText({
 The sandbox description is not added to the model prompt automatically. If the
 model should know about details such as the root directory, exposed ports, or
 public hostname, include `sandbox.description` in your system prompt,
-instructions, or user-visible context.
+instructions, user-visible context, or a tool description function.
 
 `executeCommand` also accepts an optional `workingDirectory` and `abortSignal`.
 Use `workingDirectory` when a tool needs to run a command from a directory other

--- a/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
+++ b/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
@@ -19,8 +19,8 @@ should affect execution.
 | Concept                           | Where you define it                                                | Where you read it                                                   | Use it for                                                    |
 | --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
 | `runtimeContext`                  | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, lifecycle callbacks, step results, and telemetry     | Shared generation or agent state                              |
-| `toolsContext`                    | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, approval callbacks, and tool context resolution      | A map of per-tool context values keyed by tool name           |
-| tool `context`                    | Each tool's `toolsContext` entry, validated by its `contextSchema` | Tool `execute`, `needsApproval`, and tool input lifecycle callbacks | Values needed by one tool                                     |
+| `toolsContext`                    | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, approval callbacks, tool context resolution, and tool description functions | A map of per-tool context values keyed by tool name           |
+| tool `context`                    | Each tool's `toolsContext` entry, validated by its `contextSchema` | Tool description functions, tool `execute`, `needsApproval`, and tool input lifecycle callbacks | Values needed by one tool                                     |
 | `toolContext`                     | Derived from one tool's context                                    | Tool approval callbacks and tool execution events                   | The event/callback name for one tool's context                |
 | `telemetry.includeRuntimeContext` | The generation or agent call                                       | Telemetry filtering                                                 | Top-level `runtimeContext` properties to include in telemetry |
 | `telemetry.includeToolsContext`   | The generation or agent call                                       | Telemetry filtering                                                 | Top-level tool context properties to include in telemetry     |
@@ -115,7 +115,9 @@ const result = await generateText({
 
 When at least one tool declares `contextSchema`, `toolsContext` is required for
 the tools that need context. A tool receives only its own context, not the full
-`toolsContext` map.
+`toolsContext` map. Tool description functions receive the same typed `context`
+before each model call, so descriptions can change with the current tool
+context.
 
 Treat tool context as immutable inside tools. If you need to change tool context
 between steps, inspect the previous step in `prepareStep` and return an updated
@@ -203,6 +205,7 @@ properties are sent.
 | Location                          | `runtimeContext`                              | `toolsContext`                              | Tool `context` / `toolContext`                           |
 | --------------------------------- | --------------------------------------------- | ------------------------------------------- | -------------------------------------------------------- |
 | `prepareStep`                     | Read and update                               | Read and update                             | Not directly                                             |
+| Tool description functions        | Not passed directly                           | Not passed directly                         | Read one tool's validated `context`                      |
 | Tool `execute`                    | Not passed directly                           | Not passed directly                         | Read one tool's validated `context`                      |
 | Tool approval                     | Read in generic and per-tool callbacks        | Read in generic callbacks                   | Read as `toolContext` in per-tool callbacks              |
 | Tool execution events             | Not included                                  | Not included                                | Read as `toolContext`                                    |

--- a/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
+++ b/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
@@ -16,14 +16,14 @@ should affect execution.
 
 ## Context Types
 
-| Concept                           | Where you define it                                                | Where you read it                                                   | Use it for                                                    |
-| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `runtimeContext`                  | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, lifecycle callbacks, step results, and telemetry     | Shared generation or agent state                              |
-| `toolsContext`                    | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, approval callbacks, tool context resolution, and tool description functions | A map of per-tool context values keyed by tool name           |
+| Concept                           | Where you define it                                                | Where you read it                                                                               | Use it for                                                    |
+| --------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `runtimeContext`                  | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, lifecycle callbacks, step results, and telemetry                                 | Shared generation or agent state                              |
+| `toolsContext`                    | `generateText`, `streamText`, or `ToolLoopAgent` calls             | `prepareStep`, approval callbacks, tool context resolution, and tool description functions      | A map of per-tool context values keyed by tool name           |
 | tool `context`                    | Each tool's `toolsContext` entry, validated by its `contextSchema` | Tool description functions, tool `execute`, `needsApproval`, and tool input lifecycle callbacks | Values needed by one tool                                     |
-| `toolContext`                     | Derived from one tool's context                                    | Tool approval callbacks and tool execution events                   | The event/callback name for one tool's context                |
-| `telemetry.includeRuntimeContext` | The generation or agent call                                       | Telemetry filtering                                                 | Top-level `runtimeContext` properties to include in telemetry |
-| `telemetry.includeToolsContext`   | The generation or agent call                                       | Telemetry filtering                                                 | Top-level tool context properties to include in telemetry     |
+| `toolContext`                     | Derived from one tool's context                                    | Tool approval callbacks and tool execution events                                               | The event/callback name for one tool's context                |
+| `telemetry.includeRuntimeContext` | The generation or agent call                                       | Telemetry filtering                                                                             | Top-level `runtimeContext` properties to include in telemetry |
+| `telemetry.includeToolsContext`   | The generation or agent call                                       | Telemetry filtering                                                                             | Top-level tool context properties to include in telemetry     |
 
 In agents, `runtimeContext` is the agent's shared runtime state. It flows
 through the loop and can be read or updated in `prepareStep` between model

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -345,9 +345,9 @@ To see `generateText` in action, check out [these examples](#examples).
             {
               name: 'description',
               isOptional: true,
-              type: 'string',
+              type: 'string | ((options: { context: CONTEXT; sandbox?: Sandbox }) => string)',
               description:
-                'Information about the purpose of the tool including details on how and when it can be used by the model.',
+                'Information about the purpose of the tool including details on how and when it can be used by the model. Provide a string for a fixed description, or a function to derive the description from the tool-specific context and optional sandbox before each model call.',
             },
             {
               name: 'inputSchema',
@@ -740,7 +740,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'Sandbox',
       isOptional: true,
       description:
-        'Sandbox environment that is passed through to `prepareStep` and tool execution. Tools can access it from their execution options.',
+        'Sandbox environment that is passed through to `prepareStep`, tool description functions, and tool execution. Tools can access it from their description function options and execution options.',
     },
     {
       name: 'experimental_download',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -346,9 +346,9 @@ To see `streamText` in action, check out [these examples](#examples).
             {
               name: 'description',
               isOptional: true,
-              type: 'string',
+              type: 'string | ((options: { context: CONTEXT; sandbox?: Sandbox }) => string)',
               description:
-                'Information about the purpose of the tool including details on how and when it can be used by the model.',
+                'Information about the purpose of the tool including details on how and when it can be used by the model. Provide a string for a fixed description, or a function to derive the description from the tool-specific context and optional sandbox before each model call.',
             },
             {
               name: 'inputSchema',
@@ -784,7 +784,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'Sandbox',
       isOptional: true,
       description:
-        'Sandbox environment that is passed through to `prepareStep` and tool execution. Tools can access it from their execution options.',
+        'Sandbox environment that is passed through to `prepareStep`, tool description functions, and tool execution. Tools can access it from their description function options and execution options.',
     },
     {
       name: 'experimental_download',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -683,7 +683,7 @@ const result = await agent.generate({
       type: 'Sandbox',
       isOptional: true,
       description:
-        'Sandbox environment that is passed through to `prepareStep` and tool execution. Tools can access it from their execution options.',
+        'Sandbox environment that is passed through to `prepareStep`, tool description functions, and tool execution. Tools can access it from their description function options and execution options.',
     },
     {
       name: 'options',
@@ -786,7 +786,7 @@ for await (const chunk of stream.textStream) {
       type: 'Sandbox',
       isOptional: true,
       description:
-        'Sandbox environment that is passed through to `prepareStep` and tool execution. Tools can access it from their execution options.',
+        'Sandbox environment that is passed through to `prepareStep`, tool description functions, and tool execution. Tools can access it from their description function options and execution options.',
     },
     {
       name: 'options',

--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -61,9 +61,9 @@ export const weatherTool = tool({
             {
               name: 'description',
               isOptional: true,
-              type: 'string',
+              type: 'string | ((options: { context: CONTEXT; sandbox?: Sandbox }) => string)',
               description:
-                'Information about the purpose of the tool including details on how and when it can be used by the model.',
+                'Information about the purpose of the tool including details on how and when it can be used by the model. Provide a string for a fixed description, or a function to derive the description from the tool-specific context and optional sandbox before each model call.',
             },
             {
               name: 'title',

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -54,9 +54,9 @@ export const customTool = dynamicTool({
             {
               name: 'description',
               isOptional: true,
-              type: 'string',
+              type: 'string | ((options: { context: Context; sandbox?: Sandbox }) => string)',
               description:
-                'Information about the purpose of the tool including details on how and when it can be used by the model.'
+                'Information about the purpose of the tool including details on how and when it can be used by the model. Provide a string for a fixed description, or a function to derive the description from the tool-specific context and optional sandbox before each model call.'
             },
             {
               name: 'title',

--- a/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
@@ -8,7 +8,7 @@ description: API Reference for the Sandbox interface.
 The `Sandbox` interface describes an execution environment that tools can use to
 run commands. Pass a sandbox to `generateText`, `streamText`,
 `ToolLoopAgent.generate`, `ToolLoopAgent.stream`, or agent UI stream helpers to
-make it available to tool execution.
+make it available to tool description functions and tool execution.
 
 Passing a sandbox does not sandbox the tool itself. Tool code still runs in your
 application process unless the tool explicitly delegates work to the sandbox.

--- a/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
@@ -208,7 +208,6 @@ describe('createAgentUIStreamResponse', () => {
                   "type": "object",
                 },
                 "name": "example",
-                "providerOptions": undefined,
                 "type": "function",
               },
             ],

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -2,6 +2,7 @@ import type {
   Arrayable,
   Context,
   Sandbox,
+  Tool,
   ToolSet,
 } from '@ai-sdk/provider-utils';
 import type { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
@@ -11,7 +12,11 @@ import type { UIMessageStreamOptions } from '../generate-text/stream-text-result
 import type { TimeoutConfiguration } from '../prompt/request-options';
 import type { InferUIMessageChunk } from '../ui-message-stream';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
-import type { InferUITools, UIMessage } from '../ui/ui-messages';
+import type {
+  InferUIMessageTools,
+  InferUITools,
+  UIMessage,
+} from '../ui/ui-messages';
 import { validateUIMessages } from '../ui/validate-ui-messages';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
 import type { Agent } from './agent';
@@ -67,7 +72,21 @@ export async function createAgentUIStream<
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
   >({
     messages: uiMessages,
-    tools: agent.tools,
+    // tools are compatible; the casting is required because the context param is
+    // not available in ui messages
+    tools: agent.tools as unknown as {
+      [NAME in keyof InferUIMessageTools<
+        UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
+      > &
+        string]?: Tool<
+        InferUIMessageTools<
+          UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
+        >[NAME]['input'],
+        InferUIMessageTools<
+          UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
+        >[NAME]['output']
+      >;
+    },
   });
 
   const modelMessages = await convertToModelMessages(validatedMessages, {

--- a/packages/ai/src/generate-text/filter-active-tools.ts
+++ b/packages/ai/src/generate-text/filter-active-tools.ts
@@ -1,7 +1,7 @@
 import type { ToolSet } from '@ai-sdk/provider-utils';
 import type { ActiveTools } from './active-tools';
 
-type ActiveToolSubset<
+export type ActiveToolSubset<
   TOOLS extends ToolSet | undefined,
   ACTIVE_TOOL_NAMES extends ActiveTools<NonNullable<TOOLS>>,
 > = TOOLS extends undefined

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -520,7 +520,6 @@ describe('generateText', () => {
               {
                 type: 'function',
                 name: 'tool1',
-                description: undefined,
                 inputSchema: {
                   $schema: 'http://json-schema.org/draft-07/schema#',
                   additionalProperties: false,
@@ -528,12 +527,10 @@ describe('generateText', () => {
                   required: ['value'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
               {
                 type: 'function',
                 name: 'tool2',
-                description: undefined,
                 inputSchema: {
                   $schema: 'http://json-schema.org/draft-07/schema#',
                   additionalProperties: false,
@@ -541,7 +538,6 @@ describe('generateText', () => {
                   required: ['somethingElse'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
             ]);
 
@@ -669,7 +665,6 @@ describe('generateText', () => {
               {
                 type: 'function',
                 name: 'tool1',
-                description: undefined,
                 inputSchema: {
                   $schema: 'http://json-schema.org/draft-07/schema#',
                   additionalProperties: false,
@@ -677,7 +672,6 @@ describe('generateText', () => {
                   required: ['value'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
             ]);
 
@@ -2085,7 +2079,6 @@ describe('generateText', () => {
           "temperature": 0.7,
           "tools": [
             {
-              "description": undefined,
               "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -2100,7 +2093,6 @@ describe('generateText', () => {
                 "type": "object",
               },
               "name": "tool1",
-              "providerOptions": undefined,
               "type": "function",
             },
           ],
@@ -3759,7 +3751,6 @@ describe('generateText', () => {
                     {
                       type: 'function',
                       name: 'tool1',
-                      description: undefined,
                       inputSchema: {
                         $schema: 'http://json-schema.org/draft-07/schema#',
                         additionalProperties: false,
@@ -3767,7 +3758,6 @@ describe('generateText', () => {
                         required: ['value'],
                         type: 'object',
                       },
-                      providerOptions: undefined,
                     },
                   ]);
 
@@ -4504,7 +4494,6 @@ describe('generateText', () => {
               },
               "tools": [
                 {
-                  "description": undefined,
                   "inputSchema": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": false,
@@ -4519,7 +4508,6 @@ describe('generateText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
-                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -5502,28 +5490,26 @@ describe('generateText', () => {
       });
 
       expect(tools).toMatchInlineSnapshot(`
-      [
-        {
-          "description": undefined,
-          "inputSchema": {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "type": "string",
+        [
+          {
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "type": "string",
+                },
               },
+              "required": [
+                "value",
+              ],
+              "type": "object",
             },
-            "required": [
-              "value",
-            ],
-            "type": "object",
+            "name": "tool1",
+            "type": "function",
           },
-          "name": "tool1",
-          "providerOptions": undefined,
-          "type": "function",
-        },
-      ]
-    `);
+        ]
+      `);
     });
   });
 
@@ -5604,26 +5590,22 @@ describe('generateText', () => {
               {
                 type: 'function',
                 name: 'tool1',
-                description: undefined,
                 inputSchema: {
                   additionalProperties: false,
                   properties: { value: { type: 'string' } },
                   required: ['value'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
               {
                 type: 'function',
                 name: 'tool2',
-                description: undefined,
                 inputSchema: {
                   additionalProperties: false,
                   properties: { somethingElse: { type: 'string' } },
                   required: ['somethingElse'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
             ]);
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -20,8 +20,8 @@ import { NoOutputGeneratedError } from '../error';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
-import { cloneModelMessages } from '../prompt/clone-model-message';
 import type { ModelMessage } from '../prompt';
+import { cloneModelMessages } from '../prompt/clone-model-message';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
@@ -60,7 +60,10 @@ import type { ActiveTools } from './active-tools';
 import { collectToolApprovals } from './collect-tool-approvals';
 import type { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
-import { filterActiveTools } from './filter-active-tools';
+import {
+  filterActiveTools,
+  type ActiveToolSubset,
+} from './filter-active-tools';
 import type {
   GenerateTextOnFinishCallback,
   GenerateTextOnStartCallback,
@@ -694,6 +697,11 @@ export async function generateText<
 
         const stepTools = await prepareTools({
           tools: stepActiveTools,
+          // active tools context is a subset of the tools context, so we can cast to the unknown type
+          toolsContext: toolsContext as unknown as InferToolSetContext<
+            ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
+          >,
+          sandbox: stepSandbox,
         });
 
         const stepToolChoice = prepareToolChoice({

--- a/packages/ai/src/generate-text/stream-language-model-call.test.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.test.ts
@@ -130,7 +130,6 @@ describe('streamLanguageModelCall', () => {
           "temperature": 0.7,
           "tools": [
             {
-              "description": undefined,
               "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -145,7 +144,6 @@ describe('streamLanguageModelCall', () => {
                 "type": "object",
               },
               "name": "testTool",
-              "providerOptions": undefined,
               "type": "function",
             },
           ],

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -8,8 +8,10 @@ import {
   createIdGenerator,
   type Arrayable,
   type IdGenerator,
+  type InferToolSetContext,
   type ModelMessage,
   type ProviderOptions,
+  type Sandbox,
   type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
@@ -193,6 +195,8 @@ export async function streamLanguageModelCall<
   repairToolCall,
   refineToolInput,
   callId,
+  toolsContext,
+  sandbox,
   _internal: {
     generateId = originalGenerateId,
     generateCallId = originalGenerateCallId,
@@ -214,6 +218,15 @@ export async function streamLanguageModelCall<
   repairToolCall?: ToolCallRepairFunction<TOOLS> | undefined;
   refineToolInput?: ToolInputRefinement<TOOLS> | undefined;
   callId?: string;
+  /**
+   * Tool context used to resolve per-call tool metadata such as function
+   * descriptions before sending tools to the model.
+   */
+  toolsContext?: InferToolSetContext<TOOLS>;
+  /**
+   * Sandbox passed through for resolving tool descriptions that depend on it.
+   */
+  sandbox?: Sandbox;
   _internal?: {
     generateId?: IdGenerator;
     generateCallId?: IdGenerator;
@@ -269,9 +282,7 @@ export async function streamLanguageModelCall<
     provider: resolvedModel.provider.split('.')[0],
   });
 
-  const stepTools = await prepareTools({
-    tools,
-  });
+  const stepTools = await prepareTools({ tools, toolsContext, sandbox });
 
   const stepToolChoice = prepareToolChoice({
     toolChoice,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1498,7 +1498,6 @@ describe('streamText', () => {
               {
                 type: 'function',
                 name: 'tool1',
-                description: undefined,
                 inputSchema: {
                   $schema: 'http://json-schema.org/draft-07/schema#',
                   additionalProperties: false,
@@ -1506,7 +1505,6 @@ describe('streamText', () => {
                   required: ['value'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
             ]);
 
@@ -9543,7 +9541,6 @@ describe('streamText', () => {
               },
               "tools": [
                 {
-                  "description": undefined,
                   "inputSchema": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": false,
@@ -9558,7 +9555,6 @@ describe('streamText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
-                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -9618,7 +9614,6 @@ describe('streamText', () => {
               },
               "tools": [
                 {
-                  "description": undefined,
                   "inputSchema": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": false,
@@ -9633,7 +9628,6 @@ describe('streamText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
-                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -10814,7 +10808,6 @@ describe('streamText', () => {
               },
               "tools": [
                 {
-                  "description": undefined,
                   "inputSchema": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": false,
@@ -10829,7 +10822,6 @@ describe('streamText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
-                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -14614,14 +14606,12 @@ describe('streamText', () => {
               {
                 type: 'function',
                 name: 'tool1',
-                description: undefined,
                 inputSchema: {
                   additionalProperties: false,
                   properties: { value: { type: 'string' } },
                   required: ['value'],
                   type: 'object',
                 },
-                providerOptions: undefined,
               },
             ]);
             expect(toolChoice).toStrictEqual({ type: 'required' });
@@ -17506,7 +17496,6 @@ describe('streamText', () => {
       expect(tools).toMatchInlineSnapshot(`
         [
           {
-            "description": undefined,
             "inputSchema": {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "additionalProperties": false,
@@ -17521,7 +17510,6 @@ describe('streamText', () => {
               "type": "object",
             },
             "name": "tool1",
-            "providerOptions": undefined,
             "type": "function",
           },
         ]

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -90,7 +90,10 @@ import { collectToolApprovals } from './collect-tool-approvals';
 import type { ContentPart } from './content-part';
 import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
 import { executeToolCall } from './execute-tool-call';
-import { filterActiveTools } from './filter-active-tools';
+import {
+  filterActiveTools,
+  type ActiveToolSubset,
+} from './filter-active-tools';
 import type {
   GenerateTextOnFinishCallback,
   GenerateTextOnStartCallback,
@@ -1612,6 +1615,9 @@ class DefaultStreamTextResult<
 
           const stepSandbox = prepareStepResult?.sandbox ?? sandbox;
 
+          runtimeContext = prepareStepResult?.runtimeContext ?? runtimeContext;
+          toolsContext = prepareStepResult?.toolsContext ?? toolsContext;
+
           const stepModel = resolveLanguageModel(
             prepareStepResult?.model ?? model,
           );
@@ -1623,14 +1629,16 @@ class DefaultStreamTextResult<
 
           const stepTools = await prepareTools({
             tools: stepActiveTools,
+            // active tools context is a subset of the tools context, so we can cast to the unknown type
+            toolsContext: toolsContext as unknown as InferToolSetContext<
+              ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
+            >,
+            sandbox: stepSandbox,
           });
 
           const stepToolChoice = prepareToolChoice({
             toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
           });
-
-          runtimeContext = prepareStepResult?.runtimeContext ?? runtimeContext;
-          toolsContext = prepareStepResult?.toolsContext ?? toolsContext;
 
           const stepMessages = prepareStepResult?.messages ?? stepInputMessages;
           currentStepMessages = stepMessages;
@@ -1669,6 +1677,8 @@ class DefaultStreamTextResult<
               download,
               output,
               callId,
+              toolsContext,
+              sandbox: stepSandbox,
               onLanguageModelCallStart: filterNullable(
                 onLanguageModelCallStart,
                 telemetryDispatcher.onLanguageModelCallStart as

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod/v4';
-import { tool, type Tool } from '@ai-sdk/provider-utils';
+import {
+  tool,
+  type Sandbox,
+  type Tool,
+  type ToolSet,
+} from '@ai-sdk/provider-utils';
 import { describe, expect, it } from 'vitest';
 import { prepareTools } from './prepare-tools';
 
@@ -48,7 +53,6 @@ describe('prepareTools', () => {
             "type": "object",
           },
           "name": "tool1",
-          "providerOptions": undefined,
           "type": "function",
         },
         {
@@ -67,7 +71,6 @@ describe('prepareTools', () => {
             "type": "object",
           },
           "name": "tool2",
-          "providerOptions": undefined,
           "type": "function",
         },
       ]
@@ -88,7 +91,6 @@ describe('prepareTools', () => {
             "type": "object",
           },
           "name": "tool1",
-          "providerOptions": undefined,
           "type": "function",
         },
         {
@@ -107,7 +109,6 @@ describe('prepareTools', () => {
             "type": "object",
           },
           "name": "tool2",
-          "providerOptions": undefined,
           "type": "function",
         },
         {
@@ -181,7 +182,6 @@ describe('prepareTools', () => {
             "type": "object",
           },
           "name": "tool1",
-          "providerOptions": undefined,
           "strict": true,
           "type": "function",
         },
@@ -227,10 +227,52 @@ describe('prepareTools', () => {
             "type": "object",
           },
           "name": "tool1",
-          "providerOptions": undefined,
           "type": "function",
         },
       ]
     `);
+  });
+
+  it('resolves function descriptions from toolsContext and sandbox', async () => {
+    const sandbox: Sandbox = {
+      description: 'test-sandbox',
+      executeCommand: async () => ({
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      }),
+    };
+
+    const result = await prepareTools({
+      tools: {
+        contextual: {
+          type: 'dynamic' as const,
+          description: ({ context }: { context: Record<string, unknown> }) =>
+            `User is ${String(context.userName)}`,
+          inputSchema: z.object({}),
+          execute: async () => {},
+        },
+        withSandbox: {
+          type: 'dynamic' as const,
+          description: ({ sandbox: sb }: { sandbox?: Sandbox }) =>
+            `Env: ${sb?.description ?? 'none'}`,
+          inputSchema: z.object({}),
+          execute: async () => {},
+        },
+      } as unknown as ToolSet,
+      toolsContext: { contextual: { userName: 'Ada' } },
+      sandbox,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: 'contextual',
+        description: 'User is Ada',
+      }),
+      expect.objectContaining({
+        name: 'withSandbox',
+        description: 'Env: test-sandbox',
+      }),
+    ]);
   });
 });

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -2,13 +2,23 @@ import type {
   LanguageModelV4FunctionTool,
   LanguageModelV4ProviderTool,
 } from '@ai-sdk/provider';
-import { asSchema, type ToolSet } from '@ai-sdk/provider-utils';
+import {
+  asSchema,
+  type InferToolSetContext,
+  type Sandbox,
+  type Tool,
+  type ToolSet,
+} from '@ai-sdk/provider-utils';
 import { isNonEmptyObject } from '../util/is-non-empty-object';
 
 export async function prepareTools<TOOLS extends ToolSet>({
   tools,
+  toolsContext = {} as InferToolSetContext<TOOLS>,
+  sandbox,
 }: {
   tools: TOOLS | undefined;
+  toolsContext?: InferToolSetContext<TOOLS>;
+  sandbox?: Sandbox;
 }): Promise<
   Array<LanguageModelV4FunctionTool | LanguageModelV4ProviderTool> | undefined
 > {
@@ -25,20 +35,29 @@ export async function prepareTools<TOOLS extends ToolSet>({
     switch (toolType) {
       case undefined:
       case 'dynamic':
-      case 'function':
+      case 'function': {
+        const description = resolveToolDescription({
+          tool,
+          toolName: name,
+          toolsContext,
+          sandbox,
+        });
+        const providerOptions = tool.providerOptions;
+        const inputExamples = tool.inputExamples;
+        const strict = tool.strict;
+
         languageModelTools.push({
           type: 'function' as const,
           name,
-          description: tool.description,
           inputSchema: await asSchema(tool.inputSchema).jsonSchema,
-          ...(tool.inputExamples != null
-            ? { inputExamples: tool.inputExamples }
-            : {}),
-          providerOptions: tool.providerOptions,
-          ...(tool.strict != null ? { strict: tool.strict } : {}),
+          ...(description != null ? { description } : {}),
+          ...(inputExamples != null ? { inputExamples } : {}),
+          ...(providerOptions != null ? { providerOptions } : {}),
+          ...(strict != null ? { strict } : {}),
         });
         break;
-      case 'provider':
+      }
+      case 'provider': {
         languageModelTools.push({
           type: 'provider' as const,
           name,
@@ -46,6 +65,7 @@ export async function prepareTools<TOOLS extends ToolSet>({
           args: tool.args,
         });
         break;
+      }
       default: {
         const exhaustiveCheck: never = toolType as never;
         throw new Error(`Unsupported tool type: ${exhaustiveCheck}`);
@@ -54,4 +74,25 @@ export async function prepareTools<TOOLS extends ToolSet>({
   }
 
   return languageModelTools;
+}
+
+function resolveToolDescription<TOOLS extends ToolSet>({
+  tool,
+  toolName,
+  toolsContext,
+  sandbox,
+}: {
+  tool: Tool;
+  toolName: string;
+  toolsContext: InferToolSetContext<TOOLS>;
+  sandbox?: Sandbox;
+}): string | undefined {
+  return tool.description === undefined
+    ? undefined
+    : typeof tool.description === 'string'
+      ? tool.description
+      : tool.description({
+          context: toolsContext[toolName as keyof InferToolSetContext<TOOLS>],
+          sandbox,
+        });
 }

--- a/packages/ai/src/ui/direct-chat-transport.ts
+++ b/packages/ai/src/ui/direct-chat-transport.ts
@@ -1,11 +1,15 @@
 import type { Agent } from '../agent/agent';
 import type { Output } from '../generate-text/output';
 import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
-import type { Context, ToolSet } from '@ai-sdk/provider-utils';
+import type { Context, Tool, ToolSet } from '@ai-sdk/provider-utils';
 import type { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import type { ChatTransport } from './chat-transport';
 import { convertToModelMessages } from './convert-to-model-messages';
-import type { InferUITools, UIMessage } from './ui-messages';
+import type {
+  InferUIMessageTools,
+  InferUITools,
+  UIMessage,
+} from './ui-messages';
 import { validateUIMessages } from './validate-ui-messages';
 
 /**
@@ -90,7 +94,14 @@ export class DirectChatTransport<
     // Validate the incoming UI messages
     const validatedMessages = await validateUIMessages<UI_MESSAGE>({
       messages,
-      tools: this.agent.tools,
+      // tools are compatible; the casting is required because the context param is
+      // not available in ui messages
+      tools: this.agent.tools as unknown as {
+        [NAME in keyof InferUIMessageTools<UI_MESSAGE> & string]?: Tool<
+          InferUIMessageTools<UI_MESSAGE>[NAME]['input'],
+          InferUIMessageTools<UI_MESSAGE>[NAME]['output']
+        >;
+      },
     });
 
     // Convert UI messages to model messages

--- a/packages/provider-utils/src/types/tool.test-d.ts
+++ b/packages/provider-utils/src/types/tool.test-d.ts
@@ -4,6 +4,7 @@ import type { FlexibleSchema } from '../schema';
 import type { ToolResultOutput } from './content-part';
 import type { Context } from './context';
 import type { ModelMessage } from './model-message';
+import type { Sandbox } from './sandbox';
 import {
   dynamicTool,
   tool,
@@ -32,7 +33,11 @@ describe('DynamicTool', () => {
       outputSchema: z.string(),
     };
 
-    expectTypeOf(aTool.description).toEqualTypeOf<string | undefined>();
+    expectTypeOf(aTool.description).toEqualTypeOf<
+      | string
+      | ((options: { context: Context; sandbox?: Sandbox }) => string)
+      | undefined
+    >();
     expectTypeOf(aTool.strict).toEqualTypeOf<boolean | undefined>();
     expectTypeOf(aTool.inputExamples).toEqualTypeOf<
       Array<{ input: { location: string } }> | undefined

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -9,6 +9,7 @@ import type {
   ToolExecutionOptions,
 } from './tool-execute-function';
 import type { ToolNeedsApprovalFunction } from './tool-needs-approval-function';
+import type { Sandbox } from './sandbox';
 
 /**
  * Helper type to determine the outputSchema and execute function properties of a tool.
@@ -175,10 +176,18 @@ type BaseFunctionTool<
   CONTEXT extends Context | unknown | never = any,
 > = BaseTool<INPUT, OUTPUT, CONTEXT> & {
   /**
-   * An optional description of what the tool does.
-   * Will be used by the language model to decide whether to use the tool.
+   * Optional description of what the tool does.
+   *
+   * Included in the tool definition sent to the language model so it can
+   * decide when and how to call the tool.
+   *
+   * Provide a string for a fixed description, or a function that returns a
+   * string from the current `context` (and optional `sandbox`) when the
+   * description should vary per call.
    */
-  description?: string;
+  description?:
+    | string
+    | ((options: { context: NoInfer<CONTEXT>; sandbox?: Sandbox }) => string);
 
   /**
    * Strict mode setting for the tool.

--- a/packages/workflow/src/serializable-schema.ts
+++ b/packages/workflow/src/serializable-schema.ts
@@ -43,7 +43,7 @@ export function serializeToolSet(
   return Object.fromEntries(
     Object.entries(tools).map(([name, t]) => {
       const def: SerializableToolDef = {
-        description: t.description,
+        description: t.description as string, // TODO support tools with function descriptions
         inputSchema: asSchema(t.inputSchema).jsonSchema as JSONSchema7,
       };
 


### PR DESCRIPTION
## Background

Tool description might need to use information from the tool context or the sandbox to be more effective.

## Summary

Allow tool descriptions to be functions that take context and sandbox as args.

## Future Work
* explore how workflow agent can support flexible tool descriptions