### PR TITLE
feat: instructions as prepareStep input

### DIFF
--- a/.changeset/early-geckos-dress.md
+++ b/.changeset/early-geckos-dress.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat: instructions as prepareStep input

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -482,6 +482,8 @@ It is called with the following parameters:
 - `stopWhen`: The stopping condition that was passed into `generateText`.
 - `stepNumber`: The number of the step that is being executed.
 - `steps`: The steps that have been executed so far.
+- `instructions`: The instructions that will be sent to the model for the current step. If `prepareStep` returns an `instructions` override, those instructions carry forward as the default for later steps.
+- `initialInstructions`: The instructions that were passed into `generateText` or `streamText`.
 - `messages`: The messages that will be sent to the model for the current step. Treat this as the loop's current message state. If `prepareStep` returns a `messages` override, those messages carry forward as the base for later steps.
 - `initialMessages`: The messages that were passed into `generateText` or `streamText`.
 - `responseMessages`: The accumulated assistant/tool response messages so far, including any tool results generated before the first model step from approved tool calls in the input messages.
@@ -512,6 +514,8 @@ const result = await generateText({
   },
 });
 ```
+
+If you return `instructions`, those instructions carry forward to later steps until `prepareStep` returns another `instructions` or `system` override. Use `initialInstructions` when you need to restore or compare against the top-level instructions from the original call.
 
 #### Message Modification for Longer Agentic Loops
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -620,6 +620,18 @@ To see `generateText` in action, check out [these examples](#examples).
                       description: 'The model that is being used.',
                     },
                     {
+                      name: 'instructions',
+                      type: 'Instructions | undefined',
+                      description:
+                        'The instructions that will be sent to the model for the current step. If prepareStep returns an instructions override, those instructions carry forward to later steps.',
+                    },
+                    {
+                      name: 'initialInstructions',
+                      type: 'Instructions | undefined',
+                      description:
+                        'The initial instructions that were passed into generateText or streamText.',
+                    },
+                    {
                       name: 'messages',
                       type: 'Array<ModelMessage>',
                       description:
@@ -682,7 +694,7 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'Instructions',
               isOptional: true,
               description:
-                'Optionally override the instructions sent to the model for this step.',
+                'Optionally override the instructions sent to the model for this step. The override carries forward to later steps until prepareStep returns another instructions or system override.',
             },
             {
               name: 'messages',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -664,6 +664,18 @@ To see `streamText` in action, check out [these examples](#examples).
                       description: 'The model that is being used.',
                     },
                     {
+                      name: 'instructions',
+                      type: 'Instructions | undefined',
+                      description:
+                        'The instructions that will be sent to the model for the current step. If prepareStep returns an instructions override, those instructions carry forward to later steps.',
+                    },
+                    {
+                      name: 'initialInstructions',
+                      type: 'Instructions | undefined',
+                      description:
+                        'The initial instructions that were passed into generateText or streamText.',
+                    },
+                    {
                       name: 'messages',
                       type: 'Array<ModelMessage>',
                       description:
@@ -726,7 +738,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'Instructions',
               isOptional: true,
               description:
-                'Optionally override the instructions sent to the model for this step.',
+                'Optionally override the instructions sent to the model for this step. The override carries forward to later steps until prepareStep returns another instructions or system override.',
             },
             {
               name: 'messages',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -118,6 +118,37 @@ const result = streamText({
 The `system` option is still accepted as a deprecated fallback. When both
 `instructions` and `system` are provided, `instructions` takes precedence.
 
+#### `prepareStep` Instructions Carry Forward
+
+In AI SDK 7, instructions returned from `prepareStep` are used in future steps
+until `prepareStep` returns another `instructions` or `system` override. This
+matches how `messages` returned from `prepareStep` carry forward.
+
+In AI SDK 6, `prepareStep` instruction overrides only applied to the current
+step. Later steps fell back to the top-level `system` instructions unless they
+returned their own override.
+
+If your `prepareStep` logic depends on one-step-only instruction overrides,
+return the desired instructions for each step explicitly:
+
+```tsx filename="AI SDK 7"
+const result = streamText({
+  model: yourModel,
+  instructions: 'Use the default behavior.',
+  prompt: 'Hello!',
+  prepareStep: ({ stepNumber, initialInstructions }) => ({
+    instructions:
+      stepNumber === 0
+        ? 'Use special instructions for the first step.'
+        : initialInstructions,
+  }),
+});
+```
+
+The `prepareStep` callback receives both `instructions`, which is the current
+instruction state for the step, and `initialInstructions`, which is the
+top-level instruction value from the original call.
+
 If your tool call repair function forwards the current system instructions to
 another model call, read and pass `instructions` instead of `system`:
 

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -303,11 +303,19 @@ describe('generateText types', () => {
           model: new MockLanguageModelV4(),
           prompt: 'Hello',
           prepareStep: ({
+            instructions,
+            initialInstructions,
             initialMessages,
             responseMessages,
             runtimeContext,
             toolsContext,
           }) => {
+            expectTypeOf(instructions).toEqualTypeOf<
+              Instructions | undefined
+            >();
+            expectTypeOf(initialInstructions).toEqualTypeOf<
+              Instructions | undefined
+            >();
             expectTypeOf(initialMessages).toEqualTypeOf<Array<ModelMessage>>();
             expectTypeOf(responseMessages).toEqualTypeOf<
               Array<ResponseMessage>

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1680,33 +1680,35 @@ describe('generateText', () => {
       }> = [];
       let responseCount = 0;
 
+      const model = new MockLanguageModelV4({
+        doGenerate: async () => {
+          switch (responseCount++) {
+            case 0:
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'tool-call',
+                    toolCallType: 'function',
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    input: '{ "value": "test" }',
+                  },
+                ],
+                finishReason: { unified: 'tool-calls', raw: undefined },
+              };
+            case 1:
+            default:
+              return {
+                ...dummyResponseValues,
+                content: [{ type: 'text', text: 'Done.' }],
+              };
+          }
+        },
+      });
+
       await generateText({
-        model: new MockLanguageModelV4({
-          doGenerate: async () => {
-            switch (responseCount++) {
-              case 0:
-                return {
-                  ...dummyResponseValues,
-                  content: [
-                    {
-                      type: 'tool-call',
-                      toolCallType: 'function',
-                      toolCallId: 'call-1',
-                      toolName: 'tool1',
-                      input: '{ "value": "test" }',
-                    },
-                  ],
-                  finishReason: { unified: 'tool-calls', raw: undefined },
-                };
-              case 1:
-              default:
-                return {
-                  ...dummyResponseValues,
-                  content: [{ type: 'text', text: 'Done.' }],
-                };
-            }
-          },
-        }),
+        model,
         tools: {
           tool1: tool({
             inputSchema: z.object({ value: z.string() }),
@@ -1722,6 +1724,7 @@ describe('generateText', () => {
           initialMessages,
           responseMessages,
           messages,
+          stepNumber,
         }) => {
           prepareStepCalls.push({
             instructions,
@@ -1730,7 +1733,10 @@ describe('generateText', () => {
             responseMessages: [...responseMessages],
             messages: [...messages],
           });
-          return undefined;
+
+          return stepNumber === 0
+            ? { instructions: 'prepared instructions' }
+            : undefined;
         },
       });
 
@@ -1745,7 +1751,7 @@ describe('generateText', () => {
         { role: 'user', content: 'test-input' },
       ]);
 
-      expect(prepareStepCalls[1].instructions).toBe('test instructions');
+      expect(prepareStepCalls[1].instructions).toBe('prepared instructions');
       expect(prepareStepCalls[1].initialInstructions).toBe('test instructions');
       expect(prepareStepCalls[1].initialMessages).toEqual([
         { role: 'user', content: 'test-input' },
@@ -1787,6 +1793,10 @@ describe('generateText', () => {
         ...prepareStepCalls[1].initialMessages,
         ...prepareStepCalls[1].responseMessages,
       ]);
+      expect(model.doGenerateCalls[1].prompt[0]).toEqual({
+        role: 'system',
+        content: 'prepared instructions',
+      });
     });
 
     it('should pass updated toolsContext from prepareStep', async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -29,6 +29,7 @@ import {
 } from 'vitest';
 import { z } from 'zod/v4';
 import * as logWarningsModule from '../logger/log-warnings';
+import type { Instructions } from '../prompt';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import { generateText } from './generate-text';
 import type {
@@ -1669,8 +1670,10 @@ describe('generateText', () => {
       });
     });
 
-    it('should pass initialMessages and responseMessages to prepareStep', async () => {
+    it('should pass initialInstructions, initialMessages, and responseMessages to prepareStep', async () => {
       const prepareStepCalls: Array<{
+        instructions: Instructions | undefined;
+        initialInstructions: Instructions | undefined;
         initialMessages: Array<ModelMessage>;
         responseMessages: Array<ModelMessage>;
         messages: Array<ModelMessage>;
@@ -1710,14 +1713,19 @@ describe('generateText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
+        instructions: 'test instructions',
         messages: [{ role: 'user', content: 'test-input' }],
         stopWhen: isStepCount(3),
         prepareStep: async ({
+          instructions,
+          initialInstructions,
           initialMessages,
           responseMessages,
           messages,
         }) => {
           prepareStepCalls.push({
+            instructions,
+            initialInstructions,
             initialMessages: [...initialMessages],
             responseMessages: [...responseMessages],
             messages: [...messages],
@@ -1727,6 +1735,8 @@ describe('generateText', () => {
       });
 
       expect(prepareStepCalls).toHaveLength(2);
+      expect(prepareStepCalls[0].instructions).toBe('test instructions');
+      expect(prepareStepCalls[0].initialInstructions).toBe('test instructions');
       expect(prepareStepCalls[0].initialMessages).toEqual([
         { role: 'user', content: 'test-input' },
       ]);
@@ -1735,6 +1745,8 @@ describe('generateText', () => {
         { role: 'user', content: 'test-input' },
       ]);
 
+      expect(prepareStepCalls[1].instructions).toBe('test instructions');
+      expect(prepareStepCalls[1].initialInstructions).toBe('test instructions');
       expect(prepareStepCalls[1].initialMessages).toEqual([
         { role: 'user', content: 'test-input' },
       ]);

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -629,6 +629,7 @@ export async function generateText<
       [];
     const steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'] =
       [];
+    let instructionsForNextStep = initialPrompt.instructions;
     let messagesForNextStep = [...initialMessages, ...initialResponseMessages];
 
     // Track provider-executed tool calls that support deferred results
@@ -655,7 +656,7 @@ export async function generateText<
           model,
           steps,
           stepNumber: steps.length,
-          instructions: initialPrompt.instructions,
+          instructions: instructionsForNextStep,
           initialInstructions: initialPrompt.instructions,
           messages: stepInputMessages,
           initialMessages,
@@ -674,7 +675,7 @@ export async function generateText<
         const stepInstructions =
           prepareStepResult?.instructions ??
           prepareStepResult?.system ??
-          initialPrompt.instructions;
+          instructionsForNextStep;
 
         const promptMessages = await convertToLanguageModelPrompt({
           prompt: {
@@ -1072,6 +1073,7 @@ export async function generateText<
         });
 
         steps.push(currentStepResult);
+        instructionsForNextStep = stepInstructions;
         messagesForNextStep = [...stepMessages, ...stepResponseMessages];
 
         await notify({

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -655,6 +655,8 @@ export async function generateText<
           model,
           steps,
           stepNumber: steps.length,
+          instructions: initialPrompt.instructions,
+          initialInstructions: initialPrompt.instructions,
           messages: stepInputMessages,
           initialMessages,
           responseMessages: accumulatedResponseMessages,

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -19,6 +19,8 @@ import type { StepResult } from './step-result';
  * @param options.steps - The steps that have been executed so far.
  * @param options.stepNumber - The number of the step that is being executed.
  * @param options.model - The model that is being used.
+ * @param options.instructions - The instructions that will be sent to the model for the current step.
+ * @param options.initialInstructions - The initial instructions that were passed into generateText or streamText.
  * @param options.messages - The messages that will be sent to the model for the current step. If you return a `messages` override, those messages carry forward to later steps.
  * @param options.initialMessages - The initial messages that were passed into generateText or streamText.
  * @param options.responseMessages - The response messages that have been accumulated from previous steps.
@@ -45,6 +47,16 @@ export type PrepareStepFunction<
    * The model instance that is being used for this step.
    */
   model: LanguageModel;
+
+  /**
+   * The instructions that will be sent to the model for the current step.
+   */
+  instructions: Instructions | undefined;
+
+  /**
+   * The initial instructions that were passed into generateText or streamText.
+   */
+  initialInstructions: Instructions | undefined;
 
   /**
    * The messages that will be sent to the model for the current step.
@@ -82,7 +94,7 @@ export type PrepareStepFunction<
 
 /**
  * The result type returned by a {@link PrepareStepFunction},
- * allowing per-step overrides of model, tools, or messages.
+ * allowing per-step overrides of model, tools, instructions, or messages.
  */
 export type PrepareStepResult<
   TOOLS extends ToolSet,

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -3,6 +3,7 @@ import { tool, type Context, type ModelMessage } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import { Output, streamText } from '../generate-text';
+import type { Instructions } from '../prompt';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import type { AsyncIterableStream } from '../util';
 import type { DeepPartial } from '../util/deep-partial';
@@ -418,11 +419,19 @@ describe('streamText types', () => {
           model: new MockLanguageModelV4(),
           prompt: 'Hello',
           prepareStep: ({
+            instructions,
+            initialInstructions,
             initialMessages,
             responseMessages,
             runtimeContext,
             toolsContext,
           }) => {
+            expectTypeOf(instructions).toEqualTypeOf<
+              Instructions | undefined
+            >();
+            expectTypeOf(initialInstructions).toEqualTypeOf<
+              Instructions | undefined
+            >();
             expectTypeOf(initialMessages).toEqualTypeOf<Array<ModelMessage>>();
             expectTypeOf(responseMessages).toEqualTypeOf<
               Array<ResponseMessage>

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -43,6 +43,7 @@ import {
 import { z } from 'zod/v4';
 import { Output, type LanguageModelCallEndEvent } from '..';
 import * as logWarningsModule from '../logger/log-warnings';
+import type { Instructions } from '../prompt';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import { createMockServerResponse } from '../test/mock-server-response';
 import { mockValues } from '../test/mock-values';
@@ -6688,8 +6689,10 @@ describe('streamText', () => {
       expect(stepStartEvent).not.toHaveProperty('functionId');
     });
 
-    it('should pass initialMessages and responseMessages to prepareStep', async () => {
+    it('should pass initialInstructions, initialMessages, and responseMessages to prepareStep', async () => {
       const prepareStepCalls: Array<{
+        instructions: Instructions | undefined;
+        initialInstructions: Instructions | undefined;
         initialMessages: Array<ModelMessage>;
         responseMessages: Array<ModelMessage>;
         messages: Array<ModelMessage>;
@@ -6755,14 +6758,19 @@ describe('streamText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
+        instructions: 'test instructions',
         messages: [{ role: 'user', content: 'test-input' }],
         stopWhen: isStepCount(3),
         prepareStep: async ({
+          instructions,
+          initialInstructions,
           initialMessages,
           responseMessages,
           messages,
         }) => {
           prepareStepCalls.push({
+            instructions,
+            initialInstructions,
             initialMessages: [...initialMessages],
             responseMessages: [...responseMessages],
             messages: [...messages],
@@ -6775,6 +6783,8 @@ describe('streamText', () => {
       await result.consumeStream();
 
       expect(prepareStepCalls).toHaveLength(2);
+      expect(prepareStepCalls[0].instructions).toBe('test instructions');
+      expect(prepareStepCalls[0].initialInstructions).toBe('test instructions');
       expect(prepareStepCalls[0].initialMessages).toEqual([
         { role: 'user', content: 'test-input' },
       ]);
@@ -6783,6 +6793,8 @@ describe('streamText', () => {
         { role: 'user', content: 'test-input' },
       ]);
 
+      expect(prepareStepCalls[1].instructions).toBe('test instructions');
+      expect(prepareStepCalls[1].initialInstructions).toBe('test instructions');
       expect(prepareStepCalls[1].initialMessages).toEqual([
         { role: 'user', content: 'test-input' },
       ]);

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6699,59 +6699,61 @@ describe('streamText', () => {
       }> = [];
       let responseCount = 0;
 
+      const model = new MockLanguageModelV4({
+        doStream: async () => {
+          switch (responseCount++) {
+            case 0:
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'response-metadata' as const,
+                    id: 'id-0',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  },
+                  {
+                    type: 'tool-call' as const,
+                    id: 'call-1',
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    input: '{ "value": "test" }',
+                  },
+                  {
+                    type: 'finish' as const,
+                    finishReason: {
+                      unified: 'tool-calls' as const,
+                      raw: undefined,
+                    },
+                    usage: testUsage,
+                  },
+                ]),
+              };
+            case 1:
+            default:
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'response-metadata' as const,
+                    id: 'id-1',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(1000),
+                  },
+                  { type: 'text-start' as const, id: '1' },
+                  { type: 'text-delta' as const, id: '1', delta: 'Done.' },
+                  { type: 'text-end' as const, id: '1' },
+                  {
+                    type: 'finish' as const,
+                    finishReason: { unified: 'stop' as const, raw: 'stop' },
+                    usage: testUsage,
+                  },
+                ]),
+              };
+          }
+        },
+      });
+
       const result = streamText({
-        model: new MockLanguageModelV4({
-          doStream: async () => {
-            switch (responseCount++) {
-              case 0:
-                return {
-                  stream: convertArrayToReadableStream([
-                    {
-                      type: 'response-metadata' as const,
-                      id: 'id-0',
-                      modelId: 'mock-model-id',
-                      timestamp: new Date(0),
-                    },
-                    {
-                      type: 'tool-call' as const,
-                      id: 'call-1',
-                      toolCallId: 'call-1',
-                      toolName: 'tool1',
-                      input: '{ "value": "test" }',
-                    },
-                    {
-                      type: 'finish' as const,
-                      finishReason: {
-                        unified: 'tool-calls' as const,
-                        raw: undefined,
-                      },
-                      usage: testUsage,
-                    },
-                  ]),
-                };
-              case 1:
-              default:
-                return {
-                  stream: convertArrayToReadableStream([
-                    {
-                      type: 'response-metadata' as const,
-                      id: 'id-1',
-                      modelId: 'mock-model-id',
-                      timestamp: new Date(1000),
-                    },
-                    { type: 'text-start' as const, id: '1' },
-                    { type: 'text-delta' as const, id: '1', delta: 'Done.' },
-                    { type: 'text-end' as const, id: '1' },
-                    {
-                      type: 'finish' as const,
-                      finishReason: { unified: 'stop' as const, raw: 'stop' },
-                      usage: testUsage,
-                    },
-                  ]),
-                };
-            }
-          },
-        }),
+        model,
         tools: {
           tool1: tool({
             inputSchema: z.object({ value: z.string() }),
@@ -6767,6 +6769,7 @@ describe('streamText', () => {
           initialMessages,
           responseMessages,
           messages,
+          stepNumber,
         }) => {
           prepareStepCalls.push({
             instructions,
@@ -6775,7 +6778,10 @@ describe('streamText', () => {
             responseMessages: [...responseMessages],
             messages: [...messages],
           });
-          return undefined;
+
+          return stepNumber === 0
+            ? { instructions: 'prepared instructions' }
+            : undefined;
         },
         onError: () => {},
       });
@@ -6793,7 +6799,7 @@ describe('streamText', () => {
         { role: 'user', content: 'test-input' },
       ]);
 
-      expect(prepareStepCalls[1].instructions).toBe('test instructions');
+      expect(prepareStepCalls[1].instructions).toBe('prepared instructions');
       expect(prepareStepCalls[1].initialInstructions).toBe('test instructions');
       expect(prepareStepCalls[1].initialMessages).toEqual([
         { role: 'user', content: 'test-input' },
@@ -6835,6 +6841,10 @@ describe('streamText', () => {
         ...prepareStepCalls[1].initialMessages,
         ...prepareStepCalls[1].responseMessages,
       ]);
+      expect(model.doStreamCalls[1].prompt[0]).toEqual({
+        role: 'system',
+        content: 'prepared instructions',
+      });
     });
 
     it('should pass updated toolsContext from prepareStep', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1602,6 +1602,8 @@ class DefaultStreamTextResult<
             model,
             steps: recordedSteps,
             stepNumber: recordedSteps.length,
+            instructions: initialPrompt.instructions,
+            initialInstructions: initialPrompt.instructions,
             messages: stepInputMessages,
             initialMessages,
             responseMessages: accumulatedResponseMessages,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1417,6 +1417,7 @@ class DefaultStreamTextResult<
       });
 
       const initialMessages = initialPrompt.messages;
+      let instructionsForNextStep = initialPrompt.instructions;
 
       const { approvedToolApprovals, deniedToolApprovals } =
         collectToolApprovals<TOOLS>({ messages: initialMessages });
@@ -1602,7 +1603,7 @@ class DefaultStreamTextResult<
             model,
             steps: recordedSteps,
             stepNumber: recordedSteps.length,
-            instructions: initialPrompt.instructions,
+            instructions: instructionsForNextStep,
             initialInstructions: initialPrompt.instructions,
             messages: stepInputMessages,
             initialMessages,
@@ -1639,7 +1640,8 @@ class DefaultStreamTextResult<
           const stepInstructions =
             prepareStepResult?.instructions ??
             prepareStepResult?.system ??
-            initialPrompt.instructions;
+            instructionsForNextStep;
+          instructionsForNextStep = stepInstructions;
 
           const stepProviderOptions = mergeObjects(
             providerOptions,


### PR DESCRIPTION
## Background

Instructions should behave similar to messages in `prepareStep`. The behavior for messages has been changed in #15093

## Summary

* add `instructions` option to `prepareStep`
* add `initialInstructions` option to `prepareStep`
* instructions return from `prepareStep` are used in all future steps (breaking change)

## Related Issues

Makes instructions similar to messages as in #15093
