### PR TITLE
fix(provider-utils): resolve top-level $ref in Standard Schema JSON Schema output

### DIFF
--- a/.changeset/fix-standard-schema-ref.md
+++ b/.changeset/fix-standard-schema-ref.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+fix(provider-utils): resolve top-level $ref in Standard Schema JSON Schema output
+
+Standard Schema providers like Effect's Schema.Class can produce JSON Schema with a top-level $ref and $defs. This is valid JSON Schema but some providers reject it for structured output. This fix inlines the referenced definition at the top level. Also handles $defs in additionalProperties processing.

--- a/packages/provider-utils/src/add-additional-properties-to-json-schema.test.ts
+++ b/packages/provider-utils/src/add-additional-properties-to-json-schema.test.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema7 } from '@ai-sdk/provider';
+import { JSONSchema7 } from '@ai-sdk/provider';
 import { describe, expect, it } from 'vitest';
 import { addAdditionalPropertiesToJsonSchema } from './add-additional-properties-to-json-schema';
 
@@ -240,6 +240,42 @@ describe('addAdditionalPropertiesToJsonSchema', () => {
           properties: {
             value: { type: 'string' },
             next: { $ref: '#/definitions/Node' },
+          },
+        },
+      },
+    });
+  });
+
+  it('adds additionalProperties: false to object schemas inside $defs (refs)', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        node: { $ref: '#/$defs/Node' },
+      },
+      $defs: {
+        Node: {
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+            next: { $ref: '#/$defs/Node' },
+          },
+        },
+      },
+    } as JSONSchema7;
+
+    expect(addAdditionalPropertiesToJsonSchema(schema)).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        node: { $ref: '#/$defs/Node' },
+      },
+      $defs: {
+        Node: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            value: { type: 'string' },
+            next: { $ref: '#/$defs/Node' },
           },
         },
       },

--- a/packages/provider-utils/src/add-additional-properties-to-json-schema.ts
+++ b/packages/provider-utils/src/add-additional-properties-to-json-schema.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
+import { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
 
 /**
  * Recursively adds additionalProperties: false to the JSON schema. This is necessary because some providers (e.g. OpenAI) do not support additionalProperties: true.
@@ -41,6 +41,15 @@ export function addAdditionalPropertiesToJsonSchema(
   if (definitions != null) {
     for (const key of Object.keys(definitions)) {
       definitions[key] = visit(definitions[key]);
+    }
+  }
+
+  const $defs = (jsonSchema as Record<string, any>)['$defs'] as
+    | Record<string, JSONSchema7Definition>
+    | undefined;
+  if ($defs != null) {
+    for (const key of Object.keys($defs)) {
+      $defs[key] = visit($defs[key]);
     }
   }
 

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import * as z4 from 'zod/v4';
 import { safeParseJSON } from './parse-json';
-import { asSchema, zodSchema, type StandardSchema } from './schema';
+import { asSchema, StandardSchema, zodSchema } from './schema';
+
 describe('zodSchema', () => {
   describe('zod/v4', () => {
     describe('json schema conversion', () => {
@@ -249,6 +250,43 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
           age: { type: 'number' },
         },
         required: ['name', 'age'],
+      });
+    });
+
+    it('should resolve top-level $ref with $defs to inline schema', async () => {
+      const standardSchema = createStandardSchema<{
+        rating: number;
+        summary: string;
+      }>({
+        jsonSchema: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          $defs: {
+            ReviewResult: {
+              type: 'object',
+              required: ['rating', 'summary'],
+              properties: {
+                rating: { type: 'number' },
+                summary: { type: 'string' },
+              },
+            },
+          },
+          $ref: '#/$defs/ReviewResult',
+        },
+        validate: async value => ({
+          value: value as { rating: number; summary: string },
+        }),
+      });
+
+      const schema = asSchema(standardSchema);
+
+      expect(await schema.jsonSchema).toStrictEqual({
+        type: 'object',
+        additionalProperties: false,
+        required: ['rating', 'summary'],
+        properties: {
+          rating: { type: 'number' },
+          summary: { type: 'string' },
+        },
       });
     });
 

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -1,9 +1,6 @@
-import { TypeValidationError, type JSONSchema7 } from '@ai-sdk/provider';
-import type {
-  StandardSchemaV1,
-  StandardJSONSchemaV1,
-} from '@standard-schema/spec';
-import type * as z3 from 'zod/v3';
+import { JSONSchema7, TypeValidationError } from '@ai-sdk/provider';
+import { StandardSchemaV1, StandardJSONSchemaV1 } from '@standard-schema/spec';
+import * as z3 from 'zod/v3';
 import * as z4 from 'zod/v4';
 import { addAdditionalPropertiesToJsonSchema } from './add-additional-properties-to-json-schema';
 import { zod3ToJsonSchema } from './to-json-schema/zod3-to-json-schema';
@@ -146,15 +143,44 @@ export function asSchema<OBJECT>(
         : schema();
 }
 
+function resolveTopLevelRef(schema: JSONSchema7): JSONSchema7 {
+  const ref = schema.$ref;
+  if (typeof ref !== 'string') return schema;
+
+  const defsMatch = ref.match(/^#\/(\$defs|definitions)\/(.+)$/);
+  if (!defsMatch) return schema;
+
+  const [, defsKey, defName] = defsMatch;
+  const defs = (schema as any)[defsKey] as
+    | Record<string, JSONSchema7>
+    | undefined;
+  if (defs == null || !(defName in defs)) return schema;
+
+  const { $ref: _, $schema: __, [defsKey]: _defs, ...rest } = schema as any;
+  const definition = defs[defName];
+  const remainingDefs = { ...defs };
+  delete remainingDefs[defName];
+
+  return {
+    ...rest,
+    ...definition,
+    ...(Object.keys(remainingDefs).length > 0
+      ? { [defsKey]: remainingDefs }
+      : {}),
+  };
+}
+
 function standardSchema<OBJECT>(
   standardSchema: StandardSchema<OBJECT>,
 ): Schema<OBJECT> {
   return jsonSchema(
     () =>
-      addAdditionalPropertiesToJsonSchema(
-        standardSchema['~standard'].jsonSchema.input({
-          target: 'draft-07',
-        }) as JSONSchema7,
+      resolveTopLevelRef(
+        addAdditionalPropertiesToJsonSchema(
+          standardSchema['~standard'].jsonSchema.input({
+            target: 'draft-07',
+          }) as JSONSchema7,
+        ),
       ),
     {
       validate: async value => {


### PR DESCRIPTION
## Summary

Fixes #15155

When using Effect's `Schema.Class` with `Schema.standardSchemaV1`, the resulting JSON Schema has a top-level `$ref` + `$defs` structure:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$defs": {
    "BettyReviewResult": { "type": "object", ... }
  },
  "$ref": "#/$defs/BettyReviewResult"
}
```

Some providers (e.g., OpenAI) reject this for structured output, returning HTTP 400. Meanwhile `Schema.Struct(Class.fields)` works fine because it produces flat inline schema without `$ref`.

## Changes

1. **`schema.ts`** — Added `resolveTopLevelRef()` helper that inlines the referenced definition when a Standard Schema produces JSON Schema with a top-level `$ref` pointing to `$defs` or `definitions`. Also strips the `$schema` property (not needed for provider API calls). Preserves remaining definitions for nested `$ref` usage (important for recursive schemas).

2. **`add-additional-properties-to-json-schema.ts`** — Extended to also process `$defs` in addition to the existing `definitions` handling. Effect and other Standard Schema providers use `$defs` (the newer JSON Schema keyword) rather than `definitions`.

## Testing

- Added test for `$defs` handling in `addAdditionalPropertiesToJsonSchema` (mirrors existing `definitions` test)
- Added test for Standard Schema with top-level `$ref` + `$defs` → verifies it resolves to flat inline schema with `additionalProperties: false`

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.