### PR TITLE
fix(gateway): accept model metadata without token pricing

### DIFF
--- a/.changeset/gateway-flexible-model-pricing.md
+++ b/.changeset/gateway-flexible-model-pricing.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+Allow Gateway model metadata responses with non-token pricing fields.

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -254,6 +254,51 @@ describe('GatewayFetchMetadata', () => {
       }
     });
 
+    it('should accept non-language pricing metadata from newer gateway responses', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          models: [
+            {
+              id: 'video-model',
+              name: 'Video Model',
+              modelType: 'video',
+              tags: ['video'],
+              input_tiers: [],
+              output_tiers: [],
+              input_cache_read_tiers: [],
+              input_cache_write_tiers: [],
+              video_duration_pricing: {},
+              pricing: {
+                image: '0.00001',
+              },
+              specification: {
+                specificationVersion: 'v4' as const,
+                provider: 'test-provider',
+                modelId: 'video-model',
+              },
+            },
+          ],
+        },
+      };
+
+      const metadata = createBasicMetadataFetcher();
+      const result = await metadata.getAvailableModels();
+
+      expect(result.models).toHaveLength(1);
+      expect(result.models[0]).toMatchObject({
+        id: 'video-model',
+        name: 'Video Model',
+        modelType: 'video',
+        specification: {
+          specificationVersion: 'v4',
+          provider: 'test-provider',
+          modelId: 'video-model',
+        },
+      });
+      expect(result.models[0].pricing).toBeUndefined();
+    });
+
     it('should keep known models and filter unknown from mixed response', async () => {
       server.urls['https://api.example.com/*'].response = {
         type: 'json-value',

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -90,22 +90,26 @@ const gatewayAvailableModelsResponseSchema = lazySchema(() =>
             description: z.string().nullish(),
             pricing: z
               .object({
-                input: z.string(),
-                output: z.string(),
+                input: z.string().nullish(),
+                output: z.string().nullish(),
                 input_cache_read: z.string().nullish(),
                 input_cache_write: z.string().nullish(),
               })
               .transform(
-                ({ input, output, input_cache_read, input_cache_write }) => ({
-                  input,
-                  output,
-                  ...(input_cache_read
-                    ? { cachedInputTokens: input_cache_read }
-                    : {}),
-                  ...(input_cache_write
-                    ? { cacheCreationInputTokens: input_cache_write }
-                    : {}),
-                }),
+                ({ input, output, input_cache_read, input_cache_write }) => {
+                  const pricing = {
+                    ...(input != null ? { input } : {}),
+                    ...(output != null ? { output } : {}),
+                    ...(input_cache_read != null
+                      ? { cachedInputTokens: input_cache_read }
+                      : {}),
+                    ...(input_cache_write != null
+                      ? { cacheCreationInputTokens: input_cache_write }
+                      : {}),
+                  };
+
+                  return Object.keys(pricing).length > 0 ? pricing : undefined;
+                },
               )
               .nullish(),
             specification: z.object({

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -34,11 +34,11 @@ export interface GatewayLanguageModelEntry {
     /**
      * Cost per input token in USD.
      */
-    input: string;
+    input?: string;
     /**
      * Cost per output token in USD.
      */
-    output: string;
+    output?: string;
     /**
      * Cost per cached input token in USD.
      * Only present for providers/models that support prompt caching.


### PR DESCRIPTION
## Summary

Fixes #12732.

Gateway model metadata can now accept pricing objects that do not include token-based `input` / `output` fields. This keeps newer non-language model metadata, such as video entries with image/video pricing fields, from failing schema validation.

The known token pricing fields are still normalized to the existing SDK names, and unsupported pricing fields are ignored until the public metadata type models them.

## Checks

- `corepack pnpm --dir packages/test-server exec tsup --tsconfig tsconfig.build.json`
- `corepack pnpm --dir packages/gateway exec vitest --config vitest.node.config.js --run src/gateway-fetch-metadata.test.ts`
- `corepack pnpm --filter=@ai-sdk/gateway type-check`
- `corepack pnpm exec ultracite check packages/gateway/src/gateway-fetch-metadata.ts packages/gateway/src/gateway-fetch-metadata.test.ts packages/gateway/src/gateway-model-entry.ts`
- `git diff --check`