### PR TITLE
fix: update jsdoc for instructions

### DIFF
--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -119,6 +119,7 @@ export type PrepareStepResult<
 
       /**
        * Optionally override the instructions sent to the model for this step.
+       * The override carries forward to later steps.
        */
       instructions?: Instructions;
 


### PR DESCRIPTION
## Background

Forgot to update jsdoc.

## Summary

Add missing jsdoc.
