### PR TITLE
Fix streaming gateway error conversion to preserve GatewayError instances

### DIFF
--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -852,6 +852,26 @@ describe('GatewayLanguageModel', () => {
       }
     });
 
+    it('should normalize malformed stream chunk errors', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: ['data: {invalid-json\n\n'],
+      };
+
+      try {
+        const { stream } = await createTestModel().doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+        await convertReadableStreamToArray(stream);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayResponseError.isInstance(error)).toBe(true);
+        const responseError = error as GatewayResponseError;
+        expect(responseError.message).toContain('Gateway request failed');
+      }
+    });
+
     describe('Image part encoding', () => {
       it('should not modify prompt without image parts', async () => {
         prepareStreamResponse({ content: ['response'] });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -75,6 +75,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
       : undefined;
+    const authMethod = await parseAuthMethod(resolvedHeaders ?? {});
 
     try {
       const {
@@ -122,6 +123,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
       : undefined;
+    const authMethod = await parseAuthMethod(resolvedHeaders ?? {});
 
     try {
       const { value: response, responseHeaders } = await postJsonToApi({
@@ -153,7 +155,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
                 controller.enqueue({ type: 'stream-start', warnings });
               }
             },
-            transform(chunk, controller) {
+            async transform(chunk, controller) {
               if (chunk.success) {
                 const streamPart = chunk.value;
 
@@ -173,9 +175,11 @@ export class GatewayLanguageModel implements LanguageModelV4 {
 
                 controller.enqueue(streamPart);
               } else {
-                controller.error(
+                const streamError = await asGatewayError(
                   (chunk as { success: false; error: unknown }).error,
+                  authMethod,
                 );
+                controller.error(streamError);
               }
             },
           }),
@@ -184,10 +188,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         response: { headers: responseHeaders },
       };
     } catch (error) {
-      throw await asGatewayError(
-        error,
-        await parseAuthMethod(resolvedHeaders ?? {}),
-      );
+      throw await asGatewayError(error, authMethod);
     }
   }
 


### PR DESCRIPTION
## Summary
- Compute the gateway authentication method once in `doStream` and reuse it for error conversion paths.
- Await `asGatewayError` in the streaming chunk transform so malformed chunk errors are converted into `GatewayError` instances before signaling stream failure.
- Add regression coverage for malformed stream chunks normalizing to `GatewayResponseError`.

Fixes #13396.

## Validation
- `corepack pnpm -C packages/gateway type-check`
- `corepack pnpm -C packages/gateway test:node -- --run src/gateway-language-model.test.ts --grep "GatewayLanguageModel > doStream"`
- `corepack pnpm -C packages/gateway test:node -- --run src/as-gateway-error.test.ts`