### PR TITLE
fix(workflow): pass step number into stream steps

### DIFF
--- a/.changeset/workflow-do-stream-step-number.md
+++ b/.changeset/workflow-do-stream-step-number.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Add a `stepNumber` option to `doStreamStep` so callers can create `StepResult` objects with the correct step number.

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -58,6 +58,11 @@ export interface DoStreamStepOptions {
   responseFormat?: LanguageModelV4CallOptions['responseFormat'];
   runtimeContext?: Context;
   toolsContext?: Record<string, Context | undefined>;
+  /**
+   * The step number for the returned StepResult. Defaults to 0 for direct
+   * callers; stream iterators pass their current index. See #15151.
+   */
+  stepNumber?: number;
 }
 
 /**
@@ -251,7 +256,7 @@ export async function doStreamStep(
 
   const step: StepResult<ToolSet, any> = {
     callId: 'workflow-agent',
-    stepNumber: 0,
+    stepNumber: options?.stepNumber ?? 0,
     model: {
       provider: responseMetadata?.modelId?.split(':')[0] ?? 'unknown',
       modelId: responseMetadata?.modelId ?? 'unknown',

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -756,6 +756,7 @@ describe('streamTextIterator', () => {
         expect.objectContaining({
           runtimeContext,
           toolsContext,
+          stepNumber: 0,
         }),
       );
       expect(result.value).toMatchObject({

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -337,6 +337,7 @@ export async function* streamTextIterator({
             responseFormat,
             runtimeContext: currentRuntimeContext,
             toolsContext: currentToolsContext,
+            stepNumber,
           },
         );
 


### PR DESCRIPTION
## Background

Follow-up to #15151: `doStreamStep` creates the `StepResult`, so it should receive the step number instead of relying on callers to patch the result afterward.

## Summary

Adds a defaulted `stepNumber` option for workflow stream steps.

## Manual Verification

- `pnpm turbo build --filter=@ai-sdk/workflow...`
- `pnpm test:node src/stream-text-iterator.test.ts` from `packages/workflow`
- `pnpm type-check` from `packages/workflow`

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

Follow-up to #15151.