### PR TITLE
fix(bedrock): skip passing unsigned reasoning content

### DIFF
--- a/.changeset/fuzzy-tools-destroy.md
+++ b/.changeset/fuzzy-tools-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(bedrock): skip passing unsigned reasoning content

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -914,7 +914,7 @@ describe('assistant messages', () => {
     `);
   });
 
-  it('should trim trailing whitespace from reasoning content without signature when it is the last part', async () => {
+  it('should omit reasoning content without signature', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {
         role: 'user',
@@ -927,6 +927,7 @@ describe('assistant messages', () => {
             type: 'reasoning',
             text: 'This is my reasoning with trailing space    ',
           },
+          { type: 'text', text: 'final answer' },
         ],
       },
     ]);
@@ -945,11 +946,7 @@ describe('assistant messages', () => {
           {
             "content": [
               {
-                "reasoningContent": {
-                  "reasoningText": {
-                    "text": "This is my reasoning with trailing space",
-                  },
-                },
+                "text": "final answer",
               },
             ],
             "role": "assistant",
@@ -960,7 +957,7 @@ describe('assistant messages', () => {
     `);
   });
 
-  it('should only trim last reasoning part when multiple reasoning parts have trailing spaces', async () => {
+  it('should omit multiple reasoning parts without signatures', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {
         role: 'user',
@@ -977,6 +974,7 @@ describe('assistant messages', () => {
             type: 'reasoning',
             text: 'Second reasoning with trailing space    ',
           },
+          { type: 'text', text: 'final answer' },
         ],
       },
     ]);
@@ -995,21 +993,90 @@ describe('assistant messages', () => {
           {
             "content": [
               {
-                "reasoningContent": {
-                  "reasoningText": {
-                    "text": "First reasoning with trailing space    ",
-                  },
-                },
+                "text": "final answer",
               },
+            ],
+            "role": "assistant",
+          },
+        ],
+        "system": [],
+      }
+    `);
+  });
+
+  it('should omit unsigned reasoning while preserving tool calls in multi-turn tool use', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'What is the weather?' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'I should call the weather tool.',
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            input: { city: 'SF' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            output: { type: 'text', value: 'Sunny, 72F' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": [
               {
-                "reasoningContent": {
-                  "reasoningText": {
-                    "text": "Second reasoning with trailing space",
+                "text": "What is the weather?",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "toolUse": {
+                  "input": {
+                    "city": "SF",
                   },
+                  "name": "getWeather",
+                  "toolUseId": "call-1",
                 },
               },
             ],
             "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "toolResult": {
+                  "content": [
+                    {
+                      "text": "Sunny, 72F",
+                    },
+                  ],
+                  "toolUseId": "call-1",
+                },
+              },
+            ],
+            "role": "user",
           },
         ],
         "system": [],

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -387,35 +387,11 @@ export async function convertToAmazonBedrockChatMessages(
                       },
                     },
                   });
-                } else if (
-                  part.providerOptions == null ||
-                  Object.keys(part.providerOptions).every(
-                    k => k === 'bedrock' || k === 'amazonBedrock',
-                  )
-                ) {
-                  // No foreign-provider metadata — preserve text. This covers
-                  // the prefill case where the caller hand-crafts a reasoning
-                  // block without a signature. Forwarding reasoning that was
-                  // signed by a different provider (e.g. anthropic) would
-                  // cause Bedrock to reject with
-                  // `thinking.signature: Field required`, so we drop those.
-                  // trim the last text part if it's the last message in the
-                  // block because Bedrock does not allow trailing whitespace
-                  // in pre-filled assistant responses
-                  amazonBedrockContent.push({
-                    reasoningContent: {
-                      reasoningText: {
-                        text: trimIfLast(
-                          isLastBlock,
-                          isLastMessage,
-                          isLastContentPart,
-                          part.text,
-                        ),
-                      },
-                    },
-                  });
                 }
-
+                // Unsigned reasoning is intentionally not replayed. Some
+                // Bedrock models (for example OpenAI gpt-oss) return reasoning
+                // without a signature; sending it back in multi-turn tool use
+                // can leak raw reasoning into the visible response.
                 break;
               }
 


### PR DESCRIPTION
## Background

#14720

passing unsigned reasoning content parts back to bedrock would sometimes lead to the model's thinking/reasoning tags leak into the normal response text. 

the core issue was AI SDK passing the unsigned reasoning content back and this was introduced in https://github.com/vercel/ai/pull/13972. The previous code only replayed reasoning when `reasoningMetadata != null`, which effectively required a signature or redacted data

## Summary

drop the reasoning content from being passed back to bedrock when it has no signature attached to it

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14720

Co-authored-by: Pasquale Carmine Carbone <pcarbonenearform@ipdanalytics.com>