### PR TITLE
fix(ai): preserve tool result provider options

### DIFF
--- a/.changeset/tool-model-output-provider-options.md
+++ b/.changeset/tool-model-output-provider-options.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): preserve provider options from tool result model output

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -5533,6 +5533,80 @@ describe('generateText', () => {
 
       expect(result.text).toStrictEqual('provider metadata test');
     });
+
+    it('should pass toModelOutput provider options to tool result parts', async () => {
+      let responseCount = 0;
+      let secondPrompt: LanguageModelV4Prompt | undefined;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async ({ prompt }) => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  ...dummyResponseValues,
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: 'call-1',
+                      toolName: 'cachedTool',
+                      input: '{}',
+                    },
+                  ],
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                };
+              case 1:
+                secondPrompt = prompt;
+                return {
+                  ...dummyResponseValues,
+                  content: [{ type: 'text', text: 'done' }],
+                };
+              default:
+                throw new Error(`Unexpected response count: ${responseCount}`);
+            }
+          },
+        }),
+        tools: {
+          cachedTool: tool({
+            inputSchema: z.object({}),
+            execute: async () => 'cached result',
+            toModelOutput: ({ output }) => ({
+              type: 'text',
+              value: String(output),
+              providerOptions: {
+                anthropic: { cacheControl: { type: 'ephemeral' } },
+              },
+            }),
+          }),
+        },
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      const toolMessage = secondPrompt?.find(
+        message => message.role === 'tool',
+      );
+      const toolResult = toolMessage?.content.find(
+        part => part.type === 'tool-result',
+      );
+
+      expect(toolResult).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'cachedTool',
+        output: {
+          type: 'text',
+          value: 'cached result',
+          providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+          },
+        },
+        providerOptions: {
+          anthropic: { cacheControl: { type: 'ephemeral' } },
+        },
+      });
+    });
   });
 
   describe('options.reasoning', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -24,6 +24,7 @@ import type { ModelMessage } from '../prompt';
 import { cloneModelMessages } from '../prompt/clone-model-message';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
+import { getToolResultProviderOptions } from '../prompt/get-tool-result-provider-options';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import { prepareLanguageModelCallOptions } from '../prompt/prepare-language-model-call-options';
 import { prepareToolChoice } from '../prompt/prepare-tool-choice';
@@ -584,12 +585,16 @@ export async function generateText<
           output: output.type === 'tool-result' ? output.output : output.error,
           errorMode: output.type === 'tool-error' ? 'text' : 'none',
         });
+        const providerOptions = getToolResultProviderOptions({
+          output: modelOutput,
+        });
 
         toolContent.push({
           type: 'tool-result' as const,
           toolCallId: output.toolCallId,
           toolName: output.toolName,
           output: modelOutput,
+          ...(providerOptions != null ? { providerOptions } : {}),
         });
       }
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -27,6 +27,7 @@ import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import { cloneModelMessages } from '../prompt/clone-model-message';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
+import { getToolResultProviderOptions } from '../prompt/get-tool-result-provider-options';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import { prepareLanguageModelCallOptions } from '../prompt/prepare-language-model-call-options';
 import { prepareToolChoice } from '../prompt/prepare-tool-choice';
@@ -1505,20 +1506,24 @@ class DefaultStreamTextResult<
 
             // add regular tool results for approved tool calls:
             for (const output of toolOutputs) {
+              const modelOutput = await createToolModelOutput({
+                toolCallId: output.toolCallId,
+                input: output.input,
+                tool: tools?.[output.toolName],
+                output:
+                  output.type === 'tool-result' ? output.output : output.error,
+                errorMode: output.type === 'tool-error' ? 'text' : 'none',
+              });
+              const providerOptions = getToolResultProviderOptions({
+                output: modelOutput,
+              });
+
               localToolContent.push({
                 type: 'tool-result' as const,
                 toolCallId: output.toolCallId,
                 toolName: output.toolName,
-                output: await createToolModelOutput({
-                  toolCallId: output.toolCallId,
-                  input: output.input,
-                  tool: tools?.[output.toolName],
-                  output:
-                    output.type === 'tool-result'
-                      ? output.output
-                      : output.error,
-                  errorMode: output.type === 'tool-error' ? 'text' : 'none',
-                }),
+                output: modelOutput,
+                ...(providerOptions != null ? { providerOptions } : {}),
               });
             }
 

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -460,6 +460,85 @@ describe('toResponseMessages', () => {
     `);
   });
 
+  it('should promote toModelOutput provider options to tool result parts', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: '123',
+          toolName: 'testTool',
+          input: {},
+        },
+        {
+          type: 'tool-result',
+          toolCallId: '123',
+          toolName: 'testTool',
+          output: 'Tool result',
+          input: {},
+        },
+      ],
+      tools: {
+        testTool: tool({
+          description: 'A test tool',
+          inputSchema: z.object({}),
+          toModelOutput: () => ({
+            type: 'text',
+            value: 'Tool result',
+            providerOptions: {
+              anthropic: { cacheControl: { type: 'ephemeral' } },
+            },
+          }),
+        }),
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "input": {},
+              "providerExecuted": undefined,
+              "providerOptions": undefined,
+              "toolCallId": "123",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "output": {
+                "providerOptions": {
+                  "anthropic": {
+                    "cacheControl": {
+                      "type": "ephemeral",
+                    },
+                  },
+                },
+                "type": "text",
+                "value": "Tool result",
+              },
+              "providerOptions": {
+                "anthropic": {
+                  "cacheControl": {
+                    "type": "ephemeral",
+                  },
+                },
+              },
+              "toolCallId": "123",
+              "toolName": "testTool",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ]
+    `);
+  });
+
   it('should include reasoning-file parts in the assistant message', async () => {
     const pngFile = new DefaultGeneratedFile({
       data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -5,6 +5,7 @@ import type {
   ToolModelMessage,
 } from '../prompt';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
+import { getToolResultProviderOptions } from '../prompt/get-tool-result-provider-options';
 import type { ContentPart } from './content-part';
 import type { ToolSet } from '@ai-sdk/provider-utils';
 
@@ -102,7 +103,10 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           toolCallId: part.toolCallId,
           toolName: part.toolName,
           output,
-          providerOptions: part.providerMetadata,
+          providerOptions: getToolResultProviderOptions({
+            output,
+            providerOptions: part.providerMetadata,
+          }),
         });
         break;
       }
@@ -119,7 +123,10 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           toolCallId: part.toolCallId,
           toolName: part.toolName,
           output,
-          providerOptions: part.providerMetadata,
+          providerOptions: getToolResultProviderOptions({
+            output,
+            providerOptions: part.providerMetadata,
+          }),
         });
         break;
       }
@@ -188,15 +195,17 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
       output: part.type === 'tool-result' ? part.output : part.error,
       errorMode: part.type === 'tool-error' ? 'text' : 'none',
     });
+    const providerOptions = getToolResultProviderOptions({
+      output,
+      providerOptions: part.providerMetadata,
+    });
 
     toolResultContent.push({
       type: 'tool-result',
       toolCallId: part.toolCallId,
       toolName: part.toolName,
       output,
-      ...(part.providerMetadata != null
-        ? { providerOptions: part.providerMetadata }
-        : {}),
+      ...(providerOptions != null ? { providerOptions } : {}),
     });
   }
 

--- a/packages/ai/src/prompt/get-tool-result-provider-options.ts
+++ b/packages/ai/src/prompt/get-tool-result-provider-options.ts
@@ -1,0 +1,14 @@
+import type { ProviderOptions, ToolResultOutput } from '@ai-sdk/provider-utils';
+
+export function getToolResultProviderOptions({
+  output,
+  providerOptions,
+}: {
+  output: ToolResultOutput;
+  providerOptions?: ProviderOptions;
+}): ProviderOptions | undefined {
+  return (
+    providerOptions ??
+    ('providerOptions' in output ? output.providerOptions : undefined)
+  );
+}

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -10,6 +10,7 @@ import {
   type ToolResultPart,
 } from '@ai-sdk/provider-utils';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
+import { getToolResultProviderOptions } from '../prompt/get-tool-result-provider-options';
 import { MessageConversionError } from '../prompt/message-conversion-error';
 import {
   getToolName,
@@ -241,25 +242,28 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   ) {
                     const resultProviderMetadata =
                       part.resultProviderMetadata ?? part.callProviderMetadata;
+                    const output = await createToolModelOutput({
+                      toolCallId: part.toolCallId,
+                      input: part.input,
+                      output:
+                        part.state === 'output-error'
+                          ? part.errorText
+                          : part.output,
+                      tool: options?.tools?.[toolName],
+                      errorMode:
+                        part.state === 'output-error' ? 'json' : 'none',
+                    });
+                    const providerOptions = getToolResultProviderOptions({
+                      output,
+                      providerOptions: resultProviderMetadata,
+                    });
 
                     content.push({
                       type: 'tool-result',
                       toolCallId: part.toolCallId,
                       toolName,
-                      output: await createToolModelOutput({
-                        toolCallId: part.toolCallId,
-                        input: part.input,
-                        output:
-                          part.state === 'output-error'
-                            ? part.errorText
-                            : part.output,
-                        tool: options?.tools?.[toolName],
-                        errorMode:
-                          part.state === 'output-error' ? 'json' : 'none',
-                      }),
-                      ...(resultProviderMetadata != null
-                        ? { providerOptions: resultProviderMetadata }
-                        : {}),
+                      output,
+                      ...(providerOptions != null ? { providerOptions } : {}),
                     });
                   }
                 }
@@ -359,24 +363,28 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     case 'output-error':
                     case 'output-available': {
                       const toolName = getToolName(toolPart);
+                      const output = await createToolModelOutput({
+                        toolCallId: toolPart.toolCallId,
+                        input: toolPart.input,
+                        output:
+                          toolPart.state === 'output-error'
+                            ? toolPart.errorText
+                            : toolPart.output,
+                        tool: options?.tools?.[toolName],
+                        errorMode:
+                          toolPart.state === 'output-error' ? 'text' : 'none',
+                      });
+                      const providerOptions = getToolResultProviderOptions({
+                        output,
+                        providerOptions: toolPart.callProviderMetadata,
+                      });
+
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
                         toolName,
-                        output: await createToolModelOutput({
-                          toolCallId: toolPart.toolCallId,
-                          input: toolPart.input,
-                          output:
-                            toolPart.state === 'output-error'
-                              ? toolPart.errorText
-                              : toolPart.output,
-                          tool: options?.tools?.[toolName],
-                          errorMode:
-                            toolPart.state === 'output-error' ? 'text' : 'none',
-                        }),
-                        ...(toolPart.callProviderMetadata != null
-                          ? { providerOptions: toolPart.callProviderMetadata }
-                          : {}),
+                        output,
+                        ...(providerOptions != null ? { providerOptions } : {}),
                       });
                       break;
                     }


### PR DESCRIPTION
## Summary
- closes #15185
- promotes provider options returned by `tool.toModelOutput()` onto generated `tool-result` parts when no explicit tool-result metadata is already present
- applies the fallback across `generateText`, `streamText`, `toResponseMessages`, and UI message conversion so provider converters can see cache-control metadata consistently
- adds regression coverage for generated prompts and response message conversion

## Root cause
`toModelOutput()` can return provider options on the `ToolResultOutput`, but the generated `tool-result` parts only carried existing part-level provider metadata. Provider adapters such as Anthropic read cache-control settings from the `tool-result` part, so metadata returned by `toModelOutput()` was dropped before conversion.

## Testing
- `corepack pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-text/generate-text.test.ts src/generate-text/to-response-messages.test.ts`
- `corepack pnpm --filter ai exec vitest --config vitest.node.config.js --run src/ui/convert-to-model-messages.test.ts`
- `corepack pnpm --filter ai type-check`
- `corepack pnpm --filter ai build`
- `corepack pnpm exec ultracite check .changeset/tool-model-output-provider-options.md packages/ai/src/prompt/get-tool-result-provider-options.ts packages/ai/src/generate-text/generate-text.ts packages/ai/src/generate-text/stream-text.ts packages/ai/src/generate-text/to-response-messages.ts packages/ai/src/ui/convert-to-model-messages.ts packages/ai/src/generate-text/generate-text.test.ts packages/ai/src/generate-text/to-response-messages.test.ts`
- `git diff --check`