### PR TITLE
fix(ai,amazon-bedrock): download URL assets in tool-result content

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1139,6 +1139,189 @@ describe('convertToLanguageModelPrompt', () => {
       ]);
     });
   });
+
+  describe('tool message download', () => {
+    it('should download URL file parts in tool-result content', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'tc1',
+                  toolName: 'screenshot',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'tc1',
+                  toolName: 'screenshot',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'file',
+                        data: {
+                          type: 'url',
+                          url: new URL('https://example.com/image.png'),
+                        },
+                        mediaType: 'image/png',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: createDefaultDownloadFunction(async ({ url }) => {
+          expect(url).toEqual(new URL('https://example.com/image.png'));
+          return {
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+          };
+        }),
+      });
+
+      const toolMsg = result.find(m => m.role === 'tool')!;
+      expect(toolMsg).toBeDefined();
+      const toolResult = (toolMsg as any).content[0];
+      expect(toolResult.output).toEqual({
+        type: 'content',
+        value: [
+          {
+            type: 'file',
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
+            mediaType: 'image/png',
+            filename: undefined,
+            providerOptions: undefined,
+          },
+        ],
+      });
+    });
+
+    it('should download image-url parts in tool-result content', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'tc1',
+                  toolName: 'screenshot',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'tc1',
+                  toolName: 'screenshot',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'image-url',
+                        url: 'https://example.com/photo.jpg',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: createDefaultDownloadFunction(async ({ url }) => {
+          return {
+            data: new Uint8Array([4, 5, 6]),
+            mediaType: 'image/jpeg',
+          };
+        }),
+      });
+
+      const toolMsg = result.find(m => m.role === 'tool')!;
+      const toolResult = (toolMsg as any).content[0];
+      expect(toolResult.output.value[0]).toEqual({
+        type: 'file',
+        data: { type: 'data', data: new Uint8Array([4, 5, 6]) },
+        mediaType: 'image/jpeg',
+        providerOptions: undefined,
+      });
+    });
+
+    it('should download file-url parts in tool-result content', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'tc1',
+                  toolName: 'fetch',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'tc1',
+                  toolName: 'fetch',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'file-url',
+                        url: 'https://example.com/doc.pdf',
+                        mediaType: 'application/pdf',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: createDefaultDownloadFunction(async ({ url }) => {
+          return {
+            data: new Uint8Array([7, 8, 9]),
+            mediaType: 'application/pdf',
+          };
+        }),
+      });
+
+      const toolMsg = result.find(m => m.role === 'tool')!;
+      const toolResult = (toolMsg as any).content[0];
+      expect(toolResult.output.value[0]).toEqual({
+        type: 'file',
+        data: { type: 'data', data: new Uint8Array([7, 8, 9]) },
+        mediaType: 'application/pdf',
+        providerOptions: undefined,
+      });
+    });
+  });
 });
 
 describe('convertToLanguageModelMessage', () => {
@@ -2927,6 +3110,54 @@ describe('convertToLanguageModelMessage', () => {
           "role": "tool",
         }
       `);
+    });
+
+    it('should replace URL file data with downloaded assets in tool-result content', () => {
+      const result = convertToLanguageModelMessage({
+        message: {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'tc1',
+              toolName: 'screenshot',
+              output: {
+                type: 'content',
+                value: [
+                  {
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/image.png'),
+                    },
+                    mediaType: 'image/png',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        downloadedAssets: {
+          'https://example.com/image.png': {
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+          },
+        },
+      });
+
+      const toolResult = (result as any).content[0];
+      expect(toolResult.output).toEqual({
+        type: 'content',
+        value: [
+          {
+            type: 'file',
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
+            mediaType: 'image/png',
+            filename: undefined,
+            providerOptions: undefined,
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -333,11 +333,14 @@ export function convertToLanguageModelMessage({
                   type: 'tool-result' as const,
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
-                  output: mapToolResultOutput({
-                    output: part.output,
-                    provider,
-                    warnings,
-                  }),
+                  output: replaceToolResultOutputUrls(
+                    mapToolResultOutput({
+                      output: part.output,
+                      provider,
+                      warnings,
+                    }),
+                    downloadedAssets,
+                  ),
                   providerOptions,
                 };
               }
@@ -363,15 +366,19 @@ export function convertToLanguageModelMessage({
           .map(part => {
             switch (part.type) {
               case 'tool-result': {
+                const output = mapToolResultOutput({
+                  output: part.output,
+                  provider,
+                  warnings,
+                });
                 return {
                   type: 'tool-result' as const,
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
-                  output: mapToolResultOutput({
-                    output: part.output,
-                    provider,
-                    warnings,
-                  }),
+                  output: replaceToolResultOutputUrls(
+                    output,
+                    downloadedAssets,
+                  ),
                   providerOptions: part.providerOptions,
                 };
               }
@@ -440,7 +447,8 @@ async function downloadAssets(
     data: { type: 'url'; url: URL };
   };
 
-  const plannedDownloads = messages
+  // Extract URL files from user messages
+  const userFileUrls = messages
     .filter(message => message.role === 'user')
     .map(message => message.content)
     .filter((content): content is Array<TextPart | ImagePart | FilePart> =>
@@ -453,7 +461,36 @@ async function downloadAssets(
       const mediaType = part.mediaType;
       const { data } = convertToLanguageModelV4FilePart(part.data);
       return { mediaType, data };
-    })
+    });
+
+  // Extract URL files from tool-result content in tool and assistant messages
+  const toolFileUrls: ConvertedFile[] = [];
+  for (const message of messages) {
+    if (message.role !== 'tool' && message.role !== 'assistant') continue;
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (part.type !== 'tool-result') continue;
+      if (part.output.type !== 'content') continue;
+      for (const item of part.output.value) {
+        if (item.type === 'file') {
+          const { data } = convertToLanguageModelV4FilePart(item.data);
+          toolFileUrls.push({ mediaType: item.mediaType, data });
+        } else if (item.type === 'file-url') {
+          toolFileUrls.push({
+            mediaType: item.mediaType ?? getMediaTypeFromUrl(item.url),
+            data: { type: 'url', url: new URL(item.url) },
+          });
+        } else if (item.type === 'image-url') {
+          toolFileUrls.push({
+            mediaType: 'image',
+            data: { type: 'url', url: new URL(item.url) },
+          });
+        }
+      }
+    }
+  }
+
+  const plannedDownloads = [...userFileUrls, ...toolFileUrls]
     .filter((part): part is UrlTaggedFile => part.data.type === 'url')
     .map(part => ({
       url: part.data.url,
@@ -719,6 +756,45 @@ function mapToolResultOutput({
         default:
           return item;
       }
+    }),
+  };
+}
+
+/**
+ * Replaces URL file data in tool result output with downloaded assets.
+ */
+function replaceToolResultOutputUrls(
+  output: LanguageModelV4ToolResultOutput,
+  downloadedAssets: Record<
+    string,
+    { mediaType: string | undefined; data: Uint8Array }
+  >,
+): LanguageModelV4ToolResultOutput {
+  if (output.type !== 'content') {
+    return output;
+  }
+
+  return {
+    type: 'content',
+    value: output.value.map(item => {
+      if (item.type !== 'file' || item.data.type !== 'url') {
+        return item;
+      }
+
+      const downloadedFile = downloadedAssets[item.data.url.toString()];
+      if (!downloadedFile) {
+        return item;
+      }
+
+      return {
+        ...item,
+        data: { type: 'data' as const, data: downloadedFile.data },
+        mediaType:
+          downloadedFile.mediaType != null &&
+          (item.mediaType == null || !isFullMediaType(item.mediaType))
+            ? downloadedFile.mediaType
+            : item.mediaType,
+      };
     }),
   };
 }

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -375,10 +375,7 @@ export function convertToLanguageModelMessage({
                   type: 'tool-result' as const,
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
-                  output: replaceToolResultOutputUrls(
-                    output,
-                    downloadedAssets,
-                  ),
+                  output: replaceToolResultOutputUrls(output, downloadedAssets),
                   providerOptions: part.providerOptions,
                 };
               }

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -256,9 +256,7 @@ export async function convertToAmazonBedrockChatMessages(
                                   contentPart.data.url.toString(),
                                 );
                                 bytes = convertToBase64(
-                                  new Uint8Array(
-                                    await blob.arrayBuffer(),
-                                  ),
+                                  new Uint8Array(await blob.arrayBuffer()),
                                 );
                                 break;
                               }

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -7,6 +7,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   convertToBase64,
+  downloadBlob,
   getTopLevelMediaType,
   isFullMediaType,
   parseProviderOptions,
@@ -229,48 +230,66 @@ export async function convertToAmazonBedrockChatMessages(
                 const output = part.output;
                 switch (output.type) {
                   case 'content': {
-                    toolResultContent = output.value.map(contentPart => {
-                      switch (contentPart.type) {
-                        case 'text':
-                          return { text: contentPart.text };
-                        case 'file': {
-                          if (
-                            getTopLevelMediaType(contentPart.mediaType) !==
-                            'image'
-                          ) {
-                            throw new UnsupportedFunctionalityError({
-                              functionality: `media type: ${contentPart.mediaType}`,
+                    toolResultContent = await Promise.all(
+                      output.value.map(async contentPart => {
+                        switch (contentPart.type) {
+                          case 'text':
+                            return { text: contentPart.text };
+                          case 'file': {
+                            if (
+                              getTopLevelMediaType(contentPart.mediaType) !==
+                              'image'
+                            ) {
+                              throw new UnsupportedFunctionalityError({
+                                functionality: `media type: ${contentPart.mediaType}`,
+                              });
+                            }
+
+                            let bytes: string;
+                            switch (contentPart.data.type) {
+                              case 'data': {
+                                bytes = convertToBase64(contentPart.data.data);
+                                break;
+                              }
+                              case 'url': {
+                                const blob = await downloadBlob(
+                                  contentPart.data.url.toString(),
+                                );
+                                bytes = convertToBase64(
+                                  new Uint8Array(
+                                    await blob.arrayBuffer(),
+                                  ),
+                                );
+                                break;
+                              }
+                              default: {
+                                throw new UnsupportedFunctionalityError({
+                                  functionality: `tool result file data of type "${contentPart.data.type}"`,
+                                });
+                              }
+                            }
+
+                            const fullMediaType = resolveFullMediaType({
+                              part: contentPart,
                             });
-                          }
+                            const format =
+                              getAmazonBedrockImageFormat(fullMediaType);
 
-                          if (contentPart.data.type !== 'data') {
-                            throw new UnsupportedFunctionalityError({
-                              functionality: `tool result file data of type "${contentPart.data.type}"`,
-                            });
-                          }
-
-                          const fullMediaType = resolveFullMediaType({
-                            part: contentPart,
-                          });
-                          const format =
-                            getAmazonBedrockImageFormat(fullMediaType);
-
-                          return {
-                            image: {
-                              format,
-                              source: {
-                                bytes: convertToBase64(contentPart.data.data),
+                            return {
+                              image: {
+                                format,
+                                source: { bytes },
                               },
-                            },
-                          };
+                            };
+                          }
+                          default: {
+                            throw new UnsupportedFunctionalityError({
+                              functionality: `unsupported tool content part type: ${contentPart.type}`,
+                            });
+                          }
                         }
-                        default: {
-                          throw new UnsupportedFunctionalityError({
-                            functionality: `unsupported tool content part type: ${contentPart.type}`,
-                          });
-                        }
-                      }
-                    });
+                      }),
+                    );
                     break;
                   }
                   case 'text':


### PR DESCRIPTION
## Summary

Fixes #15173 — `@ai-sdk/amazon-bedrock` throws `UnsupportedFunctionalityError` for URL-based file parts in tool-result content.

## Problem

`downloadAssets()` only scans `role === "user"` messages for downloadable URLs. Tool-result content with URL file parts (e.g., `image-url`, `file-url`, or `file` with URL data) passes through unmodified. Providers like Amazon Bedrock that require base64 data (and cannot accept URLs) then throw when encountering these undownloaded URL parts.

## Fix

**Core SDK (`packages/ai`):**
- Extend `downloadAssets()` to also extract URLs from tool-result `output.value` file parts in `tool` and `assistant` messages, including legacy `image-url` and `file-url` types
- Add `replaceToolResultOutputUrls()` to substitute downloaded data into tool-result output before passing to provider converters
- Both `tool` role messages and `assistant` role messages with inline `tool-result` parts are handled

**Amazon Bedrock (`packages/amazon-bedrock`):**
- Handle `url` data type in tool-result file parts as defense-in-depth, downloading via `downloadBlob()` when the core SDK download did not cover the URL
- Previously only `data` type was accepted; `url` and `reference` types threw

## Testing

Added tests in `convert-to-language-model-prompt.test.ts`:
- Tool-result with `file` URL data → downloaded and replaced with bytes
- Tool-result with legacy `image-url` → downloaded and replaced
- Tool-result with legacy `file-url` → downloaded and replaced
- `convertToLanguageModelMessage` unit test for URL replacement via `downloadedAssets`

Local test environment cannot run full test suite (pnpm install OOMs); relying on CI for validation.