### PR TITLE
fix(ai): sanitize JSON tool output for telemetry cloning

### DIFF
--- a/packages/ai/src/prompt/create-tool-model-output.test.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.test.ts
@@ -374,6 +374,41 @@ describe('createToolModelOutput', () => {
         }
       `);
     });
+
+    it('should sanitize non-JSON class instances with methods', async () => {
+      class ToolResultWithMethods {
+        text = 'Nested result is safe for serialization.';
+        label = 'tool-result';
+        metadata = { id: 123, nestedMethod: () => 'metadata' };
+
+        method() {
+          return this.label;
+        }
+      }
+
+      const result = await createToolModelOutput({
+        toolCallId: '123',
+        input: {},
+        output: new ToolResultWithMethods(),
+        tool: undefined,
+        errorMode: 'none',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "type": "json",
+          "value": {
+            "label": "tool-result",
+            "metadata": {
+              "id": 123,
+            },
+            "text": "Nested result is safe for serialization.",
+          },
+        }
+      `);
+
+      expect(() => structuredClone(result)).not.toThrow();
+    });
   });
 
   describe('edge cases', () => {

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -30,5 +30,67 @@ export async function createToolModelOutput({
 }
 
 function toJSONValue(value: unknown): JSONValue {
-  return value === undefined ? null : (value as JSONValue);
+  return normalizeForJSONValue(value) ?? null;
+}
+
+function normalizeForJSONValue(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): JSONValue | undefined {
+  if (value === null) {
+    return null;
+  }
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => {
+      const nested = normalizeForJSONValue(item, seen) ?? null;
+      return nested;
+    });
+  }
+
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof URL) {
+    return value.href;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return undefined;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return undefined;
+    }
+
+    seen.add(value);
+    const jsonValue = Object.fromEntries(
+      Object.entries(value)
+        .map(([key, nested]) => [key, normalizeForJSONValue(nested, seen)])
+        .filter(([, nested]) => nested !== undefined),
+    ) as JSONValue;
+    seen.delete(value);
+
+    return jsonValue;
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary

Default tool outputs are typed as `JSONValue`, but the previous implementation only cast arbitrary values. When a tool returns a nested AI SDK result object, telemetry integrations that clone messages can receive class instances with function-valued fields and throw `DataCloneError`.

This normalizes default JSON tool outputs into JSON-compatible data before they are attached to model messages. Non-serializable object fields are skipped, arrays preserve holes as `null`, and common primitive wrappers such as `Date`, `URL`, and `bigint` are converted into JSON-safe values.

Fixes #6030.

## Validation

- `corepack pnpm --dir . exec ultracite check packages/ai/src/prompt/create-tool-model-output.ts packages/ai/src/prompt/create-tool-model-output.test.ts`
- `corepack pnpm --dir packages/ai exec vitest --config vitest.node.config.js --run src/prompt/create-tool-model-output.test.ts`
- `corepack pnpm --dir . --filter ai type-check`