### PR TITLE
docs(amazon-bedrock): document API Key authentication

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -35,6 +35,31 @@ See the [Model Access Docs](https://docs.aws.amazon.com/bedrock/latest/userguide
 
 ### Authentication
 
+The Amazon Bedrock provider supports two authentication methods with automatic fallback: API key authentication (recommended) and AWS SigV4 authentication using IAM credentials or the AWS SDK credentials chain.
+
+#### Using an API Key (Recommended)
+
+API key authentication provides a simpler setup compared to AWS SigV4 authentication. When an API key is supplied, it takes precedence over any SigV4 credentials.
+
+Generate a bedrock API key from the [AWS console](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html), then either set it as the `AWS_BEARER_TOKEN_BEDROCK` environment variable:
+
+```bash
+AWS_BEARER_TOKEN_BEDROCK=your-api-key-here
+```
+
+or pass it directly to `createAmazonBedrock`:
+
+```ts
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+
+const amazonBedrock = createAmazonBedrock({
+  apiKey: 'your-api-key-here',
+  region: 'us-east-1',
+});
+```
+
+When `apiKey` is omitted, the provider falls back to `AWS_BEARER_TOKEN_BEDROCK`, and then to SigV4 authentication if neither is set.
+
 #### Using IAM Access Key and Secret Key
 
 **Step 1: Creating AWS Access Key and Secret Key**


### PR DESCRIPTION
## Summary

Adds an **API Key Authentication (Recommended)** subsection to the Amazon Bedrock provider Authentication docs. Currently the docs page does not mention API key auth at all, even though the provider has supported it for a while: `createAmazonBedrock` accepts an `apiKey` option that defaults to `AWS_BEARER_TOKEN_BEDROCK` and takes precedence over AWS SigV4 (see `packages/amazon-bedrock/src/amazon-bedrock-provider.ts`).

The [package README](https://www.npmjs.com/package/@ai-sdk/amazon-bedrock) and the [bedrock package README in this repo](https://github.com/vercel/ai/blob/main/packages/amazon-bedrock/README.md) describe API Key auth as the recommended method; the published doc page was out of sync.

## Changes

- `content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx`: Add an intro line under `### Authentication` describing the two methods with fallback behavior, and a new `#### Using an API Key (Recommended)` subsection with env-var and direct-configuration usage. The existing `#### Using IAM Access Key and Secret Key` and `#### Using AWS SDK Credentials Chain` subsections are unchanged.

## Closes

Fixes #11022

## Test plan

- [x] Verified the provider source uses `apiKey` from `options.apiKey` with env-var fallback `AWS_BEARER_TOKEN_BEDROCK` (`packages/amazon-bedrock/src/amazon-bedrock-provider.ts:173-183`)
- [x] No source/code/test changes — pure docs addition
- [x] Followed the package README phrasing for "Recommended" framing
