### PR TITLE
docs(use-completion): clarify only text parts are exposed

### DIFF
--- a/content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx
@@ -103,7 +103,7 @@ Allows you to create text completion based capabilities for your application. It
       type: "'text' | 'data'",
       isOptional: true,
       description:
-        'An optional literal that sets the type of stream to be used. Defaults to `data`. If set to `text`, the stream will be treated as a text stream.',
+        'An optional literal that sets the type of stream to be used. Defaults to `data`. If set to `text`, the stream will be treated as a text stream. Note that with either protocol, `useCompletion` only exposes text content via the `completion` field — non-text parts (e.g. `data-*` parts) emitted by the server are ignored. Use `useChat` if you need access to those parts.',
     },
     {
       name: 'fetch',


### PR DESCRIPTION
## Summary

The `streamProtocol: 'data'` option suggests that data-stream parsing is available in `useCompletion`, but in practice only the text content is surfaced via the `completion` field; `data-*` parts emitted by the server have no exposed access path from the hook.

This caused user confusion (#11619), where the reporter expected to be able to access data parts streamed alongside the text. A maintainer confirmed: _"Use completion supports the protocol but only exposes the text parts"_.

This change updates the reference docs for `streamProtocol` to make that behavior explicit and points users at `useChat` for use cases that need access to non-text stream parts.

## Changes

- `content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx`: extend the `streamProtocol` description to call out that only text parts are exposed via `completion`, with `useChat` as the suggested alternative.

## Closes

Fixes #11619

## Test plan

- [x] Verified `useCompletion` (in `packages/react/src/use-completion.ts`) returns no `data` field and only accumulates the text stream into `completion` via `setCompletion`
- [x] Verified `callCompletionApi` (the underlying call from the hook) doesn't expose data parts to the hook
- [x] No source/code/test changes — pure docs clarification
