### PR TITLE
fix: rename onRerankFinish to onRerankEnd

### DIFF
--- a/.changeset/rerank-end-telemetry.md
+++ b/.changeset/rerank-end-telemetry.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+Rename rerank telemetry finish callback to `onRerankEnd`.

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -353,6 +353,12 @@ export function myIntegration(): Telemetry {
       description: 'Called when a step (LLM call) completes.',
     },
     {
+      name: 'onRerankEnd',
+      type: '(event: RerankingModelCallEndEvent) => void | PromiseLike<void>',
+      description:
+        'Called when an individual reranking model call completes.',
+    },
+    {
       name: 'onFinish',
       type: '(event: GenerateTextEndEvent) => void | PromiseLike<void>',
       description:

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -355,8 +355,7 @@ export function myIntegration(): Telemetry {
     {
       name: 'onRerankEnd',
       type: '(event: RerankingModelCallEndEvent) => void | PromiseLike<void>',
-      description:
-        'Called when an individual reranking model call completes.',
+      description: 'Called when an individual reranking model call completes.',
     },
     {
       name: 'onFinish',

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -113,7 +113,7 @@ For multi-step text generations that use tools, the callback order is typically
         'Called when the reranking operation begins, before the reranking model is called.',
     },
     {
-      name: 'experimental_onFinish',
+      name: 'experimental_onEnd',
       type: '(event: RerankEndEvent) => void | Promise<void>',
       description:
         'Called when the reranking operation completes, after the reranking model returns.',
@@ -1142,7 +1142,7 @@ const result = await rerank({
   ]}
 />
 
-#### `experimental_onFinish`
+#### `experimental_onEnd`
 
 Called when the reranking operation completes, after the reranking model returns.
 
@@ -1153,7 +1153,7 @@ const result = await rerank({
   model: cohere.reranking('rerank-v3.5'),
   documents: ['sunny day at the beach', 'rainy afternoon in the city'],
   query: 'talk about rain',
-  experimental_onFinish: event => {
+  experimental_onEnd: event => {
     console.log('Operation:', event.operationId);
     console.log('Rankings:', event.ranking.length);
   },

--- a/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
@@ -137,7 +137,7 @@ const { ranking } = await rerank({
         'Called when the rerank operation begins, before the reranking model is called.',
     },
     {
-      name: 'experimental_onFinish',
+      name: 'experimental_onEnd',
       type: '(event: RerankEndEvent) => void | Promise<void>',
       isOptional: true,
       description:

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -470,6 +470,60 @@ const result = await generateText({
 });
 ```
 
+### Telemetry Rerank Callback: `onRerankFinish` Renamed to `onRerankEnd`
+
+The telemetry integration callback for individual reranking model calls has been renamed from `onRerankFinish` to `onRerankEnd`.
+
+This also applies to the `type` field published on `AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL`: diagnostic-channel subscribers now receive `onRerankEnd` instead of `onRerankFinish`.
+
+Update telemetry integrations and diagnostic-channel subscribers to use `onRerankEnd`.
+
+```tsx filename="AI SDK 6"
+import type { Telemetry } from 'ai';
+
+const telemetry: Telemetry = {
+  onRerankFinish(event) {
+    console.log('Rerank finished:', event.ranking.length);
+  },
+};
+```
+
+```tsx filename="AI SDK 7"
+import type { Telemetry } from 'ai';
+
+const telemetry: Telemetry = {
+  onRerankEnd(event) {
+    console.log('Rerank ended:', event.ranking.length);
+  },
+};
+```
+
+### Rerank Callback: `experimental_onFinish` Renamed to `experimental_onEnd`
+
+The per-call callback option for completed `rerank` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.
+
+```tsx filename="AI SDK 6"
+const result = await rerank({
+  model: yourRerankingModel,
+  documents,
+  query,
+  experimental_onFinish(event) {
+    console.log('Rerank finished:', event.ranking.length);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await rerank({
+  model: yourRerankingModel,
+  documents,
+  query,
+  experimental_onEnd(event) {
+    console.log('Rerank ended:', event.ranking.length);
+  },
+});
+```
+
 ### Streaming: Move `includeRawChunks` to `include.rawChunks`
 
 The top-level `includeRawChunks` option on `streamText` is deprecated in AI SDK 7. Move it into the `include` options object as `rawChunks`.

--- a/examples/ai-functions/src/telemetry/console/console-telemetry.ts
+++ b/examples/ai-functions/src/telemetry/console/console-telemetry.ts
@@ -20,7 +20,7 @@ export const consoleTelemetry = {
   onEmbedStart: logCallback('onEmbedStart'),
   onEmbedFinish: logCallback('onEmbedFinish'),
   onRerankStart: logCallback('onRerankStart'),
-  onRerankFinish: logCallback('onRerankFinish'),
+  onRerankEnd: logCallback('onRerankEnd'),
   onFinish: logCallback('onFinish'),
   onError: logCallback('onError'),
   executeTool: async ({ callId, toolCallId, execute }) => {

--- a/packages/ai/src/rerank/__snapshots__/rerank.test.ts.snap
+++ b/packages/ai/src/rerank/__snapshots__/rerank.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`rerank > options.experimental_onFinish > should send correct event information 1`] = `
+exports[`rerank > options.experimental_onEnd > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "documents": [

--- a/packages/ai/src/rerank/rerank.test.ts
+++ b/packages/ai/src/rerank/rerank.test.ts
@@ -538,7 +538,7 @@ describe('rerank', () => {
     });
   });
 
-  describe('options.experimental_onFinish', () => {
+  describe('options.experimental_onEnd', () => {
     const mockModel = new MockRerankingModelV4({
       doRerank: async () => ({
         ranking: [
@@ -561,7 +561,7 @@ describe('rerank', () => {
     });
 
     it('should send correct event information', async () => {
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -578,16 +578,16 @@ describe('rerank', () => {
         _internal: {
           generateCallId: () => 'test-call-id',
         },
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
-      expect(finishEvent).toMatchSnapshot();
+      expect(endEvent).toMatchSnapshot();
     });
 
     it('should include ranking and documents in event', async () => {
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -597,18 +597,18 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
-      expect(finishEvent.documents).toEqual([
+      expect(endEvent.documents).toEqual([
         'sunny day at the beach',
         'rainy day in the city',
         'cloudy day in the mountains',
       ]);
-      expect(finishEvent.query).toBe('rainy day');
-      expect(finishEvent.ranking).toEqual([
+      expect(endEvent.query).toBe('rainy day');
+      expect(endEvent.ranking).toEqual([
         {
           originalIndex: 2,
           score: 0.9,
@@ -628,7 +628,7 @@ describe('rerank', () => {
     });
 
     it('should include model information', async () => {
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -638,18 +638,18 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
-      expect(finishEvent.provider).toBe('mock-provider');
-      expect(finishEvent.modelId).toBe('mock-model-id');
-      expect(finishEvent.operationId).toBe('ai.rerank');
+      expect(endEvent.provider).toBe('mock-provider');
+      expect(endEvent.modelId).toBe('mock-model-id');
+      expect(endEvent.operationId).toBe('ai.rerank');
     });
 
     it('should include warnings and providerMetadata', async () => {
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -659,21 +659,21 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
-      expect(finishEvent.warnings).toEqual([
+      expect(endEvent.warnings).toEqual([
         { type: 'other', message: 'test warning' },
       ]);
-      expect(finishEvent.providerMetadata).toEqual({
+      expect(endEvent.providerMetadata).toEqual({
         aProvider: { someResponseKey: 'someResponseValue' },
       });
     });
 
     it('should include response data', async () => {
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -683,12 +683,12 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
-      expect(finishEvent.response).toEqual({
+      expect(endEvent.response).toEqual({
         id: 'mock-response-id',
         timestamp: new Date('2025-06-01T00:00:00Z'),
         modelId: 'mock-response-model-id',
@@ -711,12 +711,12 @@ describe('rerank', () => {
         }),
         documents: ['test document'],
         query: 'test query',
-        experimental_onFinish: async () => {
-          callOrder.push('onFinish');
+        experimental_onEnd: async () => {
+          callOrder.push('onEnd');
         },
       });
 
-      expect(callOrder).toEqual(['doRerank', 'onFinish']);
+      expect(callOrder).toEqual(['doRerank', 'onEnd']);
     });
 
     it('should not break reranking when callback throws', async () => {
@@ -728,7 +728,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onFinish: async () => {
+        experimental_onEnd: async () => {
           throw new Error('callback error');
         },
       });
@@ -738,7 +738,7 @@ describe('rerank', () => {
     });
   });
 
-  describe('options.experimental_onStart and experimental_onFinish together', () => {
+  describe('options.experimental_onStart and experimental_onEnd together', () => {
     const mockModel = new MockRerankingModelV4({
       doRerank: async () => ({
         ranking: [
@@ -755,7 +755,7 @@ describe('rerank', () => {
 
     it('should have consistent callId across both events', async () => {
       let startEvent!: RerankStartEvent;
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -771,17 +771,17 @@ describe('rerank', () => {
         experimental_onStart: async event => {
           startEvent = event;
         },
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
       expect(startEvent.callId).toBe('consistent-call-id');
-      expect(finishEvent.callId).toBe('consistent-call-id');
-      expect(startEvent.callId).toBe(finishEvent.callId);
+      expect(endEvent.callId).toBe('consistent-call-id');
+      expect(startEvent.callId).toBe(endEvent.callId);
     });
 
-    it('should call onStart before doRerank and onFinish after', async () => {
+    it('should call onStart before doRerank and onEnd after', async () => {
       const callOrder: string[] = [];
 
       await rerank({
@@ -798,16 +798,16 @@ describe('rerank', () => {
         experimental_onStart: async () => {
           callOrder.push('onStart');
         },
-        experimental_onFinish: async () => {
-          callOrder.push('onFinish');
+        experimental_onEnd: async () => {
+          callOrder.push('onEnd');
         },
       });
 
-      expect(callOrder).toEqual(['onStart', 'doRerank', 'onFinish']);
+      expect(callOrder).toEqual(['onStart', 'doRerank', 'onEnd']);
     });
 
-    it('should still call onFinish when onStart throws', async () => {
-      let finishCalled = false;
+    it('should still call onEnd when onStart throws', async () => {
+      let endCalled = false;
 
       const result = await rerank({
         model: mockModel,
@@ -820,18 +820,18 @@ describe('rerank', () => {
         experimental_onStart: async () => {
           throw new Error('onStart error');
         },
-        experimental_onFinish: async () => {
-          finishCalled = true;
+        experimental_onEnd: async () => {
+          endCalled = true;
         },
       });
 
-      expect(finishCalled).toBe(true);
+      expect(endCalled).toBe(true);
       expect(result.ranking).toHaveLength(3);
     });
 
     it('should fire callbacks for empty documents', async () => {
       let startEvent!: RerankStartEvent;
-      let finishEvent!: RerankEndEvent;
+      let endEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -843,16 +843,16 @@ describe('rerank', () => {
         experimental_onStart: async event => {
           startEvent = event;
         },
-        experimental_onFinish: async event => {
-          finishEvent = event;
+        experimental_onEnd: async event => {
+          endEvent = event;
         },
       });
 
       expect(startEvent.callId).toBe('empty-call-id');
       expect(startEvent.documents).toEqual([]);
-      expect(finishEvent.callId).toBe('empty-call-id');
-      expect(finishEvent.ranking).toEqual([]);
-      expect(finishEvent.documents).toEqual([]);
+      expect(endEvent.callId).toBe('empty-call-id');
+      expect(endEvent.ranking).toEqual([]);
+      expect(endEvent.documents).toEqual([]);
     });
   });
 });

--- a/packages/ai/src/rerank/rerank.ts
+++ b/packages/ai/src/rerank/rerank.ts
@@ -47,7 +47,7 @@ export async function rerank<VALUE extends JSONObject | string>({
   experimental_telemetry,
   telemetry = experimental_telemetry,
   experimental_onStart: onStart,
-  experimental_onFinish: onFinish,
+  experimental_onEnd: onEnd,
   _internal: { generateCallId = originalGenerateCallId } = {},
 }: {
   /**
@@ -117,7 +117,7 @@ export async function rerank<VALUE extends JSONObject | string>({
    * Callback that is called when the rerank operation completes,
    * after the reranking model returns.
    */
-  experimental_onFinish?: Callback<RerankEndEvent>;
+  experimental_onEnd?: Callback<RerankEndEvent>;
 
   /**
    * Internal. For test use only. May change without notice.
@@ -166,7 +166,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           modelId: model.modelId,
         },
       },
-      callbacks: [onFinish, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onFinish],
     });
 
     return new DefaultRerankResult({
@@ -243,7 +243,7 @@ export async function rerank<VALUE extends JSONObject | string>({
             documentsType: documentsToSend.type,
             ranking,
           },
-          callbacks: [telemetryDispatcher.onRerankFinish],
+          callbacks: [telemetryDispatcher.onRerankEnd],
         });
 
         return {
@@ -284,7 +284,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           body: response?.body,
         },
       },
-      callbacks: [onFinish, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onFinish],
     });
 
     return new DefaultRerankResult({

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -32,7 +32,7 @@ describe('createTelemetryDispatcher', () => {
     expect(telemetry.onEmbedStart).toBeDefined();
     expect(telemetry.onEmbedFinish).toBeDefined();
     expect(telemetry.onRerankStart).toBeDefined();
-    expect(telemetry.onRerankFinish).toBeDefined();
+    expect(telemetry.onRerankEnd).toBeDefined();
     expect(telemetry.onFinish).toBeDefined();
     expect(telemetry.onError).toBeDefined();
     expect(telemetry.executeTool).toBeUndefined();
@@ -152,7 +152,7 @@ describe('createTelemetryDispatcher', () => {
       onEmbedStart: vi.fn(),
       onEmbedFinish: vi.fn(),
       onRerankStart: vi.fn(),
-      onRerankFinish: vi.fn(),
+      onRerankEnd: vi.fn(),
       onFinish: vi.fn(),
       onError: vi.fn(),
     };
@@ -174,7 +174,7 @@ describe('createTelemetryDispatcher', () => {
     await telemetry.onEmbedStart!(dummyEvent);
     await telemetry.onEmbedFinish!(dummyEvent);
     await telemetry.onRerankStart!(dummyEvent);
-    await telemetry.onRerankFinish!(dummyEvent);
+    await telemetry.onRerankEnd!(dummyEvent);
     await telemetry.onFinish!(dummyEvent);
     await telemetry.onError!(dummyEvent);
 
@@ -191,7 +191,7 @@ describe('createTelemetryDispatcher', () => {
     expect(integration.onEmbedStart).toHaveBeenCalledOnce();
     expect(integration.onEmbedFinish).toHaveBeenCalledOnce();
     expect(integration.onRerankStart).toHaveBeenCalledOnce();
-    expect(integration.onRerankFinish).toHaveBeenCalledOnce();
+    expect(integration.onRerankEnd).toHaveBeenCalledOnce();
     expect(integration.onFinish).toHaveBeenCalledOnce();
     expect(integration.onError).toHaveBeenCalledOnce();
   });
@@ -221,7 +221,7 @@ describe('createTelemetryDispatcher', () => {
         onEmbedStart: vi.fn(),
         onEmbedFinish: vi.fn(),
         onRerankStart: vi.fn(),
-        onRerankFinish: vi.fn(),
+        onRerankEnd: vi.fn(),
         onFinish: vi.fn(),
         onError: vi.fn(),
       };
@@ -241,7 +241,7 @@ describe('createTelemetryDispatcher', () => {
       expect(telemetry.onEmbedStart).toBeUndefined();
       expect(telemetry.onEmbedFinish).toBeUndefined();
       expect(telemetry.onRerankStart).toBeUndefined();
-      expect(telemetry.onRerankFinish).toBeUndefined();
+      expect(telemetry.onRerankEnd).toBeUndefined();
       expect(telemetry.onFinish).toBeUndefined();
       expect(telemetry.onError).toBeUndefined();
       expect(telemetry.executeTool).toBeUndefined();

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -130,7 +130,7 @@ export function createTelemetryDispatcher({
     onEmbedStart: mergeTelemetryCallback('onEmbedStart'),
     onEmbedFinish: mergeTelemetryCallback('onEmbedFinish'),
     onRerankStart: mergeTelemetryCallback('onRerankStart'),
-    onRerankFinish: mergeTelemetryCallback('onRerankFinish'),
+    onRerankEnd: mergeTelemetryCallback('onRerankEnd'),
     onFinish: mergeTelemetryCallback('onFinish'),
     onError: mergeTelemetryCallback('onError'),
 

--- a/packages/ai/src/telemetry/diagnostic-channel.test.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.test.ts
@@ -115,5 +115,29 @@ describe.runIf(isNodeRuntime())(
       ]
     `);
     });
+
+    it('publishes rerank end events', async () => {
+      const event = { callId: 'diagnostic-channel-rerank-end' };
+
+      const messages = await collectDiagnosticChannelMessages(async () => {
+        const telemetry = createTelemetryDispatcher({});
+
+        await telemetry.onRerankEnd!(event as any);
+      });
+
+      expect(messages).toMatchInlineSnapshot(`
+      [
+        {
+          "event": {
+            "callId": "diagnostic-channel-rerank-end",
+            "functionId": undefined,
+            "recordInputs": undefined,
+            "recordOutputs": undefined,
+          },
+          "type": "onRerankEnd",
+        },
+      ]
+    `);
+    });
   },
 );

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -14,7 +14,7 @@ export type TelemetryDiagnosticEventType =
   | 'onEmbedStart'
   | 'onEmbedFinish'
   | 'onRerankStart'
-  | 'onRerankFinish'
+  | 'onRerankEnd'
   | 'onFinish'
   | 'onError';
 

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -69,7 +69,7 @@ export interface TelemetryDispatcher {
   onEmbedStart?: Callback<EmbeddingModelCallStartEvent>;
   onEmbedFinish?: Callback<EmbeddingModelCallEndEvent>;
   onRerankStart?: Callback<RerankingModelCallStartEvent>;
-  onRerankFinish?: Callback<RerankingModelCallEndEvent>;
+  onRerankEnd?: Callback<RerankingModelCallEndEvent>;
   onFinish?: Callback<OperationFinishEvent>;
   onError?: Callback<unknown>;
   executeTool?: Telemetry['executeTool'];
@@ -189,7 +189,7 @@ export interface Telemetry {
    * Called when an individual reranking model call (doRerank) completes.
    * Contains the ranking results from the model response.
    */
-  onRerankFinish?: Callback<InferTelemetryEvent<RerankingModelCallEndEvent>>;
+  onRerankEnd?: Callback<InferTelemetryEvent<RerankingModelCallEndEvent>>;
 
   /**
    * Called when an operation completes. Fired for text generation

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -1025,7 +1025,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     state.rerankSpan = { span: rerankSpan, context: rerankContext };
   }
 
-  onRerankFinish(event: RerankingModelCallEndEvent): void {
+  onRerankEnd(event: RerankingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rerankSpan) return;
 

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -1178,7 +1178,7 @@ export class OpenTelemetry implements Telemetry {
     state.rerankSpan = { span: rerankSpan, context: rerankContext };
   }
 
-  onRerankFinish(event: RerankingModelCallEndEvent): void {
+  onRerankEnd(event: RerankingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rerankSpan) return;
 


### PR DESCRIPTION
## Background
We are standardizing on Start/End nomenclature.

## Summary

Rename `experimental_onRerankFinish` to `experimental_onRerankEnd`