### PR TITLE
fix(provider/cohere): use secure parsing instead of JSON.parse

### DIFF
--- a/.changeset/cohere-tool-call-json-hardening.md
+++ b/.changeset/cohere-tool-call-json-hardening.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cohere': patch
+---
+
+Harden streamed tool call argument parsing against prototype keys.

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -58,6 +58,16 @@ function prepareChunksFixtureResponse(
   };
 }
 
+function prepareChunkLinesResponse(chunks: Array<Record<string, unknown>>) {
+  server.urls['https://api.cohere.com/v2/chat'].response = {
+    type: 'stream-chunks',
+    chunks: chunks.map(chunk => {
+      const line = JSON.stringify(chunk);
+      return `event: ${chunk.type}\ndata: ${line}\n\n`;
+    }),
+  };
+}
+
 describe('doGenerate', () => {
   describe('text', () => {
     beforeEach(() => {
@@ -837,6 +847,62 @@ describe('doStream', () => {
         .map(chunk =>
           chunk.type === 'tool-call' ? chunk.toolCallId : chunk.id,
         );
+    });
+
+    it('rejects prototype keys in streamed tool call arguments', async () => {
+      prepareChunkLinesResponse([
+        {
+          type: 'tool-call-start',
+          index: 0,
+          delta: {
+            message: {
+              tool_calls: {
+                id: 'test-tool-call',
+                type: 'function',
+                function: { name: 'test-tool', arguments: '' },
+              },
+            },
+          },
+        },
+        {
+          type: 'tool-call-delta',
+          index: 0,
+          delta: {
+            message: {
+              tool_calls: {
+                function: {
+                  arguments: '{"__proto__":{"polluted":true}}',
+                },
+              },
+            },
+          },
+        },
+        {
+          type: 'tool-call-end',
+          index: 0,
+        },
+      ]);
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'test-tool',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+              additionalProperties: true,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        includeRawChunks: false,
+      });
+
+      await expect(convertReadableStreamToArray(stream)).rejects.toThrow(
+        'Object contains forbidden prototype property',
+      );
     });
   });
 

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -15,6 +15,7 @@ import {
   isCustomReasoning,
   mapReasoningToProviderBudget,
   parseProviderOptions,
+  parseJSON,
   postJsonToApi,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
@@ -287,7 +288,7 @@ export class CohereChatLanguageModel implements LanguageModelV4 {
             controller.enqueue({ type: 'stream-start', warnings });
           },
 
-          transform(chunk, controller) {
+          async transform(chunk, controller) {
             if (options.includeRawChunks) {
               controller.enqueue({ type: 'raw', rawValue: chunk.rawValue });
             }
@@ -412,7 +413,9 @@ export class CohereChatLanguageModel implements LanguageModelV4 {
                     toolCallId: pendingToolCall.id,
                     toolName: pendingToolCall.name,
                     input: JSON.stringify(
-                      JSON.parse(pendingToolCall.arguments?.trim() || '{}'),
+                      await parseJSON({
+                        text: pendingToolCall.arguments?.trim() || '{}',
+                      }),
                     ),
                   });
 


### PR DESCRIPTION
## Background

The AI SDK already centralizes JSON parsing through `parseJSON` / `safeParseJSON` so provider code gets consistent error handling and prototype-key protection. Cohere's streaming tool-call path was still parsing completed tool arguments with raw `JSON.parse`, so this brings that path in line with the rest of the SDK.

## Summary

This updates Cohere streamed tool-call parsing to use the AI SDK's secure JSON parser instead of calling `JSON.parse` directly in production code.

The regression coverage now exercises streamed tool-call arguments containing prototype keys and verifies that they are rejected by the shared secure parser.