### PR TITLE
fix: rename onEmbedFinish to onEmbedEnd

### DIFF
--- a/.changeset/soft-dots-explode.md
+++ b/.changeset/soft-dots-explode.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+fix: rename onEmbedFinish to onEmbedEnd

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -353,6 +353,11 @@ export function myIntegration(): Telemetry {
       description: 'Called when a step (LLM call) completes.',
     },
     {
+      name: 'onEmbedEnd',
+      type: '(event: EmbeddingModelCallEndEvent) => void | PromiseLike<void>',
+      description: 'Called when an individual embedding model call completes.',
+    },
+    {
       name: 'onRerankEnd',
       type: '(event: RerankingModelCallEndEvent) => void | PromiseLike<void>',
       description: 'Called when an individual reranking model call completes.',

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -94,7 +94,7 @@ For multi-step text generations that use tools, the callback order is typically
         'Called when the embedding operation begins, before the embedding model is called.',
     },
     {
-      name: 'experimental_onFinish',
+      name: 'experimental_onEnd',
       type: '(event: EmbedEndEvent) => void | Promise<void>',
       description:
         'Called when the embedding operation completes, after the embedding model returns.',
@@ -997,7 +997,7 @@ const result = await embed({
   ]}
 />
 
-#### `experimental_onFinish`
+#### `experimental_onEnd`
 
 Called when the embedding operation completes. For `embed`, `embedding` is a single vector and `response` is a single response object. For `embedMany`, `embedding` is an array of vectors and `response` is an array of response objects (one per chunk).
 
@@ -1007,7 +1007,7 @@ import { embedMany } from 'ai';
 const result = await embedMany({
   model: openai.embedding('text-embedding-3-small'),
   values: ['sunny day at the beach', 'rainy afternoon in the city'],
-  experimental_onFinish: event => {
+  experimental_onEnd: event => {
     console.log('Operation:', event.operationId);
     console.log('Usage:', event.usage);
   },
@@ -1286,7 +1286,7 @@ const result = await embedMany({
       valueCount: Array.isArray(event.value) ? event.value.length : 1,
     });
   },
-  experimental_onFinish: event => {
+  experimental_onEnd: event => {
     console.log(`Embedding complete (${event.operationId})`, {
       tokens: event.usage.tokens,
     });

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -170,7 +170,7 @@ const { embedding } = await embed({
       ],
     },
     {
-      name: 'experimental_onFinish',
+      name: 'experimental_onEnd',
       type: '(event: EmbedEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -183,7 +183,7 @@ const { embeddings } = await embedMany({
       ],
     },
     {
-      name: 'experimental_onFinish',
+      name: 'experimental_onEnd',
       type: '(event: EmbedEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -498,6 +498,58 @@ const telemetry: Telemetry = {
 };
 ```
 
+### Telemetry Embed Callback: `onEmbedFinish` Renamed to `onEmbedEnd`
+
+The telemetry integration callback for individual embedding model calls has been renamed from `onEmbedFinish` to `onEmbedEnd`.
+
+This also applies to the `type` field published on `AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL`: diagnostic-channel subscribers now receive `onEmbedEnd` instead of `onEmbedFinish`.
+
+Update telemetry integrations and diagnostic-channel subscribers to use `onEmbedEnd`.
+
+```tsx filename="AI SDK 6"
+import type { Telemetry } from 'ai';
+
+const telemetry: Telemetry = {
+  onEmbedFinish(event) {
+    console.log('Embedding finished:', event.embeddings.length);
+  },
+};
+```
+
+```tsx filename="AI SDK 7"
+import type { Telemetry } from 'ai';
+
+const telemetry: Telemetry = {
+  onEmbedEnd(event) {
+    console.log('Embedding ended:', event.embeddings.length);
+  },
+};
+```
+
+### Embed Callbacks: `experimental_onFinish` Renamed to `experimental_onEnd`
+
+The per-call callback option for completed `embed` and `embedMany` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.
+
+```tsx filename="AI SDK 6"
+const result = await embed({
+  model: yourEmbeddingModel,
+  value,
+  experimental_onFinish(event) {
+    console.log('Embedding finished:', event.usage.tokens);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await embed({
+  model: yourEmbeddingModel,
+  value,
+  experimental_onEnd(event) {
+    console.log('Embedding ended:', event.usage.tokens);
+  },
+});
+```
+
 ### Rerank Callback: `experimental_onFinish` Renamed to `experimental_onEnd`
 
 The per-call callback option for completed `rerank` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.

--- a/examples/ai-functions/src/telemetry/console/console-telemetry.ts
+++ b/examples/ai-functions/src/telemetry/console/console-telemetry.ts
@@ -18,7 +18,7 @@ export const consoleTelemetry = {
   onObjectStepStart: logCallback('onObjectStepStart'),
   onObjectStepFinish: logCallback('onObjectStepFinish'),
   onEmbedStart: logCallback('onEmbedStart'),
-  onEmbedFinish: logCallback('onEmbedFinish'),
+  onEmbedEnd: logCallback('onEmbedEnd'),
   onRerankStart: logCallback('onRerankStart'),
   onRerankEnd: logCallback('onRerankEnd'),
   onFinish: logCallback('onFinish'),

--- a/packages/ai/src/embed/__snapshots__/embed-many.test.ts.snap
+++ b/packages/ai/src/embed/__snapshots__/embed-many.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.experimental_onFinish > should send correct event information (single call path) 1`] = `
+exports[`options.experimental_onEnd > should send correct event information (single call path) 1`] = `
 {
   "callId": "test-call-id",
   "embedding": [

--- a/packages/ai/src/embed/__snapshots__/embed.test.ts.snap
+++ b/packages/ai/src/embed/__snapshots__/embed.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.experimental_onFinish > should send correct event information 1`] = `
+exports[`options.experimental_onEnd > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "embedding": [

--- a/packages/ai/src/embed/embed-events.ts
+++ b/packages/ai/src/embed/embed-events.ts
@@ -35,7 +35,7 @@ export type EmbedStartEvent = {
 };
 
 /**
- * Event passed to the `onFinish` callback for embed and embedMany operations.
+ * Event passed to the `experimental_onEnd` callback for embed and embedMany operations.
  *
  * Called when the operation completes, after the embedding model returns.
  */

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -700,9 +700,9 @@ describe('options.experimental_onStart', () => {
   });
 });
 
-describe('options.experimental_onFinish', () => {
+describe('options.experimental_onEnd', () => {
   it('should send correct event information (single call path)', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -716,16 +716,16 @@ describe('options.experimental_onFinish', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent).toMatchSnapshot();
+    expect(endEvent).toMatchSnapshot();
   });
 
   it('should send correct event information (chunked path)', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
     let callCount = 0;
 
     await embedMany({
@@ -756,21 +756,21 @@ describe('options.experimental_onFinish', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.callId).toBe('test-call-id');
-    expect(finishEvent.operationId).toBe('ai.embedMany');
-    expect(finishEvent.embedding).toEqual(dummyEmbeddings);
-    expect(finishEvent.usage).toEqual({ tokens: 15 });
-    expect(finishEvent.value).toEqual(testValues);
-    expect(finishEvent.response).toHaveLength(2);
+    expect(endEvent.callId).toBe('test-call-id');
+    expect(endEvent.operationId).toBe('ai.embedMany');
+    expect(endEvent.embedding).toEqual(dummyEmbeddings);
+    expect(endEvent.usage).toEqual({ tokens: 15 });
+    expect(endEvent.value).toEqual(testValues);
+    expect(endEvent.response).toHaveLength(2);
   });
 
   it('should include embeddings and usage in event', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -778,18 +778,18 @@ describe('options.experimental_onFinish', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings, { tokens: 15 }),
       }),
       values: testValues,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.embedding).toEqual(dummyEmbeddings);
-    expect(finishEvent.usage).toEqual({ tokens: 15 });
-    expect(finishEvent.value).toEqual(testValues);
+    expect(endEvent.embedding).toEqual(dummyEmbeddings);
+    expect(endEvent.usage).toEqual({ tokens: 15 });
+    expect(endEvent.value).toEqual(testValues);
   });
 
   it('should include model information', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -797,18 +797,18 @@ describe('options.experimental_onFinish', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.provider).toBe('mock-provider');
-    expect(finishEvent.modelId).toBe('mock-model-id');
-    expect(finishEvent.operationId).toBe('ai.embedMany');
+    expect(endEvent.provider).toBe('mock-provider');
+    expect(endEvent.modelId).toBe('mock-model-id');
+    expect(endEvent.operationId).toBe('ai.embedMany');
   });
 
   it('should include responses data', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -819,12 +819,12 @@ describe('options.experimental_onFinish', () => {
         }),
       }),
       values: testValues,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.response).toEqual([
+    expect(endEvent.response).toEqual([
       {
         headers: { 'x-resp': 'val' },
         body: { result: 'ok' },
@@ -844,12 +844,12 @@ describe('options.experimental_onFinish', () => {
         },
       }),
       values: testValues,
-      experimental_onFinish: async () => {
-        callOrder.push('onFinish');
+      experimental_onEnd: async () => {
+        callOrder.push('onEnd');
       },
     });
 
-    expect(callOrder).toEqual(['doEmbed', 'onFinish']);
+    expect(callOrder).toEqual(['doEmbed', 'onEnd']);
   });
 
   it('should not break embedding when callback throws', async () => {
@@ -859,7 +859,7 @@ describe('options.experimental_onFinish', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onFinish: async () => {
+      experimental_onEnd: async () => {
         throw new Error('callback error');
       },
     });
@@ -868,10 +868,10 @@ describe('options.experimental_onFinish', () => {
   });
 });
 
-describe('options.experimental_onStart and experimental_onFinish together', () => {
+describe('options.experimental_onStart and experimental_onEnd together', () => {
   it('should have consistent callId across both events', async () => {
     let startEvent!: EmbedStartEvent;
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -885,17 +885,17 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
       experimental_onStart: async event => {
         startEvent = event;
       },
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
     expect(startEvent.callId).toBe('consistent-call-id');
-    expect(finishEvent.callId).toBe('consistent-call-id');
-    expect(startEvent.callId).toBe(finishEvent.callId);
+    expect(endEvent.callId).toBe('consistent-call-id');
+    expect(startEvent.callId).toBe(endEvent.callId);
   });
 
-  it('should call onStart before doEmbed and onFinish after', async () => {
+  it('should call onStart before doEmbed and onEnd after', async () => {
     const callOrder: string[] = [];
 
     await embedMany({
@@ -910,16 +910,16 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
       experimental_onStart: async () => {
         callOrder.push('onStart');
       },
-      experimental_onFinish: async () => {
-        callOrder.push('onFinish');
+      experimental_onEnd: async () => {
+        callOrder.push('onEnd');
       },
     });
 
-    expect(callOrder).toEqual(['onStart', 'doEmbed', 'onFinish']);
+    expect(callOrder).toEqual(['onStart', 'doEmbed', 'onEnd']);
   });
 
-  it('should still call onFinish when onStart throws', async () => {
-    let finishCalled = false;
+  it('should still call onEnd when onStart throws', async () => {
+    let endCalled = false;
 
     const result = await embedMany({
       model: new MockEmbeddingModelV4({
@@ -930,13 +930,13 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
       experimental_onStart: async () => {
         throw new Error('start error');
       },
-      experimental_onFinish: async () => {
-        finishCalled = true;
+      experimental_onEnd: async () => {
+        endCalled = true;
       },
     });
 
     assert.deepStrictEqual(result.embeddings, dummyEmbeddings);
-    expect(finishCalled).toBe(true);
+    expect(endCalled).toBe(true);
   });
 });
 

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -57,7 +57,7 @@ export async function embedMany({
   experimental_telemetry,
   telemetry = experimental_telemetry,
   experimental_onStart: onStart,
-  experimental_onFinish: onFinish,
+  experimental_onEnd: onEnd,
   _internal: { generateCallId = originalGenerateCallId } = {},
 }: {
   /**
@@ -124,7 +124,7 @@ export async function embedMany({
    * Callback that is called when the embedMany operation completes,
    * after all embedding model calls return.
    */
-  experimental_onFinish?: Callback<EmbedEndEvent>;
+  experimental_onEnd?: Callback<EmbedEndEvent>;
 
   /**
    * Internal. For test use only. May change without notice.
@@ -209,7 +209,7 @@ export async function embedMany({
               embeddings,
               usage,
             },
-            callbacks: [telemetryDispatcher.onEmbedFinish],
+            callbacks: [telemetryDispatcher.onEmbedEnd],
           });
 
           return {
@@ -240,7 +240,7 @@ export async function embedMany({
           providerMetadata,
           response: [response],
         },
-        callbacks: [onFinish, telemetryDispatcher.onFinish],
+        callbacks: [onEnd, telemetryDispatcher.onFinish],
       });
 
       return new DefaultEmbedManyResult({
@@ -311,7 +311,7 @@ export async function embedMany({
                 embeddings: chunkEmbeddings,
                 usage,
               },
-              callbacks: [telemetryDispatcher.onEmbedFinish],
+              callbacks: [telemetryDispatcher.onEmbedEnd],
             });
 
             return {
@@ -366,7 +366,7 @@ export async function embedMany({
         providerMetadata,
         response: responses,
       },
-      callbacks: [onFinish, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onFinish],
     });
 
     return new DefaultEmbedManyResult({

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -371,9 +371,9 @@ describe('options.experimental_onStart', () => {
   });
 });
 
-describe('options.experimental_onFinish', () => {
+describe('options.experimental_onEnd', () => {
   it('should send correct event information', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -386,52 +386,52 @@ describe('options.experimental_onFinish', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent).toMatchSnapshot();
+    expect(endEvent).toMatchSnapshot();
   });
 
   it('should include embedding and usage in event', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
         doEmbed: mockEmbed([testValue], [dummyEmbedding], { tokens: 15 }),
       }),
       value: testValue,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.embedding).toEqual(dummyEmbedding);
-    expect(finishEvent.usage).toEqual({ tokens: 15 });
-    expect(finishEvent.value).toBe(testValue);
+    expect(endEvent.embedding).toEqual(dummyEmbedding);
+    expect(endEvent.usage).toEqual({ tokens: 15 });
+    expect(endEvent.value).toBe(testValue);
   });
 
   it('should include model information', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.provider).toBe('mock-provider');
-    expect(finishEvent.modelId).toBe('mock-model-id');
-    expect(finishEvent.operationId).toBe('ai.embed');
+    expect(endEvent.provider).toBe('mock-provider');
+    expect(endEvent.modelId).toBe('mock-model-id');
+    expect(endEvent.operationId).toBe('ai.embed');
   });
 
   it('should include warnings and providerMetadata', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
     const expectedWarnings: Warning[] = [
       { type: 'other', message: 'test warning' },
     ];
@@ -451,17 +451,17 @@ describe('options.experimental_onFinish', () => {
         ),
       }),
       value: testValue,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.providerMetadata).toEqual(providerMetadata);
-    expect(finishEvent.warnings).toEqual(expectedWarnings);
+    expect(endEvent.providerMetadata).toEqual(providerMetadata);
+    expect(endEvent.warnings).toEqual(expectedWarnings);
   });
 
   it('should include response data', async () => {
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -471,12 +471,12 @@ describe('options.experimental_onFinish', () => {
         }),
       }),
       value: testValue,
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
-    expect(finishEvent.response).toEqual({
+    expect(endEvent.response).toEqual({
       headers: { 'x-resp': 'val' },
       body: { result: 'ok' },
     });
@@ -493,12 +493,12 @@ describe('options.experimental_onFinish', () => {
         },
       }),
       value: testValue,
-      experimental_onFinish: async () => {
-        callOrder.push('onFinish');
+      experimental_onEnd: async () => {
+        callOrder.push('onEnd');
       },
     });
 
-    expect(callOrder).toEqual(['doEmbed', 'onFinish']);
+    expect(callOrder).toEqual(['doEmbed', 'onEnd']);
   });
 
   it('should not break embedding when callback throws', async () => {
@@ -507,7 +507,7 @@ describe('options.experimental_onFinish', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onFinish: async () => {
+      experimental_onEnd: async () => {
         throw new Error('callback error');
       },
     });
@@ -516,10 +516,10 @@ describe('options.experimental_onFinish', () => {
   });
 });
 
-describe('options.experimental_onStart and experimental_onFinish together', () => {
+describe('options.experimental_onStart and experimental_onEnd together', () => {
   it('should have consistent callId across both events', async () => {
     let startEvent!: EmbedStartEvent;
-    let finishEvent!: EmbedEndEvent;
+    let endEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -532,17 +532,17 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
       experimental_onStart: async event => {
         startEvent = event;
       },
-      experimental_onFinish: async event => {
-        finishEvent = event;
+      experimental_onEnd: async event => {
+        endEvent = event;
       },
     });
 
     expect(startEvent.callId).toBe('consistent-call-id');
-    expect(finishEvent.callId).toBe('consistent-call-id');
-    expect(startEvent.callId).toBe(finishEvent.callId);
+    expect(endEvent.callId).toBe('consistent-call-id');
+    expect(startEvent.callId).toBe(endEvent.callId);
   });
 
-  it('should call onStart before doEmbed and onFinish after', async () => {
+  it('should call onStart before doEmbed and onEnd after', async () => {
     const callOrder: string[] = [];
 
     await embed({
@@ -556,16 +556,16 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
       experimental_onStart: async () => {
         callOrder.push('onStart');
       },
-      experimental_onFinish: async () => {
-        callOrder.push('onFinish');
+      experimental_onEnd: async () => {
+        callOrder.push('onEnd');
       },
     });
 
-    expect(callOrder).toEqual(['onStart', 'doEmbed', 'onFinish']);
+    expect(callOrder).toEqual(['onStart', 'doEmbed', 'onEnd']);
   });
 
-  it('should still call onFinish when onStart throws', async () => {
-    let finishCalled = false;
+  it('should still call onEnd when onStart throws', async () => {
+    let endCalled = false;
 
     const result = await embed({
       model: new MockEmbeddingModelV4({
@@ -575,13 +575,13 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
       experimental_onStart: async () => {
         throw new Error('start error');
       },
-      experimental_onFinish: async () => {
-        finishCalled = true;
+      experimental_onEnd: async () => {
+        endCalled = true;
       },
     });
 
     assert.deepStrictEqual(result.embedding, dummyEmbedding);
-    expect(finishCalled).toBe(true);
+    expect(endCalled).toBe(true);
   });
 });
 

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -48,7 +48,7 @@ export async function embed({
   experimental_telemetry,
   telemetry = experimental_telemetry,
   experimental_onStart: onStart,
-  experimental_onFinish: onFinish,
+  experimental_onEnd: onEnd,
   _internal: { generateCallId = originalGenerateCallId } = {},
 }: {
   /**
@@ -108,7 +108,7 @@ export async function embed({
    * Callback that is called when the embed operation completes,
    * after the embedding model returns.
    */
-  experimental_onFinish?: Callback<EmbedEndEvent>;
+  experimental_onEnd?: Callback<EmbedEndEvent>;
 
   /**
    * Internal. For test use only. May change without notice.
@@ -187,7 +187,7 @@ export async function embed({
             embeddings: modelResponse.embeddings,
             usage,
           },
-          callbacks: [telemetryDispatcher.onEmbedFinish],
+          callbacks: [telemetryDispatcher.onEmbedEnd],
         });
 
         return {
@@ -214,7 +214,7 @@ export async function embed({
         providerMetadata,
         response,
       },
-      callbacks: [onFinish, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onFinish],
     });
 
     return new DefaultEmbedResult({

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -30,7 +30,7 @@ describe('createTelemetryDispatcher', () => {
     expect(telemetry.onObjectStepStart).toBeDefined();
     expect(telemetry.onObjectStepFinish).toBeDefined();
     expect(telemetry.onEmbedStart).toBeDefined();
-    expect(telemetry.onEmbedFinish).toBeDefined();
+    expect(telemetry.onEmbedEnd).toBeDefined();
     expect(telemetry.onRerankStart).toBeDefined();
     expect(telemetry.onRerankEnd).toBeDefined();
     expect(telemetry.onFinish).toBeDefined();
@@ -74,7 +74,7 @@ describe('createTelemetryDispatcher', () => {
     await expect(
       telemetry.onToolExecutionStart!(dummyEvent),
     ).resolves.toBeUndefined();
-    await expect(telemetry.onEmbedFinish!(dummyEvent)).resolves.toBeUndefined();
+    await expect(telemetry.onEmbedEnd!(dummyEvent)).resolves.toBeUndefined();
   });
 
   it('broadcasts an event to all integrations that implement the method', async () => {
@@ -150,7 +150,7 @@ describe('createTelemetryDispatcher', () => {
       onObjectStepStart: vi.fn(),
       onObjectStepFinish: vi.fn(),
       onEmbedStart: vi.fn(),
-      onEmbedFinish: vi.fn(),
+      onEmbedEnd: vi.fn(),
       onRerankStart: vi.fn(),
       onRerankEnd: vi.fn(),
       onFinish: vi.fn(),
@@ -172,7 +172,7 @@ describe('createTelemetryDispatcher', () => {
     await telemetry.onObjectStepStart!(dummyEvent);
     await telemetry.onObjectStepFinish!(dummyEvent);
     await telemetry.onEmbedStart!(dummyEvent);
-    await telemetry.onEmbedFinish!(dummyEvent);
+    await telemetry.onEmbedEnd!(dummyEvent);
     await telemetry.onRerankStart!(dummyEvent);
     await telemetry.onRerankEnd!(dummyEvent);
     await telemetry.onFinish!(dummyEvent);
@@ -189,7 +189,7 @@ describe('createTelemetryDispatcher', () => {
     expect(integration.onObjectStepStart).toHaveBeenCalledOnce();
     expect(integration.onObjectStepFinish).toHaveBeenCalledOnce();
     expect(integration.onEmbedStart).toHaveBeenCalledOnce();
-    expect(integration.onEmbedFinish).toHaveBeenCalledOnce();
+    expect(integration.onEmbedEnd).toHaveBeenCalledOnce();
     expect(integration.onRerankStart).toHaveBeenCalledOnce();
     expect(integration.onRerankEnd).toHaveBeenCalledOnce();
     expect(integration.onFinish).toHaveBeenCalledOnce();
@@ -219,7 +219,7 @@ describe('createTelemetryDispatcher', () => {
         onObjectStepStart: vi.fn(),
         onObjectStepFinish: vi.fn(),
         onEmbedStart: vi.fn(),
-        onEmbedFinish: vi.fn(),
+        onEmbedEnd: vi.fn(),
         onRerankStart: vi.fn(),
         onRerankEnd: vi.fn(),
         onFinish: vi.fn(),
@@ -239,7 +239,7 @@ describe('createTelemetryDispatcher', () => {
       expect(telemetry.onObjectStepStart).toBeUndefined();
       expect(telemetry.onObjectStepFinish).toBeUndefined();
       expect(telemetry.onEmbedStart).toBeUndefined();
-      expect(telemetry.onEmbedFinish).toBeUndefined();
+      expect(telemetry.onEmbedEnd).toBeUndefined();
       expect(telemetry.onRerankStart).toBeUndefined();
       expect(telemetry.onRerankEnd).toBeUndefined();
       expect(telemetry.onFinish).toBeUndefined();

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -128,7 +128,7 @@ export function createTelemetryDispatcher({
     onObjectStepStart: mergeTelemetryCallback('onObjectStepStart'),
     onObjectStepFinish: mergeTelemetryCallback('onObjectStepFinish'),
     onEmbedStart: mergeTelemetryCallback('onEmbedStart'),
-    onEmbedFinish: mergeTelemetryCallback('onEmbedFinish'),
+    onEmbedEnd: mergeTelemetryCallback('onEmbedEnd'),
     onRerankStart: mergeTelemetryCallback('onRerankStart'),
     onRerankEnd: mergeTelemetryCallback('onRerankEnd'),
     onFinish: mergeTelemetryCallback('onFinish'),

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -12,7 +12,7 @@ export type TelemetryDiagnosticEventType =
   | 'onObjectStepStart'
   | 'onObjectStepFinish'
   | 'onEmbedStart'
-  | 'onEmbedFinish'
+  | 'onEmbedEnd'
   | 'onRerankStart'
   | 'onRerankEnd'
   | 'onFinish'

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -67,7 +67,7 @@ export interface TelemetryDispatcher {
   onObjectStepStart?: Callback<GenerateObjectStepStartEvent>;
   onObjectStepFinish?: Callback<GenerateObjectStepEndEvent>;
   onEmbedStart?: Callback<EmbeddingModelCallStartEvent>;
-  onEmbedFinish?: Callback<EmbeddingModelCallEndEvent>;
+  onEmbedEnd?: Callback<EmbeddingModelCallEndEvent>;
   onRerankStart?: Callback<RerankingModelCallStartEvent>;
   onRerankEnd?: Callback<RerankingModelCallEndEvent>;
   onFinish?: Callback<OperationFinishEvent>;
@@ -177,7 +177,7 @@ export interface Telemetry {
    * Called when an individual embedding model call (doEmbed) completes.
    * Contains the embeddings, usage, and any warnings from the model response.
    */
-  onEmbedFinish?: Callback<InferTelemetryEvent<EmbeddingModelCallEndEvent>>;
+  onEmbedEnd?: Callback<InferTelemetryEvent<EmbeddingModelCallEndEvent>>;
 
   /**
    * Called when an individual reranking model call (doRerank) begins.

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -917,7 +917,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     });
   }
 
-  onEmbedFinish(event: EmbeddingModelCallEndEvent): void {
+  onEmbedEnd(event: EmbeddingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state) return;
 

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -1032,7 +1032,7 @@ export class OpenTelemetry implements Telemetry {
     });
   }
 
-  onEmbedFinish(event: EmbeddingModelCallEndEvent): void {
+  onEmbedEnd(event: EmbeddingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state) return;
 


### PR DESCRIPTION
## Background
We are standardizing on Start/End nomenclature.

## Summary

Rename `experimental_onEmbedFinish` to `experimental_onEmbedEnd`