### PR TITLE
fix(ai): download tool-result file URLs

### DIFF
--- a/.changeset/nine-sloths-kneel.md
+++ b/.changeset/nine-sloths-kneel.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): download tool-result file URLs

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1138,6 +1138,112 @@ describe('convertToLanguageModelPrompt', () => {
         },
       ]);
     });
+
+    it('should download URL content in tool results', async () => {
+      const mockDownload = vi.fn().mockResolvedValue([
+        {
+          url: new URL('https://example.com/image.png'),
+          data: new Uint8Array([0, 1, 2, 3]),
+          mediaType: 'image/png',
+        },
+      ]);
+
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId',
+                  toolName: 'toolName',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'file',
+                        mediaType: 'image/png',
+                        data: {
+                          type: 'url',
+                          url: new URL('https://example.com/image.png'),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: mockDownload,
+      });
+
+      expect(mockDownload).toHaveBeenCalledOnce();
+      expect(mockDownload).toHaveBeenCalledWith([
+        {
+          url: new URL('https://example.com/image.png'),
+          isUrlSupportedByModel: false,
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'toolCallId',
+              toolName: 'toolName',
+              input: {},
+              providerExecuted: undefined,
+              providerOptions: undefined,
+            },
+          ],
+          providerOptions: undefined,
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'toolCallId',
+              toolName: 'toolName',
+              output: {
+                type: 'content',
+                value: [
+                  {
+                    type: 'file',
+                    mediaType: 'image/png',
+                    data: {
+                      type: 'data',
+                      data: new Uint8Array([0, 1, 2, 3]),
+                    },
+                    filename: undefined,
+                    providerOptions: undefined,
+                  },
+                ],
+              },
+              providerOptions: undefined,
+            },
+          ],
+          providerOptions: undefined,
+        },
+      ]);
+    });
   });
 });
 

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1244,6 +1244,96 @@ describe('convertToLanguageModelPrompt', () => {
         },
       ]);
     });
+
+    it('should download URL content in assistant tool results', async () => {
+      const mockDownload = vi.fn().mockResolvedValue([
+        {
+          url: new URL('https://example.com/assistant-image.png'),
+          data: new Uint8Array([4, 5, 6, 7]),
+          mediaType: 'image/png',
+        },
+      ]);
+
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'file',
+                        mediaType: 'image/png',
+                        data: {
+                          type: 'url',
+                          url: new URL(
+                            'https://example.com/assistant-image.png',
+                          ),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: mockDownload,
+      });
+
+      expect(mockDownload).toHaveBeenCalledOnce();
+      expect(mockDownload).toHaveBeenCalledWith([
+        {
+          url: new URL('https://example.com/assistant-image.png'),
+          isUrlSupportedByModel: false,
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "content",
+                  "value": [
+                    {
+                      "data": {
+                        "data": Uint8Array [
+                          4,
+                          5,
+                          6,
+                          7,
+                        ],
+                        "type": "data",
+                      },
+                      "filename": undefined,
+                      "mediaType": "image/png",
+                      "providerOptions": undefined,
+                      "type": "file",
+                    },
+                  ],
+                },
+                "providerOptions": undefined,
+                "toolCallId": "toolCallId",
+                "toolName": "toolName",
+                "type": "tool-result",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
   });
 });
 

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -337,6 +337,7 @@ export function convertToLanguageModelMessage({
                     output: part.output,
                     provider,
                     warnings,
+                    downloadedAssets,
                   }),
                   providerOptions,
                 };
@@ -371,6 +372,7 @@ export function convertToLanguageModelMessage({
                     output: part.output,
                     provider,
                     warnings,
+                    downloadedAssets,
                   }),
                   providerOptions: part.providerOptions,
                 };
@@ -440,15 +442,39 @@ async function downloadAssets(
     data: { type: 'url'; url: URL };
   };
 
-  const plannedDownloads = messages
-    .filter(message => message.role === 'user')
-    .map(message => message.content)
-    .filter((content): content is Array<TextPart | ImagePart | FilePart> =>
-      Array.isArray(content),
-    )
-    .flat()
-    .map(part => convertImagePartToFilePart(part))
-    .filter((part): part is FilePart => part.type === 'file')
+  const downloadableFiles: FilePart[] = [];
+
+  for (const message of messages) {
+    if (message.role === 'user' && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        const filePart = convertImagePartToFilePart(part);
+
+        if (filePart.type === 'file') {
+          downloadableFiles.push(filePart);
+        }
+      }
+    }
+
+    if (message.role === 'tool') {
+      for (const part of message.content) {
+        if (part.type !== 'tool-result') {
+          continue;
+        }
+
+        if (part.output.type !== 'content') {
+          continue;
+        }
+
+        for (const contentPart of part.output.value) {
+          if (contentPart.type === 'file') {
+            downloadableFiles.push(contentPart);
+          }
+        }
+      }
+    }
+  }
+
+  const plannedDownloads = downloadableFiles
     .map((part): ConvertedFile => {
       const mediaType = part.mediaType;
       const { data } = convertToLanguageModelV4FilePart(part.data);
@@ -465,7 +491,6 @@ async function downloadAssets(
           supportedUrls,
         }),
     }));
-
   // download in parallel:
   const downloadedFiles = await download(plannedDownloads);
 
@@ -557,10 +582,15 @@ function mapToolResultOutput({
   // TODO: remove in v8 when "file-id" and "image-file-id" types are removed
   provider,
   warnings = [],
+  downloadedAssets,
 }: {
   output: ToolResultOutput;
   provider?: string;
   warnings?: Warning[];
+  downloadedAssets: Record<
+    string,
+    { mediaType: string | undefined; data: Uint8Array }
+  >;
 }): LanguageModelV4ToolResultOutput {
   if (output.type !== 'content') {
     return output;
@@ -571,16 +601,18 @@ function mapToolResultOutput({
     value: output.value.map(item => {
       switch (item.type) {
         case 'file': {
-          const { data, mediaType } = convertToLanguageModelV4FilePart(
-            item.data,
+          const convertedPart = convertPartToLanguageModelPart(
+            item,
+            downloadedAssets,
           );
-          return {
-            type: 'file' as const,
-            data,
-            filename: item.filename,
-            mediaType: mediaType ?? item.mediaType,
-            providerOptions: item.providerOptions,
-          };
+
+          if (convertedPart.type !== 'file') {
+            throw new Error(
+              'Expected tool result file content to convert to file.',
+            );
+          }
+
+          return convertedPart;
         }
         case 'file-data': {
           warnings.push({

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -472,6 +472,22 @@ async function downloadAssets(
         }
       }
     }
+
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (part.type !== 'tool-result') {
+          continue;
+        }
+        if (part.output.type !== 'content') {
+          continue;
+        }
+        for (const contentPart of part.output.value) {
+          if (contentPart.type === 'file') {
+            downloadableFiles.push(contentPart);
+          }
+        }
+      }
+    }
   }
 
   const plannedDownloads = downloadableFiles


### PR DESCRIPTION
## Background

#15173

`convertToLanguageModelPrompt()` already downloaded URL-based assets for normal user file/image parts when a provider did not support URL sources. However, the same behavior was not applied to `tool-result` content parts.

This caused providers such as Bedrock Anthropic (which requires downloaded/base64 assets instead of remote URLs) to receive unresolved URL references inside tool results.

## Summary

This PR fixes tool-result file URL handling during prompt conversion.

## Manual Verification

<details>
<summary>repro:</summary>

```ts
import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
import { generateText, isStepCount, tool } from 'ai';
import { z } from 'zod';
import { run } from '../../lib/run';

run(async () => {
  const result = await generateText({
    model: amazonBedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
    tools: {
      getPreviewImage: tool({
        description: 'Return a preview image URL.',
        inputSchema: z.object({}),
        execute: async () => {
          return {
            imageUrl:
              'https://github.com/vercel/ai/blob/main/examples/ai-functions/data/comic-cat.png?raw=true',
          };
        },
        toModelOutput({ output }) {
          return {
            type: 'content',
            value: [
              { type: 'text', text: 'Here is the preview image.' },
              {
                type: 'file',
                mediaType: 'image/png',
                data: { type: 'url', url: new URL(output.imageUrl) },
              },
            ],
          };
        },
      }),
    },
    prompt: 'Use the getPreviewImage tool, then describe the returned image.',
    stopWhen: isStepCount(10),
  });
  
  console.log(JSON.stringify(result.content, null, 2));
});
```

</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15173 

Co-authored-by: adekunle <adekunlemichael1319@gmail.com>