### PR TITLE
feat: accept adaptive thinking and full reasoning_effort enum for deepseek provider

### DIFF
--- a/.changeset/deepseek-thinking-adaptive-and-reasoning-effort.md
+++ b/.changeset/deepseek-thinking-adaptive-and-reasoning-effort.md
@@ -2,4 +2,4 @@
 "@ai-sdk/deepseek": patch
 ---
 
-Align DeepSeek `providerOptions` schema with DeepSeek's API: accept `thinking.type: 'adaptive'` and expand `reasoningEffort` to `'high' | 'low' | 'medium' | 'max' | 'xhigh'`. Top-level `reasoning: 'low' | 'medium'` now passes through to DeepSeek's native `low`/`medium` effort values (previously collapsed to `'high'` with a compatibility warning); `reasoning: 'minimal'` maps to `'low'`. Fixes pre-flight `AI_InvalidArgumentError: invalid deepseek provider options` for payloads DeepSeek's API would otherwise accept.
+Accept `thinking.type: 'adaptive'` and the full `reasoningEffort` enum (`low`, `medium`, `high`, `xhigh`, `max`) for the DeepSeek provider.

--- a/.changeset/deepseek-thinking-adaptive-and-reasoning-effort.md
+++ b/.changeset/deepseek-thinking-adaptive-and-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/deepseek": patch
+---
+
+Align DeepSeek `providerOptions` schema with DeepSeek's API: accept `thinking.type: 'adaptive'` and expand `reasoningEffort` to `'high' | 'low' | 'medium' | 'max' | 'xhigh'`. Top-level `reasoning: 'low' | 'medium'` now passes through to DeepSeek's native `low`/`medium` effort values (previously collapsed to `'high'` with a compatibility warning); `reasoning: 'minimal'` maps to `'low'`. Fixes pre-flight `AI_InvalidArgumentError: invalid deepseek provider options` for payloads DeepSeek's API would otherwise accept.

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -96,13 +96,16 @@ The following optional provider options are available for DeepSeek models:
 - `thinking` _object_
 
   Optional. Controls thinking mode (chain-of-thought reasoning). You can enable thinking mode either by using the `deepseek-reasoner` model or by setting this option.
-  - `type`: `'enabled' | 'disabled'` - Enable or disable thinking mode.
+  - `type`: `'adaptive' | 'enabled' | 'disabled'` - Enable, disable, or let the model decide (`adaptive`) when to think. See [DeepSeek's thinking mode docs](https://api-docs.deepseek.com/guides/thinking_mode).
 
-- `reasoningEffort` _'high' | 'max'_
+- `reasoningEffort` _'low' | 'medium' | 'high' | 'xhigh' | 'max'_
 
-  Optional. Controls thinking strength for DeepSeek V4 reasoning models. When
-  using the top-level `reasoning` setting, `low`, `medium`, and `high` are sent
-  as `high`, while `xhigh` is sent as `max`.
+  Optional. Controls thinking strength for DeepSeek V4 reasoning models. Per
+  DeepSeek's docs, `low` and `medium` are mapped to `high`, and `xhigh` is
+  mapped to `max` server-side for compatibility with other providers. When
+  using the top-level `reasoning` setting, `minimal` is sent as `low`, and
+  `low`, `medium`, `high`, and `xhigh` pass through to DeepSeek's native
+  effort values.
 
 ```ts highlight="7-12"
 import {

--- a/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
@@ -9,17 +9,24 @@ export type DeepSeekChatModelId =
 export const deepseekLanguageModelChatOptions = z.object({
   /**
    * Type of thinking to use. Defaults to `enabled`.
+   *
+   * See https://api-docs.deepseek.com/guides/thinking_mode for the
+   * `adaptive` option, which lets the model decide when to think.
    */
   thinking: z
     .object({
-      type: z.enum(['enabled', 'disabled']).optional(),
+      type: z.enum(['adaptive', 'enabled', 'disabled']).optional(),
     })
     .optional(),
 
   /**
    * Controls the thinking strength for DeepSeek V4 reasoning models.
+   *
+   * DeepSeek's API accepts `high`, `low`, `medium`, `max`, and `xhigh`.
+   * Per their docs, `low` and `medium` are mapped to `high`, and `xhigh`
+   * is mapped to `max` server-side for compatibility with other providers.
    */
-  reasoningEffort: z.enum(['high', 'max']).optional(),
+  reasoningEffort: z.enum(['high', 'low', 'medium', 'max', 'xhigh']).optional(),
 });
 
 export type DeepSeekLanguageModelChatOptions = z.infer<

--- a/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
@@ -22,11 +22,11 @@ export const deepseekLanguageModelChatOptions = z.object({
   /**
    * Controls the thinking strength for DeepSeek V4 reasoning models.
    *
-   * DeepSeek's API accepts `high`, `low`, `medium`, `max`, and `xhigh`.
+   * DeepSeek's API accepts `low`, `medium`, `high`, `xhigh`, and `max`.
    * Per their docs, `low` and `medium` are mapped to `high`, and `xhigh`
    * is mapped to `max` server-side for compatibility with other providers.
    */
-  reasoningEffort: z.enum(['high', 'low', 'medium', 'max', 'xhigh']).optional(),
+  reasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
 });
 
 export type DeepSeekLanguageModelChatOptions = z.infer<

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
@@ -171,20 +171,81 @@ describe('DeepSeekChatLanguageModel', () => {
         });
       });
 
-      it('should map top-level reasoning low to reasoning_effort high with compatibility warning', async () => {
+      it('should map top-level reasoning low to reasoning_effort low without a compatibility warning', async () => {
         const result = await provider.chat('deepseek-reasoner').doGenerate({
           prompt: TEST_PROMPT,
           reasoning: 'low',
         });
 
         expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
-          'high',
+          'low',
+        );
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({
+            type: 'compatibility',
+            feature: 'reasoning',
+          }),
+        );
+      });
+
+      it('should map top-level reasoning medium to reasoning_effort medium', async () => {
+        await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'medium',
+        });
+
+        expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+          'medium',
+        );
+      });
+
+      it('should map top-level reasoning minimal to reasoning_effort low with compatibility warning', async () => {
+        const result = await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'minimal',
+        });
+
+        expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+          'low',
         );
         expect(result.warnings).toContainEqual({
           type: 'compatibility',
           feature: 'reasoning',
           details:
-            'reasoning "low" is not directly supported by this model. mapped to effort "high".',
+            'reasoning "minimal" is not directly supported by this model. mapped to effort "low".',
+        });
+      });
+
+      it.each(['low', 'medium', 'xhigh'] as const)(
+        'should pass providerOptions reasoningEffort %s through to the API',
+        async effort => {
+          await provider.chat('deepseek-reasoner').doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              deepseek: {
+                reasoningEffort: effort,
+              } satisfies DeepSeekLanguageModelChatOptions,
+            },
+          });
+
+          expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+            effort,
+          );
+        },
+      );
+
+      it('should pass providerOptions thinking.type=adaptive through to the API', async () => {
+        await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            deepseek: {
+              thinking: { type: 'adaptive' },
+            } satisfies DeepSeekLanguageModelChatOptions,
+          },
+        });
+
+        expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
+          type: 'adaptive',
         });
       });
 

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -153,9 +153,9 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
         ? mapReasoningToProviderEffort({
             reasoning,
             effortMap: {
-              minimal: 'high',
-              low: 'high',
-              medium: 'high',
+              minimal: 'low',
+              low: 'low',
+              medium: 'medium',
               high: 'high',
               xhigh: 'max',
             },


### PR DESCRIPTION
## Summary

Aligns `@ai-sdk/deepseek`'s `providerOptions.deepseek` Zod schema with the values DeepSeek's API actually accepts:

- `thinking.type`: `enabled | disabled` → **`adaptive | enabled | disabled`**
- `reasoningEffort`: `high | max` → **`high | low | medium | max | xhigh`**

Also updates the top-level `reasoning` `effortMap` to preserve distinctness where DeepSeek's API supports it natively (it no longer collapses `low`/`medium` to `high`):

```diff
 effortMap: {
-  minimal: 'high',
-  low: 'high',
-  medium: 'high',
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
   high: 'high',
   xhigh: 'max',
 }
```

## Why

DeepSeek's docs ([Thinking Mode Toggle and Effort Control](https://api-docs.deepseek.com/guides/thinking_mode)) document `thinking.type: adaptive` and a full effort enum of `{high, low, medium, max, xhigh}`. Their API rejects only out-of-set values (e.g. `minimal`, `auto`) and returns 200 for everything else, including server-side compat mappings like `low → high` and `xhigh → max`.

The previous AI SDK schema rejected these natively-supported values at pre-flight, throwing `AI_InvalidArgumentError: invalid deepseek provider options` before any HTTP call. This caused real production traffic to fail (no HTTP request was ever made; gateway-routed traffic was logged as `statusCode=0` provider failures and tanked DeepSeek's public uptime number).

### Direct repro against the DeepSeek API (no AI SDK)

```
reasoning_effort: "high"    → 200 ✅
reasoning_effort: "max"     → 200 ✅
reasoning_effort: "low"     → 200 ✅
reasoning_effort: "medium"  → 200 ✅
reasoning_effort: "xhigh"   → 200 ✅
reasoning_effort: "minimal" → 400 (unknown variant)

thinking.type: "enabled"    → 200 ✅
thinking.type: "disabled"   → 200 ✅
thinking.type: "adaptive"   → 200 ✅
thinking.type: "auto"       → 400 (unknown variant)
```

DeepSeek's 400 errors explicitly enumerate the legal values: `expected one of 'high', 'low', 'medium', 'max', 'xhigh'` and `expected one of 'adaptive', 'enabled', 'disabled'`.

## Test plan

- [x] Existing `xhigh → max` mapping test still passes (unchanged in this PR)
- [x] Updated `low` test to assert direct passthrough with no compatibility warning
- [x] Added `medium` direct-passthrough test
- [x] Added `minimal → low` test with compatibility warning
- [x] Added parameterized test for `providerOptions.deepseek.reasoningEffort ∈ {low, medium, xhigh}` passing through to the API
- [x] Added test for `providerOptions.deepseek.thinking.type: 'adaptive'` passing through to the API