### PR TITLE
fix(devtools): tidy ToolItem expand/collapse logic

### DIFF
--- a/.changeset/devtools-toolitem-expand.md
+++ b/.changeset/devtools-toolitem-expand.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/devtools": patch
+---
+
+Fix `ToolItem` expand/collapse logic: chevron now shows whenever there's expandable content (parameters or description), expanded view shows full description plus parameters, collapsed view shows truncated description only.

--- a/packages/devtools/src/viewer/client/components/shared-components.tsx
+++ b/packages/devtools/src/viewer/client/components/shared-components.tsx
@@ -433,6 +433,8 @@ export function TextBlock({
 export function ToolItem({ tool }: { tool: ToolDefinition }) {
   const [expanded, setExpanded] = useState(false);
 
+  const hasExpandableContent = tool.parameters || tool.description;
+
   return (
     <div className="overflow-hidden rounded-md border border-border bg-background">
       <button
@@ -440,7 +442,7 @@ export function ToolItem({ tool }: { tool: ToolDefinition }) {
         onClick={() => setExpanded(!expanded)}
       >
         <span className="font-mono text-sm text-purple">{tool.name}</span>
-        {tool.parameters && (
+        {hasExpandableContent && (
           <ChevronRight
             className={`size-3 text-muted-foreground transition-transform ${
               expanded ? 'rotate-90' : ''
@@ -448,21 +450,23 @@ export function ToolItem({ tool }: { tool: ToolDefinition }) {
           />
         )}
       </button>
-      {expanded && tool.parameters && (
-        <div className="px-2.5 pb-2.5 border-t border-border">
-          {tool.description && (
-            <p className="pt-2 mb-2 text-xs text-muted-foreground">
-              {tool.description}
-            </p>
-          )}
-          <JsonBlock data={tool.parameters} compact />
-        </div>
-      )}
       {!expanded && tool.description && (
-        <div className="px-2.5 pb-2 -mt-1">
+        <div className="px-2.5 pb-2">
           <p className="text-[11px] text-muted-foreground truncate">
             {tool.description}
           </p>
+        </div>
+      )}
+      {expanded && hasExpandableContent && (
+        <div className="px-2.5 pb-2.5 border-t border-border">
+          {tool.description && (
+            <p
+              className={`pt-2 text-xs text-muted-foreground ${tool.parameters ? 'mb-2' : ''}`}
+            >
+              {tool.description}
+            </p>
+          )}
+          {tool.parameters && <JsonBlock data={tool.parameters} compact />}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- The chevron in `ToolItem` is now shown whenever there's expandable content (parameters or description), not only when parameters exist — previously a tool with only a description had no way to reveal the full text.
- Expanded view shows the full description (if any) followed by the parameters JSON (if any).
- Collapsed view shows only the truncated description.

## Question

I noticed that the `ToolDefinition` in `devtools` is using `parameters` instead of `inputSchema`, so it will never render. Is this a bug?