### PR TITLE
fix: rename telemetry onFinish to onEnd

### DIFF
--- a/.changeset/selfish-paws-fetch.md
+++ b/.changeset/selfish-paws-fetch.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix: rename telemetry onFinish to onEnd

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -299,7 +299,7 @@ class MyIntegration implements Telemetry {
     }
   }
 
-  async onFinish(event) {
+  async onEnd(event) {
     console.log('Done. Total tokens:', event.totalUsage.totalTokens);
   }
 }
@@ -363,7 +363,7 @@ export function myIntegration(): Telemetry {
       description: 'Called when an individual reranking model call completes.',
     },
     {
-      name: 'onFinish',
+      name: 'onEnd',
       type: '(event: GenerateTextEndEvent) => void | PromiseLike<void>',
       description:
         'Called when the entire generation completes (all steps finished).',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -526,6 +526,34 @@ const telemetry: Telemetry = {
 };
 ```
 
+### Telemetry Operation Callback: `onFinish` Renamed to `onEnd`
+
+The telemetry integration callback for completed AI SDK operations has been renamed from `onFinish` to `onEnd`.
+
+This also applies to the `type` field published on `AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL`: diagnostic-channel subscribers now receive `onEnd` instead of `onFinish`.
+
+Update telemetry integrations and diagnostic-channel subscribers to use `onEnd`.
+
+```tsx filename="AI SDK 6"
+import type { Telemetry } from 'ai';
+
+const telemetry: Telemetry = {
+  onFinish(event) {
+    console.log('Operation finished:', event.operationId);
+  },
+};
+```
+
+```tsx filename="AI SDK 7"
+import type { Telemetry } from 'ai';
+
+const telemetry: Telemetry = {
+  onEnd(event) {
+    console.log('Operation ended:', event.operationId);
+  },
+};
+```
+
 ### Embed Callbacks: `experimental_onFinish` Renamed to `experimental_onEnd`
 
 The per-call callback option for completed `embed` and `embedMany` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -526,34 +526,6 @@ const telemetry: Telemetry = {
 };
 ```
 
-### Telemetry Operation Callback: `onFinish` Renamed to `onEnd`
-
-The telemetry integration callback for completed AI SDK operations has been renamed from `onFinish` to `onEnd`.
-
-This also applies to the `type` field published on `AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL`: diagnostic-channel subscribers now receive `onEnd` instead of `onFinish`.
-
-Update telemetry integrations and diagnostic-channel subscribers to use `onEnd`.
-
-```tsx filename="AI SDK 6"
-import type { Telemetry } from 'ai';
-
-const telemetry: Telemetry = {
-  onFinish(event) {
-    console.log('Operation finished:', event.operationId);
-  },
-};
-```
-
-```tsx filename="AI SDK 7"
-import type { Telemetry } from 'ai';
-
-const telemetry: Telemetry = {
-  onEnd(event) {
-    console.log('Operation ended:', event.operationId);
-  },
-};
-```
-
 ### Embed Callbacks: `experimental_onFinish` Renamed to `experimental_onEnd`
 
 The per-call callback option for completed `embed` and `embedMany` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.

--- a/examples/ai-functions/src/telemetry/console/console-telemetry.ts
+++ b/examples/ai-functions/src/telemetry/console/console-telemetry.ts
@@ -21,7 +21,7 @@ export const consoleTelemetry = {
   onEmbedEnd: logCallback('onEmbedEnd'),
   onRerankStart: logCallback('onRerankStart'),
   onRerankEnd: logCallback('onRerankEnd'),
-  onFinish: logCallback('onFinish'),
+  onEnd: logCallback('onEnd'),
   onError: logCallback('onError'),
   executeTool: async ({ callId, toolCallId, execute }) => {
     console.log('executeTool', JSON.stringify({ callId, toolCallId }, null, 2));

--- a/examples/next-workflow/lib/devtools-bridge.ts
+++ b/examples/next-workflow/lib/devtools-bridge.ts
@@ -55,6 +55,6 @@ export const devToolsTelemetry: Telemetry = {
   onStepFinish: dispatch('onStepFinish'),
   onObjectStepStart: dispatch('onObjectStepStart'),
   onObjectStepFinish: dispatch('onObjectStepFinish'),
-  onFinish: dispatch('onFinish'),
+  onEnd: dispatch('onEnd'),
   onError: dispatch('onError'),
 };

--- a/examples/next-workflow/workflow/telemetry-agent.ts
+++ b/examples/next-workflow/workflow/telemetry-agent.ts
@@ -84,7 +84,7 @@ function createTelemetryIntegration(telemetryRunId: string) {
     onToolExecutionStart: record('onToolExecutionStart'),
     onToolExecutionEnd: record('onToolExecutionEnd'),
     onStepFinish: record('onStepFinish'),
-    onFinish: record('onFinish'),
+    onEnd: record('onEnd'),
     onError: async error => {
       await recordTelemetryEvent({
         telemetryRunId,

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -2935,7 +2935,7 @@ describe('ToolLoopAgent', () => {
     });
   });
 
-  describe('onFinish', () => {
+  describe('onEnd', () => {
     describe('generate', () => {
       let mockModel: MockLanguageModelV4;
 
@@ -3300,8 +3300,8 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async () => {
                 events.push('onStepFinish');
               },
-              onFinish: async () => {
-                events.push('onFinish');
+              onEnd: async () => {
+                events.push('onEnd');
               },
             },
           },
@@ -3317,7 +3317,7 @@ describe('ToolLoopAgent', () => {
           'onStepFinish',
           'onStepStart',
           'onStepFinish',
-          'onFinish',
+          'onEnd',
         ]);
       });
 
@@ -3332,8 +3332,8 @@ describe('ToolLoopAgent', () => {
             onStepFinish: async () => {
               events.push('global-onStepFinish');
             },
-            onFinish: async () => {
-              events.push('global-onFinish');
+            onEnd: async () => {
+              events.push('global-onEnd');
             },
           },
         ];
@@ -3353,7 +3353,7 @@ describe('ToolLoopAgent', () => {
         expect(events).toEqual([
           'global-onStart',
           'global-onStepFinish',
-          'global-onFinish',
+          'global-onEnd',
         ]);
       });
 
@@ -3395,7 +3395,7 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async ({ runtimeContext }) => {
                 telemetryContexts.push(runtimeContext);
               },
-              onFinish: async event => {
+              onEnd: async event => {
                 telemetryContexts.push(
                   (event as { runtimeContext: unknown }).runtimeContext,
                 );
@@ -3446,8 +3446,8 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async () => {
                 events.push('integration-onStepFinish');
               },
-              onFinish: async () => {
-                events.push('integration-onFinish');
+              onEnd: async () => {
+                events.push('integration-onEnd');
               },
             },
           },
@@ -3461,7 +3461,7 @@ describe('ToolLoopAgent', () => {
           'agent-onStepFinish',
           'integration-onStepFinish',
           'agent-onFinish',
-          'integration-onFinish',
+          'integration-onEnd',
         ]);
       });
 
@@ -3482,7 +3482,7 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async () => {
                 throw new Error('integration error');
               },
-              onFinish: async () => {
+              onEnd: async () => {
                 throw new Error('integration error');
               },
             },
@@ -3593,8 +3593,8 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async () => {
                 events.push('onStepFinish');
               },
-              onFinish: async () => {
-                events.push('onFinish');
+              onEnd: async () => {
+                events.push('onEnd');
               },
             },
           },
@@ -3611,7 +3611,7 @@ describe('ToolLoopAgent', () => {
           'onStepFinish',
           'onStepStart',
           'onStepFinish',
-          'onFinish',
+          'onEnd',
         ]);
       });
 
@@ -3626,8 +3626,8 @@ describe('ToolLoopAgent', () => {
             onStepFinish: async () => {
               events.push('global-onStepFinish');
             },
-            onFinish: async () => {
-              events.push('global-onFinish');
+            onEnd: async () => {
+              events.push('global-onEnd');
             },
           },
         ];
@@ -3658,7 +3658,7 @@ describe('ToolLoopAgent', () => {
         expect(events).toEqual([
           'global-onStart',
           'global-onStepFinish',
-          'global-onFinish',
+          'global-onEnd',
         ]);
       });
 
@@ -3710,7 +3710,7 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async ({ runtimeContext }) => {
                 telemetryContexts.push(runtimeContext);
               },
-              onFinish: async event => {
+              onEnd: async event => {
                 telemetryContexts.push(
                   (event as { runtimeContext: unknown }).runtimeContext,
                 );
@@ -3772,8 +3772,8 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async () => {
                 events.push('integration-onStepFinish');
               },
-              onFinish: async () => {
-                events.push('integration-onFinish');
+              onEnd: async () => {
+                events.push('integration-onEnd');
               },
             },
           },
@@ -3788,7 +3788,7 @@ describe('ToolLoopAgent', () => {
           'agent-onStepFinish',
           'integration-onStepFinish',
           'agent-onFinish',
-          'integration-onFinish',
+          'integration-onEnd',
         ]);
       });
 
@@ -3819,7 +3819,7 @@ describe('ToolLoopAgent', () => {
               onStepFinish: async () => {
                 throw new Error('integration error');
               },
-              onFinish: async () => {
+              onEnd: async () => {
                 throw new Error('integration error');
               },
             },

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -240,7 +240,7 @@ export async function embedMany({
           providerMetadata,
           response: [response],
         },
-        callbacks: [onEnd, telemetryDispatcher.onFinish],
+        callbacks: [onEnd, telemetryDispatcher.onEnd],
       });
 
       return new DefaultEmbedManyResult({
@@ -366,7 +366,7 @@ export async function embedMany({
         providerMetadata,
         response: responses,
       },
-      callbacks: [onEnd, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultEmbedManyResult({

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -214,7 +214,7 @@ export async function embed({
         providerMetadata,
         response,
       },
-      callbacks: [onEnd, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultEmbedResult({

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -448,7 +448,7 @@ export async function generateObject<
         response,
         providerMetadata: resultProviderMetadata,
       },
-      callbacks: [onFinish, telemetryDispatcher.onFinish],
+      callbacks: [onFinish, telemetryDispatcher.onEnd],
     });
 
     return new DefaultGenerateObjectResult({

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -818,7 +818,7 @@ class DefaultStreamObjectResult<
                     },
                     providerMetadata,
                   },
-                  callbacks: [onFinish, telemetryDispatcher.onFinish],
+                  callbacks: [onFinish, telemetryDispatcher.onEnd],
                 });
               } catch (error) {
                 controller.enqueue({ type: 'error', error });

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -8548,7 +8548,7 @@ describe('generateText', () => {
             onStepFinish: ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onFinish: event => {
+            onEnd: event => {
               telemetryContexts.push(
                 (event as { runtimeContext: unknown }).runtimeContext,
               );
@@ -8612,7 +8612,7 @@ describe('generateText', () => {
             onStepFinish: ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
-            onFinish: event => {
+            onEnd: event => {
               telemetryContexts.push(
                 (event as { toolsContext: unknown }).toolsContext,
               );
@@ -8671,7 +8671,7 @@ describe('generateText', () => {
             onStepFinish: ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
-            onFinish: event => {
+            onEnd: event => {
               telemetryContexts.push(
                 (event as { toolsContext: unknown }).toolsContext,
               );
@@ -8712,7 +8712,7 @@ describe('generateText', () => {
             onStepFinish: ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onFinish: event => {
+            onEnd: event => {
               telemetryContexts.push(
                 (event as { runtimeContext: unknown }).runtimeContext,
               );
@@ -11366,8 +11366,8 @@ describe('generateText', () => {
             onStepFinish: async () => {
               events.push('onStepFinish');
             },
-            onFinish: async () => {
-              events.push('onFinish');
+            onEnd: async () => {
+              events.push('onEnd');
             },
           },
         },
@@ -11380,7 +11380,7 @@ describe('generateText', () => {
           "onToolExecutionStart",
           "onToolExecutionEnd",
           "onStepFinish",
-          "onFinish",
+          "onEnd",
         ]
       `);
     });
@@ -11396,8 +11396,8 @@ describe('generateText', () => {
           onStepFinish: async () => {
             events.push('global-onStepFinish');
           },
-          onFinish: async () => {
-            events.push('global-onFinish');
+          onEnd: async () => {
+            events.push('global-onEnd');
           },
         },
       ];
@@ -11415,7 +11415,7 @@ describe('generateText', () => {
       expect(events).toEqual([
         'global-onStart',
         'global-onStepFinish',
-        'global-onFinish',
+        'global-onEnd',
       ]);
     });
 
@@ -11478,8 +11478,8 @@ describe('generateText', () => {
             onStepFinish: async () => {
               events.push('integration-onStepFinish');
             },
-            onFinish: async () => {
-              events.push('integration-onFinish');
+            onEnd: async () => {
+              events.push('integration-onEnd');
             },
           },
         },
@@ -11491,7 +11491,7 @@ describe('generateText', () => {
         'user-onStepFinish',
         'integration-onStepFinish',
         'user-onFinish',
-        'integration-onFinish',
+        'integration-onEnd',
       ]);
     });
 
@@ -11512,7 +11512,7 @@ describe('generateText', () => {
             onStepFinish: async () => {
               throw new Error('integration error');
             },
-            onFinish: async () => {
+            onEnd: async () => {
               throw new Error('integration error');
             },
           },

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1165,7 +1165,7 @@ export async function generateText<
 
     await notify({
       event: onFinishEvent,
-      callbacks: [onFinish, telemetryDispatcher.onFinish],
+      callbacks: [onFinish, telemetryDispatcher.onEnd],
     });
 
     // parse output only if the last step was finished with "stop":

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test-d.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test-d.ts
@@ -53,7 +53,7 @@ describe('createRestrictedTelemetryDispatcher types', () => {
     expectTypeOf(telemetryDispatcher.onStepFinish).toMatchTypeOf<
       Callback<GenerateTextStepEndEvent<ToolSet, RuntimeContext>> | undefined
     >();
-    expectTypeOf(telemetryDispatcher.onFinish).toMatchTypeOf<
+    expectTypeOf(telemetryDispatcher.onEnd).toMatchTypeOf<
       Callback<GenerateTextEndEvent<ToolSet, RuntimeContext>> | undefined
     >();
   });

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test.ts
@@ -251,15 +251,15 @@ describe('createRestrictedTelemetryDispatcher', () => {
     expect(step.toolsContext).toEqual(toolsContext);
   });
 
-  it('includes configured runtimeContext for finish events and all steps without mutating source steps', async () => {
-    const onFinish = vi.fn();
+  it('includes configured runtimeContext for end events and all steps without mutating source steps', async () => {
+    const onEnd = vi.fn();
     const telemetryDispatcher = createRestrictedTelemetryDispatcher({
-      telemetry: { integrations: { onFinish } },
+      telemetry: { integrations: { onEnd } },
       includeRuntimeContext,
     });
     const step = createStepResult();
 
-    await telemetryDispatcher.onFinish?.({
+    await telemetryDispatcher.onEnd?.({
       ...createStepResult(),
       text: 'Hello',
       runtimeContext,
@@ -267,7 +267,7 @@ describe('createRestrictedTelemetryDispatcher', () => {
       totalUsage: createNullLanguageModelUsage(),
     } as any);
 
-    const telemetryEvent = onFinish.mock.calls[0][0];
+    const telemetryEvent = onEnd.mock.calls[0][0];
 
     expect(telemetryEvent.runtimeContext).toEqual({
       requestId: 'request-123',
@@ -279,16 +279,16 @@ describe('createRestrictedTelemetryDispatcher', () => {
     expect(step.runtimeContext).toEqual(runtimeContext);
   });
 
-  it('filters toolsContext for finish events and all steps without mutating source steps', async () => {
-    const onFinish = vi.fn();
+  it('filters toolsContext for end events and all steps without mutating source steps', async () => {
+    const onEnd = vi.fn();
     const telemetryDispatcher = createRestrictedTelemetryDispatcher({
-      telemetry: { integrations: { onFinish } },
+      telemetry: { integrations: { onEnd } },
       includeRuntimeContext: undefined,
       includeToolsContext,
     });
     const step = createStepResult({ toolContexts: toolsContext });
 
-    await telemetryDispatcher.onFinish?.({
+    await telemetryDispatcher.onEnd?.({
       ...createStepResult({ toolContexts: toolsContext }),
       text: 'Hello',
       runtimeContext,
@@ -297,7 +297,7 @@ describe('createRestrictedTelemetryDispatcher', () => {
       totalUsage: createNullLanguageModelUsage(),
     } as any);
 
-    const telemetryEvent = onFinish.mock.calls[0][0];
+    const telemetryEvent = onEnd.mock.calls[0][0];
 
     expect(telemetryEvent.toolsContext).toEqual(filteredToolsContext);
     expect(telemetryEvent.steps[0].toolsContext).toEqual(filteredToolsContext);

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.ts
@@ -37,14 +37,14 @@ export type RestrictedTelemetryDispatcher<
   | 'onStart'
   | 'onStepStart'
   | 'onStepFinish'
-  | 'onFinish'
+  | 'onEnd'
   | 'onToolExecutionStart'
   | 'onToolExecutionEnd'
 > & {
   onStart: GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
   onStepStart: GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
   onStepFinish: GenerateTextOnStepFinishCallback<TOOLS, RUNTIME_CONTEXT>;
-  onFinish: GenerateTextOnFinishCallback<TOOLS, RUNTIME_CONTEXT>;
+  onEnd: GenerateTextOnFinishCallback<TOOLS, RUNTIME_CONTEXT>;
   onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
   onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
 };
@@ -222,8 +222,8 @@ export function createRestrictedTelemetryDispatcher<
           includeToolsContext,
         }),
       ),
-    onFinish: event =>
-      telemetryDispatcher.onFinish?.({
+    onEnd: event =>
+      telemetryDispatcher.onEnd?.({
         ...event,
         runtimeContext: filterIncludedContext({
           context: event.runtimeContext,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6747,7 +6747,7 @@ describe('streamText', () => {
             onStepFinish: async ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onFinish: async event => {
+            onEnd: async event => {
               telemetryContexts.push(
                 (event as { runtimeContext: unknown }).runtimeContext,
               );
@@ -6808,7 +6808,7 @@ describe('streamText', () => {
             onStepFinish: async ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
-            onFinish: async event => {
+            onEnd: async event => {
               telemetryContexts.push(
                 (event as { toolsContext: unknown }).toolsContext,
               );
@@ -6851,7 +6851,7 @@ describe('streamText', () => {
             onStepFinish: async ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onFinish: async event => {
+            onEnd: async event => {
               telemetryContexts.push(
                 (event as { runtimeContext: unknown }).runtimeContext,
               );
@@ -25902,8 +25902,8 @@ describe('streamText', () => {
             onStepFinish: async () => {
               events.push('onStepFinish');
             },
-            onFinish: async () => {
-              events.push('onFinish');
+            onEnd: async () => {
+              events.push('onEnd');
             },
           },
         },
@@ -25918,7 +25918,7 @@ describe('streamText', () => {
           "onToolExecutionStart",
           "onToolExecutionEnd",
           "onStepFinish",
-          "onFinish",
+          "onEnd",
         ]
       `);
     });
@@ -25934,8 +25934,8 @@ describe('streamText', () => {
           onStepFinish: async () => {
             events.push('global-onStepFinish');
           },
-          onFinish: async () => {
-            events.push('global-onFinish');
+          onEnd: async () => {
+            events.push('global-onEnd');
           },
         },
       ];
@@ -25951,7 +25951,7 @@ describe('streamText', () => {
       expect(events).toEqual([
         'global-onStart',
         'global-onStepFinish',
-        'global-onFinish',
+        'global-onEnd',
       ]);
     });
 
@@ -26008,8 +26008,8 @@ describe('streamText', () => {
             onStepFinish: async () => {
               events.push('integration-onStepFinish');
             },
-            onFinish: async () => {
-              events.push('integration-onFinish');
+            onEnd: async () => {
+              events.push('integration-onEnd');
             },
           },
         },
@@ -26023,7 +26023,7 @@ describe('streamText', () => {
         'user-onStepFinish',
         'integration-onStepFinish',
         'user-onFinish',
-        'integration-onFinish',
+        'integration-onEnd',
       ]);
     });
 
@@ -26040,7 +26040,7 @@ describe('streamText', () => {
             onStepFinish: async () => {
               throw new Error('integration error');
             },
-            onFinish: async () => {
+            onEnd: async () => {
               throw new Error('integration error');
             },
           },

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1274,7 +1274,7 @@ class DefaultStreamTextResult<
               providerMetadata: finalStep.providerMetadata,
               steps: recordedSteps,
             },
-            callbacks: [onFinish, telemetryDispatcher.onFinish],
+            callbacks: [onFinish, telemetryDispatcher.onEnd],
           });
         } catch (error) {
           controller.error(error);

--- a/packages/ai/src/rerank/rerank.ts
+++ b/packages/ai/src/rerank/rerank.ts
@@ -166,7 +166,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           modelId: model.modelId,
         },
       },
-      callbacks: [onEnd, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultRerankResult({
@@ -284,7 +284,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           body: response?.body,
         },
       },
-      callbacks: [onEnd, telemetryDispatcher.onFinish],
+      callbacks: [onEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultRerankResult({

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -33,7 +33,7 @@ describe('createTelemetryDispatcher', () => {
     expect(telemetry.onEmbedEnd).toBeDefined();
     expect(telemetry.onRerankStart).toBeDefined();
     expect(telemetry.onRerankEnd).toBeDefined();
-    expect(telemetry.onFinish).toBeDefined();
+    expect(telemetry.onEnd).toBeDefined();
     expect(telemetry.onError).toBeDefined();
     expect(telemetry.executeTool).toBeUndefined();
 
@@ -58,12 +58,12 @@ describe('createTelemetryDispatcher', () => {
   it('accepts an array of integrations', () => {
     const telemetry = createTelemetryDispatcher({
       telemetry: {
-        integrations: [{ onStart: vi.fn() }, { onFinish: vi.fn() }],
+        integrations: [{ onStart: vi.fn() }, { onEnd: vi.fn() }],
       },
     });
 
     expect(telemetry.onStart).toBeDefined();
-    expect(telemetry.onFinish).toBeDefined();
+    expect(telemetry.onEnd).toBeDefined();
   });
 
   it('returns no-op listeners for methods that no integration implements', async () => {
@@ -153,7 +153,7 @@ describe('createTelemetryDispatcher', () => {
       onEmbedEnd: vi.fn(),
       onRerankStart: vi.fn(),
       onRerankEnd: vi.fn(),
-      onFinish: vi.fn(),
+      onEnd: vi.fn(),
       onError: vi.fn(),
     };
 
@@ -175,7 +175,7 @@ describe('createTelemetryDispatcher', () => {
     await telemetry.onEmbedEnd!(dummyEvent);
     await telemetry.onRerankStart!(dummyEvent);
     await telemetry.onRerankEnd!(dummyEvent);
-    await telemetry.onFinish!(dummyEvent);
+    await telemetry.onEnd!(dummyEvent);
     await telemetry.onError!(dummyEvent);
 
     expect(integration.onStart).toHaveBeenCalledOnce();
@@ -192,7 +192,7 @@ describe('createTelemetryDispatcher', () => {
     expect(integration.onEmbedEnd).toHaveBeenCalledOnce();
     expect(integration.onRerankStart).toHaveBeenCalledOnce();
     expect(integration.onRerankEnd).toHaveBeenCalledOnce();
-    expect(integration.onFinish).toHaveBeenCalledOnce();
+    expect(integration.onEnd).toHaveBeenCalledOnce();
     expect(integration.onError).toHaveBeenCalledOnce();
   });
 
@@ -202,7 +202,7 @@ describe('createTelemetryDispatcher', () => {
     });
 
     expect(telemetry.onStart).toBeDefined();
-    expect(telemetry.onFinish).toBeDefined();
+    expect(telemetry.onEnd).toBeDefined();
 
     await expect(telemetry.onStart!(dummyEvent)).resolves.toBeUndefined();
   });
@@ -222,7 +222,7 @@ describe('createTelemetryDispatcher', () => {
         onEmbedEnd: vi.fn(),
         onRerankStart: vi.fn(),
         onRerankEnd: vi.fn(),
-        onFinish: vi.fn(),
+        onEnd: vi.fn(),
         onError: vi.fn(),
       };
 
@@ -242,7 +242,7 @@ describe('createTelemetryDispatcher', () => {
       expect(telemetry.onEmbedEnd).toBeUndefined();
       expect(telemetry.onRerankStart).toBeUndefined();
       expect(telemetry.onRerankEnd).toBeUndefined();
-      expect(telemetry.onFinish).toBeUndefined();
+      expect(telemetry.onEnd).toBeUndefined();
       expect(telemetry.onError).toBeUndefined();
       expect(telemetry.executeTool).toBeUndefined();
     });
@@ -409,8 +409,8 @@ describe('createTelemetryDispatcher', () => {
           this.calls.push('start');
         }
 
-        async onFinish() {
-          this.calls.push('finish');
+        async onEnd() {
+          this.calls.push('end');
         }
       }
 
@@ -420,9 +420,9 @@ describe('createTelemetryDispatcher', () => {
       });
 
       await telemetry.onStart!(dummyEvent);
-      await telemetry.onFinish!(dummyEvent);
+      await telemetry.onEnd!(dummyEvent);
 
-      expect(instance.calls).toEqual(['start', 'finish']);
+      expect(instance.calls).toEqual(['start', 'end']);
     });
   });
 

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -131,7 +131,7 @@ export function createTelemetryDispatcher({
     onEmbedEnd: mergeTelemetryCallback('onEmbedEnd'),
     onRerankStart: mergeTelemetryCallback('onRerankStart'),
     onRerankEnd: mergeTelemetryCallback('onRerankEnd'),
-    onFinish: mergeTelemetryCallback('onFinish'),
+    onEnd: mergeTelemetryCallback('onEnd'),
     onError: mergeTelemetryCallback('onError'),
 
     /**

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -15,7 +15,7 @@ export type TelemetryDiagnosticEventType =
   | 'onEmbedEnd'
   | 'onRerankStart'
   | 'onRerankEnd'
-  | 'onFinish'
+  | 'onEnd'
   | 'onError';
 
 export type TelemetryDiagnosticChannelMessage<EVENT = unknown> = {

--- a/packages/ai/src/telemetry/telemetry-registry.test.ts
+++ b/packages/ai/src/telemetry/telemetry-registry.test.ts
@@ -20,7 +20,7 @@ describe('registerTelemetry', () => {
 
   it('adds multiple integrations in registration order', () => {
     const integration1: Telemetry = { onStart: vi.fn() };
-    const integration2: Telemetry = { onFinish: vi.fn() };
+    const integration2: Telemetry = { onEnd: vi.fn() };
 
     registerTelemetry(integration1);
     registerTelemetry(integration2);
@@ -33,7 +33,7 @@ describe('registerTelemetry', () => {
 
   it('adds multiple integrations passed in a single call', () => {
     const integration1: Telemetry = { onStart: vi.fn() };
-    const integration2: Telemetry = { onFinish: vi.fn() };
+    const integration2: Telemetry = { onEnd: vi.fn() };
     const integration3: Telemetry = { onError: vi.fn() };
 
     registerTelemetry(integration1, integration2, integration3);

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -49,7 +49,7 @@ type OperationStartEvent =
   | EmbedStartEvent
   | RerankStartEvent;
 
-type OperationFinishEvent =
+type OperationEndEvent =
   | GenerateTextEndEvent<ToolSet>
   | GenerateObjectEndEvent<unknown>
   | EmbedEndEvent
@@ -70,7 +70,7 @@ export interface TelemetryDispatcher {
   onEmbedEnd?: Callback<EmbeddingModelCallEndEvent>;
   onRerankStart?: Callback<RerankingModelCallStartEvent>;
   onRerankEnd?: Callback<RerankingModelCallEndEvent>;
-  onFinish?: Callback<OperationFinishEvent>;
+  onEnd?: Callback<OperationEndEvent>;
   onError?: Callback<unknown>;
   executeTool?: Telemetry['executeTool'];
 }
@@ -198,7 +198,7 @@ export interface Telemetry {
    *
    * Use the event shape or `operationId` to distinguish between operation types.
    */
-  onFinish?: Callback<InferTelemetryEvent<OperationFinishEvent>>;
+  onEnd?: Callback<InferTelemetryEvent<OperationEndEvent>>;
 
   /**
    * Called when an unrecoverable error occurs during the generation lifecycle.

--- a/packages/devtools/src/integration.test.ts
+++ b/packages/devtools/src/integration.test.ts
@@ -441,14 +441,14 @@ describe('DevToolsTelemetry', () => {
     });
   });
 
-  describe('onFinish', () => {
+  describe('onEnd', () => {
     it('cleans up call state so subsequent events are ignored', async () => {
       const integration = createIntegration();
 
       await integration.onStart!(makeStartEvent());
       await integration.onStepStart!(makeStepStartEvent());
       await integration.onStepFinish!(makeStepFinishEvent());
-      await integration.onFinish!({ callId: 'call-1' } as any);
+      await integration.onEnd!({ callId: 'call-1' } as any);
 
       mockCreateStep.mockClear();
       await integration.onStepStart!(makeStepStartEvent());

--- a/packages/devtools/src/integration.ts
+++ b/packages/devtools/src/integration.ts
@@ -451,9 +451,9 @@ export function DevToolsTelemetry(): Telemetry {
       state.stepStates.delete(stepResult.stepNumber);
     },
 
-    onFinish: async event => {
-      const finishEvent = event as { callId: string };
-      callStates.delete(finishEvent.callId);
+    onEnd: async event => {
+      const endEvent = event as { callId: string };
+      callStates.delete(endEvent.callId);
     },
 
     onError: async error => {

--- a/packages/otel/src/legacy-open-telemetry.test.ts
+++ b/packages/otel/src/legacy-open-telemetry.test.ts
@@ -286,7 +286,7 @@ function makeFinishEvent(overrides?: Record<string, unknown>) {
       },
     },
     ...overrides,
-  } as Parameters<NonNullable<Telemetry['onFinish']>>[0];
+  } as Parameters<NonNullable<Telemetry['onEnd']>>[0];
 }
 
 function makeToolCallStartEvent(overrides?: Record<string, unknown>) {
@@ -770,12 +770,12 @@ describe('LegacyOpenTelemetry', () => {
     });
   });
 
-  describe('onFinish', () => {
+  describe('onEnd', () => {
     it('ends the root span', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       const rootSpan = tracer.spans[0];
       expect(rootSpan.ended).toBe(true);
@@ -785,7 +785,7 @@ describe('LegacyOpenTelemetry', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(
+      otelIntegration.onEnd!(
         makeFinishEvent({
           totalUsage: {
             inputTokens: 50,
@@ -806,7 +806,7 @@ describe('LegacyOpenTelemetry', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       const rootSpan = tracer.spans[0];
       const setAttrsCall = getSetAttributesArg(rootSpan);
@@ -817,7 +817,7 @@ describe('LegacyOpenTelemetry', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(
+      otelIntegration.onEnd!(
         makeFinishEvent({
           files: [
             {
@@ -845,14 +845,14 @@ describe('LegacyOpenTelemetry', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       otelIntegration.onStepStart!(makeStepStartEvent());
       expect(tracer.spans).toHaveLength(2);
     });
 
     it('does nothing without prior onStart', () => {
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       expect(tracer.spans).toHaveLength(0);
     });
@@ -1092,7 +1092,7 @@ describe('LegacyOpenTelemetry', () => {
       otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
       otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       expect(tracer.spans).toHaveLength(3);
       expect(tracer.spans[0].name).toBe('ai.generateText');
@@ -1115,7 +1115,7 @@ describe('LegacyOpenTelemetry', () => {
       otelIntegration.onStepStart!(makeStepStartEvent({ steps: [{}] }));
       otelIntegration.onStepFinish!(makeStepFinishEvent({ stepNumber: 1 }));
 
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       expect(tracer.spans).toHaveLength(4);
       expect(tracer.spans[0].name).toBe('ai.generateText');
@@ -1143,7 +1143,7 @@ describe('LegacyOpenTelemetry', () => {
       expect(tracer.spans).toHaveLength(4);
 
       otelIntegration.onStepFinish!(makeStepFinishEvent({ callId: callId1 }));
-      otelIntegration.onFinish!(makeFinishEvent({ callId: callId1 }));
+      otelIntegration.onEnd!(makeFinishEvent({ callId: callId1 }));
 
       expect(tracer.spans[0].ended).toBe(true);
       expect(tracer.spans[2].ended).toBe(true);
@@ -1152,7 +1152,7 @@ describe('LegacyOpenTelemetry', () => {
       expect(tracer.spans[3].ended).toBe(false);
 
       otelIntegration.onStepFinish!(makeStepFinishEvent({ callId: callId2 }));
-      otelIntegration.onFinish!(makeFinishEvent({ callId: callId2 }));
+      otelIntegration.onEnd!(makeFinishEvent({ callId: callId2 }));
 
       for (const span of tracer.spans) {
         expect(span.ended).toBe(true);
@@ -1184,7 +1184,7 @@ describe('LegacyOpenTelemetry', () => {
       );
 
       otelIntegration.onStepFinish!(makeStepFinishEvent());
-      otelIntegration.onFinish!(makeFinishEvent());
+      otelIntegration.onEnd!(makeFinishEvent());
 
       expect(tracer.spans).toHaveLength(2);
       expect(tracer.spans[0].name).toBe('ai.streamText');

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -718,7 +718,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     state.stepContext = undefined;
   }
 
-  onFinish(
+  onEnd(
     event:
       | GenerateTextEndEvent<ToolSet>
       | GenerateObjectEndEvent<unknown>
@@ -732,12 +732,12 @@ export class LegacyOpenTelemetry implements Telemetry {
       state.operationId === 'ai.embed' ||
       state.operationId === 'ai.embedMany'
     ) {
-      this.onEmbedOperationFinish(event as EmbedEndEvent);
+      this.onEmbedOperationEnd(event as EmbedEndEvent);
       return;
     }
 
     if (state.operationId === 'ai.rerank') {
-      this.onRerankOperationFinish(event as RerankEndEvent);
+      this.onRerankOperationEnd(event as RerankEndEvent);
       return;
     }
 
@@ -745,14 +745,14 @@ export class LegacyOpenTelemetry implements Telemetry {
       state.operationId === 'ai.generateObject' ||
       state.operationId === 'ai.streamObject'
     ) {
-      this.onObjectOperationFinish(event as GenerateObjectEndEvent<unknown>);
+      this.onObjectOperationEnd(event as GenerateObjectEndEvent<unknown>);
       return;
     }
 
-    this.onGenerateFinish(event as GenerateTextEndEvent<ToolSet>);
+    this.onGenerateEnd(event as GenerateTextEndEvent<ToolSet>);
   }
 
-  private onGenerateFinish(event: GenerateTextEndEvent<ToolSet>): void {
+  private onGenerateEnd(event: GenerateTextEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -825,9 +825,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onObjectOperationFinish(
-    event: GenerateObjectEndEvent<unknown>,
-  ): void {
+  private onObjectOperationEnd(event: GenerateObjectEndEvent<unknown>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -858,7 +856,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onEmbedOperationFinish(event: EmbedEndEvent): void {
+  private onEmbedOperationEnd(event: EmbedEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -990,7 +988,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     });
   }
 
-  private onRerankOperationFinish(event: RerankEndEvent): void {
+  private onRerankOperationEnd(event: RerankEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -313,7 +313,7 @@ function makeFinishEvent(overrides?: Record<string, unknown>) {
       },
     },
     ...overrides,
-  } as Parameters<NonNullable<Telemetry['onFinish']>>[0];
+  } as Parameters<NonNullable<Telemetry['onEnd']>>[0];
 }
 
 function makeToolCallStartEvent(overrides?: Record<string, unknown>) {
@@ -798,12 +798,12 @@ describe('OpenTelemetry', () => {
     });
   });
 
-  describe('onFinish (generateText)', () => {
+  describe('onEnd (generateText)', () => {
     it('sets total usage and output on root span', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
       integration.onStepFinish!(makeStepFinishEvent());
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       expect(serializeSpan(tracer.spans[0], tracer)).toMatchInlineSnapshot(`
         {
@@ -833,7 +833,7 @@ describe('OpenTelemetry', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
       integration.onStepFinish!(makeStepFinishEvent());
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       const rootSpan = tracer.spans[0];
       expect(parseJsonAttributes(rootSpan.attributes, 'gen_ai.output.messages'))
@@ -1141,7 +1141,7 @@ describe('OpenTelemetry', () => {
           providerMetadata: { openai: { response: 'metadata' } },
         }),
       );
-      integration.onFinish!(
+      integration.onEnd!(
         makeFinishEvent({
           totalUsage: detailedUsage,
           providerMetadata: { openai: { response: 'metadata' } },
@@ -1263,7 +1263,7 @@ describe('OpenTelemetry', () => {
       integration.onToolExecutionStart!(makeToolCallStartEvent());
       integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       integration.onStepFinish!(makeStepFinishEvent());
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       expect(serializeTrace(tracer)).toMatchInlineSnapshot(`
         [
@@ -1346,7 +1346,7 @@ describe('OpenTelemetry', () => {
       integration.onToolExecutionStart!(makeToolCallStartEvent());
       integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       integration.onStepFinish!(makeStepFinishEvent());
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       expect(serializeTrace(tracer)).toMatchInlineSnapshot(`
         [
@@ -1494,7 +1494,7 @@ describe('OpenTelemetry', () => {
       integration.onLanguageModelCallEnd!(makeLanguageModelCallEndEvent());
       integration.onStepFinish!(makeStepFinishEvent({ stepNumber: 1 }));
 
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       expect(
         tracer.spans.map(s => ({
@@ -1537,7 +1537,7 @@ describe('OpenTelemetry', () => {
       integration.onLanguageModelCallStart!(makeLanguageModelCallStartEvent());
       integration.onLanguageModelCallEnd!(makeLanguageModelCallEndEvent());
       integration.onStepFinish!(makeStepFinishEvent());
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       expect(serializeTrace(tracer)).toMatchInlineSnapshot(`
         [
@@ -1625,7 +1625,7 @@ describe('OpenTelemetry', () => {
       integration.onLanguageModelCallEnd!(makeLanguageModelCallEndEvent());
       integration.onStepFinish!(makeStepFinishEvent({ stepNumber: 1 }));
 
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       expect(serializeTrace(tracer)).toMatchInlineSnapshot(`
         [
@@ -1731,7 +1731,7 @@ describe('OpenTelemetry', () => {
       integration.onToolExecutionStart!(makeToolCallStartEvent());
       integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       integration.onStepFinish!(makeStepFinishEvent());
-      integration.onFinish!(makeFinishEvent());
+      integration.onEnd!(makeFinishEvent());
 
       for (const span of tracer.spans) {
         for (const key of Object.keys(span.attributes)) {

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -826,7 +826,7 @@ export class OpenTelemetry implements Telemetry {
     state.stepContext = undefined;
   }
 
-  onFinish(
+  onEnd(
     event:
       | GenerateTextEndEvent<ToolSet>
       | GenerateObjectEndEvent<unknown>
@@ -840,12 +840,12 @@ export class OpenTelemetry implements Telemetry {
       state.operationId === 'ai.embed' ||
       state.operationId === 'ai.embedMany'
     ) {
-      this.onEmbedOperationFinish(event as EmbedEndEvent);
+      this.onEmbedOperationEnd(event as EmbedEndEvent);
       return;
     }
 
     if (state.operationId === 'ai.rerank') {
-      this.onRerankOperationFinish(event as RerankEndEvent);
+      this.onRerankOperationEnd(event as RerankEndEvent);
       return;
     }
 
@@ -853,14 +853,14 @@ export class OpenTelemetry implements Telemetry {
       state.operationId === 'ai.generateObject' ||
       state.operationId === 'ai.streamObject'
     ) {
-      this.onObjectOperationFinish(event as GenerateObjectEndEvent<unknown>);
+      this.onObjectOperationEnd(event as GenerateObjectEndEvent<unknown>);
       return;
     }
 
-    this.onGenerateFinish(event as GenerateTextEndEvent<ToolSet>);
+    this.onGenerateEnd(event as GenerateTextEndEvent<ToolSet>);
   }
 
-  private onGenerateFinish(event: GenerateTextEndEvent<ToolSet>): void {
+  private onGenerateEnd(event: GenerateTextEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -906,9 +906,7 @@ export class OpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onObjectOperationFinish(
-    event: GenerateObjectEndEvent<unknown>,
-  ): void {
+  private onObjectOperationEnd(event: GenerateObjectEndEvent<unknown>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -951,7 +949,7 @@ export class OpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onEmbedOperationFinish(event: EmbedEndEvent): void {
+  private onEmbedOperationEnd(event: EmbedEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -1129,7 +1127,7 @@ export class OpenTelemetry implements Telemetry {
     });
   }
 
-  private onRerankOperationFinish(event: RerankEndEvent): void {
+  private onRerankOperationEnd(event: RerankEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -1222,7 +1222,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
     });
   });
 
-  describe('onFinish', () => {
+  describe('onEnd', () => {
     describe('stream', () => {
       let mockModel: MockLanguageModelV4;
 
@@ -1374,8 +1374,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onStepFinish: async () => {
                 events.push('onStepFinish');
               },
-              onFinish: async () => {
-                events.push('onFinish');
+              onEnd: async () => {
+                events.push('onEnd');
               },
             },
           },
@@ -1395,7 +1395,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
           'onStepFinish',
           'onStepStart',
           'onStepFinish',
-          'onFinish',
+          'onEnd',
         ]);
       });
 
@@ -1443,7 +1443,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onToolExecutionStart: async event => {
                 toolStartEvent = event;
               },
-              onFinish: async event => {
+              onEnd: async event => {
                 finishEvent = event;
               },
             },
@@ -1488,8 +1488,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
             onStepFinish: async () => {
               events.push('global-onStepFinish');
             },
-            onFinish: async () => {
-              events.push('global-onFinish');
+            onEnd: async () => {
+              events.push('global-onEnd');
             },
           },
         ];
@@ -1523,7 +1523,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         expect(events).toEqual([
           'global-onStart',
           'global-onStepFinish',
-          'global-onFinish',
+          'global-onEnd',
         ]);
       });
 
@@ -1565,8 +1565,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onStepFinish: async () => {
                 events.push('integration-onStepFinish');
               },
-              onFinish: async () => {
-                events.push('integration-onFinish');
+              onEnd: async () => {
+                events.push('integration-onEnd');
               },
             },
           },
@@ -1584,7 +1584,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
           'agent-onStepFinish',
           'integration-onStepFinish',
           'agent-onFinish',
-          'integration-onFinish',
+          'integration-onEnd',
         ]);
       });
 
@@ -1615,7 +1615,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onStepFinish: async () => {
                 throw new Error('integration error');
               },
-              onFinish: async () => {
+              onEnd: async () => {
                 throw new Error('integration error');
               },
             },

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -2023,7 +2023,7 @@ export class WorkflowAgent<
             if (!wasAborted && steps.length > 0) {
               const telemetrySteps = steps.map(normalizeStepForTelemetry);
               const lastStep = telemetrySteps[telemetrySteps.length - 1];
-              await telemetryDispatcher.onFinish?.({
+              await telemetryDispatcher.onEnd?.({
                 ...lastStep,
                 steps: telemetrySteps,
                 totalUsage: aggregateUsage(steps),
@@ -2231,7 +2231,7 @@ export class WorkflowAgent<
     if (!wasAborted && steps.length > 0) {
       const telemetrySteps = steps.map(normalizeStepForTelemetry);
       const lastStep = telemetrySteps[telemetrySteps.length - 1];
-      await telemetryDispatcher.onFinish?.({
+      await telemetryDispatcher.onEnd?.({
         ...lastStep,
         steps: telemetrySteps,
         totalUsage: aggregateUsage(steps),


### PR DESCRIPTION
## Background
We are standardizing on Start/End nomenclature.

## Summary

* Rename telemetry `onFinish` to `onEnd`
* Rename `OperationFinishEvent` to `OperationEndEvent`