### PR TITLE
test(codemod): bump CI test timeout to 30s

### DIFF
--- a/packages/codemod/vitest.config.ts
+++ b/packages/codemod/vitest.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
     // Codemod tests do CPU-heavy TypeScript syntax validation and can exceed
     // Vitest's default 5s timeout on saturated CI runners, especially in the
     // Node 24 matrix where the root test job runs many packages concurrently.
+    // See https://github.com/vercel/ai/issues/15255.
     maxWorkers: process.env.CI ? 2 : undefined,
-    testTimeout: process.env.CI ? 15_000 : 5_000,
+    testTimeout: process.env.CI ? 30_000 : 5_000,
   },
 });


### PR DESCRIPTION
- Short-term mitigation for the flaky `remove-await-fn.test.ts > 'transforms correctly'` test, which is responsible for every CI re-run-and-pass on `main` over the past few days (see #15255).
- Bumps codemod CI timeout from 15s → 30s. Local timeout (5s) unchanged.

Towards #15255.