### PR TITLE
feat(xai): support 'none' and 'medium' reasoning effort, curate model IDs

### DIFF
--- a/.changeset/xai-reasoning-effort-none.md
+++ b/.changeset/xai-reasoning-effort-none.md
@@ -1,0 +1,47 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): support `'none'` and `'medium'` reasoning effort for `grok-4.3`,
+and curate the model ID autocomplete list
+
+`grok-4.3` accepts `reasoning_effort` of `"none" | "low" | "medium" | "high"`,
+where `"none"` disables reasoning entirely (no thinking tokens) and `"medium"`
+provides more thinking for less-latency-sensitive applications.
+
+- Adds `'none'` to the allowed values for `providerOptions.xai.reasoningEffort`
+  on both the chat (`xai()`) and responses (`xai.responses()`) language models.
+- Adds `'medium'` to the chat model's `reasoningEffort` enum (the responses
+  model already supported it).
+- Top-level `reasoning: 'medium'` now maps to `reasoning_effort: 'medium'` for
+  the chat model (previously it was coerced to `'low'` because `'medium'` was
+  not a valid value).
+
+In addition, the `XaiChatModelId` and `XaiResponsesModelId` autocomplete unions
+have been trimmed to xAI's current model lineup
+([docs](https://docs.x.ai/docs/models)):
+
+- `grok-4.20-0309-non-reasoning`
+- `grok-4.20-0309-reasoning`
+- `grok-4.3`
+- `grok-latest`
+
+Older entries (`grok-3*`, `grok-4`, `grok-4-0709`, `grok-4-latest`,
+`grok-4-1-fast-*`, `grok-4-fast-*`, `grok-code-fast-1`, and
+`grok-4.20-multi-agent-0309`) have been removed from the autocomplete list.
+This is **not** a runtime change — the model ID type is still open
+(`(string & {})`), so passing any model ID that the xAI API accepts continues
+to work; only IDE autocomplete is affected.
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+
+await generateText({
+  model: xai('grok-4.3'),
+  prompt: 'Hi',
+  providerOptions: {
+    xai: { reasoningEffort: 'none' },
+  },
+});
+```

--- a/.changeset/xai-reasoning-effort-none.md
+++ b/.changeset/xai-reasoning-effort-none.md
@@ -21,8 +21,8 @@ In addition, the `XaiChatModelId` and `XaiResponsesModelId` autocomplete unions
 have been trimmed to xAI's current model lineup
 ([docs](https://docs.x.ai/docs/models)):
 
-- `grok-4.20-0309-non-reasoning`
-- `grok-4.20-0309-reasoning`
+- `grok-4.20-non-reasoning`
+- `grok-4.20-reasoning`
 - `grok-4.3`
 - `grok-latest`
 

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -99,6 +99,45 @@ xAI language models can also be used in the `streamText` function
 and support structured data generation with [`Output`](/docs/reference/ai-sdk-core/output)
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Reasoning Effort
+
+For reasoning-capable models you can control how much effort the model spends
+thinking before responding via `providerOptions.xai.reasoningEffort`. This
+works for both the Responses API (default) and the Chat Completions API
+(`xai.chat()`).
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: xai('grok-4.3'),
+  prompt: 'Explain quantum entanglement.',
+  providerOptions: {
+    xai: { reasoningEffort: 'medium' },
+  },
+});
+```
+
+Supported values:
+
+- `'none'` — Disables reasoning entirely; no thinking tokens are used. Best
+  for simple use cases that need a near-instant response. Supported by
+  `grok-4.3` and newer reasoning models.
+- `'low'` (default) — Uses some reasoning tokens, but still fast. Good for
+  general agentic use and tool calling.
+- `'medium'` — More thinking for less-latency-sensitive applications such as
+  complex data analysis and long-context reasoning.
+- `'high'` — More reasoning tokens for deeper thinking. Suited for very
+  challenging problems, complex math, multi-step logic, and competition-level
+  tasks.
+
+<Note>
+  Not every Grok model accepts every value. See xAI's [reasoning
+  docs](https://docs.x.ai/docs/guides/reasoning) for the values supported by
+  your selected model. `'none'` requires `grok-4.3` or newer.
+</Note>
+
 ## Responses API (Agentic Tools)
 
 The xAI Responses API is the default when using `xai(modelId)`. You can also use `xai.responses(modelId)` explicitly. This enables the model to autonomously orchestrate tool calls and research on xAI's servers.
@@ -416,9 +455,9 @@ const result = await generateText({
 
 The following provider options are available:
 
-- **reasoningEffort** _'low' | 'medium' | 'high'_
+- **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage.
+  Control the reasoning effort for the model. See [Reasoning Effort](#reasoning-effort) for details on each value. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
 
 - **logprobs** _boolean_
 

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod/v4';
 
 export type XaiResponsesModelId =
-  | 'grok-4.20-0309-non-reasoning'
-  | 'grok-4.20-0309-reasoning'
+  | 'grok-4.20-non-reasoning'
+  | 'grok-4.20-reasoning'
   | 'grok-4.3'
   | 'grok-latest'
   | (string & {});

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -1,14 +1,10 @@
 import { z } from 'zod/v4';
 
 export type XaiResponsesModelId =
-  | 'grok-4-1-fast-reasoning'
-  | 'grok-4-1-fast-non-reasoning'
-  | 'grok-4'
-  | 'grok-4-fast-non-reasoning'
-  | 'grok-4-fast-reasoning'
   | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-0309-reasoning'
-  | 'grok-4.20-multi-agent-0309'
+  | 'grok-4.3'
+  | 'grok-latest'
   | (string & {});
 
 /**
@@ -17,9 +13,13 @@ export type XaiResponsesModelId =
 export const xaiLanguageModelResponsesOptions = z.object({
   /**
    * Constrains how hard a reasoning model thinks before responding.
-   * Possible values are `low` (uses fewer reasoning tokens), `medium` and `high` (uses more reasoning tokens).
+   * Possible values are `none` (disables reasoning entirely; supported by
+   * `grok-4.3` and newer reasoning models), `low` (uses fewer reasoning
+   * tokens), `medium`, and `high` (uses more reasoning tokens).
+   *
+   * @see https://docs.x.ai/docs/guides/reasoning
    */
-  reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   reasoningSummary: z.enum(['auto', 'concise', 'detailed']).optional(),
   logprobs: z.boolean().optional(),
   topLogprobs: z.number().int().min(0).max(8).optional(),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -582,6 +582,29 @@ describe('XaiResponsesLanguageModel', () => {
           expect(requestBody.reasoning.effort).toBe('high');
         });
 
+        it('reasoningEffort: "none"', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.3',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                reasoningEffort: 'none',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.effort).toBe('none');
+        });
+
         it('reasoningSummary', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/xai-chat-language-model-options.ts
+++ b/packages/xai/src/xai-chat-language-model-options.ts
@@ -2,8 +2,8 @@ import { z } from 'zod/v4';
 
 // https://docs.x.ai/docs/models
 export type XaiChatModelId =
-  | 'grok-4.20-0309-non-reasoning'
-  | 'grok-4.20-0309-reasoning'
+  | 'grok-4.20-non-reasoning'
+  | 'grok-4.20-reasoning'
   | 'grok-4.3'
   | 'grok-latest'
   | (string & {});

--- a/packages/xai/src/xai-chat-language-model-options.ts
+++ b/packages/xai/src/xai-chat-language-model-options.ts
@@ -2,21 +2,10 @@ import { z } from 'zod/v4';
 
 // https://docs.x.ai/docs/models
 export type XaiChatModelId =
-  | 'grok-4-1-fast-reasoning'
-  | 'grok-4-1-fast-non-reasoning'
-  | 'grok-4-fast-non-reasoning'
-  | 'grok-4-fast-reasoning'
   | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-0309-reasoning'
-  | 'grok-4.20-multi-agent-0309'
-  | 'grok-code-fast-1'
-  | 'grok-4'
-  | 'grok-4-0709'
-  | 'grok-4-latest'
-  | 'grok-3'
-  | 'grok-3-latest'
-  | 'grok-3-mini'
-  | 'grok-3-mini-latest'
+  | 'grok-4.3'
+  | 'grok-latest'
   | (string & {});
 
 // search source schemas
@@ -61,7 +50,21 @@ const searchSourceSchema = z.discriminatedUnion('type', [
 
 // xai-specific provider options
 export const xaiLanguageModelChatOptions = z.object({
-  reasoningEffort: z.enum(['low', 'high']).optional(),
+  /**
+   * Constrains how hard a reasoning model thinks before responding.
+   *
+   * - `none`: Disables reasoning entirely (supported by `grok-4.3` and newer
+   *   reasoning models). When set, no thinking tokens are used.
+   * - `low` (default): Uses some reasoning tokens, but still fast.
+   * - `medium`: More thinking for less-latency-sensitive applications.
+   * - `high`: Uses more reasoning tokens for deeper thinking.
+   *
+   * Note: Not every Grok model accepts every value. Refer to xAI's docs for
+   * the values supported by your selected model.
+   *
+   * @see https://docs.x.ai/docs/guides/reasoning
+   */
+  reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   logprobs: z.boolean().optional(),
   topLogprobs: z.number().int().min(0).max(8).optional(),
 

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1231,6 +1231,21 @@ describe('XaiChatLanguageModel', () => {
       `);
     });
 
+    it('should pass reasoning_effort: "none" via providerOptions', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await reasoningModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: { reasoningEffort: 'none' },
+        },
+      });
+
+      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+        'none',
+      );
+    });
+
     it('should map top-level reasoning to reasoning_effort', async () => {
       prepareJsonFixtureResponse('xai-text');
 
@@ -1244,7 +1259,7 @@ describe('XaiChatLanguageModel', () => {
       );
     });
 
-    it('should coerce top-level reasoning medium to low', async () => {
+    it('should map top-level reasoning medium to reasoning_effort: "medium"', async () => {
       prepareJsonFixtureResponse('xai-text');
 
       await reasoningModel.doGenerate({
@@ -1253,7 +1268,22 @@ describe('XaiChatLanguageModel', () => {
       });
 
       expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
-        'low',
+        'medium',
+      );
+    });
+
+    it('should pass reasoning_effort: "medium" via providerOptions', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await reasoningModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: { reasoningEffort: 'medium' },
+        },
+      });
+
+      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+        'medium',
       );
     });
 

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -163,7 +163,7 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
                 effortMap: {
                   minimal: 'low',
                   low: 'low',
-                  medium: 'low',
+                  medium: 'medium',
                   high: 'high',
                   xhigh: 'high',
                 },


### PR DESCRIPTION
## Background

xAI's `grok-4.3` accepts a `reasoning_effort` of `"none" | "low" | "medium" | "high"` ([docs](https://docs.x.ai/docs/guides/reasoning)), where:

- `"none"` disables reasoning entirely (no thinking tokens — useful for simple use cases requiring near-instant responses).
- `"medium"` provides more thinking for less-latency-sensitive applications.

Today the `@ai-sdk/xai` Zod schema for `providerOptions.xai.reasoningEffort` only accepts `'low' | 'high'` on the chat model and `'low' | 'medium' | 'high'` on the responses model, so `'none'` is rejected by validation before the request ever hits xAI, and `'medium'` is missing entirely on the chat model.

autocomplete unions had drifted from xAI's [current model lineup](https://docs.x.ai/docs/models). Many of the listed models are being [retired on May 15, 2026](https://docs.x.ai/developers/migration/may-15-retirement) (`grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`), the `grok-3*` family is no longer in the current lineup, and the current flagship `grok-4.3` was missing.

## Summary

**Reasoning effort:**

- Add `'none'` to the allowed values for `providerOptions.xai.reasoningEffort`
- Add `'medium'` to the chat model's `reasoningEffort` enum (the responses model already supported it).
- Top-level `reasoning: 'medium'` now maps to `reasoning_effort: 'medium'` for the chat model (previously coerced to `'low'` because `'medium'` was not a valid value).

**Model ID curation:**

 autocomplete unions to xAI's current lineup:

- `grok-4.20-0309-non-reasoning`
- `grok-4.20-0309-reasoning`
- `grok-4.3`
- `grok-latest`

Removed entries: `grok-3*`, `grok-4`, `grok-4-0709`, `grok-4-latest`, `grok-4-1-fast-*`, `grok-4-fast-*`, `grok-code-fast-1`, `grok-4.20-multi-agent-0309`.

### Usage

```ts
import { xai } from '@ai-sdk/xai';
import { generateText } from 'ai';

await generateText({
  model: xai('grok-4.3'),
  prompt: 'Hi',
  providerOptions: {
    xai: { reasoningEffort: 'none' },
  },
});
```

## Manual Verification

- `pnpm --filter @ai-sdk/xai test:node` → 316/316 passing locally. 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged) — _will sign before merge_
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features) — _see Future Work; the existing xAI provider docs page does not currently document `reasoningEffort` at all_
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

no future work