### PR TITLE
fix(xai): omit unsupported additionalProperties false

### DIFF
--- a/.changeset/xai-tool-schema-additional-properties.md
+++ b/.changeset/xai-tool-schema-additional-properties.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Remove unsupported `additionalProperties: false` entries from xAI function tool schemas.

--- a/packages/xai/src/remove-additional-properties-false.ts
+++ b/packages/xai/src/remove-additional-properties-false.ts
@@ -1,0 +1,17 @@
+export function removeAdditionalPropertiesFalse(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(removeAdditionalPropertiesFalse);
+  }
+
+  if (schema == null || typeof schema !== 'object') {
+    return schema;
+  }
+
+  return Object.fromEntries(
+    Object.entries(schema)
+      .filter(
+        ([key, value]) => key !== 'additionalProperties' || value !== false,
+      )
+      .map(([key, value]) => [key, removeAdditionalPropertiesFalse(value)]),
+  );
+}

--- a/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
@@ -423,6 +423,51 @@ describe('prepareResponsesTools', () => {
         ]
       `);
     });
+
+    it('should omit unsupported additionalProperties: false from function tool schemas', async () => {
+      const inputSchema = {
+        type: 'object',
+        properties: {
+          location: {
+            type: 'object',
+            properties: {
+              city: { type: 'string' },
+            },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      } as const;
+
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'weather',
+            description: 'get weather',
+            inputSchema,
+          },
+        ],
+      });
+
+      expect(result.tools?.[0]).toEqual({
+        type: 'function',
+        name: 'weather',
+        description: 'get weather',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: {
+              type: 'object',
+              properties: {
+                city: { type: 'string' },
+              },
+            },
+          },
+        },
+      });
+      expect(inputSchema).toHaveProperty('additionalProperties', false);
+    });
   });
 
   describe('function tools strict mode', () => {

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -4,6 +4,7 @@ import {
   type SharedV4Warning,
 } from '@ai-sdk/provider';
 import { validateTypes } from '@ai-sdk/provider-utils';
+import { removeAdditionalPropertiesFalse } from '../remove-additional-properties-false';
 import { fileSearchArgsSchema } from '../tool/file-search';
 import { mcpServerArgsSchema } from '../tool/mcp-server';
 import { webSearchArgsSchema } from '../tool/web-search';
@@ -142,7 +143,7 @@ export async function prepareResponsesTools({
         type: 'function',
         name: tool.name,
         description: tool.description,
-        parameters: tool.inputSchema,
+        parameters: removeAdditionalPropertiesFalse(tool.inputSchema),
         ...(tool.strict != null ? { strict: tool.strict } : {}),
       });
     }

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -263,7 +263,6 @@ describe('XaiChatLanguageModel', () => {
                 "name": "test-tool",
                 "parameters": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
-                  "additionalProperties": false,
                   "properties": {
                     "value": {
                       "type": "string",

--- a/packages/xai/src/xai-prepare-tools.test.ts
+++ b/packages/xai/src/xai-prepare-tools.test.ts
@@ -59,6 +59,46 @@ describe('prepareTools', () => {
     `);
   });
 
+  it('should omit unsupported additionalProperties: false from function tool schemas', () => {
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            city: { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    } as const;
+
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'weather',
+          description: 'get weather',
+          inputSchema,
+        },
+      ],
+    });
+
+    expect(result.tools?.[0].function.parameters).toEqual({
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            city: { type: 'string' },
+          },
+        },
+      },
+    });
+    expect(inputSchema).toHaveProperty('additionalProperties', false);
+  });
+
   it('should add warnings for provider-defined tools', () => {
     const result = prepareTools({
       tools: [

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -3,6 +3,7 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import { removeAdditionalPropertiesFalse } from './remove-additional-properties-false';
 import type { XaiToolChoice } from './xai-chat-prompt';
 
 export function prepareTools({
@@ -58,7 +59,7 @@ export function prepareTools({
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: removeAdditionalPropertiesFalse(tool.inputSchema),
           ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });


### PR DESCRIPTION
## Summary

Fixes #14678.

xAI rejects function tool schemas that include `additionalProperties: false`. This strips only boolean `additionalProperties: false` entries from xAI tool schemas before sending requests, while preserving the original input schema object and leaving other `additionalProperties` values intact.

The same normalization is applied to both chat completions and responses tool preparation.

## Validation

- `corepack pnpm --dir packages/xai exec vitest --config vitest.node.config.js --run src/xai-prepare-tools.test.ts src/responses/xai-responses-prepare-tools.test.ts src/xai-chat-language-model.test.ts`
- `corepack pnpm --filter @ai-sdk/xai type-check`
- `corepack pnpm exec ultracite check packages/xai/src/remove-additional-properties-false.ts packages/xai/src/xai-prepare-tools.ts packages/xai/src/xai-prepare-tools.test.ts packages/xai/src/xai-chat-language-model.test.ts packages/xai/src/responses/xai-responses-prepare-tools.ts packages/xai/src/responses/xai-responses-prepare-tools.test.ts`
- `corepack pnpm --filter @ai-sdk/xai test:node`
- `corepack pnpm --dir packages/xai clean`
- `corepack pnpm --dir packages/xai exec tsup --tsconfig tsconfig.build.json`

Note: `corepack pnpm --filter @ai-sdk/xai build` could not run directly in this Windows shell because the nested script invokes plain `pnpm`, which is not on PATH here. The equivalent clean + `tsup` build command passed.