### PR TITLE
fix(ai): wrap malformed tool call input in object for provider compatibility

### DIFF
--- a/.changeset/fix-invalid-tool-input-object-wrap.md
+++ b/.changeset/fix-invalid-tool-input-object-wrap.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): wrap malformed tool call JSON input in object to satisfy provider requirements

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -395,7 +395,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -434,7 +436,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -484,6 +488,30 @@ describe('parseToolCall', () => {
         "type": "tool-call",
       }
     `);
+  });
+
+  it('should wrap malformed JSON input in rawInvalidInput object for invalid tool calls', async () => {
+    const result = await parseToolCall({
+      toolCall: {
+        type: 'tool-call',
+        toolName: 'testTool',
+        toolCallId: '123',
+        input: 'not valid json {',
+      },
+      tools: {
+        testTool: tool({
+          inputSchema: z.object({
+            param1: z.string(),
+          }),
+        }),
+      } as const,
+      repairToolCall: undefined,
+      messages: [],
+      system: undefined,
+    });
+
+    expect(result.invalid).toBe(true);
+    expect(result.input).toEqual({ rawInvalidInput: 'not valid json {' });
   });
 
   describe('tool title', () => {

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -78,9 +78,12 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       return await doParseToolCall({ toolCall: repairedToolCall, tools });
     }
   } catch (error) {
-    // use parsed input when possible
+    // use parsed input when possible; wrap raw string in object so providers
+    // that require a JSON object (e.g. Amazon Bedrock) can still accept it
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
 
     // TODO AI SDK 6: special invalid tool call parts
     return {


### PR DESCRIPTION
## Summary

- When `parseToolCall` fails to parse a tool call's JSON input, the raw string was stored as `input` directly
- Providers like Amazon Bedrock require `toolUse.input` to be a JSON object and reject requests where it is a raw string
- This caused the model to never see the `tool-error` result on the next step

The fix wraps the unparseable raw string in `{ rawInvalidInput: toolCall.input }` so the conversation history remains valid for the next API call.

Fixes #14442

## Test plan

- [x] Updated existing inline snapshots for invalid tool call cases to expect `{ rawInvalidInput: "..." }` instead of the raw string
- [x] Added new test verifying malformed JSON input is wrapped in `rawInvalidInput` object
- [x] All 16 `parseToolCall` tests pass locally