### PR TITLE
fix(ui): wait for chat stop abort handling to finish

### DIFF
--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -904,6 +904,58 @@ describe('Chat', () => {
     });
   });
 
+  it('should resolve stop after the aborted request has finished', async () => {
+    const events: Array<string> = [];
+    let controller!: ReadableStreamDefaultController<UIMessageChunk>;
+    const responseStream = new ReadableStream<UIMessageChunk>({
+      start: controllerArg => {
+        controller = controllerArg;
+
+        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: 'start-step' });
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'Hello',
+        });
+      },
+    });
+
+    const chat = new TestChat({
+      id: '123',
+      generateId: mockId(),
+      transport: {
+        sendMessages: async options => {
+          options.abortSignal?.addEventListener('abort', () => {
+            events.push('abort');
+            controller.error(new DOMException('Aborted', 'AbortError'));
+          });
+          return responseStream;
+        },
+        reconnectToStream: () => {
+          throw new Error('not implemented');
+        },
+      },
+      onFinish: () => {
+        events.push('finish');
+      },
+    });
+
+    chat.sendMessage({
+      text: 'Hello, world!',
+    });
+
+    while ((chat.messages[1]?.parts[1] as any)?.text !== 'Hello') {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    await chat.stop().then(() => events.push('stop-resolved'));
+
+    expect(events).toEqual(['abort', 'finish', 'stop-resolved']);
+    expect(chat.status).toBe('ready');
+  });
+
   it('should include the metadata of text message', async () => {
     server.urls['http://localhost:3000/api/chat'].response = {
       type: 'stream-chunks',

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -133,6 +133,7 @@ export type ChatStatus = 'submitted' | 'streaming' | 'ready' | 'error';
 type ActiveResponse<UI_MESSAGE extends UIMessage> = {
   state: StreamingUIMessageState<UI_MESSAGE>;
   abortController: AbortController;
+  finished: Promise<void>;
 };
 
 export interface ChatState<UI_MESSAGE extends UIMessage> {
@@ -586,8 +587,11 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   stop = async () => {
     if (this.status !== 'streaming' && this.status !== 'submitted') return;
 
-    if (this.activeResponse?.abortController) {
-      this.activeResponse.abortController.abort();
+    const activeResponse = this.activeResponse;
+
+    if (activeResponse?.abortController) {
+      activeResponse.abortController.abort();
+      await activeResponse.finished;
     }
   };
 
@@ -650,6 +654,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     let isAbort = false;
     let isDisconnect = false;
     let isError = false;
+    let resolveActiveResponseFinished: (() => void) | undefined;
 
     try {
       const activeResponse = {
@@ -658,6 +663,9 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           messageId: this.generateId(),
         }),
         abortController: new AbortController(),
+        finished: new Promise<void>(resolve => {
+          resolveActiveResponseFinished = resolve;
+        }),
       } as ActiveResponse<UI_MESSAGE>;
 
       activeResponse.abortController.signal.addEventListener('abort', () => {
@@ -769,6 +777,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       }
 
       this.activeResponse = undefined;
+      resolveActiveResponseFinished?.();
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true


### PR DESCRIPTION
## Summary
Fixes #13962.

`chat.stop()` aborts the active response but returned before `makeRequest()` finished handling the abort and resetting chat state. This tracks the active response completion and awaits it after aborting so callers can safely clear or replace messages after `stop()` resolves.

The regression test verifies that `stop()` resolves only after the abort path has finished and `onFinish` has run.

## Validation
- `corepack pnpm test:node -- src/ui/chat.test.ts` from `packages/ai` (runs the package node suite; 127 files, 2710 tests)
- `corepack pnpm type-check` from `packages/ai`
- `corepack pnpm exec ultracite check packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts`
- `corepack pnpm clean` from `packages/ai`
- `corepack pnpm exec tsup --tsconfig tsconfig.build.json` from `packages/ai`
- `git diff --check`

Note: `corepack pnpm build` from `packages/ai` is not directly runnable in this Windows shell because the script calls bare `pnpm`, but the equivalent clean and tsup build steps above pass.