### PR TITLE
fix(xai): stop emitting additionalProperties flag

### DIFF
--- a/.changeset/chilled-ghosts-travel.md
+++ b/.changeset/chilled-ghosts-travel.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+fix(xai): stop emitting additionalProperties flag

--- a/packages/xai/src/remove-additional-properties.ts
+++ b/packages/xai/src/remove-additional-properties.ts
@@ -1,0 +1,23 @@
+/**
+ * Recursively removes `additionalProperties: false` entries from a JSON
+ * schema.
+ * Used to sanitize tool input schemas before sending them to the xAI API,
+ */
+export function removeAdditionalPropertiesFalse(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(removeAdditionalPropertiesFalse);
+  }
+
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, propertyValue] of Object.entries(value)) {
+    if (key === 'additionalProperties' && propertyValue === false) {
+      continue;
+    }
+    result[key] = removeAdditionalPropertiesFalse(propertyValue);
+  }
+  return result;
+}

--- a/packages/xai/src/remove-additional-properties.ts
+++ b/packages/xai/src/remove-additional-properties.ts
@@ -1,7 +1,8 @@
 /**
  * Recursively removes `additionalProperties: false` entries from a JSON
  * schema.
- * Used to sanitize tool input schemas before sending them to the xAI API,
+ * Used to sanitize tool input schemas before sending them to the xAI API.
+ * https://docs.x.ai/developers/model-capabilities/text/structured-outputs#supported-types
  */
 export function removeAdditionalPropertiesFalse(value: unknown): unknown {
   if (Array.isArray(value)) {

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1289,6 +1289,144 @@ describe('XaiResponsesLanguageModel', () => {
           ]
         `);
       });
+
+      it('should omit additionalProperties from serialized function tool schemas', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-4-fast-non-reasoning',
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        });
+
+        await createModel().doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'saveContactWithAddress',
+              description: 'Save a contact with an address.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  address: {
+                    type: 'object',
+                    properties: {
+                      city: { type: 'string' },
+                      country: { type: 'string' },
+                    },
+                    required: ['city', 'country'],
+                    additionalProperties: false,
+                  },
+                },
+                required: ['address'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+            {
+              type: 'function',
+              name: 'saveContactWithProperties',
+              description: 'Save a contact with a properties field.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  properties: {
+                    type: 'object',
+                    properties: {
+                      city: { type: 'string' },
+                      country: { type: 'string' },
+                    },
+                    required: ['city', 'country'],
+                    additionalProperties: false,
+                  },
+                },
+                required: ['properties'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+          ],
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "grok-4-fast-non-reasoning",
+            "tools": [
+              {
+                "description": "Save a contact with an address.",
+                "name": "saveContactWithAddress",
+                "parameters": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "properties": {
+                    "address": {
+                      "properties": {
+                        "city": {
+                          "type": "string",
+                        },
+                        "country": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "city",
+                        "country",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "address",
+                  ],
+                  "type": "object",
+                },
+                "type": "function",
+              },
+              {
+                "description": "Save a contact with a properties field.",
+                "name": "saveContactWithProperties",
+                "parameters": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "properties": {
+                    "properties": {
+                      "properties": {
+                        "city": {
+                          "type": "string",
+                        },
+                        "country": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "city",
+                        "country",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "properties",
+                  ],
+                  "type": "object",
+                },
+                "type": "function",
+              },
+            ],
+          }
+        `);
+      });
     });
 
     describe('citations', () => {

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -4,6 +4,7 @@ import {
   type SharedV4Warning,
 } from '@ai-sdk/provider';
 import { validateTypes } from '@ai-sdk/provider-utils';
+import { removeAdditionalPropertiesFalse } from '../remove-additional-properties';
 import { fileSearchArgsSchema } from '../tool/file-search';
 import { mcpServerArgsSchema } from '../tool/mcp-server';
 import { webSearchArgsSchema } from '../tool/web-search';
@@ -142,7 +143,7 @@ export async function prepareResponsesTools({
         type: 'function',
         name: tool.name,
         description: tool.description,
-        parameters: tool.inputSchema,
+        parameters: removeAdditionalPropertiesFalse(tool.inputSchema),
         ...(tool.strict != null ? { strict: tool.strict } : {}),
       });
     }

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -263,7 +263,6 @@ describe('XaiChatLanguageModel', () => {
                 "name": "test-tool",
                 "parameters": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
-                  "additionalProperties": false,
                   "properties": {
                     "value": {
                       "type": "string",

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -3,6 +3,7 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import { removeAdditionalPropertiesFalse } from './remove-additional-properties';
 import type { XaiToolChoice } from './xai-chat-prompt';
 
 export function prepareTools({
@@ -58,7 +59,7 @@ export function prepareTools({
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: removeAdditionalPropertiesFalse(tool.inputSchema),
           ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/14678

xAI rejects JSON schema `additionalProperties: false` entries in tool schema only when the tool schema is defined with the explicit property `properties`.

stripping it from tool preparation should be fine since the xAI docs specify they define it as false by default

## Summary

- add an xAI-scoped schema sanitizer that removes `additionalProperties: false` recursively while leaving non-boolean additionalProperties schemas intact.

## Manual Verification

<details>
<summary>rerpro:</summary>

```ts
import { xai } from '@ai-sdk/xai';
import { generateText, tool } from 'ai';
import { z } from 'zod';
import { run } from '../../lib/run';

run(async () => {
  const result = await generateText({
    model: xai.responses('grok-4-1-fast-reasoning'),
    tools: {
      saveContact: tool({
        description: 'Save a contact with an address.',
        inputSchema: z.object({
          properties: z.object({
            city: z.string(),
            country: z.string(),
          }),
        }),
        execute: async ({ properties }) => ({
          saved: true,
          properties,
        }),
      }),
    },
    prompt:
      'Save Ada Lovelace as a contact in London, United Kingdom. Use the saveContact tool.',
  });

  console.log('Text:', result.text);
  console.log('Tool Calls:', JSON.stringify(result.toolCalls, null, 2));
  console.log('Tool Results:', JSON.stringify(result.toolResults, null, 2));
});
```

</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14678

Co-authored-by: Genmin <joey@joeyroth.com>