### PR TITLE
fix(anthropic): propagate toModelOutput providerOption to anthropic tool results

### DIFF
--- a/.changeset/ten-papayas-tap.md
+++ b/.changeset/ten-papayas-tap.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+propagate toModelOutput providerOption to anthropic tool results

--- a/.changeset/ten-papayas-tap.md
+++ b/.changeset/ten-papayas-tap.md
@@ -2,4 +2,4 @@
 "@ai-sdk/anthropic": patch
 ---
 
-propagate toModelOutput providerOption to anthropic tool results
+fix(anthropic): propagate toModelOutput providerOption to anthropic tool results

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -3204,6 +3204,109 @@ describe('cache control', () => {
       });
     });
 
+    it('should set cache_control on tool result with output cache control', async () => {
+      const result = await convertToAnthropicPrompt({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'test',
+                toolCallId: 'test',
+                output: {
+                  type: 'text',
+                  value: 'test',
+                  providerOptions: {
+                    anthropic: {
+                      cacheControl: { type: 'ephemeral' },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: true,
+        warnings: [],
+        toolNameMapping: defaultToolNameMapping,
+      });
+
+      expect(result).toEqual({
+        prompt: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'tool_result',
+                  content: 'test',
+                  is_error: undefined,
+                  tool_use_id: 'test',
+                  cache_control: { type: 'ephemeral' },
+                },
+              ],
+            },
+          ],
+        },
+        betas: new Set(),
+      });
+    });
+
+    it('should set cache_control on tool result with content output cache control', async () => {
+      const result = await convertToAnthropicPrompt({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'test',
+                toolCallId: 'test',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'text',
+                      text: 'test',
+                      providerOptions: {
+                        anthropic: {
+                          cacheControl: { type: 'ephemeral' },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: true,
+        warnings: [],
+        toolNameMapping: defaultToolNameMapping,
+      });
+
+      expect(result).toEqual({
+        prompt: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'tool_result',
+                  content: [{ type: 'text', text: 'test' }],
+                  is_error: undefined,
+                  tool_use_id: 'test',
+                  cache_control: { type: 'ephemeral' },
+                },
+              ],
+            },
+          ],
+        },
+        betas: new Set(),
+      });
+    });
+
     it('should set cache_control on last tool result message part with message cache control', async () => {
       const result = await convertToAnthropicPrompt({
         prompt: [

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -321,14 +321,28 @@ export async function convertToAnthropicPrompt({
                   continue;
                 }
 
+                const output = part.output;
+                const outputProviderOptions =
+                  'providerOptions' in output
+                    ? output.providerOptions
+                    : output.type === 'content'
+                      ? output.value.find(
+                          contentPart => contentPart.providerOptions != null,
+                        )?.providerOptions
+                      : undefined;
+
                 // cache control: first add cache control from part.
-                // for the last part of a message,
-                // check also if the message has cache control.
+                // then from tool result output, and for the last part of a
+                // message, check also if the message has cache control.
                 const isLastPart = i === content.length - 1;
 
                 const cacheControl =
                   validator.getCacheControl(part.providerOptions, {
                     type: 'tool result part',
+                    canCache: true,
+                  }) ??
+                  validator.getCacheControl(outputProviderOptions, {
+                    type: 'tool result output',
                     canCache: true,
                   }) ??
                   (isLastPart
@@ -338,7 +352,6 @@ export async function convertToAnthropicPrompt({
                       })
                     : undefined);
 
-                const output = part.output;
                 let contentValue: AnthropicToolResultContent['content'];
                 switch (output.type) {
                   case 'content':


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15185

when a user used `tool.toModelOutput()` to return some providerOptions, the problem was that Anthropic never read them from that location. 

metadata existed at: `part.output.providerOptions` but the Anthropic converter only checked: `part.providerOptions`, `message.providerOptions`

so `cache_control` was silently omitted from the outgoing anthropic tool_result block

## Summary

converter now also checks provider options on the tool-result output itself, including inner content output parts

## Manual Verification

verified by running the following repro:

<details>
<summary>repro:</summary>

```ts
import {
  anthropic,
  type AnthropicLanguageModelOptions,
} from '@ai-sdk/anthropic';
import { generateText, isStepCount, tool, type ModelMessage } from 'ai';
import fs from 'node:fs';
import { z } from 'zod';
import { run } from '../../lib/run';

const cachedText = fs.readFileSync('data/error-message.txt', 'utf8');

const anthropicOptions = {
  cacheControl: { type: 'ephemeral' },
} satisfies AnthropicLanguageModelOptions;

const providerOptions = {
  anthropic: anthropicOptions,
};

const controlMessages = [
  {
    role: 'assistant',
    content: [
      {
        type: 'text',
        text: cachedText,
        providerOptions,
      },
    ],
  },
  {
    role: 'user',
    content: 'Reply with "ok".',
  },
] satisfies ModelMessage[];

const cachedTextTool = tool({
  description: 'Return a stable cached text payload.',
  inputSchema: z.object({}),
  execute: async () => cachedText,
  toModelOutput: ({ output }) => ({
    type: 'text',
    value: output,
    providerOptions,
  }),
});

function hasCacheControl(body: unknown) {
  return JSON.stringify(body).includes('"cache_control"');
}

run(async () => {
  const controlCold = await generateText({
    model: anthropic('claude-opus-4-1'),
    messages: controlMessages,
    include: { requestBody: true },
  });

  console.log('=== control cold ===');
  console.log(controlCold.finalStep.providerMetadata?.anthropic?.usage);
  console.log('request has cache_control:', hasCacheControl(controlCold.request.body));

  const controlWarm = await generateText({
    model: anthropic('claude-opus-4-1'),
    messages: controlMessages,
    include: { requestBody: true },
  });

  console.log('=== control warm ===');
  console.log(controlWarm.finalStep.providerMetadata?.anthropic?.usage);
  console.log('request has cache_control:', hasCacheControl(controlWarm.request.body));

  const toolCold = await generateText({
    model: anthropic('claude-opus-4-1'),
    prompt: 'Call the cachedText tool, then reply with "ok".',
    tools: { cachedText: cachedTextTool },
    toolChoice: { type: 'tool', toolName: 'cachedText' },
    stopWhen: isStepCount(2),
    include: { requestBody: true },
  });

  console.log('=== tool result cold ===');
  console.log(toolCold.finalStep.providerMetadata?.anthropic?.usage);
  console.log('request has cache_control:', hasCacheControl(toolCold.finalStep.request.body));

  const toolWarm = await generateText({
    model: anthropic('claude-opus-4-1'),
    messages: [
      { role: 'user', content: 'Call the cachedText tool, then reply with "ok".' },
      ...toolCold.responseMessages,
      { role: 'user', content: 'Reply with "ok" again.' },
    ],
    tools: { cachedText: cachedTextTool },
    include: { requestBody: true },
  });

  console.log('=== tool result warm ===');
  console.log(toolWarm.finalStep.providerMetadata?.anthropic?.usage);
  console.log('request has cache_control:', hasCacheControl(toolWarm.request.body));
});

```
</details>

Observed behavior before the fix is that the last 2 tool-results will show `request has cache_control: false` 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15186