### PR TITLE
fix(@ai-sdk/mcp): handle audio and embedded resource content in tool results

### DIFF
--- a/.changeset/mcp-audio-resource-content.md
+++ b/.changeset/mcp-audio-resource-content.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Handle audio and embedded resource content types in MCP tool results
+
+MCP tool results can contain `audio` content parts (per the MCP spec section 5.2.3) and `resource` content parts with embedded blob data. Previously, only `text` and `image` content types were handled in `mcpToModelOutput`, causing audio and resource blob data to be serialized as JSON text via the fallback path instead of being converted to proper file content parts.
+
+This change:
+- Converts `audio` content parts (type: "audio", data, mimeType) to file content with the correct mediaType
+- Converts embedded `resource` content parts with blob data to file content
+- Converts embedded `resource` content parts with text data to text content
+- Adds `AudioContentSchema` to the `CallToolResultSchema` union to match the MCP specification

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -483,6 +483,212 @@ describe('MCPClient', () => {
     `);
   });
 
+  it('should convert audio content to file format via toModelOutput', async () => {
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          overrideTools: [
+            {
+              name: 'get-audio',
+              description: 'Returns audio content',
+              inputSchema: { type: 'object' },
+            },
+          ],
+          toolCallResults: {
+            'get-audio': {
+              content: [
+                {
+                  type: 'audio',
+                  data: 'base64audiodata',
+                  mimeType: 'audio/wav',
+                },
+              ],
+              isError: false,
+            },
+          },
+        }),
+    );
+
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    const tools = await client.tools();
+    const tool = tools['get-audio'];
+
+    expect(tool.toModelOutput).toBeDefined();
+    expect(
+      tool.toModelOutput!({
+        toolCallId: '1',
+        input: {},
+        output: {
+          content: [
+            {
+              type: 'audio',
+              data: 'base64audiodata',
+              mimeType: 'audio/wav',
+            },
+          ],
+          isError: false,
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "type": "content",
+        "value": [
+          {
+            "data": {
+              "data": "base64audiodata",
+              "type": "data",
+            },
+            "mediaType": "audio/wav",
+            "type": "file",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should convert embedded blob resource to file format via toModelOutput', async () => {
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          overrideTools: [
+            {
+              name: 'get-resource',
+              description: 'Returns embedded resource',
+              inputSchema: { type: 'object' },
+            },
+          ],
+          toolCallResults: {
+            'get-resource': {
+              content: [
+                {
+                  type: 'resource',
+                  resource: {
+                    uri: 'file:///data/audio.ogg',
+                    mimeType: 'audio/ogg',
+                    blob: 'base64blobdata',
+                  },
+                },
+              ],
+              isError: false,
+            },
+          },
+        }),
+    );
+
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    const tools = await client.tools();
+    const tool = tools['get-resource'];
+
+    expect(tool.toModelOutput).toBeDefined();
+    expect(
+      tool.toModelOutput!({
+        toolCallId: '1',
+        input: {},
+        output: {
+          content: [
+            {
+              type: 'resource',
+              resource: {
+                uri: 'file:///data/audio.ogg',
+                mimeType: 'audio/ogg',
+                blob: 'base64blobdata',
+              },
+            },
+          ],
+          isError: false,
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "type": "content",
+        "value": [
+          {
+            "data": {
+              "data": "base64blobdata",
+              "type": "data",
+            },
+            "mediaType": "audio/ogg",
+            "type": "file",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should convert embedded text resource to text format via toModelOutput', async () => {
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          overrideTools: [
+            {
+              name: 'get-text-resource',
+              description: 'Returns text resource',
+              inputSchema: { type: 'object' },
+            },
+          ],
+          toolCallResults: {
+            'get-text-resource': {
+              content: [
+                {
+                  type: 'resource',
+                  resource: {
+                    uri: 'file:///data/readme.md',
+                    mimeType: 'text/markdown',
+                    text: '# Hello World',
+                  },
+                },
+              ],
+              isError: false,
+            },
+          },
+        }),
+    );
+
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    const tools = await client.tools();
+    const tool = tools['get-text-resource'];
+
+    expect(tool.toModelOutput).toBeDefined();
+    expect(
+      tool.toModelOutput!({
+        toolCallId: '1',
+        input: {},
+        output: {
+          content: [
+            {
+              type: 'resource',
+              resource: {
+                uri: 'file:///data/readme.md',
+                mimeType: 'text/markdown',
+                text: '# Hello World',
+              },
+            },
+          ],
+          isError: false,
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "type": "content",
+        "value": [
+          {
+            "text": "# Hello World",
+            "type": "text",
+          },
+        ],
+      }
+    `);
+  });
+
   it('should fallback to JSON for unknown content types via toModelOutput', async () => {
     createMockTransport.mockImplementation(
       () =>

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -88,6 +88,30 @@ function mcpToModelOutput({
           data: { type: 'data' as const, data: part.data as string },
         };
       }
+      if (part.type === 'audio' && 'data' in part && 'mimeType' in part) {
+        return {
+          type: 'file' as const,
+          mediaType: part.mimeType as string,
+          data: { type: 'data' as const, data: part.data as string },
+        };
+      }
+      if (part.type === 'resource' && 'resource' in part) {
+        const resource = part.resource as {
+          blob?: string;
+          text?: string;
+          mimeType?: string;
+        };
+        if ('blob' in resource && resource.blob != null) {
+          return {
+            type: 'file' as const,
+            mediaType: resource.mimeType ?? 'application/octet-stream',
+            data: { type: 'data' as const, data: resource.blob as string },
+          };
+        }
+        if ('text' in resource && resource.text != null) {
+          return { type: 'text' as const, text: resource.text as string };
+        }
+      }
       return { type: 'text' as const, text: JSON.stringify(part) };
     },
   );

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -192,6 +192,13 @@ const ImageContentSchema = z
     mimeType: z.string(),
   })
   .loose();
+const AudioContentSchema = z
+  .object({
+    type: z.literal('audio'),
+    data: z.base64(),
+    mimeType: z.string(),
+  })
+  .loose();
 export const ResourceSchema = z
   .object({
     uri: z.string(),
@@ -256,6 +263,7 @@ export const CallToolResultSchema = ResultSchema.extend({
     z.union([
       TextContentSchema,
       ImageContentSchema,
+      AudioContentSchema,
       EmbeddedResourceSchema,
       ResourceLinkContentSchema,
     ]),


### PR DESCRIPTION
## Summary

MCP tool results can return `audio` content parts (`type: 'audio'`) and embedded `resource` content parts (`type: 'resource'`) per the [MCP specification (§5.2.3, §5.2.5)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#audio-content). Previously, only `text` and `image` content types were handled in `mcpToModelOutput`, causing audio and resource blob data to fall through to the `JSON.stringify` fallback — the model then received a giant base64 string as text instead of proper binary file content.

## Problem

When an MCP tool returns audio content:
```json
{ "type": "audio", "data": "<base64>", "mimeType": "audio/ogg" }
```
or an embedded resource with blob data:
```json
{ "type": "resource", "resource": { "uri": "...", "blob": "<base64>", "mimeType": "audio/ogg" } }
```

These fell through to `JSON.stringify(part)` and were passed to the model as text, causing parse errors in downstream providers (e.g. Gemini).

## Changes

- **`mcp-client.ts`**: Added handlers for `audio` and `resource` content types in `mcpToModelOutput`:
  - `audio` → file content part with correct `mediaType`
  - `resource` with `blob` → file content part
  - `resource` with `text` → text content part
- **`types.ts`**: Added `AudioContentSchema` to `CallToolResultSchema` union to match MCP spec
- **`mcp-client.test.ts`**: Added 3 test cases for audio, blob resource, and text resource conversion

## Test Plan

```bash
pnpm vitest run src/tool/mcp-client.test.ts  # 64 tests pass
```