### PR TITLE
fix(provider/gateway): ensure multimodal input is passed in the older shape AI Gateway supports

### DIFF
--- a/.changeset/tricky-apricots-decide.md
+++ b/.changeset/tricky-apricots-decide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix(provider/gateway): ensure multimodal input is passed in the older shape AI Gateway supports

--- a/examples/ai-functions/src/generate-text/gateway/image-base64.ts
+++ b/examples/ai-functions/src/generate-text/gateway/image-base64.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'google/gemini-2.5-flash',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/gateway/image-data-url.ts
+++ b/examples/ai-functions/src/generate-text/gateway/image-data-url.ts
@@ -9,7 +9,7 @@ run(async () => {
   const dataUrl = `data:image/png;base64,${base64Data}`;
 
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'google/gemini-2.5-flash',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/gateway/image-url.ts
+++ b/examples/ai-functions/src/generate-text/gateway/image-url.ts
@@ -3,7 +3,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'google/gemini-2.5-flash',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/gateway/output-object.ts
+++ b/examples/ai-functions/src/generate-text/gateway/output-object.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3-beta',
+    model: 'google/gemini-2.5-flash-beta',
     output: Output.object({
       schema: z.object({
         recipe: z.object({

--- a/examples/ai-functions/src/generate-text/gateway/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-call.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'google/gemini-2.5-flash',
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-functions/src/stream-text/gateway/output-object.ts
+++ b/examples/ai-functions/src/stream-text/gateway/output-object.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: 'xai/grok-3',
+    model: 'google/gemini-2.5-flash',
     output: Output.object({
       schema: z.object({
         characters: z.array(

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -333,10 +333,7 @@ describe('GatewayLanguageModel', () => {
           .content[1] as LanguageModelV4FilePart;
 
         expect(imagePart.type).toBe('file');
-        expect(imagePart.data).toEqual({
-          type: 'url',
-          url: `data:image/jpeg;base64,${expectedBase64}`,
-        });
+        expect(imagePart.data).toBe(`data:image/jpeg;base64,${expectedBase64}`);
         expect(imagePart.mediaType).toBe('image/jpeg');
       });
 
@@ -367,10 +364,9 @@ describe('GatewayLanguageModel', () => {
           .content[0] as LanguageModelV4FilePart;
 
         expect(imagePart.type).toBe('file');
-        expect(imagePart.data).toEqual({
-          type: 'url',
-          url: `data:${mimeType};base64,${expectedBase64}`,
-        });
+        expect(imagePart.data).toBe(
+          `data:${mimeType};base64,${expectedBase64}`,
+        );
         expect(imagePart.mediaType).toBe(mimeType);
       });
 
@@ -400,10 +396,7 @@ describe('GatewayLanguageModel', () => {
           .content[1] as LanguageModelV4FilePart;
 
         expect(imagePart.type).toBe('file');
-        expect(imagePart.data).toEqual({
-          type: 'url',
-          url: imageUrl.toString(),
-        });
+        expect(imagePart.data).toBe(imageUrl.toString());
       });
 
       it('should handle mixed content types correctly', async () => {
@@ -441,18 +434,69 @@ describe('GatewayLanguageModel', () => {
         expect(content[0]).toEqual({ type: 'text', text: 'First text.' });
         expect(content[1]).toEqual({
           type: 'file',
-          data: {
-            type: 'url',
-            url: `data:image/gif;base64,${expectedBase64}`,
-          },
+          data: `data:image/gif;base64,${expectedBase64}`,
           mediaType: 'image/gif',
         });
         expect(content[2]).toEqual({ type: 'text', text: 'Second text.' });
         expect(content[3]).toEqual({
           type: 'file',
-          data: { type: 'url', url: imageUrl.toString() },
+          data: imageUrl.toString(),
           mediaType: 'image/png',
         });
+      });
+
+      it('should expand top-level-only media type by sniffing inline bytes', async () => {
+        prepareJsonResponse({ content: { type: 'text', text: 'response' } });
+        // PNG signature: 0x89 0x50 0x4e 0x47
+        const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+        const expectedBase64 = Buffer.from(pngBytes).toString('base64');
+        const imagePrompt: LanguageModelV4Prompt = [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: { type: 'data' as const, data: pngBytes },
+                mediaType: 'image',
+              },
+            ],
+          },
+        ];
+
+        await createTestModel().doGenerate({ prompt: imagePrompt });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        const imagePart = requestBody.prompt[0]
+          .content[0] as LanguageModelV4FilePart;
+
+        expect(imagePart.mediaType).toBe('image/png');
+        expect(imagePart.data).toBe(`data:image/png;base64,${expectedBase64}`);
+      });
+
+      it('should leave top-level-only media type as-is when sniffing is not possible', async () => {
+        prepareJsonResponse({ content: { type: 'text', text: 'response' } });
+        const imageUrl = new URL('https://example.com/image');
+        const imagePrompt: LanguageModelV4Prompt = [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: { type: 'url' as const, url: imageUrl },
+                mediaType: 'image',
+              },
+            ],
+          },
+        ];
+
+        await createTestModel().doGenerate({ prompt: imagePrompt });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        const imagePart = requestBody.prompt[0]
+          .content[0] as LanguageModelV4FilePart;
+
+        expect(imagePart.mediaType).toBe('image');
+        expect(imagePart.data).toBe(imageUrl.toString());
       });
     });
 
@@ -893,10 +937,7 @@ describe('GatewayLanguageModel', () => {
           .content[1] as LanguageModelV4FilePart;
 
         expect(imagePart.type).toBe('file');
-        expect(imagePart.data).toEqual({
-          type: 'url',
-          url: `data:image/jpeg;base64,${expectedBase64}`,
-        });
+        expect(imagePart.data).toBe(`data:image/jpeg;base64,${expectedBase64}`);
         expect(imagePart.mediaType).toBe('image/jpeg');
       });
 
@@ -929,10 +970,9 @@ describe('GatewayLanguageModel', () => {
           .content[1] as LanguageModelV4FilePart;
 
         expect(imagePart.type).toBe('file');
-        expect(imagePart.data).toEqual({
-          type: 'url',
-          url: `data:${mimeType};base64,${expectedBase64}`,
-        });
+        expect(imagePart.data).toBe(
+          `data:${mimeType};base64,${expectedBase64}`,
+        );
         expect(imagePart.mediaType).toBe(mimeType);
       });
 
@@ -963,10 +1003,7 @@ describe('GatewayLanguageModel', () => {
           .content[1] as LanguageModelV4FilePart;
 
         expect(imagePart.type).toBe('file');
-        expect(imagePart.data).toEqual({
-          type: 'url',
-          url: imageUrl.toString(),
-        });
+        expect(imagePart.data).toBe(imageUrl.toString());
         expect(imagePart.mediaType).toBe('image/jpeg');
       });
 
@@ -1006,16 +1043,13 @@ describe('GatewayLanguageModel', () => {
         expect(content[0]).toEqual({ type: 'text', text: 'First text.' });
         expect(content[1]).toEqual({
           type: 'file',
-          data: {
-            type: 'url',
-            url: `data:image/gif;base64,${expectedBase64}`,
-          },
+          data: `data:image/gif;base64,${expectedBase64}`,
           mediaType: 'image/gif',
         });
         expect(content[2]).toEqual({ type: 'text', text: 'Second text.' });
         expect(content[3]).toEqual({
           type: 'file',
-          data: { type: 'url', url: imageUrl.toString() },
+          data: imageUrl.toString(),
           mediaType: 'image/png',
         });
       });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -2,6 +2,7 @@ import type {
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4FilePart,
+  LanguageModelV4Message,
   LanguageModelV4StreamPart,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamResult,
@@ -13,6 +14,7 @@ import {
   createJsonResponseHandler,
   postJsonToApi,
   resolve,
+  resolveFullMediaType,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -28,6 +30,42 @@ import { parseAuthMethod } from './errors/parse-auth-method';
 type GatewayChatConfig = GatewayConfig & {
   provider: string;
   o11yHeaders: Resolvable<Record<string, string>>;
+};
+
+/**
+ * File part shape that the AI Gateway server actually accepts on the wire:
+ * the V3-style untagged `data` (a `Uint8Array`, base64 string, or `URL`),
+ * instead of the V4 tagged discriminated union.
+ */
+type GatewayLanguageModelV4FilePart = Omit<LanguageModelV4FilePart, 'data'> & {
+  data: Uint8Array | string | URL;
+};
+
+/**
+ * `LanguageModelV4Message` with any `LanguageModelV4FilePart` inside the
+ * content array replaced by `GatewayLanguageModelV4FilePart`. Distributed over
+ * the message role union; the `system` role (whose `content` is a string)
+ * passes through unchanged.
+ */
+type GatewayLanguageModelV4Message = LanguageModelV4Message extends infer M
+  ? M extends { content: Array<infer P> }
+    ? Omit<M, 'content'> & {
+        content: Array<
+          P extends LanguageModelV4FilePart ? GatewayLanguageModelV4FilePart : P
+        >;
+      }
+    : M
+  : never;
+
+/**
+ * Call options as sent to the AI Gateway: same as `LanguageModelV4CallOptions`
+ * but with file parts in the prompt flattened to the untagged data shape.
+ */
+type GatewayLanguageModelV4CallOptions = Omit<
+  LanguageModelV4CallOptions,
+  'prompt'
+> & {
+  prompt: GatewayLanguageModelV4Message[];
 };
 
 export class GatewayLanguageModel implements LanguageModelV4 {
@@ -191,43 +229,72 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     }
   }
 
-  private isFilePart(part: unknown) {
-    return (
-      part && typeof part === 'object' && 'type' in part && part.type === 'file'
-    );
+  /**
+   * Converts a V4 file part to the shape the AI Gateway accepts: the
+   * discriminated `data` union is flattened to the V3-style untagged
+   * `Uint8Array | string | URL`, raw bytes are base64-encoded into a data URL,
+   * and the media type is expanded to a full `type/subtype` whenever possible
+   * (some downstream providers require the full IANA media type).
+   *
+   * `reference` and `text` data variants are forwarded as-is so the Gateway
+   * can reject them with a clear error rather than us silently dropping data.
+   */
+  private encodeFilePart(
+    part: LanguageModelV4FilePart,
+  ): GatewayLanguageModelV4FilePart {
+    let mediaType = part.mediaType;
+    try {
+      mediaType = resolveFullMediaType({ part });
+    } catch {
+      // Could not resolve a full media type (e.g. URL-sourced data with a
+      // top-level-only media type). Pass mediaType through and let the
+      // Gateway / downstream provider decide.
+    }
+
+    const data = part.data;
+    let flattenedData: GatewayLanguageModelV4FilePart['data'];
+    if (data.type === 'data') {
+      if (data.data instanceof Uint8Array) {
+        const base64Data = Buffer.from(data.data).toString('base64');
+        flattenedData = new URL(
+          `data:${mediaType || 'application/octet-stream'};base64,${base64Data}`,
+        );
+      } else {
+        flattenedData = data.data;
+      }
+    } else if (data.type === 'url') {
+      flattenedData = data.url;
+    } else {
+      // `reference` / `text` variants have no V3 equivalent. Forward the
+      // tagged object as-is and let the Gateway surface a clear error.
+      flattenedData = data as unknown as GatewayLanguageModelV4FilePart['data'];
+    }
+
+    return { ...part, mediaType, data: flattenedData };
   }
 
   /**
-   * Encodes file parts in the prompt to base64. Mutates the passed options
-   * instance directly to avoid copying the file data.
-   * @param options - The options to encode.
-   * @returns The options with the file parts encoded.
+   * Rewrites the prompt so every `file` part uses the Gateway-friendly shape
+   * produced by `encodeFilePart`. Returns a fresh options object — callers
+   * should treat the input as untouched.
    */
-  private maybeEncodeFileParts(options: LanguageModelV4CallOptions) {
-    for (const message of options.prompt) {
-      for (const part of message.content) {
-        if (this.isFilePart(part)) {
-          const filePart = part as LanguageModelV4FilePart;
-          // If the file part is a URL it will get cleanly converted to a string.
-          // If it's a binary file attachment we convert it to a data url.
-          // In either case, server-side we should only ever see URLs as strings.
-          if (
-            filePart.data.type === 'data' &&
-            filePart.data.data instanceof Uint8Array
-          ) {
-            const buffer = Uint8Array.from(filePart.data.data);
-            const base64Data = Buffer.from(buffer).toString('base64');
-            filePart.data = {
-              type: 'url',
-              url: new URL(
-                `data:${filePart.mediaType || 'application/octet-stream'};base64,${base64Data}`,
-              ),
-            };
-          }
+  private maybeEncodeFileParts(
+    options: LanguageModelV4CallOptions,
+  ): GatewayLanguageModelV4CallOptions {
+    return {
+      ...options,
+      prompt: options.prompt.map(message => {
+        if (typeof message.content === 'string') {
+          return message;
         }
-      }
-    }
-    return options;
+        return {
+          ...message,
+          content: message.content.map(part =>
+            part.type === 'file' ? this.encodeFilePart(part) : part,
+          ),
+        };
+      }) as GatewayLanguageModelV4Message[],
+    };
   }
 
   private getUrl() {


### PR DESCRIPTION
## Background

**Do not merge. Work in progress.**

Passing multimodal input to Gateway currently results in a `GatewayInvalidRequestError: Invalid input` error.

Further investigation confirmed that Gateway rejects the new tagged `FilePart` shape discriminated based on `type`, which was introduced in #14733. This PR (temporarily) sends back the untagged version that spec v3 uses, and that avoids the above invalid request error.

However, that's not sufficient: For some reason, even when passing data in the old shapes, the AI model forwarded to doesn't appear to receive the image. It will make up a description of some other image, which is a clear indicator that the actual image didn't reach it.

## Manual Verification

For the original invalid request error, run `examples/ai-functions/src/generate-text/gateway/image-base64.ts` on `main`.
For the subsequent error that is still unresolved in this PR, run `examples/ai-functions/src/generate-text/gateway/image-base64.ts` on the PR branch.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
