### PR TITLE
docs(ai): correct onToolCall JSDoc on return value handling

### DIFF
--- a/.changeset/ontoolcall-jsdoc-return-value.md
+++ b/.changeset/ontoolcall-jsdoc-return-value.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+docs(ai): correct `onToolCall` JSDoc to reflect that the return value is ignored and tool output must be attached via `addToolOutput`

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -208,8 +208,12 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
    * Optional callback function that is invoked when a tool call is received.
    * Intended for automatic client-side tool execution.
    *
-   * You can optionally return a result for the tool call,
-   * either synchronously or asynchronously.
+   * To attach the tool result, call `addToolOutput({ tool, toolCallId, output })`
+   * from inside (or after) this callback. The callback's return value is
+   * ignored.
+   *
+   * When using `sendAutomaticallyWhen`, do not `await` `addToolOutput` inside
+   * this callback as it can cause deadlocks.
    */
   onToolCall?: ChatOnToolCallCallback<UI_MESSAGE>;
 


### PR DESCRIPTION
## Summary

Fixes #15268.

The JSDoc on `ChatInit.onToolCall` says the callback "can optionally return a result for the tool call, either synchronously or asynchronously." That's not true:

- The type signature is `(options) => void | PromiseLike<void>` (`packages/ai/src/ui/chat.ts:153-156`).
- The call site awaits the callback but discards its return value (`packages/ai/src/ui/process-ui-message-stream.ts:655-659`).
- The v5 migration guide already documented the removal: "`onToolCall` no longer supports returning values to automatically submit tool results."

Tool results have to be attached with `addToolOutput`. This PR updates the JSDoc to say that, and adds the `sendAutomaticallyWhen` deadlock warning that's already in the reference docs and v5 migration guide, so the hover tooltip matches what the published docs tell people to do.

## Test plan

- [x] `pnpm --filter ai test:node`: 2690 tests pass
- [x] `pnpm check`: lint and format clean
- [x] `pnpm --filter ai type-check`