### PR TITLE
fix(amazon-bedrock): disable native structured output for claude-opus-4-7

### DIFF
--- a/.changeset/bedrock-anthropic-opus-4-7-native-structured-output.md
+++ b/.changeset/bedrock-anthropic-opus-4-7-native-structured-output.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): disable native structured output for `claude-opus-4-7` on Bedrock Anthropic. Bedrock rejects `output_config.format` for this model (including the `us.`/`eu.` cross-region inference profiles) with `Extra inputs are not permitted`; the SDK now falls back to the `jsonResponseTool` path for it.

--- a/.changeset/bedrock-anthropic-opus-4-7-native-structured-output.md
+++ b/.changeset/bedrock-anthropic-opus-4-7-native-structured-output.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/amazon-bedrock': patch
----
-
-fix(amazon-bedrock): disable native structured output for `claude-opus-4-7` on Bedrock Anthropic. Bedrock rejects `output_config.format` for this model (including the `us.`/`eu.` cross-region inference profiles) with `Extra inputs are not permitted`; the SDK now falls back to the `jsonResponseTool` path for it.

--- a/.changeset/mighty-lemons-return.md
+++ b/.changeset/mighty-lemons-return.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): disable native structured output for claude-opus-4-7

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -83,6 +83,29 @@ describe('amazon-bedrock-anthropic-provider', () => {
     );
   });
 
+  it.each([
+    'anthropic.claude-opus-4-7',
+    'us.anthropic.claude-opus-4-7',
+    'eu.anthropic.claude-opus-4-7',
+  ])(
+    'should disable native structured output for %s (Bedrock rejects output_config.format)',
+    modelId => {
+      const provider = createAmazonBedrockAnthropic({
+        region: 'us-east-1',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      });
+      provider(modelId as Parameters<typeof provider>[0]);
+
+      expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+        modelId,
+        expect.objectContaining({
+          supportsNativeStructuredOutput: false,
+        }),
+      );
+    },
+  );
+
   it('should throw an error when using new keyword', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -331,6 +331,7 @@ export function createAmazonBedrockAnthropic(
 
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),
+      // native structured output via output_config.format is supported on Bedrock
       // Bedrock rejects `output_config.format` for `claude-opus-4-7`
       supportsNativeStructuredOutput: !modelId.includes('claude-opus-4-7'),
     });

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -331,8 +331,10 @@ export function createAmazonBedrockAnthropic(
 
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),
-      // native structured output via output_config.format is supported on Bedrock
-      supportsNativeStructuredOutput: true,
+      // Bedrock rejects `output_config.format` for `claude-opus-4-7`
+      // (including the `us.`/`eu.` cross-region inference profiles); fall
+      // back to the jsonResponseTool path for that model.
+      supportsNativeStructuredOutput: !modelId.includes('claude-opus-4-7'),
     });
 
   const provider = function (modelId: AmazonBedrockAnthropicModelId) {

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -332,8 +332,6 @@ export function createAmazonBedrockAnthropic(
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),
       // Bedrock rejects `output_config.format` for `claude-opus-4-7`
-      // (including the `us.`/`eu.` cross-region inference profiles); fall
-      // back to the jsonResponseTool path for that model.
       supportsNativeStructuredOutput: !modelId.includes('claude-opus-4-7'),
     });
 


### PR DESCRIPTION
## Summary

Fixes #14773.

Bedrock rejects `output_config.format` for `claude-opus-4-7` (including the `us.`/`eu.` cross-region inference profiles) with:

```
output_config.format: Extra inputs are not permitted
```

`packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts` previously hardcoded `supportsNativeStructuredOutput: true` for every Bedrock-Anthropic model. The Anthropic capability table already lists opus-4-7 as supporting structured output, so the SDK took the native path that Bedrock then refused, and any `output` / `Output.object(...)` call against opus-4-7 (including reasoning runs) failed before the model ran.

This changes the flag to `!modelId.includes('claude-opus-4-7')`. Other Bedrock-Anthropic models stay on the native path; opus-4-7 falls back to the `jsonResponseTool` path, which Bedrock accepts. Using `includes()` covers the direct `anthropic.claude-opus-4-7` id and both cross-region inference profiles (`us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-opus-4-7`).

## Test plan

- [x] Added a parameterized test for the direct id and both cross-region prefixes. The existing default-model assertion still requires `supportsNativeStructuredOutput: true` for non-opus-4-7 models.
- [x] `pnpm --filter @ai-sdk/amazon-bedrock test`: 369/369 pass (node + edge)
- [x] `pnpm check`: lint and format clean
- [x] `pnpm --filter @ai-sdk/amazon-bedrock type-check`
