### PR TITLE
feat(tools-registry): add quantoracle

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -551,4 +551,35 @@ console.log(text);`,
     websiteUrl: 'https://you.com',
     npmUrl: 'https://www.npmjs.com/package/@youdotcom-oss/ai-sdk-plugin',
   },
+  {
+    slug: 'quantoracle',
+    name: 'QuantOracle',
+    description:
+      'Deterministic quant finance tools: Black-Scholes pricing with full Greeks, Kelly Criterion position sizing, Monte Carlo simulation, full risk audit (Sharpe/Sortino/Calmar/VaR/CVaR/Hurst), hedge recommender, implied volatility solver, binomial trees for American options, correlation matrices, impermanent loss, perp liquidation price. 15 tools across 4 opt-in bundles (core, options, risk, defi). Free tier covers 13 of 15 tools with no signup or API key — 1000 calls/IP/day. Paid composite tools settle in USDC via x402 micropayments on Base or Solana mainnet.',
+    packageName: '@quantoracle/ai-tools',
+    tags: ['finance', 'quant-finance', 'options'],
+    installCommand: {
+      pnpm: 'pnpm add @quantoracle/ai-tools',
+      npm: 'npm install @quantoracle/ai-tools',
+      yarn: 'yarn add @quantoracle/ai-tools',
+      bun: 'bun add @quantoracle/ai-tools',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { quantoracleTools } from '@quantoracle/ai-tools';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5-mini',
+  prompt:
+    'Price a 30-day SPY $500 call with vol=18%, spot=$498, rate=5%. ' +
+    'Then size a $50k account position with a 55% win rate, ' +
+    '$1,200 average win, and $800 average loss.',
+  tools: quantoracleTools(),
+  stopWhen: isStepCount(5),
+});
+
+console.log(text);`,
+    docsUrl: 'https://quantoracle.dev/writing/vercel-ai-sdk-quant-tools',
+    websiteUrl: 'https://quantoracle.dev',
+    npmUrl: 'https://www.npmjs.com/package/@quantoracle/ai-tools',
+  },
 ];


### PR DESCRIPTION
## What

Adds **QuantOracle** to the tools registry — deterministic quant finance tools (Black-Scholes, Kelly, Monte Carlo, VaR, Sharpe, options, IL, liquidation price) for AI SDK agents.

## Why

LLMs hallucinate quant math. GPT-4o computing Black-Scholes in-context drifts ~5% on price and 5–30% on Greeks — and the model can't tell when it's wrong. QuantOracle provides grounded, deterministic numerical methods via a free public API:

- **15 tools across 4 opt-in bundles** (`core`, `options`, `risk`, `defi`) — keeps the LLM's tool list small by default while letting power users opt into breadth
- **Free tier covers 13 of 15 tools** — 1,000 calls/IP/day, no signup, no API key
- **Paid composite tools** ($0.04 USDC each) settle via [x402](https://github.com/coinbase/x402) on Base or Solana — no env var required, just a callback the package wires through
- **Citation-tested** against Hull / Wilmott / Lopez de Prado; sub-70ms per call
- **Structured JSON returns** stream cleanly through `useChat` and `streamText`

## Package

- npm: [`@quantoracle/ai-tools`](https://www.npmjs.com/package/@quantoracle/ai-tools)
- Source: https://github.com/QuantOracledev/quantoracle/tree/main/integrations/vercel-ai
- Tutorial: https://quantoracle.dev/writing/vercel-ai-sdk-quant-tools

## Notes on the entry

- **No `apiKeyEnvName`** — the free tier requires no API key. Paid composites use an `x402PayHandler` callback (not an env var) for wallet signing, so I left this field out rather than misrepresent the auth model.
- **Tags**: `['finance', 'quant-finance', 'options']` — first registry entry in the finance/quant category.
- **Code example** uses `model: 'openai/gpt-5-mini'` to match the gateway pattern in the most recent existing entries.

## Test plan

- [x] Package published to npm (`@quantoracle/ai-tools@0.1.0`)
- [x] Smoke-tested all 15 tools end-to-end against the live API — see <https://github.com/QuantOracledev/quantoracle/tree/main/integrations/vercel-ai#quick-start>
- [x] Code example in the entry is the same shape as the smoke test (verified working)
- [x] Followed `contributing/add-new-tool-to-registry.md` schema exactly