### PR TITLE
chore: fix flaky tests diverging on different node versions

### DIFF
--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -3738,7 +3738,18 @@ describe('streamText', () => {
       }
 
       abortController.abort();
-      const { value: abortChunk } = await reader.read();
+      let abortChunk;
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        if (value?.type === 'abort') {
+          abortChunk = value;
+          break;
+        }
+      }
+
       expect(abortChunk?.type).toBe('abort');
 
       while (true) {
@@ -3754,7 +3765,7 @@ describe('streamText', () => {
         (p: any) => p.type === 'text',
       );
       expect(textPart).toBeDefined();
-      expect(textPart.text).toBe(''); // Text was not streamed yet when aborted
+      expect(textPart.text).not.toContain(' from AI'); // Delayed text was not streamed after abort
       expect(callArgs.isAborted).toBe(true); // Stream was aborted
 
       reader.releaseLock();
@@ -14977,19 +14988,29 @@ describe('streamText', () => {
     describe('with transformation that aborts stream', () => {
       const stopWordTransform =
         <TOOLS extends ToolSet>() =>
-        ({ stopStream }: { stopStream: () => void }) =>
-          new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
+        ({ stopStream }: { stopStream: () => void }) => {
+          let stopped = false;
+
+          return new TransformStream<
+            TextStreamPart<TOOLS>,
+            TextStreamPart<TOOLS>
+          >({
             // note: this is a simplified transformation for testing;
             // in a real-world version more there would need to be
             // stream buffering and scanning to correctly emit prior text
             // and to detect all STOP occurrences.
             transform(chunk, controller) {
+              if (stopped) {
+                return;
+              }
+
               if (chunk.type !== 'text-delta') {
                 controller.enqueue(chunk);
                 return;
               }
 
               if (chunk.text.includes('STOP')) {
+                stopped = true;
                 stopStream();
 
                 controller.enqueue({
@@ -15018,6 +15039,7 @@ describe('streamText', () => {
               controller.enqueue(chunk);
             },
           });
+        };
 
       it('stream should stop when STOP token is encountered', async () => {
         const result = streamText({


### PR DESCRIPTION
## Background

our CI tests sometimes run on node verision `24.14.x` and `24.15.x` and that in turn can lead to some flakiness in test that depend on abort stream and stream transformations.

depending on which version the CI runs, the tests break

## Summary

- added a stopped guard to the STOP-token test transform so any chunks already queued after STOP are ignored, making the “stop after STOP” expectation stable across Node 24.14 and 24.15
- relaxed the abort test to wait until it observes an abort chunk, instead of requiring it to be the immediate next chunk, while still verifying no delayed post-abort text is included

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)