### PR TITLE
feat(openai): add opt-in pass-through for unsupported file media types

### DIFF
--- a/.changeset/smart-wasps-develop.md
+++ b/.changeset/smart-wasps-develop.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(openai): add opt-in pass-through for unsupported file media types

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -165,6 +165,10 @@ The following provider options are available:
 
   Whether to store the generation. Defaults to `true`.
 
+- **passThroughUnsupportedFiles** _boolean_
+
+  Whether to pass through non-image file types as generic input files. Defaults to `false`, which restricts inline file inputs to images and PDFs. Enable this when the target OpenAI Responses model supports additional file media types.
+
 - **maxToolCalls** _integer_
   The maximum number of total calls to built-in tools that can be processed in a response.
   This maximum number applies across all built-in tool calls, not per individual tool.

--- a/examples/ai-functions/src/generate-text/openai/responses-unsupported-file-type.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-unsupported-file-type.ts
@@ -1,0 +1,36 @@
+import {
+  openai,
+  type OpenAILanguageModelResponsesOptions,
+} from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai.responses('gpt-4.1-nano'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What names appear in this CSV? Reply with just the names.',
+          },
+          {
+            type: 'file',
+            filename: 'names.csv',
+            mediaType: 'text/csv',
+            data: Buffer.from('name,role\nAda,engineer\nGrace,scientist\n'),
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      openai: {
+        passThroughUnsupportedFiles: true,
+      } satisfies OpenAILanguageModelResponsesOptions,
+    },
+  });
+
+  console.log(result.text);
+});

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -592,6 +592,44 @@ describe('convertToOpenAIResponsesInput', () => {
       ).rejects.toThrow('file part media type text/plain');
     });
 
+    it('should pass through unsupported file types when enabled', async () => {
+      const base64Data = 'bmFtZSxyb2xlCkFkYSxlbmdpbmVlcgo=';
+
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/csv',
+                data: { type: 'data' as const, data: base64Data },
+                filename: 'names.csv',
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        passThroughUnsupportedFiles: true,
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              filename: 'names.csv',
+              file_data: `data:text/csv;base64,${base64Data}`,
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should convert PDF file parts with URL to input_file with file_url', async () => {
       const result = await convertToOpenAIResponsesInput({
         prompt: [

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -58,6 +58,7 @@ export async function convertToOpenAIResponsesInput({
   systemMessageMode,
   providerOptionsName,
   fileIdPrefixes,
+  passThroughUnsupportedFiles = false,
   store,
   hasConversation = false,
   hasLocalShellTool = false,
@@ -71,6 +72,7 @@ export async function convertToOpenAIResponsesInput({
   providerOptionsName: string;
   /** @deprecated Use provider references instead. */
   fileIdPrefixes?: readonly string[];
+  passThroughUnsupportedFiles?: boolean;
   store: boolean;
   hasConversation?: boolean; // when true, skip assistant messages that already have item IDs
   hasLocalShellTool?: boolean;
@@ -178,7 +180,10 @@ export async function convertToOpenAIResponsesInput({
                       }
 
                       const fullMediaType = resolveFullMediaType({ part });
-                      if (fullMediaType !== 'application/pdf') {
+                      if (
+                        fullMediaType !== 'application/pdf' &&
+                        !passThroughUnsupportedFiles
+                      ) {
                         throw new UnsupportedFunctionalityError({
                           functionality: `file part media type ${fullMediaType}`,
                         });
@@ -190,8 +195,12 @@ export async function convertToOpenAIResponsesInput({
                         isFileId(part.data.data, fileIdPrefixes)
                           ? { file_id: part.data.data }
                           : {
-                              filename: part.filename ?? `part-${index}.pdf`,
-                              file_data: `data:application/pdf;base64,${convertToBase64(part.data.data)}`,
+                              filename:
+                                part.filename ??
+                                (fullMediaType === 'application/pdf'
+                                  ? `part-${index}.pdf`
+                                  : `part-${index}`),
+                              file_data: `data:${fullMediaType};base64,${convertToBase64(part.data.data)}`,
                             }),
                       };
                     }

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -270,6 +270,15 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
       store: z.boolean().nullish(),
 
       /**
+       * Whether to pass through non-image file types as generic input files.
+       *
+       * By default, inline file inputs are restricted to images and PDFs.
+       * Enable this when the target OpenAI Responses model supports additional
+       * file media types, such as text/csv.
+       */
+      passThroughUnsupportedFiles: z.boolean().optional(),
+
+      /**
        * Whether to use strict JSON schema validation.
        * Defaults to `true`.
        */

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -249,6 +249,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
             : modelCapabilities.systemMessageMode),
         providerOptionsName,
         fileIdPrefixes: this.config.fileIdPrefixes,
+        passThroughUnsupportedFiles:
+          openaiOptions?.passThroughUnsupportedFiles ?? false,
         store: openaiOptions?.store ?? true,
         hasConversation: openaiOptions?.conversation != null,
         hasLocalShellTool: hasOpenAITool('openai.local_shell'),


### PR DESCRIPTION
## Background

#14747

AI SDK currently applies a hardcoded allowlist when converting user file parts for some providers (in this case OpenAI) even though OpenAI can accept other file inputs generically. Currently, unsupported non-image inline files are rejected or dropped unless they are PDFs.

## Summary

- adds an opt-in `passThroughUnsupportedFiles` provider option for OpenAI file-part conversion

## Manual Verification

verified by running the example `examples/ai-functions/src/generate-text/openai/responses-unsupported-file-type.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14747 

Co-authored-by: priyanshu <priyanshukumar@priyanshus-MacBook-Air-4.local>