### PR TITLE
fix(gateway): add automatic caching provider option

### DIFF
--- a/.changeset/gateway-caching-option.md
+++ b/.changeset/gateway-caching-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix: add `caching: 'auto'` to Gateway provider options

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -806,6 +806,12 @@ The following gateway provider options are available:
 
   Example: `tags: ['chat', 'v2']` will tag this request with "chat" and "v2" for filtering in usage analytics.
 
+- **caching** _'auto'_
+
+  Enables AI Gateway automatic prompt caching for the request.
+
+  Example: `caching: 'auto'` will let AI Gateway automatically cache prompt content for supported models.
+
 - **byok** _Record&lt;string, Array&lt;Record&lt;string, unknown&gt;&gt;&gt;_
 
   Request-scoped BYOK (Bring Your Own Key) credentials to use for this request. When provided, any cached BYOK credentials configured in the gateway system are not considered. Requests may still fall back to use system credentials if the provided credentials fail.

--- a/packages/gateway/src/gateway-provider-options.test-d.ts
+++ b/packages/gateway/src/gateway-provider-options.test-d.ts
@@ -1,0 +1,16 @@
+import type { GatewayProviderOptions } from './gateway-provider-options';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('GatewayProviderOptions', () => {
+  it('accepts automatic caching', () => {
+    expectTypeOf<{
+      caching: 'auto',
+    }>().toMatchTypeOf<GatewayProviderOptions>();
+  });
+
+  it('does not accept unsupported caching modes', () => {
+    expectTypeOf<{
+      caching: 'manual';
+    }>().not.toMatchTypeOf<GatewayProviderOptions>();
+  });
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -44,6 +44,10 @@ const gatewayProviderOptions = lazySchema(() =>
        */
       tags: z.array(z.string()).optional(),
       /**
+       * Whether to enable AI Gateway automatic prompt caching for the request.
+       */
+      caching: z.literal('auto').optional(),
+      /**
        * Array of model slugs specifying fallback models to use in order.
        *
        * Example: `['openai/gpt-5-nano', 'zai/glm-4.6']` will try `openai/gpt-5-nano` first, then `zai/glm-4.6` as fallback.


### PR DESCRIPTION
## Background

`GatewayProviderOptions` did not include the documented `caching: 'auto'` option, so strict TypeScript usage with `satisfies GatewayProviderOptions` failed.

## Summary

- Adds `caching: 'auto'` to `GatewayProviderOptions`
- Adds a type-level test covering the accepted caching mode
- Updates the AI Gateway provider options docs
- Adds a patch changeset for `@ai-sdk/gateway`

## Manual Verification

- `pnpm --filter @ai-sdk/gateway type-check`
- `pnpm --filter @ai-sdk/gateway test:node -- gateway-language-model.test.ts`

Note: both commands print the local Node v26 engine warning, but pass.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14595
