### PR TITLE
ci: declare workflow-level `contents: read` on 1 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release-v*
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: 'Lint & Format'


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 1 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `ai-provider-api-changes.yml`, `ai-provider-models.yml`, `verify-changesets.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.