### PR TITLE
fix: rename Sandbox.executeCommand to Sandbox.runCommand

### DIFF
--- a/.changeset/weak-ants-film.md
+++ b/.changeset/weak-ants-film.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider-utils": patch
+"ai": patch
+---
+
+rename Sandbox.executeCommand to Sandbox.runCommand

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -158,7 +158,7 @@ const agent = new ToolLoopAgent({
           throw new Error('Experimental sandbox is not available');
         }
 
-        return experimental_sandbox.executeCommand({
+        return experimental_sandbox.runCommand({
           command,
           workingDirectory,
           abortSignal,

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -88,7 +88,7 @@ const shell = tool({
       throw new Error('Experimental sandbox is not available');
     }
 
-    return experimental_sandbox.executeCommand({ command });
+    return experimental_sandbox.runCommand({ command });
   },
 });
 
@@ -911,7 +911,7 @@ call when a tool needs to run commands or code in an execution environment. The 
 </Note>
 
 Tool code still runs wherever your application runs. Only the operations that your tool explicitly delegates to
-the experimental sandbox, such as `experimental_sandbox.executeCommand(...)`,
+the experimental sandbox, such as `experimental_sandbox.runCommand(...)`,
 run in the experimental sandbox environment.
 
 ```ts highlight="7-15,21"
@@ -934,7 +934,7 @@ const result = await generateText({
           throw new Error('Experimental sandbox is not available');
         }
 
-        return experimental_sandbox.executeCommand({
+        return experimental_sandbox.runCommand({
           command,
           workingDirectory,
           abortSignal,
@@ -950,7 +950,7 @@ const result = await generateText({
 The experimental sandbox description is not added to the model prompt automatically. If the model should know about details such as the root directory, exposed ports, or public hostname, include `experimental_sandbox.description` in your system prompt,
 instructions, user-visible context, or a tool description function.
 
-`executeCommand` also accepts an optional `workingDirectory` and `abortSignal`.
+`runCommand` also accepts an optional `workingDirectory` and `abortSignal`.
 Use `workingDirectory` when a tool needs to run a command from a directory other
 than the experimental sandbox implementation's default working directory. Forward
 `abortSignal` from the tool execution options so the experimental sandbox can cancel the command if the overall operation is aborted or times out.

--- a/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
@@ -30,7 +30,7 @@ make it available to tool description functions and tool execution.
 ```ts
 type Experimental_Sandbox = {
   readonly description: string;
-  readonly executeCommand: (options: {
+  readonly runCommand: (options: {
     command: string;
     workingDirectory?: string;
     abortSignal?: AbortSignal;
@@ -53,7 +53,7 @@ type Experimental_Sandbox = {
         'Description of the experimental sandbox environment. Include this in your prompt or instructions when the model needs to know details such as the root directory, exposed ports, public hostname, or other environment constraints. The AI SDK does not add it to the prompt automatically.',
     },
     {
-      name: 'executeCommand',
+      name: 'runCommand',
       type: '(options: { command: string; workingDirectory?: string; abortSignal?: AbortSignal }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
       description:
         'Executes a command in the experimental sandbox and resolves with the command exit code, standard output, and standard error.',
@@ -113,7 +113,7 @@ const shell = tool({
       throw new Error('Experimental sandbox is not available');
     }
 
-    return experimental_sandbox.executeCommand({
+    return experimental_sandbox.runCommand({
       command,
       workingDirectory,
       abortSignal,

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -738,7 +738,7 @@ const result = await generateText({
   },
   experimental_sandbox: {
     description: 'A sandboxed shell environment.',
-    executeCommand: async ({ command }) => {
+    runCommand: async ({ command }) => {
       // Run the command in your sandbox and return the result.
       return {
         exitCode: 0,

--- a/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
+++ b/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
@@ -23,7 +23,7 @@ export class VercelSandbox implements Sandbox {
     >,
   ) {}
 
-  async executeCommand({
+  async runCommand({
     command,
     workingDirectory,
     abortSignal,

--- a/examples/ai-e2e-next/tool/sandbox-shell-tool.ts
+++ b/examples/ai-e2e-next/tool/sandbox-shell-tool.ts
@@ -17,7 +17,7 @@ export function sandboxShellTool() {
       if (!sandbox) {
         throw new Error('Sandbox is not available');
       }
-      return sandbox.executeCommand({
+      return sandbox.runCommand({
         command,
         workingDirectory,
         abortSignal,

--- a/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
@@ -4,7 +4,7 @@ import { type Bash } from 'just-bash';
 export class JustBashSandbox implements Sandbox {
   constructor(private readonly bash: Bash) {}
 
-  async executeCommand({
+  async runCommand({
     command,
     workingDirectory,
     abortSignal,

--- a/examples/ai-functions/src/sandbox/local-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/local-sandbox.ts
@@ -24,7 +24,7 @@ export class LocalSandbox implements Sandbox {
     this.rootDirectory = rootDirectory;
   }
 
-  async executeCommand({
+  async runCommand({
     command,
     workingDirectory,
     abortSignal,

--- a/examples/ai-functions/src/sandbox/vercel-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/vercel-sandbox.ts
@@ -10,7 +10,7 @@ export class VercelSandbox implements Sandbox {
     >,
   ) {}
 
-  async executeCommand({
+  async runCommand({
     command,
     workingDirectory,
     abortSignal,

--- a/examples/ai-functions/src/tools/sandbox-shell-tool.ts
+++ b/examples/ai-functions/src/tools/sandbox-shell-tool.ts
@@ -17,7 +17,7 @@ export function sandboxShellTool() {
       if (!sandbox) {
         throw new Error('Sandbox is not available');
       }
-      return sandbox.executeCommand({
+      return sandbox.runCommand({
         command,
         workingDirectory,
         abortSignal,

--- a/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
@@ -363,7 +363,7 @@ describe('createAgentUIStreamResponse', () => {
   it('should pass sandbox to tool execution', async () => {
     const sandbox = {
       description: 'test sandbox',
-      executeCommand: async () => ({
+      runCommand: async () => ({
         exitCode: 0,
         stdout: 'ok',
         stderr: '',

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -104,7 +104,7 @@ describe('ToolLoopAgent', () => {
     it('should pass sandbox to prepareCall', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -157,7 +157,7 @@ describe('ToolLoopAgent', () => {
     it('should pass sandbox to tool execution', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -689,7 +689,7 @@ describe('ToolLoopAgent', () => {
     it('should pass sandbox to prepareCall', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -751,7 +751,7 @@ describe('ToolLoopAgent', () => {
     it('should pass sandbox to tool execution', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -87,7 +87,7 @@ describe('executeToolCall', () => {
     it('should pass sandbox to tool execution', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',

--- a/packages/ai/src/generate-text/execute-tools-from-stream.test.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.test.ts
@@ -237,7 +237,7 @@ describe('executeToolsFromStream', () => {
   it('should pass sandbox to tool execution', async () => {
     const sandbox = {
       description: 'test sandbox',
-      executeCommand: vi.fn(async () => ({
+      runCommand: vi.fn(async () => ({
         exitCode: 0,
         stdout: 'ok',
         stderr: '',

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -381,7 +381,7 @@ describe('generateText types', () => {
           prepareStep: () => ({
             experimental_sandbox: {
               description: 'test sandbox',
-              executeCommand: async () => ({
+              runCommand: async () => ({
                 exitCode: 0,
                 stdout: 'ok',
                 stderr: '',

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -8415,7 +8415,7 @@ describe('generateText', () => {
     it('should pass sandbox to tool execution', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -8479,7 +8479,7 @@ describe('generateText', () => {
     it('should pass sandbox to prepareStep', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -8508,7 +8508,7 @@ describe('generateText', () => {
     it('should use sandbox returned from prepareStep for that step only', async () => {
       const sandbox = {
         description: 'default sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -8516,7 +8516,7 @@ describe('generateText', () => {
       } satisfies Sandbox;
       const stepSandbox = {
         description: 'step sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -497,7 +497,7 @@ describe('streamText types', () => {
           prepareStep: () => ({
             experimental_sandbox: {
               description: 'test sandbox',
-              executeCommand: async () => ({
+              runCommand: async () => ({
                 exitCode: 0,
                 stdout: 'ok',
                 stderr: '',

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -20148,7 +20148,7 @@ describe('streamText', () => {
     it('should pass sandbox to tool execution', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -20224,7 +20224,7 @@ describe('streamText', () => {
     it('should pass sandbox to prepareStep', async () => {
       const sandbox = {
         description: 'test sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -20264,7 +20264,7 @@ describe('streamText', () => {
     it('should use sandbox returned from prepareStep for that step only', async () => {
       const sandbox = {
         description: 'default sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -20272,7 +20272,7 @@ describe('streamText', () => {
       } satisfies Sandbox;
       const stepSandbox = {
         description: 'step sandbox',
-        executeCommand: vi.fn(async () => ({
+        runCommand: vi.fn(async () => ({
           exitCode: 0,
           stdout: 'ok',
           stderr: '',
@@ -24555,7 +24555,7 @@ describe('streamText', () => {
         executeFunction = vi.fn().mockReturnValue('result1');
         sandbox = {
           description: 'test sandbox',
-          executeCommand: vi.fn(async () => ({
+          runCommand: vi.fn(async () => ({
             exitCode: 0,
             stdout: 'ok',
             stderr: '',

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -236,7 +236,7 @@ describe('prepareTools', () => {
   it('resolves function descriptions from toolsContext and sandbox', async () => {
     const sandbox: Sandbox = {
       description: 'test-sandbox',
-      executeCommand: async () => ({
+      runCommand: async () => ({
         exitCode: 0,
         stdout: '',
         stderr: '',

--- a/packages/anthropic/src/tool/bash_20241022.test.ts
+++ b/packages/anthropic/src/tool/bash_20241022.test.ts
@@ -16,7 +16,7 @@ describe('bash_20241022 tool', () => {
         context: {},
         experimental_sandbox: {
           description: 'test sandbox',
-          executeCommand: async ({ abortSignal }) => {
+          runCommand: async ({ abortSignal }) => {
             receivedAbortSignal = abortSignal;
 
             return {

--- a/packages/anthropic/src/tool/bash_20241022.ts
+++ b/packages/anthropic/src/tool/bash_20241022.ts
@@ -54,7 +54,7 @@ type Bash20241022OptionsWithNullableExecute<OUTPUT> = Omit<
   execute?: Bash20241022Options<OUTPUT>['execute'] | null;
 };
 
-type Bash20241022DefaultOutput = Awaited<ReturnType<Sandbox['executeCommand']>>;
+type Bash20241022DefaultOutput = Awaited<ReturnType<Sandbox['runCommand']>>;
 
 export function bash_20241022(
   options?: Omit<Bash20241022Options<Bash20241022DefaultOutput>, 'execute'> & {
@@ -87,7 +87,7 @@ export function bash_20241022<OUTPUT>(
           throw new Error('Sandbox is not available');
         }
 
-        return await sandbox.executeCommand({
+        return await sandbox.runCommand({
           command,
           abortSignal,
         });

--- a/packages/anthropic/src/tool/bash_20250124.test.ts
+++ b/packages/anthropic/src/tool/bash_20250124.test.ts
@@ -16,7 +16,7 @@ describe('bash_20250124 tool', () => {
         context: {},
         experimental_sandbox: {
           description: 'test sandbox',
-          executeCommand: async ({ abortSignal }) => {
+          runCommand: async ({ abortSignal }) => {
             receivedAbortSignal = abortSignal;
 
             return {

--- a/packages/anthropic/src/tool/bash_20250124.ts
+++ b/packages/anthropic/src/tool/bash_20250124.ts
@@ -54,7 +54,7 @@ type Bash20250124OptionsWithNullableExecute<OUTPUT> = Omit<
   execute?: Bash20250124Options<OUTPUT>['execute'] | null;
 };
 
-type Bash20250124DefaultOutput = Awaited<ReturnType<Sandbox['executeCommand']>>;
+type Bash20250124DefaultOutput = Awaited<ReturnType<Sandbox['runCommand']>>;
 
 export function bash_20250124(
   options?: Omit<Bash20250124Options<Bash20250124DefaultOutput>, 'execute'> & {
@@ -87,7 +87,7 @@ export function bash_20250124<OUTPUT>(
           throw new Error('Sandbox is not available');
         }
 
-        return await sandbox.executeCommand({
+        return await sandbox.runCommand({
           command,
           abortSignal,
         });

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -10,9 +10,9 @@ export type Experimental_Sandbox = {
   readonly description: string;
 
   /**
-   * Execute a command in the sandbox.
+   * Run a command in the sandbox.
    */
-  readonly executeCommand: (options: {
+  readonly runCommand: (options: {
     /**
      * Command to execute in the sandbox.
      */

--- a/packages/provider-utils/src/types/tool-execute-function.test-d.ts
+++ b/packages/provider-utils/src/types/tool-execute-function.test-d.ts
@@ -19,7 +19,7 @@ describe('tool execute function types', () => {
   });
 
   it('should include abort signal in sandbox command options', () => {
-    expectTypeOf<Parameters<Sandbox['executeCommand']>[0]>().toEqualTypeOf<{
+    expectTypeOf<Parameters<Sandbox['runCommand']>[0]>().toEqualTypeOf<{
       command: string;
       workingDirectory?: string;
       abortSignal?: AbortSignal;


### PR DESCRIPTION
## Background
`runCommand` is a common name that is shorter than `executeCommand`

## Summary

rename Sandbox.executeCommand to Sandbox.runCommand
