### PR TITLE
fix: support tools with optional context

### DIFF
--- a/.changeset/thick-bulldogs-brake.md
+++ b/.changeset/thick-bulldogs-brake.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider-utils": patch
+"ai": patch
+---
+
+fix: support tools with optional context

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -4,6 +4,7 @@ import {
   type Context,
   type ModelMessage,
   type SystemModelMessage,
+  type Tool,
 } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
@@ -122,6 +123,21 @@ describe('generateText types', () => {
       execute: async () => 'result',
     }),
   };
+
+  type ToolWithFullyOptionalContext = {
+    weather: Tool<{ location: string }, never, { weatherApiKey?: string }>;
+  };
+
+  type ToolWithOptionalContextObject = {
+    weather: Tool<
+      { location: string },
+      never,
+      { weatherApiKey: string } | undefined
+    >;
+  };
+
+  const toolWithFullyOptionalContext = {} as ToolWithFullyOptionalContext;
+  const toolWithOptionalContextObject = {} as ToolWithOptionalContextObject;
 
   describe('experimental_refineToolInput', () => {
     it('should infer input and return types for each tool', async () => {
@@ -443,6 +459,73 @@ describe('generateText types', () => {
           tools: toolWithoutContext,
           // @ts-expect-error toolsContext is not accepted when no tools require it
           toolsContext: {},
+        });
+      });
+    });
+
+    describe('single tool with fully optional contextSchema', () => {
+      it('should reject no toolsContext', async () => {
+        // @ts-expect-error toolsContext is required when a tool has contextSchema
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithFullyOptionalContext,
+        });
+      });
+
+      it('should accept empty toolsContext entry', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithFullyOptionalContext,
+          toolsContext: { weather: {} },
+        });
+      });
+    });
+
+    describe('single tool with optional context object', () => {
+      it('should accept no toolsContext', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+        });
+      });
+
+      it('should accept empty toolsContext', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          toolsContext: {},
+        });
+      });
+
+      it('should accept undefined toolsContext entry', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          toolsContext: { weather: undefined },
+        });
+      });
+
+      it('should accept defined toolsContext entry', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          toolsContext: { weather: { weatherApiKey: 'key' } },
+        });
+      });
+
+      it('should reject missing required fields when context object is provided', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          // @ts-expect-error missing required weather.weatherApiKey
+          toolsContext: { weather: {} },
         });
       });
     });

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -1,5 +1,10 @@
 import type { JSONValue } from '@ai-sdk/provider';
-import { tool, type Context, type ModelMessage } from '@ai-sdk/provider-utils';
+import {
+  tool,
+  type Context,
+  type ModelMessage,
+  type Tool,
+} from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import { Output, streamText } from '../generate-text';
@@ -238,6 +243,21 @@ describe('streamText types', () => {
       execute: async () => 'result',
     }),
   };
+
+  type ToolWithFullyOptionalContext = {
+    weather: Tool<{ location: string }, never, { weatherApiKey?: string }>;
+  };
+
+  type ToolWithOptionalContextObject = {
+    weather: Tool<
+      { location: string },
+      never,
+      { weatherApiKey: string } | undefined
+    >;
+  };
+
+  const toolWithFullyOptionalContext = {} as ToolWithFullyOptionalContext;
+  const toolWithOptionalContextObject = {} as ToolWithOptionalContextObject;
 
   describe('experimental_refineToolInput', () => {
     it('should infer input and return types for each tool', async () => {
@@ -559,6 +579,73 @@ describe('streamText types', () => {
           tools: toolWithoutContext,
           // @ts-expect-error toolsContext is not accepted when no tools require it
           toolsContext: {},
+        });
+      });
+    });
+
+    describe('single tool with fully optional contextSchema', () => {
+      it('should reject no toolsContext', async () => {
+        // @ts-expect-error toolsContext is required when a tool has contextSchema
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithFullyOptionalContext,
+        });
+      });
+
+      it('should accept empty toolsContext entry', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithFullyOptionalContext,
+          toolsContext: { weather: {} },
+        });
+      });
+    });
+
+    describe('single tool with optional context object', () => {
+      it('should accept no toolsContext', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+        });
+      });
+
+      it('should accept empty toolsContext', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          toolsContext: {},
+        });
+      });
+
+      it('should accept undefined toolsContext entry', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          toolsContext: { weather: undefined },
+        });
+      });
+
+      it('should accept defined toolsContext entry', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          toolsContext: { weather: { weatherApiKey: 'key' } },
+        });
+      });
+
+      it('should reject missing required fields when context object is provided', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          tools: toolWithOptionalContextObject,
+          // @ts-expect-error missing required weather.weatherApiKey
+          toolsContext: { weather: {} },
         });
       });
     });

--- a/packages/ai/src/generate-text/tools-context-parameter.test-d.ts
+++ b/packages/ai/src/generate-text/tools-context-parameter.test-d.ts
@@ -45,6 +45,38 @@ describe('ToolsContextParameter', () => {
     expectTypeOf<Expected>().toMatchTypeOf<ToolsContextParameter<Tools>>();
   });
 
+  it('makes toolsContext required when a tool has optional-only context properties', () => {
+    type Tools = {
+      weather: Tool<{ city: string }, any, { userId?: string }>;
+    };
+    type Expected = {
+      tools?: Tools;
+      toolsContext: {
+        weather: {
+          userId?: string;
+        };
+      };
+    };
+
+    expectTypeOf<ToolsContextParameter<Tools>>().toMatchTypeOf<Expected>();
+    expectTypeOf<Expected>().toMatchTypeOf<ToolsContextParameter<Tools>>();
+  });
+
+  it('makes toolsContext optional when the context object is optional', () => {
+    type Tools = {
+      weather: Tool<{ city: string }, any, { userId: string } | undefined>;
+    };
+    type Expected = {
+      tools?: Tools;
+      toolsContext?: {
+        weather?: { userId: string } | undefined;
+      };
+    };
+
+    expectTypeOf<ToolsContextParameter<Tools>>().toMatchTypeOf<Expected>();
+    expectTypeOf<Expected>().toMatchTypeOf<ToolsContextParameter<Tools>>();
+  });
+
   it('includes only contextual tools in the inferred toolsContext map', () => {
     type Tools = {
       weather: Tool<{ location: string }>;
@@ -148,6 +180,19 @@ describe('ToolsContextParameter', () => {
     }>();
   });
 
+  it('uses toolsContext?: never when a tool has an empty context object', () => {
+    type Tools = {
+      weather: Tool<{ city: string }, any, {}>;
+    };
+    type Expected = {
+      tools?: Tools;
+      toolsContext?: never;
+    };
+
+    expectTypeOf<ToolsContextParameter<Tools>>().toMatchTypeOf<Expected>();
+    expectTypeOf<Expected>().toMatchTypeOf<ToolsContextParameter<Tools>>();
+  });
+
   describe('negative cases', () => {
     it('errors when toolsContext is provided for an empty toolset', () => {
       type Tools = {};
@@ -193,6 +238,42 @@ describe('ToolsContextParameter', () => {
       };
 
       expectTypeOf(missingRequiredField).toEqualTypeOf<
+        ToolsContextParameter<Tools>
+      >();
+    });
+
+    it('errors when optional-only nested tool context fields have the wrong type', () => {
+      type Tools = {
+        weather: Tool<{ city: string }, any, { userId?: string }>;
+      };
+
+      const invalidOptionalField: ToolsContextParameter<Tools> = {
+        toolsContext: {
+          weather: {
+            // @ts-expect-error - optional nested tool context fields must match their declared type
+            userId: 123,
+          },
+        },
+      };
+
+      expectTypeOf(invalidOptionalField).toEqualTypeOf<
+        ToolsContextParameter<Tools>
+      >();
+    });
+
+    it('errors when optional context object fields are missing after the entry is provided', () => {
+      type Tools = {
+        weather: Tool<{ city: string }, any, { userId: string } | undefined>;
+      };
+
+      const missingOptionalObjectField: ToolsContextParameter<Tools> = {
+        toolsContext: {
+          // @ts-expect-error - provided optional context objects must satisfy their object type
+          weather: {},
+        },
+      };
+
+      expectTypeOf(missingOptionalObjectField).toEqualTypeOf<
         ToolsContextParameter<Tools>
       >();
     });

--- a/packages/ai/src/generate-text/tools-context-parameter.ts
+++ b/packages/ai/src/generate-text/tools-context-parameter.ts
@@ -5,10 +5,18 @@ import type {
 } from '@ai-sdk/provider-utils';
 
 /**
- * Helper type to make the toolsContext parameter optional or required based on the tool set.
+ * Checks whether a tool context map contains any contextual tool entries.
+ */
+type IsEmptyObject<OBJECT> = keyof OBJECT extends never ? true : false;
+
+/**
+ * Helper type to make the toolsContext parameter optional, required, or
+ * unavailable based on the tool set.
  */
 export type ToolsContextParameter<TOOLS extends ToolSet> = {
   tools?: TOOLS;
-} & (HasRequiredKey<InferToolSetContext<TOOLS>> extends true
-  ? { toolsContext: InferToolSetContext<TOOLS> }
-  : { toolsContext?: never });
+} & (IsEmptyObject<InferToolSetContext<TOOLS>> extends true
+  ? { toolsContext?: never }
+  : HasRequiredKey<InferToolSetContext<TOOLS>> extends true
+    ? { toolsContext: InferToolSetContext<TOOLS> }
+    : { toolsContext?: InferToolSetContext<TOOLS> });

--- a/packages/provider-utils/src/types/infer-tool-context.test-d.ts
+++ b/packages/provider-utils/src/types/infer-tool-context.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
 import type { InferToolContext } from './infer-tool-context';
-import { tool } from './tool';
+import { tool, type Tool } from './tool';
 
 describe('InferToolContext', () => {
   it('infers the context type from a tool with contextSchema', () => {
@@ -31,5 +31,36 @@ describe('InferToolContext', () => {
     });
 
     expectTypeOf<InferToolContext<typeof weatherTool>>().toEqualTypeOf<never>();
+  });
+
+  it('infers optional-only context object properties', () => {
+    type WeatherTool = Tool<
+      { city: string },
+      never,
+      { userId?: string; role?: string }
+    >;
+
+    expectTypeOf<InferToolContext<WeatherTool>>().toEqualTypeOf<{
+      userId?: string;
+      role?: string;
+    }>();
+  });
+
+  it('infers optional context objects', () => {
+    type WeatherTool = Tool<
+      { city: string },
+      never,
+      { userId: string } | undefined
+    >;
+
+    expectTypeOf<InferToolContext<WeatherTool>>().toEqualTypeOf<
+      { userId: string } | undefined
+    >();
+  });
+
+  it('infers never for an empty context object', () => {
+    type WeatherTool = Tool<{ city: string }, never, {}>;
+
+    expectTypeOf<InferToolContext<WeatherTool>>().toEqualTypeOf<never>();
   });
 });

--- a/packages/provider-utils/src/types/infer-tool-context.ts
+++ b/packages/provider-utils/src/types/infer-tool-context.ts
@@ -1,12 +1,41 @@
-import type { HasRequiredKey } from '../has-required-key';
+import type { Context } from './context';
 import type { Tool } from './tool';
+
+/**
+ * Detects the `any` type so untyped tools can be treated as having no explicit
+ * context type.
+ */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+ * Detects exact empty object contexts, including `{}` combined with
+ * `undefined`, which do not provide tool-specific context properties.
+ */
+type IsEmptyObject<T> = keyof NonNullable<T> extends never ? true : false;
+
+/**
+ * Detects context types that come from omitted or broad context declarations
+ * rather than a concrete tool context schema.
+ */
+type IsUntypedContext<CONTEXT> =
+  IsAny<CONTEXT> extends true
+    ? true
+    : unknown extends CONTEXT
+      ? true
+      : IsEmptyObject<CONTEXT> extends true
+        ? true
+        : string extends keyof CONTEXT
+          ? CONTEXT extends Context
+            ? true
+            : false
+          : false;
 
 /**
  * Infer the context type of a tool.
  */
 export type InferToolContext<TOOL extends Tool> =
   TOOL extends Tool<any, any, infer CONTEXT>
-    ? HasRequiredKey<CONTEXT> extends true
-      ? CONTEXT
-      : never
+    ? IsUntypedContext<CONTEXT> extends true
+      ? never
+      : CONTEXT
     : never;

--- a/packages/provider-utils/src/types/infer-tool-set-context.test-d.ts
+++ b/packages/provider-utils/src/types/infer-tool-set-context.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
 import type { InferToolSetContext } from './infer-tool-set-context';
-import { tool } from './tool';
+import { tool, type Tool } from './tool';
 
 describe('InferToolSetContext', () => {
   it('maps tool names to required context types across a tool set', () => {
@@ -85,5 +85,40 @@ describe('InferToolSetContext', () => {
         userId: string;
       };
     }>();
+  });
+
+  it('keeps tools with optional-only context properties', () => {
+    type Tools = {
+      weather: Tool<
+        { city: string },
+        never,
+        { userId?: string; role?: string }
+      >;
+    };
+
+    expectTypeOf<InferToolSetContext<Tools>>().toEqualTypeOf<{
+      weather: {
+        userId?: string;
+        role?: string;
+      };
+    }>();
+  });
+
+  it('makes tool entries optional when the context object is optional', () => {
+    type Tools = {
+      weather: Tool<{ city: string }, never, { userId: string } | undefined>;
+    };
+
+    expectTypeOf<InferToolSetContext<Tools>>().toEqualTypeOf<{
+      weather?: { userId: string } | undefined;
+    }>();
+  });
+
+  it('omits tools with empty context objects', () => {
+    type Tools = {
+      weather: Tool<{ city: string }, never, {}>;
+    };
+
+    expectTypeOf<InferToolSetContext<Tools>>().toEqualTypeOf<{}>();
   });
 });

--- a/packages/provider-utils/src/types/infer-tool-set-context.ts
+++ b/packages/provider-utils/src/types/infer-tool-set-context.ts
@@ -2,14 +2,43 @@ import type { InferToolContext } from './infer-tool-context';
 import type { ToolSet } from './tool-set';
 
 /**
- * Infer the context type for a tool set.
- *
- * The inferred type maps each tool name to its required context type.
- *
- * Tools without required context properties are omitted from the result.
+ * Builds the required portion of the tool context map for tools whose context
+ * type does not include `undefined`.
  */
-export type InferToolSetContext<TOOLS extends ToolSet> = {
+type RequiredToolSetContext<TOOLS extends ToolSet> = {
   [K in keyof TOOLS as InferToolContext<NoInfer<TOOLS[K]>> extends never
     ? never
-    : K]: InferToolContext<NoInfer<TOOLS[K]>>;
+    : undefined extends InferToolContext<NoInfer<TOOLS[K]>>
+      ? never
+      : K]: InferToolContext<NoInfer<TOOLS[K]>>;
 };
+
+/**
+ * Builds the optional portion of the tool context map for tools whose context
+ * object itself may be `undefined`.
+ */
+type OptionalToolSetContext<TOOLS extends ToolSet> = {
+  [K in keyof TOOLS as InferToolContext<NoInfer<TOOLS[K]>> extends never
+    ? never
+    : undefined extends InferToolContext<NoInfer<TOOLS[K]>>
+      ? K
+      : never]?: InferToolContext<NoInfer<TOOLS[K]>>;
+};
+
+/**
+ * Flattens intersected mapped types so type equality assertions and editor
+ * hovers show the resulting object shape.
+ */
+type Normalize<OBJECT> = { [KEY in keyof OBJECT]: OBJECT[KEY] };
+
+/**
+ * Infer the context type for a tool set.
+ *
+ * The inferred type maps each contextual tool name to its context type.
+ *
+ * Tools without concrete context are omitted. Tool contexts that include
+ * `undefined` are represented as optional properties.
+ */
+export type InferToolSetContext<TOOLS extends ToolSet> = Normalize<
+  RequiredToolSetContext<TOOLS> & OptionalToolSetContext<TOOLS>
+>;


### PR DESCRIPTION
## Background

Tools with optional context schemas and with context schemas that only contained optional parameters were rejected with type errors on `toolsContext`.

## Summary

Fix tool context type inference.