### PR TITLE
Use specific tool in tool choice

### DIFF
--- a/.changeset/clean-jeans-cough.md
+++ b/.changeset/clean-jeans-cough.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mistral": minor
+---
+
+Use Mistral's official tool choice syntax when defining a specific tool to be called

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -76,13 +76,13 @@ export function prepareTools({
       return { tools: mistralTools, toolChoice: type, toolWarnings };
     case 'required':
       return { tools: mistralTools, toolChoice: 'any', toolWarnings };
-
-    // mistral does not support tool mode directly,
-    // so we filter the tools and force the tool choice through 'any'
     case 'tool':
       return {
         tools: mistralTools,
-        toolChoice: { type: 'function', function: { name: toolChoice.toolName } },
+        toolChoice: {
+          type: 'function',
+          function: { name: toolChoice.toolName },
+        },
         toolWarnings,
       };
     default: {

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -81,10 +81,8 @@ export function prepareTools({
     // so we filter the tools and force the tool choice through 'any'
     case 'tool':
       return {
-        tools: mistralTools.filter(
-          tool => tool.function.name === toolChoice.toolName,
-        ),
-        toolChoice: 'any',
+        tools: mistralTools,
+        toolChoice: { type: 'function', function: { name: toolChoice.toolName } },
         toolWarnings,
       };
     default: {


### PR DESCRIPTION
## Background

Mistral now supports picking a specific tool as an argument to `tool_choice` as documented [here](https://docs.mistral.ai/api/endpoint/chat?property=operation-chat_completion_v1_chat_completions_post_request_tool_choice#operation-chat_completion_v1_chat_completions_post_request_tool_choice), so the workaround is no longer necessary. In my testing these two options also behave drastically different.

I didn't add tests as there were no pre-existing tests for this part of the code.

I was unsure about the changelog, but I marked this as a minor change as the API stays the same (although the underlying behavior does change).

## Summary

I removed the current workaround of filtering down tool choices and making the tool choice required and instead directly set the desired tool choice.

## Manual Verification

In our local setup I applied the same changes to the files in `node_modules`'s `dist` folder and could see it working and observe that it behaves differently (actually making the tool call instead of generating a lot of output and never actually succeeding in making the specified tool call).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)