### PR TITLE
feat(openai): pass reasoning parts through to reasoning_content for opt-in providers

### DIFF
--- a/packages/openai/src/chat/convert-to-openai-chat-messages-reasoning.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages-reasoning.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import { convertToOpenAIChatMessages } from './convert-to-openai-chat-messages';
+
+describe('convertToOpenAIChatMessages — reasoning round-trip', () => {
+  it('drops reasoning parts by default and emits a warning', () => {
+    const { messages, warnings } = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Let me think about this...' },
+            { type: 'text', text: 'The answer is 42.' },
+          ],
+        },
+      ],
+    });
+
+    expect(messages).toEqual([
+      { role: 'assistant', content: 'The answer is 42.' },
+    ]);
+    // No reasoning_content field — current behavior preserved for OpenAI
+    expect(messages[0]).not.toHaveProperty('reasoning_content');
+    // But the drop is now visible (was silent before this PR)
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        type: 'other',
+        message: expect.stringContaining('reasoning parts were dropped'),
+      }),
+    ]);
+  });
+
+  it('does not emit a warning when no reasoning parts are present', () => {
+    const { messages, warnings } = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+
+    expect(messages).toEqual([{ role: 'assistant', content: 'Hello' }]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('does not emit a warning when includeReasoningContent is true even if no reasoning parts are present', () => {
+    const { warnings } = convertToOpenAIChatMessages({
+      includeReasoningContent: true,
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('serializes reasoning parts as reasoning_content when includeReasoningContent is true', () => {
+    const { messages, warnings } = convertToOpenAIChatMessages({
+      includeReasoningContent: true,
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Step 1: parse input.' },
+            { type: 'reasoning', text: ' Step 2: produce output.' },
+            { type: 'text', text: 'Done.' },
+          ],
+        },
+      ],
+    });
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'Done.',
+        reasoning_content: 'Step 1: parse input. Step 2: produce output.',
+      },
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('omits reasoning_content when no reasoning parts are present (even with the flag on)', () => {
+    const { messages } = convertToOpenAIChatMessages({
+      includeReasoningContent: true,
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Plain answer.' }],
+        },
+      ],
+    });
+
+    expect(messages).toEqual([{ role: 'assistant', content: 'Plain answer.' }]);
+    expect(messages[0]).not.toHaveProperty('reasoning_content');
+  });
+
+  it('round-trips reasoning_content across a tool-use turn (the DeepSeek failure case)', () => {
+    // This mirrors the canonical pattern from the AI SDK tool-calling
+    // docs. The user asks something, the model responds with both
+    // `reasoning` and `tool-call` parts, the caller invokes the tool,
+    // then constructs a follow-up `messages` array that includes the
+    // assistant turn from `result.response.messages`. Without this PR,
+    // the second `convertToOpenAIChatMessages` invocation drops the
+    // reasoning parts and DeepSeek rejects the request.
+    const { messages, warnings } = convertToOpenAIChatMessages({
+      includeReasoningContent: true,
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'What is 2+2?' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: '2+2 is a basic arithmetic op.' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call_1',
+              toolName: 'calculator',
+              input: { expr: '2+2' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'calculator',
+              output: { type: 'json', value: { result: 4 } },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages).toMatchObject([
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        // Note: upstream v4 emits `null` (not `''`) when toolCalls fire
+        // and the text-channel is empty. The original v3 draft expected
+        // `''`; updated here for v4 compatibility. The PR's core
+        // contribution — `reasoning_content` round-trip — is unaffected.
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'calculator', arguments: '{"expr":"2+2"}' },
+          },
+        ],
+        // <-- Without this PR, this property is absent and DeepSeek
+        //     rejects with "The reasoning_content in the thinking
+        //     mode must be passed back to the API."
+        reasoning_content: '2+2 is a basic arithmetic op.',
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call_1',
+        content: '{"result":4}',
+      },
+    ]);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -18,9 +18,19 @@ function serializeToolCallArguments(input: unknown): string {
 export function convertToOpenAIChatMessages({
   prompt,
   systemMessageMode = 'system',
+  includeReasoningContent = false,
 }: {
   prompt: LanguageModelV4Prompt;
   systemMessageMode?: 'system' | 'developer' | 'remove';
+  /**
+   * When true, `reasoning` parts on assistant turns are serialized
+   * as a top-level `reasoning_content` string on the assistant
+   * message. This is the field name DeepSeek's API (and most other
+   * OpenAI-compatible reasoning providers) expect on the round trip.
+   * Default false — pure OpenAI calls drop reasoning parts (with a
+   * warning) since the OpenAI API doesn't accept them.
+   */
+  includeReasoningContent?: boolean;
 }): {
   messages: OpenAIChatPrompt;
   warnings: Array<SharedV4Warning>;
@@ -175,6 +185,7 @@ export function convertToOpenAIChatMessages({
 
       case 'assistant': {
         let text = '';
+        let reasoningText = '';
         const toolCalls: Array<{
           id: string;
           type: 'function';
@@ -185,6 +196,10 @@ export function convertToOpenAIChatMessages({
           switch (part.type) {
             case 'text': {
               text += part.text;
+              break;
+            }
+            case 'reasoning': {
+              reasoningText += part.text;
               break;
             }
             case 'tool-call': {
@@ -201,10 +216,23 @@ export function convertToOpenAIChatMessages({
           }
         }
 
+        if (reasoningText.length > 0 && !includeReasoningContent) {
+          warnings.push({
+            type: 'other',
+            message:
+              'Assistant reasoning parts were dropped because ' +
+              '`includeReasoningContent` is not enabled. Set the ' +
+              'option to pass them through as `reasoning_content`.',
+          });
+        }
+
         messages.push({
           role: 'assistant',
           content: toolCalls.length > 0 ? text || null : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          ...(includeReasoningContent && reasoningText.length > 0
+            ? { reasoning_content: reasoningText }
+            : {}),
         });
 
         break;

--- a/packages/openai/src/chat/openai-chat-prompt.ts
+++ b/packages/openai/src/chat/openai-chat-prompt.ts
@@ -52,6 +52,13 @@ export interface ChatCompletionAssistantMessage {
   role: 'assistant';
   content?: string | null;
   tool_calls?: Array<ChatCompletionMessageToolCall>;
+  /**
+   * Provider-extension field. Used by DeepSeek and other OpenAI-
+   * compatible reasoning providers to round-trip the previous turn's
+   * thinking content back to the model. Optional and ignored by
+   * OpenAI's own API.
+   */
+  reasoning_content?: string;
 }
 
 export interface ChatCompletionMessageToolCall {


### PR DESCRIPTION
# feat(openai): pass reasoning parts through to `reasoning_content` for opt-in providers

## Summary

`convertToOpenAIChatMessages` currently has no `case 'reasoning':` arm
in its assistant-role part loop. Reasoning parts on assistant turns are
**silently dropped** during request serialization. This breaks
multi-turn round-trips against any OpenAI-compatible provider whose API
echoes reasoning back via `assistant.reasoning_content` — most notably
DeepSeek's `deepseek-v4-flash` and `deepseek-v4-pro` reasoning models.

This PR makes the drop **non-silent** (always warns) and adds an opt-in
flag `includeReasoningContent: boolean` that passes the reasoning text
through as a top-level `reasoning_content` string on the assistant
message.

## Repro (pre-PR behavior)

```ts
import { generateText, stepCountIs } from "ai";
import { createOpenAI } from "@ai-sdk/openai";

const deepseek = createOpenAI({
  baseURL: "https://api.deepseek.com",
  apiKey: process.env.DEEPSEEK_API_KEY,
});

// Step 1: model emits reasoning + tool call
const r1 = await generateText({
  model: deepseek("deepseek-v4-flash"),
  messages: [{ role: "user", content: "What is 2+2? Use the calculator tool." }],
  tools: { calculator: /* ... */ },
  stopWhen: stepCountIs(1),
});

// Step 2: feed back into the model — this is where it dies
const r2 = await generateText({
  model: deepseek("deepseek-v4-flash"),
  messages: [
    { role: "user", content: "What is 2+2?" },
    ...r1.response.messages, // <-- contains reasoning parts
    { role: "tool", content: [{ type: "tool-result", toolCallId, output }] },
  ],
});
```

DeepSeek's API rejects step 2:

```
HTTP 400 Bad Request
{
  "error": {
    "message": "The reasoning_content in the thinking mode must be passed back to the API.",
    "type": "invalid_request_error"
  }
}
```

The reasoning content was on `r1.response.messages` (correctly emitted
by the language model), but `convertToOpenAIChatMessages` dropped it
during serialization.

## Root cause

`packages/openai/src/chat/convert-to-openai-chat-messages.ts`, lines
~156–181 (current `main`):

```ts
case 'assistant': {
  let text = '';
  const toolCalls: Array<{ /* ... */ }> = [];

  for (const part of content) {
    switch (part.type) {
      case 'text': {
        text += part.text;
        break;
      }
      case 'tool-call': {
        toolCalls.push({ /* ... */ });
        break;
      }
      // ← No 'reasoning' case. Falls through silently.
    }
  }

  messages.push({
    role: 'assistant',
    content: text,
    tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
  });
  break;
}
```

There's no `default:` arm, no warning push, and no handling of the
`'reasoning'` part type that the AI SDK type system officially
recognizes (`LanguageModelV3ReasoningPart` in
`packages/provider/src/language-model/v3/language-model-v3-prompt.ts`).

## The fix

Two surgical changes, both backwards-compatible:

### 1. New optional parameter `includeReasoningContent` (default `false`)

When `false` (default — pure OpenAI behavior preserved):
- Reasoning parts are still dropped, but a `warnings` entry is now
  pushed: `'Assistant reasoning parts were dropped because
  includeReasoningContent is not enabled. Set the option to pass them
  through as reasoning_content.'`
- This makes the drop **observable** — calling code can detect it
  via the returned `warnings` array.

When `true`:
- Reasoning parts are concatenated into a `reasoningText` string and
  emitted as a top-level `reasoning_content` field on the assistant
  message.
- Output shape:
  ```ts
  { role: 'assistant', content: '...', reasoning_content: '...' }
  ```
- This matches the field name DeepSeek's API expects on the round
  trip. Most other OpenAI-compatible reasoning providers (Moonshot,
  Zhipu) use the same field name.

### 2. New optional field on `ChatCompletionAssistantMessage`

```ts
export interface ChatCompletionAssistantMessage {
  role: 'assistant';
  content?: string | null;
  tool_calls?: Array<ChatCompletionMessageToolCall>;
+  /**
+   * Provider-extension field. Used by DeepSeek and other OpenAI-
+   * compatible reasoning providers to round-trip the previous turn's
+   * thinking content back to the model. Optional and ignored by
+   * OpenAI's own API.
+   */
+  reasoning_content?: string;
}
```

This is a non-breaking add. Pure OpenAI users who never set the flag
will never see this field on serialized messages.

## Tests

New file:
`packages/openai/src/chat/convert-to-openai-chat-messages-reasoning.test.ts`

Six cases:
1. Default behavior: reasoning parts are dropped + warning surfaces
2. No-reasoning case: no warning surfaces
3. `includeReasoningContent: true` + no reasoning parts: no warning, no
   `reasoning_content` field
4. `includeReasoningContent: true` + reasoning parts: concatenated and
   emitted on the assistant message
5. `includeReasoningContent: true` + only text: no `reasoning_content`
   field (only added when there's actual reasoning content)
6. **End-to-end DeepSeek failure case**: full prompt with user → assistant
   (reasoning + tool-call) → tool result, validating the entire round
   trip serializes correctly.

## Backwards compatibility

- Default behavior is unchanged: callers that don't pass the new flag
  see the same `messages` array as before.
- The only behavioral diff for those callers is: a new `warnings`
  entry surfaces when reasoning parts were silently dropped. This is
  arguably a fix in itself — the silent drop has bitten production
  callers (see the Daat case below).
- TypeScript: `ChatCompletionAssistantMessage.reasoning_content` is
  `?: string`, optional. No call site needs to change.

## Real-world evidence

Daat (https://github.com/CrhistianHeredia/daat-code) is an AI CLI
shipping as `npm i -g daat`, with active DeepSeek users running
tool-use loops against `deepseek-v4-flash`/`v4-pro`. We rediscovered
this bug in production on 2026-05-05. Our mitigation stack today:

1. **Model swap** (`src/utils/deepseek-thinking-swap.ts`): silently
   reroute the affected DeepSeek models to `deepseek-chat` — a
   non-thinking alias that doesn't emit `reasoning_content`. Works
   until DeepSeek retires the alias on 2026-07-24.
2. **Retirement-aware warning**: stderr-warn at boot once the swap
   target is known to be dying.
3. **`extra_body` thinking-disabled**: pass
   `providerOptions.openai.extraBody = { thinking: { type: "disabled" } }`
   so the model doesn't emit reasoning parts in the first place. This
   only works for non-thinking inference and forfeits the entire
   thinking-mode capability.

That we shipped three layers of mitigation should signal how deep the
bug runs from inside `convertToOpenAIChatMessages`. None of these
workarounds is suitable upstream — they all sacrifice the thinking
capability the user paid for.

Once this PR ships, Daat will:
- Drop the swap module (`src/utils/deepseek-thinking-swap.ts`)
- Drop `setModel()` and `resolveWorkerModel()` swap calls
- Re-enable thinking mode by default on the affected models
- Pass `includeReasoningContent: true` for DeepSeek-compatible providers

## Why this PR keeps the scope tight

Things this PR explicitly does NOT do:
- Does not change behavior for callers that don't pass the new flag
- Does not touch any other case in the part switch (text, tool-call,
  system, user, tool roles)
- Does not change the OpenAI defaults — pure OpenAI users see no
  difference, including for `o1`/`o3` reasoning. That's a separate
  question (OpenAI's API may have its own conventions); this PR only
  unblocks the *option* of passing reasoning back for providers that
  need it.
- Does not couple the language model layer
  (`openai-chat-language-model.ts`) to the new flag. The fix is local
  to the message converter; higher layers can opt in via their own
  configuration if/when the maintainers want.

## Checklist

- [x] Patch is local to `packages/openai/src/chat/`
- [x] Backwards-compatible (no behavior change for callers that don't
      pass the new flag)
- [x] Includes tests covering all new code paths + the DeepSeek
      end-to-end repro
- [x] No new dependencies
- [x] TypeScript: new field is `?: string` (optional) — no breakage
      for existing message construction
- [ ] Run package tests: `cd packages/openai && pnpm test
      convert-to-openai-chat-messages` (user action — applying repo
      tooling)
- [ ] Run full repo lint: `pnpm lint` (user action)