### PR TITLE
fix(provider/google): support `functionCall.id` when returned by Gemini API and provide matching `functionResponse.id`

### DIFF
--- a/.changeset/five-needles-poke.md
+++ b/.changeset/five-needles-poke.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(provider/google): support `functionCall.id` when returned by Gemini API and provide matching `functionResponse.id`

--- a/examples/ai-functions/src/generate-text/google/function-call-id.ts
+++ b/examples/ai-functions/src/generate-text/google/function-call-id.ts
@@ -1,0 +1,54 @@
+import { google } from '@ai-sdk/google';
+import { generateText, isStepCount, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+/*
+ * Exercises Gemini 3's parallel function calling across two turns. Gemini 3
+ * emits an `id` on each `functionCall` part. The matching `functionResponse`
+ * parts we send back in turn 2 should carry the same `id` so the model can
+ * correlate each response to its call. If we drop the id on either side, the
+ * API may reject the request or the model may mis-correlate parallel calls.
+ */
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  // Turn 1: model emits parallel tool calls; tools execute automatically.
+  const turn1 = await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  console.log('Turn 1 tool call IDs:');
+  for (const call of turn1.toolCalls) {
+    console.log(`  - ${call.toolCallId} (${call.toolName})`);
+  }
+
+  messages.push(...turn1.finalStep.response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  // Turn 2: send the parallel tool results back. Gemini 3 expects the ids
+  // it issued in turn 1 to round-trip on the corresponding functionResponse
+  // parts. Without the provider plumbing the id through, this turn fails.
+  const turn2 = await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log('\nTurn 2 text:', turn2.text);
+});

--- a/examples/ai-functions/src/stream-text/google/function-call-id.ts
+++ b/examples/ai-functions/src/stream-text/google/function-call-id.ts
@@ -1,0 +1,70 @@
+import { google } from '@ai-sdk/google';
+import { isStepCount, streamText, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+/*
+ * Exercises Gemini 3's parallel function calling across two turns via
+ * streaming. Gemini 3 emits an `id` on each `functionCall` part. The matching
+ * `functionResponse` parts we send back in turn 2 should carry the same `id`
+ * so the model can correlate each response to its call. If we drop the id on
+ * either side, the API may reject the request or the model may mis-correlate
+ * parallel calls.
+ */
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  // Turn 1: model emits parallel tool calls; tools execute automatically.
+  const turn1 = streamText({
+    model: google('gemini-3-flash-preview'),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  for await (const part of turn1.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log(
+        `Turn 1 tool call (${part.toolCallId}): ${part.toolName}`,
+        JSON.stringify(part.input),
+      );
+    } else if (part.type === 'tool-result') {
+      console.log(
+        `Turn 1 tool result (${part.toolCallId}):`,
+        JSON.stringify(part.output),
+      );
+    }
+  }
+
+  messages.push(...(await turn1.finalStep).response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  // Turn 2: send the parallel tool results back. Gemini 3 expects the ids
+  // it issued in turn 1 to round-trip on the corresponding functionResponse
+  // parts. Without the provider plumbing the id through, this turn fails.
+  const turn2 = streamText({
+    model: google('gemini-3-flash-preview'),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log('\nTurn 2 text:');
+  for await (const part of turn2.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+  console.log();
+});

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -71,6 +71,7 @@ describe('thought signatures', () => {
                   "args": {
                     "value": "test",
                   },
+                  "id": "call1",
                   "name": "test",
                 },
                 "thoughtSignature": "sig3",
@@ -134,6 +135,7 @@ describe('thought signatures with vertex providerOptionsName', () => {
                   "args": {
                     "location": "London",
                   },
+                  "id": "call1",
                   "name": "getWeather",
                 },
                 "thoughtSignature": "sig3",
@@ -171,6 +173,7 @@ describe('thought signatures with vertex providerOptionsName', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
@@ -201,6 +204,7 @@ describe('thought signatures with vertex providerOptionsName', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
@@ -258,6 +262,7 @@ describe('thought signatures with google providerOptionsName (gateway failover)'
                   "args": {
                     "location": "London",
                   },
+                  "id": "call1",
                   "name": "getWeather",
                 },
                 "thoughtSignature": "sig3",
@@ -295,6 +300,7 @@ describe('thought signatures with google providerOptionsName (gateway failover)'
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
@@ -322,6 +328,7 @@ describe('thought signatures with google providerOptionsName (gateway failover)'
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
@@ -634,6 +641,7 @@ describe('tool messages', () => {
           parts: [
             {
               functionResponse: {
+                id: 'testCallId',
                 name: 'testFunction',
                 response: {
                   name: 'testFunction',
@@ -683,6 +691,7 @@ describe('tool messages', () => {
           parts: [
             {
               functionResponse: {
+                id: 'testCallId',
                 name: 'imageGenerator',
                 response: {
                   name: 'imageGenerator',
@@ -731,6 +740,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'documentReader',
         response: {
           name: 'documentReader',
@@ -777,6 +787,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'imageGenerator',
         response: {
           name: 'imageGenerator',
@@ -823,6 +834,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'imageGenerator',
         response: {
           name: 'imageGenerator',
@@ -861,6 +873,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'documentReader',
         response: {
           name: 'documentReader',
@@ -910,6 +923,7 @@ describe('tool messages', () => {
     expect(result.contents[0].parts).toEqual([
       {
         functionResponse: {
+          id: 'testCallId',
           name: 'imageGenerator',
           response: {
             name: 'imageGenerator',
@@ -1366,6 +1380,7 @@ describe('parallel tool calls', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'call1',
         args: { city: 'paris' },
         name: 'checkweather',
       },
@@ -1374,6 +1389,7 @@ describe('parallel tool calls', () => {
 
     expect(result.contents[0].parts[1]).toEqual({
       functionCall: {
+        id: 'call2',
         args: { city: 'london' },
         name: 'checkweather',
       },
@@ -1416,6 +1432,7 @@ describe('tool results with thought signatures', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'call1',
         args: { userId: '123' },
         name: 'readdata',
       },
@@ -1424,6 +1441,7 @@ describe('tool results with thought signatures', () => {
 
     expect(result.contents[1].parts[0]).toEqual({
       functionResponse: {
+        id: 'call1',
         name: 'readdata',
         response: {
           content: 'file not found',
@@ -1486,6 +1504,7 @@ describe('server tool combination round-trip', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
+        id: 'tc-1',
         name: 'weather',
         args: { location: 'SF' },
       },

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -64,6 +64,7 @@ function appendToolResultParts(
     LanguageModelV4ToolResultOutput,
     { type: 'content' }
   >['value'],
+  toolCallId?: string,
 ): void {
   const functionResponseParts: GoogleFunctionResponsePart[] = [];
   const responseTextParts: string[] = [];
@@ -106,6 +107,7 @@ function appendToolResultParts(
 
   parts.push({
     functionResponse: {
+      ...(toolCallId != null ? { id: toolCallId } : {}),
       name: toolName,
       response: {
         name: toolName,
@@ -133,12 +135,14 @@ function appendLegacyToolResultParts(
     LanguageModelV4ToolResultOutput,
     { type: 'content' }
   >['value'],
+  toolCallId?: string,
 ): void {
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
       case 'text':
         parts.push({
           functionResponse: {
+            ...(toolCallId != null ? { id: toolCallId } : {}),
             name: toolName,
             response: {
               name: toolName,
@@ -447,6 +451,9 @@ export function convertToGoogleMessages(
 
                   return {
                     functionCall: {
+                      ...(part.toolCallId != null
+                        ? { id: part.toolCallId }
+                        : {}),
                       name: part.toolName,
                       args: part.input,
                     },
@@ -533,13 +540,24 @@ export function convertToGoogleMessages(
 
           if (output.type === 'content') {
             if (supportsFunctionResponseParts) {
-              appendToolResultParts(parts, part.toolName, output.value);
+              appendToolResultParts(
+                parts,
+                part.toolName,
+                output.value,
+                part.toolCallId,
+              );
             } else {
-              appendLegacyToolResultParts(parts, part.toolName, output.value);
+              appendLegacyToolResultParts(
+                parts,
+                part.toolName,
+                output.value,
+                part.toolCallId,
+              );
             }
           } else {
             parts.push({
               functionResponse: {
+                ...(part.toolCallId != null ? { id: part.toolCallId } : {}),
                 name: part.toolName,
                 response: {
                   name: part.toolName,

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -387,7 +387,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       } else if ('functionCall' in part && part.functionCall.name != null) {
         content.push({
           type: 'tool-call' as const,
-          toolCallId: this.config.generateId(),
+          toolCallId: part.functionCall.id ?? this.config.generateId(),
           toolName: part.functionCall.name,
           input: JSON.stringify(part.functionCall.args ?? {}),
           providerMetadata: part.thoughtSignature
@@ -838,7 +838,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                     part.functionCall.name != null &&
                     part.functionCall.willContinue === true
                   ) {
-                    const toolCallId = generateId();
+                    const toolCallId = part.functionCall.id ?? generateId();
                     const accumulator = new GoogleJSONAccumulator();
                     activeStreamingToolCalls.push({
                       toolCallId,
@@ -920,7 +920,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
                   hasToolCalls = true;
                 } else if (isCompleteCall) {
-                  const toolCallId = generateId();
+                  const toolCallId = part.functionCall.id ?? generateId();
                   const toolName = part.functionCall.name!;
                   const args =
                     typeof part.functionCall.args === 'string'
@@ -957,7 +957,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
                   hasToolCalls = true;
                 } else if (isNoArgsCompleteCall) {
-                  const toolCallId = generateId();
+                  const toolCallId = part.functionCall.id ?? generateId();
                   const toolName = part.functionCall.name!;
 
                   controller.enqueue({
@@ -1333,6 +1333,7 @@ const getContentSchema = () =>
           // note: order matters since text can be fully empty
           z.object({
             functionCall: z.object({
+              id: z.string().nullish(),
               name: z.string().nullish(),
               args: z.unknown().nullish(),
               partialArgs: z.array(partialArgSchema).nullish(),

--- a/packages/google/src/google-prompt.ts
+++ b/packages/google/src/google-prompt.ts
@@ -27,9 +27,13 @@ export type GoogleContentPart =
       thought?: boolean;
       thoughtSignature?: string;
     }
-  | { functionCall: { name: string; args: unknown }; thoughtSignature?: string }
+  | {
+      functionCall: { id?: string; name: string; args: unknown };
+      thoughtSignature?: string;
+    }
   | {
       functionResponse: {
+        id?: string;
         name: string;
         response: unknown;
         parts?: Array<GoogleFunctionResponsePart>;


### PR DESCRIPTION
## Background

The Gemini API has been supporting returning `functionCall.id` for a while, but AI SDK so far is ignoring that value and generating its own instead.

See:
- https://ai.google.dev/api/caching#FunctionCall
- https://ai.google.dev/api/caching#FunctionResponse

This does not cause any known bugs in production, but future updates may lead to the API getting more strict about that (e.g. similar behavior how we've seen it over time for thought signatures), so we should respect the field value if present in the response.

## Summary

* adds `functionCall.id` and `functionResponse.id` to the Google API spec and processes these values
* falls back to `generateId()` only if no `functionCall.id` is included in the API response

## Manual Verification

Examples are added: Running these without the `packages/google` changes in this PR will _not_ cause an error, but you will see that the format of the IDs differs - that's because Gemini API returns different IDs than our `generateId()` helper function does.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)