### PR TITLE
fix(ai): default missing embedding warnings

### DIFF
--- a/.changeset/silent-cameras-embed.md
+++ b/.changeset/silent-cameras-embed.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): default missing embedding warnings to an empty array

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -10,6 +10,7 @@ import {
   vitest,
 } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import type { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
@@ -423,6 +424,21 @@ describe('result.warnings', () => {
     expect(result.warnings).toStrictEqual(expectedWarnings);
   });
 
+  it('should default missing v2 provider warnings to an empty array in the single call path', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV2<string>({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () => ({
+          embeddings: dummyEmbeddings,
+          usage: { tokens: 3 },
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+
   it('should aggregate warnings from multiple calls', async () => {
     const warning1: Warning = {
       type: 'other',
@@ -459,6 +475,35 @@ describe('result.warnings', () => {
     });
 
     expect(result.warnings).toStrictEqual([warning1, warning2]);
+  });
+
+  it('should default missing v2 provider warnings to an empty array in the chunked path', async () => {
+    let callCount = 0;
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV2<string>({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                usage: { tokens: 2 },
+              };
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                usage: { tokens: 1 },
+              };
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
   });
 });
 

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -215,7 +215,7 @@ export async function embedMany({
           return {
             embeddings,
             usage,
-            warnings: modelResponse.warnings,
+            warnings: modelResponse.warnings ?? [],
             providerMetadata: modelResponse.providerMetadata,
             response: modelResponse.response,
           };
@@ -317,7 +317,7 @@ export async function embedMany({
             return {
               embeddings: chunkEmbeddings,
               usage,
-              warnings: modelResponse.warnings,
+              warnings: modelResponse.warnings ?? [],
               providerMetadata: modelResponse.providerMetadata,
               response: modelResponse.response,
             };

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -2,6 +2,7 @@ import type { EmbeddingModelV4 } from '@ai-sdk/provider';
 import assert from 'node:assert';
 import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import type { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { embed } from './embed';
@@ -180,6 +181,20 @@ describe('result.warnings', () => {
     });
 
     expect(result.warnings).toStrictEqual(expectedWarnings);
+  });
+
+  it('should default missing v2 provider warnings to an empty array', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV2<string>({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          usage: { tokens: 1 },
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
   });
 });
 

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -193,7 +193,7 @@ export async function embed({
         return {
           embedding,
           usage,
-          warnings: modelResponse.warnings,
+          warnings: modelResponse.warnings ?? [],
           providerMetadata: modelResponse.providerMetadata,
           response: modelResponse.response,
         };


### PR DESCRIPTION
## Summary

Fixes #14926.

EmbeddingModelV2 providers can return doEmbed results without a warnings field. embed() and embedMany() currently forward that missing value into result/logging paths that expect an array, which can crash at runtime.

This defaults missing embedding warnings to [] at the embed boundary for:

- embed()
- embedMany() single-call path
- embedMany() chunked path

## Tests

- pnpm --dir packages/ai exec vitest --config vitest.node.config.js --run src/embed/embed.test.ts src/embed/embed-many.test.ts
- pnpm --dir packages/ai exec vitest --config vitest.edge.config.js --run src/embed/embed.test.ts src/embed/embed-many.test.ts
- pnpm --filter ai type-check
