### PR TITLE
docs: mention tool name migration

### DIFF
--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -301,6 +301,38 @@ const someTool = tool({
   codebase.
 </Note>
 
+### Tool `name` Property Removal
+
+The `name` property has been removed from `tool()`. In AI SDK 6, the tool name
+comes from the key in the `tools` object.
+
+```tsx filename="AI SDK 5"
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = tool({
+  name: 'weather',
+  description: 'Get the weather',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+});
+```
+
+```tsx filename="AI SDK 6"
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  weather: tool({
+    description: 'Get the weather',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+  }),
+};
+```
+
 ### `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` Deprecation
 
 `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` have been deprecated.


### PR DESCRIPTION
## Summary

Fixes #12213.

Adds a short AI SDK 6 migration guide section explaining that `tool({ name })` was removed and that the tool name now comes from the key in the `tools` object.

## Tests

- git diff --check
