### PR TITLE
fix(gateway): add caching provider option

### DIFF
--- a/.changeset/gateway-caching-provider-option.md
+++ b/.changeset/gateway-caching-provider-option.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Add `caching: 'auto'` to `GatewayProviderOptions`.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -794,6 +794,12 @@ The following gateway provider options are available:
 
   Example: `models: ['openai/gpt-5.4-nano', 'gemini-3-flash-preview']` will try the fallback models in order if the primary model fails.
 
+- **caching** _'auto'_
+
+  Enables automatic prompt caching. When set to `'auto'`, AI Gateway automatically applies the appropriate caching strategy based on the routed provider.
+
+  Example: `caching: 'auto'` will let AI Gateway add cache markers for providers that require explicit prompt caching.
+
 - **user** _string_
 
   Optional identifier for the end user on whose behalf the request is being made. This is used for spend tracking and attribution purposes, allowing you to track usage per end-user in your application.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -6,6 +6,7 @@ import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { GatewayLanguageModel } from './gateway-language-model';
 import type { GatewayConfig } from './gateway-config';
+import type { GatewayProviderOptions } from './gateway-provider-options';
 import {
   GatewayAuthenticationError,
   GatewayRateLimitError,
@@ -1523,18 +1524,24 @@ describe('GatewayLanguageModel', () => {
         content: { type: 'text', text: 'Test response' },
       });
 
+      const gatewayOptions = {
+        order: ['anthropic', 'bedrock', 'openai'],
+        caching: 'auto',
+      } satisfies GatewayProviderOptions;
+
       await createTestModel().doGenerate({
         prompt: TEST_PROMPT,
         providerOptions: {
-          gateway: {
-            order: ['anthropic', 'bedrock', 'openai'],
-          },
+          gateway: gatewayOptions,
         },
       });
 
       const requestBody = await server.calls[0].requestBodyJson;
       expect(requestBody.providerOptions).toEqual({
-        gateway: { order: ['anthropic', 'bedrock', 'openai'] },
+        gateway: {
+          order: ['anthropic', 'bedrock', 'openai'],
+          caching: 'auto',
+        },
       });
     });
 

--- a/packages/gateway/src/gateway-provider-options.test-d.ts
+++ b/packages/gateway/src/gateway-provider-options.test-d.ts
@@ -1,0 +1,12 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { GatewayProviderOptions } from './gateway-provider-options';
+
+describe('GatewayProviderOptions type', () => {
+  it('should allow automatic caching', () => {
+    const options = {
+      caching: 'auto',
+    } satisfies GatewayProviderOptions;
+
+    expectTypeOf(options).toMatchTypeOf<GatewayProviderOptions>();
+  });
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -50,6 +50,11 @@ const gatewayProviderOptions = lazySchema(() =>
        */
       models: z.array(z.string()).optional(),
       /**
+       * Whether AI Gateway should automatically apply the appropriate prompt
+       * caching strategy based on the routed provider.
+       */
+      caching: z.enum(['auto']).optional(),
+      /**
        * Request-scoped BYOK credentials to use instead of cached credentials.
        *
        * When provided, cached BYOK credentials are ignored entirely.


### PR DESCRIPTION
## Summary
- add the documented gateway.caching automatic provider option to GatewayProviderOptions
- verify typed gateway options can include automatic caching
- verify caching auto is forwarded in gateway request provider options
- document the option in the AI Gateway provider options list

Fixes #14595.

## Kage usage
- Used Kage scoped to packages/gateway to orient around gateway provider options and request forwarding tests.
- Captured a repo-local memory packet explaining that #14595 was a schema/type mismatch for documented automatic caching.
- Local Kage metrics after refresh: 59 files, 1,279 symbols, 1,587 calls, 370 tests, 100% indexed coverage, 3 memory packets, 71 memory graph entities, 72 evidence-backed edges, 0 stale packets.

## Tests
- pnpm --dir packages/gateway exec vitest --config vitest.node.config.js --run src/gateway-language-model.test.ts src/gateway-provider-options.test-d.ts
- pnpm --filter @ai-sdk/gateway type-check

Note: local verification emitted the repository Node engine warning because this shell runs Node v25.9.0 while the repo declares support for ^18/^20/^22/^24.