### PR TITLE
docs(ui): clarify stream finish message id

### DIFF
--- a/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
@@ -438,6 +438,9 @@ data: {"type":"finish-step"}
 
 A part indicating the completion of a message.
 
+The message is identified by the preceding `start` part. Send the `messageId`
+on the `start` part, not on the `finish` part.
+
 Format: Server-Sent Event with JSON object
 
 Example:


### PR DESCRIPTION
## Summary
- clarify that the UI stream message is identified by the preceding start part
- document that messageId belongs on start, not finish

Fixes #8095.

## Kage usage
- Used Kage scoped to packages/ai to capture the stream-protocol nuance for future agents.
- Local Kage metrics after refresh: 436 files, 7,411 symbols, 8,863 calls, 2,068 tests, 100% indexed coverage, 3 memory packets, 53 memory graph entities, 54 evidence-backed edges, 0 stale packets.

## Tests
- git diff --check

Docs-only change.