### PR TITLE
docs(ui): replace removed useAssistant example link

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2076,7 +2076,7 @@ import { useAssistant } from '@ai-sdk/react';
 // Use useChat with appropriate configuration instead
 ```
 
-For an implementation of the assistant functionality with AI SDK v5, see this [example repository](https://github.com/vercel-labs/ai-sdk-openai-assistants-api).
+To rebuild assistant-style interactions with AI SDK v5, use the [chatbot guide](/docs/ai-sdk-ui/chatbot) and [`useChat` reference](/docs/reference/ai-sdk-ui/use-chat).
 
 #### Attachments → File Parts
 


### PR DESCRIPTION
## Summary
- replace the removed vercel-labs assistant example link in the AI SDK v5 migration guide
- point users to maintained internal chatbot and useChat docs instead

Fixes #7571.

## Kage usage
- Used Kage scoped to packages/ai to capture the migration-guide decision for future agents.
- Local Kage metrics after refresh: 436 files, 7,411 symbols, 8,863 calls, 2,068 tests, 100% indexed coverage, 3 memory packets, 53 memory graph entities, 55 evidence-backed edges, 0 stale packets.

## Tests
- git diff --check

Docs-only change.