### PR TITLE
docs(vertex): show image provider setup

### DIFF
--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -903,8 +903,13 @@ You can create image models using the `.image()` factory method. The Google Vert
 [Imagen models](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images) generate images using the Imagen on Vertex AI API.
 
 ```ts
-import { googleVertex } from '@ai-sdk/google-vertex';
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
 import { generateImage } from 'ai';
+
+const googleVertex = createGoogleVertex({
+  project: 'my-project',
+  location: 'us-central1',
+});
 
 const { image } = await generateImage({
   model: googleVertex.image('imagen-4.0-generate-001'),


### PR DESCRIPTION
## Summary
- update the Google Vertex image-generation example to show explicit provider setup
- include project and location before calling googleVertex.image

Fixes #7587.

## Kage usage
- Used Kage scoped to packages/google-vertex to capture the docs nuance for future agents.
- Local Kage metrics after refresh: 69 files, 751 symbols, 784 calls, 204 tests, 100% indexed coverage, 3 memory packets, 48 memory graph entities, 50 evidence-backed edges, 0 stale packets.

## Tests
- git diff --check

Docs-only change.