### PR TITLE
fix(provider/xai): dedupe reasoning-start on multi-summary-part responses to prevent xai 400s on continuations

### DIFF
--- a/.changeset/fuzzy-ravens-decide.md
+++ b/.changeset/fuzzy-ravens-decide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+fix reasoning-start dedupe on multi-summary-part responses to prevent xai 400 on continuation requests

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -2179,6 +2179,99 @@ describe('XaiResponsesLanguageModel', () => {
         expect(endIdx).toBeLessThan(textIdx);
       });
 
+      it('should emit only one reasoning-start when multiple reasoning_summary_part.added events share an item_id', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4.3',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'reasoning',
+              id: 'rs_456',
+              status: 'in_progress',
+              summary: [],
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.reasoning_summary_part.added',
+            item_id: 'rs_456',
+            output_index: 0,
+            summary_index: 0,
+            part: { type: 'summary_text', text: '' },
+          }),
+          JSON.stringify({
+            type: 'response.reasoning_summary_text.delta',
+            item_id: 'rs_456',
+            output_index: 0,
+            summary_index: 0,
+            delta: 'First summary part.',
+          }),
+          JSON.stringify({
+            type: 'response.reasoning_summary_part.added',
+            item_id: 'rs_456',
+            output_index: 0,
+            summary_index: 1,
+            part: { type: 'summary_text', text: '' },
+          }),
+          JSON.stringify({
+            type: 'response.reasoning_summary_text.delta',
+            item_id: 'rs_456',
+            output_index: 0,
+            summary_index: 1,
+            delta: ' Second summary part.',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'reasoning',
+              id: 'rs_456',
+              status: 'completed',
+              summary: [
+                { type: 'summary_text', text: 'First summary part.' },
+                { type: 'summary_text', text: ' Second summary part.' },
+              ],
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4.3',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 20 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        const reasoningStarts = parts.filter(p => p.type === 'reasoning-start');
+        const reasoningEnds = parts.filter(p => p.type === 'reasoning-end');
+
+        expect(reasoningStarts).toHaveLength(1);
+        expect(reasoningEnds).toHaveLength(1);
+        expect(reasoningStarts[0]).toMatchObject({
+          type: 'reasoning-start',
+          id: 'reasoning-rs_456',
+          providerMetadata: { xai: { itemId: 'rs_456' } },
+        });
+      });
+
       it('should stream x_search tool call', async () => {
         prepareChunksFixtureResponse('xai-x-search-tool');
 

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -573,16 +573,18 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
             if (event.type === 'response.reasoning_summary_part.added') {
               const blockId = `reasoning-${event.item_id}`;
 
-              activeReasoning[event.item_id] = {};
-              controller.enqueue({
-                type: 'reasoning-start',
-                id: blockId,
-                providerMetadata: {
-                  xai: {
-                    itemId: event.item_id,
+              if (activeReasoning[event.item_id] == null) {
+                activeReasoning[event.item_id] = {};
+                controller.enqueue({
+                  type: 'reasoning-start',
+                  id: blockId,
+                  providerMetadata: {
+                    xai: {
+                      itemId: event.item_id,
+                    },
                   },
-                },
-              });
+                });
+              }
             }
 
             if (event.type === 'response.reasoning_summary_text.delta') {


### PR DESCRIPTION
## background

multi-step tool-calling with `grok-4.3` and `grok-4.20-reasoning` intermittently fails on the continuation step with `400 Bad Request` from xai (~4-12% rate). the surfaced error is opaque; the actual xai body is `"Invalid request content: Each message must have at least one content element."`

## summary

every `response.reasoning_summary_part.added` event was emitting a new `reasoning-start`. when xai splits a reasoning block across multiple summary parts, this created multiple reasoning content parts sharing the same `itemId`, which then serialized to duplicate `{type: 'reasoning', id}` items on the continuation and got rejected by xai.

fix: null guard on `activeReasoning[event.item_id]`, matching the existing pattern used for `response.reasoning_text.delta`.

## verification

<details>
<summary>live repro against api.x.ai/v1/responses with multi-step tool calls (maxOutputTokens 16000, stopWhen stepCountIs 10)</summary>

```
before fix:  direct-responses 48/50 (4% failure, duplicate reasoning ids in failing request body)
after fix:   direct-responses 100/100 (0 duplicate ids in 208 captured requests)
```

xai response body on the failing request: `{"code":"Client specified an invalid argument","error":"Invalid request content: Each message must have at least one content element."}`

</details>

## follow-ups

- backport to `release-v6.0` and `release-v5.0`
- surface full xai error detail in `APICallError.message` instead of falling back to http status text (shaper raised)