### PR TITLE
fix(provider/xai): surface full xai error detail in APICallError.message

### DIFF
--- a/.changeset/selfish-games-care.md
+++ b/.changeset/selfish-games-care.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+surface full xai error detail in APICallError.message instead of falling back to http status text

--- a/examples/ai-functions/src/e2e/xai.test.ts
+++ b/examples/ai-functions/src/e2e/xai.test.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { expect } from 'vitest';
-import { xai as provider, type XaiErrorData } from '@ai-sdk/xai';
+import { xai as provider } from '@ai-sdk/xai';
 import {
   createFeatureTestSuite,
   createLanguageModelWithCapabilities,
@@ -34,7 +34,7 @@ createFeatureTestSuite({
   timeout: 30000,
   customAssertions: {
     errorValidator: (error: APICallError) => {
-      expect((error.data as XaiErrorData).error.message).toContain('model');
+      expect(error.message).toContain('model');
     },
   },
 })();

--- a/packages/xai/src/xai-error.test.ts
+++ b/packages/xai/src/xai-error.test.ts
@@ -1,0 +1,53 @@
+import { APICallError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { xaiFailedResponseHandler } from './xai-error';
+
+function makeResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 400,
+    statusText: 'Bad Request',
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('xaiFailedResponseHandler', () => {
+  it('extracts message from chat completions error shape', async () => {
+    const response = makeResponse({
+      error: {
+        message: 'Invalid value: temperature must be between 0 and 2',
+        type: 'invalid_request_error',
+        code: 'invalid_value',
+      },
+    });
+
+    const { value } = await xaiFailedResponseHandler({
+      url: 'https://api.x.ai/v1/chat/completions',
+      requestBodyValues: {},
+      response,
+    });
+
+    expect(value).toBeInstanceOf(APICallError);
+    expect(value.message).toBe(
+      'Invalid value: temperature must be between 0 and 2',
+    );
+  });
+
+  it('extracts message and code from responses api error shape', async () => {
+    const response = makeResponse({
+      code: 'Client specified an invalid argument',
+      error:
+        'Invalid request content: Each message must have at least one content element.',
+    });
+
+    const { value } = await xaiFailedResponseHandler({
+      url: 'https://api.x.ai/v1/responses',
+      requestBodyValues: {},
+      response,
+    });
+
+    expect(value).toBeInstanceOf(APICallError);
+    expect(value.message).toBe(
+      'Client specified an invalid argument: Invalid request content: Each message must have at least one content element.',
+    );
+  });
+});

--- a/packages/xai/src/xai-error.ts
+++ b/packages/xai/src/xai-error.ts
@@ -1,8 +1,7 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-// Add error schema and structure
-export const xaiErrorDataSchema = z.object({
+const chatCompletionsErrorSchema = z.object({
   error: z.object({
     message: z.string(),
     type: z.string().nullish(),
@@ -11,9 +10,20 @@ export const xaiErrorDataSchema = z.object({
   }),
 });
 
+const responsesErrorSchema = z.object({
+  code: z.string(),
+  error: z.string(),
+});
+
+export const xaiErrorDataSchema = z.union([
+  chatCompletionsErrorSchema,
+  responsesErrorSchema,
+]);
+
 export type XaiErrorData = z.infer<typeof xaiErrorDataSchema>;
 
 export const xaiFailedResponseHandler = createJsonErrorResponseHandler({
   errorSchema: xaiErrorDataSchema,
-  errorToMessage: data => data.error.message,
+  errorToMessage: data =>
+    'code' in data ? `${data.code}: ${data.error}` : data.error.message,
 });


### PR DESCRIPTION
## background

xai 4xx errors surfaced as opaque `APICallError.message = "Bad Request"` regardless of what xai actually returned. the real detail was always in `responseBody` but never in `message`, making errors hard to diagnose at a glance.

## summary

the error schema in `packages/xai/src/xai-error.ts` only matched the OpenAI-style shape `{error: {message, type, ...}}`. xai's Responses API (and Chat Completions, per live testing) returns `{code, error: string}`, which fails schema validation and causes `createJsonErrorResponseHandler` to fall back to HTTP `statusText`.

fix: schema is now a union of both shapes, and `errorToMessage` extracts the appropriate field per variant.

## follow-ups

- backport to `release-v6.0` and `release-v5.0`