### PR TITLE
fix(openai-compatible): add minChunkSize option to buffer tiny SSE chunks

### DIFF
--- a/packages/openai-compatible/src/chat/__fixtures__/tiny-chunks.chunks.txt
+++ b/packages/openai-compatible/src/chat/__fixtures__/tiny-chunks.chunks.txt
@@ -1,0 +1,17 @@
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"First"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":","},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" the"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" user"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" said"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":":"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" \""},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":"Hello"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":".\""},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" That"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" is"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":" simple"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":"."},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"content":" there"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+{"id":"test-1","object":"chat.completion.chunk","created":1711357598,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2123,6 +2123,63 @@ describe('doStream', () => {
     `);
   });
 
+  it('should buffer tiny reasoning and content chunks when minChunkSize is set', async () => {
+    const bufferedProvider = createOpenAICompatible({
+      baseURL: 'https://my.api.com/v1/',
+      name: 'test-provider',
+      headers: {
+        Authorization: `Bearer test-api-key`,
+      },
+      minChunkSize: 20,
+    });
+
+    const bufferedModel = bufferedProvider('test-model');
+
+    prepareChunksFixtureResponse('tiny-chunks');
+
+    const { stream } = await bufferedModel.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const chunks = await convertReadableStreamToArray(stream);
+
+    const reasoningDeltas = chunks.filter(
+      c => c.type === 'reasoning-delta',
+    );
+    const textDeltas = chunks.filter(c => c.type === 'text-delta');
+
+    expect(reasoningDeltas.length).toBeLessThan(13);
+    expect(textDeltas.length).toBeLessThan(3);
+
+    const totalReasoning = reasoningDeltas
+      .map(d => (d as any).delta)
+      .join('');
+    const totalText = textDeltas.map(d => (d as any).delta).join('');
+
+    expect(totalReasoning).toBe('First, the user said: "Hello." That is simple.');
+    expect(totalText).toBe('Hi there!');
+  });
+
+  it('should stream reasoning and content chunks immediately when minChunkSize is not set', async () => {
+    prepareChunksFixtureResponse('tiny-chunks');
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const chunks = await convertReadableStreamToArray(stream);
+
+    const reasoningDeltas = chunks.filter(
+      c => c.type === 'reasoning-delta',
+    );
+    const textDeltas = chunks.filter(c => c.type === 'text-delta');
+
+    expect(reasoningDeltas.length).toBe(13);
+    expect(textDeltas.length).toBe(3);
+  });
+
   it('should stream tool deltas', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -91,6 +91,22 @@ export type OpenAICompatibleChatConfig = {
   convertUsage?: (
     usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
   ) => LanguageModelV4Usage;
+
+  /**
+   * Minimum chunk size for streaming text and reasoning content.
+   * Some providers send very small chunks (1-2 words), which can cause UI stuttering.
+   * When set, content is buffered until this threshold is reached before being emitted.
+   * Set to 0 or leave undefined for immediate emission (default behavior).
+   *
+   * @example
+   * // Buffer until 80 characters accumulated
+   * const provider = createOpenAICompatible({
+   *   name: 'baseten',
+   *   baseURL: 'https://inference.baseten.co/v1',
+   *   minChunkSize: 80,
+   * });
+   */
+  minChunkSize?: number;
 };
 
 type PendingToolCall = {
@@ -536,6 +552,40 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
       usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
     ) => this.convertUsage(usage);
 
+    const minChunkSize = this.config.minChunkSize;
+    const reasoningBuffer = new Map<number, string>();
+    const contentBuffer = new Map<number, string>();
+
+    function flushReasoningBuffer(
+      choiceIndex: number,
+      controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
+    ) {
+      const buffered = reasoningBuffer.get(choiceIndex);
+      if (buffered && buffered.length > 0) {
+        controller.enqueue({
+          type: 'reasoning-delta',
+          id: 'reasoning-0',
+          delta: buffered,
+        });
+        reasoningBuffer.delete(choiceIndex);
+      }
+    }
+
+    function flushContentBuffer(
+      choiceIndex: number,
+      controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
+    ) {
+      const buffered = contentBuffer.get(choiceIndex);
+      if (buffered && buffered.length > 0) {
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'txt-0',
+          delta: buffered,
+        });
+        contentBuffer.delete(choiceIndex);
+      }
+    }
+
     return {
       stream: response.pipeThrough(
         new TransformStream<
@@ -630,16 +680,34 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
                 isActiveReasoning = true;
               }
 
-              controller.enqueue({
-                type: 'reasoning-delta',
-                id: 'reasoning-0',
-                delta: reasoningContent,
-              });
+              const choiceIndex = choice.index ?? 0;
+              if (minChunkSize != null && minChunkSize > 0) {
+                const current = reasoningBuffer.get(choiceIndex) ?? '';
+                const accumulated = current + reasoningContent;
+                if (accumulated.length >= minChunkSize) {
+                  controller.enqueue({
+                    type: 'reasoning-delta',
+                    id: 'reasoning-0',
+                    delta: accumulated,
+                  });
+                  reasoningBuffer.delete(choiceIndex);
+                } else {
+                  reasoningBuffer.set(choiceIndex, accumulated);
+                }
+              } else {
+                controller.enqueue({
+                  type: 'reasoning-delta',
+                  id: 'reasoning-0',
+                  delta: reasoningContent,
+                });
+              }
             }
 
             if (delta.content) {
               // end active reasoning block before text starts
               if (isActiveReasoning) {
+                const choiceIndex = choice.index ?? 0;
+                flushReasoningBuffer(choiceIndex, controller);
                 controller.enqueue({
                   type: 'reasoning-end',
                   id: 'reasoning-0',
@@ -652,16 +720,34 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
                 isActiveText = true;
               }
 
-              controller.enqueue({
-                type: 'text-delta',
-                id: 'txt-0',
-                delta: delta.content,
-              });
+              const choiceIndex = choice.index ?? 0;
+              if (minChunkSize != null && minChunkSize > 0) {
+                const current = contentBuffer.get(choiceIndex) ?? '';
+                const accumulated = current + delta.content;
+                if (accumulated.length >= minChunkSize) {
+                  controller.enqueue({
+                    type: 'text-delta',
+                    id: 'txt-0',
+                    delta: accumulated,
+                  });
+                  contentBuffer.delete(choiceIndex);
+                } else {
+                  contentBuffer.set(choiceIndex, accumulated);
+                }
+              } else {
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: 'txt-0',
+                  delta: delta.content,
+                });
+              }
             }
 
             if (delta.tool_calls != null) {
               // end active reasoning block before tool calls start
               if (isActiveReasoning) {
+                const choiceIndex = choice.index ?? 0;
+                flushReasoningBuffer(choiceIndex, controller);
                 controller.enqueue({
                   type: 'reasoning-end',
                   id: 'reasoning-0',
@@ -676,6 +762,13 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
           },
 
           flush(controller) {
+            for (const [index] of reasoningBuffer) {
+              flushReasoningBuffer(index, controller);
+            }
+            for (const [index] of contentBuffer) {
+              flushContentBuffer(index, controller);
+            }
+
             if (isActiveReasoning) {
               controller.enqueue({ type: 'reasoning-end', id: 'reasoning-0' });
             }

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -115,6 +115,14 @@ export interface OpenAICompatibleProviderSettings {
    * differ from the default OpenAI-compatible shape.
    */
   convertUsage?: OpenAICompatibleChatConfig['convertUsage'];
+
+  /**
+   * Minimum chunk size for streaming text and reasoning content.
+   * Some providers send very small chunks (1-2 words), which can cause UI stuttering.
+   * When set, content is buffered until this threshold is reached before being emitted.
+   * Set to 0 or leave undefined for immediate emission (default behavior).
+   */
+  minChunkSize?: number;
 }
 
 /**
@@ -176,6 +184,7 @@ export function createOpenAICompatible<
       transformRequestBody: options.transformRequestBody,
       metadataExtractor: options.metadataExtractor,
       convertUsage: options.convertUsage,
+      minChunkSize: options.minChunkSize,
     });
 
   const createCompletionModel = (modelId: COMPLETION_MODEL_IDS) =>


### PR DESCRIPTION
## Summary

Some OpenAI-compatible providers (like Baseten GLM, xAI Grok) send `reasoning_content` and `content` in very small chunks (1-2 words per SSE event), causing UI stuttering when the stream updates too frequently.

This PR adds an opt-in `minChunkSize` configuration option that buffers streaming content until the threshold is reached before emitting, reducing the frequency of UI updates and eliminating stuttering.

## Changes

- Added `minChunkSize?: number` option to `OpenAICompatibleChatConfig`
- Implemented buffering logic for `reasoning_content` and `content` in `doStream()`
- Added flush functions to emit buffered content when threshold is reached or stream ends
- Added test fixture for tiny chunks
- Added tests for buffering behavior

## Usage

```typescript
const provider = createOpenAICompatible({
  name: 'baseten',
  baseURL: 'https://inference.baseten.co/v1',
  minChunkSize: 80, // Buffer until 80 chars accumulated
});
```

## Test Plan

- Added test fixture `tiny-chunks.chunks.txt` with 13 reasoning chunks and 3 content chunks
- Test verifies that with `minChunkSize: 20`, chunks are buffered and fewer deltas are emitted
- Test verifies that without `minChunkSize`, all chunks are emitted immediately

Fixes #15343

🤖 Generated with [Claude Code](https://claude.ai/code)