### PR TITLE
ci(release): link GitHub releases and npm in notify comments

### DIFF
--- a/.changeset/notify-released-github-npm-links.md
+++ b/.changeset/notify-released-github-npm-links.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Post-publish release notifications now link to each package’s GitHub release and npm page.

--- a/.github/scripts/notify-released/index.mjs
+++ b/.github/scripts/notify-released/index.mjs
@@ -207,7 +207,10 @@ console.log(
 
 const packageTable = publishedPackages
   .map(pkg => {
-    return `| \`${pkg.name}\` | [\`${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version}) |`;
+    const tag = `${pkg.name}@${pkg.version}`;
+    const githubReleaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${encodeURIComponent(tag)}`;
+    const npmUrl = `https://www.npmjs.com/package/${encodeURIComponent(pkg.name)}/v/${pkg.version}`;
+    return `| \`${pkg.name}\` | ${pkg.version} [github](${githubReleaseUrl}) [npm](${npmUrl}) |`;
   })
   .join('\n');
 


### PR DESCRIPTION
Updates `.github/scripts/notify-released/index.mjs` so the post-publish table lists each version with separate **[github](…)** (repo release tag) and **[npm](…)** links. It currently only links to npm which does not have the changelog, only confirms that the package was indeed published successfully.