### PR TITLE
docs(ai): clarify onToolCall output handling

### DIFF
--- a/.changeset/clarify-ontoolcall-output.md
+++ b/.changeset/clarify-ontoolcall-output.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+docs(ai): clarify `onToolCall` output handling

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -208,8 +208,8 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
    * Optional callback function that is invoked when a tool call is received.
    * Intended for automatic client-side tool execution.
    *
-   * You can optionally return a result for the tool call,
-   * either synchronously or asynchronously.
+   * To provide the tool output, call `addToolOutput` from inside or after
+   * this callback. The callback return value is not consumed.
    */
   onToolCall?: ChatOnToolCallCallback<UI_MESSAGE>;
 


### PR DESCRIPTION
## Summary
- Clarifies the `onToolCall` JSDoc so it matches the callback type and stream processing behavior.
- Points users to `addToolOutput` for attaching tool output.
- Adds a patch changeset for the published `ai` package docs surface.

## Why
`ChatOnToolCallCallback` returns `void | PromiseLike<void>`, and `process-ui-message-stream` awaits the callback without consuming a return value. The old JSDoc said a tool result could be returned, which could send users down the wrong path.

Fixes #15268.

## Validation
- `npx -y pnpm@10.11.0 install --frozen-lockfile`
- `npx -y pnpm@10.11.0 exec ultracite check packages/ai/src/ui/chat.ts .changeset/clarify-ontoolcall-output.md`
- `npx -y pnpm@10.11.0 --filter ai type-check`
- `npx -y pnpm@10.11.0 changeset status --since=main`
- `git diff --check`

Note: local validation ran on Node v25.8.2, so pnpm emitted the repo engine warning for supported Node versions.