### PR TITLE
fix: wrong structure of tool Metadata in react mcp-app

### DIFF
--- a/.changeset/mean-rice-join.md
+++ b/.changeset/mean-rice-join.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk/react": major
+"@ai-sdk/react": patch
 ---
 
 Fix wrong property path of toolMetadata in react mcp-app

--- a/.changeset/mean-rice-join.md
+++ b/.changeset/mean-rice-join.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/react": major
+---
+
+Fix wrong property path of toolMetadata in react mcp-app

--- a/packages/react/src/mcp-apps/utils.test.ts
+++ b/packages/react/src/mcp-apps/utils.test.ts
@@ -11,13 +11,11 @@ describe('getMCPAppFromToolPart', () => {
       state: 'input-available',
       input: { topic: 'usage' },
       toolMetadata: {
-        mcp: {
-          clientName: 'local-mcp-apps',
-          app: {
-            resourceUri: 'ui://ai-sdk-e2e/dashboard',
-            mimeType: 'text/html;profile=mcp-app',
-            visibility: ['model', 'app'],
-          },
+        clientName: 'local-mcp-apps',
+        app: {
+          resourceUri: 'ui://ai-sdk-e2e/dashboard',
+          mimeType: 'text/html;profile=mcp-app',
+          visibility: ['model', 'app'],
         },
       },
     } satisfies MCPAppRendererProps['part'];
@@ -42,7 +40,7 @@ describe('getMCPAppFromToolPart', () => {
       state: 'input-available',
       input: {},
       toolMetadata: {
-        mcp: { clientName: 'local-mcp-apps' },
+        clientName: 'local-mcp-apps',
       },
     } satisfies MCPAppRendererProps['part'];
 

--- a/packages/react/src/mcp-apps/utils.ts
+++ b/packages/react/src/mcp-apps/utils.ts
@@ -15,9 +15,8 @@ import type { MCPAppMetadata, MCPAppRendererProps } from './types';
  *   toolMetadata: {
  *     clientName: 'local-mcp-apps',
  *     app: {
- *         resourceUri: 'ui://example/dashboard',
- *         mimeType: 'text/html;profile=mcp-app',
- *       },
+ *       resourceUri: 'ui://example/dashboard',
+ *       mimeType: 'text/html;profile=mcp-app',
  *     },
  *   },
  * });
@@ -27,7 +26,7 @@ import type { MCPAppMetadata, MCPAppRendererProps } from './types';
 export function getMCPAppFromToolPart(
   part: MCPAppRendererProps['part'],
 ): MCPAppMetadata | undefined {
-  const mcpMetadata = part.toolMetadata;
+  const mcpMetadata = part.toolMetadata?.mcp;
   const rawAppMetadata = isJSONObject(mcpMetadata)
     ? mcpMetadata.app
     : undefined;

--- a/packages/react/src/mcp-apps/utils.ts
+++ b/packages/react/src/mcp-apps/utils.ts
@@ -13,8 +13,8 @@ import type { MCPAppMetadata, MCPAppRendererProps } from './types';
  *   state: 'input-available',
  *   input: { topic: 'usage' },
  *   toolMetadata: {
- *     mcp: {
- *       app: {
+ *     clientName: 'local-mcp-apps',
+ *     app: {
  *         resourceUri: 'ui://example/dashboard',
  *         mimeType: 'text/html;profile=mcp-app',
  *       },
@@ -27,7 +27,7 @@ import type { MCPAppMetadata, MCPAppRendererProps } from './types';
 export function getMCPAppFromToolPart(
   part: MCPAppRendererProps['part'],
 ): MCPAppMetadata | undefined {
-  const mcpMetadata = part.toolMetadata?.mcp;
+  const mcpMetadata = part.toolMetadata;
   const rawAppMetadata = isJSONObject(mcpMetadata)
     ? mcpMetadata.app
     : undefined;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The package @ai-sdk/react has supported mcp-app, there is a logic to fetch app metadata in the method `getMCPAppFromToolPart`。

```ts
export function getMCPAppFromToolPart(
  part: MCPAppRendererProps['part'],
): MCPAppMetadata | undefined {
  const mcpMetadata = part.toolMetadata?.mcp;
  const rawAppMetadata = isJSONObject(mcpMetadata)
    ? mcpMetadata.app
    : undefined;
  const appMetadata = isJSONObject(rawAppMetadata) ? rawAppMetadata : undefined;

  if (
    appMetadata == null ||
    appMetadata.mimeType !== 'text/html;profile=mcp-app' ||
    typeof appMetadata.resourceUri !== 'string' ||
    !appMetadata.resourceUri.startsWith('ui://') ||
    (appMetadata.visibility != null &&
      (!Array.isArray(appMetadata.visibility) ||
        appMetadata.visibility.some(
          value => value !== 'model' && value !== 'app',
        )))
  ) {
    return undefined;
  }

  return appMetadata as MCPAppMetadata;
}
```
But refert to the pull request https://github.com/vercel/ai/pull/15021/changes, all metadata are directly added under the property `toolMetadata` , not `toolMetadata.mcp`

Based on the testing with `ai` sdk and `@ai-sdk/react`, I also found that the actually data of `toolMetadata` is 

```
{
    "clientName": "approval-mcp-client",
    "toolName": "approval-request",
    "title": "Approval Request",
    "app": {
        "resourceUri": "ui://localhost:8080/mcp-apps/request-approval",
        "mimeType": "text/html;profile=mcp-app"
    }
}
``` 

## Summary

Fix the `getMCPAppFromToolPart` method, directly get the `MCPAppMetadata` from `toolMetadata.app` not `toolMetadata.mcp.app`

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ x ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ x ] Tests have been added / updated (for bug fixes / features)
- [ x ] Documentation has been added / updated (for bug fixes / features)
- [ x ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ x ] I have reviewed this pull request (self-review)
