### PR TITLE
docs(gateway): clarify OpenAI Responses persistence with BYOK

### DIFF
--- a/content/cookbook/00-guides/19-openai-responses.mdx
+++ b/content/cookbook/00-guides/19-openai-responses.mdx
@@ -163,6 +163,11 @@ For more details on configuring the MCP tool, including authentication, tool fil
 
 With the Responses API, you can persist chat history with OpenAI across requests. This allows you to send just the user's last message and OpenAI can access the entire chat history.
 
+The examples below use the direct OpenAI provider. If you route Responses API
+persistence through AI Gateway, use OpenAI BYOK so requests that pass
+`previousResponseId` or `conversation` continue against the same upstream OpenAI
+account that stored the response or conversation.
+
 There are two options available to use persistence:
 
 ### With previousResponseId

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -158,6 +158,13 @@ You can connect your own provider credentials to use with Vercel AI Gateway. Thi
 
 To set up BYOK, add your provider credentials in your Vercel team's AI Gateway settings. Once configured, AI Gateway automatically uses your credentials. No code changes are needed.
 
+Use BYOK when a provider feature depends on resources that are scoped to the
+same upstream provider account. For example, OpenAI Responses API persistence
+with `previousResponseId` or `conversation` needs to continue against the same
+OpenAI account that stored the response or conversation. Configure OpenAI BYOK,
+or call the OpenAI provider directly, when your application relies on that
+persistence.
+
 For providers like Azure where you can use custom deployment names, you can configure model mappings to map gateway model slugs to your deployment names. See [model mappings](https://vercel.com/docs/ai-gateway/byok#model-mappings) for details.
 
 Learn more in the [BYOK documentation](https://vercel.com/docs/ai-gateway/byok).


### PR DESCRIPTION
## Summary
- note that OpenAI Responses persistence through AI Gateway should use OpenAI BYOK when passing `previousResponseId` or `conversation`
- mirror the same caveat in the OpenAI Responses API guide before the persistence examples

## Context
This addresses the documentation/workaround side of #15308: Responses API persistence IDs need to remain resolvable by the upstream OpenAI account that stored them. The issue also describes a possible Gateway routing fix, but this PR intentionally keeps to the narrow docs clarification.

## Tests
- `git diff --check`