### PR TITLE
fix(amazon-bedrock): preserve inference-profile ARN model IDs unencoded in REST URLs

### DIFF
--- a/.changeset/efdb949d-bedrock-arn.md
+++ b/.changeset/efdb949d-bedrock-arn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Preserve Bedrock inference-profile ARNs unencoded in REST URL paths. Previously `encodeURIComponent` escaped `:` and `/` characters in ARN model IDs (e.g. `arn:aws:bedrock:...:application-inference-profile/abc123`), producing 400 "The provided model identifier is invalid" responses from Bedrock.

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -41,6 +41,7 @@ import {
   type AmazonBedrockLanguageModelChatOptions,
   type AmazonBedrockChatModelId,
 } from './amazon-bedrock-chat-language-model-options';
+import { encodeBedrockModelId } from './amazon-bedrock-encode-model-id';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { createAmazonBedrockEventStreamResponseHandler } from './amazon-bedrock-event-stream-response-handler';
 import { prepareTools } from './amazon-bedrock-prepare-tools';
@@ -1049,7 +1050,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = encodeBedrockModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}`;
   }
 }

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -19,6 +19,7 @@ import {
   amazonBedrockEmbeddingModelOptionsSchema,
   type AmazonBedrockEmbeddingModelId,
 } from './amazon-bedrock-embedding-model-options';
+import { encodeBedrockModelId } from './amazon-bedrock-encode-model-id';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { z } from 'zod/v4';
 
@@ -56,7 +57,7 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
   ) {}
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = encodeBedrockModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 

--- a/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { encodeBedrockModelId } from './amazon-bedrock-encode-model-id';
+
+describe('encodeBedrockModelId', () => {
+  it('URL-encodes regular model IDs containing colons', () => {
+    expect(encodeBedrockModelId('us.amazon.nova-2-lite-v1:0')).toBe(
+      'us.amazon.nova-2-lite-v1%3A0',
+    );
+  });
+
+  it('returns application-inference-profile ARNs unencoded', () => {
+    const arn =
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123';
+    expect(encodeBedrockModelId(arn)).toBe(arn);
+  });
+
+  it('returns cross-region inference-profile ARNs unencoded', () => {
+    const arn =
+      'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.amazon.nova-2-lite-v1:0';
+    expect(encodeBedrockModelId(arn)).toBe(arn);
+  });
+});

--- a/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Encode a Bedrock model identifier for use in REST URL paths.
+ *
+ * Bedrock inference-profile ARNs (e.g. `arn:aws:bedrock:...:application-inference-profile/abc`)
+ * must be passed unencoded — the API rejects URL-escaped colons and slashes with
+ * a 400 "The provided model identifier is invalid" error.
+ *
+ * All other model IDs go through `encodeURIComponent` so version separators
+ * (e.g. `nova-2-lite-v1:0`) are escaped.
+ */
+export function encodeBedrockModelId(modelId: string): string {
+  return modelId.startsWith('arn:') ? modelId : encodeURIComponent(modelId);
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
@@ -20,6 +20,7 @@ import {
   modelMaxImagesPerCall,
   type AmazonBedrockImageModelId,
 } from './amazon-bedrock-image-settings';
+import { encodeBedrockModelId } from './amazon-bedrock-encode-model-id';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { z } from 'zod/v4';
 
@@ -55,7 +56,7 @@ export class AmazonBedrockImageModel implements ImageModelV4 {
   }
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = encodeBedrockModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -16,6 +16,7 @@ import {
   anthropicTools,
   AnthropicLanguageModel,
 } from '@ai-sdk/anthropic/internal';
+import { encodeBedrockModelId } from '../amazon-bedrock-encode-model-id';
 import {
   createApiKeyFetchFunction,
   createSigV4FetchFunction,
@@ -258,7 +259,7 @@ export function createAmazonBedrockAnthropic(
       fetch: fetchFunction,
 
       buildRequestUrl: (baseURL, isStreaming) =>
-        `${baseURL}/model/${encodeURIComponent(modelId)}/${
+        `${baseURL}/model/${encodeBedrockModelId(modelId)}/${
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 


### PR DESCRIPTION
Fixes #14117.

## Background

AWS Bedrock supports two model-id shapes in `/model/{modelId}/...` REST paths:

1. Bare model IDs like `us.amazon.nova-2-lite-v1:0` — these MUST be URL-encoded so the `:` survives path parsing.
2. Inference-profile ARNs like `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123` — these MUST be passed verbatim, unencoded, or Bedrock returns `400 The provided model identifier is invalid`.

The current code uses `encodeURIComponent(modelId)` unconditionally, so case (2) breaks.

## Change

Introduce `encodeBedrockModelId(modelId)` that returns ARNs as-is and `encodeURIComponent`s everything else. Update the four URL-path construction sites in `@ai-sdk/amazon-bedrock` to use it.

## Note re prior PRs

PRs #14138 and #14257 attempted similar fixes but reference the old `bedrock-*.ts` filenames — they predate the package rename to `amazon-bedrock-*.ts` and have been untouched for over a month. This PR targets the current file layout.

## Tests

Added unit tests for the helper covering regular IDs, application-inference-profile ARNs, and cross-region inference-profile ARNs. Verified with `pnpm --filter @ai-sdk/amazon-bedrock test`.