### PR TITLE
fix(xai, deepseek, groq, mistral): only send null content for assistant messages with tool calls

### DIFF
--- a/.changeset/null-content-tool-only-providers.md
+++ b/.changeset/null-content-tool-only-providers.md
@@ -1,0 +1,12 @@
+---
+"@ai-sdk/xai": patch
+"@ai-sdk/deepseek": patch
+"@ai-sdk/groq": patch
+"@ai-sdk/mistral": patch
+---
+
+fix(xai, deepseek, groq, mistral): only send null content for assistant messages with tool calls
+
+Apply the same fix as #14950 (openai, openai-compatible) to four additional OpenAI-compatible providers. When an assistant message contains only `tool-call` parts (no text), emit `content: null` so providers that route to Bedrock or strictly follow the OpenAI spec stop rejecting the request with `ValidationException: messages: text content blocks must be non-empty`. When the message has no tool calls, preserve the original string (including empty string) so we do not regress the OpenAI-spec rule "content is required unless tool_calls or function_call is specified".
+
+Closes #14612.

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -131,7 +131,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -190,7 +190,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -261,7 +261,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [
@@ -336,7 +336,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -421,7 +421,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [
@@ -486,6 +486,30 @@ describe('convertToDeepSeekChatMessages', () => {
             {
               "content": "Again",
               "role": "user",
+            },
+          ],
+          "warnings": [],
+        }
+      `);
+    });
+
+    it('should preserve empty string content for assistant messages without tool calls', () => {
+      const result = convertToDeepSeekChatMessages({
+        prompt: [
+          { role: 'assistant', content: [{ type: 'text', text: '' }] },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-chat',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "",
+              "reasoning_content": undefined,
+              "role": "assistant",
+              "tool_calls": undefined,
             },
           ],
           "warnings": [],

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -129,7 +129,7 @@ export function convertToDeepSeekChatMessages({
         // string when the source message had no reasoning part at all.
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           reasoning_content: reasoning ?? (isDeepSeekV4 ? '' : undefined),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -123,7 +123,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "role": "assistant",
           "tool_calls": [
             {
@@ -167,7 +167,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "reasoning": "I think the tool will return the correct value.",
           "role": "assistant",
           "tool_calls": [
@@ -310,5 +310,20 @@ describe('top-level-only media type resolution', () => {
       type: 'image_url',
       image_url: { url: `data:image/png;base64,${pngBase64}` },
     });
+  });
+
+  it('should preserve empty string content for assistant messages without tool calls', () => {
+    const result = convertToGroqChatMessages([
+      { role: 'assistant', content: [{ type: 'text', text: '' }] },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "",
+          "role": "assistant",
+        },
+      ]
+    `);
   });
 });

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -112,7 +112,7 @@ export function convertToGroqChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           ...(reasoning.length > 0 ? { reasoning } : null),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -163,7 +163,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -216,7 +216,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -279,7 +279,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -332,7 +332,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -455,5 +455,22 @@ describe('top-level-only media type resolution', () => {
       type: 'image_url',
       image_url: `data:image/png;base64,${pngBase64}`,
     });
+  });
+
+  it('should preserve empty string content for assistant messages without tool calls', () => {
+    const result = convertToMistralChatMessages([
+      { role: 'assistant', content: [{ type: 'text', text: '' }] },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "",
+          "prefix": undefined,
+          "role": "assistant",
+          "tool_calls": undefined,
+        },
+      ]
+    `);
   });
 });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -138,7 +138,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -225,7 +225,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',
@@ -270,7 +270,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',
@@ -413,5 +413,16 @@ describe('convertToXaiChatMessages', () => {
         image_url: { url: `data:image/png;base64,${pngBase64}` },
       });
     });
+  });
+
+  it('should preserve empty string content for assistant messages without tool calls', () => {
+    const { messages, warnings } = convertToXaiChatMessages([
+      { role: 'assistant', content: [{ type: 'text', text: '' }] },
+    ]);
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      { role: 'assistant', content: '', tool_calls: undefined },
+    ]);
   });
 });

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -113,7 +113,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## Background

#13744 introduced `content: text || null` for assistant messages so that tool-only assistant turns (no text part) send `content: null` to the upstream API. #14950 refined this further for `@ai-sdk/openai` and `@ai-sdk/openai-compatible` to **only** apply the null when `tool_calls.length > 0` — preventing a regression where empty assistant content without tool calls was being incorrectly converted to `null`, which OpenAI's spec rejects.

Issue #14612 points out the same `content: ""` pattern still exists in four other OpenAI-compatible providers and causes Bedrock-routed gateways (and strict spec validators) to reject the request with:

> `ValidationException: messages: text content blocks must be non-empty`

## Summary of changes

Apply the same pattern as #14950 in four providers:

```diff
- content: text,
+ content: toolCalls.length > 0 ? text || null : text,
```

Files changed:
- `packages/xai/src/convert-to-xai-chat-messages.ts`
- `packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts`
- `packages/groq/src/convert-to-groq-chat-messages.ts`
- `packages/mistral/src/convert-to-mistral-chat-messages.ts`

For each provider, the existing test snapshots that asserted `content: ''` for tool-only assistant messages are updated to expect `content: null`. A new regression test is added in each test file to assert that an assistant message with empty text and **no** tool calls still produces `content: ''` (mirroring the regression #14950 was guarding against).

A patch changeset covers all four packages.

## Verification

- Updated all existing tool-only test snapshots in the 4 packages (13 assertions across 4 files).
- Added 4 new regression tests for the empty-text-no-tool-calls case.
- All edits follow the exact pattern of #14950's reference fix.

I do **not** have a local Node toolchain to run the suite myself; relying on the project's CI to confirm the snapshots match. Happy to push fixups if anything turns red.

## Mistral note

The issue flags that Mistral's chat-completions spec should be verified to accept `null` content. Mistral's docs describe `content` as either a string or an array of content parts; their OpenAI-compatible chat endpoint accepts the OpenAI spec where `content` is nullable when `tool_calls` is present. If maintainers prefer to scope this to xai/deepseek/groq only and address mistral separately, I'll happily split the PR.

Closes #14612. Follow-up to #14950, #13744.