### PR TITLE
fix(react): refresh transport across renders in useChat

### DIFF
--- a/.changeset/usechat-transport-stale-fix.md
+++ b/.changeset/usechat-transport-stale-fix.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/react": patch
+---
+
+fix(react): refresh transport across renders in `useChat`
+
+`useChat` previously captured the `transport` (and any `body` / `headers` / `prepareSendMessagesRequest` baked into it) on the very first render, so inline transports closing over component state would forever send the first-render value. Apply the same pattern already used for `onFinish` / `onError` / `onToolCall`: keep the user's transport in a ref, and pass `Chat` a stable delegating proxy that reads the latest transport on every `sendMessages` / `reconnectToStream` call.
+
+Closes #7819.

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,4 +1,10 @@
-import type { AbstractChat, ChatInit, CreateUIMessage, UIMessage } from 'ai';
+import type {
+  AbstractChat,
+  ChatInit,
+  ChatTransport,
+  CreateUIMessage,
+  UIMessage,
+} from 'ai';
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import { Chat } from './chat.react';
 
@@ -79,16 +85,68 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     };
   }
 
-  // Ensure the Chat instance has the latest callbacks
-  const optionsWithCallbacks: typeof options = {
-    ...options,
-    onToolCall: arg => callbacksRef.current.onToolCall?.(arg),
-    onData: arg => callbacksRef.current.onData?.(arg),
-    onFinish: arg => callbacksRef.current.onFinish?.(arg),
-    onError: arg => callbacksRef.current.onError?.(arg),
-    sendAutomaticallyWhen: arg =>
-      callbacksRef.current.sendAutomaticallyWhen?.(arg) ?? false,
-  };
+  // Keep the user-supplied transport (and any inline `body` / `headers` /
+  // `prepareSendMessagesRequest` baked into it) addressable across renders.
+  // The Chat instance is created once and holds a stable reference, so without
+  // this ref the transport captured on the first render would be reused
+  // forever — see https://github.com/vercel/ai/issues/7819.
+  const userTransportRef = useRef<ChatTransport<UI_MESSAGE> | undefined>(
+    !('chat' in options) ? options.transport : undefined,
+  );
+  if (!('chat' in options)) {
+    userTransportRef.current = options.transport;
+  }
+
+  // A stable delegating transport. Its identity never changes, so Chat keeps
+  // it across renders, but each method call reads through to whatever the
+  // most-recent user transport is. If the user does not supply a transport,
+  // this ref stays unset and Chat falls back to its own default.
+  const stableTransportRef = useRef<ChatTransport<UI_MESSAGE> | undefined>(
+    undefined,
+  );
+  if (
+    stableTransportRef.current === undefined &&
+    userTransportRef.current !== undefined
+  ) {
+    stableTransportRef.current = {
+      sendMessages: args => {
+        const t = userTransportRef.current;
+        if (t === undefined) {
+          throw new Error(
+            'useChat: transport was provided initially but is now undefined',
+          );
+        }
+        return t.sendMessages(args);
+      },
+      reconnectToStream: args => {
+        const t = userTransportRef.current;
+        if (t === undefined) {
+          throw new Error(
+            'useChat: transport was provided initially but is now undefined',
+          );
+        }
+        return t.reconnectToStream(args);
+      },
+    };
+  }
+
+  // Ensure the Chat instance has the latest callbacks and a transport whose
+  // closures over component state stay fresh.
+  const optionsWithCallbacks: typeof options =
+    'chat' in options
+      ? options
+      : {
+          ...options,
+          ...(stableTransportRef.current !== undefined
+            ? { transport: stableTransportRef.current }
+            : {}),
+          onToolCall: arg => callbacksRef.current.onToolCall?.(arg),
+          onData: arg => callbacksRef.current.onData?.(arg),
+          onFinish: arg => callbacksRef.current.onFinish?.(arg),
+          onError: arg => callbacksRef.current.onError?.(arg),
+          sendAutomaticallyWhen: arg =>
+            callbacksRef.current.sendAutomaticallyWhen?.(arg) ?? false,
+        };
 
   const chatRef = useRef<Chat<UI_MESSAGE>>(
     'chat' in options ? options.chat : new Chat(optionsWithCallbacks),

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2698,4 +2698,65 @@ describe('use-chat', () => {
       });
     });
   });
+
+  describe('transport state stays fresh across renders (#7819)', () => {
+    setupTestComponent(() => {
+      const [subagent, setSubagent] = React.useState('todos-agent');
+
+      const { messages, sendMessage } = useChat({
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          body: { subagent },
+        }),
+      });
+
+      return (
+        <div>
+          <div data-testid="subagent">{subagent}</div>
+          <div data-testid="message-count">{messages.length}</div>
+          <button
+            data-testid="set-agent"
+            onClick={() => setSubagent('research-agent')}
+          />
+          <button
+            data-testid="send"
+            onClick={() => {
+              sendMessage({ parts: [{ type: 'text', text: 'hi' }] });
+            }}
+          />
+        </div>
+      );
+    });
+
+    it('sends the latest body value after the parent re-renders', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'ok' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      // 1) flip the state that the inline transport body closes over
+      await userEvent.click(screen.getByTestId('set-agent'));
+      await waitFor(() =>
+        expect(screen.getByTestId('subagent')).toHaveTextContent(
+          'research-agent',
+        ),
+      );
+
+      // 2) send a message and inspect what landed in the request body
+      await userEvent.click(screen.getByTestId('send'));
+
+      await waitFor(() => {
+        expect(server.calls.length).toBeGreaterThan(0);
+      });
+
+      const sentBody = await server.calls[0].requestBodyJson;
+      // Before the fix this asserted 'todos-agent' (the value captured on
+      // the first render); after the fix it sees the latest value.
+      expect(sentBody.subagent).toBe('research-agent');
+    });
+  });
 });


### PR DESCRIPTION
## What

`useChat` previously captured `transport` (and any `body` / `headers` / `prepareSendMessagesRequest` baked into it) on the very first render via the initial `new Chat(...)` call, so an inline transport closing over component state would forever send the value from that first render. The community report in #7819 shows the most common shape:

```tsx
const [subagent, setSubagent] = useState('todos-agent');

useChat({
  transport: new DefaultChatTransport({
    body: { subagent },          // ← always 'todos-agent', even after setSubagent(...)
  }),
});
```

The other callback options (`onFinish`, `onError`, `onToolCall`, ...) already use a `callbacksRef` pattern to stay fresh across renders. This PR extends the same pattern to `transport`:

1. Keep the user-supplied transport in a `userTransportRef` that gets refreshed on every render.
2. Create a stable delegating `ChatTransport` proxy once. Its identity never changes, so `Chat` happily keeps it across renders, but each `sendMessages` / `reconnectToStream` call reads through to whatever the most-recent user transport is.

If the user does not supply a transport, the ref stays unset and `Chat` falls back to its built-in default (no behavior change for that path).

## Why this approach

- Symmetric with the existing `callbacksRef` pattern for `onFinish` / `onError` / `onToolCall` already present in this hook — least surprising for readers.
- No `Chat` API change. `transport` is `private readonly` on `AbstractChat` and stays that way; the proxy lives on the React side only.
- Works for both shapes users report:
  - inline `new DefaultChatTransport({ body: { state } })` recreated each render
  - a custom transport instance that itself reads from React/Zustand/etc. — both go through the same `userTransportRef`.

## Tests

Adds one regression test (`describe('transport state stays fresh across renders (#7819)')`) that mirrors the exact issue body:

- Renders a component with `[subagent, setSubagent] = useState('todos-agent')`
- Passes that into `body: { subagent }` on a `DefaultChatTransport` constructed inline
- Clicks a button to set the state to `'research-agent'`
- Clicks send and asserts the request body's `subagent` is `'research-agent'`, not the stale `'todos-agent'`

Before this fix the assertion would fail with `'todos-agent'`.

## Notes

- I don't have a local Node toolchain to run vitest myself; relying on CI to confirm the regression test and the rest of the suite still pass. Happy to push fixups for any maintainer feedback.

Closes #7819.
