### PR TITLE
fix(cerebras): send historical reasoning as `reasoning` field

### DIFF
--- a/.changeset/cerebras-assistant-reasoning-field.md
+++ b/.changeset/cerebras-assistant-reasoning-field.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/cerebras': patch
+---
+
+fix(cerebras): send historical assistant reasoning as `reasoning` (not `reasoning_content`)
+
+Cerebras rejects `reasoning_content` on input assistant messages, so multi-step runs with reasoning models (e.g. `zai-glm-4.7`, `qwen-3-235b-a22b-thinking-2507`) failed after step 1 with `400 wrong_api_format: property 'messages.N.assistant.reasoning_content' is unsupported`.
+
+The Cerebras provider now serializes reasoning back as the `reasoning` field per the Cerebras chat-completions API. The underlying `@ai-sdk/openai-compatible` chat model gains an `assistantReasoningSerialization` option (`'reasoning_content'` (default) | `'reasoning'` | `'none'`) so other providers can opt in to the same behavior.

--- a/packages/cerebras/src/cerebras-provider.test.ts
+++ b/packages/cerebras/src/cerebras-provider.test.ts
@@ -97,6 +97,17 @@ describe('CerebrasProvider', () => {
       const model = provider(modelId);
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
+
+    it('should serialize assistant reasoning as `reasoning` (Cerebras expects this field, not `reasoning_content`)', () => {
+      const provider = createCerebras();
+      provider('zai-glm-4.7');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+
+      expect(config.assistantReasoningSerialization).toBe('reasoning');
+    });
   });
 
   describe('languageModel', () => {

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -101,6 +101,11 @@ export function createCerebras(
       fetch: options.fetch,
       errorStructure: cerebrasErrorStructure,
       supportsStructuredOutputs: true,
+      // Cerebras rejects `reasoning_content` on input assistant messages; it
+      // expects historical reasoning to be passed back as a `reasoning` field.
+      // Without this, multi-step runs with reasoning models (e.g. `zai-glm-4.7`,
+      // `qwen-3-235b-a22b-thinking-2507`) fail with HTTP 400 after step 1.
+      assistantReasoningSerialization: 'reasoning',
     });
   };
 

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -1097,6 +1097,78 @@ describe('provider-specific metadata merging', () => {
   });
 });
 
+describe('assistant reasoning serialization', () => {
+  const promptWithReasoning = [
+    {
+      role: 'assistant' as const,
+      content: [
+        { type: 'reasoning' as const, text: 'thinking out loud' },
+        { type: 'text' as const, text: 'done.' },
+      ],
+    },
+  ];
+
+  it('serializes reasoning as reasoning_content by default', () => {
+    expect(convertToOpenAICompatibleChatMessages(promptWithReasoning)).toEqual([
+      {
+        role: 'assistant',
+        content: 'done.',
+        reasoning_content: 'thinking out loud',
+        tool_calls: undefined,
+      },
+    ]);
+  });
+
+  it('serializes reasoning as `reasoning` when requested', () => {
+    expect(
+      convertToOpenAICompatibleChatMessages(promptWithReasoning, {
+        assistantReasoningSerialization: 'reasoning',
+      }),
+    ).toEqual([
+      {
+        role: 'assistant',
+        content: 'done.',
+        reasoning: 'thinking out loud',
+        tool_calls: undefined,
+      },
+    ]);
+  });
+
+  it('omits reasoning entirely when set to `none`', () => {
+    expect(
+      convertToOpenAICompatibleChatMessages(promptWithReasoning, {
+        assistantReasoningSerialization: 'none',
+      }),
+    ).toEqual([
+      {
+        role: 'assistant',
+        content: 'done.',
+        tool_calls: undefined,
+      },
+    ]);
+  });
+
+  it('does not add a reasoning field when no reasoning parts are present', () => {
+    expect(
+      convertToOpenAICompatibleChatMessages(
+        [
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'hello' }],
+          },
+        ],
+        { assistantReasoningSerialization: 'reasoning' },
+      ),
+    ).toEqual([
+      {
+        role: 'assistant',
+        content: 'hello',
+        tool_calls: undefined,
+      },
+    ]);
+  });
+});
+
 describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
   it('should serialize thought signature to extra_content for single tool call', () => {
     const result = convertToOpenAICompatibleChatMessages([

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -17,6 +17,23 @@ function getOpenAIMetadata(message: {
   return message?.providerOptions?.openaiCompatible ?? {};
 }
 
+/**
+ * Controls how assistant `reasoning` content parts are serialized when sending
+ * messages back to the provider.
+ *
+ * - `'reasoning_content'` (default): emit a `reasoning_content` field, which is
+ *   the convention most OpenAI-compatible providers (xai, groq, deepseek, ...)
+ *   use.
+ * - `'reasoning'`: emit a `reasoning` field. Required by providers that reject
+ *   `reasoning_content` on input (e.g. Cerebras, which expects `reasoning`).
+ * - `'none'`: drop reasoning parts from outgoing assistant messages. Useful for
+ *   providers that reject any historical reasoning field at all.
+ */
+export type AssistantReasoningSerialization =
+  | 'reasoning_content'
+  | 'reasoning'
+  | 'none';
+
 function getAudioFormat(mediaType: string): 'wav' | 'mp3' | null {
   switch (mediaType) {
     case 'audio/wav':
@@ -31,7 +48,12 @@ function getAudioFormat(mediaType: string): 'wav' | 'mp3' | null {
 
 export function convertToOpenAICompatibleChatMessages(
   prompt: LanguageModelV4Prompt,
+  options: {
+    assistantReasoningSerialization?: AssistantReasoningSerialization;
+  } = {},
 ): OpenAICompatibleChatPrompt {
+  const assistantReasoningSerialization =
+    options.assistantReasoningSerialization ?? 'reasoning_content';
   const messages: OpenAICompatibleChatPrompt = [];
   for (const { role, content, ...message } of prompt) {
     const metadata = getOpenAIMetadata({ ...message });
@@ -221,10 +243,15 @@ export function convertToOpenAICompatibleChatMessages(
           }
         }
 
+        const reasoningField =
+          reasoning.length > 0 && assistantReasoningSerialization !== 'none'
+            ? { [assistantReasoningSerialization]: reasoning }
+            : {};
+
         messages.push({
           role: 'assistant',
           content: toolCalls.length > 0 ? text || null : text,
-          ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
+          ...reasoningField,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,
         });

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -345,6 +345,55 @@ describe('doGenerate', () => {
     `);
   });
 
+  describe('assistant reasoning serialization', () => {
+    const reasoningPrompt: LanguageModelV4Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'thinking out loud' },
+          { type: 'text', text: 'done.' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ];
+
+    it('serializes assistant reasoning as reasoning_content by default', async () => {
+      prepareJsonResponse({ content: '' });
+
+      await provider('grok-3').doGenerate({ prompt: reasoningPrompt });
+
+      const messages = (await server.calls[0].requestBodyJson).messages;
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: 'done.',
+        reasoning_content: 'thinking out loud',
+      });
+    });
+
+    it('serializes assistant reasoning as `reasoning` when configured', async () => {
+      prepareJsonResponse({ content: '' });
+
+      const cerebrasStyleProvider = createOpenAICompatible({
+        baseURL: 'https://my.api.com/v1/',
+        name: 'cerebras-style',
+        headers: { Authorization: `Bearer test-api-key` },
+        assistantReasoningSerialization: 'reasoning',
+      });
+
+      await cerebrasStyleProvider('zai-glm-4.7').doGenerate({
+        prompt: reasoningPrompt,
+      });
+
+      const messages = (await server.calls[0].requestBodyJson).messages;
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: 'done.',
+        reasoning: 'thinking out loud',
+      });
+    });
+  });
+
   it('should support partial usage', async () => {
     prepareJsonResponse({
       usage: { prompt_tokens: 20, total_tokens: 20 },

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -40,7 +40,10 @@ import {
   type ProviderErrorStructure,
 } from '../openai-compatible-error';
 import { convertOpenAICompatibleChatUsage } from './convert-openai-compatible-chat-usage';
-import { convertToOpenAICompatibleChatMessages } from './convert-to-openai-compatible-chat-messages';
+import {
+  convertToOpenAICompatibleChatMessages,
+  type AssistantReasoningSerialization,
+} from './convert-to-openai-compatible-chat-messages';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapOpenAICompatibleFinishReason } from './map-openai-compatible-finish-reason';
 import {
@@ -91,6 +94,15 @@ export type OpenAICompatibleChatConfig = {
   convertUsage?: (
     usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
   ) => LanguageModelV4Usage;
+
+  /**
+   * Controls how assistant `reasoning` content parts are serialized when
+   * sending messages back to the provider. Defaults to `'reasoning_content'`.
+   * Set to `'reasoning'` for providers that expect a `reasoning` field instead
+   * (e.g. Cerebras), or `'none'` to omit reasoning from outgoing assistant
+   * messages entirely.
+   */
+  assistantReasoningSerialization?: AssistantReasoningSerialization;
 };
 
 type PendingToolCall = {
@@ -314,7 +326,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
         verbosity: compatibleOptions.textVerbosity,
 
         // messages:
-        messages: convertToOpenAICompatibleChatMessages(prompt),
+        messages: convertToOpenAICompatibleChatMessages(prompt, {
+          assistantReasoningSerialization:
+            this.config.assistantReasoningSerialization,
+        }),
 
         // tools:
         tools: openaiTools,

--- a/packages/openai-compatible/src/index.ts
+++ b/packages/openai-compatible/src/index.ts
@@ -1,4 +1,5 @@
 export { OpenAICompatibleChatLanguageModel } from './chat/openai-compatible-chat-language-model';
+export type { AssistantReasoningSerialization } from './chat/convert-to-openai-compatible-chat-messages';
 export type {
   OpenAICompatibleChatModelId,
   OpenAICompatibleLanguageModelChatOptions,

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -115,6 +115,14 @@ export interface OpenAICompatibleProviderSettings {
    * differ from the default OpenAI-compatible shape.
    */
   convertUsage?: OpenAICompatibleChatConfig['convertUsage'];
+
+  /**
+   * Controls how assistant `reasoning` content parts are serialized when
+   * sending messages back to the provider. Defaults to `'reasoning_content'`.
+   * Set to `'reasoning'` for providers that expect a `reasoning` field
+   * (e.g. Cerebras), or `'none'` to omit reasoning entirely.
+   */
+  assistantReasoningSerialization?: OpenAICompatibleChatConfig['assistantReasoningSerialization'];
 }
 
 /**
@@ -176,6 +184,7 @@ export function createOpenAICompatible<
       transformRequestBody: options.transformRequestBody,
       metadataExtractor: options.metadataExtractor,
       convertUsage: options.convertUsage,
+      assistantReasoningSerialization: options.assistantReasoningSerialization,
     });
 
   const createCompletionModel = (modelId: COMPLETION_MODEL_IDS) =>


### PR DESCRIPTION
## Summary

Fixes #15042.

Cerebras rejects `reasoning_content` on input assistant messages:

```
POST https://api.cerebras.ai/v1/chat/completions
400 Bad Request
{
  "code": "wrong_api_format",
  "message": "messages.3.assistant.reasoning_content: property 'messages.3.assistant.reasoning_content' is unsupported"
}
```

`packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts` always serialized assistant `reasoning` parts as `reasoning_content` (the xai/groq/deepseek convention). Cerebras's chat-completions API uses a `reasoning` field instead, so any multi-step run with a Cerebras reasoning model (`zai-glm-4.7`, `qwen-3-235b-a22b-thinking-2507`) failed at step 2: the SDK echoed the prior assistant turn back with `reasoning_content`, and Cerebras refused it before the model ran.

This adds an `assistantReasoningSerialization` option to `OpenAICompatibleChatConfig` (`'reasoning_content'` (default) | `'reasoning'` | `'none'`), threaded through `createOpenAICompatible`, so the converter emits the configured field name. `@ai-sdk/cerebras` opts in to `'reasoning'`. Every other openai-compatible-based provider (xai, groq, togetherai, fireworks, baseten, vercel, deepinfra) keeps the existing `reasoning_content` behavior unchanged.

## Test plan

- [x] Added converter tests for all three serialization modes plus the no-reasoning-parts case.
- [x] Added an `OpenAICompatibleChatLanguageModel` request-body test asserting `reasoning_content` by default and `reasoning` when configured via `createOpenAICompatible`.
- [x] Added a Cerebras provider test asserting `assistantReasoningSerialization: 'reasoning'` is passed to the underlying chat model.
- [x] `pnpm --filter @ai-sdk/openai-compatible test`: 238/238 pass (node + edge)
- [x] `pnpm --filter @ai-sdk/cerebras test`: 8/8 pass (node + edge)
- [x] `pnpm --filter @ai-sdk/baseten --filter @ai-sdk/vercel --filter @ai-sdk/togetherai --filter @ai-sdk/fireworks test`: all green (no regression in dependent providers)
- [x] `pnpm check`: lint and format clean
- [x] `pnpm --filter @ai-sdk/openai-compatible --filter @ai-sdk/cerebras type-check`