### PR TITLE
test(gateway): cover Seedance reference images

### DIFF
--- a/examples/ai-functions/src/generate-video/gateway/bytedance-seedance-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/gateway/bytedance-seedance-reference-images.ts
@@ -1,0 +1,28 @@
+import { gateway, experimental_generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Generating video...', () =>
+    experimental_generateVideo({
+      model: gateway.videoModel('bytedance/seedance-2.0'),
+      prompt:
+        'A boy wearing glasses and a blue T-shirt from [Image 1] and a corgi dog from [Image 2], sitting on the lawn from [Image 3], in 3D cartoon style.',
+      aspectRatio: '16:9',
+      duration: 5,
+      resolution: '720p',
+      providerOptions: {
+        bytedance: {
+          referenceImages: [
+            'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seelite_ref_1.png',
+            'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seelite_ref_2.png',
+            'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seelite_ref_3.png',
+          ],
+        },
+      },
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -155,6 +155,52 @@ describe('GatewayVideoModel', () => {
       });
     });
 
+    it('should forward ByteDance Seedance reference image options', async () => {
+      prepareJsonResponse();
+
+      const model = new GatewayVideoModel('bytedance/seedance-2.0', {
+        provider: 'gateway',
+        baseURL: 'https://api.test.com',
+        headers: () => ({
+          Authorization: 'Bearer test-token',
+          'ai-gateway-auth-method': 'api-key',
+        }),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+      const prompt = 'Animate this scene using the reference character.';
+
+      await model.doGenerate({
+        prompt,
+        image: undefined,
+        n: 1,
+        aspectRatio: '16:9',
+        resolution: '720p',
+        duration: 5,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {
+          bytedance: {
+            referenceImages: ['https://example.com/character.png'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt,
+        n: 1,
+        aspectRatio: '16:9',
+        resolution: '720p',
+        duration: 5,
+        providerOptions: {
+          bytedance: {
+            referenceImages: ['https://example.com/character.png'],
+          },
+        },
+      });
+    });
+
     it('should omit optional parameters when not provided', async () => {
       prepareJsonResponse();
 


### PR DESCRIPTION
## Summary

- add a Gateway video example for `bytedance/seedance-2.0` reference images
- add a `GatewayVideoModel` test covering the public SDK request shape for `providerOptions.bytedance.referenceImages`

## Why

Refs #15382. The direct `@ai-sdk/bytedance` provider already maps `referenceImages` to ByteDance content entries with `role: "reference_image"`. This pins the Gateway-side client contract so the hosted Gateway translation layer can rely on the public SDK forwarding those reference images unchanged.

## Validation

- `git diff --check`
- Not run: local test suite, to keep this proof pass bounded.