### PR TITLE
fix(ai): parse generateText output for text-only final steps when finishReason isn't `stop`

### DIFF
--- a/.changeset/generate-text-parse-output-without-stop-finish-reason.md
+++ b/.changeset/generate-text-parse-output-without-stop-finish-reason.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+fix(ai): parse `generateText` output when the last step is text-only, even if `finishReason` is not `stop`
+
+`generateText` previously only parsed `Output.object` / `Output.array` / `Output.choice` / `Output.json` / `Output.text` when `lastStep.finishReason === 'stop'`. Some providers report `tool-calls` as the finish reason for text-only final steps — most notably Cerebras `zai-glm-4.7` after the agent has already executed tools — which buried a perfectly parseable structured response behind `NoOutputGeneratedError`.
+
+Output is now also parsed when the last step has no tool calls and produced non-empty text. Steps that actually contain tool calls (i.e. the agent loop should have continued but a stop condition fired first) still throw `NoOutputGeneratedError` exactly as before.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -6928,6 +6928,27 @@ describe('generateText', () => {
       expect(result.toolCalls).toHaveLength(1);
       expect(result.toolResults).toHaveLength(1);
     });
+
+    it('should parse output when finish reason is tool-calls but the last step contained only text (e.g. Cerebras zai-glm-4.7)', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            // Some providers (e.g. Cerebras GLM) report `tool-calls` as the
+            // finish reason even when the assistant turn carries only text.
+            finishReason: { unified: 'tool-calls', raw: undefined },
+            content: [{ type: 'text', text: `{ "value": "test-value" }` }],
+          }),
+        }),
+        prompt: 'prompt',
+        output: Output.object({
+          schema: z.object({ value: z.string() }),
+        }),
+      });
+
+      expect(result.output).toEqual({ value: 'test-value' });
+      expect(result.toolCalls).toHaveLength(0);
+    });
   });
 
   describe('tool execution errors', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1225,9 +1225,17 @@ export async function generateText<
       callbacks: [onFinish, telemetryDispatcher.onEnd],
     });
 
-    // parse output only if the last step was finished with "stop":
+    // Parse output when the last step represents a final assistant turn:
+    // either the provider reported `stop`, or the step produced text and no
+    // tool calls (so the agent loop has exited naturally). The second clause
+    // covers providers that report `tool-calls` for text-only final steps
+    // (e.g. Cerebras `zai-glm-4.7`), which would otherwise bury structured
+    // output behind `NoOutputGeneratedError`.
     let resolvedOutput;
-    if (lastStep.finishReason === 'stop') {
+    if (
+      lastStep.finishReason === 'stop' ||
+      (lastStep.toolCalls.length === 0 && lastStep.text.length > 0)
+    ) {
       const outputSpecification = output ?? text();
       resolvedOutput = await outputSpecification.parseCompleteOutput(
         { text: lastStep.text },


### PR DESCRIPTION
## Summary

Fixes #15349.

`generateText` only parsed `Output.object` / `Output.array` / `Output.choice` / `Output.json` / `Output.text` when the last step's `finishReason === 'stop'`:

```ts
// packages/ai/src/generate-text/generate-text.ts
if (lastStep.finishReason === 'stop') {
  resolvedOutput = await outputSpecification.parseCompleteOutput(...);
}
```

Some providers report `tool-calls` as the finish reason for text-only final steps. Cerebras `zai-glm-4.7` (and other GLM models on Cerebras) is the most visible case: after the agent has already executed tools, the model emits the structured JSON output as text, but Cerebras still returns `finish_reason: "tool_calls"` even though no tool call is in the response. With the old check, that valid output gets buried behind:

```
AI_NoOutputGeneratedError: No output generated.
  finishReason: tool-calls
  lastText: "{\"result\":\"2026\"}"
```

The fix relaxes the condition to also accept the case where the last step produced text and contains no tool calls, meaning the agent loop has already exited naturally because there was nothing left to execute. Steps that actually contain tool calls (the agent loop should have continued but a stop condition fired first) still throw `NoOutputGeneratedError`, exactly as today.

This also aligns `generateText` with `streamText`, whose `output` getter already always tries to parse the final-step text without a `finishReason` guard.

## Test plan

- [x] Added regression test in `generate-text.test.ts` covering `Output.object` with a text-only final step and `finishReason: 'tool-calls'`. Asserts the parsed object is returned and `toolCalls` is empty.
- [x] Existing test "should not parse output when finish reason is tool-calls" (where an actual tool call is present) still passes unchanged.
- [x] `pnpm --filter ai test`: 2717/2717 pass on both node and edge runtimes.
- [x] `pnpm check`: lint and format clean.
- [x] `pnpm --filter ai type-check`: clean.