### PR TITLE
fix(cerebras): match actual Cerebras error envelope shape

### DIFF
--- a/.changeset/cerebras-error-schema.md
+++ b/.changeset/cerebras-error-schema.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+fix(cerebras): match Cerebras's actual error envelope shape so API errors surface as `APICallError`
+
+The Cerebras error schema previously expected `{ message, type, param, code }` at the top level, but Cerebras actually returns errors nested under `error` (with a top-level `status_code` on server errors). On any non-2xx response the response body failed schema validation, so callers saw a confusing `TypeValidationError` with a Zod parse failure instead of a clean `APICallError` carrying the upstream message.
+
+`cerebrasErrorSchema` now mirrors the OpenAI-compatible envelope (`error.message` required, `error.type`/`error.param`/`error.code` nullish, `code` accepting `string | number`). 5xx responses from Cerebras GLM / Qwen / gpt-oss now surface with the actual upstream message.
+
+**Note**: `CerebrasErrorData` (the inferred type) now reflects the nested shape. The previous flat shape never matched a real Cerebras response, so this only affects code that was already broken.

--- a/examples/ai-functions/src/e2e/cerebras.test.ts
+++ b/examples/ai-functions/src/e2e/cerebras.test.ts
@@ -27,7 +27,9 @@ createFeatureTestSuite({
   timeout: 30000,
   customAssertions: {
     errorValidator: (error: APICallError) => {
-      expect((error.data as CerebrasErrorData).message).toMatch(/not exist/i);
+      expect((error.data as CerebrasErrorData).error.message).toMatch(
+        /not exist/i,
+      );
     },
   },
 })();

--- a/packages/cerebras/src/cerebras-error.test.ts
+++ b/packages/cerebras/src/cerebras-error.test.ts
@@ -1,0 +1,79 @@
+import { APICallError } from '@ai-sdk/provider';
+import { describe, expect, it, vi } from 'vitest';
+import { createCerebras } from './cerebras-provider';
+
+const TEST_PROMPT = [
+  { role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] },
+];
+
+describe('cerebras error envelope parsing', () => {
+  it('parses a Cerebras 500 error body without TypeValidationError (fixes #11783)', async () => {
+    // Exact response body shape returned by Cerebras for an upstream 500.
+    // The previous error schema expected `{ message, type, param, code }` at
+    // the top level, which threw `TypeValidationError` instead of surfacing
+    // the API error.
+    const cerebrasErrorBody = {
+      status_code: 500,
+      error: {
+        message: 'Encountered a server error, please try again.',
+        type: 'server_error',
+        param: '',
+        code: '',
+        id: '',
+      },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(cerebrasErrorBody), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const cerebras = createCerebras({
+      apiKey: 'test',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      cerebras('zai-glm-4.7').doGenerate({ prompt: TEST_PROMPT }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(APICallError.isInstance(error)).toBe(true);
+      expect((error as APICallError).message).toBe(
+        'Encountered a server error, please try again.',
+      );
+      return true;
+    });
+  });
+
+  it('tolerates a 400 with `code` returned as a number', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: 'Bad request',
+            type: 'invalid_request_error',
+            code: 400,
+          },
+        }),
+        {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    const cerebras = createCerebras({
+      apiKey: 'test',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      cerebras('zai-glm-4.7').doGenerate({ prompt: TEST_PROMPT }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(APICallError.isInstance(error)).toBe(true);
+      expect((error as APICallError).message).toBe('Bad request');
+      return true;
+    });
+  });
+});

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -17,19 +17,27 @@ import type { CerebrasChatModelId } from './cerebras-chat-options';
 import { z } from 'zod/v4';
 import { VERSION } from './version';
 
-// Add error schema and structure
+// Cerebras returns errors with the standard OpenAI-compatible envelope:
+// `{ error: { message, type, code, param, ... } }` (plus a top-level
+// `status_code` on server errors). The previous schema expected those fields
+// at the top level, which caused any non-2xx response to fall through to
+// `TypeValidationError` instead of `APICallError`. The non-`message` fields
+// are nullish because Cerebras commonly returns empty strings or omits them
+// depending on the error class.
 const cerebrasErrorSchema = z.object({
-  message: z.string(),
-  type: z.string(),
-  param: z.string(),
-  code: z.string(),
+  error: z.object({
+    message: z.string(),
+    type: z.string().nullish(),
+    param: z.any().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+  }),
 });
 
 export type CerebrasErrorData = z.infer<typeof cerebrasErrorSchema>;
 
 const cerebrasErrorStructure: ProviderErrorStructure<CerebrasErrorData> = {
   errorSchema: cerebrasErrorSchema,
-  errorToMessage: data => data.message,
+  errorToMessage: data => data.error.message,
 };
 
 export interface CerebrasProviderSettings {


### PR DESCRIPTION
## Summary

Fixes #11783.

`packages/cerebras/src/cerebras-provider.ts` defined a custom error schema that expects four required strings at the top level:

```ts
const cerebrasErrorSchema = z.object({
  message: z.string(),
  type: z.string(),
  param: z.string(),
  code: z.string(),
});
```

Cerebras actually returns the standard OpenAI-compatible envelope, with a top-level `status_code` on server errors:

```json
{
  "status_code": 500,
  "error": {
    "message": "Encountered a server error, please try again.",
    "type": "server_error",
    "param": "",
    "code": "",
    "id": ""
  }
}
```

On any non-2xx response the body fails schema validation, so the call falls through to `TypeValidationError` with a confusing Zod parse failure (visible in the issue body) instead of `APICallError` carrying the upstream message. This blocks normal error handling such as retries and user-facing messages.

The schema now mirrors the OpenAI-compatible envelope used by groq, deepseek, and the default openai-compatible structure: `error.message` required; `error.type`, `error.param`, `error.code` nullish; `code` accepting `string | number` (Cerebras returns empty strings for these on 5xx, omits them on some 4xx, and the spec allows numeric codes). `errorToMessage` reads from `data.error.message`.

`CerebrasErrorData` (the inferred type) now reflects the nested shape. The previous flat shape never matched a real Cerebras response, so this only affects code that was already broken.

## Test plan

- [x] New `cerebras-error.test.ts` with two cases:
  - The exact 500 body from the issue parses to an `APICallError` with message `"Encountered a server error, please try again."`.
  - A 400 with numeric `code` parses to an `APICallError` with the upstream message.
- [x] `pnpm --filter @ai-sdk/cerebras test`: 9/9 pass (node + edge).
- [x] `pnpm check`: lint and format clean.
- [x] `pnpm --filter @ai-sdk/cerebras type-check`: clean.