### PR TITLE
feat(vue): add useChat composable

### DIFF
--- a/.changeset/vue-use-chat.md
+++ b/.changeset/vue-use-chat.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/vue": patch
+---
+
+Add `useChat` composable for `@ai-sdk/vue`, providing a reactive wrapper around `Chat` with auto-recreation when the init object changes.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,6 +25,12 @@
       "rules": {
         "import/no-cycle": "off"
       }
+    },
+    {
+      "files": ["packages/vue/**"],
+      "rules": {
+        "react-hooks/rules-of-hooks": "off"
+      }
     }
   ],
   "rules": {

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -190,22 +190,22 @@ Update your root page (`pages/index.vue`) with the following code to show a list
 
 ```typescript filename="pages/index.vue"
 <script setup lang="ts">
-import { Chat } from "@ai-sdk/vue";
+import { useChat } from "@ai-sdk/vue";
 import { ref } from "vue";
 
 const input = ref("");
-const chat = new Chat({});
+const { messages, sendMessage } = useChat();
 
 const handleSubmit = (e: Event) => {
     e.preventDefault();
-    chat.sendMessage({ text: input.value });
+    sendMessage({ text: input.value });
     input.value = "";
 };
 </script>
 
 <template>
     <div>
-        <div v-for="(m, index) in chat.messages" :key="m.id ? m.id : index">
+        <div v-for="(m, index) in messages" :key="m.id ? m.id : index">
             {{ m.role === "user" ? "User: " : "AI: " }}
             <div
                 v-for="(part, index) in m.parts"
@@ -331,22 +331,22 @@ To display the tool invocation in your UI, update your `pages/index.vue` file:
 
 ```typescript filename="pages/index.vue" highlight="16-18"
 <script setup lang="ts">
-import { Chat } from "@ai-sdk/vue";
+import { useChat } from "@ai-sdk/vue";
 import { ref } from "vue";
 
 const input = ref("");
-const chat = new Chat({});
+const { messages, sendMessage } = useChat();
 
 const handleSubmit = (e: Event) => {
     e.preventDefault();
-    chat.sendMessage({ text: input.value });
+    sendMessage({ text: input.value });
     input.value = "";
 };
 </script>
 
 <template>
     <div>
-        <div v-for="(m, index) in chat.messages" :key="m.id ? m.id : index">
+        <div v-for="(m, index) in messages" :key="m.id ? m.id : index">
             {{ m.role === "user" ? "User: " : "AI: " }}
             <div
                 v-for="(part, index) in m.parts"
@@ -504,22 +504,22 @@ Update your UI to handle the new temperature conversion tool by modifying the to
 
 ```typescript filename="pages/index.vue" highlight="24"
 <script setup lang="ts">
-import { Chat } from "@ai-sdk/vue";
+import { useChat } from "@ai-sdk/vue";
 import { ref } from "vue";
 
 const input = ref("");
-const chat = new Chat({});
+const { messages, sendMessage } = useChat();
 
 const handleSubmit = (e: Event) => {
     e.preventDefault();
-    chat.sendMessage({ text: input.value });
+    sendMessage({ text: input.value });
     input.value = "";
 };
 </script>
 
 <template>
     <div>
-        <div v-for="(m, index) in chat.messages" :key="m.id ? m.id : index">
+        <div v-for="(m, index) in messages" :key="m.id ? m.id : index">
             {{ m.role === "user" ? "User: " : "AI: " }}
             <div
                 v-for="(part, index) in m.parts"

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -29,7 +29,7 @@ Allows you to easily create a conversational user interface for your chatbot app
     <Snippet text="import { Chat } from '@ai-sdk/svelte'" dark prompt={false} />
   </Tab>
   <Tab>
-    <Snippet text="import { Chat } from '@ai-sdk/vue'" dark prompt={false} />
+    <Snippet text="import { useChat } from '@ai-sdk/vue'" dark prompt={false} />
   </Tab>
   <Tab>
     <Snippet

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -1247,6 +1247,62 @@ const mcpClient = await createMCPClient({
 
 If the MCP server you use does not issue redirects, no changes are needed — the new default is more secure.
 
+## Vue Package
+
+### `Chat` Class Deprecated in Favor of `useChat` Composable
+
+The `Chat` class exported from `@ai-sdk/vue` is deprecated in AI SDK 7 in favor of the new `useChat` composable. `useChat` exposes reactive refs for `messages`, `status`, and `error`, and automatically recreates the underlying chat when its init object changes — so reactive inputs (a route param, a selected model, etc.) flow through without manual orchestration.
+
+```tsx filename="AI SDK 6"
+<script setup lang="ts">
+import { Chat } from '@ai-sdk/vue';
+
+const chat = new Chat({});
+</script>
+
+<template>
+  <div v-for="m in chat.messages" :key="m.id">
+    <!-- ... -->
+  </div>
+  <button @click="chat.sendMessage({ text: 'hi' })">Send</button>
+</template>
+```
+
+```tsx filename="AI SDK 7"
+<script setup lang="ts">
+import { useChat } from '@ai-sdk/vue';
+
+const { messages, sendMessage } = useChat({
+  id: chatId,
+  transport: new DefaultChatTransport({
+    api: `/api/chats/${chatId}`,
+    body: { model: model.value },
+  }),
+});
+</script>
+
+<template>
+  <div v-for="m in messages" :key="m.id">
+    <!-- ... -->
+  </div>
+  <button @click="sendMessage({ text: 'hi' })">Send</button>
+</template>
+```
+
+To make the init reactive (recreate the chat when its inputs change), pass a getter or ref:
+
+```tsx filename="AI SDK 7"
+const { messages, sendMessage } = useChat(() => ({
+  id: chatId.value,
+  transport: new DefaultChatTransport({
+    api: `/api/chats/${chatId.value}`,
+    body: { model: model.value },
+  }),
+}));
+```
+
+The `Chat` class continues to work as a deprecated export, so you can migrate incrementally.
+
 ## Anthropic Provider
 
 ### `providerMetadata.anthropic.cacheCreationInputTokens` Removed

--- a/packages/vue/src/chat.vue.ts
+++ b/packages/vue/src/chat.vue.ts
@@ -1,6 +1,6 @@
 import {
   AbstractChat,
-  type ChatInit as BaseChatInit,
+  type ChatInit,
   type ChatState,
   type ChatStatus,
   type UIMessage,
@@ -60,7 +60,7 @@ class VueChatState<
 export class Chat<
   UI_MESSAGE extends UIMessage,
 > extends AbstractChat<UI_MESSAGE> {
-  constructor({ messages, ...init }: BaseChatInit<UI_MESSAGE>) {
+  constructor({ messages, ...init }: ChatInit<UI_MESSAGE>) {
     super({
       ...init,
       state: new VueChatState(messages),

--- a/packages/vue/src/chat.vue.ts
+++ b/packages/vue/src/chat.vue.ts
@@ -57,6 +57,10 @@ class VueChatState<
   snapshot = <T>(value: T): T => value;
 }
 
+/**
+ * @deprecated Use the {@link useChat} composable instead. It exposes reactive
+ * refs and automatically recreates the chat when its init object changes.
+ */
 export class Chat<
   UI_MESSAGE extends UIMessage,
 > extends AbstractChat<UI_MESSAGE> {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,4 @@
 export * from './use-completion';
 export { Chat } from './chat.vue';
+export { useChat, type UseChatHelpers } from './use-chat';
 export * from './use-object';

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -16,7 +16,6 @@ import {
   type MaybeRefOrGetter,
   type ShallowRef,
 } from 'vue';
-import type { Chat } from './chat.vue';
 
 /**
  * @internal
@@ -146,8 +145,8 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
   // the instance is created right away thanks to immediate: true. We do it this
   // way instead of a computed to ensure all changes to reactive state happen
   // in the same tick
-  const chatInstance = shallowRef<Chat<UI_MESSAGE>>() as ShallowRef<
-    Chat<UI_MESSAGE>
+  const chatInstance = shallowRef<VueChat<UI_MESSAGE>>() as ShallowRef<
+    VueChat<UI_MESSAGE>
   >;
 
   watch(

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -174,7 +174,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
     addToolApprovalResponse: (...args) =>
       chatInstance.value.addToolApprovalResponse(...args),
     addToolOutput: (...args) => chatInstance.value.addToolOutput(...args),
-    clearError: () => (chatStateWrapper.error = undefined),
+    clearError: () => chatInstance.value.clearError(),
     regenerate: () => chatInstance.value.regenerate(),
     sendMessage: (...args) => chatInstance.value.sendMessage(...args),
     stop: () => chatInstance.value.stop(),

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -1,0 +1,183 @@
+import {
+  AbstractChat,
+  type ChatInit as BaseChatInit,
+  type ChatInit,
+  type ChatState,
+  type ChatStatus,
+  type UIMessage,
+} from 'ai';
+import {
+  computed,
+  shallowRef,
+  toValue,
+  triggerRef,
+  watch,
+  type ComputedRef,
+  type MaybeRefOrGetter,
+  type ShallowRef,
+} from 'vue';
+import type { Chat } from './chat.vue';
+
+/**
+ * @internal
+ */
+export class VueChat<
+  UI_MESSAGE extends UIMessage,
+> extends AbstractChat<UI_MESSAGE> {
+  constructor({
+    state,
+    ...init
+  }: Omit<ChatInit<UI_MESSAGE>, 'messages'> & {
+    state: ChatState<UI_MESSAGE>;
+  }) {
+    super({
+      ...init,
+      state,
+    });
+  }
+}
+
+/**
+ * Return type of the {@link useChat} composable, which includes the chat
+ * instance methods and reactive properties for messages, status, and error.
+ */
+export interface UseChatHelpers<UI_MESSAGE extends UIMessage> extends Pick<
+  AbstractChat<UI_MESSAGE>,
+  | 'sendMessage'
+  | 'regenerate'
+  | 'stop'
+  | 'resumeStream'
+  | 'addToolOutput'
+  | 'addToolApprovalResponse'
+  | 'clearError'
+> {
+  /**
+   * The id of the chat.
+   */
+  id: ComputedRef<string>;
+
+  /**
+   * The current error state of the chat, if any.
+   */
+  error: ShallowRef<Error | undefined>;
+
+  /**
+   * The current status of the chat, which can be 'ready', 'generating', 'streaming', or 'error'.
+   */
+  status: ShallowRef<ChatStatus>;
+
+  /**
+   * The list of messages in the chat, which can be updated by the chat instance methods or directly by setting this property.
+   */
+  messages: ShallowRef<UI_MESSAGE[]>;
+}
+
+/**
+ * Composable to access messages, status, and other chat properties and
+ * methods. Accepts an optional reactive initial configuration object
+ *
+ * @example
+ *
+ * ```ts
+ * // passing a getter if any reactive properties are used within
+ * // the init object
+ * const { messages, sendMessage } = useChat(() => ({
+ *   // ...
+ * })
+ * ```
+ *
+ * @see BaseChatInit
+ */
+export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
+  init?: MaybeRefOrGetter<BaseChatInit<UI_MESSAGE>>,
+): UseChatHelpers<UI_MESSAGE> {
+  const messages = shallowRef<UI_MESSAGE[]>([]);
+  const status = shallowRef<ChatStatus>('ready');
+  const error = shallowRef<Error | undefined>();
+
+  // this wrapper doesn't need to be reactive and can be reused across chat
+  // instance changes, because the inner refs are reactive and the wrapper
+  // methods trigger updates when needed
+  const chatStateWrapper = {
+    get messages(): UI_MESSAGE[] {
+      return messages.value;
+    },
+
+    set messages(messageList: UI_MESSAGE[]) {
+      messages.value = messageList;
+    },
+
+    get status(): ChatStatus {
+      return status.value;
+    },
+
+    set status(statusValue: ChatStatus) {
+      status.value = statusValue;
+    },
+
+    get error(): Error | undefined {
+      return error.value;
+    },
+
+    set error(errorValue: Error | undefined) {
+      error.value = errorValue;
+    },
+
+    pushMessage(message: UI_MESSAGE) {
+      messages.value.push(message);
+      // needed because messagesRef is a shallowRef
+      triggerRef(messages);
+    },
+
+    popMessage() {
+      messages.value.pop();
+      triggerRef(messages);
+    },
+
+    replaceMessage(index: number, message: UI_MESSAGE) {
+      // message is cloned here because vue's deep reactivity shows unexpected behavior, particularly when updating tool invocation parts
+      messages.value[index] = { ...message };
+      triggerRef(messages);
+    },
+
+    snapshot: <T>(value: T): T => value,
+  } satisfies ChatState<UI_MESSAGE>;
+
+  // the instance is created right away thanks to immediate: true. We do it this
+  // way instead of a computed to ensure all changes to reactive state happen
+  // in the same tick
+  const chatInstance = shallowRef<Chat<UI_MESSAGE>>() as ShallowRef<
+    Chat<UI_MESSAGE>
+  >;
+
+  watch(
+    () => toValue(init),
+    opts => {
+      // reset the initial state
+      messages.value = opts?.messages ?? [];
+      status.value = 'ready';
+      error.value = undefined;
+
+      chatInstance.value = new VueChat<UI_MESSAGE>({
+        ...opts,
+        state: chatStateWrapper,
+      });
+    },
+    { immediate: true },
+  );
+
+  return {
+    id: computed(() => chatInstance.value.id),
+    status,
+    messages,
+    error,
+    addToolApprovalResponse: (...args) =>
+      chatInstance.value.addToolApprovalResponse(...args),
+    addToolOutput: (...args) => chatInstance.value.addToolOutput(...args),
+    clearError: () => (chatStateWrapper.error = undefined),
+    regenerate: () => chatInstance.value.regenerate(),
+    sendMessage: (...args) => chatInstance.value.sendMessage(...args),
+    stop: () => chatInstance.value.stop(),
+    resumeStream: () => chatInstance.value.resumeStream(),
+  };
+}

--- a/packages/vue/src/use-chat.ui.test.ts
+++ b/packages/vue/src/use-chat.ui.test.ts
@@ -1,0 +1,214 @@
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import type { UIMessageChunk } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { defineComponent, h, ref } from 'vue';
+import { setupTestComponent } from './setup-test-component';
+import { useChat } from './use-chat';
+
+function formatChunk(part: UIMessageChunk) {
+  return `data: ${JSON.stringify(part)}\n\n`;
+}
+
+const server = createTestServer({
+  '/api/chat': {},
+});
+
+describe('useChat', () => {
+  describe('initial messages', () => {
+    setupTestComponent(
+      defineComponent({
+        setup() {
+          const { messages } = useChat({
+            messages: [
+              {
+                id: 'id-0',
+                role: 'user',
+                parts: [{ type: 'text', text: 'hi' }],
+              },
+            ],
+          });
+          return () =>
+            h(
+              'div',
+              { 'data-testid': 'messages' },
+              JSON.stringify(messages.value),
+            );
+        },
+      }),
+    );
+
+    it('seeds messages from init', () => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toStrictEqual([
+        { id: 'id-0', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ]);
+    });
+  });
+
+  describe('data protocol stream', () => {
+    setupTestComponent(
+      defineComponent({
+        setup() {
+          const { messages, status, error, sendMessage } = useChat({
+            generateId: mockId(),
+          });
+          return () =>
+            h('div', [
+              h('div', { 'data-testid': 'status' }, status.value),
+              error.value
+                ? h('div', { 'data-testid': 'error' }, error.value.toString())
+                : null,
+              h(
+                'div',
+                { 'data-testid': 'messages' },
+                JSON.stringify(messages.value),
+              ),
+              h('button', {
+                'data-testid': 'do-send',
+                onClick: () => sendMessage({ text: 'hi' }),
+              }),
+            ]);
+        },
+      }),
+    );
+
+    it('streams an assistant response and ends in ready status', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ', world.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: 'id-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'hi' }],
+          },
+          {
+            id: 'id-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Hello, world.', state: 'done' }],
+          },
+        ]);
+      });
+      expect(screen.getByTestId('status').textContent).toBe('ready');
+    });
+
+    it('surfaces server errors and sets status to error', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'error',
+        status: 404,
+        body: 'Not found',
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error').textContent).toBe('Error: Not found');
+      expect(screen.getByTestId('status').textContent).toBe('error');
+    });
+  });
+
+  describe('reactive init', () => {
+    setupTestComponent(
+      defineComponent({
+        setup() {
+          const which = ref<'a' | 'b'>('a');
+          const { messages, id } = useChat(() => ({
+            id: which.value,
+            messages:
+              which.value === 'a'
+                ? [
+                    {
+                      id: 'm-1',
+                      role: 'user',
+                      parts: [{ type: 'text', text: 'first' }],
+                    },
+                  ]
+                : [],
+          }));
+          return () =>
+            h('div', [
+              h('div', { 'data-testid': 'id' }, id.value),
+              h(
+                'div',
+                { 'data-testid': 'message-count' },
+                String(messages.value.length),
+              ),
+              h('button', {
+                'data-testid': 'swap',
+                onClick: () => (which.value = 'b'),
+              }),
+            ]);
+        },
+      }),
+    );
+
+    it('recreates the chat and resets messages when init changes', async () => {
+      expect(screen.getByTestId('id').textContent).toBe('a');
+      expect(screen.getByTestId('message-count').textContent).toBe('1');
+
+      await userEvent.click(screen.getByTestId('swap'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('id').textContent).toBe('b');
+      });
+      expect(screen.getByTestId('message-count').textContent).toBe('0');
+    });
+  });
+
+  describe('clearError', () => {
+    setupTestComponent(
+      defineComponent({
+        setup() {
+          const { error, sendMessage, clearError } = useChat();
+          return () =>
+            h('div', [
+              error.value
+                ? h('div', { 'data-testid': 'error' }, error.value.toString())
+                : null,
+              h('button', {
+                'data-testid': 'do-send',
+                onClick: () => sendMessage({ text: 'hi' }),
+              }),
+              h('button', {
+                'data-testid': 'do-clear',
+                onClick: () => clearError(),
+              }),
+            ]);
+        },
+      }),
+    );
+
+    it('removes the error after clearError is called', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'error',
+        status: 500,
+        body: 'boom',
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+      await screen.findByTestId('error');
+
+      await userEvent.click(screen.getByTestId('do-clear'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('error')).toBeNull();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds a `useChat` composable for `@ai-sdk/vue` that wraps `Chat` with reactive refs and auto-recreates the instance when its init object changes.

## Example

```ts
import { useChat } from '@ai-sdk/vue'
import { DefaultChatTransport } from 'ai'

const { messages, sendMessage, status, error } = useChat(() => ({
  id: data.value?.id,
  messages: data.value?.messages,
  transport: new DefaultChatTransport({
    api: `/api/chats/${data.value?.id}`,
    body: { model: model.value },
  }),
  onError(err) {
    toast.add({ description: err.message, color: 'error' })
  },
}))
```

Passing a getter (or ref) makes the init reactive: when `data.value.id` or `model.value` change, the chat is recreated automatically. With `new Chat({...})` you had to manage that yourself.

It's worth noting that I made the messages array a shallowRef since it could potentially get very large but since we always know when it gets modified, it makes no sense to have deep reactivity (and poorer performance/memory)

I also marked `Chat` as deprecated in favor of this more idiomatic `useChat()`. What do you think?