### PR TITLE
fix(google-vertex): propagate project-id set in provider instance creation

### DIFF
--- a/.changeset/empty-trains-own.md
+++ b/.changeset/empty-trains-own.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(google-vertex): propagate project-id set in provider instance creation

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -78,6 +78,43 @@ describe('google-vertex-provider', () => {
     });
   });
 
+  it('passes project to createAuthTokenGenerator as projectId', async () => {
+    createVertexNode({
+      project: 'test-project',
+    });
+
+    expect(createGoogleVertexOriginal).toHaveBeenCalledTimes(1);
+    const passedOptions = vi.mocked(createGoogleVertexOriginal).mock
+      .calls[0][0];
+
+    await resolve(passedOptions?.headers); // call the headers function
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith({
+      projectId: 'test-project',
+    });
+  });
+
+  it('does not override explicit googleAuthOptions projectId', async () => {
+    createVertexNode({
+      project: 'provider-project',
+      googleAuthOptions: {
+        projectId: 'auth-project',
+        keyFile: 'path/to/key.json',
+      },
+    });
+
+    expect(createGoogleVertexOriginal).toHaveBeenCalledTimes(1);
+    const passedOptions = vi.mocked(createGoogleVertexOriginal).mock
+      .calls[0][0];
+
+    await resolve(passedOptions?.headers); // call the headers function
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith({
+      projectId: 'auth-project',
+      keyFile: 'path/to/key.json',
+    });
+  });
+
   it('should pass options through to base provider when apiKey is provided', async () => {
     createVertexNode({
       apiKey: 'test-api-key',

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -30,7 +30,15 @@ export function createGoogleVertex(
     return createGoogleVertexOriginal(options);
   }
 
-  const generateAuthToken = createAuthTokenGenerator(options.googleAuthOptions);
+  const googleAuthOptions =
+    options.project == null
+      ? options.googleAuthOptions
+      : {
+          projectId: options.project,
+          ...options.googleAuthOptions,
+        };
+
+  const generateAuthToken = createAuthTokenGenerator(googleAuthOptions);
 
   return createGoogleVertexOriginal({
     ...options,


### PR DESCRIPTION
## Background

reported in https://github.com/vercel/ai/issues/15302

the first half of the issue was already resolved in a previous release of AI SDK. but there was a second bug where the project-id set in the `createVertex` function would not be propagated to the createAuthTokenGenerator. 

this was in the case of when a user didn't define `googleAuthOptions`

## Summary

- changed the options passed to the `createAuthTokenGenerator` function which now include the `project` param if set
- priority is still given to `googleAuthOptions` if set

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15302