### PR TITLE
ci: reuse package builds in test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Run TypeScript type check
         run: pnpm run type-check:full
 
-  bundle-size:
-    name: 'Bundle Size Check'
+  build-packages:
+    name: 'Build Packages'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -131,6 +131,45 @@ jobs:
       - name: Build packages
         run: pnpm run build:packages
 
+      - name: Archive package build artifacts
+        run: tar -czf package-build-artifacts.tgz packages/*/dist
+
+      - name: Upload package build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: package-build-artifacts
+          path: package-build-artifacts.tgz
+
+  bundle-size:
+    name: 'Bundle Size Check'
+    runs-on: ubuntu-latest
+    needs: build-packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10.11.0
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download package build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-build-artifacts
+
+      - name: Extract package build artifacts
+        run: tar -xzf package-build-artifacts.tgz
+
       - name: Check bundle size
         run: cd packages/ai && pnpm run check-bundle-size
 
@@ -144,6 +183,7 @@ jobs:
   test_matrix:
     name: 'Test'
     runs-on: ubuntu-latest
+    needs: build-packages
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -168,29 +208,38 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Download package build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-build-artifacts
+
+      - name: Extract package build artifacts
+        run: tar -xzf package-build-artifacts.tgz
+
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm test:ci
 
   # separate "test" job to set as required in branch protections,
   # as the matrix build names above change each time Node versions change
   test:
     runs-on: ubuntu-latest
-    needs: test_matrix
+    needs: [build-packages, test_matrix]
     if: ${{ !cancelled() }}
     steps:
-      - name: All matrix versions passed
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+      - name: All required jobs passed
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
         run: exit 0
-      - name: Some matrix version failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+      - name: Some required job failed or was skipped
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1
 
   load-time_matrix:
     name: 'Load Time Check'
     runs-on: ubuntu-latest
+    needs: build-packages
     strategy:
       fail-fast: false
       matrix:
@@ -223,8 +272,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build packages
-        run: pnpm run build:packages
+      - name: Download package build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-build-artifacts
+
+      - name: Extract package build artifacts
+        run: tar -xzf package-build-artifacts.tgz
 
       - name: Measure and check load time for ${{ matrix.module }}
         id: load-time
@@ -263,12 +317,12 @@ jobs:
   # as the matrix build names above change each time modules are added/removed
   load-time:
     runs-on: ubuntu-latest
-    needs: load-time_matrix
+    needs: [build-packages, load-time_matrix]
     if: ${{ !cancelled() }}
     steps:
-      - name: All matrix versions passed
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+      - name: All required jobs passed
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
         run: exit 0
-      - name: Some matrix version failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+      - name: Some required job failed or was skipped
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type-check:full": "tsc --build tsconfig.with-examples.json",
     "publint": "turbo publint",
     "test": "turbo test --concurrency 16 --filter=!@example/*",
+    "test:ci": "turbo test --concurrency 16 --filter=!@example/* --only",
     "test:update": "turbo test:update --concurrency 16 --filter=!@example/*",
     "ci:release": "turbo clean && turbo build && changeset publish",
     "ci:version": "changeset version && node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile",


### PR DESCRIPTION
## Background

Test matrix rebuilds packages before tests. Fixes #15399.

## Summary

- build packages once
- upload/download `packages/*/dist` tarball
- run Test matrix with `turbo --only`

## Manual Verification

- `pnpm run check`
- `pnpm exec turbo test --filter=ai --only --dry-run=json` → only `ai#test`
- CI: Test (22) Run tests **245s**, `54 tasks` (was ~394s, `111 tasks`)

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15399