### PR TITLE
ci: shard ai and codemod tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build AI dependencies
+        run: pnpm exec turbo build --filter=ai
+
       - name: Run AI tests
         working-directory: packages/ai
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,20 +172,80 @@ jobs:
         run: pnpm exec playwright install --with-deps
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm test:ci
+
+  test_ai_matrix:
+    name: 'Test AI'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+        shard: ['1/4', '2/4', '3/4', '4/4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10.11.0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run AI tests
+        working-directory: packages/ai
+        run: |
+          pnpm test:node --shard ${{ matrix.shard }}
+          pnpm test:edge --shard ${{ matrix.shard }}
+
+  test_codemod_matrix:
+    name: 'Test Codemod'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+        shard: ['1/4', '2/4', '3/4', '4/4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10.11.0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run codemod tests
+        working-directory: packages/codemod
+        run: pnpm exec vitest --config vitest.config.ts --run --shard ${{ matrix.shard }}
 
   # separate "test" job to set as required in branch protections,
   # as the matrix build names above change each time Node versions change
   test:
     runs-on: ubuntu-latest
-    needs: test_matrix
+    needs: [test_matrix, test_ai_matrix, test_codemod_matrix]
     if: ${{ !cancelled() }}
     steps:
       - name: All matrix versions passed
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
         run: exit 0
       - name: Some matrix version failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1
 
   load-time_matrix:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type-check:full": "tsc --build tsconfig.with-examples.json",
     "publint": "turbo publint",
     "test": "turbo test --concurrency 16 --filter=!@example/*",
+    "test:ci": "turbo test --concurrency 16 --filter=!@example/* --filter=!ai --filter=!@ai-sdk/codemod",
     "test:update": "turbo test:update --concurrency 16 --filter=!@example/*",
     "ci:release": "turbo clean && turbo build && changeset publish",
     "ci:version": "changeset version && node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile",

--- a/packages/codemod/vitest.config.ts
+++ b/packages/codemod/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: ['dist/**', 'node_modules/**'],
     // Codemod tests do CPU-heavy TypeScript syntax validation and can exceed
     // Vitest's default 5s timeout on saturated CI runners, especially in the
     // Node 24 matrix where the root test job runs many packages concurrently.


### PR DESCRIPTION
## Background

`ai` + `codemod` are slow tail tasks. Fixes #15403.

## Summary

- exclude `ai` + `@ai-sdk/codemod` from regular Test matrix
- add dedicated 4-shard matrices for both
- keep Node 20/22/24 coverage

## Manual Verification

- `pnpm run check`
- `pnpm --dir packages/ai test:node --shard 1/4`
- `pnpm --dir packages/codemod exec vitest --config vitest.config.ts --run --shard 1/4`
- dry run confirms regular matrix excludes `ai#test` and `@ai-sdk/codemod#test`

## Impact

CI run 26050427856 passed.

Regular **Run tests** step:

- Node 20: **351s** (baseline ~451s)
- Node 22: **334s** (baseline ~394s)
- Node 24: **276s** (baseline ~361s)

Shard jobs:

- AI shards: max job **127s**, shard test step max **39s**
- Codemod shards: max job **53s**, shard test step max **8s**

Net: regular Test jobs got faster, but CI fanout increased. Useful as isolation/sharding groundwork; wall-time win is mixed until combined with the other PRs.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15403