### PR TITLE
test(ai): share Vitest config

### DIFF
--- a/packages/ai/vitest.config.js
+++ b/packages/ai/vitest.config.js
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { defineConfig } from 'vitest/config';
+
+const version = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+).version;
+
+export function createVitestConfig(environment) {
+  return defineConfig({
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(version),
+    },
+    test: {
+      environment,
+      include: ['**/*.test.ts{,x}'],
+      exclude: [
+        '**/*.ui.test.ts{,x}',
+        '**/*.e2e.test.ts{,x}',
+        '**/node_modules/**',
+      ],
+      typecheck: {
+        enabled: true,
+      },
+    },
+  });
+}

--- a/packages/ai/vitest.edge.config.js
+++ b/packages/ai/vitest.edge.config.js
@@ -1,25 +1,3 @@
-import { defineConfig } from 'vitest/config';
-import { readFileSync } from 'node:fs';
+import { createVitestConfig } from './vitest.config.js';
 
-const version = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
-).version;
-
-// https://vitejs.dev/config/
-export default defineConfig({
-  define: {
-    __PACKAGE_VERSION__: JSON.stringify(version),
-  },
-  test: {
-    environment: 'edge-runtime',
-    include: ['**/*.test.ts{,x}'],
-    exclude: [
-      '**/*.ui.test.ts{,x}',
-      '**/*.e2e.test.ts{,x}',
-      '**/node_modules/**',
-    ],
-    typecheck: {
-      enabled: true,
-    },
-  },
-});
+export default createVitestConfig('edge-runtime');

--- a/packages/ai/vitest.node.config.js
+++ b/packages/ai/vitest.node.config.js
@@ -1,25 +1,3 @@
-import { defineConfig } from 'vitest/config';
-import { readFileSync } from 'node:fs';
+import { createVitestConfig } from './vitest.config.js';
 
-const version = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
-).version;
-
-// https://vitejs.dev/config/
-export default defineConfig({
-  define: {
-    __PACKAGE_VERSION__: JSON.stringify(version),
-  },
-  test: {
-    environment: 'node',
-    include: ['**/*.test.ts{,x}'],
-    exclude: [
-      '**/*.ui.test.ts{,x}',
-      '**/*.e2e.test.ts{,x}',
-      '**/node_modules/**',
-    ],
-    typecheck: {
-      enabled: true,
-    },
-  },
-});
+export default createVitestConfig('node');


### PR DESCRIPTION
## Background

`ai` has duplicate node/edge Vitest config. Fixes #15405.

## Summary

- move shared `ai` Vitest settings to `vitest.config.js`
- keep node/edge wrappers for existing scripts

## Manual Verification

- `pnpm run check`
- `pnpm --dir packages/ai test:node --shard 1/4`
- `pnpm --dir packages/ai test:edge --shard 1/4`

## Impact

CI run 26049760221 passed.

No speed win expected; this is cleanup/enabler only.

Measured **Run tests**:

- Node 20: **428s**
- Node 22: **379s**
- Node 24: **349s**

Roughly baseline range.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15405