### PR TITLE
fix(cerebras): serialize reasoning parts as 'reasoning' on assistant messages

### DIFF
--- a/.changeset/ten-shoes-scream.md
+++ b/.changeset/ten-shoes-scream.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/cerebras": patch
+---
+
+fix(cerebras): serialize reasoning parts as 'reasoning' on assistant messages

--- a/packages/cerebras/src/cerebras-provider.test.ts
+++ b/packages/cerebras/src/cerebras-provider.test.ts
@@ -97,6 +97,71 @@ describe('CerebrasProvider', () => {
       const model = provider(modelId);
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
+
+    it('should convert assistant reasoning_content to reasoning', () => {
+      const provider = createCerebras();
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+
+      expect(
+        config.transformRequestBody({
+          model: 'model-id',
+          messages: [
+            { role: 'user', content: 'what is the magic number?' },
+            {
+              role: 'assistant',
+              content: null,
+              reasoning_content: 'I should call a tool.',
+              tool_calls: [
+                {
+                  id: 'tool-call-id',
+                  type: 'function',
+                  function: { name: 'getNumber', arguments: '{}' },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              tool_call_id: 'tool-call-id',
+              content: '2026',
+            },
+          ],
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "what is the magic number?",
+              "role": "user",
+            },
+            {
+              "content": null,
+              "reasoning": "I should call a tool.",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{}",
+                    "name": "getNumber",
+                  },
+                  "id": "tool-call-id",
+                  "type": "function",
+                },
+              ],
+            },
+            {
+              "content": "2026",
+              "role": "tool",
+              "tool_call_id": "tool-call-id",
+            },
+          ],
+          "model": "model-id",
+        }
+      `);
+    });
   });
 
   describe('languageModel', () => {

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -32,6 +32,39 @@ const cerebrasErrorStructure: ProviderErrorStructure<CerebrasErrorData> = {
   errorToMessage: data => data.message,
 };
 
+/**
+ * Cerebras expects assistant reasoning history in the `reasoning` field, while
+ * the shared OpenAI-compatible converter serializes it as `reasoning_content`.
+ */
+function transformCerebrasRequestBody(
+  args: Record<string, any>,
+): Record<string, any> {
+  return {
+    ...args,
+    messages: Array.isArray(args.messages)
+      ? args.messages.map(message => {
+          if (
+            message == null ||
+            typeof message !== 'object' ||
+            message.role !== 'assistant' ||
+            !('reasoning_content' in message)
+          ) {
+            return message;
+          }
+
+          const { reasoning_content, ...rest } = message;
+
+          return {
+            ...rest,
+            ...(!('reasoning' in rest) && reasoning_content !== undefined
+              ? { reasoning: reasoning_content }
+              : {}),
+          };
+        })
+      : args.messages,
+  };
+}
+
 export interface CerebrasProviderSettings {
   /**
    * Cerebras API key.
@@ -101,6 +134,7 @@ export function createCerebras(
       fetch: options.fetch,
       errorStructure: cerebrasErrorStructure,
       supportsStructuredOutputs: true,
+      transformRequestBody: transformCerebrasRequestBody,
     });
   };
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15042

alternate solution to https://github.com/vercel/ai/pull/15383

`@ai-sdk/openai-compatible` serializes the assistant reasoning as `reasoning_content` but cerebras's chat-completions API doesnt accept `reasoning_content` on input. their assistant-message schema uses a `reasoning` field instead

## Summary

made the change specific to cerebras so that assistant message reasoning parts are branded as `reasoning` instead of `reasoning_content`

## Manual Verification

verified by running the following repro: 
```ts
import { isStepCount, tool, streamText } from "ai";
import z from "zod";
import { cerebras } from "@ai-sdk/cerebras";
import { run } from '../../lib/run';

run(async () => {
  const result = streamText({
  model: cerebras('zai-glm-4.7'),
  tools: {
    create_thing: tool({
      inputSchema: z.object({ name: z.string() }),
      execute: async ({ name }) => ({ id: 'abc', name }),
    }),
  },
  stopWhen: isStepCount(5),
  messages: [{ role: 'user', content: 'create a thing called foo, then say done' }],
});

  for await (const _ of result.fullStream) {}
  console.log('steps:', (await result.steps).length);
});
```

it will fail after the first step before the fix

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

look into the error seen in https://github.com/vercel/ai/issues/15349

## Related Issues

fixes #15402