### PR TITLE
refactor(ai): introduce agent UI message generic

### DIFF
--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -41,6 +41,8 @@ export async function createAgentUIStream<
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = never,
   MESSAGE_METADATA = unknown,
+  UI_MESSAGE extends UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>> =
+    UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>,
 >({
   agent,
   uiMessages,
@@ -61,30 +63,17 @@ export async function createAgentUIStream<
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
   onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
   // TODO `originalMessages` is part of this for bc, omit in v7
-} & UIMessageStreamOptions<
-  UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
->): Promise<
-  AsyncIterableStream<
-    InferUIMessageChunk<UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>>
-  >
+} & UIMessageStreamOptions<UI_MESSAGE>): Promise<
+  AsyncIterableStream<InferUIMessageChunk<UI_MESSAGE>>
 > {
-  const validatedMessages = await validateUIMessages<
-    UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
-  >({
+  const validatedMessages = await validateUIMessages<UI_MESSAGE>({
     messages: uiMessages,
     // tools are compatible; the casting is required because the context param is
     // not available in ui messages
     tools: agent.tools as unknown as {
-      [NAME in keyof InferUIMessageTools<
-        UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
-      > &
-        string]?: Tool<
-        InferUIMessageTools<
-          UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
-        >[NAME]['input'],
-        InferUIMessageTools<
-          UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
-        >[NAME]['output']
+      [NAME in keyof InferUIMessageTools<UI_MESSAGE> & string]?: Tool<
+        InferUIMessageTools<UI_MESSAGE>[NAME]['input'],
+        InferUIMessageTools<UI_MESSAGE>[NAME]['output']
       >;
     },
   });


### PR DESCRIPTION
## Summary
- Introduce a `UI_MESSAGE` generic in `createAgentUIStream` to avoid repeating `UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>` throughout the function signature and tool typing.

## Test plan
- `pnpm --filter ai type-check`