### PR TITLE
fix(vue): forward args in useChat methods

### DIFF
--- a/.changeset/vue-use-chat-forward-args.md
+++ b/.changeset/vue-use-chat-forward-args.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/vue": patch
+---
+
+fix(vue): forward args in useChat methods

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -170,13 +170,13 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
     status,
     messages,
     error,
-    addToolApprovalResponse: (...args) =>
-      chatInstance.value.addToolApprovalResponse(...args),
-    addToolOutput: (...args) => chatInstance.value.addToolOutput(...args),
+    addToolApprovalResponse: opts =>
+      chatInstance.value.addToolApprovalResponse(opts),
+    addToolOutput: opts => chatInstance.value.addToolOutput(opts),
     clearError: () => chatInstance.value.clearError(),
-    regenerate: () => chatInstance.value.regenerate(),
+    regenerate: opts => chatInstance.value.regenerate(opts),
     sendMessage: (...args) => chatInstance.value.sendMessage(...args),
     stop: () => chatInstance.value.stop(),
-    resumeStream: () => chatInstance.value.resumeStream(),
+    resumeStream: opts => chatInstance.value.resumeStream(opts),
   };
 }


### PR DESCRIPTION
Forgot to pass the args.

Should I add `...args` to all methods, or keep it specific like the current change?