### PR TITLE
docs: fix code highlights

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -375,7 +375,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. By default
 
 Modify your `app/api/chat/route.ts` file to include the `stopWhen` condition:
 
-```tsx filename="app/api/chat/route.ts" highlight="16"
+```tsx filename="app/api/chat/route.ts" highlight="6,17,33-35"
 import {
   streamText,
   UIMessage,

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -368,7 +368,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. By default
 
 Modify your `app/api/chat/route.ts` file to include the `stopWhen` condition:
 
-```tsx filename="app/api/chat/route.ts"  highlight="16"
+```tsx filename="app/api/chat/route.ts"  highlight="6,17"
 import {
   streamText,
   UIMessage,

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -372,7 +372,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. By default
 
 Modify your `src/routes/api/chat/+server.ts` file to include the `stopWhen` condition:
 
-```ts filename="src/routes/api/chat/+server.ts" highlight="15"
+```ts filename="src/routes/api/chat/+server.ts" highlight="7,23"
 import {
   createGateway,
   streamText,
@@ -425,7 +425,7 @@ By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 
 
 Update your `src/routes/api/chat/+server.ts` file to add a new tool to convert the temperature from Fahrenheit to Celsius:
 
-```tsx filename="src/routes/api/chat/+server.ts" highlight="32-45"
+```tsx filename="src/routes/api/chat/+server.ts" highlight="38-51"
 import {
   createGateway,
   streamText,

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -378,7 +378,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. By default
 
 Modify your `server/api/chat.ts` file to include the `stopWhen` condition:
 
-```typescript filename="server/api/chat.ts" highlight="22"
+```typescript filename="server/api/chat.ts" highlight="7,24"
 import {
   createGateway,
   streamText,

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -196,7 +196,7 @@ Let's enhance your agent by adding a simple weather tool.
 
 Modify your `index.ts` file to include the new weather tool:
 
-```ts filename="index.ts" highlight="2,4,24-37"
+```ts filename="index.ts" highlight="1,4,23-39"
 import { ModelMessage, streamText, tool } from 'ai';
 __PROVIDER_IMPORT__;
 import 'dotenv/config';
@@ -338,7 +338,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. This featu
 
 Modify your `index.ts` file to configure stopping conditions with `stopWhen`:
 
-```ts filename="index.ts" highlight="38-41"
+```ts filename="index.ts" highlight="1,40-45"
 import { ModelMessage, streamText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import 'dotenv/config';

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -472,7 +472,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. By default
 
 Modify your `app/api/chat+api.ts` file to include the `stopWhen` condition:
 
-```tsx filename="app/api/chat+api.ts" highlight="10"
+```tsx filename="app/api/chat+api.ts" highlight="6,17"
 import {
   streamText,
   UIMessage,
@@ -529,7 +529,7 @@ By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 
 
 Update your `app/api/chat+api.ts` file to add a new tool to convert the temperature from Fahrenheit to Celsius:
 
-```tsx filename="app/api/chat+api.ts" highlight="28-41"
+```tsx filename="app/api/chat+api.ts" highlight="32-45"
 import {
   streamText,
   UIMessage,

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -85,7 +85,7 @@ results. If a tool needs server-side values such as credentials, scoped
 permissions, or default settings, pass them through `toolsContext` and declare
 them with the tool's `contextSchema`.
 
-```ts highlight="8-15,21-31,37-49"
+```ts highlight="12-15,20-26,31-40"
 import { ToolLoopAgent, tool } from 'ai';
 import { z } from 'zod';
 

--- a/content/docs/03-agents/06-tool-approvals.mdx
+++ b/content/docs/03-agents/06-tool-approvals.mdx
@@ -65,7 +65,7 @@ When `runCommand` is called, the agent returns a `tool-approval-request` instead
 
 Use a per-tool approval function when the decision depends on the parsed tool input. The function receives the typed input plus `toolCallId`, `messages`, `toolContext`, and `runtimeContext`.
 
-```ts highlight="22-25"
+```ts highlight="17-24"
 import { ToolLoopAgent, tool } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -99,7 +99,7 @@ In this example, non-admin users are denied automatically, large payments requir
 
 Pass a function directly as `toolApproval` when approval depends on the full tool call, shared state across tools, or the complete tool set. This is called a `GenericToolApprovalFunction`.
 
-```ts highlight="17-28"
+```ts highlight="13-23"
 const agent = new ToolLoopAgent({
   model: __MODEL__,
   tools: {
@@ -175,7 +175,7 @@ Manual approval requires two calls:
 4. Add a `tool-approval-response` to the messages.
 5. Call the agent again with the updated messages.
 
-```ts highlight="11-18,21-28"
+```ts highlight="11-18,21-24,26"
 import { type ModelMessage, type ToolApprovalResponse } from 'ai';
 
 const messages: ModelMessage[] = [{ role: 'user', content: 'Delete temp.txt' }];

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -96,7 +96,7 @@ When using `generateText`, you can provide an `onFinish` callback that is trigge
 ).
 It contains the text, usage information, finish reason, messages, steps, total usage, and more:
 
-```tsx highlight="6-8"
+```tsx highlight="7-11"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -261,7 +261,7 @@ Errors become part of the stream and are not thrown to prevent e.g. servers from
 
 To log errors, you can provide an `onError` callback that is triggered when an error occurs.
 
-```tsx highlight="6-8"
+```tsx highlight="7-9"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -289,7 +289,7 @@ It receives the following chunk types:
 - `tool-result`
 - `raw`
 
-```tsx highlight="6-11"
+```tsx highlight="7-12"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -312,7 +312,7 @@ When using `streamText`, you can provide an `onFinish` callback that is triggere
 ).
 It contains the text, usage information, finish reason, messages, steps, total usage, and more:
 
-```tsx highlight="6-8"
+```tsx highlight="7-11"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -114,7 +114,7 @@ You can consume the structured output on the client with the [`useObject`](/docs
 
 To handle errors, provide an `onError` callback:
 
-```tsx highlight="5-7"
+```tsx highlight="6-8"
 import { streamText, Output } from 'ai';
 
 const result = streamText({
@@ -318,7 +318,7 @@ const { output } = await generateText({
 
 You can add `.describe("...")` to individual schema properties to give the model hints about what each property is for. This helps improve the quality and accuracy of generated structured data:
 
-```ts highlight="5,9"
+```ts highlight="9,16,19,20"
 import { generateText, Output } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -355,7 +355,7 @@ Property descriptions are particularly useful for:
 
 You can optionally specify a `name` and `description` for the output. These are used by some providers for additional LLM guidance, e.g. via tool or schema name.
 
-```ts highlight="6-7"
+```ts highlight="8-9"
 import { generateText, Output } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -20,7 +20,7 @@ Function tools and dynamic tools contain several core elements:
 
 The `tools` parameter of `generateText` and `streamText` is an object that has the tool names as keys and the tools as values:
 
-```ts highlight="6-17"
+```ts highlight="7-18"
 import { z } from 'zod';
 import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
@@ -169,7 +169,7 @@ The older `needsApproval` property on `tool()` definitions is deprecated. Existi
 
 ### Configure `toolApproval`
 
-```ts highlight="8-10"
+```ts highlight="4-6"
 const result = await generateText({
   model: __MODEL__,
   tools: { runCommand },
@@ -413,7 +413,7 @@ In the following example, there are two steps:
    1. The tool result is sent to the model.
    1. The model generates a response considering the tool result.
 
-```ts highlight="18-19"
+```ts highlight="19"
 import { z } from 'zod';
 import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
@@ -447,7 +447,7 @@ It contains all the text, tool calls, tool results, per-step `performance`, and 
 
 #### Example: Extract tool results from all steps
 
-```ts highlight="3,9-10"
+```ts highlight="4,11"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -772,7 +772,7 @@ It supports the following settings:
 - `none`: the model must not call tools
 - `{ type: 'tool', toolName: string (typed) }`: the model must call the specified tool
 
-```ts highlight="18"
+```ts highlight="19"
 import { z } from 'zod';
 import { generateText, tool } from 'ai';
 __PROVIDER_IMPORT__;
@@ -876,7 +876,7 @@ const result = await generateText({
 The abort signals from `generateText` and `streamText` are forwarded to the tool execution.
 You can access them in the second parameter of the `execute` function and e.g. abort long-running computations or forward them to fetch calls inside tools.
 
-```ts highlight="6,11,14"
+```ts highlight="7,12,15"
 import { z } from 'zod';
 import { generateText, tool } from 'ai';
 __PROVIDER_IMPORT__;
@@ -983,7 +983,7 @@ between prompt context, runtime context, and tool context, see
 Tool context often contains server-side values such as API keys, access tokens, or internal identifiers.
 Use `telemetry.includeToolsContext` to include selected top-level context properties in telemetry integrations:
 
-```ts highlight="24-30"
+```ts highlight="29-35"
 const weatherTool = tool({
   description: 'Get the weather in a location',
   inputSchema: z.object({
@@ -1045,7 +1045,7 @@ The following tool input lifecycle hooks are available:
 
 ### Example
 
-```ts highlight="15-23"
+```ts highlight="16-24"
 import { streamText, tool } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -1338,7 +1338,7 @@ the AI SDK provides the `activeTools` property.
 It is an array of tool names that are currently active.
 By default, the value is `undefined` and all tools are active.
 
-```ts highlight="7"
+```ts highlight="8"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;

--- a/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
+++ b/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
@@ -78,7 +78,7 @@ Use `toolsContext` for values that belong to a specific tool. Each tool declares
 the context it expects with `contextSchema`; the matching `toolsContext` entry is
 validated and passed to the tool as `context`.
 
-```ts highlight="11-15,26-31"
+```ts highlight="9-12,25-30"
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 
@@ -131,7 +131,7 @@ include selected top-level runtime context properties in telemetry, and
 `telemetry.includeToolsContext` to include selected top-level tool context
 properties per tool.
 
-```ts highlight="36-45"
+```ts highlight="34-43"
 import { ToolLoopAgent, tool } from 'ai';
 import { z } from 'zod';
 

--- a/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
+++ b/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
@@ -134,7 +134,7 @@ console.log(result.warnings);
 You can inspect the input messages that were sent to the model for the final step using `request.messages`.
 Set `include.requestMessages` to `true` to include these messages in step results.
 
-```ts highlight="6"
+```ts highlight="4,7"
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Hello, world!',

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -59,7 +59,7 @@ const transcript = await transcribe({
 When `audio` is a URL, the SDK downloads the file with a default **2 GiB** size limit.
 You can customize this using `createDownload`:
 
-```ts highlight="1,8"
+```ts highlight="1,7"
 import { experimental_transcribe as transcribe, createDownload } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -72,7 +72,7 @@ const transcript = await transcribe({
 
 You can also provide a fully custom download function:
 
-```ts highlight="6-12"
+```ts highlight="7-13"
 import { experimental_transcribe as transcribe } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -115,7 +115,7 @@ that you can use to abort the transcription process or set a timeout.
 
 This is particularly useful when combined with URL downloads to prevent long-running requests:
 
-```ts highlight="8"
+```ts highlight="7"
 import { openai } from '@ai-sdk/openai';
 import { experimental_transcribe as transcribe } from 'ai';
 

--- a/content/docs/03-ai-sdk-core/39-file-uploads.mdx
+++ b/content/docs/03-ai-sdk-core/39-file-uploads.mdx
@@ -41,7 +41,7 @@ const { text } = await generateText({
 
 As a shorthand, you can pass a provider instance directly to `api` instead of calling `.files()` explicitly — the SDK will call `.files()` for you:
 
-```ts highlight="3"
+```ts highlight="2"
 const { providerReference } = await uploadFile({
   api: openai, // shorthand for openai.files()
   data: fs.readFileSync('./photo.png'),
@@ -80,7 +80,7 @@ Use the `providerReference` in a file content part with its media type:
 Some providers accept additional options through `providerOptions`.
 For example, OpenAI requires a `purpose` field:
 
-```ts highlight="5-9"
+```ts highlight="6-10"
 import { openai, type OpenAIFilesOptions } from '@ai-sdk/openai';
 
 const { providerReference } = await uploadFile({

--- a/content/docs/03-ai-sdk-core/50-error-handling.mdx
+++ b/content/docs/03-ai-sdk-core/50-error-handling.mdx
@@ -9,7 +9,7 @@ description: Learn how to handle errors in the AI SDK Core
 
 Regular errors are thrown and can be handled using the `try/catch` block.
 
-```ts highlight="3,8-10"
+```ts highlight="4,9-11"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -31,7 +31,7 @@ When errors occur during streams that do not support error chunks,
 the error is thrown as a regular error.
 You can handle these errors using the `try/catch` block.
 
-```ts highlight="3,12-14"
+```ts highlight="4,13-15"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -56,7 +56,7 @@ You can handle those parts similar to other parts.
 It is recommended to also add a try-catch block for errors that
 happen outside of the streaming.
 
-```ts highlight="13-21"
+```ts highlight="14-23"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -99,7 +99,7 @@ When streams are aborted (e.g., via chat stop button), you may want to perform c
 
 The `onAbort` callback is called when a stream is aborted via `AbortSignal`, but `onFinish` is not called. This ensures you can still update your UI state appropriately.
 
-```ts highlight="5-9"
+```ts highlight="7-10"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -127,7 +127,7 @@ The `onAbort` callback receives:
 
 You can also handle abort events directly in the stream:
 
-```ts highlight="10-13"
+```ts highlight="11-15"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -125,7 +125,7 @@ In this example, telemetry integrations receive `runtimeContext` as `{ requestId
 Tool-specific context can also contain values that are useful during execution but should not be sent to telemetry providers, such as API keys or access tokens.
 Use `telemetry.includeToolsContext` to include selected top-level properties from a tool's `context` in telemetry:
 
-```ts highlight="18-24"
+```ts highlight="23-29"
 const weatherTool = tool({
   inputSchema: z.object({
     location: z.string(),
@@ -216,7 +216,7 @@ registerTelemetryIntegration(new OpenTelemetry(), DevToolsTelemetry());
 
 You can also pass one or more integrations to individual `generateText` or `streamText` calls. When per-call integrations are provided, they replace the globally registered integrations for that call:
 
-```ts highlight="6-8"
+```ts highlight="7-9"
 import { streamText } from 'ai';
 import { DevToolsTelemetry } from '@ai-sdk/devtools';
 

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -907,7 +907,7 @@ and Anthropic `claude-sonnet-4-5-20250929` support reasoning tokens.
 These tokens are typically sent before the message content.
 You can forward them to the client with the `sendReasoning` option:
 
-```ts filename="app/api/chat/route.ts" highlight="13"
+```ts filename="app/api/chat/route.ts" highlight="12"
 import { convertToModelMessages, streamText, UIMessage } from 'ai';
 
 export async function POST(req: Request) {
@@ -959,7 +959,7 @@ Some providers such as [Perplexity](/providers/ai-sdk-providers/perplexity#sourc
 Currently sources are limited to web pages that ground the response.
 You can forward them to the client with the `sendSources` option:
 
-```ts filename="app/api/chat/route.ts" highlight="13"
+```ts filename="app/api/chat/route.ts" highlight="12"
 import { convertToModelMessages, streamText, UIMessage } from 'ai';
 
 export async function POST(req: Request) {

--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -78,7 +78,7 @@ When processing messages on the server that contain tool calls, custom metadata,
 
 When your messages include tool calls, validate them against your tool definitions:
 
-```tsx filename="app/api/chat/route.ts" highlight="7-25,32-37"
+```tsx filename="app/api/chat/route.ts" highlight="7-24,31-36"
 import {
   convertToModelMessages,
   streamText,
@@ -270,7 +270,7 @@ parts, validate them using `validateUIMessages` before processing (see the
 Storing messages is done in the `onFinish` callback of the `toUIMessageStreamResponse` function.
 `onFinish` receives the complete messages including the new AI response as `UIMessage[]`.
 
-```tsx filename="app/api/chat/route.ts" highlight="6,11-17"
+```tsx filename="app/api/chat/route.ts" highlight="6,14-19"
 import { openai } from '@ai-sdk/openai';
 import { saveChat } from '@util/chat-store';
 import { convertToModelMessages, streamText, UIMessage } from 'ai';
@@ -340,7 +340,7 @@ When implementing persistence, you have two options for generating server-side I
 
 You can control the ID format by providing ID generators using [`createIdGenerator()`](/docs/reference/ai-sdk-core/create-id-generator):
 
-```tsx filename="app/api/chat/route.ts" highlight="7-11"
+```tsx filename="app/api/chat/route.ts" highlight="11-15"
 import { createIdGenerator, streamText } from 'ai';
 
 export async function POST(req: Request) {
@@ -429,7 +429,7 @@ This reduces the amount of data sent to the server on each request and can impro
 To achieve this, you can provide a `prepareSendMessagesRequest` function to the transport.
 This function receives the messages and the chat ID, and returns the request body to be sent to the server.
 
-```tsx filename="ui/chat.tsx" highlight="7-12"
+```tsx filename="ui/chat.tsx" highlight="7-13"
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
@@ -496,7 +496,7 @@ and then save the result as usual.
 `consumeStream` effectively removes the backpressure,
 meaning that the result is stored even when the client has already disconnected.
 
-```tsx filename="app/api/chat/route.ts" highlight="19-21"
+```tsx filename="app/api/chat/route.ts" highlight="13-15"
 import { convertToModelMessages, streamText, UIMessage } from 'ai';
 import { saveChat } from '@util/chat-store';
 

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -51,7 +51,7 @@ This will cancel the stream from the client side to the server.
   both.
 </Note>
 
-```tsx file="app/page.tsx" highlight="9,18-20"
+```tsx file="app/page.tsx" highlight="6,11-15"
 'use client';
 
 import { useCompletion } from '@ai-sdk/react';

--- a/content/docs/09-troubleshooting/10-use-chat-tools-no-response.mdx
+++ b/content/docs/09-troubleshooting/10-use-chat-tools-no-response.mdx
@@ -14,7 +14,7 @@ When I log the incoming messages on the server, I can see the tool call and the 
 
 To resolve this issue, convert the incoming messages to the `ModelMessage` format using the [`convertToModelMessages`](/docs/reference/ai-sdk-ui/convert-to-model-messages) function.
 
-```tsx highlight="9"
+```tsx highlight="10"
 import { openai } from '@ai-sdk/openai';
 import { convertToModelMessages, streamText } from 'ai';
 __PROVIDER_IMPORT__;


### PR DESCRIPTION
Navigating the docs I found a lot of misplaced highlights. I tried to fix some of them but I couldn't figure out how to preview the docs locally. I must admit I heavily relied on AI + git blame to adapt the highlights as I'm not that familiar with the codebase