### PR TITLE
fix(ai): make input optional on input-streaming tool parts

### DIFF
--- a/.changeset/fix-input-streaming-optional-input.md
+++ b/.changeset/fix-input-streaming-optional-input.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ui): drop the redundant `| undefined` from the already-optional `input` field on the `input-streaming` `UIToolInvocation` variant so the type matches the runtime validator (`z.unknown().optional()`)

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -291,7 +291,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
 } & (
   | {
       state: 'input-streaming';
-      input?: DeepPartial<asUITool<TOOL>['input']> | undefined;
+      input?: DeepPartial<asUITool<TOOL>['input']>;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;


### PR DESCRIPTION
The TS discriminated union for `UIToolInvocation` and `DynamicToolUIPart` declares `input: T | undefined` on the `input-streaming` variant. The Zod validator in `validate-ui-messages.ts` already declares the same field as `z.unknown().optional()` for both the dynamic and typed tool shapes, so the validated runtime object can omit `input` entirely. Under `exactOptionalPropertyTypes`, the type forces consumers to set the property explicitly to `undefined`, which never matches the validated payload and which the rest of the codebase does not do.

Switching the type to `input?: ...` aligns the static shape with the existing Zod schema and with the existing call sites in `process-ui-message-stream.ts`. No runtime behaviour change, no API surface change in the success path. This is the change paired with a `patch` changeset.