### PR TITLE
fix(smooth-stream): preserve providerMetadata in chunked stream parts

### DIFF
--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -152,7 +152,7 @@ export function smoothStream<TOOLS extends ToolSet>({
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
+          controller.enqueue({ type, text: match, id, ...(providerMetadata != null ? { providerMetadata } : {}) });
           buffer = buffer.slice(match.length);
 
           await delay(delayInMs);


### PR DESCRIPTION
\`smoothStream\` splits text chunks into smaller pieces when a \`delayInMs\` is set. The while-loop that enqueues these split chunks was not spreading \`providerMetadata\` from the original chunk, causing it to be silently dropped on all chunked parts except the last flush.

\`flushBuffer\` already correctly spreads \`providerMetadata\`. This PR applies the same pattern to the while-loop enqueue.

Fixes #14373