### PR TITLE
fix(gateway): add caching option to provider options type

### DIFF
--- a/packages/gateway/src/gateway-provider-options.test-d.ts
+++ b/packages/gateway/src/gateway-provider-options.test-d.ts
@@ -1,0 +1,12 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { GatewayProviderOptions } from './gateway-provider-options';
+
+describe('GatewayProviderOptions', () => {
+  it('supports automatic caching', () => {
+    const options = {
+      caching: 'auto',
+    } satisfies GatewayProviderOptions;
+
+    expectTypeOf(options.caching).toEqualTypeOf<'auto'>();
+  });
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -44,6 +44,10 @@ const gatewayProviderOptions = lazySchema(() =>
        */
       tags: z.array(z.string()).optional(),
       /**
+       * Enables automatic prompt caching behavior for supported providers.
+       */
+      caching: z.literal('auto').optional(),
+      /**
        * Array of model slugs specifying fallback models to use in order.
        *
        * Example: `['openai/gpt-5-nano', 'zai/glm-4.6']` will try `openai/gpt-5-nano` first, then `zai/glm-4.6` as fallback.


### PR DESCRIPTION
## Summary

Adds the documented `caching: "auto"` Gateway provider option to `GatewayProviderOptions`.

The AI Gateway docs show `providerOptions.gateway.caching = "auto"`, but the current type does not allow `caching`, which causes strict TypeScript users to hit `ts(2353)` when using `satisfies GatewayProviderOptions`.

This change:
- adds `caching: "auto"` to the Gateway provider options schema
- adds a focused type test for the documented usage

Fixes #14595.

## Test plan

- `pnpm --filter @ai-sdk/gateway type-check`
- `pnpm --filter @ai-sdk/gateway test:node`