### PR TITLE
fix(ai): guard against missing inputTokens/outputTokens in provider usage

### DIFF
--- a/.changeset/fix-usage-null-guards.md
+++ b/.changeset/fix-usage-null-guards.md
@@ -1,0 +1,15 @@
+---
+'ai': patch
+---
+
+fix(ai): guard against missing `inputTokens` / `outputTokens` in provider usage
+
+`asLanguageModelUsage` now reads `usage.inputTokens?.total` and
+`usage.outputTokens?.total` (and the nested detail fields) with optional
+chaining. Some providers in the wild (and instrumented call paths such as
+`@trigger.dev` task wrappers) return `usage` objects that omit
+`inputTokens` / `outputTokens` entirely, which crashed with
+`TypeError: Cannot read properties of undefined (reading 'total')` inside
+`generateText` and `streamText` telemetry recording (see #15446).
+
+Closes #15446.

--- a/packages/ai/src/types/usage.test.ts
+++ b/packages/ai/src/types/usage.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { asLanguageModelUsage, createNullLanguageModelUsage } from './usage';
+
+describe('asLanguageModelUsage', () => {
+  it('maps a fully populated provider usage object', () => {
+    const result = asLanguageModelUsage({
+      inputTokens: {
+        total: 100,
+        noCache: 80,
+        cacheRead: 15,
+        cacheWrite: 5,
+      },
+      outputTokens: {
+        total: 50,
+        text: 40,
+        reasoning: 10,
+      },
+      raw: { provider_specific: 'value' },
+    });
+
+    expect(result).toEqual({
+      inputTokens: 100,
+      inputTokenDetails: {
+        noCacheTokens: 80,
+        cacheReadTokens: 15,
+        cacheWriteTokens: 5,
+      },
+      outputTokens: 50,
+      outputTokenDetails: {
+        textTokens: 40,
+        reasoningTokens: 10,
+      },
+      totalTokens: 150,
+      raw: { provider_specific: 'value' },
+    });
+  });
+
+  // Regression test for https://github.com/vercel/ai/issues/15446.
+  // Some providers omit `usage.inputTokens` / `usage.outputTokens` entirely
+  // (rather than emitting the documented `{ total: undefined, ... }` shape).
+  // The conversion must not throw — it should fall back to undefined fields.
+  it('does not throw when inputTokens or outputTokens is missing', () => {
+    expect(() =>
+      asLanguageModelUsage({
+        inputTokens: undefined as never,
+        outputTokens: undefined as never,
+      }),
+    ).not.toThrow();
+
+    const result = asLanguageModelUsage({
+      inputTokens: undefined as never,
+      outputTokens: undefined as never,
+    });
+
+    expect(result).toEqual({
+      inputTokens: undefined,
+      inputTokenDetails: {
+        noCacheTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokens: undefined,
+      outputTokenDetails: {
+        textTokens: undefined,
+        reasoningTokens: undefined,
+      },
+      totalTokens: undefined,
+      raw: undefined,
+    });
+  });
+
+  it('handles only inputTokens missing', () => {
+    const result = asLanguageModelUsage({
+      inputTokens: undefined as never,
+      outputTokens: {
+        total: 42,
+        text: 42,
+        reasoning: undefined,
+      },
+    });
+
+    expect(result.inputTokens).toBeUndefined();
+    expect(result.outputTokens).toBe(42);
+    expect(result.totalTokens).toBe(42);
+  });
+});
+
+describe('createNullLanguageModelUsage', () => {
+  it('returns an all-undefined usage shape', () => {
+    expect(createNullLanguageModelUsage()).toEqual({
+      inputTokens: undefined,
+      inputTokenDetails: {
+        noCacheTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokens: undefined,
+      outputTokenDetails: {
+        textTokens: undefined,
+        reasoningTokens: undefined,
+      },
+      totalTokens: undefined,
+    });
+  });
+});

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -82,20 +82,20 @@ export function asLanguageModelUsage(
   usage: LanguageModelV4Usage,
 ): LanguageModelUsage {
   return {
-    inputTokens: usage.inputTokens.total,
+    inputTokens: usage.inputTokens?.total,
     inputTokenDetails: {
-      noCacheTokens: usage.inputTokens.noCache,
-      cacheReadTokens: usage.inputTokens.cacheRead,
-      cacheWriteTokens: usage.inputTokens.cacheWrite,
+      noCacheTokens: usage.inputTokens?.noCache,
+      cacheReadTokens: usage.inputTokens?.cacheRead,
+      cacheWriteTokens: usage.inputTokens?.cacheWrite,
     },
-    outputTokens: usage.outputTokens.total,
+    outputTokens: usage.outputTokens?.total,
     outputTokenDetails: {
-      textTokens: usage.outputTokens.text,
-      reasoningTokens: usage.outputTokens.reasoning,
+      textTokens: usage.outputTokens?.text,
+      reasoningTokens: usage.outputTokens?.reasoning,
     },
     totalTokens: addTokenCounts(
-      usage.inputTokens.total,
-      usage.outputTokens.total,
+      usage.inputTokens?.total,
+      usage.outputTokens?.total,
     ),
     raw: usage.raw,
   };


### PR DESCRIPTION
## Summary

Fixes #15446. `asLanguageModelUsage` (in `packages/ai/src/types/usage.ts`) read `usage.inputTokens.total`, `usage.outputTokens.total`, and the nested detail fields without null-guarding the outer objects. Some providers and instrumented call paths (e.g. `@trigger.dev` task wrappers) emit `usage` objects that omit `inputTokens` / `outputTokens` entirely, which crashed `generateText` and `streamText` inside telemetry recording with:

```
TypeError: Cannot read properties of undefined (reading 'total')
```

The shape returned by `asLanguageModelUsage` (`LanguageModelUsage`) already declares every numeric field as `number | undefined`, so propagating `undefined` from a missing token-group object is well-typed and the only consistent behavior.

## Fix

Switch every `usage.inputTokens.X` / `usage.outputTokens.X` access in `asLanguageModelUsage` to `usage.inputTokens?.X` / `usage.outputTokens?.X`. `addTokenCounts` already handles `undefined` on both sides, so `totalTokens` continues to behave correctly (returns `undefined` when both are absent, otherwise sums the present values).

Diff is 9 lines, mechanical `.` → `?.`:

```diff
-    inputTokens: usage.inputTokens.total,
+    inputTokens: usage.inputTokens?.total,
     inputTokenDetails: {
-      noCacheTokens: usage.inputTokens.noCache,
-      cacheReadTokens: usage.inputTokens.cacheRead,
-      cacheWriteTokens: usage.inputTokens.cacheWrite,
+      noCacheTokens: usage.inputTokens?.noCache,
+      cacheReadTokens: usage.inputTokens?.cacheRead,
+      cacheWriteTokens: usage.inputTokens?.cacheWrite,
     },
-    outputTokens: usage.outputTokens.total,
+    outputTokens: usage.outputTokens?.total,
     outputTokenDetails: {
-      textTokens: usage.outputTokens.text,
-      reasoningTokens: usage.outputTokens.reasoning,
+      textTokens: usage.outputTokens?.text,
+      reasoningTokens: usage.outputTokens?.reasoning,
     },
     totalTokens: addTokenCounts(
-      usage.inputTokens.total,
-      usage.outputTokens.total,
+      usage.inputTokens?.total,
+      usage.outputTokens?.total,
     ),
```

## Test plan

Added `packages/ai/src/types/usage.test.ts` with four cases:

- Maps a fully-populated provider usage object correctly (positive path).
- **Regression for #15446**: does not throw when `inputTokens` and `outputTokens` are both missing — falls back to all-undefined fields.
- Handles only `inputTokens` missing while `outputTokens` is present (verifies `totalTokens` still sums what's available).
- `createNullLanguageModelUsage` snapshot.

- [x] `pnpm test:node src/types/usage.test.ts` — 4/4 pass
- [x] `pnpm test:node src/types/ src/generate-object/ src/generate-text/stream-language-model-call` — 142/142 pass (no regression in callers of `asLanguageModelUsage`)
- [x] `pnpm tsc --noEmit` in `packages/ai` — only 2 pre-existing errors (`@ai-sdk/test-server/with-vitest` not found in `src/ui/chat.test.ts` / `http-chat-transport.test.ts`); both exist on `main` and are unrelated to this change.
- [x] `pnpm exec oxfmt` — clean.
- [x] Patch changeset added (`'ai': patch`).

Closes #15446.