### PR TITLE
docs(google): add link to Gemini agents docs

### DIFF
--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1545,9 +1545,10 @@ Agents also chain through `previousInteractionId` like model-id calls.
 
 ### Managed Agents
 
-Managed agents run inside a sandboxed Linux environment provisioned per
-interaction. Pass the `environment` provider option to control how the
-sandbox is set up; the option is only accepted on agent calls.
+[Managed agents](https://ai.google.dev/gemini-api/docs/agents) run inside a
+sandboxed Linux environment provisioned per interaction. Pass the `environment`
+provider option to control how the sandbox is set up; the option is only
+accepted on agent calls.
 
 The simplest form provisions a fresh sandbox:
 


### PR DESCRIPTION
## Background

Adds a link to Gemini's managed agents docs to clarify in case of user confusion.

## Summary

Just added a link.

## Manual Verification

None.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

No patch changeset was created for the google package but lmk if this is required.