### PR TITLE
feat(provider-utils): narrow tool() return when execute is provided

### DIFF
--- a/.changeset/tool-execute-narrowing.md
+++ b/.changeset/tool-execute-narrowing.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat(provider-utils): narrow `tool()` return type to `ExecutableTool<...>` when `execute` is provided

--- a/packages/provider-utils/src/types/tool.test-d.ts
+++ b/packages/provider-utils/src/types/tool.test-d.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 import type { FlexibleSchema } from '../schema';
 import type { ToolResultOutput } from './content-part';
 import type { Context } from './context';
+import type { ExecutableTool } from './executable-tool';
 import type { ModelMessage } from './model-message';
 import type { Experimental_Sandbox as Sandbox } from './sandbox';
 import {
@@ -553,7 +554,9 @@ describe('tool helper', () => {
       });
 
       expectTypeOf(aTool).toEqualTypeOf<
-        Tool<{ number: number }, 'test', z.infer<typeof contextSchema>>
+        ExecutableTool<
+          Tool<{ number: number }, 'test', z.infer<typeof contextSchema>>
+        >
       >();
     });
 
@@ -597,10 +600,10 @@ describe('tool helper', () => {
       });
 
       expectTypeOf(aTool).toEqualTypeOf<
-        Tool<{ number: number }, 'test', Context>
+        ExecutableTool<Tool<{ number: number }, 'test', Context>>
       >();
-      expectTypeOf(aTool.execute).toExtend<
-        ToolExecuteFunction<{ number: number }, 'test', Context> | undefined
+      expectTypeOf(aTool.execute).toEqualTypeOf<
+        ToolExecuteFunction<{ number: number }, 'test', Context>
       >();
       expectTypeOf(aTool.execute).not.toEqualTypeOf<undefined>();
       expectTypeOf(aTool.inputSchema).toEqualTypeOf<
@@ -617,10 +620,10 @@ describe('tool helper', () => {
       });
 
       expectTypeOf(aTool).toEqualTypeOf<
-        Tool<{ number: number }, 'test', Context>
+        ExecutableTool<Tool<{ number: number }, 'test', Context>>
       >();
       expectTypeOf(aTool.execute).toEqualTypeOf<
-        ToolExecuteFunction<{ number: number }, 'test', Context> | undefined
+        ToolExecuteFunction<{ number: number }, 'test', Context>
       >();
       expectTypeOf(aTool.inputSchema).toEqualTypeOf<
         FlexibleSchema<{ number: number }>

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -2,6 +2,7 @@ import type { JSONValue, JSONObject } from '@ai-sdk/provider';
 import type { FlexibleSchema } from '../schema';
 import type { ToolResultOutput } from './content-part';
 import type { Context } from './context';
+import type { ExecutableTool } from './executable-tool';
 import type { NeverOptional } from './never-optional';
 import type { ProviderOptions } from './provider-options';
 import type {
@@ -338,8 +339,20 @@ export type Tool<
  * Infer the tool type from a tool object.
  *
  * This is useful for type inference when working with tool objects.
+ *
+ * When the input has an `execute` function, the return type narrows to
+ * `ExecutableTool<Tool<...>>` so that `.execute` is non-nullable without
+ * needing `isExecutableTool` or a `!` assertion at the call site.
  */
-// Note: overload order is important for auto-completion
+// Note: overload order is important for auto-completion.
+// The "with execute" overload comes first so calls that include an
+// `execute` function get the narrowed return type. Calls without
+// `execute` fall through to the overloads below.
+export function tool<INPUT, OUTPUT, CONTEXT extends Context>(
+  tool: Tool<INPUT, OUTPUT, CONTEXT> & {
+    execute: ToolExecuteFunction<INPUT, OUTPUT, CONTEXT>;
+  },
+): ExecutableTool<Tool<INPUT, OUTPUT, CONTEXT>>;
 export function tool<INPUT, OUTPUT, CONTEXT extends Context>(
   tool: Tool<INPUT, OUTPUT, CONTEXT>,
 ): Tool<INPUT, OUTPUT, CONTEXT>;


### PR DESCRIPTION
## Background

Consumers that define a tool with `execute` in their own codebase and then call `.execute(...)` (most often in tests) currently hit a typing gap. The inferred type of `tool({ ...with execute... })` is the wide `Tool<INPUT, OUTPUT, CONTEXT>` union, where `execute` is `ToolExecuteFunction<...> | undefined`. That forces `isExecutableTool` narrowing, a `!` assertion, or `?.()` chaining at the call site even when the consumer statically knows `execute` is defined.

The SDK already ships the right primitive: `ExecutableTool<TOOL>` from `@ai-sdk/provider-utils` (added in #14516). It just isn't wired into `tool()`'s own return type. Current options to get a narrowed tool are:

1. Call `isExecutableTool(t)` (runtime guard) at every consumption site.
2. Cast at the definition site with `as ExecutableTool<...>`.
3. Wrap `tool()` in a project-local factory that re-applies the cast.

## Summary

Add a fifth overload to `tool()` that matches calls whose config includes an `execute` function. That overload returns `ExecutableTool<Tool<INPUT, OUTPUT, CONTEXT>>` instead of the wider `Tool<INPUT, OUTPUT, CONTEXT>`. Calls without `execute` fall through to the existing four overloads unchanged.

```ts
// New overload (added at the top so it wins for execute-bearing calls):
export function tool<INPUT, OUTPUT, CONTEXT extends Context>(
  tool: Tool<INPUT, OUTPUT, CONTEXT> & {
    execute: ToolExecuteFunction<INPUT, OUTPUT, CONTEXT>;
  },
): ExecutableTool<Tool<INPUT, OUTPUT, CONTEXT>>;
```

This is non-breaking:

- Runtime: identical. The implementation body is still `return tool;`.
- Value-level type: `ExecutableTool<Tool<I, O, C>>` is `Tool<I, O, C> & { execute: NonNullable<...> }`. Strictly assignable to the old return; anything that took a `Tool<...>` keeps compiling.
- Property-level type: `t.execute` narrows from `ToolExecuteFunction<...> | undefined` to `ToolExecuteFunction<...>`. Existing runtime null checks become provably-true but still compile.

The existing type tests in `tool.test-d.ts` codified the wider contract. This PR updates the three affected assertions to expect the narrower one.

Effect at a call site:

```ts
const t = tool({
  inputSchema: z.object({ q: z.string() }),
  execute: async ({ q }) => ({ result: q.toUpperCase() }),
});

// Before: t.execute is `ToolExecuteFunction<...> | undefined`.
//   Needs isExecutableTool(t), or t.execute!(...), or t.execute?.(...).
// After:  t.execute is `ToolExecuteFunction<...>`. Direct call type-checks.
await t.execute({ q: 'hi' }, { toolCallId: 'x', messages: [], context: {} });
```

## Manual Verification

- `pnpm type-check:full` passes.
- `pnpm exec vitest --typecheck.only` in `packages/provider-utils`: 26 type-test files, 184 assertions, all pass.
- `pnpm exec vitest --typecheck.only` in `packages/ai`: 30 type-test files, 504 assertions, all pass.
- `pnpm --filter '@ai-sdk/provider-utils' test:node`: 65 test files, 606 tests, all pass.
- `pnpm check` (lint + format) clean.

## Open question for maintainers

This is small enough to land standalone, but #14516 deliberately introduced `ExecutableTool` and `isExecutableTool` as additive primitives and chose not to wire them into `tool()` itself. Was that intentional?

If you'd rather keep `tool()`'s return wide and expose narrowing as an opt-in, happy to close this and instead propose:

- A named `executableTool()` factory exported from `@ai-sdk/provider-utils` (symmetric with `isExecutableTool`/`ExecutableTool`).
- A short doc paragraph in `content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx` covering `isExecutableTool` for the runtime-discovered case (MCP etc).

Marking this as a draft until you've had a chance to weigh in.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)

## Related

- #14516 — introduced `ExecutableTool` and `isExecutableTool`.
- #14849 — restructured `Tool` into a 4-variant union.
- No prior issues filed for this specific friction (searched many phrasings).
