### PR TITLE
fix(ai): type agent tool call callback aliases

### DIFF
--- a/.changeset/agent-tool-call-alias-types.md
+++ b/.changeset/agent-tool-call-alias-types.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix Agent call types for deprecated tool callback aliases.

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -92,9 +92,23 @@ export type AgentCallParameters<
     onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
 
     /**
+     * Callback that is called before each tool execution begins.
+     *
+     * @deprecated Use `onToolExecutionStart` instead.
+     */
+    experimental_onToolCallStart?: OnToolExecutionStartCallback<TOOLS>;
+
+    /**
      * Callback that is called after each tool execution completes.
      */
     onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
+
+    /**
+     * Callback that is called after each tool execution completes.
+     *
+     * @deprecated Use `onToolExecutionEnd` instead.
+     */
+    experimental_onToolCallFinish?: OnToolExecutionEndCallback<TOOLS>;
 
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -232,6 +232,46 @@ describe('ToolLoopAgent', () => {
     }),
   };
 
+  describe('deprecated tool callback aliases', () => {
+    it('should accept deprecated aliases for generate', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools: toolWithoutContext,
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        experimental_onToolCallStart: async event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+          expectTypeOf(event.toolCall.toolName).toEqualTypeOf<string>();
+        },
+        experimental_onToolCallFinish: async event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+          expectTypeOf(event.toolCall.toolName).toEqualTypeOf<string>();
+        },
+      });
+    });
+
+    it('should accept deprecated aliases for stream', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools: toolWithoutContext,
+      });
+
+      await agent.stream({
+        prompt: 'Hello, world!',
+        experimental_onToolCallStart: async event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+          expectTypeOf(event.toolCall.toolName).toEqualTypeOf<string>();
+        },
+        experimental_onToolCallFinish: async event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+          expectTypeOf(event.toolCall.toolName).toEqualTypeOf<string>();
+        },
+      });
+    });
+  });
+
   describe('runtimeContext', () => {
     it('should accept no runtimeContext', async () => {
       new ToolLoopAgent({

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -2215,6 +2215,34 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
+      it('should call deprecated tool call start alias from generate method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        await agent.generate({
+          prompt: 'test',
+          experimental_onToolCallStart: async () => {
+            calls.push('method');
+          },
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
       it('should call both constructor and method in correct order', async () => {
         const calls: string[] = [];
 
@@ -2408,6 +2436,36 @@ describe('ToolLoopAgent', () => {
         const result = await agent.stream({
           prompt: 'test',
           onToolExecutionStart: async () => {
+            calls.push('method');
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
+      it('should call deprecated tool call start alias from stream method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallStreamMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'test',
+          experimental_onToolCallStart: async () => {
             calls.push('method');
           },
         });
@@ -2642,6 +2700,34 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
+      it('should call deprecated tool call finish alias from generate method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        await agent.generate({
+          prompt: 'test',
+          experimental_onToolCallFinish: async () => {
+            calls.push('method');
+          },
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
       it('should call both constructor and method in correct order', async () => {
         const calls: string[] = [];
 
@@ -2846,6 +2932,36 @@ describe('ToolLoopAgent', () => {
         const result = await agent.stream({
           prompt: 'test',
           onToolExecutionEnd: async () => {
+            calls.push('method');
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
+      it('should call deprecated tool call finish alias from stream method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallStreamMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'test',
+          experimental_onToolCallFinish: async () => {
             calls.push('method');
           },
         });

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -165,7 +165,9 @@ export class ToolLoopAgent<
     experimental_onStart,
     experimental_onStepStart,
     onToolExecutionStart,
+    experimental_onToolCallStart,
     onToolExecutionEnd,
+    experimental_onToolCallFinish,
     onStepFinish,
     onFinish,
     ...options
@@ -173,6 +175,10 @@ export class ToolLoopAgent<
     GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>
   > {
     const generate = generateText<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
+    const resolvedOnToolExecutionStart =
+      onToolExecutionStart ?? experimental_onToolCallStart;
+    const resolvedOnToolExecutionEnd =
+      onToolExecutionEnd ?? experimental_onToolCallFinish;
     const preparedCall = await this.prepareCall({
       ...options,
       experimental_sandbox: sandbox,
@@ -195,11 +201,11 @@ export class ToolLoopAgent<
       ),
       onToolExecutionStart: mergeCallbacks(
         this.settings.onToolExecutionStart,
-        onToolExecutionStart,
+        resolvedOnToolExecutionStart,
       ),
       onToolExecutionEnd: mergeCallbacks(
         this.settings.onToolExecutionEnd,
-        onToolExecutionEnd,
+        resolvedOnToolExecutionEnd,
       ),
       onStepFinish: mergeCallbacks(this.settings.onStepFinish, onStepFinish),
       onFinish: mergeCallbacks(this.settings.onFinish, onFinish),
@@ -222,7 +228,9 @@ export class ToolLoopAgent<
     experimental_onStart,
     experimental_onStepStart,
     onToolExecutionStart,
+    experimental_onToolCallStart,
     onToolExecutionEnd,
+    experimental_onToolCallFinish,
     onStepFinish,
     onFinish,
     ...options
@@ -230,6 +238,10 @@ export class ToolLoopAgent<
     StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>
   > {
     const stream = streamText<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
+    const resolvedOnToolExecutionStart =
+      onToolExecutionStart ?? experimental_onToolCallStart;
+    const resolvedOnToolExecutionEnd =
+      onToolExecutionEnd ?? experimental_onToolCallFinish;
     const preparedCall = await this.prepareCall({
       ...options,
       experimental_sandbox: sandbox,
@@ -253,11 +265,11 @@ export class ToolLoopAgent<
       ),
       onToolExecutionStart: mergeCallbacks(
         this.settings.onToolExecutionStart,
-        onToolExecutionStart,
+        resolvedOnToolExecutionStart,
       ),
       onToolExecutionEnd: mergeCallbacks(
         this.settings.onToolExecutionEnd,
-        onToolExecutionEnd,
+        resolvedOnToolExecutionEnd,
       ),
       onStepFinish: mergeCallbacks(this.settings.onStepFinish, onStepFinish),
       onFinish: mergeCallbacks(this.settings.onFinish, onFinish),


### PR DESCRIPTION
Fixes #14278.

Adds the deprecated tool-call callback aliases to Agent call options and normalizes them before calling generateText/streamText.

Checks:
- pnpm --filter ai exec vitest --config vitest.node.config.js --run src/agent/tool-loop-agent.test-d.ts src/agent/tool-loop-agent.test.ts
- pnpm --filter ai type-check