### PR TITLE
fix(ai): propagate abort signal to telemetry onError callback

### DIFF
--- a/.changeset/wild-gifts-worry.md
+++ b/.changeset/wild-gifts-worry.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): propagate abort signal to telemetry onError callback

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -19637,6 +19637,137 @@ describe('streamText', () => {
         `);
       });
 
+      // this test should already pass; added for sanity check
+      it('should call telemetry onEnd when a stream completes', async () => {
+        const telemetryCalls: string[] = [];
+        let pullCalls = 0;
+
+        const result = streamText({
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: new ReadableStream({
+                pull(controller) {
+                  switch (pullCalls++) {
+                    case 0:
+                      controller.enqueue({
+                        type: 'stream-start',
+                        warnings: [],
+                      });
+                      break;
+                    case 1:
+                      controller.enqueue({
+                        type: 'text-start',
+                        id: '1',
+                      });
+                      break;
+                    case 2:
+                      controller.enqueue({
+                        type: 'text-delta',
+                        id: '1',
+                        delta: 'Hello',
+                      });
+                      break;
+                    case 3:
+                      controller.enqueue({
+                        type: 'text-end',
+                        id: '1',
+                      });
+                      break;
+                    case 4:
+                      controller.enqueue({
+                        type: 'finish',
+                        finishReason: { unified: 'stop', raw: 'stop' },
+                        usage: testUsage,
+                      });
+                      controller.close();
+                      break;
+                  }
+                },
+              }),
+            }),
+          }),
+          prompt: 'test-input',
+          telemetry: {
+            integrations: {
+              onEnd: () => {
+                telemetryCalls.push('onEnd');
+              },
+              onError: () => {
+                telemetryCalls.push('onError');
+              },
+            },
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(telemetryCalls).toEqual(['onEnd']);
+      });
+
+      // this was failing before we propagated abort signal to telemetry's onError
+      it('should call telemetry onError when the abort signal is triggered', async () => {
+        const telemetryCalls: string[] = [];
+        const abortController = new AbortController();
+        let pullCalls = 0;
+
+        const result = streamText({
+          abortSignal: abortController.signal,
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: new ReadableStream({
+                pull(controller) {
+                  switch (pullCalls++) {
+                    case 0:
+                      controller.enqueue({
+                        type: 'stream-start',
+                        warnings: [],
+                      });
+                      break;
+                    case 1:
+                      controller.enqueue({
+                        type: 'text-start',
+                        id: '1',
+                      });
+                      break;
+                    case 2:
+                      controller.enqueue({
+                        type: 'text-delta',
+                        id: '1',
+                        delta: 'Hello',
+                      });
+                      break;
+                    case 3:
+                      abortController.abort();
+                      controller.error(
+                        new DOMException(
+                          'The user aborted a request.',
+                          'AbortError',
+                        ),
+                      );
+                      break;
+                  }
+                },
+              }),
+            }),
+          }),
+          prompt: 'test-input',
+          telemetry: {
+            integrations: {
+              onEnd: () => {
+                telemetryCalls.push('onEnd');
+              },
+              onError: () => {
+                telemetryCalls.push('onError');
+              },
+            },
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(telemetryCalls).toEqual(['onError']);
+      });
+
       it.skipIf(isNodeVersionAtLeast(24, 15))(
         'should only stream initial chunks in full stream',
         async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1298,7 +1298,7 @@ class DefaultStreamTextResult<
 
       async pull(controller) {
         // abort handling:
-        function abort() {
+        async function abort() {
           onAbort?.({ steps: recordedSteps });
           controller.enqueue({
             type: 'abort',
@@ -1308,6 +1308,14 @@ class DefaultStreamTextResult<
             ...(abortSignal?.reason !== undefined
               ? { reason: getErrorMessage(abortSignal.reason) }
               : {}),
+          });
+          await notify({
+            event: {
+              callId,
+              error: abortSignal?.reason,
+            },
+            // `onError` is not called for abort errors according to previous tests, so we only call `telemetryDispatcher.onError`.
+            callbacks: [telemetryDispatcher.onError],
           });
           controller.close();
         }
@@ -1321,14 +1329,14 @@ class DefaultStreamTextResult<
           }
 
           if (abortSignal?.aborted) {
-            abort();
+            await abort();
             return;
           }
 
           controller.enqueue(value);
         } catch (error) {
           if (isAbortError(error) && abortSignal?.aborted) {
-            abort();
+            await abort();
           } else {
             controller.error(error);
           }

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -6,7 +6,8 @@ import {
   type SpanOptions,
   type Tracer,
 } from '@opentelemetry/api';
-import type { Telemetry } from 'ai';
+import { streamText, type Telemetry } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
 import { OpenTelemetry, type EnrichSpan } from './open-telemetry';
 
 type MockSpan = Span & {
@@ -1416,6 +1417,95 @@ describe('OpenTelemetry', () => {
             "status": {
               "code": 2,
               "message": "something went wrong",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('closes streamText spans when AbortController aborts the stream', async () => {
+      const abortController = new AbortController();
+      const abortError = Object.assign(
+        new Error('The user aborted a request.'),
+        {
+          name: 'AbortError',
+        },
+      );
+      let pullCalls = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({
+                      type: 'stream-start',
+                      warnings: [],
+                    });
+                    break;
+                  case 1:
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: '1',
+                    });
+                    break;
+                  case 2:
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: '1',
+                      delta: 'Hello',
+                    });
+                    break;
+                  case 3:
+                    abortController.abort(abortError);
+                    controller.error(abortError);
+                    break;
+                }
+              },
+            }),
+          }),
+        }),
+        prompt: 'test-input',
+        abortSignal: abortController.signal,
+        telemetry: {
+          integrations: integration,
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(
+        tracer.spans.map(s => ({
+          name: s.name,
+          status: s.status,
+          ended: s.ended,
+        })),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "ended": true,
+            "name": "invoke_agent mock-model-id",
+            "status": {
+              "code": 2,
+              "message": "The user aborted a request.",
+            },
+          },
+          {
+            "ended": true,
+            "name": "step 1",
+            "status": {
+              "code": 2,
+              "message": "The user aborted a request.",
+            },
+          },
+          {
+            "ended": true,
+            "name": "chat mock-model-id",
+            "status": {
+              "code": 2,
+              "message": "The user aborted a request.",
             },
           },
         ]


### PR DESCRIPTION
## Background

When aborting a request using AbortController, neither onEnd or onError (telemetry specific, not user facing) are called via the telemetry dispatcher., resulting in traces that are marked as indeterminate

## Summary

send a terminal telemetry event through `telemetryDispatcher.onError` before closing the stream

## Manual Verification

verified by unit tests added in `open-telemetry.test.ts` and the `stream-text.test.ts` files. the failing snapshots will prove this gap

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

consider introducing an `onAbort` callback on the telemetry interface later