### PR TITLE
feat(ai): wrap the model call in telemetry context

### DIFF
--- a/.changeset/rare-seals-know.md
+++ b/.changeset/rare-seals-know.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+feat(ai): wrap the model call in telemetry context

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -178,6 +178,42 @@ describe('generateText', () => {
     logWarningsSpy.mockRestore();
   });
 
+  describe('telemetry model-call context', () => {
+    it('should execute doGenerate inside executeLanguageModelCall context', async () => {
+      let activeContext: string | undefined;
+      let capturedContext: string | undefined;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            capturedContext = activeContext;
+
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'done' }],
+            };
+          },
+        }),
+        telemetry: {
+          isEnabled: true,
+          integrations: {
+            executeLanguageModelCall: async ({ callId, execute }) => {
+              activeContext = callId;
+              try {
+                return await execute();
+              } finally {
+                activeContext = undefined;
+              }
+            },
+          },
+        },
+        ...defaultSettings(),
+      });
+
+      expect(capturedContext).toBe('test-telemetry-call-id');
+    });
+  });
+
   describe('result.content', () => {
     it('should generate content', async () => {
       const result = await generateText({

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -772,16 +772,25 @@ export async function generateText<
 
         const stepStartTimestampMs = now();
 
+        const executeLanguageModelCallInTelemetryContext =
+          telemetryDispatcher.executeLanguageModelCall ??
+          (async <T>({ execute }: { execute: () => PromiseLike<T> }) =>
+            await execute());
+
         currentModelResponse = await retry(async () => {
-          const result = await stepModel.doGenerate({
-            ...callSettings,
-            tools: stepTools,
-            toolChoice: stepToolChoice,
-            responseFormat: await output?.responseFormat,
-            prompt: promptMessages,
-            providerOptions: stepProviderOptions,
-            abortSignal: mergedAbortSignal,
-            headers: headersWithUserAgent,
+          const result = await executeLanguageModelCallInTelemetryContext({
+            callId,
+            execute: async () =>
+              await stepModel.doGenerate({
+                ...callSettings,
+                tools: stepTools,
+                toolChoice: stepToolChoice,
+                responseFormat: await output?.responseFormat,
+                prompt: promptMessages,
+                providerOptions: stepProviderOptions,
+                abortSignal: mergedAbortSignal,
+                headers: headersWithUserAgent,
+              }),
           });
 
           const responseData = {

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -22,6 +22,7 @@ import type { LanguageModelCallOptions } from '../prompt/language-model-call-opt
 import { prepareToolChoice } from '../prompt/prepare-tool-choice';
 import { prepareTools } from '../prompt/prepare-tools';
 import { standardizePrompt } from '../prompt/standardize-prompt';
+import type { Telemetry } from '../telemetry/telemetry';
 import type {
   CallWarning,
   FinishReason,
@@ -205,6 +206,8 @@ export async function streamLanguageModelCall<
   providerOptions,
   repairToolCall,
   refineToolInput,
+  executeLanguageModelCallInTelemetryContext = async ({ execute }) =>
+    await execute(),
   callId,
   toolsContext,
   experimental_sandbox: sandbox,
@@ -229,6 +232,7 @@ export async function streamLanguageModelCall<
   providerOptions?: ProviderOptions;
   repairToolCall?: ToolCallRepairFunction<TOOLS> | undefined;
   refineToolInput?: ToolInputRefinement<TOOLS> | undefined;
+  executeLanguageModelCallInTelemetryContext?: Telemetry['executeLanguageModelCall'];
   callId?: string;
   /**
    * Tool context used to resolve per-call tool metadata such as function
@@ -329,16 +333,20 @@ export async function streamLanguageModelCall<
     stream: languageModelStream,
     response,
     request,
-  } = await resolvedModel.doStream({
-    ...callSettings,
-    tools: stepTools,
-    toolChoice: stepToolChoice,
-    responseFormat: await output?.responseFormat,
-    prompt: promptMessages,
-    providerOptions,
-    abortSignal,
-    headers,
-    includeRawChunks,
+  } = await executeLanguageModelCallInTelemetryContext({
+    callId: effectiveCallId,
+    execute: async () =>
+      await resolvedModel.doStream({
+        ...callSettings,
+        tools: stepTools,
+        toolChoice: stepToolChoice,
+        responseFormat: await output?.responseFormat,
+        prompt: promptMessages,
+        providerOptions,
+        abortSignal,
+        headers,
+        includeRawChunks,
+      }),
   });
 
   const standardizedStream = languageModelStream.pipeThrough(

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -467,6 +467,58 @@ describe('streamText', () => {
     logWarningsSpy.mockRestore();
   });
 
+  describe('telemetry model-call context', () => {
+    it('should execute doStream inside executeLanguageModelCall context', async () => {
+      let activeContext: string | undefined;
+      let capturedContext: string | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            capturedContext = activeContext;
+
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'done' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        telemetry: {
+          isEnabled: true,
+          integrations: {
+            executeLanguageModelCall: async ({ callId, execute }) => {
+              activeContext = callId;
+              try {
+                return await execute();
+              } finally {
+                activeContext = undefined;
+              }
+            },
+          },
+        },
+        ...defaultSettings(),
+      });
+
+      await result.consumeStream();
+
+      expect(capturedContext).toBe('test-telemetry-call-id');
+    });
+  });
+
   describe('result.textStream', () => {
     it('should send text deltas', async () => {
       const result = streamText({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1685,6 +1685,8 @@ class DefaultStreamTextResult<
               download,
               output,
               callId,
+              executeLanguageModelCallInTelemetryContext:
+                telemetryDispatcher.executeLanguageModelCall,
               toolsContext,
               experimental_sandbox: stepSandbox,
               onLanguageModelCallStart: filterNullable(

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -34,6 +34,7 @@ describe('createTelemetryDispatcher', () => {
     expect(telemetry.onRerankEnd).toBeDefined();
     expect(telemetry.onEnd).toBeDefined();
     expect(telemetry.onError).toBeDefined();
+    expect(telemetry.executeLanguageModelCall).toBeUndefined();
     expect(telemetry.executeTool).toBeUndefined();
 
     await expect(telemetry.onStart!(dummyEvent)).resolves.toBeUndefined();
@@ -219,6 +220,8 @@ describe('createTelemetryDispatcher', () => {
         onRerankEnd: vi.fn(),
         onEnd: vi.fn(),
         onError: vi.fn(),
+        executeLanguageModelCall: async ({ execute }) => execute(),
+        executeTool: async ({ execute }) => execute(),
       };
 
       const telemetry = createTelemetryDispatcher({
@@ -238,12 +241,14 @@ describe('createTelemetryDispatcher', () => {
       expect(telemetry.onRerankEnd).toBeUndefined();
       expect(telemetry.onEnd).toBeUndefined();
       expect(telemetry.onError).toBeUndefined();
+      expect(telemetry.executeLanguageModelCall).toBeUndefined();
       expect(telemetry.executeTool).toBeUndefined();
     });
 
     it('ignores globally registered integrations when isEnabled is false', () => {
       registerTelemetry({
         onStart: vi.fn(),
+        executeLanguageModelCall: async ({ execute }) => execute(),
         executeTool: async ({ execute }) => execute(),
       });
 
@@ -252,6 +257,7 @@ describe('createTelemetryDispatcher', () => {
       });
 
       expect(telemetry.onStart).toBeUndefined();
+      expect(telemetry.executeLanguageModelCall).toBeUndefined();
       expect(telemetry.executeTool).toBeUndefined();
     });
 
@@ -417,6 +423,69 @@ describe('createTelemetryDispatcher', () => {
       await telemetry.onEnd!(dummyEvent);
 
       expect(instance.calls).toEqual(['start', 'end']);
+    });
+  });
+
+  describe('executeLanguageModelCall', () => {
+    it('returns undefined when no integrations implement executeLanguageModelCall', () => {
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { integrations: { onStart: vi.fn() } },
+      });
+
+      expect(telemetry.executeLanguageModelCall).toBeUndefined();
+    });
+
+    it('wraps execute with a single integration', async () => {
+      const execute = vi.fn().mockResolvedValue('result');
+      let wrapperCalls = 0;
+      const wrapper: Telemetry['executeLanguageModelCall'] = async ({
+        execute,
+      }) => {
+        wrapperCalls += 1;
+        return `wrapped:${await execute()}` as any;
+      };
+
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { integrations: { executeLanguageModelCall: wrapper } },
+      });
+
+      await expect(
+        telemetry.executeLanguageModelCall!({
+          callId: 'call-1',
+          execute,
+        }),
+      ).resolves.toBe('wrapped:result');
+
+      expect(wrapperCalls).toBe(1);
+      expect(execute).toHaveBeenCalledOnce();
+    });
+
+    it('auto-binds class-based executeLanguageModelCall integrations', async () => {
+      class ExecuteLanguageModelCallIntegration implements Telemetry {
+        calls = 0;
+
+        async executeLanguageModelCall<T>({
+          execute,
+        }: {
+          callId: string;
+          execute: () => PromiseLike<T>;
+        }) {
+          this.calls += 1;
+          return execute();
+        }
+      }
+
+      const integration = new ExecuteLanguageModelCallIntegration();
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { integrations: integration },
+      });
+
+      await telemetry.executeLanguageModelCall!({
+        callId: 'call-1',
+        execute: async () => 'done',
+      });
+
+      expect(integration.calls).toBe(1);
     });
   });
 

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -13,7 +13,8 @@ import type { TelemetryOptions } from './telemetry-options';
 
 /**
  * The subset of `TelemetryDispatcher` keys whose values are Callback callbacks.
- * This excludes non-Callback properties such as `executeTool`.
+ * This excludes non-Callback properties such as `executeLanguageModelCall` and
+ * `executeTool`.
  */
 type TelemetryCallbackKey = keyof {
   [K in keyof TelemetryDispatcher as TelemetryDispatcher[K] extends
@@ -110,7 +111,13 @@ export function createTelemetryDispatcher({
     );
   };
 
-  const executeWrappers = integrations
+  const executeLanguageModelCallWrappers = integrations
+    .map(integration => integration.executeLanguageModelCall?.bind(integration))
+    .filter(Boolean) as Array<
+    NonNullable<Telemetry['executeLanguageModelCall']>
+  >;
+
+  const executeToolWrappers = integrations
     .map(integration => integration.executeTool?.bind(integration))
     .filter(Boolean) as Array<NonNullable<Telemetry['executeTool']>>;
 
@@ -133,6 +140,19 @@ export function createTelemetryDispatcher({
     onEnd: mergeTelemetryCallback('onEnd'),
     onError: mergeTelemetryCallback('onError'),
 
+    executeLanguageModelCall:
+      executeLanguageModelCallWrappers.length > 0
+        ? async args => {
+            let execute = args.execute;
+            for (const executeWrapper of executeLanguageModelCallWrappers) {
+              const innerExecute = execute;
+              execute = () =>
+                executeWrapper({ ...args, execute: innerExecute });
+            }
+            return await execute();
+          }
+        : undefined,
+
     /**
      * Composes all `executeTool` wrappers around the original tool execution.
      * Each wrapper receives an `execute` function that calls the next wrapper in
@@ -140,10 +160,10 @@ export function createTelemetryDispatcher({
      * delegating to the underlying tool.
      */
     executeTool:
-      executeWrappers.length > 0
+      executeToolWrappers.length > 0
         ? async args => {
             let execute = args.execute;
-            for (const executeWrapper of executeWrappers) {
+            for (const executeWrapper of executeToolWrappers) {
               const innerExecute = execute;
               execute = () =>
                 executeWrapper({ ...args, execute: innerExecute });

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -70,6 +70,7 @@ export interface TelemetryDispatcher {
   onRerankEnd?: Callback<RerankingModelCallEndEvent>;
   onEnd?: Callback<OperationEndEvent>;
   onError?: Callback<unknown>;
+  executeLanguageModelCall?: Telemetry['executeLanguageModelCall'];
   executeTool?: Telemetry['executeTool'];
 }
 
@@ -200,6 +201,19 @@ export interface Telemetry {
    * Use this to record error details on telemetry spans and set error status.
    */
   onError?: Callback<unknown>;
+
+  /**
+   * Optionally runs the language model call in a telemetry-integration-specific context. This enables
+   * auto-instrumented model provider requests to become children of the current
+   * model-call span.
+   *
+   * @param options.callId - The call ID of the generation.
+   * @param options.execute - The function that performs the model call.
+   */
+  executeLanguageModelCall?: <T>(options: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }) => PromiseLike<T>;
 
   /**
    * Optionally runs the tool execute function in a telemetry-integration-specific context. This enables

--- a/packages/otel/src/legacy-open-telemetry.test.ts
+++ b/packages/otel/src/legacy-open-telemetry.test.ts
@@ -12,7 +12,9 @@ import {
 import * as assert from 'node:assert';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  context,
   SpanStatusCode,
+  trace,
   type Attributes,
   type Span,
   type SpanOptions,
@@ -487,6 +489,35 @@ describe('LegacyOpenTelemetry', () => {
       const attrs = getStartSpanAttributes(tracer, 1);
       expect(attrs['ai.prompt.tools']).toBeDefined();
       expect(attrs['ai.prompt.toolChoice']).toBeDefined();
+    });
+  });
+
+  describe('executeLanguageModelCall', () => {
+    it('runs the model call inside the active step span context', async () => {
+      let activeSpan: Span | undefined;
+      const contextWithSpy = vi
+        .spyOn(context, 'with')
+        .mockImplementation((nextContext, fn, thisArg, ...args) => {
+          activeSpan = trace.getSpan(nextContext) ?? undefined;
+          return fn.call(thisArg, ...args);
+        });
+
+      try {
+        otelIntegration.onStart!(makeOnStartEvent());
+        otelIntegration.onStepStart!(makeStepStartEvent());
+
+        await expect(
+          otelIntegration.executeLanguageModelCall!({
+            callId,
+            execute: async () => 'result',
+          }),
+        ).resolves.toBe('result');
+
+        const activeSpanRecord = tracer.spans.find(span => span === activeSpan);
+        expect(activeSpanRecord?.name).toBe('ai.generateText.doGenerate');
+      } finally {
+        contextWithSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -174,6 +174,26 @@ export class LegacyOpenTelemetry implements Telemetry {
     return context.with(toolSpanEntry.context, execute);
   }
 
+  /**
+   * Runs the provider `doGenerate`/`doStream` call with the active legacy
+   * model-call context.
+   */
+  executeLanguageModelCall<T>({
+    callId,
+    execute,
+  }: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }): PromiseLike<T> {
+    const stepContext = this.getCallState(callId)?.stepContext;
+
+    if (stepContext == null) {
+      return execute();
+    }
+
+    return context.with(stepContext, execute);
+  }
+
   onStart(
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-  SpanStatusCode,
+  context,
+  trace,
   type Attributes,
   type Span,
   type SpanOptions,
@@ -557,6 +558,38 @@ describe('OpenTelemetry', () => {
           ],
         }
       `);
+    });
+  });
+
+  describe('executeLanguageModelCall', () => {
+    it('runs the model call inside the active chat span context', async () => {
+      let activeSpan: Span | undefined;
+      const contextWithSpy = vi
+        .spyOn(context, 'with')
+        .mockImplementation((nextContext, fn, thisArg, ...args) => {
+          activeSpan = trace.getSpan(nextContext) ?? undefined;
+          return fn.call(thisArg, ...args);
+        });
+
+      try {
+        integration.onStart!(makeOnStartEvent());
+        integration.onStepStart!(makeStepStartEvent());
+        integration.onLanguageModelCallStart!(
+          makeLanguageModelCallStartEvent(),
+        );
+
+        await expect(
+          integration.executeLanguageModelCall!({
+            callId,
+            execute: async () => 'result',
+          }),
+        ).resolves.toBe('result');
+
+        const activeSpanRecord = tracer.spans.find(span => span === activeSpan);
+        expect(activeSpanRecord?.name).toBe('chat gpt-4');
+      } finally {
+        contextWithSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -156,6 +156,27 @@ export class OpenTelemetry implements Telemetry {
     return context.with(toolSpanEntry.context, execute);
   }
 
+  /**
+   * Runs the provider `doGenerate`/`doStream` call with the active model-call
+   * context.
+   */
+  executeLanguageModelCall<T>({
+    callId,
+    execute,
+  }: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }): PromiseLike<T> {
+    const state = this.getCallState(callId);
+    const modelCallContext = state?.inferenceContext ?? state?.stepContext;
+
+    if (modelCallContext == null) {
+      return execute();
+    }
+
+    return context.with(modelCallContext, execute);
+  }
+
   onStart(
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>


### PR DESCRIPTION
## Background

continuing from https://github.com/vercel/ai/pull/14732

There seems to be a regression with telemetry spans from v6 -> v7 where the AI Gateway stream fetch request spans seem to be disconnected from the AI SDK traces.

For v6, those requests were visibly child spans. In v7, the AI Gateway requests are not child spans.

The reason seems to be that in v6, we used to wrap the entire doStream model call with OpenTelemetry context and so all subsequent calls/requests were nested properly

## Summary

introduce another helper execute composite (similar to what we do for tool execution `executeTools`) that will help wrap the language model calls for generate text and stream text

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

monitor issues for any regressions