### PR TITLE
fix(mcp): singleflight HTTP OAuth refresh

### DIFF
--- a/.changeset/mcp-http-oauth-singleflight.md
+++ b/.changeset/mcp-http-oauth-singleflight.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Avoid duplicate Streamable HTTP OAuth refreshes during concurrent 401 recovery.

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpMCPTransport } from './mcp-http-transport';
 import { LATEST_PROTOCOL_VERSION } from './types';
 import { MCPClientError } from '../error/mcp-client-error';
+import type { OAuthClientProvider } from './oauth';
 
 describe('HttpMCPTransport', () => {
   const server = createTestServer({
@@ -49,8 +50,8 @@ describe('HttpMCPTransport', () => {
     const received = await messagePromise;
     expect(received).toEqual({ jsonrpc: '2.0', id: 1, result: { ok: true } });
 
-    expect(server.calls[1].requestMethod).toBe('POST');
-    expect(server.calls[1].requestHeaders).toEqual({
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestHeaders).toEqual({
       'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
       accept: 'application/json, text/event-stream',
       'content-type': 'application/json',
@@ -61,14 +62,9 @@ describe('HttpMCPTransport', () => {
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/stream' });
     const controller = new TestResponseController();
 
-    // Avoid locking a single ReadableStream for both GET (start) and POST (send)
-    // GET from start -> 405 (no inbound SSE)
-    // POST send -> controlled stream with text/event-stream
     server.urls['http://localhost:4000/stream'].response = ({ callNumber }) => {
       switch (callNumber) {
         case 0:
-          return { type: 'error', status: 405 };
-        case 1:
           return {
             type: 'controlled-stream',
             controller,
@@ -107,16 +103,13 @@ describe('HttpMCPTransport', () => {
   it('should (re)open inbound SSE after 202 Accepted', async () => {
     const controller = new TestResponseController();
 
-    // Call 0 (GET from start): 405 -> no inbound SSE
-    // Call 1 (POST send): 202 -> should trigger inbound SSE open
-    // Call 2 (GET after 202): controlled stream opens successfully
+    // Call 0 (POST send): 202 -> should trigger inbound SSE open
+    // Call 1 (GET after 202): controlled stream opens successfully
     server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
       switch (callNumber) {
         case 0:
-          return { type: 'error', status: 405 };
-        case 1:
           return { type: 'empty', status: 202 };
-        case 2:
+        case 1:
           return { type: 'controlled-stream', controller };
         default:
           return { type: 'empty', status: 200 };
@@ -135,27 +128,314 @@ describe('HttpMCPTransport', () => {
 
     // openInboundSse() is fire-and-forget, so wait for the GET request to appear
     await vi.waitFor(() => {
-      expect(server.calls[2]).toBeDefined();
+      expect(server.calls[1]).toBeDefined();
     });
 
-    expect(server.calls[2].requestMethod).toBe('GET');
-    expect(server.calls[2].requestHeaders.accept).toBe('text/event-stream');
+    expect(server.calls[1].requestMethod).toBe('GET');
+    expect(server.calls[1].requestHeaders.accept).toBe('text/event-stream');
+  });
+
+  it('should defer inbound SSE until after initialize provides a session', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return {
+            type: 'json-value',
+            headers: { 'mcp-session-id': 'initialized-session' },
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+        case 1:
+          return { type: 'controlled-stream', controller };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(server.calls).toHaveLength(0);
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(server.calls[1]?.requestMethod).toBe('GET');
+    });
+
+    expect(server.calls[1].requestHeaders['mcp-session-id']).toBe(
+      'initialized-session',
+    );
+  });
+
+  it('should cache unsupported inbound SSE until an explicit retry transition', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+        case 1:
+          return { type: 'error', status: 405 };
+        case 2:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 2, result: { ok: true } },
+          };
+        case 3:
+          return { type: 'empty', status: 202 };
+        case 4:
+          return { type: 'controlled-stream', controller };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(server.calls[1]?.requestMethod).toBe('GET');
+    });
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'tools/list',
+      id: 2,
+      params: {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(server.calls).toHaveLength(3);
+    expect(server.calls[2].requestMethod).toBe('POST');
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+    });
+
+    await vi.waitFor(() => {
+      expect(server.calls[4]?.requestMethod).toBe('GET');
+    });
+    expect(server.calls[4].requestHeaders.accept).toBe('text/event-stream');
+  });
+
+  it('should honor forced inbound SSE retry requested while a probe is in flight', async () => {
+    let postCalls = 0;
+    let getCalls = 0;
+    let resolveFirstGet!: (response: Response) => void;
+
+    const fetchFn = vi.fn(
+      async (_input: URL | RequestInfo, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          getCalls += 1;
+
+          if (getCalls === 1) {
+            return new Promise<Response>(resolve => {
+              resolveFirstGet = resolve;
+            });
+          }
+
+          return new Response(null, { status: 405 });
+        }
+
+        postCalls += 1;
+
+        if (postCalls === 1) {
+          return Response.json({
+            jsonrpc: '2.0',
+            id: 1,
+            result: { ok: true },
+          });
+        }
+
+        return new Response(null, { status: 202 });
+      },
+    );
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      fetch: fetchFn,
+    });
+
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(getCalls).toBe(1);
+    });
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+    });
+    expect(getCalls).toBe(1);
+
+    resolveFirstGet(new Response(null, { status: 405 }));
+
+    await vi.waitFor(() => {
+      expect(getCalls).toBe(2);
+    });
+  });
+
+  it('should singleflight concurrent OAuth refreshes', async () => {
+    let tokens = {
+      access_token: 'expired-token',
+      refresh_token: 'refresh-token',
+      token_type: 'Bearer',
+    };
+    let tokenRequests = 0;
+
+    const authProvider: OAuthClientProvider = {
+      get redirectUrl() {
+        return 'http://localhost:3000/callback';
+      },
+      get clientMetadata() {
+        return {
+          redirect_uris: ['http://localhost:3000/callback'],
+          client_name: 'Test Client',
+        };
+      },
+      clientInformation: vi.fn().mockResolvedValue({
+        client_id: 'test-client',
+        client_secret: 'test-secret',
+      }),
+      tokens: vi.fn(() => tokens),
+      saveTokens: vi.fn(newTokens => {
+        tokens = newTokens as typeof tokens;
+      }),
+      redirectToAuthorization: vi.fn(),
+      saveCodeVerifier: vi.fn(),
+      codeVerifier: vi.fn(),
+    };
+
+    const fetchFn = vi.fn(
+      async (input: URL | RequestInfo, init?: RequestInit) => {
+        const requestUrl =
+          input instanceof Request ? input.url : input.toString();
+
+        if (requestUrl === 'http://localhost:4000/mcp') {
+          if (init?.method === 'POST') {
+            const authorization = new Headers(init.headers).get(
+              'authorization',
+            );
+            if (authorization === 'Bearer refreshed-token') {
+              const body = JSON.parse(init.body as string);
+              return Response.json({
+                jsonrpc: '2.0',
+                id: body.id,
+                result: { ok: true },
+              });
+            }
+
+            return new Response('Unauthorized', {
+              status: 401,
+              headers: {
+                'www-authenticate':
+                  'Bearer resource_metadata="http://localhost:4000/.well-known/oauth-protected-resource"',
+              },
+            });
+          }
+
+          return new Response(null, { status: 405 });
+        }
+
+        if (
+          requestUrl ===
+          'http://localhost:4000/.well-known/oauth-protected-resource'
+        ) {
+          return Response.json({
+            resource: 'http://localhost:4000/mcp',
+            authorization_servers: ['http://localhost:4000'],
+          });
+        }
+
+        if (
+          requestUrl ===
+          'http://localhost:4000/.well-known/oauth-authorization-server'
+        ) {
+          return Response.json({
+            issuer: 'http://localhost:4000',
+            authorization_endpoint: 'http://localhost:4000/authorize',
+            token_endpoint: 'http://localhost:4000/token',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          });
+        }
+
+        if (requestUrl === 'http://localhost:4000/token') {
+          tokenRequests += 1;
+          return Response.json({
+            access_token: 'refreshed-token',
+            refresh_token: 'next-refresh-token',
+            token_type: 'Bearer',
+            expires_in: 3600,
+          });
+        }
+
+        throw new Error(`Unexpected fetch call: ${requestUrl}`);
+      },
+    );
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      authProvider,
+      fetch: fetchFn as typeof fetch,
+    });
+
+    await transport.start();
+
+    await Promise.all([
+      transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'tools/list',
+        id: 1,
+        params: {},
+      }),
+      transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'prompts/list',
+        id: 2,
+        params: {},
+      }),
+    ]);
+
+    expect(tokenRequests).toBe(1);
+    expect(authProvider.saveTokens).toHaveBeenCalledTimes(1);
   });
 
   it('should DELETE to terminate session on close when session exists', async () => {
-    // Call 0: GET from start returns 405 (skip SSE)
-    // Call 1: POST returns JSON and sets mcp-session-id header
+    // Call 0: POST returns JSON and sets mcp-session-id header
+    // Call 1: GET after initialize returns 405 (skip SSE)
     // Call 2: DELETE on close to terminate session
     server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
       switch (callNumber) {
         case 0:
-          return { type: 'error', status: 405 };
-        case 1:
           return {
             type: 'json-value',
             headers: { 'mcp-session-id': 'xyz-session' },
             body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
           };
+        case 1:
+          return { type: 'error', status: 405 };
         case 2:
           return { type: 'empty', status: 200 };
         default:
@@ -171,6 +451,10 @@ describe('HttpMCPTransport', () => {
       params: {},
     });
 
+    await vi.waitFor(() => {
+      expect(server.calls[1]).toBeDefined();
+    });
+
     await transport.close();
 
     expect(server.calls[2].requestMethod).toBe('DELETE');
@@ -182,20 +466,7 @@ describe('HttpMCPTransport', () => {
   it('should report HTTP errors from POST', async () => {
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/mcp' });
 
-    const controller = new TestResponseController();
-    server.urls['http://localhost:4000/mcp'].response = {
-      type: 'controlled-stream',
-      controller,
-      headers: { 'content-type': 'text/event-stream' },
-    };
-
     await transport.start();
-
-    while (
-      !(server.calls.length > 0 && server.calls[0].requestMethod === 'GET')
-    ) {
-      await vi.advanceTimersByTimeAsync(0);
-    }
 
     // Now make POST fail
     server.urls['http://localhost:4000/mcp'].response = {
@@ -224,10 +495,22 @@ describe('HttpMCPTransport', () => {
 
   it('should handle invalid JSON-RPC messages from inbound SSE', async () => {
     const controller = new TestResponseController();
-    server.urls['http://localhost:4000/mcp'].response = {
-      type: 'controlled-stream',
-      controller,
-      headers: { 'content-type': 'text/event-stream' },
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+        case 1:
+          return {
+            type: 'controlled-stream',
+            controller,
+            headers: { 'content-type': 'text/event-stream' },
+          };
+        default:
+          return { type: 'empty', status: 200 };
+      }
     };
 
     const errorPromise = new Promise(resolve => {
@@ -235,6 +518,16 @@ describe('HttpMCPTransport', () => {
     });
 
     await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(server.calls[1]?.requestMethod).toBe('GET');
+    });
 
     controller.write(
       `event: message\ndata: ${JSON.stringify({ foo: 'bar' })}\n\n`,
@@ -249,12 +542,12 @@ describe('HttpMCPTransport', () => {
     server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
       switch (callNumber) {
         case 0:
-          return { type: 'error', status: 405 };
-        case 1:
           return {
             type: 'json-value',
             body: { ok: true },
           };
+        case 1:
+          return { type: 'error', status: 405 };
         default:
           return { type: 'empty', status: 200 };
       }
@@ -273,8 +566,6 @@ describe('HttpMCPTransport', () => {
   });
 
   it('should send custom headers with all requests', async () => {
-    const controller = new TestResponseController();
-
     const customHeaders = {
       authorization: 'Bearer test-token',
       'x-custom-header': 'test-value',
@@ -285,19 +576,16 @@ describe('HttpMCPTransport', () => {
       headers: customHeaders as unknown as Record<string, string>,
     });
 
-    // Avoid reusing the same stream across GET (start) and POST (send)
-    // GET from start -> 405 (no inbound SSE)
-    // POST send -> JSON OK
     server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
       switch (callNumber) {
         case 0:
-          return { type: 'error', status: 405 };
-        case 1:
           return {
             type: 'json-value',
             body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
             headers: { 'content-type': 'application/json' },
           };
+        case 1:
+          return { type: 'error', status: 405 };
         default:
           return { type: 'empty', status: 200 };
       }
@@ -314,17 +602,21 @@ describe('HttpMCPTransport', () => {
 
     await transport.send(message);
 
+    await vi.waitFor(() => {
+      expect(server.calls[1]).toBeDefined();
+    });
+
     expect(server.calls[0].requestHeaders).toEqual({
+      'content-type': 'application/json',
       'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
-      accept: 'text/event-stream',
+      accept: 'application/json, text/event-stream',
       ...customHeaders,
     });
     expect(server.calls[0].requestUserAgent).toContain('ai-sdk/');
 
     expect(server.calls[1].requestHeaders).toEqual({
-      'content-type': 'application/json',
       'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
-      accept: 'application/json, text/event-stream',
+      accept: 'text/event-stream',
       ...customHeaders,
     });
     expect(server.calls[1].requestUserAgent).toContain('ai-sdk/');
@@ -342,12 +634,12 @@ describe('HttpMCPTransport', () => {
       server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
         switch (callNumber) {
           case 0:
-            return { type: 'error', status: 405 };
-          case 1:
             return {
               type: 'json-value',
               body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
             };
+          case 1:
+            return { type: 'error', status: 405 };
           default:
             return { type: 'empty', status: 200 };
         }
@@ -371,7 +663,7 @@ describe('HttpMCPTransport', () => {
       fetchSpy.mockRestore();
     });
 
-    it('should pass redirect: error to GET fetch on start()', async () => {
+    it('should pass redirect: error to GET fetch after successful send()', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
       transport = new HttpMCPTransport({
@@ -379,21 +671,33 @@ describe('HttpMCPTransport', () => {
         redirect: 'error',
       });
 
-      server.urls['http://localhost:4000/mcp'].response = {
-        type: 'error',
-        status: 405,
+      server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+        switch (callNumber) {
+          case 0:
+            return { type: 'empty', status: 202 };
+          case 1:
+            return { type: 'error', status: 405 };
+          default:
+            return { type: 'empty', status: 200 };
+        }
       };
 
       await transport.start();
+      fetchSpy.mockClear();
 
-      await vi.waitFor(() => {
-        expect(fetchSpy).toHaveBeenCalled();
+      await transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'initialize',
+        id: 1,
+        params: {},
       });
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        'http://localhost:4000/mcp',
-        expect.objectContaining({ redirect: 'error', method: 'GET' }),
-      );
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          'http://localhost:4000/mcp',
+          expect.objectContaining({ redirect: 'error', method: 'GET' }),
+        );
+      });
 
       fetchSpy.mockRestore();
     });
@@ -405,28 +709,40 @@ describe('HttpMCPTransport', () => {
         url: 'http://localhost:4000/mcp',
       });
 
-      server.urls['http://localhost:4000/mcp'].response = {
-        type: 'error',
-        status: 405,
+      server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+        switch (callNumber) {
+          case 0:
+            return { type: 'empty', status: 202 };
+          case 1:
+            return { type: 'error', status: 405 };
+          default:
+            return { type: 'empty', status: 200 };
+        }
       };
 
       await transport.start();
+      fetchSpy.mockClear();
 
-      await vi.waitFor(() => {
-        expect(fetchSpy).toHaveBeenCalled();
+      await transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'initialize',
+        id: 1,
+        params: {},
       });
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        'http://localhost:4000/mcp',
-        expect.objectContaining({ redirect: 'error', method: 'GET' }),
-      );
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          'http://localhost:4000/mcp',
+          expect.objectContaining({ redirect: 'error', method: 'GET' }),
+        );
+      });
 
       fetchSpy.mockRestore();
     });
   });
 
   describe('custom fetch', () => {
-    it('should use provided fetch function instead of globalThis.fetch', async () => {
+    it('should use provided fetch function for inbound SSE after send()', async () => {
       const customFetch = vi.fn(globalThis.fetch);
 
       transport = new HttpMCPTransport({
@@ -434,21 +750,32 @@ describe('HttpMCPTransport', () => {
         fetch: customFetch,
       });
 
-      server.urls['http://localhost:4000/mcp'].response = {
-        type: 'error',
-        status: 405,
+      server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+        switch (callNumber) {
+          case 0:
+            return { type: 'empty', status: 202 };
+          case 1:
+            return { type: 'error', status: 405 };
+          default:
+            return { type: 'empty', status: 200 };
+        }
       };
 
       await transport.start();
 
-      await vi.waitFor(() => {
-        expect(customFetch).toHaveBeenCalled();
+      await transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'initialize',
+        id: 1,
+        params: {},
       });
 
-      expect(customFetch).toHaveBeenCalledWith(
-        'http://localhost:4000/mcp',
-        expect.objectContaining({ method: 'GET' }),
-      );
+      await vi.waitFor(() => {
+        expect(customFetch).toHaveBeenCalledWith(
+          'http://localhost:4000/mcp',
+          expect.objectContaining({ method: 'GET' }),
+        );
+      });
     });
 
     it('should use provided fetch function for POST send()', async () => {
@@ -496,7 +823,7 @@ describe('HttpMCPTransport', () => {
 
       await transport.send(message);
 
-      expect(server.calls[1].requestHeaders['mcp-protocol-version']).toBe(
+      expect(server.calls[0].requestHeaders['mcp-protocol-version']).toBe(
         LATEST_PROTOCOL_VERSION,
       );
     });

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -16,9 +16,19 @@ import {
   extractResourceMetadataUrl,
   UnauthorizedError,
   auth,
+  type AuthResult,
   type OAuthClientProvider,
 } from './oauth';
 import { LATEST_PROTOCOL_VERSION } from './types';
+
+const authorizationPromises = new WeakMap<
+  OAuthClientProvider,
+  Map<string, Promise<AuthResult>>
+>();
+
+function authorizationKey(serverUrl: URL, resourceMetadataUrl?: URL): string {
+  return resourceMetadataUrl?.href ?? serverUrl.href;
+}
 
 /**
  * HTTP MCP transport implementing the Streamable HTTP style.
@@ -35,6 +45,9 @@ export class HttpMCPTransport implements MCPTransport {
   private resourceMetadataUrl?: URL;
   private sessionId?: string;
   private inboundSseConnection?: { close: () => void };
+  private inboundSsePromise?: Promise<void>;
+  private inboundSseUnavailable = false;
+  private inboundSseForcedRetryPending = false;
   private redirectMode: RequestRedirect;
   private fetchFn: FetchFunction;
 
@@ -107,13 +120,19 @@ export class HttpMCPTransport implements MCPTransport {
           'MCP HTTP Transport Error: Transport already started. Note: client.connect() calls start() automatically.',
       });
     }
+    this.inboundSseConnection = undefined;
+    this.inboundSsePromise = undefined;
+    this.inboundSseUnavailable = false;
+    this.inboundSseForcedRetryPending = false;
+    this.lastInboundEventId = undefined;
+    this.inboundReconnectAttempts = 0;
     this.abortController = new AbortController();
-
-    void this.openInboundSse();
   }
 
   async close(): Promise<void> {
     this.inboundSseConnection?.close();
+    this.inboundSseConnection = undefined;
+    this.inboundSseForcedRetryPending = false;
     try {
       if (
         this.sessionId &&
@@ -158,13 +177,10 @@ export class HttpMCPTransport implements MCPTransport {
         }
 
         if (response.status === 401 && this.authProvider && !triedAuth) {
-          this.resourceMetadataUrl = extractResourceMetadataUrl(response);
+          const resourceMetadataUrl = extractResourceMetadataUrl(response);
+          this.resourceMetadataUrl = resourceMetadataUrl;
           try {
-            const result = await auth(this.authProvider, {
-              serverUrl: this.url,
-              resourceMetadataUrl: this.resourceMetadataUrl,
-              fetchFn: this.fetchFn,
-            });
+            const result = await this.authorize(resourceMetadataUrl);
             if (result !== 'AUTHORIZED') {
               const error = new UnauthorizedError();
               throw error;
@@ -181,7 +197,7 @@ export class HttpMCPTransport implements MCPTransport {
           // If inbound SSE was not available earlier (e.g. 405 before init), try again now
           // Do not await to avoid blocking send()
           if (!this.inboundSseConnection) {
-            void this.openInboundSse();
+            this.openInboundSseIfNeeded({ force: true });
           }
           return;
         }
@@ -207,6 +223,7 @@ export class HttpMCPTransport implements MCPTransport {
         // Some servers return 200 with acknowledgment JSON instead of 202
         const isNotification = !('id' in message);
         if (isNotification) {
+          this.openInboundSseIfNeeded();
           return;
         }
 
@@ -217,6 +234,7 @@ export class HttpMCPTransport implements MCPTransport {
             ? data.map((m: unknown) => JSONRPCMessageSchema.parse(m))
             : [JSONRPCMessageSchema.parse(data)];
           for (const m of messages) this.onmessage?.(m);
+          this.openInboundSseIfNeeded();
           return;
         }
 
@@ -264,6 +282,7 @@ export class HttpMCPTransport implements MCPTransport {
           };
 
           processEvents();
+          this.openInboundSseIfNeeded();
           return;
         }
 
@@ -312,6 +331,67 @@ export class HttpMCPTransport implements MCPTransport {
     }, delay);
   }
 
+  private async authorize(resourceMetadataUrl?: URL): Promise<AuthResult> {
+    const authProvider = this.authProvider;
+    if (!authProvider) {
+      return 'REDIRECT';
+    }
+
+    const key = authorizationKey(this.url, resourceMetadataUrl);
+    let providerPromises = authorizationPromises.get(authProvider);
+    if (!providerPromises) {
+      providerPromises = new Map();
+      authorizationPromises.set(authProvider, providerPromises);
+    }
+
+    let authorizationPromise = providerPromises.get(key);
+    if (!authorizationPromise) {
+      authorizationPromise = auth(authProvider, {
+        serverUrl: this.url,
+        resourceMetadataUrl,
+        fetchFn: this.fetchFn,
+      }).finally(() => {
+        providerPromises.delete(key);
+        if (providerPromises.size === 0) {
+          authorizationPromises.delete(authProvider);
+        }
+      });
+      providerPromises.set(key, authorizationPromise);
+    }
+
+    return authorizationPromise;
+  }
+
+  private openInboundSseIfNeeded({ force = false } = {}): void {
+    if (force) {
+      this.inboundSseUnavailable = false;
+    } else if (this.inboundSseUnavailable) {
+      return;
+    }
+
+    if (this.inboundSseConnection) {
+      return;
+    }
+
+    if (this.inboundSsePromise) {
+      if (force) {
+        this.inboundSseForcedRetryPending = true;
+      }
+      return;
+    }
+
+    this.inboundSsePromise = this.openInboundSse().finally(() => {
+      this.inboundSsePromise = undefined;
+      const shouldRetry =
+        this.inboundSseForcedRetryPending && !this.inboundSseConnection;
+      this.inboundSseForcedRetryPending = false;
+      if (shouldRetry) {
+        this.openInboundSseIfNeeded({ force: true });
+      }
+    });
+    void this.inboundSsePromise;
+  }
+
   // Open optional inbound SSE stream; best-effort and resumable
   private async openInboundSse(
     triedAuth: boolean = false,
@@ -338,13 +418,10 @@ export class HttpMCPTransport implements MCPTransport {
       }
 
       if (response.status === 401 && this.authProvider && !triedAuth) {
-        this.resourceMetadataUrl = extractResourceMetadataUrl(response);
+        const resourceMetadataUrl = extractResourceMetadataUrl(response);
+        this.resourceMetadataUrl = resourceMetadataUrl;
         try {
-          const result = await auth(this.authProvider, {
-            serverUrl: this.url,
-            resourceMetadataUrl: this.resourceMetadataUrl,
-            fetchFn: this.fetchFn,
-          });
+          const result = await this.authorize(resourceMetadataUrl);
           if (result !== 'AUTHORIZED') {
             const error = new UnauthorizedError();
             this.onerror?.(error);
@@ -358,6 +435,7 @@ export class HttpMCPTransport implements MCPTransport {
       }
 
       if (response.status === 405) {
+        this.inboundSseUnavailable = true;
         return;
       }
 
@@ -416,6 +494,7 @@ export class HttpMCPTransport implements MCPTransport {
       this.inboundSseConnection = {
         close: () => reader.cancel(),
       };
+      this.inboundSseUnavailable = false;
       this.inboundReconnectAttempts = 0;
       processEvents();
     } catch (error) {


### PR DESCRIPTION
## Summary
- defer optional Streamable HTTP inbound SSE until after the first successful POST so startup GETs can include negotiated session headers
- singleflight OAuth recovery per auth provider and resource metadata URL so concurrent 401s share one refresh
- remember 405 unsupported inbound SSE and only retry on explicit 202 transitions

Fixes #15465.

## Testing
- `pnpm --filter @ai-sdk/mcp... build`
- `pnpm --filter @ai-sdk/mcp build`
- `pnpm --filter @ai-sdk/mcp exec vitest --config vitest.node.config.js --run src/tool/mcp-http-transport.test.ts`
- `pnpm --filter @ai-sdk/mcp type-check`
- `pnpm exec ultracite check packages/mcp/src/tool/mcp-http-transport.ts packages/mcp/src/tool/mcp-http-transport.test.ts`
- `pnpm --filter @ai-sdk/mcp test`
- `git diff --check`