### PR TITLE
fix(ai): make input optional on input-streaming UIMessagePart variants

### DIFF
--- a/.changeset/sharp-weeks-wonder.md
+++ b/.changeset/sharp-weeks-wonder.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): make input optional on input-streaming UIMessagePart variants

--- a/packages/ai/src/ui/ui-messages.test-d.ts
+++ b/packages/ai/src/ui/ui-messages.test-d.ts
@@ -1,0 +1,54 @@
+import { describe, it } from 'vitest';
+import type { DynamicToolUIPart, ToolUIPart } from './ui-messages';
+
+type TestTools = {
+  weather: {
+    input: {
+      city: string;
+      units?: 'celsius' | 'fahrenheit';
+    };
+    output: string;
+  };
+};
+
+type AssertAssignable<Target, Source extends Target> = Source;
+
+describe('UIMessagePart', () => {
+  it('allows dynamic input-streaming tool parts with optional input', () => {
+    type Part = {
+      type: 'dynamic-tool';
+      state: 'input-streaming';
+      toolCallId: string;
+      toolName: string;
+      input?: unknown;
+      providerExecuted?: boolean;
+    };
+
+    type _ = AssertAssignable<DynamicToolUIPart, Part>;
+  });
+
+  it('allows static input-streaming tool parts with optional input', () => {
+    type Part = {
+      type: 'tool-weather';
+      state: 'input-streaming';
+      toolCallId: string;
+      input?: {
+        city?: string;
+      };
+      providerExecuted?: boolean;
+    };
+
+    type _ = AssertAssignable<ToolUIPart<TestTools>, Part>;
+  });
+
+  it('allows static input-streaming tool parts with explicit undefined input', () => {
+    type Part = {
+      type: 'tool-weather';
+      state: 'input-streaming';
+      toolCallId: 'call-1';
+      input: undefined;
+    };
+
+    type _ = AssertAssignable<ToolUIPart<TestTools>, Part>;
+  });
+});

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -291,7 +291,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
 } & (
   | {
       state: 'input-streaming';
-      input: DeepPartial<asUITool<TOOL>['input']> | undefined;
+      input?: DeepPartial<asUITool<TOOL>['input']> | undefined;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
@@ -404,7 +404,7 @@ export type DynamicToolUIPart = {
 } & (
   | {
       state: 'input-streaming';
-      input: unknown | undefined;
+      input?: unknown;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/14703

when the tsconfig property `exactOptionalPropertyTypes: true` is set,  a `UIMessage` cannot be assigned from a structurally equivalent value if the input field on an `input-streaming` tool part is declared as optional.

the types require the input key to exist. But the validator [already allows](https://github.com/vercel/ai/blob/main/packages/ai/src/ui/validate-ui-messages.ts#L96) it to be absent

## Summary

continued from https://github.com/vercel/ai/pull/14990 + added a focused test

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14703 

Co-authored-by:  Mmartinrusso <maartinrusso@gmail.com>