### PR TITLE
fix(google): read serviceTier from usageMetadata in stream + generate

### DIFF
--- a/.changeset/google-stream-service-tier-usage-metadata.md
+++ b/.changeset/google-stream-service-tier-usage-metadata.md
@@ -1,0 +1,11 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): read `serviceTier` from `usageMetadata.serviceTier` in both generate and stream paths
+
+The previous implementation read `serviceTier` from the `x-gemini-service-tier`
+response header, which is only populated on non-streaming responses. Gemini
+streaming includes the value in `usageMetadata.serviceTier` on every chunk, so
+`providerMetadata.google.serviceTier` was always `null` for streams. Read from
+`usageMetadata` for both paths instead.

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -245,10 +245,7 @@ The following optional provider options are available for Google models:
 
   Because Priority can be gracefully downgraded to Standard under load, the
   tier the request actually ran on is surfaced on
-  `result.providerMetadata.google.serviceTier` (read from the
-  `x-gemini-service-tier` response header). On `streamText` this value is
-  currently always `null`: Google's `streamGenerateContent` endpoint does
-  not return the header. See
+  `result.providerMetadata.google.serviceTier`. See
   [Priority inference](https://ai.google.dev/gemini-api/docs/priority-inference)
   and [Flex inference](https://ai.google.dev/gemini-api/docs/flex-inference).
 

--- a/packages/google/src/convert-google-usage.ts
+++ b/packages/google/src/convert-google-usage.ts
@@ -12,6 +12,7 @@ export type GoogleUsageMetadata = {
   cachedContentTokenCount?: number | null;
   thoughtsTokenCount?: number | null;
   trafficType?: string | null;
+  serviceTier?: string | null;
   promptTokensDetails?: GoogleTokenDetail[] | null;
   candidatesTokensDetails?: GoogleTokenDetail[] | null;
 };

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -716,11 +716,27 @@ describe('doGenerate', () => {
     );
   });
 
-  it('should read serviceTier from x-gemini-service-tier response header', async () => {
-    prepareJsonResponse({
-      content: 'test response',
-      headers: { 'x-gemini-service-tier': 'priority' },
-    });
+  it('should read serviceTier from usageMetadata.serviceTier', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Blue.' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        promptFeedback: { safetyRatings: SAFETY_RATINGS },
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 2,
+          totalTokenCount: 3,
+          serviceTier: 'priority',
+        },
+      },
+    };
 
     const { providerMetadata } = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4772,11 +4788,29 @@ describe('doStream', () => {
     ).toBeNull();
   });
 
-  it('should read serviceTier from x-gemini-service-tier response header', async () => {
-    prepareStreamResponse({
-      content: ['test'],
-      headers: { 'x-gemini-service-tier': 'priority' },
-    });
+  it('should read serviceTier from chunk usageMetadata', async () => {
+    // Gemini streaming does not set the x-gemini-service-tier response header
+    // but does include serviceTier in each chunk's usageMetadata.
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: 'Blue' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 1,
+            totalTokenCount: 11,
+            serviceTier: 'priority',
+          },
+        })}\n\n`,
+      ],
+    };
 
     const { stream } = await model.doStream({
       prompt: TEST_PROMPT,

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -518,10 +518,6 @@ export class GoogleLanguageModel implements LanguageModelV4 {
         safetyRatings: candidate.safetyRatings ?? null,
         usageMetadata: usageMetadata ?? null,
         finishMessage: candidate.finishMessage ?? null,
-        // Gemini API also exposes this via the `x-gemini-service-tier`
-        // response header on non-streaming responses, but the body field is
-        // present in both streaming and non-streaming so we read it from
-        // there for consistency with the streaming path.
         serviceTier: usageMetadata?.serviceTier ?? null,
       } satisfies GoogleProviderMetadata),
       request: { body: args },
@@ -1466,10 +1462,6 @@ const usageSchema = z.object({
   totalTokenCount: z.number().nullish(),
   // https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#TrafficType
   trafficType: z.string().nullish(),
-  // Gemini API returns the applied service tier here in both streaming chunks
-  // and non-streaming responses. The `x-gemini-service-tier` header carries
-  // the same value but is only set on non-streaming responses, so for streams
-  // this field is the only available signal.
   serviceTier: z.string().nullish(),
   // https://ai.google.dev/api/generate-content#Modality
   promptTokensDetails: tokenDetailsSchema,

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -518,7 +518,11 @@ export class GoogleLanguageModel implements LanguageModelV4 {
         safetyRatings: candidate.safetyRatings ?? null,
         usageMetadata: usageMetadata ?? null,
         finishMessage: candidate.finishMessage ?? null,
-        serviceTier: responseHeaders?.['x-gemini-service-tier'] ?? null,
+        // Gemini API also exposes this via the `x-gemini-service-tier`
+        // response header on non-streaming responses, but the body field is
+        // present in both streaming and non-streaming so we read it from
+        // there for consistency with the streaming path.
+        serviceTier: usageMetadata?.serviceTier ?? null,
       } satisfies GoogleProviderMetadata),
       request: { body: args },
       response: {
@@ -565,8 +569,6 @@ export class GoogleLanguageModel implements LanguageModelV4 {
     let providerMetadata: SharedV4ProviderMetadata | undefined = undefined;
     let lastGroundingMetadata: GroundingMetadataSchema | null = null;
     let lastUrlContextMetadata: UrlContextMetadataSchema | null = null;
-    const serviceTier: string | null =
-      responseHeaders?.['x-gemini-service-tier'] ?? null;
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;
@@ -1051,7 +1053,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                 safetyRatings: candidate.safetyRatings ?? null,
                 usageMetadata: usageMetadata ?? null,
                 finishMessage: candidate.finishMessage ?? null,
-                serviceTier,
+                serviceTier: usage?.serviceTier ?? null,
               } satisfies GoogleProviderMetadata);
             }
           },
@@ -1464,6 +1466,11 @@ const usageSchema = z.object({
   totalTokenCount: z.number().nullish(),
   // https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#TrafficType
   trafficType: z.string().nullish(),
+  // Gemini API returns the applied service tier here in both streaming chunks
+  // and non-streaming responses. The `x-gemini-service-tier` header carries
+  // the same value but is only set on non-streaming responses, so for streams
+  // this field is the only available signal.
+  serviceTier: z.string().nullish(),
   // https://ai.google.dev/api/generate-content#Modality
   promptTokensDetails: tokenDetailsSchema,
   candidatesTokensDetails: tokenDetailsSchema,


### PR DESCRIPTION
## Summary

- The Gemini API returns the applied service tier in two places: the `x-gemini-service-tier` response header (non-streaming only) and `usageMetadata.serviceTier` in the response body (both streaming and non-streaming).
- The previous implementation only read the header, so `providerMetadata.google.serviceTier` was always `null` on `streamText`.
- Read `usageMetadata.serviceTier` from the body for both `doGenerate` and `doStream`. Single source of truth, no header involvement, matches the pattern Vertex already uses (`usageMetadata.trafficType`).
- Docs updated to drop the implementation detail about where the value comes from.

## Test plan

- [x] `pnpm test` in `packages/google` — 583 tests pass (node + edge), incl. two new tests asserting `serviceTier` is populated from `usageMetadata` in both generate and stream paths.
- [x] `pnpm type-check:full` — clean.
- [x] Verified live against the Gemini API:
  - `pnpm tsx src/generate-text/google/service-tier.ts` → `serviceTier: priority` (still works after dropping header read)
  - `pnpm tsx src/stream-text/google/service-tier.ts` → `serviceTier: priority` (previously `null`)
- [x] Verified Vertex examples unaffected:
  - `pnpm tsx src/generate-text/google/vertex-service-tier.ts` → `trafficType: ON_DEMAND_PRIORITY`
  - `pnpm tsx src/stream-text/google/vertex-service-tier.ts` → `trafficType: ON_DEMAND_PRIORITY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)