### PR TITLE
fix(provider/openai): skip duplicate items when previousResponseId is set in Responses API

### DIFF
--- a/.changeset/openai-responses-skip-dup-items-previous-response-id.md
+++ b/.changeset/openai-responses-skip-dup-items-previous-response-id.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): skip duplicate items when `previousResponseId` is set in Responses API
+
+When using the Responses API with `providerOptions.openai.previousResponseId` and `store: true`, prior assistant items were emitted as `item_reference`s in `input` while ALSO being present in the chain via `previous_response_id`. OpenAI rejects this with `400 Duplicate item found with id rs_...`.
+
+The dedup already existed for `conversation` (`hasConversation` flag); this PR adds the equivalent `hasPreviousResponseId` flag and applies it to the same five skip sites (assistant text, tool call, tool result, reasoning, compaction). Behavior is unchanged when neither `conversation` nor `previousResponseId` is set, and unchanged for `conversation` users.
+
+Reported pattern: multi-step tool loops using `streamText` with `previousResponseId` advanced per step via `prepareStep`/`onStepFinish` (the documented way to preserve reasoning state across reasoning-model tool calls).

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -4549,6 +4549,216 @@ describe('convertToOpenAIResponsesInput', () => {
     });
   });
 
+  describe('hasPreviousResponseId', () => {
+    // Mirrors `hasConversation`. When the assistant items are already on the
+    // server side (chained via `previous_response_id`), re-sending them as
+    // `item_reference`s in `input` produces "Duplicate item found" 400s.
+
+    it('should skip assistant text messages with item IDs when hasPreviousResponseId is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'Hi there!',
+                providerOptions: { openai: { itemId: 'msg_existing_123' } },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the weather?' }],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "What is the weather?",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
+    it('should skip assistant tool-call messages with item IDs when hasPreviousResponseId is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the weather?' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_123',
+                toolName: 'getWeather',
+                input: { location: 'San Francisco' },
+                providerOptions: {
+                  openai: { itemId: 'fc_existing_456' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'getWeather',
+                output: { type: 'json', value: { temp: 72 } },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      // Tool-call assistant message is skipped (already in chain); only the
+      // tool result is sent. OpenAI matches the result to the function call
+      // in the chain by call_id.
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "What is the weather?",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "call_id": "call_123",
+            "output": "{"temp":72}",
+            "type": "function_call_output",
+          },
+        ]
+      `);
+    });
+
+    it('should skip reasoning parts with item IDs when hasPreviousResponseId is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Solve this' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'reasoning',
+                text: '',
+                providerOptions: {
+                  openai: { itemId: 'rs_existing_789' },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Solve this",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
+    it('should skip compaction when hasPreviousResponseId is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'custom',
+                kind: 'openai.compaction',
+                providerOptions: {
+                  openai: {
+                    type: 'compaction',
+                    itemId: 'cmp_789',
+                    encryptedContent: 'encrypted_data',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+  });
+
   describe('compaction', () => {
     it('should convert compaction to item_reference when store is true', async () => {
       const result = await convertToOpenAIResponsesInput({

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -61,6 +61,7 @@ export async function convertToOpenAIResponsesInput({
   passThroughUnsupportedFiles = false,
   store,
   hasConversation = false,
+  hasPreviousResponseId = false,
   hasLocalShellTool = false,
   hasShellTool = false,
   hasApplyPatchTool = false,
@@ -75,6 +76,7 @@ export async function convertToOpenAIResponsesInput({
   passThroughUnsupportedFiles?: boolean;
   store: boolean;
   hasConversation?: boolean; // when true, skip assistant messages that already have item IDs
+  hasPreviousResponseId?: boolean; // when true, skip assistant messages that already have item IDs (chained via previous_response_id)
   hasLocalShellTool?: boolean;
   hasShellTool?: boolean;
   hasApplyPatchTool?: boolean;
@@ -228,8 +230,10 @@ export async function convertToOpenAIResponsesInput({
                 | null
                 | undefined;
 
-              // when using conversation, skip items that already exist in the conversation context to avoid "Duplicate item found" errors
-              if (hasConversation && id != null) {
+              // when the assistant items are already in OpenAI's server-side context
+              // (via conversation or previous_response_id), skip them to avoid
+              // "Duplicate item found" errors
+              if ((hasConversation || hasPreviousResponseId) && id != null) {
                 break;
               }
 
@@ -260,7 +264,7 @@ export async function convertToOpenAIResponsesInput({
                 | string
                 | undefined;
 
-              if (hasConversation && id != null) {
+              if ((hasConversation || hasPreviousResponseId) && id != null) {
                 break;
               }
 
@@ -409,7 +413,7 @@ export async function convertToOpenAIResponsesInput({
                 break;
               }
 
-              if (hasConversation) {
+              if (hasConversation || hasPreviousResponseId) {
                 break;
               }
 
@@ -505,7 +509,10 @@ export async function convertToOpenAIResponsesInput({
 
               const reasoningId = providerOptions?.itemId;
 
-              if (hasConversation && reasoningId != null) {
+              if (
+                (hasConversation || hasPreviousResponseId) &&
+                reasoningId != null
+              ) {
                 break;
               }
 
@@ -603,7 +610,7 @@ export async function convertToOpenAIResponsesInput({
                   part.providerOptions?.[providerOptionsName];
                 const id = providerOpts?.itemId as string | undefined;
 
-                if (hasConversation && id != null) {
+                if ((hasConversation || hasPreviousResponseId) && id != null) {
                   break;
                 }
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -253,6 +253,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
           openaiOptions?.passThroughUnsupportedFiles ?? false,
         store: openaiOptions?.store ?? true,
         hasConversation: openaiOptions?.conversation != null,
+        hasPreviousResponseId: openaiOptions?.previousResponseId != null,
         hasLocalShellTool: hasOpenAITool('openai.local_shell'),
         hasShellTool: hasOpenAITool('openai.shell'),
         hasApplyPatchTool: hasOpenAITool('openai.apply_patch'),


### PR DESCRIPTION
## Background

When using the Responses API with `providerOptions.openai.previousResponseId` and `store: true`, the converter emits prior assistant items as `item_reference`s in `input` while those same items are already present in the server-side chain via `previous_response_id`. OpenAI rejects this with:

```
Error [AI_APICallError]: Duplicate item found with id rs_0c44cfe6e9bf2d84006a0e434c5a70819bb8b57fbf1d10c2df.
Remove duplicate items from your input and try again.
url: https://api.openai.com/v1/responses
statusCode: 400
```

## How to reproduce

A reasoning model (`gpt-5` / `gpt-5.1` / etc.) using `streamText` with tools and `previousResponseId` advanced per step via `prepareStep` / `onStepFinish` — the documented pattern for preserving reasoning state across reasoning-model tool calls. See the [OpenAI cookbook](https://cookbook.openai.com/examples/responses_api/reasoning_items):

> If you use `previous_response_id` for multi-turn conversations, the model will automatically have access to all previously produced reasoning items.

Today, doing this with the AI SDK fails because the converter doesn't realize the assistant items are already on the server side.

## Fix

The same dedup already exists for the Conversations API via `hasConversation` (added in commit `000fa96` / PR #11899). This change introduces the symmetric `hasPreviousResponseId` flag and applies it to the same five skip sites:

1. assistant text parts with itemId
2. assistant tool-call parts with itemId
3. assistant tool-result parts (provider-executed tools)
4. assistant reasoning parts with itemId
5. assistant compaction parts with itemId

At the call site in `openai-responses-language-model.ts`:

```ts
hasConversation: openaiOptions?.conversation != null,
hasPreviousResponseId: openaiOptions?.previousResponseId != null,
```

The five existing skip conditions become `if ((hasConversation || hasPreviousResponseId) && id != null)` (or the equivalent for the unconditional tool-result skip).

## Compatibility

- Behavior is **unchanged** when neither `conversation` nor `previousResponseId` is set.
- Behavior is **unchanged** for existing `conversation` users.
- For `previousResponseId` users with `store: true`, this is the fix — they would previously have hit `Duplicate item found` 400s as soon as any chained assistant item had an itemId.

## Tests

4 new tests in `packages/openai/src/responses/convert-to-openai-responses-input.test.ts` mirror the existing `hasConversation` coverage (text, tool-call, reasoning, compaction). All **714 existing tests** in `@ai-sdk/openai` continue to pass on both node and edge environments.

## Changeset

`.changeset/openai-responses-skip-dup-items-previous-response-id.md` — `@ai-sdk/openai: patch`.

## Related

- Original `hasConversation` fix: commit `000fa96`, PR #11899
- OpenAI cookbook on reasoning items + tools: <https://cookbook.openai.com/examples/responses_api/reasoning_items>
- OpenAI conversation-state guide: <https://platform.openai.com/docs/guides/conversation-state>

Made with [Cursor](https://cursor.com)