### PR TITLE
fix(ai): reject streamText result promises when stream is cancelled mid-body

### DIFF
--- a/.changeset/streamtext-reject-on-midstream-cancel.md
+++ b/.changeset/streamtext-reject-on-midstream-cancel.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): reject `streamText` result promises when the stream is cancelled mid-body
+
+When the underlying fetch body stream is cancelled mid-flight (e.g. a custom `fetch` combines its own `AbortSignal.timeout` via `AbortSignal.any`, or any error surfaces after response headers arrive but before a `finish` chunk), `streamText`/`ToolLoopAgent.stream()` would hang forever: `result.text`, `result.steps`, and the other awaited result promises never settled because the event processor's `flush` only runs on a graceful close. The stream error is now propagated to the still-pending result promises so they reject instead of hanging.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2363,6 +2363,55 @@ describe('streamText', () => {
         'No output generated. Check the stream for errors.',
       );
     });
+
+    it(
+      'should reject text and steps promises (instead of hanging) when the ' +
+        'stream errors mid-body without an abort signal',
+      async () => {
+        // Simulates the fetch body stream being cancelled mid-flight by a
+        // signal the SDK does not control (e.g. a custom fetch combining its
+        // own AbortSignal.timeout via AbortSignal.any): the model stream errors
+        // after headers/first chunks arrive but before a `finish` chunk, and
+        // streamText's own abortSignal is never aborted.
+        const result = streamText({
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({ type: 'stream-start', warnings: [] });
+                  controller.enqueue({
+                    type: 'response-metadata',
+                    id: 'id-0',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  });
+                  controller.enqueue({ type: 'text-start', id: '1' });
+                  controller.enqueue({
+                    type: 'text-delta',
+                    id: '1',
+                    delta: 'Hello',
+                  });
+                  controller.error(
+                    new DOMException(
+                      'The operation timed out.',
+                      'TimeoutError',
+                    ),
+                  );
+                },
+              }),
+            }),
+          }),
+          prompt: 'test-input',
+          onError: () => {},
+        });
+
+        await expect(result.text).rejects.toThrow('The operation timed out.');
+        await expect(result.steps).rejects.toThrow('The operation timed out.');
+      },
+      // a generous timeout so a regression (hang) fails fast instead of
+      // running until the default test timeout
+      10_000,
+    );
   });
 
   describe('retries', () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1289,6 +1289,7 @@ class DefaultStreamTextResult<
     this.closeStream = stitchableStream.close;
 
     // resilient stream that handles abort signals and errors:
+    const resultRef = this;
     const reader = stitchableStream.stream.getReader();
     let stream = new ReadableStream<TextStreamPart<TOOLS>>({
       async start(controller) {
@@ -1330,6 +1331,12 @@ class DefaultStreamTextResult<
           if (isAbortError(error) && abortSignal?.aborted) {
             abort();
           } else {
+            // The stream errored (e.g. the fetch body was cancelled mid-flight)
+            // before a `finish` chunk arrived. The downstream event processor's
+            // `flush` only runs on a graceful close, so the result promises
+            // would otherwise hang forever. Reject any still-pending result
+            // promises so that `text`, `steps`, etc. settle with the error.
+            resultRef.rejectPendingResultPromises(error);
             controller.error(error);
           }
         }
@@ -2229,6 +2236,23 @@ class DefaultStreamTextResult<
     const [stream1, stream2] = this.baseStream.tee();
     this.baseStream = stream2;
     return stream1;
+  }
+
+  /**
+   * Rejects the result promises (`steps`, `finishReason`, `totalUsage`, etc.)
+   * with the given error if they are still pending. This is used when the
+   * underlying stream errors before a graceful finish (e.g. the fetch body is
+   * cancelled mid-flight), in which case the event processor's `flush` never
+   * runs and would otherwise leave these promises pending forever.
+   */
+  private rejectPendingResultPromises(error: unknown): void {
+    if (this._finishReason.isPending()) this._finishReason.reject(error);
+    if (this._rawFinishReason.isPending()) this._rawFinishReason.reject(error);
+    if (this._totalUsage.isPending()) this._totalUsage.reject(error);
+    if (this._steps.isPending()) this._steps.reject(error);
+    if (this._initialResponseMessages.isPending()) {
+      this._initialResponseMessages.reject(error);
+    }
   }
 
   get textStream(): AsyncIterableStream<string> {


### PR DESCRIPTION
## Summary

`streamText` / `ToolLoopAgent.stream()` hangs forever when the underlying fetch
body stream is cancelled mid-flight — i.e. an error/cancellation surfaces after
response headers arrive but before a `finish` chunk. In that case `result.text`,
`result.steps`, and the other awaited result promises never settle. This is the
common case for long-running agent runs whose fetch timeout fires while the model
is still streaming (adaptive thinking + many tool calls), and it also reproduces
when a custom `fetch` combines its own `AbortSignal.timeout` via `AbortSignal.any`.

## Root cause

The result promises are resolved/rejected only in the event processor
`TransformStream`'s `flush`, which runs only on a *graceful* close. When the
stream errors before a `finish` chunk (and `streamText`'s own `abortSignal` is
not the one that aborted), the resilient stream calls `controller.error(...)`,
the error propagates downstream, `flush` is skipped, and the result promises are
left pending indefinitely.

## Fix

Propagate the stream error to the still-pending result promises (`steps`,
`finishReason`, `rawFinishReason`, `totalUsage`, and the internal initial
response messages) so they reject instead of hanging. Settled promises are left
untouched (guarded with `isPending()`), so the existing graceful-abort and
normal-finish paths are unchanged.

## Test plan

- [x] Added a regression test that errors the model stream mid-body (no `finish`
      chunk, no SDK-level abort) and asserts `result.text` and `result.steps`
      reject; it carries a short per-test timeout so a regression fails fast
      instead of hanging.
- [x] Confirmed the test times out (hangs) on `main` without the fix and passes
      with it.
- [x] `pnpm test:node` and `pnpm test:edge` for `stream-text.test.ts` (390 each),
      plus the full `generate-text` + `agent` suites (1224), all pass.
- [x] `tsc --build` and lint clean.

Fixes #15430