### PR TITLE
feat(gateway): add serviceTier option to GatewayProviderOptions

### DIFF
--- a/.changeset/gateway-service-tier-option.md
+++ b/.changeset/gateway-service-tier-option.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+Add `serviceTier: 'flex' | 'priority'` to `GatewayProviderOptions`. The
+AI Gateway translates this unified intent into whichever per-provider
+option each provider expects (OpenAI's `serviceTier`, Google's
+`serviceTier`, Vertex's `sharedRequestType`), so callers no longer have
+to know each provider's spelling.

--- a/.changeset/gateway-service-tier-option.md
+++ b/.changeset/gateway-service-tier-option.md
@@ -2,8 +2,4 @@
 "@ai-sdk/gateway": patch
 ---
 
-Add `serviceTier: 'flex' | 'priority'` to `GatewayProviderOptions`. The
-AI Gateway translates this unified intent into whichever per-provider
-option each provider expects (OpenAI's `serviceTier`, Google's
-`serviceTier`, Vertex's `sharedRequestType`), so callers no longer have
-to know each provider's spelling.
+Add `serviceTier: 'flex' | 'priority'` to `GatewayProviderOptions`.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -846,18 +846,10 @@ The following gateway provider options are available:
 
 - **serviceTier** _'flex' | 'priority'_
 
-  Unified service tier intent. The gateway translates this into whichever
-  per-provider option each provider expects, so you don't have to know the
-  individual provider's spelling:
-
-  | Gateway value | OpenAI                            | Google                            | Vertex                                                                         |
-  | ------------- | --------------------------------- | --------------------------------- | ------------------------------------------------------------------------------ |
-  | `'flex'`      | `openai.serviceTier = 'flex'`     | `google.serviceTier = 'flex'`     | `vertex.sharedRequestType = 'flex'` (and `vertex.requestType` is stripped)     |
-  | `'priority'`  | `openai.serviceTier = 'priority'` | `google.serviceTier = 'priority'` | `vertex.sharedRequestType = 'priority'` (and `vertex.requestType` is stripped) |
-
-  If you also set a tier in the per-provider options, the gateway value
-  overrides it. Leave unset to use each provider's default tier.
-  See the [OpenAI](/providers/ai-sdk-providers/openai),
+  Unified service tier intent. The gateway translates it into whichever
+  per-provider option each provider expects, and overrides any tier
+  also set in the per-provider options. Leave unset for provider
+  default. See the [OpenAI](/providers/ai-sdk-providers/openai),
   [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai),
   and [Google Vertex AI](/providers/ai-sdk-providers/google-vertex)
   provider docs for tier semantics, model availability, and graceful

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -844,6 +844,40 @@ The following gateway provider options are available:
 
   For full details, see [Provider Timeouts](https://vercel.com/docs/ai-gateway/models-and-providers/provider-timeouts).
 
+- **serviceTier** _'flex' | 'priority'_
+
+  Unified service tier intent. The gateway translates this into whichever
+  per-provider option each provider expects, so you don't have to know the
+  individual provider's spelling:
+
+  | Gateway value | OpenAI                            | Google                            | Vertex                                                                         |
+  | ------------- | --------------------------------- | --------------------------------- | ------------------------------------------------------------------------------ |
+  | `'flex'`      | `openai.serviceTier = 'flex'`     | `google.serviceTier = 'flex'`     | `vertex.sharedRequestType = 'flex'` (and `vertex.requestType` is stripped)     |
+  | `'priority'`  | `openai.serviceTier = 'priority'` | `google.serviceTier = 'priority'` | `vertex.sharedRequestType = 'priority'` (and `vertex.requestType` is stripped) |
+
+  If you also set a tier in the per-provider options, the gateway value
+  overrides it. Leave unset to use each provider's default tier.
+  See the [OpenAI](/providers/ai-sdk-providers/openai),
+  [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai),
+  and [Google Vertex AI](/providers/ai-sdk-providers/google-vertex)
+  provider docs for tier semantics, model availability, and graceful
+  downgrade behavior on each provider.
+
+  ```ts
+  import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+  import { generateText } from 'ai';
+
+  const { text } = await generateText({
+    model: 'openai/gpt-5-mini',
+    prompt: 'Hello',
+    providerOptions: {
+      gateway: {
+        serviceTier: 'priority',
+      } satisfies GatewayProviderOptions,
+    },
+  });
+  ```
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -104,6 +104,19 @@ const gatewayProviderOptions = lazySchema(() =>
           byok: z.record(z.string(), z.number().int().min(1000)).optional(),
         })
         .optional(),
+      /**
+       * Service tier for the request. Translated by the gateway into the
+       * per-provider option that each provider expects:
+       *
+       * - OpenAI: `openai.serviceTier`
+       * - Google: `google.serviceTier` (body field)
+       * - Vertex: `vertex.sharedRequestType` (request header).
+       *   `vertex.requestType` is stripped if set.
+       *
+       * If the user has also set a per-provider tier directly, the gateway
+       * value overrides it. Leave unset to use each provider's default tier.
+       */
+      serviceTier: z.enum(['flex', 'priority']).optional(),
     }),
   ),
 );

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -105,16 +105,10 @@ const gatewayProviderOptions = lazySchema(() =>
         })
         .optional(),
       /**
-       * Service tier for the request. Translated by the gateway into the
-       * per-provider option that each provider expects:
-       *
-       * - OpenAI: `openai.serviceTier`
-       * - Google: `google.serviceTier` (body field)
-       * - Vertex: `vertex.sharedRequestType` (request header).
-       *   `vertex.requestType` is stripped if set.
-       *
-       * If the user has also set a per-provider tier directly, the gateway
-       * value overrides it. Leave unset to use each provider's default tier.
+       * Unified service tier intent. Translated by the gateway into the
+       * per-provider option each provider expects, and overrides any tier
+       * also set in the per-provider options. Leave unset for provider
+       * default.
        */
       serviceTier: z.enum(['flex', 'priority']).optional(),
     }),


### PR DESCRIPTION
## Summary

Adds a unified `serviceTier: 'flex' | 'priority'` option to `GatewayProviderOptions`. The AI Gateway translates this into whichever per-provider option each provider expects.

If the user also set a per-provider tier directly, the gateway value overrides it.