### PR TITLE
feat(examples): add Bilig WorkPaper MCP client

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -40,6 +40,7 @@ Available examples/folders:
 - `mcp-prompts` - MCP prompts example
 - `mcp-resources` - MCP resources example
 - `stdio` - Stdio Transport (requires `pnpm stdio:build` first)
+- `bilig-workpaper` - Stdio MCP server from npm for spreadsheet-style formula workbooks
 - `elicitation` - MCP elicitation example
 - `elicitation-multi-step` - MCP multi-step elicitation example
 - `elicitation-ui` - MCP elicitation with UI (server only)
@@ -55,6 +56,15 @@ In another terminal, run the HTTP client:
 
 ```sh
 pnpm client:http
+```
+
+Run the Bilig WorkPaper example without starting a separate server. It downloads
+the published `@bilig/workpaper` package, starts its stdio MCP server, creates a
+demo WorkPaper JSON file, edits an input cell, recalculates dependent formulas,
+and prints verified readback:
+
+```sh
+pnpm client:bilig-workpaper
 ```
 
 To test the example with the UI, you will first need to run the MCP server:

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -24,6 +24,7 @@
     "client:provider-metadata": "tsx src/provider-metadata/client.ts",
     "server:server-instructions": "tsx src/server-instructions/server.ts",
     "client:server-instructions": "tsx src/server-instructions/client.ts",
+    "client:bilig-workpaper": "tsx src/bilig-workpaper/client.ts",
     "stdio:build": "tsc src/stdio/server.ts --outDir src/stdio/dist --target es2023 --module nodenext",
     "client:stdio": "tsx src/stdio/client.ts",
     "custom-transport:build": "tsc src/custom-transport/server.ts --outDir src/custom-transport/dist --target es2023 --module nodenext",

--- a/examples/mcp/src/bilig-workpaper/client.ts
+++ b/examples/mcp/src/bilig-workpaper/client.ts
@@ -1,0 +1,235 @@
+import { createMCPClient } from "@ai-sdk/mcp";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import "dotenv/config";
+import { z } from "zod";
+
+const toolExecutionOptions = {
+  messages: [],
+  context: {},
+};
+
+interface ToolResult<T> {
+  structuredContent?: T;
+}
+
+interface SheetList {
+  sheets: Array<{
+    name: string;
+    dimensions: {
+      width: number;
+      height: number;
+    };
+  }>;
+}
+
+interface RangeReadback {
+  values: unknown[][];
+}
+
+interface CellEditReadback {
+  editedCell: string;
+  before: {
+    serialized: unknown;
+  };
+  after: {
+    serialized: unknown;
+  };
+  checks: {
+    persisted: boolean;
+    restoredMatchesAfter: boolean;
+  };
+}
+
+interface DisplayReadback {
+  displayValue: string;
+}
+
+interface FormulaValidation {
+  formula: string;
+  valid: boolean;
+}
+
+async function main() {
+  let mcpClient;
+
+  try {
+    const transport = new StdioClientTransport({
+      command: "npm",
+      args: [
+        "exec",
+        "--yes",
+        "--package",
+        "@bilig/workpaper",
+        "--",
+        "bilig-workpaper-mcp",
+        "--workpaper",
+        "./bilig-ai-sdk-demo.workpaper.json",
+        "--init-demo-workpaper",
+        "--writable",
+      ],
+    });
+
+    mcpClient = await createMCPClient({ transport });
+
+    const tools = await mcpClient.tools({
+      schemas: {
+        list_sheets: {
+          inputSchema: z.object({}),
+        },
+        read_range: {
+          inputSchema: z.object({
+            range: z.string(),
+            sheetName: z.string().optional(),
+          }),
+        },
+        set_cell_contents: {
+          inputSchema: z.object({
+            sheetName: z.string(),
+            address: z.string(),
+            value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+          }),
+        },
+        get_cell_display_value: {
+          inputSchema: z.object({
+            sheetName: z.string(),
+            address: z.string(),
+          }),
+        },
+        validate_formula: {
+          inputSchema: z.object({
+            formula: z.string(),
+          }),
+        },
+      },
+    });
+
+    const sheets = await tools.list_sheets.execute(
+      {},
+      {
+        ...toolExecutionOptions,
+        toolCallId: "list-sheets",
+      }
+    );
+
+    const before = await tools.read_range.execute(
+      { range: "Summary!A1:B5" },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "read-before",
+      }
+    );
+
+    const edit = await tools.set_cell_contents.execute(
+      {
+        sheetName: "Inputs",
+        address: "B3",
+        value: 0.4,
+      },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "set-win-rate",
+      }
+    );
+
+    const after = await tools.read_range.execute(
+      { range: "Summary!A1:B5" },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "read-after",
+      }
+    );
+
+    const displayValue = await tools.get_cell_display_value.execute(
+      {
+        sheetName: "Summary",
+        address: "B3",
+      },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "display-expected-arr",
+      }
+    );
+
+    const formulaCheck = await tools.validate_formula.execute(
+      {
+        formula: "=Inputs!B2*Inputs!B3",
+      },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "validate-formula",
+      }
+    );
+
+    const sheetList = requireStructured<SheetList>(sheets, "list_sheets");
+    const summaryBefore = requireStructured<RangeReadback>(
+      before,
+      "read_range before edit"
+    );
+    const summaryAfter = requireStructured<RangeReadback>(
+      after,
+      "read_range after edit"
+    );
+    const editReadback = requireStructured<CellEditReadback>(
+      edit,
+      "set_cell_contents"
+    );
+    const expectedArrDisplay = requireStructured<DisplayReadback>(
+      displayValue,
+      "get_cell_display_value"
+    );
+    const validatedFormula = requireStructured<FormulaValidation>(
+      formulaCheck,
+      "validate_formula"
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          sheets: sheetList.sheets,
+          before: summaryRows(summaryBefore),
+          edit: {
+            cell: editReadback.editedCell,
+            previousInput: editReadback.before.serialized,
+            newInput: editReadback.after.serialized,
+            persisted: editReadback.checks.persisted,
+            restoredMatchesAfter: editReadback.checks.restoredMatchesAfter,
+          },
+          after: summaryRows(summaryAfter),
+          expectedArrDisplay: expectedArrDisplay.displayValue,
+          formulaCheck: validatedFormula,
+        },
+        null,
+        2
+      )
+    );
+  } finally {
+    await mcpClient?.close();
+  }
+}
+
+function requireStructured<T>(result: unknown, label: string): T {
+  const maybeResult = result as ToolResult<T>;
+  if (maybeResult.structuredContent === undefined) {
+    throw new Error(`${label} did not return structured content`);
+  }
+  return maybeResult.structuredContent;
+}
+
+function summaryRows(readback: RangeReadback) {
+  return readback.values.slice(1).map((row) => ({
+    metric: cellValue(row[0]),
+    value: cellValue(row[1]),
+  }));
+}
+
+function cellValue(cell: unknown): unknown {
+  if (typeof cell === "object" && cell !== null && "value" in cell) {
+    return (cell as { value: unknown }).value;
+  }
+  return cell;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Background

The AI SDK MCP example package shows how to connect to MCP servers, but it does not include a local stdio example for deterministic spreadsheet-style calculations.

This is a common agent workflow: launch a local tool server, edit structured inputs, read calculated outputs, and verify persisted state without running a separate hosted service.

## Summary

Adds a Bilig WorkPaper example to `examples/mcp` that starts the published `@bilig/workpaper` stdio MCP server with `npm exec`, then uses `createMCPClient()` to:

- list workbook sheets
- read input and formula summary ranges
- edit `Inputs!B3`
- verify recalculated readback
- validate a formula
- print persisted WorkPaper state

The example is scoped to `examples/mcp` and does not modify AI SDK package code.

## Manual Verification

```bash
pnpm --dir examples/mcp type-check
pnpm --dir examples/mcp client:bilig-workpaper
```

The local run verified ARR changed from `60000` to `96000` after editing the win rate, and the persisted WorkPaper JSON readback matched the edited value.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A follow-up could add an agent-facing UI or approval flow around writable MCP tools. This PR keeps the example to a CLI client so the MCP behavior stays easy to review.
