### PR TITLE
fix(amazon-bedrock): accept citation deltas in Converse stream schema

### DIFF
--- a/.changeset/fix-bedrock-citations-stream-schema.md
+++ b/.changeset/fix-bedrock-citations-stream-schema.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+Accept `citation` deltas in the Converse stream schema so that streaming with `providerOptions.bedrock.citations.enabled = true` no longer fails with `AI_TypeValidationError`. The citation payload is currently passed through without being surfaced; this only fixes the validation crash.

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -1133,7 +1133,7 @@ const AmazonBedrockResponseSchema = z.object({
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const AmazonBedrockStreamSchema = z.object({
+export const AmazonBedrockStreamSchema = z.object({
   contentBlockDelta: z
     .object({
       contentBlockIndex: z.number(),
@@ -1152,6 +1152,7 @@ const AmazonBedrockStreamSchema = z.object({
           z.object({
             reasoningContent: z.object({ data: z.string() }),
           }),
+          z.object({ citation: z.unknown() }),
         ])
         .nullish(),
     })

--- a/packages/amazon-bedrock/src/amazon-bedrock-stream-schema.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-stream-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { AmazonBedrockStreamSchema } from './amazon-bedrock-chat-language-model';
+
+describe('AmazonBedrockStreamSchema', () => {
+  it('accepts text content block deltas', () => {
+    const result = AmazonBedrockStreamSchema.safeParse({
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { text: 'Hello' },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts citation content block deltas when citations are enabled', () => {
+    const result = AmazonBedrockStreamSchema.safeParse({
+      contentBlockDelta: {
+        contentBlockIndex: 3,
+        delta: {
+          citation: {
+            location: {
+              documentPage: { documentIndex: 0, end: 2, start: 1 },
+            },
+            sourceContent: [{ text: 'CONTENT_OF_PDF' }],
+            title: 'document-1',
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9101.

The Converse stream schema in `@ai-sdk/amazon-bedrock` does not include `citation` in the `contentBlockDelta.delta` union. When a caller enables citations via `providerOptions.bedrock.citations.enabled = true` (or the equivalent `amazonBedrock` key), Bedrock streams deltas like:

```json
{
  "contentBlockDelta": {
    "contentBlockIndex": 3,
    "delta": {
      "citation": {
        "location": { "documentPage": { "documentIndex": 0, "end": 2, "start": 1 } },
        "sourceContent": [{ "text": "CONTENT_OF_PDF" }],
        "title": "document-1"
      }
    }
  }
}
```

These fail schema validation in `AmazonBedrockStreamSchema`. The stream transform converts the parse failure into an `error` chunk and sets `finishReason: 'error'`, dropping the rest of the response.

The request side already wires `citations: { enabled: true }` into the Converse request body (`convert-to-amazon-bedrock-chat-messages.ts:75`), so this only affects the response side.

This adds `citation` to the delta union as `z.unknown()` to match the project's response-schema guidance (minimal, flexible to API changes). The provider does not currently surface citation chunks to consumers; this PR only stops the validation crash so the rest of the response is preserved. Emitting citation parts (e.g. as `source` stream parts) can be a follow-up.

`AmazonBedrockStreamSchema` is now `export`ed so it can be unit-tested directly. The existing tests use a mocked event-stream handler that bypasses validation, so a focused schema test was the only way to actually exercise this change.

## Test plan

- [x] New `amazon-bedrock-stream-schema.test.ts` asserts the schema accepts the exact citation delta payload from the issue and a baseline text delta. The citation case fails on `main` (`Invalid input` on the delta union) and passes with this change.
- [x] `pnpm --filter @ai-sdk/amazon-bedrock test`: 387/387 pass on both node and edge runtimes.
- [x] `pnpm --filter @ai-sdk/amazon-bedrock type-check`: clean.
- [x] `pnpm check`: lint and format clean.