### PR TITLE
fix(openai): skip passing reasoning items when using previous response id

### DIFF
--- a/.changeset/two-ravens-sleep.md
+++ b/.changeset/two-ravens-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+fix(openai): skip passing reasoning items when using previous response id

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -4549,6 +4549,119 @@ describe('convertToOpenAIResponsesInput', () => {
     });
   });
 
+  describe('hasPreviousResponseId', () => {
+    it('should keep text item references and skip function call item references when hasPreviousResponseId is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'Hi there!',
+                providerOptions: { openai: { itemId: 'msg_existing_123' } },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call_123',
+                toolName: 'getWeather',
+                input: { location: 'San Francisco' },
+                providerOptions: {
+                  openai: { itemId: 'fc_existing_456' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'getWeather',
+                output: { type: 'json', value: { temp: 72 } },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "id": "msg_existing_123",
+            "type": "item_reference",
+          },
+          {
+            "call_id": "call_123",
+            "output": "{"temp":72}",
+            "type": "function_call_output",
+          },
+        ]
+      `);
+    });
+
+    it('should skip reasoning parts with item IDs when hasPreviousResponseId is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'reasoning',
+                text: 'Let me think...',
+                providerOptions: {
+                  openai: { itemId: 'rs_existing_789' },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+  });
+
   describe('compaction', () => {
     it('should convert compaction to item_reference when store is true', async () => {
       const result = await convertToOpenAIResponsesInput({

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -61,6 +61,7 @@ export async function convertToOpenAIResponsesInput({
   passThroughUnsupportedFiles = false,
   store,
   hasConversation = false,
+  hasPreviousResponseId = false,
   hasLocalShellTool = false,
   hasShellTool = false,
   hasApplyPatchTool = false,
@@ -75,6 +76,7 @@ export async function convertToOpenAIResponsesInput({
   passThroughUnsupportedFiles?: boolean;
   store: boolean;
   hasConversation?: boolean; // when true, skip assistant messages that already have item IDs
+  hasPreviousResponseId?: boolean; // when true, skip reasoning and function-call items that already exist in the previous response chain
   hasLocalShellTool?: boolean;
   hasShellTool?: boolean;
   hasApplyPatchTool?: boolean;
@@ -307,6 +309,9 @@ export async function convertToOpenAIResponsesInput({
               }
 
               if (store && id != null) {
+                if (hasPreviousResponseId) {
+                  break;
+                }
                 input.push({ type: 'item_reference', id });
                 break;
               }
@@ -505,7 +510,10 @@ export async function convertToOpenAIResponsesInput({
 
               const reasoningId = providerOptions?.itemId;
 
-              if (hasConversation && reasoningId != null) {
+              if (
+                (hasConversation || hasPreviousResponseId) &&
+                reasoningId != null
+              ) {
                 break;
               }
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -844,6 +844,107 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should not send item references for reasoning items when previousResponseId is set', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Hello' }],
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'Let me think...',
+                  providerOptions: {
+                    openai: { itemId: 'rs_existing_123' },
+                  },
+                },
+              ],
+            },
+          ],
+          providerOptions: {
+            openai: {
+              previousResponseId: 'resp_123',
+              store: true,
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-4o',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          previous_response_id: 'resp_123',
+          store: true,
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should not send item references for function calls when previousResponseId is set', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'What is the weather?' }],
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_123',
+                  toolName: 'weather',
+                  input: { location: 'San Francisco' },
+                  providerOptions: {
+                    openai: { itemId: 'fc_existing_123' },
+                  },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_123',
+                  toolName: 'weather',
+                  output: { type: 'json', value: { temp: 72 } },
+                },
+              ],
+            },
+          ],
+          providerOptions: {
+            openai: {
+              previousResponseId: 'resp_123',
+              store: true,
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-4o',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'What is the weather?' }],
+            },
+            {
+              type: 'function_call_output',
+              call_id: 'call_123',
+              output: '{"temp":72}',
+            },
+          ],
+          previous_response_id: 'resp_123',
+          store: true,
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send metadata provider option', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -253,6 +253,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
           openaiOptions?.passThroughUnsupportedFiles ?? false,
         store: openaiOptions?.store ?? true,
         hasConversation: openaiOptions?.conversation != null,
+        hasPreviousResponseId: openaiOptions?.previousResponseId != null,
         hasLocalShellTool: hasOpenAITool('openai.local_shell'),
         hasShellTool: hasOpenAITool('openai.shell'),
         hasApplyPatchTool: hasOpenAITool('openai.apply_patch'),


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15502 / reported in https://github.com/vercel/ai/pull/15492

when `previousResponseId` is used with the openai provider, with `store: true`, we observe that duplicate reasoning items and function call items are being passed and the provider throws a 404 error.

[openai docs highlight](https://developers.openai.com/cookbook/examples/responses_api/reasoning_items#:~:text=If%20you%20use%20previous_response_id%20for%20multi%2Dturn%20conversations%2C%20the%20model%20will%20automatically%20have%20access%20to%20all%20previously%20produced%20reasoning%20items.) that:

> If you use previous_response_id for multi-turn conversations, the model will automatically have access to all previously produced reasoning items

so it's fine if we skip passing those items under those conditions

## Summary

- introduced a flag `hasPreviousResponseId` and if it does - we skip passing ONLY the reasoning items and function calls

## Manual Verification

verified by running the repro in the issue: 

<details>
<summary>repro:</summary>

```ts
import {
  openai,
  type OpenaiResponsesProviderMetadata,
  type OpenAILanguageModelResponsesOptions,
} from '@ai-sdk/openai';
import { isStepCount, streamText, tool } from 'ai';
import { z } from 'zod';
import { run } from '../../lib/run';

run(async () => {
  let previousResponseId: string | undefined;

  const result = streamText({
    model: openai.responses('gpt-5-mini'),
    maxRetries: 0,
    stopWhen: isStepCount(2),
    tools: {
      getWeather: tool({
        description: 'Get the weather in a city.',
        inputSchema: z.object({
          city: z.string().describe('The city to get the weather for.'),
        }),
        execute: async ({ city }) => ({
          city,
          weather: 'sunny',
          temperature: 72,
        }),
      }),
    },
    prompt: 'Use the weather tool for San Francisco, then answer briefly.',
    reasoning: 'low',
    include: {
      requestBody: true,
    },
    prepareStep: ({ stepNumber }) => ({
      toolChoice:
        stepNumber === 0 ? { type: 'tool', toolName: 'getWeather' } : 'auto',
      providerOptions: {
        openai: {
          store: true,
          ...(previousResponseId != null ? { previousResponseId } : {}),
        } satisfies OpenAILanguageModelResponsesOptions,
      },
    }),
    onStepFinish: step => {
      const providerMetadata = step.providerMetadata as
        | OpenaiResponsesProviderMetadata
        | undefined;

      previousResponseId =
        providerMetadata?.openai.responseId ?? previousResponseId;

      console.log('Step response ID:', previousResponseId);
    },
  });

  for await (const chunk of result.fullStream) {
    switch (chunk.type) {
      case 'start-step':
        console.log(
          'Request body:',
          JSON.stringify(chunk.request.body, null, 2),
        );
        break;

      case 'tool-call':
        console.log('Tool call:', chunk.toolName, chunk.input);
        break;

      case 'tool-result':
        console.log('Tool result:', chunk.output);
        break;

      case 'text-delta':
        process.stdout.write(chunk.text);
        break;

      case 'error':
        throw chunk.error;
    }
  }
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15502