### PR TITLE
Backport: build: add fallback for VERSION for local dev

### DIFF
--- a/packages/alibaba/src/version.ts
+++ b/packages/alibaba/src/version.ts
@@ -1,3 +1,6 @@
-declare const __PACKAGE_VERSION__: string;
-
-export const VERSION = __PACKAGE_VERSION__;
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/moonshotai/src/version.ts
+++ b/packages/moonshotai/src/version.ts
@@ -1,3 +1,6 @@
-declare const __PACKAGE_VERSION__: string;
-
-export const VERSION = __PACKAGE_VERSION__;
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';


### PR DESCRIPTION
This is a manual backport of #15505 to the `release-v5.0` branch.

Only `packages/alibaba` and `packages/moonshotai` are included — the `bytedance` and `klingai` packages from the original PR do not exist on this branch.