### PR TITLE
fix(mcp): deduplicate auth refresh on http transport

### DIFF
--- a/.changeset/six-camels-obey.md
+++ b/.changeset/six-camels-obey.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): deduplicate auth refresh on http transport

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -3,9 +3,12 @@ import {
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMCPClient } from './mcp-client';
 import { HttpMCPTransport } from './mcp-http-transport';
 import { LATEST_PROTOCOL_VERSION } from './types';
 import { MCPClientError } from '../error/mcp-client-error';
+import type { OAuthClientProvider } from './oauth';
+import type { OAuthTokens } from './oauth-types';
 
 describe('HttpMCPTransport', () => {
   const server = createTestServer({
@@ -328,6 +331,138 @@ describe('HttpMCPTransport', () => {
       ...customHeaders,
     });
     expect(server.calls[1].requestUserAgent).toContain('ai-sdk/');
+  });
+
+  it('should deduplicate OAuth refresh when inbound SSE and initialize both get 401', async () => {
+    const trace: string[] = [];
+    let storedTokens: OAuthTokens = {
+      access_token: 'expired-access-token',
+      token_type: 'Bearer',
+      refresh_token: 'rotating-refresh-token',
+    };
+    let releaseRefresh: () => void;
+    const refreshGate = new Promise<void>(resolve => {
+      releaseRefresh = resolve;
+    });
+    const refreshRequests: URLSearchParams[] = [];
+
+    const authProvider: OAuthClientProvider = {
+      tokens: vi.fn(async () => storedTokens),
+      saveTokens: vi.fn(async tokens => {
+        storedTokens = tokens;
+      }),
+      redirectToAuthorization: vi.fn(),
+      saveCodeVerifier: vi.fn(),
+      codeVerifier: vi.fn(async () => 'verifier'),
+      redirectUrl: 'http://localhost:4000/callback',
+      clientMetadata: {
+        redirect_uris: ['http://localhost:4000/callback'],
+      },
+      clientInformation: vi.fn(async () => ({ client_id: 'test-client' })),
+    };
+
+    const fetchFn = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        const method = init?.method ?? 'GET';
+        const headers = new Headers(init?.headers);
+        trace.push(`${method} ${url.pathname}`);
+
+        if (url.href === 'http://localhost:4000/mcp') {
+          if (headers.get('authorization') === 'Bearer expired-access-token') {
+            trace.push(`${method} ${url.pathname} 401`);
+            return new Response(null, {
+              status: 401,
+              headers: {
+                'www-authenticate':
+                  'Bearer resource_metadata="http://localhost:4000/.well-known/oauth-protected-resource"',
+              },
+            });
+          }
+
+          if (method === 'GET') {
+            return new Response(null, { status: 405 });
+          }
+
+          if (
+            typeof init?.body === 'string' &&
+            init.body.includes('notifications/initialized')
+          ) {
+            return new Response(null, { status: 202 });
+          }
+
+          return Response.json({
+            jsonrpc: '2.0',
+            id: 0,
+            result: {
+              protocolVersion: LATEST_PROTOCOL_VERSION,
+              capabilities: {},
+              serverInfo: { name: 'test-server', version: '1.0.0' },
+            },
+          });
+        }
+
+        if (
+          url.href ===
+          'http://localhost:4000/.well-known/oauth-protected-resource'
+        ) {
+          return Response.json({
+            resource: 'http://localhost:4000',
+            authorization_servers: ['http://localhost:4000'],
+          });
+        }
+
+        if (
+          url.href ===
+          'http://localhost:4000/.well-known/oauth-authorization-server'
+        ) {
+          return Response.json({
+            issuer: 'http://localhost:4000',
+            authorization_endpoint: 'http://localhost:4000/authorize',
+            token_endpoint: 'http://localhost:4000/token',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+            grant_types_supported: ['refresh_token'],
+            token_endpoint_auth_methods_supported: ['none'],
+          });
+        }
+
+        if (url.href === 'http://localhost:4000/token') {
+          refreshRequests.push(init?.body as URLSearchParams);
+          await refreshGate;
+
+          return Response.json({
+            access_token: `refreshed-access-token-${refreshRequests.length}`,
+            token_type: 'Bearer',
+            refresh_token: `rotating-refresh-token-${refreshRequests.length}`,
+          });
+        }
+
+        return new Response(null, { status: 404 });
+      },
+    );
+
+    const clientPromise = createMCPClient({
+      transport: {
+        type: 'http',
+        url: 'http://localhost:4000/mcp',
+        authProvider,
+        fetch: fetchFn,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(trace).toContain('GET /mcp 401');
+      expect(trace).toContain('POST /mcp 401');
+    });
+
+    expect(refreshRequests).toHaveLength(1);
+
+    releaseRefresh!();
+    const client = await clientPromise;
+    await client.close();
+
+    expect(refreshRequests).toHaveLength(1);
   });
 
   describe('redirect option', () => {

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -16,6 +16,7 @@ import {
   extractResourceMetadataUrl,
   UnauthorizedError,
   auth,
+  type AuthResult,
   type OAuthClientProvider,
 } from './oauth';
 import { LATEST_PROTOCOL_VERSION } from './types';
@@ -37,6 +38,7 @@ export class HttpMCPTransport implements MCPTransport {
   private inboundSseConnection?: { close: () => void };
   private redirectMode: RequestRedirect;
   private fetchFn: FetchFunction;
+  private authPromise?: Promise<AuthResult>;
 
   // Inbound SSE resumption and reconnection state
   private lastInboundEventId?: string;
@@ -100,6 +102,27 @@ export class HttpMCPTransport implements MCPTransport {
     );
   }
 
+  /**
+   * Runs a single OAuth recovery flow for concurrent 401 responses.
+   */
+  private authorizeOnce(resourceMetadataUrl?: URL): Promise<AuthResult> {
+    if (!this.authProvider) {
+      return Promise.resolve('REDIRECT');
+    }
+
+    if (!this.authPromise) {
+      this.authPromise = auth(this.authProvider, {
+        serverUrl: this.url,
+        resourceMetadataUrl,
+        fetchFn: this.fetchFn,
+      }).finally(() => {
+        this.authPromise = undefined;
+      });
+    }
+
+    return this.authPromise;
+  }
+
   async start(): Promise<void> {
     if (this.abortController) {
       throw new MCPClientError({
@@ -160,11 +183,7 @@ export class HttpMCPTransport implements MCPTransport {
         if (response.status === 401 && this.authProvider && !triedAuth) {
           this.resourceMetadataUrl = extractResourceMetadataUrl(response);
           try {
-            const result = await auth(this.authProvider, {
-              serverUrl: this.url,
-              resourceMetadataUrl: this.resourceMetadataUrl,
-              fetchFn: this.fetchFn,
-            });
+            const result = await this.authorizeOnce(this.resourceMetadataUrl);
             if (result !== 'AUTHORIZED') {
               const error = new UnauthorizedError();
               throw error;
@@ -340,11 +359,7 @@ export class HttpMCPTransport implements MCPTransport {
       if (response.status === 401 && this.authProvider && !triedAuth) {
         this.resourceMetadataUrl = extractResourceMetadataUrl(response);
         try {
-          const result = await auth(this.authProvider, {
-            serverUrl: this.url,
-            resourceMetadataUrl: this.resourceMetadataUrl,
-            fetchFn: this.fetchFn,
-          });
+          const result = await this.authorizeOnce(this.resourceMetadataUrl);
           if (result !== 'AUTHORIZED') {
             const error = new UnauthorizedError();
             this.onerror?.(error);


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15465

Before, both 401 paths in the transport independently called `auth()`:
- `send()` handles POST /mcp initialize 401.
- `openInboundSse()` handles background GET /mcp 401.

that meant if one request is already refreshing tokens, any other concurrent 401 recovery would start its own recovery. this could lead to a race condition in the refresh and return invalid auth / force re auth.

## Summary

- introduce a new function `authorizeOnce()` that runs a single OAuth recovery flow for concurrent 401 responses

## Manual Verification

verified in the reproduction in the unit tests

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15465 