### PR TITLE
ci: scope release concurrency group per branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         default: false
 
 concurrency:
-  group: 'release'
+  group: 'release-${{ github.ref }}'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         default: false
 
 concurrency:
-  group: 'release-${{ github.ref }}'
+  group: 'release-${{ github.ref_name }}'
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Summary

- Change `concurrency.group` in `.github/workflows/release.yml` from a single global `'release'` to `'release-${{ github.ref }}'` so each release branch (`main`, `release-v6.0`, `release-v5.0`) gets its own concurrency slot.

## Why

Today all three Release runs share one concurrency group. With `cancel-in-progress: false`, GitHub queues at most one pending run per group — so when three pushes arrive in quick succession (as happened today on #15509, #15513, #15517), the middle pending run gets bumped out of the queue and canceled. Run [26246209250](https://github.com/vercel/ai/actions/runs/26246209250) was canceled this way.

Scoping the group per branch lets each branch's Release workflow run independently while still serializing runs within a single branch.

## Test plan

- [ ] Mirror change on `release-v6.0` and `release-v5.0` branches
- [ ] Confirm subsequent overlapping pushes across branches no longer cancel each other