### PR TITLE
ci: scope release concurrency group per branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'release-${{ github.ref }}'
+  group: 'release-${{ github.ref_name }}'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'release'
+  group: 'release-${{ github.ref }}'
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Summary

- Backport of #15519 to `release-v6.0`.
- Change `concurrency.group` in `.github/workflows/release.yml` from a single global `'release'` to `'release-${{ github.ref }}'` so each release branch (`main`, `release-v6.0`, `release-v5.0`) gets its own concurrency slot.

## Why

All three Release runs currently share one concurrency group. With `cancel-in-progress: false`, GitHub queues at most one pending run per group, so when pushes land on multiple branches within seconds (as today across #15509, #15513, #15517), the middle pending run gets bumped from the queue and canceled — e.g. run [26246209250](https://github.com/vercel/ai/actions/runs/26246209250).

Scoping the group per branch lets each branch's Release workflow run independently while still serializing within a single branch.

## Test plan

- [ ] Land on `main` (#15519), `release-v6.0`, and `release-v5.0`
- [ ] Verify overlapping pushes across branches no longer cancel each other