### PR TITLE
fix(bfl): use 'image' field instead of 'input_image' for fill pro model

### DIFF
--- a/.changeset/plenty-cats-wash.md
+++ b/.changeset/plenty-cats-wash.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/black-forest-labs": patch
+---
+
+fix(bfl): use 'image' field instead of 'input_image' for fill pro model

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -2,23 +2,26 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
 import { BlackForestLabsImageModel } from './black-forest-labs-image-model';
+import type { BlackForestLabsImageModelId } from './black-forest-labs-image-settings';
 
 const prompt = 'A cute baby sea otter';
 
 function createBasicModel({
+  modelId = 'test-model',
   headers,
   fetch,
   currentDate,
   pollIntervalMillis,
   pollTimeoutMillis,
 }: {
+  modelId?: BlackForestLabsImageModelId;
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
   currentDate?: () => Date;
   pollIntervalMillis?: number;
   pollTimeoutMillis?: number;
 } = {}) {
-  return new BlackForestLabsImageModel('test-model', {
+  return new BlackForestLabsImageModel(modelId, {
     provider: 'black-forest-labs.image',
     baseURL: 'https://api.example.com/v1',
     headers: headers ?? (() => ({ 'x-key': 'test-key' })),
@@ -34,6 +37,15 @@ function createBasicModel({
 describe('BlackForestLabsImageModel', () => {
   const server = createTestServer({
     'https://api.example.com/v1/test-model': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.example.com/poll',
+        },
+      },
+    },
+    'https://api.example.com/v1/flux-pro-1.0-fill': {
       response: {
         type: 'json-value',
         body: {
@@ -85,6 +97,65 @@ describe('BlackForestLabsImageModel', () => {
         prompt,
         aspect_ratio: '16:9',
         prompt_upsampling: true,
+      });
+    });
+
+    it('uses image field for flux-pro-1.0-fill input images', async () => {
+      const model = createBasicModel({ modelId: 'flux-pro-1.0-fill' });
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: Buffer.from('test-image'),
+          },
+        ],
+        mask: {
+          type: 'file',
+          mediaType: 'image/png',
+          data: Buffer.from('test-mask'),
+        },
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        prompt,
+        aspect_ratio: '1:1',
+        image: Buffer.from('test-image').toString('base64'),
+        mask: Buffer.from('test-mask').toString('base64'),
+      });
+    });
+
+    it('uses input_image field for non-fill input images', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: Buffer.from('test-image'),
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        prompt,
+        aspect_ratio: '1:1',
+        input_image: Buffer.from('test-image').toString('base64'),
       });
     });
 

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -126,10 +126,12 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       throw new Error('Black Forest Labs supports up to 10 input images.');
     }
 
+    const inputImageField =
+      this.modelId === 'flux-pro-1.0-fill' ? 'image' : 'input_image';
     const inputImagesObj: Record<string, string> = inputImages.reduce<
       Record<string, string>
     >((acc, img, index) => {
-      acc[`input_image${index === 0 ? '' : `_${index + 1}`}`] = img;
+      acc[`${inputImageField}${index === 0 ? '' : `_${index + 1}`}`] = img;
       return acc;
     }, {});
 


### PR DESCRIPTION
## Background

reported in https://github.com/vercel/ai/issues/14351

when using the model id `flux-pro-1.0-fill`, the BFL api expects the the field `image` instead of `input_image`

this is also logged in their docs in the request sent [here](https://docs.bfl.ml/flux_tools/flux_1_fill#create-a-request)

## Summary

change just that field for the mode id `flux-pro-1.0-fill` based on a conditional check

## Manual Verification

verified by running the repro: 

<details>
<summary>repro </summary>

```ts
import {
  blackForestLabs,
  type BlackForestLabsImageModelOptions,
} from '@ai-sdk/black-forest-labs';
import { generateImage } from 'ai';
import sharp from 'sharp';
import { run } from '../../lib/run';
import { presentImages } from '../../lib/present-image';

run(async () => {
  const image = await sharp({
    create: {
      width: 256,
      height: 256,
      channels: 3,
      background: { r: 120, g: 180, b: 255 },
    },
  })
    .png()
    .toBuffer();
  const mask = await sharp({
    create: {
      width: 256,
      height: 256,
      channels: 3,
      background: { r: 255, g: 255, b: 255 },
    },
  })
    .png()
    .toBuffer();

  console.log(
    'Running BFL fill inpainting with a 256x256 input image and mask.',
  );

  const result = await generateImage({
    model: blackForestLabs.image('flux-pro-1.0-fill'),
    prompt: {
      text: 'Replace the masked area with a red square.',
      images: [image],
      mask,
    },
    aspectRatio: '1:1',
    providerOptions: {
      blackForestLabs: {
        outputFormat: 'png',
        steps: 25,
        guidance: 7.5,
      } satisfies BlackForestLabsImageModelOptions,
    },
  });

  await presentImages(result.images);
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14351 