### PR TITLE
feat (provider/anthropic-aws): new @ai-sdk/anthropic-aws provider (v1.0.0)

### DIFF
--- a/.changeset/anthropic-aws-provider.md
+++ b/.changeset/anthropic-aws-provider.md
@@ -2,8 +2,4 @@
 '@ai-sdk/anthropic-aws': major
 ---
 
-feat(anthropic-aws): new @ai-sdk/anthropic-aws provider for Claude Platform on AWS
-
-New `@ai-sdk/anthropic-aws` package exposing `createAnthropicAws` for [Claude Platform on AWS](https://aws.amazon.com/marketplace) — Anthropic's Messages API hosted in AWS at `aws-external-anthropic.{region}.api.aws`. Same wire format and feature set as `@ai-sdk/anthropic` (model IDs, streaming, prompt caching, tool use, computer use, `anthropic-beta` headers) with AWS SigV4 or AWS-provisioned API key authentication.
-
-Reads `AWS_REGION`, `ANTHROPIC_AWS_WORKSPACE_ID`, and `ANTHROPIC_AWS_API_KEY` from the environment by default.
+feat (provider/anthropic-aws): new @ai-sdk/anthropic-aws provider (v1.0.0)

--- a/.changeset/anthropic-aws-provider.md
+++ b/.changeset/anthropic-aws-provider.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/anthropic-aws': major
+---
+
+feat(anthropic-aws): new @ai-sdk/anthropic-aws provider for Claude Platform on AWS
+
+New `@ai-sdk/anthropic-aws` package exposing `createAnthropicAws` for [Claude Platform on AWS](https://aws.amazon.com/marketplace) — Anthropic's Messages API hosted in AWS at `aws-external-anthropic.{region}.api.aws`. Same wire format and feature set as `@ai-sdk/anthropic` (model IDs, streaming, prompt caching, tool use, computer use, `anthropic-beta` headers) with AWS SigV4 or AWS-provisioned API key authentication.
+
+Reads `AWS_REGION`, `ANTHROPIC_AWS_WORKSPACE_ID`, and `ANTHROPIC_AWS_API_KEY` from the environment by default.

--- a/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
+++ b/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
@@ -1,0 +1,151 @@
+---
+title: Claude Platform on AWS
+description: Learn how to use the Claude Platform on AWS provider.
+---
+
+# Claude Platform on AWS Provider
+
+The Claude Platform on AWS provider for the [AI SDK](/docs) gives you access to the Anthropic Messages API hosted inside your AWS environment. Anthropic operates the stack, so you get the same API surface and feature set as the first-party [Anthropic provider](/providers/ai-sdk-providers/anthropic) — including streaming, prompt caching, tool use, computer use, and `anthropic-beta` headers — with AWS-native authentication and AWS Marketplace billing.
+
+This differs from [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock) in two important ways: Claude Platform on AWS uses Anthropic's Messages API directly (not Bedrock's `Converse`/`InvokeModel`), and new features are available the same day they launch on the first-party Claude API (no AWS integration delay).
+
+## Setup
+
+The Claude Platform on AWS provider is available in the `@ai-sdk/anthropic-aws` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/anthropic-aws" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/anthropic-aws" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/anthropic-aws" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/anthropic-aws" dark />
+  </Tab>
+</Tabs>
+
+### Prerequisites
+
+Before you can use the provider, your AWS account must be subscribed to Claude Platform on AWS through the AWS Marketplace, and outbound web identity federation must be enabled on the account (a one-time setup step):
+
+```bash
+aws iam enable-outbound-web-identity-federation
+```
+
+Without this, every request returns `Outbound web identity federation is disabled for your account`. This is the most common setup error.
+
+You'll also need your workspace ID. When you subscribe, AWS provisions an initial workspace for your account in the selected region. You can find the ID in the Claude Console under **Workspaces** (accessed from the AWS Console via the Claude Platform on AWS service page).
+
+### Authentication
+
+The provider supports two authentication methods:
+
+#### Using AWS SigV4 (recommended for production)
+
+SigV4 integrates with your existing AWS IAM policies, roles, and auditing. Configure AWS credentials using any method supported by the AWS default credential provider chain — environment variables, shared credentials file, web identity (IRSA), ECS container credentials, or EC2 instance metadata.
+
+```bash
+AWS_REGION=us-west-2
+ANTHROPIC_AWS_WORKSPACE_ID=wrkspc_…
+AWS_ACCESS_KEY_ID=…
+AWS_SECRET_ACCESS_KEY=…
+# AWS_SESSION_TOKEN=…  # only for temporary credentials (SSO, STS, assumed role)
+```
+
+Then use the default provider instance:
+
+```ts
+import { anthropicAws } from '@ai-sdk/anthropic-aws';
+```
+
+Or instantiate explicitly:
+
+```ts
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+
+const anthropicAws = createAnthropicAws({
+  region: 'us-west-2',
+  workspaceId: 'wrkspc_…',
+});
+```
+
+For dynamic credentials (e.g., assuming a role at request time):
+
+```ts
+const anthropicAws = createAnthropicAws({
+  region: 'us-west-2',
+  workspaceId: 'wrkspc_…',
+  credentialProvider: async () => fetchCredentialsFromSTS(),
+});
+```
+
+#### Using an API key
+
+For simpler integration paths (local development, scripts, migration from the first-party Claude API), you can authenticate with an API key instead of SigV4. Your Anthropic account representative provisions API keys for Claude Platform on AWS.
+
+```bash
+ANTHROPIC_AWS_API_KEY=sk-…
+```
+
+When `apiKey` is set, it takes precedence over any SigV4 credentials in the environment.
+
+```ts
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+
+const anthropicAws = createAnthropicAws({
+  region: 'us-west-2',
+  workspaceId: 'wrkspc_…',
+  apiKey: 'sk-…',
+});
+```
+
+### Provider Settings
+
+| Setting | Description |
+| --- | --- |
+| `region` | AWS region for the Claude Platform on AWS endpoint. Reads from `AWS_REGION` if omitted. Required — no fallback default. |
+| `workspaceId` | Anthropic workspace ID for this AWS account. Sent on every request via the `anthropic-workspace-id` header. Reads from `ANTHROPIC_AWS_WORKSPACE_ID` if omitted. |
+| `apiKey` | API key for `x-api-key` authentication. When provided, used instead of SigV4. Reads from `ANTHROPIC_AWS_API_KEY` if omitted. |
+| `accessKeyId` | AWS access key ID for SigV4. Reads from `AWS_ACCESS_KEY_ID`. |
+| `secretAccessKey` | AWS secret access key for SigV4. Reads from `AWS_SECRET_ACCESS_KEY`. |
+| `sessionToken` | AWS session token for SigV4 (temporary credentials only). Reads from `AWS_SESSION_TOKEN`. |
+| `baseURL` | Base URL override. Defaults to `https://aws-external-anthropic.{region}.api.aws/v1`. |
+| `headers` | Custom headers to include on every request. |
+| `fetch` | Custom fetch implementation for testing or middleware. |
+| `credentialProvider` | Function returning dynamic AWS credentials. Overrides `accessKeyId`, `secretAccessKey`, and `sessionToken`. |
+
+## Language Models
+
+You can create models that call the Anthropic Messages API on AWS using the provider instance:
+
+```ts
+import { anthropicAws } from '@ai-sdk/anthropic-aws';
+
+const model = anthropicAws('claude-sonnet-4-6');
+```
+
+Model IDs are identical to the first-party Anthropic API. See the [Anthropic provider docs](/providers/ai-sdk-providers/anthropic#language-models) for the full list of language model options, prompt caching, computer use, web search, and code execution. All of these work identically here because Claude Platform on AWS uses Anthropic's runtime directly.
+
+### Example
+
+```ts
+import { anthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: anthropicAws('claude-sonnet-4-6'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+## IAM permissions
+
+Your IAM principal needs permission to call the Claude Platform on AWS actions on your workspace. AWS provides three managed policies:
+
+- `AnthropicFullAccess` — grants `aws-external-anthropic:*` on all resources.
+- `AnthropicInferenceAccess` — grants read actions plus `CreateInference`, `CreateBatchInference`, `CancelBatchInference`, `DeleteBatchInference`, and `CountTokens` on all workspaces. **This is the minimum for calling models.**
+- `AnthropicReadOnlyAccess` — grants `Get*`, `List*`, and `CallWithBearerToken` on all workspaces. Insufficient for inference.

--- a/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
+++ b/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Claude Platform on AWS provider.
 
 # Claude Platform on AWS Provider
 
-The Claude Platform on AWS provider for the [AI SDK](/docs) gives you access to the Anthropic Messages API hosted inside your AWS environment. Anthropic operates the stack, so you get the same API surface and feature set as the first-party [Anthropic provider](/providers/ai-sdk-providers/anthropic) — including streaming, prompt caching, tool use, computer use, and `anthropic-beta` headers — with AWS-native authentication and AWS Marketplace billing.
+The Claude Platform on AWS provider for the [AI SDK](/docs) gives you access to the Anthropic Messages API hosted inside your AWS environment. Anthropic operates the stack, so you get the same API surface and feature set as the first-party [Anthropic provider](/providers/ai-sdk-providers/anthropic) — including streaming, prompt caching, tool use, computer use, Agent Skills, and `anthropic-beta` headers — with AWS-native authentication and AWS Marketplace billing.
 
 This differs from [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock) in two important ways: Claude Platform on AWS uses Anthropic's Messages API directly (not Bedrock's `Converse`/`InvokeModel`), and new features are available the same day they launch on the first-party Claude API (no AWS integration delay).
 
@@ -128,7 +128,7 @@ import { anthropicAws } from '@ai-sdk/anthropic-aws';
 const model = anthropicAws('claude-sonnet-4-6');
 ```
 
-Model IDs are identical to the first-party Anthropic API. See the [Anthropic provider docs](/providers/ai-sdk-providers/anthropic#language-models) for the full list of language model options, prompt caching, computer use, web search, and code execution. All of these work identically here because Claude Platform on AWS uses Anthropic's runtime directly.
+Model IDs are identical to the first-party Anthropic API. See the [Anthropic provider docs](/providers/ai-sdk-providers/anthropic#language-models) for the full list of language model options, prompt caching, computer use, web search, code execution, and Agent Skills. All of these work identically here because Claude Platform on AWS uses Anthropic's runtime directly.
 
 ### Example
 

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -6,6 +6,7 @@
     "@ai-sdk/alibaba": "workspace:*",
     "@ai-sdk/amazon-bedrock": "workspace:*",
     "@ai-sdk/anthropic": "workspace:*",
+    "@ai-sdk/anthropic-aws": "workspace:*",
     "@ai-sdk/assemblyai": "workspace:*",
     "@ai-sdk/azure": "workspace:*",
     "@ai-sdk/baseten": "workspace:*",

--- a/examples/ai-functions/src/generate-text/anthropic-aws/basic.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-aws/basic.ts
@@ -1,0 +1,22 @@
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+// API-key auth path. Set in .env or shell:
+//   AWS_REGION=us-east-2
+//   ANTHROPIC_AWS_WORKSPACE_ID=wrkspc_…
+//   ANTHROPIC_AWS_API_KEY=sk-…
+const anthropicAws = createAnthropicAws();
+
+run(async () => {
+  const result = await generateText({
+    model: anthropicAws('claude-sonnet-4-6'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    maxRetries: 0,
+  });
+
+  print('Content:', result.content);
+  print('Usage:', result.usage);
+  print('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/anthropic-aws/sigv4.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-aws/sigv4.ts
@@ -1,0 +1,25 @@
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+// SigV4 auth path. Picks up AWS credentials from the default chain:
+//   AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_SESSION_TOKEN)
+// or any other source the AWS SDK normally resolves.
+//
+// Required env vars:
+//   AWS_REGION=us-east-2
+//   ANTHROPIC_AWS_WORKSPACE_ID=wrkspc_…
+const anthropicAws = createAnthropicAws();
+
+run(async () => {
+  const result = await generateText({
+    model: anthropicAws('claude-sonnet-4-6'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    maxRetries: 0,
+  });
+
+  print('Content:', result.content);
+  print('Usage:', result.usage);
+  print('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/anthropic-aws/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-aws/tool-call.ts
@@ -1,0 +1,26 @@
+import { anthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropicAws('claude-sonnet-4-6'),
+    maxOutputTokens: 512,
+    tools: {
+      weather: weatherTool,
+      cityAttractions: tool({
+        inputSchema: z.object({ city: z.string() }),
+      }),
+    },
+    stopWhen: stepCountIs(5),
+    prompt:
+      'What is the weather in San Francisco and what attractions should I visit?',
+  });
+
+  console.log('Text:', result.text);
+  console.log('Tool Calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool Results:', JSON.stringify(result.toolResults, null, 2));
+  console.log('Steps:', result.steps.length);
+});

--- a/examples/ai-functions/src/generate-text/anthropic-aws/web-search.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-aws/web-search.ts
@@ -1,0 +1,18 @@
+import { anthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropicAws('claude-sonnet-4-6'),
+    tools: {
+      web_search: anthropicAws.tools.webSearch_20250305(),
+    },
+    prompt: 'What were the major AI announcements last week?',
+  });
+
+  print('Content:', result.content);
+  print('Sources:', result.sources);
+  print('Usage:', result.usage);
+});

--- a/examples/ai-functions/src/generate-text/anthropic-aws/web-search.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-aws/web-search.ts
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: anthropicAws('claude-sonnet-4-6'),
     tools: {
-      web_search: anthropicAws.tools.webSearch_20250305(),
+      web_search: anthropicAws.tools.webSearch_20260209(),
     },
     prompt: 'What were the major AI announcements last week?',
   });

--- a/packages/anthropic-aws/CHANGELOG.md
+++ b/packages/anthropic-aws/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ai-sdk/anthropic-aws

--- a/packages/anthropic-aws/README.md
+++ b/packages/anthropic-aws/README.md
@@ -1,0 +1,46 @@
+# AI SDK - Claude Platform on AWS Provider
+
+The **[Claude Platform on AWS provider](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic-aws)** for the [AI SDK](https://ai-sdk.dev/docs)
+gives you access to the Anthropic Messages API hosted in AWS at
+`aws-external-anthropic.{region}.api.aws`, authenticated with AWS SigV4 or an
+AWS-provisioned API key.
+
+Same wire format and feature set as `@ai-sdk/anthropic` — model IDs, streaming,
+prompt caching, tool use, computer use, and `anthropic-beta` headers all match
+the first-party Claude API.
+
+## Setup
+
+```bash
+npm install @ai-sdk/anthropic-aws
+```
+
+## Provider Instance
+
+```ts
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+
+// SigV4 — picks up AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
+const anthropicAws = createAnthropicAws({
+  region: 'us-west-2',
+  workspaceId: 'wrkspc_…',
+});
+```
+
+## Example
+
+```ts
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText } from 'ai';
+
+const anthropicAws = createAnthropicAws();
+
+const { text } = await generateText({
+  model: anthropicAws('claude-sonnet-4-6'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+## Documentation
+
+Please check out the **[Claude Platform on AWS provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic-aws)** for more information.

--- a/packages/anthropic-aws/package.json
+++ b/packages/anthropic-aws/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@ai-sdk/anthropic-aws",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist docs *.tsbuildinfo",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*",
+    "aws4fetch": "^1.0.20"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "20.17.24",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/anthropic-aws"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/anthropic-aws/src/anthropic-aws-fetch.test.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-fetch.test.ts
@@ -1,0 +1,706 @@
+import {
+  createSigV4FetchFunction,
+  createApiKeyFetchFunction,
+} from './anthropic-aws-fetch';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+// Mock the version module
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+// Mock provider-utils to control runtime environment detection
+vi.mock('@ai-sdk/provider-utils', async () => {
+  const actual = await vi.importActual('@ai-sdk/provider-utils');
+  return {
+    ...actual,
+    getRuntimeEnvironmentUserAgent: vi.fn(() => 'runtime/testenv'),
+  };
+});
+
+// Mock AwsV4Signer so that no real crypto calls are made.
+vi.mock('aws4fetch', () => {
+  class MockAwsV4Signer {
+    options: Record<string, unknown>;
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+    }
+    async sign() {
+      // Return a fake Headers instance with predetermined signing headers.
+      const headers = new Headers();
+      headers.set('x-amz-date', '20240315T000000Z');
+      headers.set('authorization', 'AWS4-HMAC-SHA256 Credential=test');
+      if (this.options.sessionToken) {
+        headers.set(
+          'x-amz-security-token',
+          this.options.sessionToken as string,
+        );
+      }
+      return { headers };
+    }
+  }
+  return { AwsV4Signer: MockAwsV4Signer };
+});
+
+const createFetchFunction = (dummyFetch: typeof fetch) =>
+  createSigV4FetchFunction(
+    () => ({
+      region: 'us-west-2',
+      accessKeyId: 'test-access-key',
+      secretAccessKey: 'test-secret',
+    }),
+    dummyFetch,
+  );
+
+describe('createSigV4FetchFunction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should bypass signing for non-POST requests', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const response = await fetchFn('http://example.com', { method: 'GET' });
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'GET',
+      headers: {
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should bypass signing if POST request has no body', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const response = await fetchFn('http://example.com', { method: 'POST' });
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      headers: {
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should handle a POST request with a string body and merge signed headers including user-agent', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+
+    // Provide settings (including a sessionToken) so that the signer includes that header.
+    const fetchFn = createSigV4FetchFunction(
+      () => ({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret',
+        sessionToken: 'test-session-token',
+      }),
+      dummyFetch,
+    );
+
+    const inputUrl = 'http://example.com';
+    const init: RequestInit = {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'Custom-Header': 'value',
+      },
+    };
+
+    await fetchFn(inputUrl, init);
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    // `combinedHeaders` should merge the original headers with the signing
+    // headers added by the AwsV4Signer mock.
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers['content-type']).toEqual('application/json');
+    expect(headers['custom-header']).toEqual('value');
+    expect(headers['empty-header']).toBeUndefined();
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+    expect(headers['x-amz-security-token']).toEqual('test-session-token');
+    expect(headers['user-agent']).toEqual(
+      'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+    );
+    // Body is left unmodified for a string body.
+    expect(calledInit.body).toEqual('{"test": "data"}');
+  });
+
+  it('shold handle a POST request with a Request object', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const request = new Request(inputUrl, {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: { 'X-From-Request': 'from-request' },
+    });
+    const init: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Custom-Header': 'value',
+      },
+    };
+    await fetchFn(request, init);
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledRequest = dummyFetch.mock.calls[0][0] as Request;
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(calledRequest.url).toEqual('http://example.com/');
+    expect(calledInit.body).toEqual('{"test": "data"}');
+    expect(headers['content-type']).toEqual('application/json');
+    expect(headers['custom-header']).toEqual('value');
+    expect(headers['x-from-request']).toEqual('from-request');
+  });
+
+  it('should sign when input is a POST Request with body and no init', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const request = new Request('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-From-Request': 'from-request',
+      },
+    });
+
+    await fetchFn(request);
+
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+
+    expect(calledInit.body).toEqual('{"test": "data"}');
+    expect(headers['content-type']).toEqual('application/json');
+    expect(headers['x-from-request']).toEqual('from-request');
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+    expect(headers['user-agent']).toEqual(
+      'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+    );
+  });
+
+  it('should handle non-string body by stringifying it', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const jsonBody = { field: 'value' };
+
+    await fetchFn(inputUrl, {
+      method: 'POST',
+      body: jsonBody as unknown as BodyInit,
+      headers: {},
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    // The body should be stringified.
+    expect(calledInit.body).toEqual(JSON.stringify(jsonBody));
+  });
+
+  it('should handle Uint8Array body', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const uint8Body = new TextEncoder().encode('binaryTest');
+
+    await fetchFn(inputUrl, {
+      method: 'POST',
+      body: uint8Body,
+      headers: {},
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    // The Uint8Array body should have been decoded to a string.
+    expect(calledInit.body).toEqual('binaryTest');
+  });
+
+  it('should handle ArrayBuffer body', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const text = 'bufferTest';
+    const buffer = new TextEncoder().encode(text).buffer;
+
+    await fetchFn(inputUrl, {
+      method: 'POST',
+      body: buffer,
+      headers: {},
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    expect(calledInit.body).toEqual(text);
+  });
+
+  it('should extract headers from a Headers instance', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const h = new Headers();
+    h.set('A', 'value-a');
+    h.set('B', 'value-b');
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: h,
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers['a'] || headers['A']).toEqual('value-a');
+    expect(headers['b'] || headers['B']).toEqual('value-b');
+  });
+
+  it('should handle headers provided as an array', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const headersArray: [string, string][] = [
+      ['Array-Header', 'array-value'],
+      ['Another-Header', 'another-value'],
+    ];
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: headersArray,
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers['array-header'] || headers['Array-Header']).toEqual(
+      'array-value',
+    );
+    expect(headers['another-header'] || headers['Another-Header']).toEqual(
+      'another-value',
+    );
+    // Also check that the signing headers are included.
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+  });
+
+  it('should call original fetch if init is undefined', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const response = await fetchFn('http://example.com');
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: {
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should correctly handle async credential providers', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+
+    // Create a function that returns a Promise of credentials
+    const asyncCredentialsProvider = () =>
+      Promise.resolve({
+        region: 'us-east-1',
+        accessKeyId: 'async-access-key',
+        secretAccessKey: 'async-secret-key',
+        sessionToken: 'async-session-token',
+      });
+
+    const fetchFn = createSigV4FetchFunction(
+      asyncCredentialsProvider,
+      dummyFetch,
+    );
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "async"}',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    // Verify the request was properly signed
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+
+    // Check that the signing headers were added
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+    expect(headers['x-amz-security-token']).toEqual('async-session-token');
+    expect(headers['content-type']).toEqual('application/json');
+  });
+
+  it('should handle async credential providers that reject', async () => {
+    const dummyFetch = vi.fn();
+    const errorMessage = 'Failed to get credentials';
+
+    // Create a function that returns a rejected Promise
+    const failingCredentialsProvider = () =>
+      Promise.reject(new Error(errorMessage));
+
+    const fetchFn = createSigV4FetchFunction(
+      failingCredentialsProvider,
+      dummyFetch,
+    );
+
+    // The fetch call should propagate the rejection
+    await expect(
+      fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      }),
+    ).rejects.toThrow(errorMessage);
+
+    // The underlying fetch should not be called
+    expect(dummyFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('createApiKeyFetchFunction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should add x-api-key header with user-agent', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-123';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const response = await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'test-api-key-123',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should merge x-api-key header with existing headers', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-456';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'Custom-Header': 'custom-value',
+        'X-Request-ID': 'req-123',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'custom-header': 'custom-value',
+        'x-request-id': 'req-123',
+        'x-api-key': 'test-api-key-456',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work with Headers instance', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-789';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('X-Custom', 'value');
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers,
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-custom': 'value',
+        'x-api-key': 'test-api-key-789',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work with headers as array', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-array';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const headersArray: [string, string][] = [
+      ['Content-Type', 'application/json'],
+      ['X-Array-Header', 'array-value'],
+    ];
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: headersArray,
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-array-header': 'array-value',
+        'x-api-key': 'test-api-key-array',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work with GET requests', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-get';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        'x-api-key': 'test-api-key-get',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work when no headers are provided', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-no-headers';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'x-api-key': 'test-api-key-no-headers',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work when init is undefined', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-undefined';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com');
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: {
+        'x-api-key': 'test-api-key-undefined',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should override existing x-api-key header', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-override';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': 'old-token',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'test-api-key-override',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should use default fetch when no custom fetch provided', async () => {
+    const originalFetch = globalThis.fetch;
+    const mockGlobalFetch = vi.fn().mockResolvedValue(new Response('OK'));
+    globalThis.fetch = mockGlobalFetch;
+
+    try {
+      const apiKey = 'test-api-key-default';
+      const fetchFn = createApiKeyFetchFunction(apiKey);
+
+      await fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      });
+
+      expect(mockGlobalFetch).toHaveBeenCalledWith('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+        headers: {
+          'x-api-key': 'test-api-key-default',
+          'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should resolve default fetch lazily when no custom fetch provided', async () => {
+    const originalFetch = globalThis.fetch;
+    const initialFetch = vi.fn().mockResolvedValue(new Response('Initial'));
+    const patchedFetch = vi.fn().mockResolvedValue(new Response('Patched'));
+
+    globalThis.fetch = initialFetch;
+    const fetchFn = createApiKeyFetchFunction('test-api-key-lazy');
+    globalThis.fetch = patchedFetch;
+
+    try {
+      await fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      });
+
+      expect(initialFetch).not.toHaveBeenCalled();
+      expect(patchedFetch).toHaveBeenCalledWith('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+        headers: {
+          'x-api-key': 'test-api-key-lazy',
+          'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should handle empty string API key', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = '';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'x-api-key': '',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should preserve request body and other properties', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-preserve';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const requestBody = JSON.stringify({ data: 'test' });
+    await fetchFn('http://example.com', {
+      method: 'PUT',
+      body: requestBody,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'PUT',
+      body: requestBody,
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'test-api-key-preserve',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+    });
+  });
+});

--- a/packages/anthropic-aws/src/anthropic-aws-fetch.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-fetch.ts
@@ -1,0 +1,145 @@
+import {
+  combineHeaders,
+  normalizeHeaders,
+  withUserAgentSuffix,
+  getRuntimeEnvironmentUserAgent,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { AwsV4Signer } from 'aws4fetch';
+import { VERSION } from './version';
+
+export interface AnthropicAwsCredentials {
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+/**
+ * Creates a fetch function that applies AWS Signature Version 4 signing for
+ * Claude Platform on AWS.
+ *
+ * @param getCredentials - Function that returns the AWS credentials to use when signing.
+ * @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+ * @returns A FetchFunction that signs requests before passing them to the underlying fetch.
+ */
+export function createSigV4FetchFunction(
+  getCredentials: () =>
+    | AnthropicAwsCredentials
+    | PromiseLike<AnthropicAwsCredentials>,
+  fetch?: FetchFunction,
+): FetchFunction {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    // avoid caching globalThis.fetch in case it is patched by other libraries
+    const effectiveFetch = fetch ?? globalThis.fetch;
+    const request = input instanceof Request ? input : undefined;
+    const originalHeaders = combineHeaders(
+      normalizeHeaders(request?.headers),
+      normalizeHeaders(init?.headers),
+    );
+    const headersWithUserAgent = withUserAgentSuffix(
+      originalHeaders,
+      `ai-sdk/anthropic-aws/${VERSION}`,
+      getRuntimeEnvironmentUserAgent(),
+    );
+
+    let effectiveBody: BodyInit | undefined = init?.body ?? undefined;
+    if (effectiveBody === undefined && request && request.body !== null) {
+      try {
+        effectiveBody = await request.clone().text();
+      } catch {}
+    }
+
+    const effectiveMethod = init?.method ?? request?.method;
+
+    if (effectiveMethod?.toUpperCase() !== 'POST' || !effectiveBody) {
+      return effectiveFetch(input, {
+        ...init,
+        headers: headersWithUserAgent as HeadersInit,
+      });
+    }
+
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+
+    const body = prepareBodyString(effectiveBody);
+    const credentials = await getCredentials();
+    const signer = new AwsV4Signer({
+      url,
+      method: 'POST',
+      headers: Object.entries(headersWithUserAgent),
+      body,
+      region: credentials.region,
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
+      service: 'aws-external-anthropic',
+    });
+
+    const signingResult = await signer.sign();
+    const signedHeaders = normalizeHeaders(signingResult.headers);
+
+    // Use the combined headers directly as HeadersInit
+    const combinedHeaders = combineHeaders(headersWithUserAgent, signedHeaders);
+
+    return effectiveFetch(input, {
+      ...init,
+      body,
+      headers: combinedHeaders as HeadersInit,
+    });
+  };
+}
+
+function prepareBodyString(body: BodyInit | undefined): string {
+  if (typeof body === 'string') {
+    return body;
+  } else if (body instanceof Uint8Array) {
+    return new TextDecoder().decode(body);
+  } else if (body instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(body));
+  } else {
+    return JSON.stringify(body);
+  }
+}
+
+/**
+ * Creates a fetch function that applies x-api-key header authentication.
+ *
+ * @param apiKey - The API key to use for x-api-key header authentication.
+ * @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+ * @returns A FetchFunction that adds the x-api-key header to requests.
+ */
+export function createApiKeyFetchFunction(
+  apiKey: string,
+  fetch?: FetchFunction,
+): FetchFunction {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    // avoid caching globalThis.fetch in case it is patched by other libraries
+    const effectiveFetch = fetch ?? globalThis.fetch;
+    const originalHeaders = normalizeHeaders(init?.headers);
+    const headersWithUserAgent = withUserAgentSuffix(
+      originalHeaders,
+      `ai-sdk/anthropic-aws/${VERSION}`,
+      getRuntimeEnvironmentUserAgent(),
+    );
+
+    const finalHeaders = combineHeaders(headersWithUserAgent, {
+      'x-api-key': apiKey,
+    });
+
+    return effectiveFetch(input, {
+      ...init,
+      headers: finalHeaders as HeadersInit,
+    });
+  };
+}

--- a/packages/anthropic-aws/src/anthropic-aws-fetch.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-fetch.ts
@@ -33,7 +33,6 @@ export function createSigV4FetchFunction(
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
-    // avoid caching globalThis.fetch in case it is patched by other libraries
     const effectiveFetch = fetch ?? globalThis.fetch;
     const request = input instanceof Request ? input : undefined;
     const originalHeaders = combineHeaders(
@@ -85,8 +84,6 @@ export function createSigV4FetchFunction(
 
     const signingResult = await signer.sign();
     const signedHeaders = normalizeHeaders(signingResult.headers);
-
-    // Use the combined headers directly as HeadersInit
     const combinedHeaders = combineHeaders(headersWithUserAgent, signedHeaders);
 
     return effectiveFetch(input, {
@@ -124,7 +121,6 @@ export function createApiKeyFetchFunction(
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
-    // avoid caching globalThis.fetch in case it is patched by other libraries
     const effectiveFetch = fetch ?? globalThis.fetch;
     const originalHeaders = normalizeHeaders(init?.headers);
     const headersWithUserAgent = withUserAgentSuffix(

--- a/packages/anthropic-aws/src/anthropic-aws-provider.test.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-provider.test.ts
@@ -1,0 +1,566 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAnthropicAws } from './anthropic-aws-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+vi.mock('aws4fetch', () => {
+  class MockAwsV4Signer {
+    options: Record<string, unknown>;
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+    }
+    async sign() {
+      const headers = new Headers();
+      headers.set('x-amz-date', '20240315T000000Z');
+      headers.set('authorization', 'AWS4-HMAC-SHA256 Credential=test');
+      return { headers };
+    }
+  }
+  return { AwsV4Signer: MockAwsV4Signer };
+});
+
+const TEST_PROMPT: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+const createSuccessfulResponse = () =>
+  new Response(
+    JSON.stringify({
+      type: 'message',
+      id: 'msg_123',
+      model: 'claude-sonnet-4-6',
+      content: [{ type: 'text', text: 'Hi' }],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+
+const createFetchMock = () =>
+  vi.fn().mockResolvedValue(createSuccessfulResponse());
+
+const stubDefaultEnv = () => {
+  vi.stubEnv('AWS_REGION', 'us-west-2');
+  vi.stubEnv('ANTHROPIC_AWS_WORKSPACE_ID', 'wrkspc_default');
+  vi.stubEnv('ANTHROPIC_AWS_API_KEY', undefined);
+  vi.stubEnv('AWS_ACCESS_KEY_ID', undefined);
+  vi.stubEnv('AWS_SECRET_ACCESS_KEY', undefined);
+  vi.stubEnv('AWS_SESSION_TOKEN', undefined);
+};
+
+describe('createAnthropicAws', () => {
+  describe('baseURL configuration', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      stubDefaultEnv();
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('uses the default Claude Platform on AWS base URL with region templating', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-east-1',
+        workspaceId: 'wrkspc_test',
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe(
+        'https://aws-external-anthropic.us-east-1.api.aws/v1/messages',
+      );
+    });
+
+    it('reads AWS_REGION from the environment when region option is omitted', async () => {
+      vi.stubEnv('AWS_REGION', 'eu-west-1');
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        workspaceId: 'wrkspc_test',
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe(
+        'https://aws-external-anthropic.eu-west-1.api.aws/v1/messages',
+      );
+    });
+
+    it('prefers the baseURL option over the default template', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        apiKey: 'test-api-key',
+        baseURL: 'https://proxy.example.com/v1/',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://proxy.example.com/v1/messages');
+    });
+  });
+});
+
+describe('anthropicAws provider - authentication', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('apiKey option', () => {
+    it('sends x-api-key header when apiKey is provided', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        apiKey: 'sk-aws-platform-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [, requestOptions] = fetchMock.mock.calls[0]!;
+      expect(requestOptions.headers['x-api-key']).toBe('sk-aws-platform-key');
+      expect(requestOptions.headers.authorization).toBeUndefined();
+    });
+
+    it('reads apiKey from ANTHROPIC_AWS_API_KEY when option is omitted', async () => {
+      vi.stubEnv('ANTHROPIC_AWS_API_KEY', 'sk-from-env');
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [, requestOptions] = fetchMock.mock.calls[0]!;
+      expect(requestOptions.headers['x-api-key']).toBe('sk-from-env');
+    });
+  });
+
+  describe('SigV4 path', () => {
+    it('signs requests with SigV4 when apiKey is not provided', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        accessKeyId: 'akid',
+        secretAccessKey: 'secret',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [, requestOptions] = fetchMock.mock.calls[0]!;
+      expect(requestOptions.headers.authorization).toBe(
+        'AWS4-HMAC-SHA256 Credential=test',
+      );
+      expect(requestOptions.headers['x-amz-date']).toBe('20240315T000000Z');
+      expect(requestOptions.headers['x-api-key']).toBeUndefined();
+    });
+
+    it('honors a credentialProvider for dynamic SigV4 credentials', async () => {
+      const fetchMock = createFetchMock();
+      const credentialProvider = vi.fn().mockResolvedValue({
+        accessKeyId: 'dynamic-akid',
+        secretAccessKey: 'dynamic-secret',
+        sessionToken: 'dynamic-session',
+      });
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        credentialProvider,
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      expect(credentialProvider).toHaveBeenCalled();
+    });
+
+    it('throws a guided error when SigV4 credentials are missing', async () => {
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+      });
+
+      await expect(
+        provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toThrow(/AWS SigV4 authentication requires AWS credentials/);
+    });
+
+    it('wraps credentialProvider rejections with a guided message', async () => {
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        credentialProvider: async () => {
+          throw new Error('STS denied');
+        },
+      });
+
+      await expect(
+        provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toThrow(/AWS credential provider failed: STS denied/);
+    });
+  });
+});
+
+describe('anthropicAws provider - workspaceId', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('sends the anthropic-version header on every request', async () => {
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-version']).toBe('2023-06-01');
+  });
+
+  it('sends the anthropic-workspace-id header on every request', async () => {
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_unique',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_unique',
+    );
+  });
+
+  it('reads workspaceId from ANTHROPIC_AWS_WORKSPACE_ID when option is omitted', async () => {
+    vi.stubEnv('ANTHROPIC_AWS_WORKSPACE_ID', 'wrkspc_from_env');
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_from_env',
+    );
+  });
+
+  it('throws when workspaceId is not resolvable at request time', async () => {
+    vi.stubEnv('ANTHROPIC_AWS_WORKSPACE_ID', undefined);
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT }),
+    ).rejects.toThrow(/workspace/i);
+  });
+});
+
+describe('anthropicAws provider - region', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when region is not resolvable at model creation time', () => {
+    vi.stubEnv('AWS_REGION', undefined);
+    const provider = createAnthropicAws({
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+    expect(() => provider('claude-sonnet-4-6')).toThrow(/region/i);
+  });
+});
+
+describe('anthropicAws provider - headers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('merges custom headers with the workspace-id header', async () => {
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+      headers: { 'x-custom': 'value' },
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_test',
+    );
+    expect(requestOptions.headers['x-custom']).toBe('value');
+  });
+});
+
+describe('anthropicAws provider - supportedUrls', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should support image/* URLs', async () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-sonnet-4-6');
+    const supportedUrls = await model.supportedUrls;
+
+    expect(supportedUrls['image/*']).toBeDefined();
+    expect(
+      supportedUrls['image/*']![0]!.test('https://example.com/image.png'),
+    ).toBe(true);
+  });
+
+  it('should support application/pdf URLs', async () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-sonnet-4-6');
+    const supportedUrls = await model.supportedUrls;
+
+    expect(supportedUrls['application/pdf']).toBeDefined();
+    expect(
+      supportedUrls['application/pdf']![0]!.test(
+        'https://arxiv.org/pdf/2401.00001',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('anthropicAws provider - model identity', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('sets the provider name to anthropic-aws.messages on the model', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-sonnet-4-6');
+    expect(model.provider).toBe('anthropic-aws.messages');
+  });
+
+  it('throws NoSuchModelError when embeddingModel is invoked', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    expect(() => provider.embeddingModel('any-model-id')).toThrow(
+      /no such embeddingModel/i,
+    );
+  });
+
+  it('throws NoSuchModelError when imageModel is invoked', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    expect(() => provider.imageModel('any-model-id')).toThrow(
+      /no such imageModel/i,
+    );
+  });
+
+  it('throws if the provider function is called with new', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    expect(
+      () =>
+        new (provider as unknown as new (m: string) => unknown)(
+          'claude-sonnet-4-6',
+        ),
+    ).toThrow(/cannot be called with the new keyword/);
+  });
+});
+
+describe('anthropicAws provider - auth precedence', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers the API-key path when both apiKey and AWS SigV4 creds are present', async () => {
+    vi.stubEnv('AWS_ACCESS_KEY_ID', 'should-be-ignored');
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'should-be-ignored');
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'sk-aws-platform-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['x-api-key']).toBe('sk-aws-platform-key');
+    expect(requestOptions.headers.authorization).toBeUndefined();
+    expect(requestOptions.headers['x-amz-date']).toBeUndefined();
+  });
+});
+
+describe('anthropicAws provider - streaming', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('forwards doStream through the SigV4 / api-key fetch wrapper and yields stream events', async () => {
+    const sseBody = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-6","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}',
+      '',
+      'event: content_block_stop',
+      'data: {"type":"content_block_stop","index":0}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}',
+      '',
+      'event: message_stop',
+      'data: {"type":"message_stop"}',
+      '',
+    ].join('\n');
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    const { stream } = await provider('claude-sonnet-4-6').doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const parts: unknown[] = [];
+    for await (const part of stream) {
+      parts.push(part);
+    }
+
+    expect(parts.length).toBeGreaterThan(0);
+    expect(
+      parts.some(
+        p =>
+          typeof p === 'object' &&
+          p !== null &&
+          'type' in p &&
+          (p as { type: string }).type === 'text-delta',
+      ),
+    ).toBe(true);
+
+    // confirm the same workspace + version headers we tested for doGenerate
+    // also fire for streaming requests
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-version']).toBe('2023-06-01');
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_test',
+    );
+    expect(requestOptions.headers['x-api-key']).toBe('test-api-key');
+  });
+});

--- a/packages/anthropic-aws/src/anthropic-aws-provider.test.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-provider.test.ts
@@ -538,9 +538,12 @@ describe('anthropicAws provider - streaming', () => {
       prompt: TEST_PROMPT,
     });
 
+    const reader = stream.getReader();
     const parts: unknown[] = [];
-    for await (const part of stream) {
-      parts.push(part);
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parts.push(value);
     }
 
     expect(parts.length).toBeGreaterThan(0);

--- a/packages/anthropic-aws/src/anthropic-aws-provider.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-provider.ts
@@ -1,0 +1,262 @@
+import {
+  NoSuchModelError,
+  type LanguageModelV3,
+  type ProviderV3,
+} from '@ai-sdk/provider';
+import {
+  loadOptionalSetting,
+  loadSetting,
+  withoutTrailingSlash,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import {
+  AnthropicMessagesLanguageModel,
+  anthropicTools,
+  type AnthropicMessagesModelId,
+} from '@ai-sdk/anthropic/internal';
+import {
+  createApiKeyFetchFunction,
+  createSigV4FetchFunction,
+  type AnthropicAwsCredentials,
+} from './anthropic-aws-fetch';
+
+export interface AnthropicAwsProvider extends ProviderV3 {
+  /**
+   * Creates a model for text generation.
+   */
+  (modelId: AnthropicMessagesModelId): LanguageModelV3;
+
+  /**
+   * Creates a model for text generation.
+   */
+  languageModel(modelId: AnthropicMessagesModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+
+  tools: typeof anthropicTools;
+}
+
+export interface AnthropicAwsProviderSettings {
+  /**
+   * The AWS region to use for Claude Platform on AWS. Defaults to the value of the
+   * `AWS_REGION` environment variable. Required — no fallback default.
+   */
+  region?: string;
+
+  /**
+   * The Anthropic workspace ID for this AWS account. Sent on every request via the
+   * `anthropic-workspace-id` header. Defaults to the value of the
+   * `ANTHROPIC_AWS_WORKSPACE_ID` environment variable.
+   */
+  workspaceId?: string;
+
+  /**
+   * API key for authenticating requests via the `x-api-key` header.
+   * When provided, this will be used instead of AWS SigV4 authentication.
+   * Defaults to the value of the `ANTHROPIC_AWS_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * The AWS access key ID to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_ACCESS_KEY_ID` environment variable.
+   */
+  accessKeyId?: string;
+
+  /**
+   * The AWS secret access key to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SECRET_ACCESS_KEY` environment variable.
+   */
+  secretAccessKey?: string;
+
+  /**
+   * The AWS session token to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SESSION_TOKEN` environment variable.
+   */
+  sessionToken?: string;
+
+  /**
+   * Base URL for the Claude Platform on AWS API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string | undefined>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+
+  /**
+   * The AWS credential provider to use to get dynamic credentials similar to the
+   * AWS SDK. Setting a provider here will cause its credential values to be used
+   * instead of the `accessKeyId`, `secretAccessKey`, and `sessionToken` settings.
+   */
+  credentialProvider?: () => PromiseLike<
+    Omit<AnthropicAwsCredentials, 'region'>
+  >;
+
+  generateId?: () => string;
+}
+
+/**
+ * Create a Claude Platform on AWS provider instance.
+ * This provider uses the Anthropic Messages API hosted in AWS, authenticated
+ * with AWS SigV4 or an AWS-provisioned API key.
+ */
+export function createAnthropicAws(
+  options: AnthropicAwsProviderSettings = {},
+): AnthropicAwsProvider {
+  const apiKey = loadOptionalSetting({
+    settingValue: options.apiKey,
+    environmentVariableName: 'ANTHROPIC_AWS_API_KEY',
+  });
+
+  const fetchFunction = apiKey
+    ? createApiKeyFetchFunction(apiKey, options.fetch)
+    : createSigV4FetchFunction(async () => {
+        const region = loadSetting({
+          settingValue: options.region,
+          settingName: 'region',
+          environmentVariableName: 'AWS_REGION',
+          description: 'AWS region',
+        });
+
+        if (options.credentialProvider) {
+          try {
+            return {
+              ...(await options.credentialProvider()),
+              region,
+            };
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            throw new Error(
+              `AWS credential provider failed: ${errorMessage}. ` +
+                'Please ensure your credential provider returns valid AWS credentials ' +
+                'with accessKeyId and secretAccessKey properties.',
+            );
+          }
+        }
+
+        try {
+          return {
+            region,
+            accessKeyId: loadSetting({
+              settingValue: options.accessKeyId,
+              settingName: 'accessKeyId',
+              environmentVariableName: 'AWS_ACCESS_KEY_ID',
+              description: 'AWS access key ID',
+            }),
+            secretAccessKey: loadSetting({
+              settingValue: options.secretAccessKey,
+              settingName: 'secretAccessKey',
+              environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
+              description: 'AWS secret access key',
+            }),
+            sessionToken: loadOptionalSetting({
+              settingValue: options.sessionToken,
+              environmentVariableName: 'AWS_SESSION_TOKEN',
+            }),
+          };
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          if (
+            errorMessage.includes('AWS_ACCESS_KEY_ID') ||
+            errorMessage.includes('accessKeyId')
+          ) {
+            throw new Error(
+              'AWS SigV4 authentication requires AWS credentials. Please provide either:\n' +
+                '1. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables\n' +
+                '2. Provide accessKeyId and secretAccessKey in options\n' +
+                '3. Use a credentialProvider function\n' +
+                '4. Use API key authentication with ANTHROPIC_AWS_API_KEY or apiKey option\n' +
+                `Original error: ${errorMessage}`,
+            );
+          }
+          if (
+            errorMessage.includes('AWS_SECRET_ACCESS_KEY') ||
+            errorMessage.includes('secretAccessKey')
+          ) {
+            throw new Error(
+              'AWS SigV4 authentication requires both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. ' +
+                'Please ensure both credentials are provided.\n' +
+                `Original error: ${errorMessage}`,
+            );
+          }
+          throw error;
+        }
+      }, options.fetch);
+
+  const getBaseURL = (): string =>
+    withoutTrailingSlash(options.baseURL) ??
+    `https://aws-external-anthropic.${loadSetting({
+      settingValue: options.region,
+      settingName: 'region',
+      environmentVariableName: 'AWS_REGION',
+      description: 'AWS region',
+    })}.api.aws/v1`;
+
+  const getHeaders = (): Record<string, string | undefined> => ({
+    'anthropic-version': '2023-06-01',
+    'anthropic-workspace-id': loadSetting({
+      settingValue: options.workspaceId,
+      settingName: 'workspaceId',
+      environmentVariableName: 'ANTHROPIC_AWS_WORKSPACE_ID',
+      description: 'Anthropic AWS workspace ID',
+    }),
+    ...options.headers,
+  });
+
+  const createChatModel = (modelId: AnthropicMessagesModelId) =>
+    new AnthropicMessagesLanguageModel(modelId, {
+      provider: 'anthropic-aws.messages',
+      baseURL: getBaseURL(),
+      headers: getHeaders,
+      fetch: fetchFunction,
+      generateId: options.generateId,
+      supportedUrls: () => ({
+        'image/*': [/^https?:\/\/.*$/],
+        'application/pdf': [/^https?:\/\/.*$/],
+      }),
+    });
+
+  const provider = function (modelId: AnthropicMessagesModelId) {
+    if (new.target) {
+      throw new Error(
+        'The Anthropic AWS model function cannot be called with the new keyword.',
+      );
+    }
+    return createChatModel(modelId);
+  };
+
+  provider.specificationVersion = 'v3' as const;
+  provider.languageModel = createChatModel;
+  provider.chat = createChatModel;
+  provider.messages = createChatModel;
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  provider.tools = anthropicTools;
+
+  return provider;
+}
+
+/**
+ * Default Claude Platform on AWS provider instance.
+ */
+export const anthropicAws = createAnthropicAws();

--- a/packages/anthropic-aws/src/index.ts
+++ b/packages/anthropic-aws/src/index.ts
@@ -1,0 +1,7 @@
+export { anthropicAws, createAnthropicAws } from './anthropic-aws-provider';
+export type {
+  AnthropicAwsProvider,
+  AnthropicAwsProviderSettings,
+} from './anthropic-aws-provider';
+export type { AnthropicAwsCredentials } from './anthropic-aws-fetch';
+export { VERSION } from './version';

--- a/packages/anthropic-aws/src/version.ts
+++ b/packages/anthropic-aws/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/anthropic-aws/tsconfig.build.json
+++ b/packages/anthropic-aws/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/anthropic-aws/tsconfig.json
+++ b/packages/anthropic-aws/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../anthropic"
+    },
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    }
+  ]
+}

--- a/packages/anthropic-aws/tsup.config.ts
+++ b/packages/anthropic-aws/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/anthropic-aws/turbo.json
+++ b/packages/anthropic-aws/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/anthropic-aws/vitest.edge.config.js
+++ b/packages/anthropic-aws/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/anthropic-aws/vitest.node.config.js
+++ b/packages/anthropic-aws/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: workspace:*
         version: link:../../packages/anthropic
+      '@ai-sdk/anthropic-aws':
+        specifier: workspace:*
+        version: link:../../packages/anthropic-aws
       '@ai-sdk/assemblyai':
         specifier: workspace:*
         version: link:../../packages/assemblyai
@@ -1499,6 +1502,40 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/anthropic-aws:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../anthropic
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
     devDependencies:
       '@ai-sdk/test-server':
         specifier: workspace:*
@@ -20166,7 +20203,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -20180,13 +20217,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
-      css-loader: 7.1.2(webpack@5.105.0)
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
+      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -20194,22 +20231,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
-      license-webpack-plugin: 4.0.2(webpack@5.105.0)
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0)
+      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -20219,7 +20256,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -20249,7 +20286,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -25657,7 +25694,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -30579,7 +30616,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -31371,7 +31408,7 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -31478,7 +31515,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0):
+  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -34971,7 +35008,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -34999,7 +35036,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0):
+  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -36090,7 +36127,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -37618,7 +37655,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -38645,7 +38682,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -39088,7 +39125,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0):
+  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -41314,7 +41351,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "packages/amazon-bedrock" },
     { "path": "packages/angular" },
     { "path": "packages/anthropic" },
+    { "path": "packages/anthropic-aws" },
     { "path": "packages/assemblyai" },
     { "path": "packages/azure" },
     { "path": "packages/black-forest-labs" },


### PR DESCRIPTION
## Summary

New `@ai-sdk/anthropic-aws` package for [Claude Platform on AWS](https://aws.amazon.com/marketplace) — Anthropic's Messages API hosted inside AWS at `aws-external-anthropic.{region}.api.aws`. Same wire format and feature set as `@ai-sdk/anthropic` with AWS-native auth (SigV4 or AWS-provisioned API key) and AWS Marketplace billing.

This is the **v6 (LanguageModelV3) backport** of the corresponding main-branch PR ([#15230](https://github.com/vercel/ai/pull/15230)), to be released as **v1.0.0** stable. Per the team's release plan in [#15459](https://github.com/vercel/ai/issues/15459)'s pattern (which mirrors what `@ai-sdk/quiverai` did via PRs #15463 / #15461):

1. **This PR** lands first, publishing `@ai-sdk/anthropic-aws@1.0.0`
2. Then the [main PR](https://github.com/vercel/ai/pull/15230) gets `pre.json` updated to register `@ai-sdk/anthropic-aws@1.0.0` and its changeset bumped to `major`, which will publish v2.0.0 on the canary tag

## What's in the package

- `createAnthropicAws()` factory + default `anthropicAws` instance
- Two auth paths: AWS SigV4 (default, integrates with IAM/IRSA/SSO) or AWS-provisioned API key
- Provider settings: `region`, `workspaceId`, `apiKey`, `accessKeyId`, `secretAccessKey`, `sessionToken`, `baseURL`, `headers`, `fetch`, `credentialProvider`, `generateId`
- Provider surface: call sig, `languageModel`, `chat`, `messages`, `textEmbeddingModel` (deprecated throw), `tools`
- Templated base URL: `https://aws-external-anthropic.{region}.api.aws/v1`
- Required headers: `anthropic-version: 2023-06-01` + `anthropic-workspace-id`
- SigV4 service name: `aws-external-anthropic`

## Differences from the main (v7) variant

The v7 anthropic package exposes `AnthropicFiles` and `AnthropicSkills` from its `/internal` entrypoint. v6 does not have those classes. The Files API and Skills API methods (`provider.files()`, `provider.skills()`) are **intentionally omitted from this v6 release** for that reason — users who need them should adopt v7. Everything else is at parity: same auth, same wire format, same surface.

Spec version: `LanguageModelV3` / `ProviderV3` (vs `V4` on main). Otherwise the implementation is identical to main.

## Test plan

- [x] `pnpm --filter @ai-sdk/anthropic-aws build` — clean cjs + esm + dts
- [x] `pnpm --filter @ai-sdk/anthropic-aws test` — **48 / 48 passing** (25 fetch helper + 23 provider — main has 50 because of the 2 files/skills tests that don't apply here)
- [ ] End-to-end smoke test against a real Claude Platform on AWS workspace (deferred until workspace creds are provisioned; already validated on main via real-workspace smoke tests that surfaced + fixed an `anthropic-version` header bug)

## Files changed

```
.changeset/anthropic-aws-provider.md                          (major bump for 1.0.0)
content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx    (docs)
examples/ai-functions/package.json                            (+ @ai-sdk/anthropic-aws dep)
examples/ai-functions/src/generate-text/anthropic-aws/*.ts    (basic, sigv4, tool-call examples)
packages/anthropic-aws/**                                     (new package)
tsconfig.json                                                 (new project reference)
```