### PR TITLE
fix(amazon-bedrock): support document files in tool results

### DIFF
--- a/.changeset/giant-wolves-rescue.md
+++ b/.changeset/giant-wolves-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): support document files in tool results

--- a/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
@@ -179,7 +179,11 @@ export interface AmazonBedrockImageBlock {
 export interface AmazonBedrockToolResultBlock {
   toolResult: {
     toolUseId: string;
-    content: Array<AmazonBedrockTextBlock | AmazonBedrockImageBlock>;
+    content: Array<
+      | AmazonBedrockTextBlock
+      | AmazonBedrockImageBlock
+      | AmazonBedrockDocumentBlock
+    >;
   };
 }
 

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1439,6 +1439,52 @@ describe('tool messages', () => {
     });
   });
 
+  it('should convert tool result with content array containing PDF', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-123',
+            toolName: 'document-reader',
+            output: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  data: { type: 'data', data: 'base64data' },
+                  mediaType: 'application/pdf',
+                  filename: 'tool-result.pdf',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.messages[0]).toEqual({
+      role: 'user',
+      content: [
+        {
+          toolResult: {
+            toolUseId: 'call-123',
+            content: [
+              {
+                document: {
+                  format: 'pdf',
+                  name: 'tool-result',
+                  source: { bytes: 'base64data' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
   it('should throw error for unsupported image format in tool result content', async () => {
     await expect(
       convertToAmazonBedrockChatMessages([
@@ -1468,7 +1514,7 @@ describe('tool messages', () => {
     );
   });
 
-  it('should throw error for unsupported mime type in tool result image content', async () => {
+  it('should throw error for unsupported mime type in tool result file content', async () => {
     await expect(
       convertToAmazonBedrockChatMessages([
         {
@@ -1493,7 +1539,7 @@ describe('tool messages', () => {
         },
       ]),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[AI_UnsupportedFunctionalityError: 'media type: unsupported/mime-type' functionality not supported.]`,
+      `[AI_UnsupportedFunctionalityError: Unsupported file mime type: unsupported/mime-type, expected one of: application/pdf, text/csv, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, text/html, text/plain, text/markdown]`,
     );
   });
 

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -229,48 +229,69 @@ export async function convertToAmazonBedrockChatMessages(
                 const output = part.output;
                 switch (output.type) {
                   case 'content': {
-                    toolResultContent = output.value.map(contentPart => {
-                      switch (contentPart.type) {
-                        case 'text':
-                          return { text: contentPart.text };
-                        case 'file': {
-                          if (
-                            getTopLevelMediaType(contentPart.mediaType) !==
-                            'image'
-                          ) {
-                            throw new UnsupportedFunctionalityError({
-                              functionality: `media type: ${contentPart.mediaType}`,
+                    toolResultContent = await Promise.all(
+                      output.value.map(async contentPart => {
+                        switch (contentPart.type) {
+                          case 'text':
+                            return { text: contentPart.text };
+                          case 'file': {
+                            if (contentPart.data.type !== 'data') {
+                              throw new UnsupportedFunctionalityError({
+                                functionality: `tool result file data of type "${contentPart.data.type}"`,
+                              });
+                            }
+
+                            const fullMediaType = resolveFullMediaType({
+                              part: contentPart,
                             });
-                          }
 
-                          if (contentPart.data.type !== 'data') {
-                            throw new UnsupportedFunctionalityError({
-                              functionality: `tool result file data of type "${contentPart.data.type}"`,
-                            });
-                          }
+                            if (
+                              getTopLevelMediaType(fullMediaType) !== 'image'
+                            ) {
+                              const enableCitations =
+                                await shouldEnableCitations(
+                                  contentPart.providerOptions,
+                                );
 
-                          const fullMediaType = resolveFullMediaType({
-                            part: contentPart,
-                          });
-                          const format =
-                            getAmazonBedrockImageFormat(fullMediaType);
+                              return {
+                                document: {
+                                  format:
+                                    getAmazonBedrockDocumentFormat(
+                                      fullMediaType,
+                                    ),
+                                  name: contentPart.filename
+                                    ? stripFileExtension(contentPart.filename)
+                                    : generateDocumentName(),
+                                  source: {
+                                    bytes: convertToBase64(
+                                      contentPart.data.data,
+                                    ),
+                                  },
+                                  ...(enableCitations && {
+                                    citations: { enabled: true },
+                                  }),
+                                },
+                              };
+                            }
 
-                          return {
-                            image: {
-                              format,
-                              source: {
-                                bytes: convertToBase64(contentPart.data.data),
+                            return {
+                              image: {
+                                format:
+                                  getAmazonBedrockImageFormat(fullMediaType),
+                                source: {
+                                  bytes: convertToBase64(contentPart.data.data),
+                                },
                               },
-                            },
-                          };
+                            };
+                          }
+                          default: {
+                            throw new UnsupportedFunctionalityError({
+                              functionality: `unsupported tool content part type: ${contentPart.type}`,
+                            });
+                          }
                         }
-                        default: {
-                          throw new UnsupportedFunctionalityError({
-                            functionality: `unsupported tool content part type: ${contentPart.type}`,
-                          });
-                        }
-                      }
-                    });
+                      }),
+                    );
                     break;
                   }
                   case 'text':


### PR DESCRIPTION
## Background

reported in https://github.com/vercel/ai/issues/15319 

alternate to https://github.com/vercel/ai/pull/15361 with all signed commits + reproduction

the `tool-result case 'file'` branch only allows image media types, everything else throws
`UnsupportedFunctionalityError`. PDFs and other documents are unsupported, even though Bedrock's Converse API accepts documents.

## Summary

tool-result file handling now mirrors user-message file handling:

- image tool-result files still convert to Bedrock image blocks
- non-image tool-result files now convert to Bedrock document blocks

## Manual Verification

<details>
<summary>repro:</summary>

```ts
import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
import { generateText, tool } from 'ai';
import { run } from '../../lib/run';
import { z } from 'zod';

function createPdfData(text: string): Uint8Array {
  const stream = `BT
/F1 24 Tf
72 720 Td
(${text}) Tj
ET`;

  const objects = [
    '<< /Type /Catalog /Pages 2 0 R >>',
    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
    `<< /Length ${stream.length} >>
stream
${stream}
endstream`,
  ];

  let pdf = '%PDF-1.4\n';
  const offsets = [0];

  for (const [index, object] of objects.entries()) {
    offsets.push(pdf.length);
    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
  }

  const xrefOffset = pdf.length;
  pdf += `xref
0 ${objects.length + 1}
0000000000 65535 f 
${offsets
  .slice(1)
  .map(offset => `${offset.toString().padStart(10, '0')} 00000 n `)
  .join('\n')}
trailer
<< /Size ${objects.length + 1} /Root 1 0 R >>
startxref
${xrefOffset}
%%EOF`;

  return new TextEncoder().encode(pdf);
}

const pdfData = createPdfData('This PDF was returned by a tool result.');

run(async () => {
  const result = await generateText({
    model: amazonBedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
    tools: {
      readDocument: tool({
        description: 'Read a PDF document',
        inputSchema: z.object({}),
        execute: async () => ({ ok: true }),
      }),
    },
    messages: [
      {
        role: 'user',
        content: 'Read the PDF returned by the tool.',
      },
      {
        role: 'assistant',
        content: [
          {
            type: 'tool-call',
            toolCallId: 'call-read-document',
            toolName: 'readDocument',
            input: {},
          },
        ],
      },
      {
        role: 'tool',
        content: [
          {
            type: 'tool-result',
            toolCallId: 'call-read-document',
            toolName: 'readDocument',
            output: {
              type: 'content',
              value: [
                {
                  type: 'file',
                  data: { type: 'data', data: pdfData },
                  mediaType: 'application/pdf',
                  filename: 'repro.pdf',
                },
              ],
            },
          },
        ],
      },
      {
        role: 'user',
        content: 'Summarize the PDF.',
      },
    ],
  });

  console.log(result.text);
});
```

</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15319 

Co-authored-by: Pragnyan Ramtha <pragnyanramtha@gmail.com>