### PR TITLE
docs(agents): add Authenticated Outbound Requests page

### DIFF
--- a/content/docs/03-agents/08-authenticated-outbound-requests.mdx
+++ b/content/docs/03-agents/08-authenticated-outbound-requests.mdx
@@ -1,0 +1,85 @@
+---
+title: Authenticated Outbound Requests
+description: Cryptographically sign outbound HTTP calls made by agent tools so destinations can verify the agent's identity, trust tier, and capability scope.
+---
+
+# Authenticated Outbound Requests
+
+Some agent tools need to call third-party APIs or websites that gate access on verified agent identity — bot-defense systems, enterprise APIs, marketplaces with agent-specific pricing, regulated industries with audit requirements.
+
+By default, an agent's outbound `fetch` calls look programmatic to the destination's bot-defense layer (no mouse movement, no scroll, datacenter IPs, consistent TLS fingerprint). The destination then either overblocks (rejecting legitimate agent traffic) or underblocks (allowing scrapers wearing the same shape).
+
+You can wrap your tool's outbound `fetch` with a passport-signing library so destinations can cryptographically verify the agent at the edge.
+
+<Note>
+  This pattern is library-agnostic — wrap your outbound `fetch` with whatever
+  authentication scheme your destination expects. The example below uses
+  [AgentPKI](https://agentpki.dev), one open-spec implementation.
+</Note>
+
+## Pattern
+
+Create the signed client once, capture it in a closure, then use its signed `fetch` inside any tool's `execute` function:
+
+```ts highlight="6-9,15"
+import { tool } from 'ai';
+import { z } from 'zod';
+import { AgentPKI } from '@agentpki/sdk';
+
+// Create once, capture in closure
+const agent = new AgentPKI({
+  passportProvider: yourMintFn, // your own issuer or a hosted service
+  mode: 'B',                    // RFC 9421 HTTP Message Signatures
+});
+
+const fetchArticle = tool({
+  description: 'Fetch the full text of an article from a URL',
+  inputSchema: z.object({ url: z.string().url() }),
+  execute: async ({ url }) => {
+    const res = await agent.fetch(url); // ← passport attached automatically
+    return await res.text();
+  },
+});
+```
+
+The signed client wraps `fetch` and attaches an authentication header (and optionally an [RFC 9421](https://datatracker.ietf.org/doc/html/rfc9421) HTTP Message Signature) to every outbound request. Destinations verify the credential against the issuer's well-known endpoint and decide whether to serve based on the agent's identity, trust tier, and capability scope.
+
+## Use cases
+
+- **Bot-defense compatibility** — stop being misclassified by Cloudflare / DataDome / hCaptcha / Arkose when fetching from sites whose detection model flags your agent's TLS shape as suspicious.
+- **Capability scoping** — emit credentials with a declared scope such as `purchase:up-to-100usd` or `read:articles`. Destinations enforce the limit cryptographically rather than trusting client-side state.
+- **Multi-agent setups** — each sub-agent (researcher, writer, auditor, …) gets its own credential. Audit trails on destinations show exactly which sub-agent performed each action.
+
+## Example: signed request inside an agent loop
+
+```ts
+import { ToolLoopAgent, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { AgentPKI } from '@agentpki/sdk';
+__PROVIDER_IMPORT__;
+
+const agent = new AgentPKI({
+  passportProvider: yourMintFn,
+  mode: 'B',
+});
+
+const looper = new ToolLoopAgent({
+  model: __MODEL__,
+  tools: {
+    fetchArticle: tool({
+      description: 'Fetch an article from a URL',
+      inputSchema: z.object({ url: z.string().url() }),
+      execute: async ({ url }) => (await agent.fetch(url)).text(),
+    }),
+  },
+  stopWhen: stepCountIs(5),
+});
+```
+
+Every call `fetchArticle` makes inherits the agent's identity automatically. The model doesn't see the signing detail; the destination does.
+
+## Further reading
+
+- Spec and live demo: [agentpki.dev](https://agentpki.dev)
+- Full AI SDK integration examples (single-agent, multi-agent, signed-body purchase flows): [github.com/agentpki/sdk-typescript/tree/main/examples/vercel-ai-sdk](https://github.com/agentpki/sdk-typescript/tree/main/examples/vercel-ai-sdk)
+- AgentPKI is community-maintained and not affiliated with Vercel.


### PR DESCRIPTION
## Summary

Adds a new docs page under `content/docs/03-agents/` covering the pattern of wrapping a tool's outbound `fetch` with a signing/auth library so destinations can verify the agent at the edge.

This pattern is **library-agnostic** — the page presents it as a general technique (wrap outbound `fetch` with an auth client) and uses [AgentPKI](https://agentpki.dev) (open spec, Apache 2.0) as one concrete example, with a clear `<Note>` callout that the library is community-maintained and not affiliated with Vercel.

## Motivation

Agents built with the AI SDK increasingly need to fetch from destinations that gate access on agent identity (bot-defense, capability-scoped APIs, regulated industries with audit needs). The docs currently cover tool definition, approvals, sub-agents, and memory — but not the outbound-auth pattern, which is a question that comes up in discussions and is well-served by a short page that shows the closure pattern in 8 lines.

## What's in the page

- The problem (programmatic shape vs. bot-defense)
- The pattern (create signed client once, use `agent.fetch` inside `execute`)
- Three short use-case bullets (bot-defense compat, capability scoping, multi-agent audit trails)
- A `ToolLoopAgent`-flavored example matching the style of existing docs
- Links to upstream spec + worked examples

## Format

Matches the existing `03-agents/` MDX conventions:

- Frontmatter (`title`, `description`)
- `<Note>` callout for the library-agnostic framing
- `highlight=` on the integration code block
- `__PROVIDER_IMPORT__` / `__MODEL__` placeholders for the agent-loop example so it picks up your existing provider-substitution

No changes to code, types, or build config.

## Checklist

- [x] Docs-only change (no changesets needed)
- [x] MDX matches existing `03-agents/` file style
- [x] No third-party promotion — page presents the pattern, names one example library with a clear disclaimer
- [x] Internal cross-links + external references both included

Happy to revise framing, examples, or placement based on your feedback.