### PR TITLE
Fix broken Google provider docs link in README

### DIFF
--- a/packages/google/README.md
+++ b/packages/google/README.md
@@ -1,6 +1,6 @@
 # AI SDK - Google Provider
 
-The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
+The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Google (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 
@@ -42,4 +42,4 @@ const { text } = await generateText({
 
 ## Documentation
 
-Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for more information.
+Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for more information.


### PR DESCRIPTION
## Background

The Google provider `README.md` inside the `packages` folder contained a documentation link that points to a non-existent page on `ai-sdk.dev`.

The broken link was:

https://ai-sdk.dev/docs/reference/stream-helpers/google-generative-ai-stream

This currently redirects to a 404 page. The correct documentation page is:

https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai

## Summary

Updated both occurrences of the broken Google provider documentation link in the README file.

The links now point to the correct Google Generative AI provider documentation page:

https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15541