### PR TITLE
fix(anthropic): treat bare ANTHROPIC_BASE_URL host as /v1 endpoint

### DIFF
--- a/.changeset/fix-anthropic-base-url-bare-host.md
+++ b/.changeset/fix-anthropic-base-url-bare-host.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+Treat `ANTHROPIC_BASE_URL=https://api.anthropic.com` (the bare canonical host used by the official Anthropic SDK and tools such as Claude Code) as the `/v1` endpoint, so embedded apps no longer 404 when the env var is injected from the outside. Custom proxy URLs and explicit `/v1` paths are left unchanged.

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -83,6 +83,24 @@ describe('createAnthropic', () => {
       expect(requestUrl).toBe('https://proxy.anthropic.example/v1/messages');
     });
 
+    it('treats the bare canonical Anthropic host as the /v1 endpoint', async () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+
+      const fetchMock = createFetchMock();
+      const provider = createAnthropic({
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-3-haiku-20240307').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://api.anthropic.com/v1/messages');
+    });
+
     it('prefers the baseURL option over ANTHROPIC_BASE_URL', async () => {
       process.env.ANTHROPIC_BASE_URL = 'https://env.anthropic.example/v1';
 

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -18,6 +18,7 @@ import { AnthropicFiles } from './anthropic-files';
 import { AnthropicLanguageModel } from './anthropic-language-model';
 import type { AnthropicModelId } from './anthropic-language-model-options';
 import { anthropicTools } from './anthropic-tools';
+import { normalizeAnthropicBaseURL } from './normalize-anthropic-base-url';
 import { AnthropicSkills } from './skills/anthropic-skills';
 import { VERSION } from './version';
 
@@ -102,11 +103,13 @@ export function createAnthropic(
   options: AnthropicProviderSettings = {},
 ): AnthropicProvider {
   const baseURL =
-    withoutTrailingSlash(
-      loadOptionalSetting({
-        settingValue: options.baseURL,
-        environmentVariableName: 'ANTHROPIC_BASE_URL',
-      }),
+    normalizeAnthropicBaseURL(
+      withoutTrailingSlash(
+        loadOptionalSetting({
+          settingValue: options.baseURL,
+          environmentVariableName: 'ANTHROPIC_BASE_URL',
+        }),
+      ),
     ) ?? 'https://api.anthropic.com/v1';
 
   const providerName = options.name ?? 'anthropic.messages';

--- a/packages/anthropic/src/normalize-anthropic-base-url.test.ts
+++ b/packages/anthropic/src/normalize-anthropic-base-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAnthropicBaseURL } from './normalize-anthropic-base-url';
+
+describe('normalizeAnthropicBaseURL', () => {
+  it('appends /v1 when the canonical Anthropic host is provided without a path', () => {
+    expect(normalizeAnthropicBaseURL('https://api.anthropic.com')).toBe(
+      'https://api.anthropic.com/v1',
+    );
+  });
+
+  it('appends /v1 when the canonical Anthropic host has only a trailing slash', () => {
+    expect(normalizeAnthropicBaseURL('https://api.anthropic.com/')).toBe(
+      'https://api.anthropic.com/v1',
+    );
+  });
+
+  it('returns the canonical Anthropic host unchanged when /v1 is already present', () => {
+    expect(normalizeAnthropicBaseURL('https://api.anthropic.com/v1')).toBe(
+      'https://api.anthropic.com/v1',
+    );
+  });
+
+  it('leaves custom proxies on the Anthropic host alone when they specify a path', () => {
+    expect(
+      normalizeAnthropicBaseURL('https://api.anthropic.com/custom/path'),
+    ).toBe('https://api.anthropic.com/custom/path');
+  });
+
+  it('leaves third-party proxy URLs alone', () => {
+    expect(normalizeAnthropicBaseURL('https://proxy.example.com')).toBe(
+      'https://proxy.example.com',
+    );
+    expect(normalizeAnthropicBaseURL('https://litellm.example.com/v1')).toBe(
+      'https://litellm.example.com/v1',
+    );
+  });
+
+  it('returns undefined when undefined is provided', () => {
+    expect(normalizeAnthropicBaseURL(undefined)).toBeUndefined();
+  });
+
+  it('returns invalid URLs unchanged', () => {
+    expect(normalizeAnthropicBaseURL('not a url')).toBe('not a url');
+  });
+});

--- a/packages/anthropic/src/normalize-anthropic-base-url.ts
+++ b/packages/anthropic/src/normalize-anthropic-base-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Normalize the configured Anthropic base URL so that the bare canonical host
+ * (`https://api.anthropic.com`), which is the form used by the official
+ * Anthropic SDK and tools like Claude Code, also resolves to the versioned
+ * `/v1` prefix that this provider appends paths to.
+ *
+ * Any other value (custom proxies, LiteLLM gateways, hosts that already
+ * include a path) is returned unchanged.
+ */
+export function normalizeAnthropicBaseURL(
+  baseURL: string | undefined,
+): string | undefined {
+  if (baseURL == null) {
+    return baseURL;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(baseURL);
+  } catch {
+    return baseURL;
+  }
+
+  if (url.host !== 'api.anthropic.com') {
+    return baseURL;
+  }
+
+  if (url.pathname !== '' && url.pathname !== '/') {
+    return baseURL;
+  }
+
+  url.pathname = '/v1';
+  return url.toString().replace(/\/$/, '');
+}


### PR DESCRIPTION
## Summary

Fixes #15542.

`@ai-sdk/anthropic` defaults its base URL to `https://api.anthropic.com/v1` and appends paths like `/messages` directly. The official `@anthropic-ai/sdk`, and tools that embed it such as Claude Code and Cursor, instead use `https://api.anthropic.com` and prepend `/v1/messages` internally. They expose that bare-host form as `ANTHROPIC_BASE_URL` to child processes.

When an app embeds `@ai-sdk/anthropic` inside one of those tools, it inherits `ANTHROPIC_BASE_URL=https://api.anthropic.com` from the parent and every call 404s on `https://api.anthropic.com/messages`.

This adds a `normalizeAnthropicBaseURL` helper used right after the env var is read. If the resolved base URL points at the canonical Anthropic host (`api.anthropic.com`) with no path (or just `/`), the helper appends `/v1` so the rest of the request-building code keeps working. Every other URL, including LiteLLM proxies, on-prem gateways, custom paths under `api.anthropic.com`, and the existing `…/v1` form, is returned unchanged.

The helper lives in `packages/anthropic/`; nothing outside the provider is touched.

## Test plan

- [x] New `normalize-anthropic-base-url.test.ts` covers: bare canonical host, canonical host with trailing slash, canonical host already at `/v1`, custom path on the canonical host, third-party proxy URLs, undefined input, invalid URLs.
- [x] New `createAnthropic > baseURL configuration > treats the bare canonical Anthropic host as the /v1 endpoint` integration test asserts a request driven by `ANTHROPIC_BASE_URL=https://api.anthropic.com` hits `https://api.anthropic.com/v1/messages`. Reverting the helper makes this test fail with the exact pre-fix URL (`https://api.anthropic.com/messages`).
- [x] Existing `ANTHROPIC_BASE_URL` tests (default, custom proxy with `/v1`, `baseURL` option override) still pass.
- [x] `pnpm --filter @ai-sdk/anthropic test`: 426/426 pass on node + edge.
- [x] `pnpm --filter @ai-sdk/anthropic type-check`: clean.
- [x] `pnpm check`: lint and format clean.