### PR TITLE
docs: update Google provider README links

### DIFF
--- a/packages/google/README.md
+++ b/packages/google/README.md
@@ -1,6 +1,6 @@
 # AI SDK - Google Provider
 
-The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
+The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Google (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 
@@ -42,4 +42,4 @@ const { text } = await generateText({
 
 ## Documentation
 
-Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for more information.
+Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for more information.


### PR DESCRIPTION
## Problem

The Google provider package README still links to the old `google-generative-ai` provider docs slug. The current docs source for this provider is `content/providers/01-ai-sdk-providers/15-google.mdx`, which publishes under `/providers/ai-sdk-providers/google`.

This also aligns with the broken Google-provider docs link reported in #15539.

## Solution

Update both Google provider README links to the current Google provider docs URL.

## Validation

- `git diff --check`
- Verified `content/providers/01-ai-sdk-providers/15-google.mdx` exists
- Verified `packages/google/README.md` no longer references `providers/ai-sdk-providers/google-generative-ai`

## Confidence

82/100 — docs/broken-link category. This is a small README-only URL update to an existing docs page; no code behavior changes.
