### PR TITLE
chore(examples): reproduction scripts for Gemini 3 thoughtSignature issues

### DIFF
--- a/examples/ai-functions/src/stream-text/gateway/issue-10344-client-side-tools.ts
+++ b/examples/ai-functions/src/stream-text/gateway/issue-10344-client-side-tools.ts
@@ -1,0 +1,219 @@
+import 'dotenv/config';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+/**
+ * Reproduction attempt for @pheuter's post-close note on #10344:
+ *
+ *   "Gemini 3 models require a thoughtSignature on every functionCall part
+ *   when replaying conversation history. The AI SDK normally preserves this
+ *   through callProviderMetadata, but it's possible in certain edge cases for
+ *   clients not to store/send it back. In our codebase, it can happen with
+ *   client-side tool execution."
+ *
+ * Client-side tool execution path:
+ *   - Tool is defined WITHOUT `execute`
+ *   - Turn 1: streamText returns a tool-call; the SDK does not run it
+ *   - The application (the "client") runs the tool externally
+ *   - Turn 2: streamText is called again with the assistant tool-call
+ *     message + a tool-result message
+ *
+ * If the application code strips/loses providerMetadata.google.thoughtSignature
+ * when reconstructing the messages, the Gemini API rejects Turn 2 with:
+ *   "Function call is missing a thought_signature in functionCall parts."
+ *
+ * This script runs two Turn 2 variants:
+ *   A) "well-behaved client": preserves providerMetadata.google.thoughtSignature
+ *   B) "buggy client": strips providerMetadata before sending the next turn
+ */
+async function main() {
+  const MODEL_ID = 'google/gemini-3-flash';
+
+  // Tool with no `execute` — the SDK will not auto-run it. The caller
+  // (this script) plays the role of the application-side executor.
+  const weatherTool = tool({
+    description: 'Get the weather for a location',
+    inputSchema: z.object({
+      location: z.string().describe('The location to get the weather for'),
+    }),
+    // no execute -> client-side execution
+  });
+
+  // --- Turn 1: capture a tool-call + thoughtSignature ---
+  console.log('=== Turn 1: client-side tool — capture tool-call ===\n');
+
+  const turn1 = streamText({
+    model: MODEL_ID,
+    tools: { weather: weatherTool },
+    toolChoice: 'required',
+    prompt: 'What is the weather in San Francisco? Use the weather tool.',
+    stopWhen: stepCountIs(1),
+    providerOptions: {
+      gateway: {
+        only: ['google'],
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const chunk of turn1.fullStream) {
+    if (chunk.type === 'text-delta') process.stdout.write(chunk.text);
+  }
+
+  const steps1 = await turn1.steps;
+  const finalStep1 = steps1[steps1.length - 1];
+  const turn1AssistantMessages = finalStep1.response.messages.filter(
+    m => m.role === 'assistant',
+  );
+
+  let toolCallId: string | undefined;
+  let toolCallInput: any;
+  let toolCallSignature: string | undefined;
+  for (const msg of turn1AssistantMessages) {
+    if (typeof msg.content === 'string') continue;
+    for (const part of msg.content) {
+      if (part.type === 'tool-call') {
+        toolCallId = part.toolCallId;
+        toolCallInput = part.input;
+        toolCallSignature = (part as any).providerOptions?.google
+          ?.thoughtSignature;
+      }
+    }
+  }
+
+  if (!toolCallId || !toolCallSignature) {
+    console.log(
+      '\nTurn 1 did not produce a tool-call with signature. Cannot continue.',
+    );
+    console.log(
+      'turn1 assistant content:',
+      JSON.stringify(
+        turn1AssistantMessages.map(m => m.content),
+        null,
+        2,
+      ),
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `\n[Turn 1] tool-call ${toolCallId} input=${JSON.stringify(toolCallInput)} sigPrefix=${toolCallSignature.substring(0, 16)}... (len=${toolCallSignature.length})`,
+  );
+
+  // --- Application-side tool execution ---
+  const toolResultValue = {
+    location: 'San Francisco',
+    temperature: 72,
+    condition: 'sunny',
+  };
+  console.log(
+    `[client] executed tool externally, result: ${JSON.stringify(toolResultValue)}`,
+  );
+
+  const buildHistory = (preserveSignature: boolean) => [
+    {
+      role: 'user' as const,
+      content: 'What is the weather in San Francisco? Use the weather tool.',
+    },
+    {
+      role: 'assistant' as const,
+      content: [
+        {
+          type: 'tool-call' as const,
+          toolCallId: toolCallId!,
+          toolName: 'weather',
+          input: toolCallInput,
+          ...(preserveSignature
+            ? {
+                providerOptions: {
+                  google: { thoughtSignature: toolCallSignature! },
+                },
+              }
+            : {}),
+        },
+      ],
+    },
+    {
+      role: 'tool' as const,
+      content: [
+        {
+          type: 'tool-result' as const,
+          toolCallId: toolCallId!,
+          toolName: 'weather',
+          output: { type: 'json' as const, value: toolResultValue },
+        },
+      ],
+    },
+  ];
+
+  const runTurn = async (label: string, preserveSignature: boolean) => {
+    const result = streamText({
+      model: MODEL_ID,
+      tools: { weather: weatherTool },
+      messages: buildHistory(preserveSignature),
+      stopWhen: stepCountIs(1),
+      providerOptions: {
+        gateway: {
+          only: ['google'],
+        } satisfies GatewayProviderOptions,
+      },
+    });
+
+    let streamError: any;
+    for await (const chunk of result.fullStream) {
+      if (chunk.type === 'text-delta') process.stdout.write(chunk.text);
+      if (chunk.type === 'error') streamError = chunk.error;
+    }
+
+    if (streamError) {
+      const e: any = streamError;
+      console.error(`\n✗ ${label} FAILED:`);
+      console.error('  statusCode:', e.statusCode);
+      console.error('  message:   ', e.message);
+      if (e.responseBody) {
+        const body = String(e.responseBody);
+        const match = body.match(
+          /thought_signature[^"]*missing[^"]*functionCall parts[^"]*/i,
+        );
+        if (match)
+          console.error(
+            '  matched bug signature: ' + match[0].slice(0, 120) + '...',
+          );
+        else console.error('  responseBody:', body.slice(0, 400));
+      }
+      return false;
+    }
+    console.log(`\n\n✓ ${label} succeeded.`);
+    return true;
+  };
+
+  // --- Turn 2A: well-behaved client (signature preserved) ---
+  console.log(
+    '\n=== Turn 2A: well-behaved client — signature preserved on tool-call ===\n',
+  );
+  const okA = await runTurn('Turn 2A (signature preserved)', true);
+
+  // --- Turn 2B: buggy client (signature stripped) ---
+  console.log(
+    '\n=== Turn 2B: buggy client — providerMetadata stripped from tool-call ===',
+  );
+  console.log(
+    '  Expectation: Gemini rejects with HTTP 400 "missing thought_signature".\n',
+  );
+  const okB = await runTurn('Turn 2B (signature stripped)', false);
+
+  console.log('\n--- Summary ---');
+  console.log(
+    `  Turn 2A (well-behaved): ${okA ? 'succeeded ✓ (expected)' : 'failed ✗ (unexpected)'}`,
+  );
+  console.log(
+    `  Turn 2B (signature stripped): ${okB ? 'succeeded — bug NOT reproduced' : 'failed with 400 ✓ — bug reproduced (expected)'}`,
+  );
+}
+
+main().catch(error => {
+  console.error('top-level error:', error.message);
+  if (error.responseBody)
+    console.error('  responseBody:', String(error.responseBody).slice(0, 500));
+  process.exit(1);
+});

--- a/examples/ai-functions/src/stream-text/gateway/issue-10344-zod-validation.ts
+++ b/examples/ai-functions/src/stream-text/gateway/issue-10344-zod-validation.ts
@@ -1,0 +1,122 @@
+import 'dotenv/config';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+/**
+ * Reproduction attempt for the post-close claim on #10344:
+ *
+ *   hsheth2: "For me this is particularly happening when the tool call fails
+ *   due to zod validation. When the tool calls succeed it does seem to pass
+ *   the thought_signature properly."
+ *
+ * We force a tool execution failure mid-conversation and check whether the
+ * next step succeeds (the SDK should still preserve the thoughtSignature on
+ * the tool-call assistant message) or fails with
+ *   "Function call is missing a thought_signature in functionCall parts."
+ *
+ * Scenarios:
+ *   A) execute() throws — most common "tool call fails" path
+ *   B) zod schema rejects the model's args (handled by experimental_repairToolCall? otherwise propagates)
+ */
+async function main() {
+  const MODEL_ID = 'google/gemini-3-flash';
+  const HUNT_PROMPT =
+    "You're on a treasure hunt. Call the clue tool with codename 'start' first, then keep calling with each new codename you receive until you find the treasure.";
+
+  // --- Scenario A: execute() throws on the third call ---
+  console.log('=== Scenario A: execute() throws mid-chain ===\n');
+  let callIndex = 0;
+  const flakyClueTool = tool({
+    description:
+      'Follow a treasure-hunt clue. Returns the next hint, which contains the codename to pass on the next call.',
+    inputSchema: z.object({
+      codename: z
+        .string()
+        .describe(
+          "Codename from the previous hint. Use 'start' on the first call.",
+        ),
+    }),
+    execute: async ({ codename }) => {
+      callIndex += 1;
+      if (callIndex === 3) {
+        throw new Error(
+          'BOOM: simulated tool failure on the third call (codename was: ' +
+            codename +
+            ')',
+        );
+      }
+      const chain: Record<string, string> = {
+        start: 'Look under the doormat (codename: doormat).',
+        doormat: 'Check inside the mailbox (codename: mailbox).',
+        mailbox: 'Inspect the flowerpot (codename: flowerpot).',
+        flowerpot: 'Lift the welcome rug (codename: rug).',
+        rug: 'Search behind the picture frame (codename: frame).',
+        frame: 'The treasure is in the chest!',
+      };
+      return { hint: chain[codename] ?? 'Unknown codename.' };
+    },
+  });
+
+  try {
+    const result = streamText({
+      model: MODEL_ID,
+      tools: { clue: flakyClueTool },
+      prompt: HUNT_PROMPT,
+      stopWhen: stepCountIs(10),
+      providerOptions: {
+        gateway: {
+          only: ['google'],
+        } satisfies GatewayProviderOptions,
+      },
+      onStepFinish: step => {
+        console.log(
+          `\n[step ${step.stepNumber}] finishReason=${step.finishReason} toolCalls=${step.toolCalls.length} toolResults=${step.toolResults.length}`,
+        );
+        const contentSummary = (step.content ?? []).map((p: any) => ({
+          type: p.type,
+          toolName: p.toolName,
+          input: p.input ? JSON.stringify(p.input).slice(0, 60) : undefined,
+          textPreview:
+            p.type === 'text' && p.text ? p.text.slice(0, 60) : undefined,
+          errorMsg:
+            p.type === 'tool-error'
+              ? (p.error?.message ?? String(p.error)).slice(0, 100)
+              : undefined,
+          sigPrefix: p.providerMetadata?.google?.thoughtSignature
+            ? String(p.providerMetadata.google.thoughtSignature).slice(0, 12)
+            : undefined,
+        }));
+        console.log('  content:', JSON.stringify(contentSummary));
+      },
+    });
+
+    for await (const chunk of result.fullStream) {
+      if (chunk.type === 'text-delta') process.stdout.write(chunk.text);
+    }
+
+    const steps = await result.steps;
+    console.log(
+      `\n\n✓ Scenario A completed without provider error. Steps: ${steps.length}. Tool failure was absorbed by the SDK.`,
+    );
+  } catch (error: any) {
+    console.error('\n✗ Scenario A FAILED with provider error:');
+    console.error('  statusCode:', error.statusCode);
+    console.error('  message:   ', error.message);
+    if (error.responseBody)
+      console.error(
+        '  responseBody:',
+        String(error.responseBody).substring(0, 800),
+      );
+    if (error.data?.providerMetadata?.gateway?.routing)
+      console.error(
+        '  routing:',
+        JSON.stringify(error.data.providerMetadata.gateway.routing, null, 2),
+      );
+  }
+}
+
+main().catch(error => {
+  console.error('top-level error:', error.message);
+  process.exit(1);
+});

--- a/examples/ai-functions/src/stream-text/gateway/issue-14196.ts
+++ b/examples/ai-functions/src/stream-text/gateway/issue-14196.ts
@@ -1,0 +1,237 @@
+import 'dotenv/config';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+/**
+ * Reproduction for https://github.com/vercel/ai/issues/14196
+ *
+ * AI Gateway: Vertex rejects thought signatures from Google AI Studio on
+ * mid-conversation failover.
+ *
+ * Bug scenario (as reported):
+ *   1. Gateway is configured with order: ['google','vertex']
+ *   2. Turn 1..10 succeed on Google AI Studio (model: google/gemini-3-flash).
+ *      Assistant messages carry a `thoughtSignature` issued by Google AI
+ *      Studio, stored under `providerOptions.google`.
+ *   3. Turn 11: Google AI Studio returns 503. Gateway fails over to Vertex.
+ *   4. Vertex receives the same conversation with the Google-AI-Studio
+ *      signature and returns 400:
+ *        "Unable to submit request because Thought signature is not valid."
+ *
+ * This script reproduces by driving everything through the AI Gateway:
+ *   Turn 1: gateway → only:['google']  — gets real signatures via Google AI Studio.
+ *   Turn 2: gateway → only:['vertex']  — simulates the failover; Vertex receives
+ *                                        the Google-AI-Studio signatures.
+ *   Turn 3: gateway → order:['google','vertex'] — sanity check; succeeds because
+ *                                        Google AI Studio is healthy in this run.
+ */
+async function main() {
+  const MODEL_ID = 'google/gemini-3-flash';
+
+  const nextClue: Record<string, { hint: string; final?: boolean }> = {
+    start: { hint: 'Look under the doormat (codename: doormat).' },
+    doormat: { hint: 'Check inside the mailbox (codename: mailbox).' },
+    mailbox: { hint: 'Inspect the flowerpot (codename: flowerpot).' },
+    flowerpot: { hint: 'Lift the welcome rug (codename: rug).' },
+    rug: { hint: 'Search behind the picture frame (codename: frame).' },
+    frame: { hint: 'Open the desk drawer (codename: drawer).' },
+    drawer: { hint: 'Read the diary on the shelf (codename: diary).' },
+    diary: { hint: 'Peek inside the wardrobe (codename: wardrobe).' },
+    wardrobe: { hint: 'Climb to the attic (codename: attic).' },
+    attic: { hint: 'The treasure is in the chest!', final: true },
+  };
+  const clueTool = tool({
+    description:
+      'Follow a treasure-hunt clue. Returns the next hint, which contains the codename to pass on the next call.',
+    inputSchema: z.object({
+      codename: z
+        .string()
+        .describe(
+          "Codename from the previous hint. Use 'start' on the first call.",
+        ),
+    }),
+    execute: async ({ codename }) =>
+      nextClue[codename] ?? {
+        hint: 'Unknown codename — start over with "start".',
+      },
+  });
+
+  const HUNT_PROMPT =
+    "Follow the treasure-hunt clues. Start with codename 'start'. After each tool result, call the clue tool again with the new codename. Keep going until you find the treasure.";
+
+  // --- Turn 1: Gateway → only:['google'] ---
+  console.log('=== Turn 1: gateway only:["google"] ===\n');
+
+  const turn1 = streamText({
+    model: MODEL_ID,
+    tools: { clue: clueTool },
+    prompt: HUNT_PROMPT,
+    stopWhen: stepCountIs(12),
+    providerOptions: {
+      gateway: {
+        only: ['google'],
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const chunk of turn1.fullStream) {
+    if (chunk.type === 'text-delta') process.stdout.write(chunk.text);
+  }
+
+  const steps1 = await turn1.steps;
+  const finalStep1 = steps1[steps1.length - 1];
+  // On release-v6.0, `step.response.messages` is cumulative across the chain,
+  // so take just the last step's messages to get the conversation once.
+  const response1Messages = finalStep1.response.messages;
+  console.log(
+    '\n\n[Turn 1] gateway routing:',
+    JSON.stringify(finalStep1.providerMetadata?.gateway?.routing, null, 2),
+  );
+
+  let signatureCount = 0;
+  const signatureNamespaces = new Set<string>();
+  for (const msg of response1Messages) {
+    if (msg.role === 'assistant' && typeof msg.content !== 'string') {
+      for (const part of msg.content) {
+        const opts: any = (part as any).providerOptions;
+        if (!opts) continue;
+        for (const ns of Object.keys(opts)) {
+          if (opts[ns]?.thoughtSignature) {
+            signatureCount += 1;
+            signatureNamespaces.add(ns);
+            const sig = String(opts[ns].thoughtSignature);
+            console.log(
+              `[Turn 1] ${(part as any).type} thoughtSignature #${signatureCount} under [${ns}]: ${sig.substring(0, 32)}... (len=${sig.length})`,
+            );
+          }
+        }
+      }
+    }
+  }
+  console.log(
+    `\n[Turn 1] total signatures captured: ${signatureCount} under namespaces [${[...signatureNamespaces].join(', ')}]`,
+  );
+  if (signatureCount === 0) {
+    console.log(
+      '\nTurn 1 produced no thoughtSignature — Gateway probably routed away from google. Aborting.',
+    );
+    process.exit(0);
+  }
+
+  // --- Turn 2: Gateway → only:['vertex'] (the failover simulation) ---
+  console.log(
+    '\n=== Turn 2: gateway only:["vertex"] — simulating failover from google to vertex ===\n',
+  );
+
+  try {
+    const turn2 = streamText({
+      model: MODEL_ID,
+      tools: { clue: clueTool },
+      messages: [
+        { role: 'user', content: HUNT_PROMPT },
+        ...response1Messages,
+        { role: 'user', content: 'Summarize the trail you followed.' },
+      ],
+      stopWhen: stepCountIs(2),
+      providerOptions: {
+        gateway: {
+          only: ['vertex'],
+        } satisfies GatewayProviderOptions,
+      },
+    });
+
+    for await (const chunk of turn2.fullStream) {
+      if (chunk.type === 'text-delta') process.stdout.write(chunk.text);
+    }
+
+    const steps2 = await turn2.steps;
+    const finalStep2 = steps2[steps2.length - 1];
+    console.log(
+      '\n\n[Turn 2] gateway routing:',
+      JSON.stringify(finalStep2.providerMetadata?.gateway?.routing, null, 2),
+    );
+    console.log(
+      '\n✓ Turn 2 succeeded — Vertex accepted Google AI Studio signatures via Gateway (bug NOT reproduced).',
+    );
+  } catch (error: any) {
+    console.error(
+      '\n✗ Turn 2 FAILED (matches #14196 if "Thought signature is not valid"):',
+    );
+    console.error('  statusCode:', error.statusCode);
+    console.error('  message:   ', error.message);
+    if (error.responseBody) {
+      console.error(
+        '  responseBody:',
+        String(error.responseBody).substring(0, 800),
+      );
+    }
+    if (error.data?.providerMetadata?.gateway?.routing) {
+      console.error(
+        '  gateway routing:',
+        JSON.stringify(error.data.providerMetadata.gateway.routing, null, 2),
+      );
+    }
+  }
+
+  // --- Turn 3: Gateway → order:['google','vertex'] (the reporter's exact config) ---
+  console.log(
+    '\n=== Turn 3: gateway order:["google","vertex"] (reporter\'s config) ===\n',
+  );
+
+  try {
+    const turn3 = streamText({
+      model: MODEL_ID,
+      tools: { clue: clueTool },
+      messages: [
+        { role: 'user', content: HUNT_PROMPT },
+        ...response1Messages,
+        { role: 'user', content: 'Summarize the trail you followed.' },
+      ],
+      stopWhen: stepCountIs(2),
+      providerOptions: {
+        gateway: {
+          order: ['google', 'vertex'],
+        } satisfies GatewayProviderOptions,
+      },
+    });
+
+    for await (const chunk of turn3.fullStream) {
+      if (chunk.type === 'text-delta') process.stdout.write(chunk.text);
+    }
+
+    const steps3 = await turn3.steps;
+    const finalStep3 = steps3[steps3.length - 1];
+    console.log(
+      '\n\n[Turn 3] gateway routing:',
+      JSON.stringify(finalStep3.providerMetadata?.gateway?.routing, null, 2),
+    );
+    console.log('\n✓ Turn 3 succeeded via Gateway with order.');
+  } catch (error: any) {
+    console.error('\n✗ Turn 3 FAILED:');
+    console.error('  statusCode:', error.statusCode);
+    console.error('  message:   ', error.message);
+    if (error.responseBody)
+      console.error(
+        '  responseBody:',
+        String(error.responseBody).substring(0, 800),
+      );
+    if (error.data?.providerMetadata?.gateway?.routing) {
+      console.error(
+        '  gateway routing:',
+        JSON.stringify(error.data.providerMetadata.gateway.routing, null, 2),
+      );
+    }
+  }
+}
+
+main().catch(error => {
+  console.error('top-level error:', error.message);
+  if (error.statusCode) console.error('  statusCode:', error.statusCode);
+  if (error.responseBody)
+    console.error(
+      '  responseBody:',
+      String(error.responseBody).substring(0, 800),
+    );
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds three reproduction scripts under `examples/ai-functions/src/stream-text/gateway/` covering the active `thought_signature` issues against `google/gemini-3-flash` on `release-v6.0`. Each script targets one specific claim from the issue tracker; together they map out where the bug is and is not.

| File | Issue / claim targeted | Outcome on `ai@6.0.190` / `@ai-sdk/gateway@3.0.119` / `@ai-sdk/google@3.0.79` / `@ai-sdk/google-vertex@4.0.135` |
| --- | --- | --- |
| `issue-14196.ts` | #14196 — Vertex rejects Google-AI-Studio `thoughtSignature` on Gateway failover (`order: ['google','vertex']`). | **Not reproduced.** Turn 1 (`only: ['google']`) → 200 with 10 google-namespaced signatures. Turn 2 (`only: ['vertex']`, the failover sim) → 200; Vertex accepts the signatures. Turn 3 (reporter's exact `order: ['google','vertex']`) → 200 on Google, no failover triggered. |
| `issue-10344-zod-validation.ts` | #10344 (post-close, hsheth2) — "tool call fails due to zod validation" drops the signature. | **Not reproduced.** Forced `execute()` throw on the 3rd call. SDK preserves `providerMetadata.google.thoughtSignature` on both the `tool-call` and the synthetic `tool-error` content parts. Gemini accepts the next request, model retries, chain completes at step 7. |
| `issue-10344-client-side-tools.ts` | #10344 (post-close, pheuter) — client-side tool execution path where the application drops `providerMetadata` between turns. | **Reproduced deterministically.** Turn 2A (signature preserved) → 200. Turn 2B (signature stripped from the assistant tool-call) → **HTTP 400** `Function call is missing a thought_signature in functionCall parts.` |

## What this tells us

- The SDK preserves `thoughtSignature` correctly on the wire — across direct provider calls, Gateway routing, mid-chain tool failures, and the Vertex/Google namespace boundary (PR #13060).
- The remaining failure mode is at the **application layer**: anywhere assistant `tool-call` parts are serialized/persisted/re-hydrated without round-tripping `providerOptions` (custom DB schemas, `useChat` server routes that rebuild messages from the client payload, synthetic tool-call injection). When that happens, the next Gemini 3 request fails with HTTP 400.
- Follow-up issue **#15550** proposes a warning in `@ai-sdk/google` that fires when an outbound Gemini 3 request contains `functionCall` parts with no `thoughtSignature` under any recognised namespace — making the cause visible before the 400 hits.

## How to run

Set `AI_GATEWAY_API_KEY` to a key whose team allows both the `google` and `vertex` providers, then from `examples/ai-functions/`:

```bash
pnpm tsx src/stream-text/gateway/issue-14196.ts
pnpm tsx src/stream-text/gateway/issue-10344-zod-validation.ts
pnpm tsx src/stream-text/gateway/issue-10344-client-side-tools.ts
```

Each script ends with a clear ✓/✗ summary. The third one is also useful as a smoke check — if `Turn 2B` ever starts returning 200, Google has relaxed signature validation and #10344-style failures will quietly disappear; if `Turn 2A` ever starts failing, the SDK is dropping signatures somewhere it shouldn't.

Refs: #10344 #11413 #14196 #15550, related fix in #13060.

## Test plan

- [x] All three scripts run cleanly with a valid `AI_GATEWAY_API_KEY` whose team allows `google` and `vertex` providers
- [x] `issue-14196.ts`: three Gateway turns all return 200 today
- [x] `issue-10344-zod-validation.ts`: chain completes despite mid-chain tool failure; signatures preserved on the error step
- [x] `issue-10344-client-side-tools.ts`: Turn 2A returns 200, Turn 2B returns 400 with the expected error wording — deterministic
- [x] Type-checks under `examples/ai-functions`