### PR TITLE
Handle errors in anthropic's web search tool

### DIFF
--- a/.changeset/mighty-pets-decide.md
+++ b/.changeset/mighty-pets-decide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+Handle errors from anthropic websearch tool

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -209,13 +209,18 @@ export interface AnthropicToolResultContent {
 export interface AnthropicWebSearchToolResultContent {
   type: 'web_search_tool_result';
   tool_use_id: string;
-  content: Array<{
-    url: string;
-    title: string | null;
-    page_age: string | null;
-    encrypted_content: string;
-    type: string;
-  }>;
+  content:
+    | Array<{
+        url: string;
+        title: string | null;
+        page_age: string | null;
+        encrypted_content: string;
+        type: string;
+      }>
+    | {
+        type: 'web_search_tool_result_error';
+        error_code: string;
+      };
   cache_control: AnthropicCacheControl | undefined;
 }
 

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -1691,6 +1691,150 @@ describe('assistant messages', () => {
     expect(warnings).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should convert anthropic web_search tool call with error result (error-json string)', async () => {
+    const warnings: SharedV4Warning[] = [];
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              input: {
+                query: 'test query',
+              },
+              providerExecuted: true,
+              toolCallId: 'srvtoolu_error1',
+              toolName: 'web_search',
+              type: 'tool-call',
+            },
+            {
+              output: {
+                type: 'error-json',
+                value: JSON.stringify({
+                  type: 'web_search_tool_result_error',
+                  errorCode: 'invalid_tool_input',
+                }),
+              },
+              toolCallId: 'srvtoolu_error1',
+              toolName: 'web_search',
+              type: 'tool-result',
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings,
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "betas": Set {},
+        "prompt": {
+          "messages": [
+            {
+              "content": [
+                {
+                  "cache_control": undefined,
+                  "id": "srvtoolu_error1",
+                  "input": {
+                    "query": "test query",
+                  },
+                  "name": "web_search",
+                  "type": "server_tool_use",
+                },
+                {
+                  "cache_control": undefined,
+                  "content": {
+                    "error_code": "invalid_tool_input",
+                    "type": "web_search_tool_result_error",
+                  },
+                  "tool_use_id": "srvtoolu_error1",
+                  "type": "web_search_tool_result",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "system": undefined,
+        },
+      }
+    `);
+    expect(warnings).toMatchInlineSnapshot(`[]`);
+  });
+
+  it('should convert anthropic web_search tool call with error result (error-json object)', async () => {
+    const warnings: SharedV4Warning[] = [];
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              input: {
+                query: 'test query',
+              },
+              providerExecuted: true,
+              toolCallId: 'srvtoolu_error2',
+              toolName: 'web_search',
+              type: 'tool-call',
+            },
+            {
+              output: {
+                type: 'error-json',
+                value: {
+                  type: 'web_search_tool_result_error',
+                  errorCode: 'max_uses_exceeded',
+                },
+              },
+              toolCallId: 'srvtoolu_error2',
+              toolName: 'web_search',
+              type: 'tool-result',
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings,
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "betas": Set {},
+        "prompt": {
+          "messages": [
+            {
+              "content": [
+                {
+                  "cache_control": undefined,
+                  "id": "srvtoolu_error2",
+                  "input": {
+                    "query": "test query",
+                  },
+                  "name": "web_search",
+                  "type": "server_tool_use",
+                },
+                {
+                  "cache_control": undefined,
+                  "content": {
+                    "error_code": "max_uses_exceeded",
+                    "type": "web_search_tool_result_error",
+                  },
+                  "tool_use_id": "srvtoolu_error2",
+                  "type": "web_search_tool_result",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "system": undefined,
+        },
+      }
+    `);
+    expect(warnings).toMatchInlineSnapshot(`[]`);
+  });
+
   it('should convert anthropic web_fetch tool call and result parts', async () => {
     const warnings: SharedV4Warning[] = [];
     const result = await convertToAnthropicPrompt({

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -41,6 +41,29 @@ function convertBytesDataToString(data: Uint8Array | string): string {
   return new TextDecoder().decode(data);
 }
 
+/**
+ * Extract error information from a provider tool error result value.
+ * Handles both stringified JSON and plain object forms.
+ */
+function extractErrorValue(value: unknown): { errorCode?: string } {
+  try {
+    if (typeof value === 'string') {
+      return JSON.parse(value);
+    } else if (typeof value === 'object' && value !== null) {
+      return value as { errorCode?: string };
+    }
+  } catch {
+    const extractedErrorCode = (value as Record<string, unknown>)?.errorCode;
+    return {
+      errorCode:
+        typeof extractedErrorCode === 'string'
+          ? extractedErrorCode
+          : 'unavailable',
+    };
+  }
+  return {};
+}
+
 export async function convertToAnthropicPrompt({
   prompt,
   sendReasoning,
@@ -952,35 +975,14 @@ export async function convertToAnthropicPrompt({
                   const output = part.output;
 
                   if (output.type === 'error-json') {
-                    let errorValue: { errorCode?: string } = {};
-                    try {
-                      if (typeof output.value === 'string') {
-                        errorValue = JSON.parse(output.value);
-                      } else if (
-                        typeof output.value === 'object' &&
-                        output.value !== null
-                      ) {
-                        errorValue = output.value as typeof errorValue;
-                      }
-                    } catch {
-                      // If parsing fails, treat the value as-is
-                      const extractedErrorCode = (
-                        output.value as Record<string, unknown>
-                      )?.errorCode;
-                      errorValue = {
-                        errorCode:
-                          typeof extractedErrorCode === 'string'
-                            ? extractedErrorCode
-                            : 'unavailable',
-                      };
-                    }
-
                     anthropicContent.push({
                       type: 'web_fetch_tool_result',
                       tool_use_id: part.toolCallId,
                       content: {
                         type: 'web_fetch_tool_result_error',
-                        error_code: errorValue.errorCode ?? 'unavailable',
+                        error_code:
+                          extractErrorValue(output.value).errorCode ??
+                          'unavailable',
                       },
                       cache_control: cacheControl,
                     });
@@ -1034,6 +1036,22 @@ export async function convertToAnthropicPrompt({
 
                 if (providerToolName === 'web_search') {
                   const output = part.output;
+
+                  if (output.type === 'error-json') {
+                    anthropicContent.push({
+                      type: 'web_search_tool_result',
+                      tool_use_id: part.toolCallId,
+                      content: {
+                        type: 'web_search_tool_result_error',
+                        error_code:
+                          extractErrorValue(output.value).errorCode ??
+                          'unavailable',
+                      },
+                      cache_control: cacheControl,
+                    });
+
+                    break;
+                  }
 
                   if (output.type !== 'json') {
                     warnings.push({


### PR DESCRIPTION
## Background

Currently if web search returns an error, we mishandled it and
lose the tool response when continuing the conversation.

This would result in errors like:
```
Error: messages.1: `web_search` tool use with id `srvtoolu_01DZi3ZdTUsKUj24ZhA1XdSV` was found without a corresponding `web_search_tool_result` block
```

## Summary

web fetch already has handling for this, so reuse that.

## Manual Verification

I verified that trying to continue a conversation with an error failed
on the old version and works with this one.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
