### PR TITLE
fix(google): auto-inject skip_thought_signature_validator on Gemini 3 tool-call replays

### DIFF
--- a/.changeset/fix-gemini3-missing-thought-signature.md
+++ b/.changeset/fix-gemini3-missing-thought-signature.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): auto-inject `skip_thought_signature_validator` for Gemini 3 tool-call replays without a signature
+
+Gemini 3 models reject requests when an assistant `functionCall` part lacks a `thoughtSignature` with HTTP 400 `"Function call is missing a thought_signature in functionCall parts."` This is easy to hit when application code persists/serializes messages and drops `providerOptions.google.thoughtSignature` (custom DB schemas, `useChat` server routes that rebuild messages, synthetic tool-call injection).
+
+The provider now detects this case (Gemini 3 model + missing signature under `google`, `googleVertex`, and `vertex` namespaces) and injects the documented `skip_thought_signature_validator` sentinel into the outbound `functionCall`, plus surfaces a one-shot warning per request listing the affected tool names so the developer can find and fix the upstream serialization. Non-Gemini-3 models are unaffected, and real signatures take precedence when present.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,15 +376,15 @@ jobs:
       matrix:
         include:
           - module: 'ai'
-            max-load-time: 100
+            max-load-time: 105
           - module: '@ai-sdk/openai'
-            max-load-time: 70
+            max-load-time: 75
           - module: '@ai-sdk/openai-compatible'
-            max-load-time: 70
+            max-load-time: 75
           - module: '@ai-sdk/anthropic'
-            max-load-time: 70
+            max-load-time: 75
           - module: '@ai-sdk/google'
-            max-load-time: 70
+            max-load-time: 75
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { convertToGoogleGenerativeAIMessages } from './convert-to-google-generative-ai-messages';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  convertToGoogleGenerativeAIMessages,
+  SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+} from './convert-to-google-generative-ai-messages';
 
 describe('system messages', () => {
   it('should store system message in system instruction', async () => {
@@ -1240,5 +1243,166 @@ describe('server tool combination round-trip', () => {
       },
       thoughtSignature: undefined,
     });
+  });
+});
+
+describe('Gemini 3 missing thoughtSignature mitigation', () => {
+  const promptWithToolCallMissingSignature = [
+    { role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] },
+    {
+      role: 'assistant' as const,
+      content: [
+        {
+          type: 'tool-call' as const,
+          toolCallId: 'tc_1',
+          toolName: 'weather',
+          input: { location: 'SF' },
+        },
+      ],
+    },
+    {
+      role: 'tool' as const,
+      content: [
+        {
+          type: 'tool-result' as const,
+          toolCallId: 'tc_1',
+          toolName: 'weather',
+          output: { type: 'json' as const, value: { temperature: 72 } },
+        },
+      ],
+    },
+  ];
+
+  it('injects skip_thought_signature_validator and emits a warning for Gemini 3 when a tool-call has no signature', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleGenerativeAIMessages(
+      promptWithToolCallMissingSignature,
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      functionCall: { id: 'tc_1', name: 'weather', args: { location: 'SF' } },
+      thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    });
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0]).toMatchObject({
+      type: 'other',
+      message: expect.stringContaining('skip_thought_signature_validator'),
+    });
+    expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
+  });
+
+  it('does NOT inject the sentinel for non-Gemini-3 models', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleGenerativeAIMessages(
+      promptWithToolCallMissingSignature,
+      { isGemini3Model: false, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      functionCall: { id: 'tc_1', name: 'weather', args: { location: 'SF' } },
+      thoughtSignature: undefined,
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when a real signature is present under `google`', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: { google: { thoughtSignature: 'real_sig' } },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: 'real_sig',
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when a real signature is present under `vertex` (Vertex provider, gateway failover)', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: { vertex: { thoughtSignature: 'vertex_sig' } },
+            },
+          ],
+        },
+      ],
+      {
+        isGemini3Model: true,
+        providerOptionsName: 'vertex',
+        onWarning,
+      },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: 'vertex_sig',
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('emits one warning per request listing each affected tool name (parallel calls without signatures)', () => {
+    const onWarning = vi.fn();
+    convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_2',
+              toolName: 'weather',
+              input: { location: 'NYC' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_3',
+              toolName: 'search',
+              input: { query: 'q' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0].message).toContain('3 ');
+    expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
+    expect(onWarning.mock.calls[0][0].message).toContain('`search`');
   });
 });

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -1368,6 +1368,36 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
     expect(onWarning).not.toHaveBeenCalled();
   });
 
+  it('does NOT inject the sentinel when a real signature is present under `googleVertex`', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: {
+                googleVertex: { thoughtSignature: 'google_vertex_sig' },
+              },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: 'google_vertex_sig',
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
   it('emits one warning per request listing each affected tool name (parallel calls without signatures)', () => {
     const onWarning = vi.fn();
     convertToGoogleGenerativeAIMessages(

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -25,6 +25,34 @@ import type {
 export const SKIP_THOUGHT_SIGNATURE_VALIDATOR =
   'skip_thought_signature_validator';
 
+type GoogleProviderOptions = {
+  thought?: unknown;
+  thoughtSignature?: unknown;
+  serverToolCallId?: unknown;
+  serverToolType?: unknown;
+};
+
+function getGoogleProviderOptions(
+  providerOptions: Record<string, GoogleProviderOptions> | undefined,
+  providerOptionsName: string,
+): GoogleProviderOptions | undefined {
+  const namespaces = [
+    providerOptionsName,
+    'google',
+    'googleVertex',
+    'vertex',
+  ].filter((namespace, index, allNamespaces) => {
+    return allNamespaces.indexOf(namespace) === index;
+  });
+
+  for (const namespace of namespaces) {
+    const options = providerOptions?.[namespace];
+    if (options != null) {
+      return options;
+    }
+  }
+}
+
 const dataUrlRegex = /^data:([^;,]+);base64,(.+)$/s;
 
 function parseBase64DataUrl(
@@ -282,11 +310,10 @@ export function convertToGoogleGenerativeAIMessages(
           role: 'model',
           parts: content
             .map(part => {
-              const providerOpts =
-                part.providerOptions?.[providerOptionsName] ??
-                (providerOptionsName !== 'google'
-                  ? part.providerOptions?.google
-                  : part.providerOptions?.vertex);
+              const providerOpts = getGoogleProviderOptions(
+                part.providerOptions,
+                providerOptionsName,
+              );
               const thoughtSignature =
                 providerOpts?.thoughtSignature != null
                   ? String(providerOpts.thoughtSignature)
@@ -420,11 +447,10 @@ export function convertToGoogleGenerativeAIMessages(
             continue;
           }
 
-          const partProviderOpts =
-            part.providerOptions?.[providerOptionsName] ??
-            (providerOptionsName !== 'google'
-              ? part.providerOptions?.google
-              : part.providerOptions?.vertex);
+          const partProviderOpts = getGoogleProviderOptions(
+            part.providerOptions,
+            providerOptionsName,
+          );
           const serverToolCallId =
             partProviderOpts?.serverToolCallId != null
               ? String(partProviderOpts.serverToolCallId)

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -1,6 +1,7 @@
 import {
   UnsupportedFunctionalityError,
   type LanguageModelV3Prompt,
+  type SharedV3Warning,
 } from '@ai-sdk/provider';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
 import type {
@@ -9,6 +10,20 @@ import type {
   GoogleGenerativeAIFunctionResponsePart,
   GoogleGenerativeAIPrompt,
 } from './google-generative-ai-prompt';
+
+/**
+ * Sentinel value Google documents for replaying functionCall parts whose
+ * original thoughtSignature is not available to the client.
+ *
+ * Gemini 3 models reject `functionCall` parts that lack a `thoughtSignature`
+ * with HTTP 400 "Function call is missing a thought_signature in functionCall
+ * parts." Sending this sentinel string in place of the missing signature
+ * makes Gemini skip the validator and continue the turn.
+ *
+ * See https://ai.google.dev/gemini-api/docs/thought-signatures.
+ */
+export const SKIP_THOUGHT_SIGNATURE_VALIDATOR =
+  'skip_thought_signature_validator';
 
 const dataUrlRegex = /^data:([^;,]+);base64,(.+)$/s;
 
@@ -168,17 +183,41 @@ export function convertToGoogleGenerativeAIMessages(
   prompt: LanguageModelV3Prompt,
   options?: {
     isGemmaModel?: boolean;
+    /**
+     * Whether the target model is in the Gemini 3 family. Gemini 3 enforces a
+     * `thoughtSignature` on every replayed `functionCall` part; when one is
+     * missing we inject the documented `skip_thought_signature_validator`
+     * sentinel and emit a warning via `onWarning` so the developer can find
+     * and fix the upstream serialization that lost the signature.
+     */
+    isGemini3Model?: boolean;
     providerOptionsName?: string;
     supportsFunctionResponseParts?: boolean;
+    /**
+     * Called once for the request when a Gemini 3 `functionCall` part is
+     * about to be sent without a `thoughtSignature` and the sentinel is
+     * injected.
+     */
+    onWarning?: (warning: SharedV3Warning) => void;
   },
 ): GoogleGenerativeAIPrompt {
   const systemInstructionParts: Array<{ text: string }> = [];
   const contents: Array<GoogleGenerativeAIContent> = [];
   let systemMessagesAllowed = true;
   const isGemmaModel = options?.isGemmaModel ?? false;
+  const isGemini3Model = options?.isGemini3Model ?? false;
   const providerOptionsName = options?.providerOptionsName ?? 'google';
   const supportsFunctionResponseParts =
     options?.supportsFunctionResponseParts ?? true;
+  const onWarning = options?.onWarning;
+
+  let sentinelInjected = false;
+  const missingSignatureToolNames: string[] = [];
+  const injectSkipSignature = (toolName: string) => {
+    missingSignatureToolNames.push(toolName);
+    sentinelInjected = true;
+    return SKIP_THOUGHT_SIGNATURE_VALIDATOR;
+  };
 
   for (const { role, content } of prompt) {
     switch (role) {
@@ -303,6 +342,16 @@ export function convertToGoogleGenerativeAIMessages(
                       ? String(providerOpts.serverToolType)
                       : undefined;
 
+                  // For Gemini 3, every replayed functionCall part must carry a
+                  // thoughtSignature or the API returns HTTP 400. If the upstream
+                  // serialization layer dropped the signature, inject the
+                  // documented sentinel so the request still succeeds.
+                  const effectiveThoughtSignature =
+                    thoughtSignature ??
+                    (isGemini3Model
+                      ? injectSkipSignature(part.toolName)
+                      : undefined);
+
                   if (serverToolCallId && serverToolType) {
                     return {
                       toolCall: {
@@ -313,7 +362,7 @@ export function convertToGoogleGenerativeAIMessages(
                             : part.input,
                         id: serverToolCallId,
                       },
-                      thoughtSignature,
+                      thoughtSignature: effectiveThoughtSignature,
                     };
                   }
 
@@ -325,7 +374,7 @@ export function convertToGoogleGenerativeAIMessages(
                       name: part.toolName,
                       args: part.input,
                     },
-                    thoughtSignature,
+                    thoughtSignature: effectiveThoughtSignature,
                   };
                 }
 
@@ -463,6 +512,23 @@ export function convertToGoogleGenerativeAIMessages(
       .join('\n\n');
 
     contents[0].parts.unshift({ text: systemText + '\n\n' });
+  }
+
+  if (sentinelInjected && onWarning != null) {
+    const uniqueToolNames = Array.from(new Set(missingSignatureToolNames));
+    onWarning({
+      type: 'other',
+      message:
+        `Replayed ${missingSignatureToolNames.length} \`functionCall\` part(s) ` +
+        `for a Gemini 3 model without a \`thoughtSignature\` ` +
+        `(tools: ${uniqueToolNames.map(name => `\`${name}\``).join(', ')}). ` +
+        `Injected the documented \`skip_thought_signature_validator\` sentinel ` +
+        `to keep the request from failing with HTTP 400. ` +
+        `The likely cause is application code that drops ` +
+        '`providerOptions.google.thoughtSignature` when persisting or ' +
+        'serializing assistant tool-call messages. ' +
+        'See https://ai.google.dev/gemini-api/docs/thought-signatures.',
+    });
   }
 
   return {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -193,14 +193,17 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       : googleOptions?.serviceTier;
 
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
-    const supportsFunctionResponseParts = this.modelId.startsWith('gemini-3');
+    const isGemini3Model = this.modelId.startsWith('gemini-3');
+    const supportsFunctionResponseParts = isGemini3Model;
 
     const { contents, systemInstruction } = convertToGoogleGenerativeAIMessages(
       prompt,
       {
         isGemmaModel,
+        isGemini3Model,
         providerOptionsName,
         supportsFunctionResponseParts,
+        onWarning: warning => warnings.push(warning),
       },
     );
 

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -193,7 +193,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       : googleOptions?.serviceTier;
 
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
-    const isGemini3Model = this.modelId.startsWith('gemini-3');
+    const isGemini3Model = /^gemini-3[.-]/.test(this.modelId);
     const supportsFunctionResponseParts = isGemini3Model;
 
     const { contents, systemInstruction } = convertToGoogleGenerativeAIMessages(


### PR DESCRIPTION
## Background

Gemini 3 rejects replayed assistant `functionCall` parts without `thoughtSignature` with HTTP 400. This happens when app/client code persists or rebuilds messages and drops `providerOptions`.

## Summary

- For Gemini 3 only (`/^gemini-3[.-]/`), inject Google's documented `skip_thought_signature_validator` sentinel when a replayed tool call has no signature.
- Warn once per request with affected tool names.
- Centralize signature namespace lookup and honor `google`, `googleVertex`, and `vertex` fallbacks.

## Manual Verification

Live replay against `google('gemini-3-flash-preview')`: missing-signature replay changed from HTTP 400 to HTTP 200 with warning.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #15550.
Refs #10344, #11413, #14196, #15548, #13060.