### PR TITLE
feat(provider/anthropic): add containerUpload option to pass files to code execution tool

### DIFF
--- a/.changeset/lazy-crews-enjoy.md
+++ b/.changeset/lazy-crews-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+Add containerUpload provider option to support passing files to Anthropic's code execution tool via container_upload content blocks

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -1276,6 +1276,49 @@ const result = await generateText({
   file operations), and `codeExecution_20250522` (supports Bash only).
 </Note>
 
+#### Uploading Files for Code Execution
+
+You can upload files via the [Files API](https://docs.anthropic.com/en/docs/build-with-claude/files) and make them available inside the code execution sandbox. First upload the file, then reference it in your message using `containerUpload: true` in the provider options:
+
+```ts
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, uploadFile } from 'ai';
+import * as fs from 'fs';
+
+const { providerReference } = await uploadFile({
+  api: anthropic.files(),
+  data: fs.readFileSync('./data.csv'),
+  filename: 'data.csv',
+  mediaType: 'text/csv',
+});
+
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5'),
+  tools: {
+    code_execution: anthropic.tools.codeExecution_20250825(),
+  },
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Analyze this CSV data' },
+        {
+          type: 'file',
+          mediaType: 'text/csv',
+          data: { type: 'reference', reference: providerReference },
+          providerOptions: {
+            anthropic: { containerUpload: true },
+          },
+        },
+      ],
+    },
+  ],
+});
+```
+
+Supported file types include CSV, Excel, JSON, XML, images (JPEG, PNG, GIF, WebP), and text files.
+
+
 #### Error Handling
 
 Code execution errors are handled differently depending on whether you're using streaming or non-streaming:

--- a/examples/ai-functions/data/sample.csv
+++ b/examples/ai-functions/data/sample.csv
@@ -1,0 +1,7 @@
+month,revenue,expenses,profit
+January,12500,8200,4300
+February,13800,8500,5300
+March,15200,9100,6100
+April,14100,8800,5300
+May,16300,9500,6800
+June,17800,10200,7600

--- a/examples/ai-functions/src/generate-text/anthropic/code-execution-file-upload.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/code-execution-file-upload.ts
@@ -1,0 +1,41 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, uploadFile } from 'ai';
+import { run } from '../../lib/run';
+import * as fs from 'fs';
+
+run(async () => {
+  const { providerReference } = await uploadFile({
+    api: anthropic.files(),
+    data: fs.readFileSync('./data/sample.csv'),
+    filename: 'sample.csv',
+    mediaType: 'text/csv',
+  });
+
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    tools: {
+      code_execution: anthropic.tools.codeExecution_20250825(),
+    },
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Analyze this CSV data and calculate the total profit and average monthly revenue.',
+          },
+          {
+            type: 'file',
+            mediaType: 'text/csv',
+            data: { type: 'reference', reference: providerReference },
+            providerOptions: {
+              anthropic: { containerUpload: true },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  console.dir(result.content, { depth: Infinity });
+});

--- a/examples/ai-functions/src/stream-text/anthropic/code-execution-file-upload.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/code-execution-file-upload.ts
@@ -1,0 +1,69 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText, uploadFile } from 'ai';
+import { run } from '../../lib/run';
+import * as fs from 'fs';
+
+run(async () => {
+  const { providerReference } = await uploadFile({
+    api: anthropic.files(),
+    data: fs.readFileSync('./data/sample.csv'),
+    filename: 'sample.csv',
+    mediaType: 'text/csv',
+  });
+
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    tools: {
+      code_execution: anthropic.tools.codeExecution_20250825(),
+    },
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Analyze this CSV data and calculate the total profit and average monthly revenue.',
+          },
+          {
+            type: 'file',
+            mediaType: 'text/csv',
+            data: { type: 'reference', reference: providerReference },
+            providerOptions: {
+              anthropic: { containerUpload: true },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta': {
+        process.stdout.write(part.text);
+        break;
+      }
+
+      case 'tool-call': {
+        process.stdout.write(
+          `\n\nTool call: '${part.toolName}'\nInput: ${JSON.stringify(part.input, null, 2)}\n`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        process.stdout.write(
+          `\nTool result: '${part.toolName}'\nOutput: ${JSON.stringify(part.output, null, 2)}\n`,
+        );
+        break;
+      }
+
+      case 'error': {
+        console.error('\n\nCode execution error:', part.error);
+        break;
+      }
+    }
+  }
+
+  process.stdout.write('\n\n');
+});

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -24,6 +24,7 @@ export interface AnthropicUserMessage {
     | AnthropicTextContent
     | AnthropicImageContent
     | AnthropicDocumentContent
+    | AnthropicContainerUploadContent
     | AnthropicToolResultContent
   >;
 }
@@ -110,6 +111,12 @@ export interface AnthropicDocumentContent {
   title?: string;
   context?: string;
   citations?: { enabled: boolean };
+  cache_control: AnthropicCacheControl | undefined;
+}
+
+export interface AnthropicContainerUploadContent {
+  type: 'container_upload';
+  file_id: string;
   cache_control: AnthropicCacheControl | undefined;
 }
 

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -50,6 +50,14 @@ export const anthropicFilePartProviderOptions = z.object({
    * Useful for storing document metadata as text or stringified JSON.
    */
   context: z.string().optional(),
+
+  /**
+   * When true, the file reference is sent as a `container_upload` content
+   * block instead of a `document` block to the model. This is used to make
+   * uploaded files (e.g. CSV, Excel, JSON, images) available to Anthropic's
+   * code execution tool.
+   */
+  containerUpload: z.boolean().optional(),
 });
 
 export type AnthropicFilePartProviderOptions = z.infer<

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -755,6 +755,96 @@ describe('user messages', () => {
       "No provider reference found for provider 'anthropic'. Available providers: openai",
     );
   });
+
+  it('should convert file reference with containerUpload option to container_upload block', async () => {
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'text/csv',
+              data: {
+                type: 'reference' as const,
+                reference: { anthropic: 'file-csv-12345' },
+              },
+              providerOptions: {
+                anthropic: { containerUpload: true },
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'container_upload',
+                file_id: 'file-csv-12345',
+                cache_control: undefined,
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(['files-api-2025-04-14']),
+    });
+  });
+
+  it('should use container_upload for image references when containerUpload option is true', async () => {
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: {
+                type: 'reference' as const,
+                reference: { anthropic: 'file-img-99999' },
+              },
+              providerOptions: {
+                anthropic: { containerUpload: true },
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'container_upload',
+                file_id: 'file-img-99999',
+                cache_control: undefined,
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(['files-api-2025-04-14']),
+    });
+  });
 });
 
 describe('tool messages', () => {

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -164,7 +164,21 @@ export async function convertToAnthropicPrompt({
                         });
                         betas.add('files-api-2025-04-14');
 
-                        if (getTopLevelMediaType(part.mediaType) === 'image') {
+                        const filePartOptions = await parseProviderOptions({
+                          provider: 'anthropic',
+                          providerOptions: part.providerOptions,
+                          schema: anthropicFilePartProviderOptions,
+                        });
+
+                        if (filePartOptions?.containerUpload) {
+                          anthropicContent.push({
+                            type: 'container_upload',
+                            file_id: fileId,
+                            cache_control: cacheControl,
+                          });
+                        } else if (
+                          getTopLevelMediaType(part.mediaType) === 'image'
+                        ) {
                           anthropicContent.push({
                             type: 'image',
                             source: { type: 'file', file_id: fileId },


### PR DESCRIPTION
## Background

Anthropic's code execution tool supports file uploads via the Files API, allowing files like CSV, Excel, and JSON to be made available inside the execution sandbox using `container_upload` content blocks. This was not previously supported in the AI SDK, there was no way to pass uploaded files to the code execution tool.

## Summary

- Added `AnthropicContainerUploadContent` interface to `anthropic-api.ts` and included it in `AnthropicUserMessage`
- Added `containerUpload: boolean` option to `anthropicFilePartProviderOptions` in `anthropic-language-model-options.ts`
- Updated `convert-to-anthropic-prompt.ts` to emit a `container_upload` content block when `containerUpload: true` is set on a file part with a provider reference, instead of the default `document` block
- Added examples for `generateText` and `streamText` with CSV file upload
- Updated Anthropic provider docs with usage example

## Manual Verification

Tested by running the examples to ensure it works as expected: 
`pnpm tsx src/generate-text/anthropic/code-execution-file-upload.ts`
 `pnpm tsx src/stream-text/anthropic/code-execution-file-upload.ts`

Claude successfully read the uploaded CSV from $INPUT_DIR, executed Python to analyze it, and returned correct results.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Addresses #12449
