### PR TITLE
fix(bytedance): set first_frame role on input image in First-and-Last Frame video mode

### DIFF
--- a/.changeset/fix-bytedance-first-frame-role.md
+++ b/.changeset/fix-bytedance-first-frame-role.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/bytedance": patch
+---
+
+fix(bytedance): set `first_frame` role on the input image in First-and-Last Frame video mode

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -574,7 +574,7 @@ describe('ByteDanceVideoModel', () => {
       });
     });
 
-    it('should add last frame image with role', async () => {
+    it('should add last frame image with role and tag the input image as first frame', async () => {
       const model = createBasicModel({
         modelId: 'seedance-1-5-pro-251215',
       });
@@ -601,6 +601,7 @@ describe('ByteDanceVideoModel', () => {
         {
           type: 'image_url',
           image_url: { url: 'https://example.com/first-frame.png' },
+          role: 'first_frame',
         },
         {
           type: 'image_url',

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -179,6 +179,11 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
       content.push({
         type: 'image_url',
         image_url: { url: convertImageModelFileToDataUri(options.image) },
+        // In First-and-Last-Frame mode the API requires a role on every
+        // image content, so tag the input image as the first frame.
+        ...(byteDanceOptions?.lastFrameImage != null
+          ? { role: 'first_frame' }
+          : {}),
       });
     }
 


### PR DESCRIPTION
In First-and-Last Frame video mode, `@ai-sdk/bytedance` builds a request the ByteDance API rejects with `role must be specified for image contents`.

The last frame image is sent with `role: 'last_frame'`, but the input (first frame) image is sent with no `role`. ByteDance requires a role on every image content once any image carries one ([first-and-last-frame docs](https://docs.byteplus.com/en/docs/ModelArk/1366799)).

This tags the input image with `role: 'first_frame'` when `lastFrameImage` is set. Plain image-to-video (no `lastFrameImage`) is unchanged — the input image still goes out without a role.

Updated the existing last-frame test to assert the new role; `pnpm test` passes (41/41, node + edge).

Fixes #14378