### PR TITLE
fix(google): auto-inject skip_thought_signature_validator on Gemini 3 replays

### DIFF
--- a/.changeset/fix-gemini3-missing-thought-signature-main.md
+++ b/.changeset/fix-gemini3-missing-thought-signature-main.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): auto-inject `skip_thought_signature_validator` for Gemini 3 tool-call replays without a signature
+

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { convertToGoogleMessages } from './convert-to-google-messages';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  convertToGoogleMessages,
+  SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+} from './convert-to-google-messages';
 
 describe('system messages', () => {
   it('should store system message in system instruction', async () => {
@@ -1633,6 +1636,197 @@ describe('server tool combination round-trip', () => {
       },
       thoughtSignature: undefined,
     });
+  });
+});
+
+describe('Gemini 3 missing thoughtSignature mitigation', () => {
+  const promptWithToolCallMissingSignature = [
+    { role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] },
+    {
+      role: 'assistant' as const,
+      content: [
+        {
+          type: 'tool-call' as const,
+          toolCallId: 'tc_1',
+          toolName: 'weather',
+          input: { location: 'SF' },
+        },
+      ],
+    },
+    {
+      role: 'tool' as const,
+      content: [
+        {
+          type: 'tool-result' as const,
+          toolCallId: 'tc_1',
+          toolName: 'weather',
+          output: { type: 'json' as const, value: { temperature: 72 } },
+        },
+      ],
+    },
+  ];
+
+  it('injects skip_thought_signature_validator and emits a warning for Gemini 3 when a tool-call has no signature', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(promptWithToolCallMissingSignature, {
+      isGemini3Model: true,
+      onWarning,
+    });
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      functionCall: { id: 'tc_1', name: 'weather', args: { location: 'SF' } },
+      thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    });
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0]).toMatchObject({
+      type: 'other',
+      message: expect.stringContaining('skip_thought_signature_validator'),
+    });
+    expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
+  });
+
+  it('does NOT inject the sentinel for non-Gemini-3 models', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(promptWithToolCallMissingSignature, {
+      isGemini3Model: false,
+      onWarning,
+    });
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      functionCall: { id: 'tc_1', name: 'weather', args: { location: 'SF' } },
+      thoughtSignature: undefined,
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when a real signature is present under `google`', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: { google: { thoughtSignature: 'real_sig' } },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: 'real_sig',
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when a real signature is present under `vertex`', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: { vertex: { thoughtSignature: 'vertex_sig' } },
+            },
+          ],
+        },
+      ],
+      {
+        isGemini3Model: true,
+        providerOptionsNames: ['googleVertex', 'vertex'],
+        onWarning,
+      },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: 'vertex_sig',
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when a real signature is present under `googleVertex`', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: {
+                googleVertex: { thoughtSignature: 'google_vertex_sig' },
+              },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: 'google_vertex_sig',
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('emits one warning per request listing each affected tool name', () => {
+    const onWarning = vi.fn();
+    convertToGoogleMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'SF' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_2',
+              toolName: 'weather',
+              input: { location: 'NYC' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_3',
+              toolName: 'search',
+              input: { query: 'q' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0].message).toContain('3 ');
+    expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
+    expect(onWarning.mock.calls[0][0].message).toContain('`search`');
   });
 });
 

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -2,6 +2,7 @@ import {
   UnsupportedFunctionalityError,
   type LanguageModelV4Prompt,
   type LanguageModelV4ToolResultOutput,
+  type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   convertToBase64,
@@ -16,6 +17,15 @@ import type {
   GoogleFunctionResponsePart,
   GooglePrompt,
 } from './google-prompt';
+
+/**
+ * Sentinel value Google documents for replaying functionCall parts whose
+ * original thoughtSignature is not available to the client.
+ *
+ * See https://ai.google.dev/gemini-api/docs/thought-signatures.
+ */
+export const SKIP_THOUGHT_SIGNATURE_VALIDATOR =
+  'skip_thought_signature_validator';
 
 const dataUrlRegex = /^data:([^;,]+);base64,(.+)$/s;
 
@@ -183,6 +193,8 @@ export function convertToGoogleMessages(
   prompt: LanguageModelV4Prompt,
   options?: {
     isGemmaModel?: boolean;
+    isGemini3Model?: boolean;
+    onWarning?: (warning: SharedV4Warning) => void;
     /**
      * Names to look up under `providerOptions` when reading per-part metadata
      * (e.g. thought signatures). Tried in order; first match wins. For the
@@ -197,10 +209,20 @@ export function convertToGoogleMessages(
   const contents: Array<GoogleContent> = [];
   let systemMessagesAllowed = true;
   const isGemmaModel = options?.isGemmaModel ?? false;
+  const isGemini3Model = options?.isGemini3Model ?? false;
+  const onWarning = options?.onWarning;
   const providerOptionsNames = options?.providerOptionsNames ?? ['google'];
   const isVertexLike = !providerOptionsNames.includes('google');
   const supportsFunctionResponseParts =
     options?.supportsFunctionResponseParts ?? true;
+
+  let sentinelInjected = false;
+  const missingSignatureToolNames: string[] = [];
+  const injectSkipSignature = (toolName: string) => {
+    missingSignatureToolNames.push(toolName);
+    sentinelInjected = true;
+    return SKIP_THOUGHT_SIGNATURE_VALIDATOR;
+  };
 
   const readProviderOpts = (part: {
     providerOptions?: Record<string, unknown> | undefined;
@@ -434,6 +456,11 @@ export function convertToGoogleMessages(
                     providerOpts?.serverToolType != null
                       ? String(providerOpts.serverToolType)
                       : undefined;
+                  const effectiveThoughtSignature =
+                    thoughtSignature ??
+                    (isGemini3Model
+                      ? injectSkipSignature(part.toolName)
+                      : undefined);
 
                   if (serverToolCallId && serverToolType) {
                     return {
@@ -445,7 +472,7 @@ export function convertToGoogleMessages(
                             : part.input,
                         id: serverToolCallId,
                       },
-                      thoughtSignature,
+                      thoughtSignature: effectiveThoughtSignature,
                     };
                   }
 
@@ -457,7 +484,7 @@ export function convertToGoogleMessages(
                       name: part.toolName,
                       args: part.input,
                     },
-                    thoughtSignature,
+                    thoughtSignature: effectiveThoughtSignature,
                   };
                 }
 
@@ -591,6 +618,23 @@ export function convertToGoogleMessages(
       .join('\n\n');
 
     contents[0].parts.unshift({ text: systemText + '\n\n' });
+  }
+
+  if (sentinelInjected && onWarning != null) {
+    const uniqueToolNames = Array.from(new Set(missingSignatureToolNames));
+    onWarning({
+      type: 'other',
+      message:
+        `Replayed ${missingSignatureToolNames.length} \`functionCall\` part(s) ` +
+        `for a Gemini 3 model without a \`thoughtSignature\` ` +
+        `(tools: ${uniqueToolNames.map(name => `\`${name}\``).join(', ')}). ` +
+        `Injected the documented \`skip_thought_signature_validator\` sentinel ` +
+        `to keep the request from failing with HTTP 400. ` +
+        `The likely cause is application code that drops ` +
+        '`providerOptions.google.thoughtSignature` when persisting or ' +
+        'serializing assistant tool-call messages. ' +
+        'See https://ai.google.dev/gemini-api/docs/thought-signatures.',
+    });
   }
 
   return {

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -221,10 +221,13 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       : googleOptions?.serviceTier;
 
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
-    const supportsFunctionResponseParts = this.modelId.startsWith('gemini-3');
+    const isGemini3Model = /^gemini-3[.-]/.test(this.modelId);
+    const supportsFunctionResponseParts = isGemini3Model;
 
     const { contents, systemInstruction } = convertToGoogleMessages(prompt, {
       isGemmaModel,
+      isGemini3Model,
+      onWarning: warning => warnings.push(warning),
       providerOptionsNames,
       supportsFunctionResponseParts,
     });


### PR DESCRIPTION
## Background

Gemini 3 rejects replayed assistant `functionCall` parts without `thoughtSignature` with HTTP 400. This happens when app/client code persists or rebuilds messages and drops `providerOptions`.

## Summary

- For Gemini 3 only (`/^gemini-3[.-]/`), inject Google's documented `skip_thought_signature_validator` sentinel when a replayed tool call has no signature.
- Warn once per request with affected tool names.
- Adapted to `main` V4 Google provider files and existing `google` / `googleVertex` / `vertex` namespace lookup.

## Manual Verification

Live replay against `google('gemini-3-flash-preview')`: missing-signature replay changed from HTTP 400 to HTTP 200 with warning.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #15550.
Refs #10344, #11413, #14196, #15548, #13060.