### PR TITLE
fix(mcp): resolve npx/uv ENOENT on Windows via shell spawn

### DIFF
--- a/.changeset/fix-mcp-stdio-windows-shell.md
+++ b/.changeset/fix-mcp-stdio-windows-shell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Fix `Experimental_StdioMCPTransport` failing with `spawn ENOENT` on Windows when launching commands that resolve through `.cmd`/`.bat` shims (e.g. `npx`, `uv`, `npm`). Enable `shell: true` on `win32` so Node's `child_process.spawn` resolves PATH-installed shims; non-Windows behavior is unchanged. Closes #10732.

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
@@ -1,6 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as childProcessModule from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import * as getEnvironmentModule from './get-environment';
 import os from 'node:os';
+
+// Wrap node:child_process.spawn so tests can override per-call.
+// Existing tests still receive a real ChildProcess via the wrapper;
+// platform-shell tests below override with mockReturnValueOnce.
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<typeof childProcessModule>();
+  return {
+    ...actual,
+    spawn: vi.fn((...args: Parameters<typeof actual.spawn>) =>
+      actual.spawn(...args),
+    ),
+  };
+});
 
 const DEFAULT_ENV = {
   PATH: 'path',
@@ -60,13 +75,17 @@ describe('createChildProcess', () => {
     );
 
     expect(childProcessWithArgs.pid).toBeDefined();
-    expect(childProcessWithArgs.spawnargs).toContain(process.execPath);
-    expect(childProcessWithArgs.spawnargs).toEqual([
-      process.execPath,
-      '-c',
-      'echo',
-      'test',
-    ]);
+    // On Windows the spawn call is shell-wrapped via cmd.exe (see #10732)
+    // so spawnargs reflects the wrapped invocation rather than the raw args.
+    if (process.platform !== 'win32') {
+      expect(childProcessWithArgs.spawnargs).toContain(process.execPath);
+      expect(childProcessWithArgs.spawnargs).toEqual([
+        process.execPath,
+        '-c',
+        'echo',
+        'test',
+      ]);
+    }
 
     childProcessWithArgs.kill();
   });
@@ -90,5 +109,67 @@ describe('createChildProcess', () => {
     expect(childProcessWithStderr.pid).toBeDefined();
     expect(childProcessWithStderr.stderr).toBeDefined();
     childProcessWithStderr.kill();
+  });
+});
+
+describe('createChildProcess shell option per platform', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  const makeFakeChildProcess = () => {
+    const fakeCp = new EventEmitter() as ReturnType<
+      typeof childProcessModule.spawn
+    >;
+    (fakeCp as { pid?: number }).pid = 12345;
+    (fakeCp as { kill?: () => boolean }).kill = () => true;
+    return fakeCp;
+  };
+
+  it('passes shell: true on Windows so npx/uv .cmd shims resolve via PATH', () => {
+    const spawnMock = vi.mocked(childProcessModule.spawn);
+    spawnMock.mockReturnValueOnce(makeFakeChildProcess());
+
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+
+    createChildProcess(
+      { command: 'npx', args: ['-v'] },
+      new AbortController().signal,
+    );
+
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      'npx',
+      ['-v'],
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it('passes shell: false on non-Windows platforms', () => {
+    const spawnMock = vi.mocked(childProcessModule.spawn);
+    spawnMock.mockReturnValueOnce(makeFakeChildProcess());
+
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true,
+    });
+
+    createChildProcess(
+      { command: 'npx', args: ['-v'] },
+      new AbortController().signal,
+    );
+
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      'npx',
+      ['-v'],
+      expect.objectContaining({ shell: false }),
+    );
   });
 });

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
@@ -9,7 +9,7 @@ export function createChildProcess(
   return spawn(config.command, config.args ?? [], {
     env: getEnvironment(config.env),
     stdio: ['pipe', 'pipe', config.stderr ?? 'inherit'],
-    shell: false,
+    shell: globalThis.process.platform === 'win32',
     signal,
     windowsHide: globalThis.process.platform === 'win32' && isElectron(),
     cwd: config.cwd,


### PR DESCRIPTION
Closes #10732.

On Windows, `Experimental_StdioMCPTransport` fails with `spawn ENOENT` when launching commands that resolve through `.cmd`/`.bat` shims (`npx`, `uv`, `npm`). Node's raw `child_process.spawn` cannot find PATHEXT-resolved shims unless invoked through a shell.

### Change

Sets `shell: globalThis.process.platform === 'win32'` in `packages/mcp/src/tool/mcp-stdio/create-child-process.ts`. Non-Windows behavior is unchanged.

For reference, the upstream `@modelcontextprotocol/sdk` solves the same problem by importing `spawn` from `cross-spawn` ([client/stdio.ts](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/stdio.ts)). This PR takes the smaller, dependency-free path the issue author proposed. **Happy to switch to `cross-spawn` if maintainers prefer matching upstream exactly** — that path adds `cross-spawn` to dependencies but avoids the Node DEP0190 warning about un-escaped args with `shell: true`.

### Tests

Added two cases in `create-child-process.test.ts` that mock `process.platform` and assert the `shell` arg passed to `spawn`:

- `passes shell: true on Windows so npx/uv .cmd shims resolve via PATH`
- `passes shell: false on non-Windows platforms`

Both use `vi.mock('node:child_process', ...)` to wrap `spawn` so existing tests still run real child processes through the wrapper.

The existing `should spawn a child process with args` assertion (lines 78–87) is now gated to non-Windows since `shell: true` legitimately changes `spawnargs` to include the `cmd.exe` wrapper. A comment links the gating back to this issue.

### CI / Windows coverage

The repo's existing CI matrix doesn't include `windows-latest` for the `@ai-sdk/mcp` package, so the Windows-positive case is verified via mocked `process.platform`. Happy to add a `windows-latest` job in a follow-up if maintainers want first-class coverage of this regression.

### Notes

- DEP0190 warning surfaces when `shell: true` is combined with args. Worth a JSDoc note on `StdioConfig` about shell-metacharacter handling if users may interpolate untrusted input. Can add in this PR if requested.
- Tested locally on Windows 11 + Node 24.14.1; the modified test file passes 7/7.