### PR TITLE
docs(examples/next): expand README with setup, env vars, and feature test steps

### DIFF
--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -1,1 +1,56 @@
-A minimal example to test persistence, SSR, and stream resume.
+# Next.js + AI SDK Example
+
+A minimal [Next.js](https://nextjs.org/) example that demonstrates three features of the AI SDK together: chat persistence, server-side rendering, and resumable streams.
+
+## What this example demonstrates
+
+- **Persistence**: chat history is stored on the server via a file-backed `chat-store`, so a refresh does not lose state.
+- **SSR**: existing chat history is rendered server-side at first paint, then hydrated on the client.
+- **Resumable streams**: an in-flight model response can be resumed from another tab or after a disconnect, via a Redis-backed resumable-stream context.
+
+The example uses `openai/gpt-5-mini` through the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway), so no direct OpenAI key is required.
+
+## Usage
+
+1. From the root of the AI SDK repo, install dependencies and build the workspace:
+
+```sh
+pnpm install
+pnpm build
+```
+
+2. Create `.env.local` inside `examples/next/`:
+
+```sh
+# Required — Vercel AI Gateway credentials for the model call
+VERCEL_API_KEY=""
+
+# Optional — needed only to test the resumable-stream path.
+# Provision via https://vercel.com/marketplace/redis
+REDIS_URL=""
+
+# Optional — needed only to test attachment uploads.
+# Provision via https://vercel.com/docs/storage/vercel-blob
+BLOB_READ_WRITE_TOKEN=""
+```
+
+If you are running the example inside a Vercel deployment, `VERCEL_OIDC_TOKEN` can substitute for `VERCEL_API_KEY`.
+
+3. From `examples/next/`, run the dev server:
+
+```sh
+pnpm dev
+```
+
+4. Open http://localhost:3000 in a browser.
+
+## Testing the features
+
+- **Persistence**: send a message, refresh the page — the conversation survives.
+- **SSR**: in DevTools → Network → view the initial document HTML; rendered messages appear in the source before client hydration.
+- **Resumable streams** (requires `REDIS_URL`): send a long message, then open the same chat URL in a second tab — the in-flight stream resumes there.
+
+## Requirements
+
+- Node.js `^22.0.0 || ^24.0.0 || ^26.0.0`
+- `pnpm@10.x` (see `packageManager` in the root `package.json`)


### PR DESCRIPTION
Closes #15563.

## Why

The current `examples/next/README.md` is one line:

> A minimal example to test persistence, SSR, and stream resume.

A new contributor coming to the example has to dig through `package.json`, `.env.local.example`, and `app/api/chat/route.ts` to figure out what env vars are needed, which model the example uses, how to run it, and how to actually exercise the three features (persistence, SSR, resumable streams). Issue #15563 asks for the missing setup steps.

## What's in this PR

Expands the README with:

- a short summary of what the example demonstrates and the three AI SDK features it stitches together
- install + build steps from the monorepo root (`pnpm install && pnpm build`), matching the convention in other example READMEs (e.g. `examples/express/README.md`)
- the required env var `VERCEL_API_KEY` (or `VERCEL_OIDC_TOKEN` when deployed on Vercel) so the AI Gateway call to `openai/gpt-5-mini` works, plus the optional ones (`REDIS_URL` for resumable streams, `BLOB_READ_WRITE_TOKEN` for attachment uploads) with links to provisioning docs
- the `pnpm dev` command and the local dev URL (`http://localhost:3000`)
- per-feature test instructions so a contributor can verify each path locally — refresh-to-test persistence, view-source to confirm SSR, second-tab to confirm resumable streams
- Node.js (`^22 || ^24 || ^26`) and pnpm (`10.x`) version notes pulled from the root `package.json`

No code changes — README only.

## Test plan

- [x] Read flow verified against current `app/api/chat/route.ts` (model name, env vars), `.env.local.example` (var list), root `package.json` (engines + packageManager).
- [ ] Maintainer to confirm wording around AI Gateway language matches latest house style.