### PR TITLE
docs(mcp): add Bilig WorkPaper stdio example

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -40,6 +40,7 @@ Available examples/folders:
 - `mcp-prompts` - MCP prompts example
 - `mcp-resources` - MCP resources example
 - `stdio` - Stdio Transport (requires `pnpm stdio:build` first)
+- `bilig-workpaper` - Stdio MCP server from npm for spreadsheet-style formula workbooks
 - `elicitation` - MCP elicitation example
 - `elicitation-multi-step` - MCP multi-step elicitation example
 - `elicitation-ui` - MCP elicitation with UI (server only)
@@ -55,6 +56,15 @@ In another terminal, run the HTTP client:
 
 ```sh
 pnpm client:http
+```
+
+Run the Bilig WorkPaper example without starting a separate server. It downloads
+the published `@bilig/workpaper` package, starts its stdio MCP server, creates a
+demo WorkPaper JSON file, edits an input cell, recalculates dependent formulas,
+and prints verified readback:
+
+```sh
+pnpm client:bilig-workpaper
 ```
 
 To test the example with the UI, you will first need to run the MCP server:

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -24,6 +24,7 @@
     "client:provider-metadata": "tsx src/provider-metadata/client.ts",
     "server:server-instructions": "tsx src/server-instructions/server.ts",
     "client:server-instructions": "tsx src/server-instructions/client.ts",
+    "client:bilig-workpaper": "tsx src/bilig-workpaper/client.ts",
     "stdio:build": "tsc src/stdio/server.ts --outDir src/stdio/dist --target es2023 --module nodenext",
     "client:stdio": "tsx src/stdio/client.ts",
     "custom-transport:build": "tsc src/custom-transport/server.ts --outDir src/custom-transport/dist --target es2023 --module nodenext",

--- a/examples/mcp/src/bilig-workpaper/client.ts
+++ b/examples/mcp/src/bilig-workpaper/client.ts
@@ -1,0 +1,235 @@
+import { createMCPClient } from "@ai-sdk/mcp";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import "dotenv/config";
+import { z } from "zod";
+
+const toolExecutionOptions = {
+  messages: [],
+  context: {},
+};
+
+interface ToolResult<T> {
+  structuredContent?: T;
+}
+
+interface SheetList {
+  sheets: Array<{
+    name: string;
+    dimensions: {
+      width: number;
+      height: number;
+    };
+  }>;
+}
+
+interface RangeReadback {
+  values: unknown[][];
+}
+
+interface CellEditReadback {
+  editedCell: string;
+  before: {
+    serialized: unknown;
+  };
+  after: {
+    serialized: unknown;
+  };
+  checks: {
+    persisted: boolean;
+    restoredMatchesAfter: boolean;
+  };
+}
+
+interface DisplayReadback {
+  displayValue: string;
+}
+
+interface FormulaValidation {
+  formula: string;
+  valid: boolean;
+}
+
+async function main() {
+  let mcpClient;
+
+  try {
+    const transport = new StdioClientTransport({
+      command: "npm",
+      args: [
+        "exec",
+        "--yes",
+        "--package",
+        "@bilig/workpaper",
+        "--",
+        "bilig-workpaper-mcp",
+        "--workpaper",
+        "./bilig-ai-sdk-demo.workpaper.json",
+        "--init-demo-workpaper",
+        "--writable",
+      ],
+    });
+
+    mcpClient = await createMCPClient({ transport });
+
+    const tools = await mcpClient.tools({
+      schemas: {
+        list_sheets: {
+          inputSchema: z.object({}),
+        },
+        read_range: {
+          inputSchema: z.object({
+            range: z.string(),
+            sheetName: z.string().optional(),
+          }),
+        },
+        set_cell_contents: {
+          inputSchema: z.object({
+            sheetName: z.string(),
+            address: z.string(),
+            value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+          }),
+        },
+        get_cell_display_value: {
+          inputSchema: z.object({
+            sheetName: z.string(),
+            address: z.string(),
+          }),
+        },
+        validate_formula: {
+          inputSchema: z.object({
+            formula: z.string(),
+          }),
+        },
+      },
+    });
+
+    const sheets = await tools.list_sheets.execute(
+      {},
+      {
+        ...toolExecutionOptions,
+        toolCallId: "list-sheets",
+      }
+    );
+
+    const before = await tools.read_range.execute(
+      { range: "Summary!A1:B5" },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "read-before",
+      }
+    );
+
+    const edit = await tools.set_cell_contents.execute(
+      {
+        sheetName: "Inputs",
+        address: "B3",
+        value: 0.4,
+      },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "set-win-rate",
+      }
+    );
+
+    const after = await tools.read_range.execute(
+      { range: "Summary!A1:B5" },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "read-after",
+      }
+    );
+
+    const displayValue = await tools.get_cell_display_value.execute(
+      {
+        sheetName: "Summary",
+        address: "B3",
+      },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "display-expected-arr",
+      }
+    );
+
+    const formulaCheck = await tools.validate_formula.execute(
+      {
+        formula: "=Inputs!B2*Inputs!B3",
+      },
+      {
+        ...toolExecutionOptions,
+        toolCallId: "validate-formula",
+      }
+    );
+
+    const sheetList = requireStructured<SheetList>(sheets, "list_sheets");
+    const summaryBefore = requireStructured<RangeReadback>(
+      before,
+      "read_range before edit"
+    );
+    const summaryAfter = requireStructured<RangeReadback>(
+      after,
+      "read_range after edit"
+    );
+    const editReadback = requireStructured<CellEditReadback>(
+      edit,
+      "set_cell_contents"
+    );
+    const expectedArrDisplay = requireStructured<DisplayReadback>(
+      displayValue,
+      "get_cell_display_value"
+    );
+    const validatedFormula = requireStructured<FormulaValidation>(
+      formulaCheck,
+      "validate_formula"
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          sheets: sheetList.sheets,
+          before: summaryRows(summaryBefore),
+          edit: {
+            cell: editReadback.editedCell,
+            previousInput: editReadback.before.serialized,
+            newInput: editReadback.after.serialized,
+            persisted: editReadback.checks.persisted,
+            restoredMatchesAfter: editReadback.checks.restoredMatchesAfter,
+          },
+          after: summaryRows(summaryAfter),
+          expectedArrDisplay: expectedArrDisplay.displayValue,
+          formulaCheck: validatedFormula,
+        },
+        null,
+        2
+      )
+    );
+  } finally {
+    await mcpClient?.close();
+  }
+}
+
+function requireStructured<T>(result: unknown, label: string): T {
+  const maybeResult = result as ToolResult<T>;
+  if (maybeResult.structuredContent === undefined) {
+    throw new Error(`${label} did not return structured content`);
+  }
+  return maybeResult.structuredContent;
+}
+
+function summaryRows(readback: RangeReadback) {
+  return readback.values.slice(1).map((row) => ({
+    metric: cellValue(row[0]),
+    value: cellValue(row[1]),
+  }));
+}
+
+function cellValue(cell: unknown): unknown {
+  if (typeof cell === "object" && cell !== null && "value" in cell) {
+    return (cell as { value: unknown }).value;
+  }
+  return cell;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a runnable MCP example that connects the AI SDK MCP client to Bilig WorkPaper's stdio MCP server from npm.

The example starts `bilig-workpaper-mcp`, initializes a demo WorkPaper JSON file, lists sheets, reads a formula-backed summary range, edits `Inputs!B3`, reads recalculated outputs, validates a formula, and prints structured proof that the edit persisted and restored correctly.

## Why

The current MCP examples cover transport mechanics well. This adds a small business-logic example where MCP tools mutate state and verify computed readback, without needing an API key or a separate server process.

## Validation

```bash
pnpm --dir examples/mcp type-check
pnpm --dir examples/mcp client:bilig-workpaper
git diff --check
```

The client run returned `Expected ARR` changing from `60000` to `96000`, `persisted: true`, `restoredMatchesAfter: true`, and a valid formula check.
