### PR TITLE
fix(ai): flush buffered partial-tag content at end of stream in extractReasoningMiddleware

### DIFF
--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -1118,6 +1118,55 @@ describe('extractReasoningMiddleware', () => {
       `);
     });
 
+    it('should flush buffered partial-tag content at end of stream', async () => {
+      // If the last text-delta ends with characters that are a prefix of the
+      // opening tag (e.g. "<th" when tagName is "think"), getPotentialStartIndex
+      // holds them in the buffer waiting for more chunks.  Without a flush()
+      // callback those characters are silently dropped.
+      const mockModel = new MockLanguageModelV4({
+        async doStream() {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              // The response ends with "<th" — a valid prefix of "<think>" that
+              // must NOT be silently dropped.
+              { type: 'text-delta', id: '1', delta: 'answer: <th' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      });
+
+      const result = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        }),
+        prompt: 'Test prompt',
+      });
+
+      const fullStream = await convertAsyncIterableToArray(result.fullStream);
+      const textDeltas = fullStream
+        .filter(part => part.type === 'text-delta')
+        .map(part => (part as { text: string }).text)
+        .join('');
+
+      // "<th" must appear in the output — it is not a complete tag and should
+      // be emitted verbatim instead of being swallowed.
+      expect(textDeltas).toBe('answer: <th');
+    });
+
     it('should handle empty <think></think> tags without crashing', async () => {
       const mockModel = new MockLanguageModelV4({
         async doStream() {

--- a/packages/ai/src/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.ts
@@ -240,6 +240,34 @@ export function extractReasoningMiddleware({
                 }
               } while (true);
             },
+
+            flush: controller => {
+              // At end-of-stream, any content still in a buffer could not have
+              // been a complete tag (no more deltas are coming), so emit it as
+              // plain text or reasoning verbatim.
+              for (const extraction of Object.values(reasoningExtractions)) {
+                if (extraction.buffer.length > 0) {
+                  if (extraction.isReasoning) {
+                    controller.enqueue({
+                      type: 'reasoning-delta',
+                      delta: extraction.buffer,
+                      id: `reasoning-${extraction.idCounter}`,
+                    });
+                  } else {
+                    if (delayedTextStart) {
+                      controller.enqueue(delayedTextStart);
+                      delayedTextStart = undefined;
+                    }
+                    controller.enqueue({
+                      type: 'text-delta',
+                      delta: extraction.buffer,
+                      id: extraction.textId,
+                    });
+                  }
+                  extraction.buffer = '';
+                }
+              }
+            },
           }),
         ),
         ...rest,


### PR DESCRIPTION
## Problem

`extractReasoningMiddleware` buffers incoming `text-delta` characters when a potential opening/closing tag is detected (via `getPotentialStartIndex`). If the **last** `text-delta` in a stream ends with characters that are a valid prefix of the configured tag (e.g. `<th` when `tagName` is `"think"`), those characters sit in the per-id buffer with no further chunk coming to resolve them.

Because the `TransformStream` had **no `flush()` callback**, that buffered content was silently dropped the moment the stream ended.

### Minimal repro

```ts
// tag: "think" — model response ends with "<th" (not a complete tag)
{ type: 'text-start', id: '1' },
{ type: 'text-delta', id: '1', delta: 'answer: <th' },  // "<th" → held in buffer
{ type: 'text-end', id: '1' },
// stream ends — "<th" is silently dropped without this fix
```

## Fix

Add a `flush(controller)` callback to the `TransformStream`. At end-of-stream a partial potential tag is guaranteed to not be a real tag (no more deltas are coming), so the remaining buffer is emitted verbatim as a `text-delta` (or `reasoning-delta` if the buffer belongs to an open reasoning block).

## Test

New test case: `"should flush buffered partial-tag content at end of stream"` — red before the fix, green after. All 12 existing `wrapStream` tests continue to pass.