### PR TITLE
feat(google,google-vertex): add gemini-embedding-2 GA model ID

### DIFF
--- a/.changeset/gemini-embedding-2-ga.md
+++ b/.changeset/gemini-embedding-2-ga.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
+---
+
+feat(google,google-vertex): add `gemini-embedding-2` GA model ID

--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -103,7 +103,7 @@ const { embedding } = await embed({
 });
 ```
 
-Google's `gemini-embedding-2-preview` model also supports multimodal embedding content through `providerOptions.google.content`. Each entry corresponds to the value at the same index and can contain `{ text: string }`, `{ inlineData: { mimeType: string; data: string } }`, or `{ fileData: { fileUri: string; mimeType: string } }` parts. `fileUri` can reference remote content such as HTTP URLs or Google Cloud Storage URIs (`gs://...`).
+Google's `gemini-embedding-2` model (also available as `gemini-embedding-2-preview`) supports multimodal embedding content through `providerOptions.google.content`. Each entry corresponds to the value at the same index and can contain `{ text: string }`, `{ inlineData: { mimeType: string; data: string } }`, or `{ fileData: { fileUri: string; mimeType: string } }` parts. `fileUri` can reference remote content such as HTTP URLs or Google Cloud Storage URIs (`gs://...`).
 
 ### Parallel Requests
 
@@ -225,6 +225,7 @@ Several providers offer embedding models:
 | [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                 | `text-embedding-3-small`        | 1536                 | <Cross size={18} /> |
 | [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                 | `text-embedding-ada-002`        | 1536                 | <Cross size={18} /> |
 | [Google](/providers/ai-sdk-providers/google#embedding-models)                 | `gemini-embedding-001`          | 3072                 | <Cross size={18} /> |
+| [Google](/providers/ai-sdk-providers/google#embedding-models)                 | `gemini-embedding-2`            | 3072                 | <Check size={18} /> |
 | [Google](/providers/ai-sdk-providers/google#embedding-models)                 | `gemini-embedding-2-preview`    | 3072                 | <Check size={18} /> |
 | [Mistral](/providers/ai-sdk-providers/mistral#embedding-models)               | `mistral-embed`                 | 1024                 | <Cross size={18} /> |
 | [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                 | `embed-english-v3.0`            | 1024                 | <Cross size={18} /> |

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1733,7 +1733,7 @@ import { google, type GoogleEmbeddingModelOptions } from '@ai-sdk/google';
 import { embedMany } from 'ai';
 
 const { embeddings } = await embedMany({
-  model: google.embedding('gemini-embedding-2-preview'),
+  model: google.embedding('gemini-embedding-2'),
   values: ['sunny day at the beach', 'rainy afternoon in the city'],
   providerOptions: {
     google: {
@@ -1767,13 +1767,14 @@ The following optional provider options are available for Google embedding model
 
 - **content**: _array_
 
-  Optional. Per-value multimodal content parts for embedding non-text content (images, video, PDF, audio). Each entry corresponds to the embedding value at the same index — its parts are merged with the text value in the request. Use `null` for entries that are text-only. The array length must match the number of values being embedded. Each non-null entry is an array of parts, where each part can be `{ text: string }`, `{ inlineData: { mimeType: string, data: string } }` for inline base64 data, or `{ fileData: { fileUri: string, mimeType: string } }` to reference remote content via HTTP URL or Google Cloud Storage URI (`gs://...`). Supported by `gemini-embedding-2-preview`.
+  Optional. Per-value multimodal content parts for embedding non-text content (images, video, PDF, audio). Each entry corresponds to the embedding value at the same index — its parts are merged with the text value in the request. Use `null` for entries that are text-only. The array length must match the number of values being embedded. Each non-null entry is an array of parts, where each part can be `{ text: string }`, `{ inlineData: { mimeType: string, data: string } }` for inline base64 data, or `{ fileData: { fileUri: string, mimeType: string } }` to reference remote content via HTTP URL or Google Cloud Storage URI (`gs://...`). Supported by `gemini-embedding-2` (and `gemini-embedding-2-preview`).
 
 ### Model Capabilities
 
 | Model                        | Default Dimensions | Custom Dimensions   | Multimodal          |
 | ---------------------------- | ------------------ | ------------------- | ------------------- |
 | `gemini-embedding-001`       | 3072               | <Check size={18} /> | <Cross size={18} /> |
+| `gemini-embedding-2`         | 3072               | <Check size={18} /> | <Check size={18} /> |
 | `gemini-embedding-2-preview` | 3072               | <Check size={18} /> | <Check size={18} /> |
 
 ## Image Models

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -917,6 +917,7 @@ The following optional provider options are available for Google Vertex AI embed
 | Model                        | Max Values Per Call | Parallel Calls      | Multimodal          |
 | ---------------------------- | ------------------- | ------------------- | ------------------- |
 | `text-embedding-005`         | 2048                | <Check size={18} /> | <Cross size={18} /> |
+| `gemini-embedding-2`         | 2048                | <Check size={18} /> | <Check size={18} /> |
 | `gemini-embedding-2-preview` | 2048                | <Check size={18} /> | <Check size={18} /> |
 
 <Note>

--- a/packages/google-vertex/src/google-vertex-embedding-model-options.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model-options.ts
@@ -11,6 +11,7 @@ export type GoogleVertexEmbeddingModelId =
   | 'text-embedding-004'
   | 'text-embedding-005'
   | 'gemini-embedding-001'
+  | 'gemini-embedding-2'
   | 'gemini-embedding-2-preview'
   | (string & {});
 

--- a/packages/google/src/google-embedding-model-options.ts
+++ b/packages/google/src/google-embedding-model-options.ts
@@ -7,6 +7,7 @@ import { z } from 'zod/v4';
 
 export type GoogleEmbeddingModelId =
   | 'gemini-embedding-001'
+  | 'gemini-embedding-2'
   | 'gemini-embedding-2-preview'
   | (string & {});
 


### PR DESCRIPTION
## Summary

`gemini-embedding-2` is now generally available and no longer in preview. When using multi-region endpoints (e.g. `eu`), the previous preview model is not available at all.

This PR adds `gemini-embedding-2` as a first-class model ID to both the Google and Google Vertex providers.

## Changes

- **`@ai-sdk/google`**: Add `'gemini-embedding-2'` to `GoogleEmbeddingModelId` type union
- **`@ai-sdk/google-vertex`**: Add `'gemini-embedding-2'` to `GoogleVertexEmbeddingModelId` type union
- **Docs**: Add `gemini-embedding-2` to model capability tables and update examples to reference the GA model name
- **Changeset**: Patch for both packages

The `-preview` alias is kept for backwards compatibility.

Closes #15582