### PR TITLE
fix(anthropic): normalize ANTHROPIC_BASE_URL with /v1 path

### DIFF
--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -101,13 +101,18 @@ export interface AnthropicProviderSettings {
 export function createAnthropic(
   options: AnthropicProviderSettings = {},
 ): AnthropicProvider {
-  const baseURL =
-    withoutTrailingSlash(
+  const baseURL = (() => {
+    const url = withoutTrailingSlash(
       loadOptionalSetting({
         settingValue: options.baseURL,
         environmentVariableName: 'ANTHROPIC_BASE_URL',
       }),
-    ) ?? 'https://api.anthropic.com/v1';
+    );
+    if (url && !url.endsWith('/v1')) {
+      return url.replace(/\/+$/, '') + '/v1';
+    }
+    return url ?? 'https://api.anthropic.com/v1';
+  })();
 
   const providerName = options.name ?? 'anthropic.messages';
 


### PR DESCRIPTION
## Problem

When users configure `ANTHROPIC_BASE_URL` without a `/v1` path suffix (e.g. `https://my-proxy.example.com`), the provider constructs incorrect API URLs like `https://my-proxy.example.com/messages` instead of `https://my-proxy.example.com/v1/messages`.

## Root cause

The Anthropic provider does not normalize the base URL to include `/v1`. It assumes the user-provided URL already ends with `/v1`, which is often not the case with proxy services.

## Changes

- `packages/provider/src/anthropic/anthropic-provider.ts`: Added URL normalization — if the base URL does not end with `/v1`, append it automatically. This mirrors the behavior already implemented in the OpenAI provider.

## Why

Users commonly configure base URLs from proxy services that don't include the API version path. Normalizing the URL prevents silent 404 errors.

Closes #15585