### PR TITLE
fix(ai): type legacy tool callbacks on agents

### DIFF
--- a/.changeset/agent-tool-call-callback-types.md
+++ b/.changeset/agent-tool-call-callback-types.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add legacy tool call callback fields to `AgentCallParameters`.

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -107,9 +107,19 @@ export type AgentCallParameters<
     onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
 
     /**
+     * @deprecated Use `onToolExecutionStart` instead.
+     */
+    experimental_onToolCallStart?: OnToolExecutionStartCallback<TOOLS>;
+
+    /**
      * Callback that is called after each tool execution completes.
      */
     onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
+
+    /**
+     * @deprecated Use `onToolExecutionEnd` instead.
+     */
+    experimental_onToolCallFinish?: OnToolExecutionEndCallback<TOOLS>;
 
     /**
      * Callback that is called when each step (LLM call) ends, including intermediate steps.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -98,6 +98,23 @@ describe('ToolLoopAgent', () => {
       expectTypeOf<typeof output>().toEqualTypeOf<{ value: string }>();
     });
 
+    it('should accept legacy tool call callbacks', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+          }),
+        },
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        experimental_onToolCallStart: async () => {},
+        experimental_onToolCallFinish: async () => {},
+      });
+    });
+
     it('should type toolApproval in settings and prepareCall', () => {
       const tools = {
         testTool: tool({
@@ -228,6 +245,23 @@ describe('ToolLoopAgent', () => {
         onStepStart: event => {
           expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
         },
+      });
+    });
+
+    it('should accept legacy tool call callbacks', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+          }),
+        },
+      });
+
+      await agent.stream({
+        prompt: 'Hello, world!',
+        experimental_onToolCallStart: async () => {},
+        experimental_onToolCallFinish: async () => {},
       });
     });
   });

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -2394,6 +2394,34 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
+      it('should call legacy experimental_onToolCallStart from generate method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        await agent.generate({
+          prompt: 'test',
+          experimental_onToolCallStart: async () => {
+            calls.push('legacy');
+          },
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "legacy",
+          ]
+        `);
+      });
+
       it('should call both constructor and method in correct order', async () => {
         const calls: string[] = [];
 
@@ -2596,6 +2624,36 @@ describe('ToolLoopAgent', () => {
         expect(calls).toMatchInlineSnapshot(`
           [
             "method",
+          ]
+        `);
+      });
+
+      it('should call legacy experimental_onToolCallStart from stream method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallStreamMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'test',
+          experimental_onToolCallStart: async () => {
+            calls.push('legacy');
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "legacy",
           ]
         `);
       });
@@ -2821,6 +2879,34 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
+      it('should call legacy experimental_onToolCallFinish from generate method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        await agent.generate({
+          prompt: 'test',
+          experimental_onToolCallFinish: async () => {
+            calls.push('legacy');
+          },
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "legacy",
+          ]
+        `);
+      });
+
       it('should call both constructor and method in correct order', async () => {
         const calls: string[] = [];
 
@@ -3034,6 +3120,36 @@ describe('ToolLoopAgent', () => {
         expect(calls).toMatchInlineSnapshot(`
           [
             "method",
+          ]
+        `);
+      });
+
+      it('should call legacy experimental_onToolCallFinish from stream method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallStreamMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'test',
+          experimental_onToolCallFinish: async () => {
+            calls.push('legacy');
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "legacy",
           ]
         `);
       });

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -189,6 +189,8 @@ export class ToolLoopAgent<
     experimental_onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
+    experimental_onToolCallStart,
+    experimental_onToolCallFinish,
     onStepEnd,
     onStepFinish,
     onFinish,
@@ -221,10 +223,12 @@ export class ToolLoopAgent<
       onToolExecutionStart: mergeCallbacks(
         this.settings.onToolExecutionStart,
         onToolExecutionStart,
+        experimental_onToolCallStart,
       ),
       onToolExecutionEnd: mergeCallbacks(
         this.settings.onToolExecutionEnd,
         onToolExecutionEnd,
+        experimental_onToolCallFinish,
       ),
       onStepEnd: mergeCallbacks(
         this.settings.onStepEnd ?? this.settings.onStepFinish,
@@ -253,6 +257,8 @@ export class ToolLoopAgent<
     experimental_onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
+    experimental_onToolCallStart,
+    experimental_onToolCallFinish,
     onStepEnd,
     onStepFinish,
     onFinish,
@@ -286,10 +292,12 @@ export class ToolLoopAgent<
       onToolExecutionStart: mergeCallbacks(
         this.settings.onToolExecutionStart,
         onToolExecutionStart,
+        experimental_onToolCallStart,
       ),
       onToolExecutionEnd: mergeCallbacks(
         this.settings.onToolExecutionEnd,
         onToolExecutionEnd,
+        experimental_onToolCallFinish,
       ),
       onStepEnd: mergeCallbacks(
         this.settings.onStepEnd ?? this.settings.onStepFinish,


### PR DESCRIPTION
﻿## Background

`ToolLoopAgent.generate()` and `ToolLoopAgent.stream()` forward extra call options into `generateText()` and `streamText()`. The legacy `experimental_onToolCallStart` and `experimental_onToolCallFinish` callbacks therefore work at runtime, but the agent call parameter type did not expose them.

That left consumers needing `as any` for callbacks that the underlying text APIs still support.

## Summary

- add the two legacy callback fields to `AgentCallParameters`
- keep them marked as deprecated aliases for the newer `onToolExecutionStart` / `onToolExecutionEnd` fields
- cover both `generate()` and `stream()` in the agent d.ts test
- add a patch changeset for `ai`

## Manual Verification

```bash
pnpm --filter ai type-check
pnpm --filter ai test:node -- src/agent/tool-loop-agent.test.ts
pnpm exec oxfmt --check packages/ai/src/agent/agent.ts packages/ai/src/agent/tool-loop-agent.test-d.ts .changeset/agent-tool-call-callback-types.md
pnpm exec oxlint packages/ai/src/agent/agent.ts packages/ai/src/agent/tool-loop-agent.test-d.ts
pnpm --filter ai build
```

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14278
