### PR TITLE
fix(mcp): await addClientAuthentication in token exchange and refresh

### DIFF
--- a/.changeset/await-add-client-authentication.md
+++ b/.changeset/await-add-client-authentication.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+Await the optional `addClientAuthentication` callback in `exchangeAuthorization` and `refreshAuthorization`. The provider interface declares the callback as `void | Promise<void>`, but the call sites invoked it without `await`, so async implementations (e.g. ones that read credentials from a database) finished setting form parameters after the token-exchange request had already been dispatched. Matches the awaited call in `modelcontextprotocol/typescript-sdk` (`packages/client/src/client/auth.ts:1491`).

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1124,6 +1124,36 @@ describe('exchangeAuthorization', () => {
     const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
     expect(body.get('resource')).toBe('https://mcp.example.com');
   });
+
+  it('awaits async addClientAuthentication before dispatching token request', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validTokens,
+    });
+
+    const addClientAuthentication = async (
+      _headers: Headers,
+      params: URLSearchParams,
+    ) => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      params.set('client_id', 'set-by-async-provider');
+      params.set('client_secret', 'secret-by-async-provider');
+    };
+
+    await exchangeAuthorization('https://auth.example.com', {
+      metadata: validMetadata as AuthorizationServerMetadata,
+      clientInformation: validClientInfo,
+      authorizationCode: 'code123',
+      codeVerifier: 'verifier123',
+      redirectUri: 'http://localhost:3000/callback',
+      addClientAuthentication,
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('client_id')).toBe('set-by-async-provider');
+    expect(body.get('client_secret')).toBe('secret-by-async-provider');
+  });
 });
 
 describe('refreshAuthorization', () => {
@@ -1316,6 +1346,34 @@ describe('refreshAuthorization', () => {
 
     const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
     expect(body.get('resource')).toBe('https://mcp.example.com');
+  });
+
+  it('awaits async addClientAuthentication before dispatching refresh request', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validTokens,
+    });
+
+    const addClientAuthentication = async (
+      _headers: Headers,
+      params: URLSearchParams,
+    ) => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      params.set('client_id', 'set-by-async-provider');
+      params.set('client_secret', 'secret-by-async-provider');
+    };
+
+    await refreshAuthorization('https://auth.example.com', {
+      metadata: validMetadata as AuthorizationServerMetadata,
+      clientInformation: validClientInfo,
+      refreshToken: 'refresh123',
+      addClientAuthentication,
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('client_id')).toBe('set-by-async-provider');
+    expect(body.get('client_secret')).toBe('secret-by-async-provider');
   });
 });
 

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -667,7 +667,12 @@ export async function exchangeAuthorization(
   });
 
   if (addClientAuthentication) {
-    addClientAuthentication(headers, params, authorizationServerUrl, metadata);
+    await addClientAuthentication(
+      headers,
+      params,
+      authorizationServerUrl,
+      metadata,
+    );
   } else {
     const supportedMethods =
       metadata?.token_endpoint_auth_methods_supported ?? [];
@@ -754,7 +759,12 @@ export async function refreshAuthorization(
   });
 
   if (addClientAuthentication) {
-    addClientAuthentication(headers, params, authorizationServerUrl, metadata);
+    await addClientAuthentication(
+      headers,
+      params,
+      authorizationServerUrl,
+      metadata,
+    );
   } else {
     const supportedMethods =
       metadata?.token_endpoint_auth_methods_supported ?? [];


### PR DESCRIPTION
## Summary

`OAuthClientProvider.addClientAuthentication?(...)` is typed `void | Promise<void>` (`packages/mcp/src/tool/oauth.ts:61-66`), but the two call sites in `exchangeAuthorization` and `refreshAuthorization` invoke it without `await`. Async implementations finish writing to `params` / `headers` after the token POST has already been dispatched, so the request goes out without `client_id` / `client_secret` and the auth server rejects it (`invalid_client`).

The upstream MCP TypeScript SDK awaits the callback at `packages/client/src/client/auth.ts:1491`; this fork dropped the `await` during the OAuth refactor.

## Why this matters

Any provider that reads credentials from async storage (database, KMS, secrets manager, etc.) is silently broken on this code path. I hit this in production when a `DatabaseOAuthClientProvider.addClientAuthentication` queried Postgres before setting `client_id` - the request went out empty, the server returned 401 `Missing client_id`.

## Test plan

- [x] New unit tests in `packages/mcp/src/tool/oauth.test.ts` covering both `exchangeAuthorization` and `refreshAuthorization`. Each mocks an async `addClientAuthentication` that writes `client_id` / `client_secret` after a 5 ms delay and asserts both values are present in the form body sent to the token endpoint. Fails on `main`, passes with this patch.
- [x] Changeset added (`patch` to `@ai-sdk/mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
