### PR TITLE
feat(provider): add Gradium AI SDK provider

### DIFF
--- a/.changeset/gradium-provider.md
+++ b/.changeset/gradium-provider.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gradium": major
+---
+
+Add the Gradium provider with speech generation and transcription support.

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -45,6 +45,7 @@ The AI SDK comes with a wide range of providers that you can use to interact wit
 - [Hume Provider](/providers/ai-sdk-providers/hume) (`@ai-sdk/hume`)
 - [Rev.ai Provider](/providers/ai-sdk-providers/revai) (`@ai-sdk/revai`)
 - [Deepgram Provider](/providers/ai-sdk-providers/deepgram) (`@ai-sdk/deepgram`)
+- [Gradium Provider](/providers/ai-sdk-providers/gradium) (`@ai-sdk/gradium`)
 - [Gladia Provider](/providers/ai-sdk-providers/gladia) (`@ai-sdk/gladia`)
 - [AssemblyAI Provider](/providers/ai-sdk-providers/assemblyai) (`@ai-sdk/assemblyai`)
 - [Baseten Provider](/providers/ai-sdk-providers/baseten) (`@ai-sdk/baseten`)

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -218,6 +218,7 @@ try {
 | [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova` (+ variants)      |
 | [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-2` (+ variants)    |
 | [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-3` (+ variants)    |
+| [Gradium](/providers/ai-sdk-providers/gradium#transcription-models)       | `default`                |
 | [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)         | `default`                |
 | [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `best`                   |
 | [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `nano`                   |

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -162,6 +162,7 @@ try {
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models) | `eleven_flash_v2`        |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models) | `eleven_turbo_v2_5`      |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models) | `eleven_turbo_v2`        |
+| [Gradium](/providers/ai-sdk-providers/gradium#speech-models)       | `default`                |
 | [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)             | `aurora`                 |
 | [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)             | `blizzard`               |
 | [Hume](/providers/ai-sdk-providers/hume#speech-models)             | `default`                |

--- a/content/providers/01-ai-sdk-providers/190-gradium.mdx
+++ b/content/providers/01-ai-sdk-providers/190-gradium.mdx
@@ -1,0 +1,347 @@
+---
+title: Gradium
+description: Learn how to use the Gradium provider for the AI SDK.
+---
+
+# Gradium Provider
+
+The [Gradium](https://gradium.ai/) provider contains support for Gradium speech generation and transcription APIs. Gradium is designed for low-latency voice applications, with natural text-to-speech, speech-to-text, telephony-friendly audio formats, voice management, pronunciation dictionaries, and realtime APIs for agent turn-taking.
+
+## Capabilities
+
+- **Speech generation**: Generate natural speech with Gradium voices or custom voice clones using the AI SDK `generateSpeech` function.
+- **Transcription**: Transcribe audio into text and timestamped segments using the AI SDK `transcribe` function.
+- **Low-latency audio formats**: Use `wav`, `pcm`, `opus`, telephony formats such as `ulaw_8000` and `alaw_8000`, or explicit PCM sample rates such as `pcm_16000`.
+- **Voice and pronunciation APIs**: List, create, update, and delete voices and pronunciation dictionaries from the provider instance.
+- **Realtime agent features**: Gradium's WebSocket APIs provide streaming audio, semantic VAD `step` messages, adaptive `delay_in_frames`, and `flush` for turn boundaries.
+
+<Note>
+  The AI SDK `generateSpeech` and `transcribe` helpers use Gradium's request/response APIs. For live microphones, telephony streams, LLM token-to-speech streaming, semantic VAD events, or flush-driven turn-taking, use Gradium's realtime WebSocket APIs directly. See the [Gradium speech-to-text guide](https://docs.gradium.ai/guides/speech-to-text) and [turn-taking recipe](https://docs.gradium.ai/guides/recipes/turn-taking).
+</Note>
+
+## Setup
+
+The Gradium provider is available in the `@ai-sdk/gradium` module. You can install it with
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/gradium" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/gradium" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/gradium" dark />
+  </Tab>
+
+  <Tab>
+    <Snippet text="bun add @ai-sdk/gradium" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default provider instance `gradium` from `@ai-sdk/gradium`:
+
+```ts
+import { gradium } from '@ai-sdk/gradium';
+```
+
+If you need a customized setup, you can import `createGradium` from `@ai-sdk/gradium` and create a provider instance with your settings:
+
+```ts
+import { createGradium } from '@ai-sdk/gradium';
+
+const gradium = createGradium({
+  // custom settings, e.g.
+  fetch: customFetch,
+});
+```
+
+You can use the following optional settings to customize the Gradium provider instance:
+
+- **baseURL** _string_
+
+  Use a different Gradium API URL prefix. It defaults to `https://api.gradium.ai/api`.
+
+- **apiKey** _string_
+
+  API key that is sent using the `x-api-key` header.
+  It defaults to the `GRADIUM_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
+## Speech Models
+
+You can create models that call the [Gradium text-to-speech API](https://api.gradium.ai/api/post/speech/tts)
+using the `.speech()` factory method.
+
+Use this API when you want the AI SDK to return a complete audio result for a text input. For realtime LLM-to-speech flows where text arrives token-by-token and audio should begin playing as soon as possible, use Gradium's WebSocket TTS API directly.
+
+The first argument is the model id. Use `default` for Gradium's production model.
+
+```ts
+const model = gradium.speech('default');
+```
+
+The `voice` argument can be set to any Gradium library voice ID or custom clone ID.
+
+```ts highlight="6"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { gradium } from '@ai-sdk/gradium';
+
+const result = await generateSpeech({
+  model: gradium.speech('default'),
+  text: 'Welcome to Gradium.',
+  voice: 'YTpq7expH9539ERJ',
+  outputFormat: 'wav',
+});
+```
+
+You can also pass additional provider-specific options using the `providerOptions` argument:
+
+```ts highlight="7-14"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { gradium, type GradiumSpeechModelOptions } from '@ai-sdk/gradium';
+
+const result = await generateSpeech({
+  model: gradium.speech('default'),
+  text: 'Bonjour, monde.',
+  providerOptions: {
+    gradium: {
+      voiceId: 'custom-clone-id',
+      outputFormat: 'ulaw_8000',
+      rewriteRules: 'fr',
+      paddingBonus: -1.2,
+      cfgCoef: 2.4,
+      temperature: 0.35,
+    } satisfies GradiumSpeechModelOptions,
+  },
+});
+```
+
+The following provider options are available:
+
+- **voiceId** _string_
+
+  Overrides the top-level `voice` argument. Accepts any Gradium library voice ID or custom clone ID.
+  Optional.
+
+- **outputFormat** _string_
+
+  Overrides the top-level `outputFormat` argument. Supports `wav`, `pcm`, `opus`, `ulaw_8000`, `mulaw_8000`, `alaw_8000`, `pcm_8000`, `pcm_16000`, `pcm_22050`, `pcm_24000`, `pcm_44100`, and `pcm_48000`.
+  Use telephony formats when sending generated speech directly to phone audio streams, and explicit PCM rates when your downstream player or transport expects a fixed sample rate.
+  Optional.
+
+- **paddingBonus** _number_
+
+  Extra pause duration between spoken chunks. Lower values, including negative values, make speech feel faster; higher values add spacing.
+  The top-level AI SDK `speed` setting is mapped to this option when `paddingBonus` is not provided.
+  Optional.
+
+- **cfgCoef** _number_
+
+  Voice-similarity coefficient between `1.0` and `4.0`.
+  Optional.
+
+- **temperature** _number_
+
+  Sampling temperature for generation.
+  Optional.
+
+- **rewriteRules** _string_
+
+  Text-rewrite rules applied before synthesis. Pass a language code such as `en`, `fr`, `de`, `es`, or `pt`, or a comma-separated list of rule names.
+  Optional.
+
+- **pronunciationDictionary** _string_
+
+  Pronunciation dictionary ID to apply during synthesis.
+  Optional.
+
+- **onlyAudio** _boolean_
+
+  When `true`, the response body is raw audio. When `false`, Gradium returns JSON messages and the provider extracts the audio.
+  Optional. Defaults to `true`.
+
+- **jsonConfig** _string_
+
+  Raw `json_config` string forwarded verbatim for advanced Gradium options.
+  Optional.
+
+### Realtime Speech
+
+The AI SDK speech model returns a complete audio response. Gradium also supports realtime TTS over WebSocket for voice agents and LLM output streaming. In that mode, your application sends a `setup` message once, streams `text` messages as they arrive, and receives `audio` chunks as soon as they are generated.
+
+Use realtime TTS when you need:
+
+- Low first-byte latency for interactive voice agents.
+- Audio playback while the upstream LLM is still generating text.
+- A persistent socket for multiple utterances or multiplexed requests.
+- Fine control over chunking, interruption, and graceful `end_of_stream` handling.
+
+### Model Capabilities
+
+| Model     |
+| --------- |
+| `default` |
+
+## Transcription Models
+
+You can create models that call the [Gradium transcription API](https://api.gradium.ai/api/post/speech/asr)
+using the `.transcription()` factory method.
+
+Use this API when you have an audio file or audio buffer and want the AI SDK to return a transcript. For live microphone or telephony audio, Gradium's WebSocket STT API gives lower latency and emits additional realtime signals for turn-taking.
+
+The first argument is the model id. Use `default` for Gradium's production model.
+
+```ts
+const model = gradium.transcription('default');
+```
+
+You can use the model with the `transcribe` function:
+
+```ts
+import { experimental_transcribe as transcribe } from 'ai';
+import { gradium } from '@ai-sdk/gradium';
+import { readFile } from 'node:fs/promises';
+
+const result = await transcribe({
+  model: gradium.transcription('default'),
+  audio: await readFile('audio.wav'),
+  mediaType: 'audio/wav',
+});
+```
+
+You can also pass additional provider-specific options using the `providerOptions` argument:
+
+```ts highlight="8-13"
+import { experimental_transcribe as transcribe } from 'ai';
+import {
+  gradium,
+  type GradiumTranscriptionModelOptions,
+} from '@ai-sdk/gradium';
+
+const result = await transcribe({
+  model: gradium.transcription('default'),
+  audio: new Uint8Array([1, 2, 3, 4]),
+  mediaType: 'audio/wav',
+  providerOptions: {
+    gradium: {
+      language: 'en',
+      inputFormat: 'pcm_16000',
+    } satisfies GradiumTranscriptionModelOptions,
+  },
+});
+```
+
+Advanced STT controls are passed through `jsonConfig` as a JSON string:
+
+```ts highlight="10-16"
+import { experimental_transcribe as transcribe } from 'ai';
+import {
+  gradium,
+  type GradiumTranscriptionModelOptions,
+} from '@ai-sdk/gradium';
+
+const result = await transcribe({
+  model: gradium.transcription('default'),
+  audio,
+  mediaType: 'audio/pcm',
+  providerOptions: {
+    gradium: {
+      inputFormat: 'pcm_16000',
+      jsonConfig: JSON.stringify({
+        language: 'en',
+        temp: 0.3,
+        padding_bonus: -1,
+        delay_in_frames: 16,
+      }),
+    } satisfies GradiumTranscriptionModelOptions,
+  },
+});
+```
+
+The following provider options are available:
+
+- **inputFormat** _string_
+
+  Overrides the input format detected from `mediaType`. Supports `wav`, `pcm`, `opus`, and explicit-rate or telephony variants such as `pcm_16000` and `ulaw_8000`.
+  Optional.
+
+- **language** _string_
+
+  Language hint passed inside `json_config.language`.
+  Optional.
+
+- **jsonConfig** _string_
+
+  Raw `json_config` string forwarded verbatim as the `?json_config=` query parameter. Use this for advanced Gradium settings such as `temp`, `padding_bonus`, and `delay_in_frames`.
+  Optional.
+
+### Semantic VAD, Adaptive Delay, and Flush
+
+Gradium's realtime STT WebSocket API is built for conversational agents. It emits semantic VAD `step` messages every 80 ms. Each `step` includes future horizons with an `inactivity_prob`, which lets your application decide when the speaker has probably finished instead of relying on a simple silence detector.
+
+```json
+{
+  "type": "step",
+  "vad": [
+    {"horizon_s": 0.5, "inactivity_prob": 0.05},
+    {"horizon_s": 1.0, "inactivity_prob": 0.08},
+    {"horizon_s": 2.0, "inactivity_prob": 0.62}
+  ],
+  "step_duration_s": 0.08
+}
+```
+
+A common starting point is to watch the longest horizon and treat values above `0.5` as a possible end of turn. For noisy audio or high-stakes flows, require several consecutive high-confidence steps before responding.
+
+`delay_in_frames` controls the latency/quality tradeoff for realtime STT. Each frame is 80 ms. Lower values are more reactive; higher values give the model more context and can improve transcript stability. Gradium supports `7`, `8`, `10`, `12`, `14`, `16`, `20`, `24`, `32`, `36`, and `48`.
+
+When your app decides a turn has ended, send `flush` on the WebSocket. Gradium processes buffered audio immediately and responds with `flushed`, so the agent can move to the next step without waiting for natural silence.
+
+<Note>
+  The AI SDK `transcribe` function returns transcript text, segments, warnings, and response metadata. It does not expose realtime WebSocket `step`, `flush`, or `flushed` events. Use Gradium's realtime STT API directly when those signals are part of your application logic.
+</Note>
+
+### Model Capabilities
+
+| Model     |
+| --------- |
+| `default` |
+
+## Gradium Resource APIs
+
+The provider also exposes Gradium-specific resource APIs that are useful around speech workflows:
+
+```ts
+import { gradium } from '@ai-sdk/gradium';
+
+const voices = await gradium.voices.list({ includeCatalog: true });
+const credits = await gradium.credits.get();
+
+const pronunciation = await gradium.pronunciations.create({
+  name: 'Product terms',
+  language: 'en',
+  rules: [
+    {
+      original: 'Gradium',
+      rewrite: 'gray-dee-um',
+    },
+  ],
+});
+```
+
+- **voices**: Manage library and custom cloned voices for TTS.
+- **pronunciations**: Create dictionaries for brand names, domain terms, acronyms, and other words that need controlled pronunciation.
+- **credits**: Read the authenticated account's billing-period credit balance.

--- a/packages/gradium/CHANGELOG.md
+++ b/packages/gradium/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ai-sdk/gradium

--- a/packages/gradium/README.md
+++ b/packages/gradium/README.md
@@ -1,0 +1,91 @@
+# AI SDK - Gradium Provider
+
+The **[Gradium provider](https://ai-sdk.dev/providers/ai-sdk-providers/gradium)** for the [AI SDK](https://ai-sdk.dev/docs)
+contains speech model support for the Gradium text-to-speech API and transcription model support for the Gradium speech-to-text API.
+
+Gradium is built for low-latency voice applications. This package exposes Gradium's request/response TTS and STT APIs through the AI SDK, plus helper APIs for voices, pronunciation dictionaries, and credits. For live microphones, telephony streams, semantic VAD, adaptive delay control, and flush-driven turn-taking, use Gradium's realtime WebSocket APIs directly.
+
+## Setup
+
+The Gradium provider is available in the `@ai-sdk/gradium` module. You can install it with
+
+```bash
+npm i @ai-sdk/gradium
+```
+
+## Provider Instance
+
+You can import the default provider instance `gradium` from `@ai-sdk/gradium`:
+
+```ts
+import { gradium } from '@ai-sdk/gradium';
+```
+
+## Examples
+
+### Text-to-Speech
+
+```ts
+import { gradium } from '@ai-sdk/gradium';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+
+const { audio } = await generateSpeech({
+  model: gradium.speech('default'),
+  text: 'Hello from Gradium.',
+  voice: 'YTpq7expH9539ERJ',
+});
+```
+
+### Transcription
+
+```ts
+import { gradium } from '@ai-sdk/gradium';
+import { experimental_transcribe as transcribe } from 'ai';
+
+const { text } = await transcribe({
+  model: gradium.transcription('default'),
+  audio: new Uint8Array([1, 2, 3, 4]),
+  mediaType: 'audio/wav',
+});
+```
+
+### Advanced Transcription Settings
+
+```ts
+import { gradium, type GradiumTranscriptionModelOptions } from '@ai-sdk/gradium';
+import { experimental_transcribe as transcribe } from 'ai';
+
+const { text } = await transcribe({
+  model: gradium.transcription('default'),
+  audio,
+  mediaType: 'audio/pcm',
+  providerOptions: {
+    gradium: {
+      inputFormat: 'pcm_16000',
+      jsonConfig: JSON.stringify({
+        language: 'en',
+        delay_in_frames: 16,
+      }),
+    } satisfies GradiumTranscriptionModelOptions,
+  },
+});
+```
+
+`delay_in_frames` tunes the latency/quality tradeoff for Gradium STT. Semantic VAD `step` events and `flush` confirmations are realtime WebSocket features and are not emitted by the AI SDK `transcribe` helper.
+
+### Resource APIs
+
+```ts
+const voices = await gradium.voices.list({ includeCatalog: true });
+const credits = await gradium.credits.get();
+
+const dictionary = await gradium.pronunciations.create({
+  name: 'Product terms',
+  language: 'en',
+  rules: [{ original: 'Gradium', rewrite: 'gray-dee-um' }],
+});
+```
+
+## Documentation
+
+Please check out the **[Gradium provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/gradium)** for more information.

--- a/packages/gradium/package.json
+++ b/packages/gradium/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@ai-sdk/gradium",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "tsup --tsconfig tsconfig.build.json",
+    "build:watch": "tsup --tsconfig tsconfig.build.json --watch",
+    "clean": "del-cli dist docs",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/190-gradium.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "type-check": "tsc --noEmit",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run",
+    "test:node:watch": "vitest --config vitest.node.config.js --watch"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.6.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/gradium"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/gradium/src/gradium-api-types.ts
+++ b/packages/gradium/src/gradium-api-types.ts
@@ -1,0 +1,132 @@
+// Wire-level types for the Gradium REST API.
+// Mirrors the request/response shapes documented at
+// https://gradium.ai/api_docs.html and in the local OpenAPI spec.
+
+/**
+ * Audio output formats accepted by `POST /post/speech/tts`.
+ *
+ * `wav`, `pcm`, `opus` are the canonical formats and the only ones the
+ * AI SDK's top-level `outputFormat` maps to today. The remaining values
+ * cover telephony (mu-law / a-law / 8 kHz PCM) and explicit sample-rate
+ * PCM variants — pass them via `providerOptions.gradium.outputFormat`.
+ */
+export type GradiumTTSOutputFormat =
+  | 'wav'
+  | 'pcm'
+  | 'opus'
+  | 'ulaw_8000'
+  | 'mulaw_8000'
+  | 'alaw_8000'
+  | 'pcm_8000'
+  | 'pcm_16000'
+  | 'pcm_22050'
+  | 'pcm_24000'
+  | 'pcm_44100'
+  | 'pcm_48000';
+
+export const GRADIUM_TTS_OUTPUT_FORMATS = [
+  'wav',
+  'pcm',
+  'opus',
+  'ulaw_8000',
+  'mulaw_8000',
+  'alaw_8000',
+  'pcm_8000',
+  'pcm_16000',
+  'pcm_22050',
+  'pcm_24000',
+  'pcm_44100',
+  'pcm_48000',
+] as const satisfies readonly GradiumTTSOutputFormat[];
+
+/** Audio container types Gradium STT accepts on the wire. */
+export type GradiumSTTInputFormat =
+  | 'wav'
+  | 'pcm'
+  | 'opus'
+  | 'pcm_8000'
+  | 'pcm_16000'
+  | 'pcm_22050'
+  | 'pcm_24000'
+  | 'pcm_44100'
+  | 'pcm_48000'
+  | 'ulaw_8000'
+  | 'mulaw_8000'
+  | 'alaw_8000';
+
+export const GRADIUM_STT_INPUT_FORMATS = [
+  'wav',
+  'pcm',
+  'opus',
+  'pcm_8000',
+  'pcm_16000',
+  'pcm_22050',
+  'pcm_24000',
+  'pcm_44100',
+  'pcm_48000',
+  'ulaw_8000',
+  'mulaw_8000',
+  'alaw_8000',
+] as const satisfies readonly GradiumSTTInputFormat[];
+
+/** Request body for `POST /post/speech/tts`. */
+export interface GradiumTTSRequestBody {
+  text: string;
+  voice_id: string;
+  output_format: GradiumTTSOutputFormat;
+  only_audio?: boolean;
+  model_name?: string;
+  json_config?: string;
+}
+
+/** Settings accepted inside `json_config` for `POST /post/speech/tts`. */
+export interface GradiumTTSJsonConfig {
+  padding_bonus?: number;
+  cfg_coef?: number;
+  temp?: number;
+  rewrite_rules?: string;
+  pronunciation_dictionary?: string;
+}
+
+/** JSON messages returned by TTS when `only_audio` is false. */
+export type GradiumTTSMessage =
+  | {
+      type: 'audio';
+      audio: string;
+      stream_id?: number;
+    }
+  | {
+      type: 'text';
+      text: string;
+      start_s?: number;
+      stop_s?: number;
+      stream_id?: number;
+    }
+  | {
+      type: 'error';
+      message: string;
+      code?: number | string;
+    }
+  | {
+      type: string;
+      [key: string]: unknown;
+    };
+
+/** A single NDJSON line returned by `POST /post/speech/asr`. */
+export type GradiumSTTMessage =
+  | {
+      type: 'text';
+      text: string;
+      start_s: number;
+      stream_id?: number;
+    }
+  | {
+      type: 'end_text';
+      stop_s: number;
+      stream_id?: number;
+    }
+  | {
+      type: 'error';
+      message: string;
+      code?: number;
+    };

--- a/packages/gradium/src/gradium-config.ts
+++ b/packages/gradium/src/gradium-config.ts
@@ -1,0 +1,24 @@
+export type GradiumConfig = {
+  provider: string;
+  url: (path: { path: string; modelId: string }) => string;
+  headers: () => Record<string, string>;
+  fetch?: typeof globalThis.fetch;
+  generateId?: () => string;
+};
+
+/**
+ * Drop `undefined` values from a header bag so the result is acceptable
+ * to DOM `fetch`'s `HeadersInit` (which rejects `string | undefined`).
+ * `combineHeaders` from `@ai-sdk/provider-utils` produces the loose form
+ * intentionally so providers can compose headers; we tighten at the call
+ * site.
+ */
+export function cleanHeaders(
+  headers: Record<string, string | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}

--- a/packages/gradium/src/gradium-error.test.ts
+++ b/packages/gradium/src/gradium-error.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGradium } from './index';
+
+function fakeFetch(response: Response) {
+  return vi.fn(async () => response) as unknown as typeof fetch;
+}
+
+describe('gradiumFailedResponseHandler', () => {
+  it('surfaces a JSON-object error message', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        new Response(
+          JSON.stringify({
+            error: { message: 'invalid voice id', code: 'bad_voice' },
+          }),
+          { status: 400, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    });
+
+    await expect(gradium.speech().doGenerate({ text: 'boom' })).rejects.toThrow(
+      /invalid voice id/,
+    );
+  });
+
+  it('surfaces a JSON string error payload', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        new Response(JSON.stringify({ error: 'forbidden voice' }), {
+          status: 403,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    });
+
+    await expect(gradium.speech().doGenerate({ text: 'boom' })).rejects.toThrow(
+      /forbidden voice/,
+    );
+  });
+
+  it('surfaces a plain-text error body (Gradium auth case)', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        new Response(
+          'error from server Some(1008): API key is revoked or expired\n' +
+            'Need more support? Feel free to reach out by email at support@gradium.ai',
+          {
+            status: 500,
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+          },
+        ),
+      ),
+    });
+
+    await expect(gradium.speech().doGenerate({ text: 'boom' })).rejects.toThrow(
+      /API key is revoked or expired/,
+    );
+  });
+
+  it('marks the Gradium 1008 auth case as non-retryable to avoid wasted retries', async () => {
+    let calls = 0;
+    const fetchSpy = vi.fn(async () => {
+      calls += 1;
+      return new Response(
+        'error from server Some(1008): API key is revoked or expired',
+        { status: 500, headers: { 'content-type': 'text/plain' } },
+      );
+    }) as unknown as typeof fetch;
+
+    const gradium = createGradium({ apiKey: 'test-key', fetch: fetchSpy });
+
+    await expect(gradium.speech().doGenerate({ text: 'boom' })).rejects.toThrow(
+      /API key is revoked/,
+    );
+
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/gradium/src/gradium-error.ts
+++ b/packages/gradium/src/gradium-error.ts
@@ -1,0 +1,98 @@
+import { APICallError } from '@ai-sdk/provider';
+import {
+  extractResponseHeaders,
+  type ResponseHandler,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const gradiumErrorDataSchema = z.object({
+  error: z
+    .object({
+      message: z.string(),
+      type: z.string().optional(),
+      code: z.union([z.string(), z.number()]).optional(),
+    })
+    .or(z.string())
+    .optional(),
+  message: z.string().optional(),
+  detail: z.string().optional(),
+});
+
+export type GradiumErrorData = z.infer<typeof gradiumErrorDataSchema>;
+
+function extractMessage(parsed: GradiumErrorData): string | null {
+  if (typeof parsed.error === 'string') return parsed.error;
+  if (parsed.error?.message) return parsed.error.message;
+  if (parsed.message) return parsed.message;
+  if (parsed.detail) return parsed.detail;
+  return null;
+}
+
+// Gradium currently returns HTTP 500 for auth failures with a plain-text body
+// like `error from server Some(1008): API key is revoked or expired`. The AI
+// SDK retries 5xx responses by default, which wastes ~7s on permanent failures.
+// Recognise the auth signature so we mark those non-retryable.
+const PERMANENT_ERROR_PATTERNS = [
+  /Some\(1008\)/i,
+  /api\s*key/i,
+  /revoked/i,
+  /expired/i,
+  /unauthori[sz]ed/i,
+  /forbidden/i,
+];
+
+function isPermanentByStatus(status: number): boolean {
+  return status === 400 || status === 401 || status === 403 || status === 404;
+}
+
+export const gradiumFailedResponseHandler: ResponseHandler<
+  APICallError
+> = async ({ response, url, requestBodyValues }) => {
+  const responseHeaders = extractResponseHeaders(response);
+  const responseBody = await response.text();
+
+  let message: string | null = null;
+  let parsed: GradiumErrorData | undefined;
+
+  if (responseBody.length > 0) {
+    try {
+      const json = JSON.parse(responseBody);
+      const result = gradiumErrorDataSchema.safeParse(json);
+      if (result.success) {
+        parsed = result.data;
+        message = extractMessage(result.data);
+      }
+    } catch {
+      // Not JSON — fall through to plain-text path.
+    }
+
+    // Plain-text body, or JSON without a recognised message field.
+    // Strip trailing support-link cruft Gradium appends to error bodies.
+    if (message == null) {
+      message = responseBody
+        .split(/\r?\n/)[0]!
+        .replace(/^error from server\s+/i, '')
+        .trim();
+    }
+  }
+
+  if (!message) message = response.statusText || 'Unknown Gradium error';
+
+  const permanent =
+    isPermanentByStatus(response.status) ||
+    PERMANENT_ERROR_PATTERNS.some(rx => rx.test(responseBody));
+
+  return {
+    responseHeaders,
+    value: new APICallError({
+      message,
+      url,
+      requestBodyValues,
+      statusCode: response.status,
+      responseHeaders,
+      responseBody,
+      isRetryable: !permanent,
+      data: parsed,
+    }),
+  };
+};

--- a/packages/gradium/src/gradium-helpers.test.ts
+++ b/packages/gradium/src/gradium-helpers.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGradium } from './index';
+
+type Captured = { url?: string; init?: RequestInit };
+
+const voice = {
+  uid: 'voice_123',
+  name: 'Demo Voice',
+  is_catalog: false,
+  is_pro_clone: false,
+  tags: [],
+};
+
+const dictionary = {
+  uid: 'dict_123',
+  org_uid: 'org_123',
+  name: 'Brand names',
+  language: 'en',
+  rules: [{ original: 'Gradium', rewrite: 'Grad-ium' }],
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+function jsonResponse(value: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+function fakeFetch(captured: Captured, response: Response) {
+  return vi.fn(async (url: string, init: RequestInit) => {
+    captured.url = url;
+    captured.init = init;
+    return response;
+  }) as unknown as typeof fetch;
+}
+
+describe('Gradium helper APIs', () => {
+  it('lists voices with catalog and pagination query parameters', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured, jsonResponse([voice])),
+    });
+
+    const result = await gradium.voices.list({
+      skip: 10,
+      limit: 20,
+      includeCatalog: true,
+    });
+
+    expect(result).toEqual([voice]);
+    expect(captured.url).toBe(
+      'https://api.gradium.ai/api/voices/?skip=10&limit=20&include_catalog=true',
+    );
+    expect(
+      (captured.init!.headers as Record<string, string>)['x-api-key'],
+    ).toBe('test-key');
+  });
+
+  it('creates voices with multipart form data', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured, jsonResponse(voice)),
+    });
+
+    await gradium.voices.create({
+      name: 'Demo Voice',
+      audioFile: new Uint8Array([1, 2, 3]),
+      audioFileName: 'sample.wav',
+      audioContentType: 'audio/wav',
+      inputFormat: 'wav',
+      language: 'en',
+      description: 'Friendly demo voice',
+      startSeconds: 1,
+      timeoutSeconds: 8,
+    });
+
+    const body = captured.init!.body as FormData;
+    expect(captured.url).toBe('https://api.gradium.ai/api/voices/');
+    expect(captured.init!.method).toBe('POST');
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('name')).toBe('Demo Voice');
+    expect(body.get('input_format')).toBe('wav');
+    expect(body.get('language')).toBe('en');
+    expect(body.get('description')).toBe('Friendly demo voice');
+    expect(body.get('start_s')).toBe('1');
+    expect(body.get('timeout_s')).toBe('8');
+    expect(
+      (captured.init!.headers as Record<string, string>)['content-type'],
+    ).toBe(undefined);
+  });
+
+  it('updates and deletes voices against encoded IDs', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(voice))
+      .mockResolvedValueOnce(
+        new Response(null, { status: 204 }),
+      ) as unknown as typeof fetch;
+    const gradium = createGradium({ apiKey: 'test-key', fetch: fetchSpy });
+
+    await gradium.voices.update('voice/123', { name: 'Updated' });
+    await gradium.voices.delete('voice/123');
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      'https://api.gradium.ai/api/voices/voice%2F123',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ name: 'Updated' }),
+      }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      'https://api.gradium.ai/api/voices/voice%2F123',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('manages pronunciation dictionaries', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ dictionaries: [dictionary], total: 1 }),
+      )
+      .mockResolvedValueOnce(jsonResponse(dictionary))
+      .mockResolvedValueOnce(jsonResponse(dictionary))
+      .mockResolvedValueOnce(jsonResponse(dictionary))
+      .mockResolvedValueOnce(
+        new Response(null, { status: 204 }),
+      ) as unknown as typeof fetch;
+    const gradium = createGradium({ apiKey: 'test-key', fetch: fetchSpy });
+
+    const list = await gradium.pronunciations.list({
+      limit: 5,
+      offset: 10,
+      language: 'en',
+    });
+    await gradium.pronunciations.get('dict/123');
+    await gradium.pronunciations.create({
+      name: 'Brand names',
+      language: 'en',
+      rules: [{ original: 'Gradium', rewrite: 'Grad-ium' }],
+    });
+    await gradium.pronunciations.update('dict/123', { description: 'Updated' });
+    await gradium.pronunciations.delete('dict/123');
+
+    expect(list.total).toBe(1);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      'https://api.gradium.ai/api/pronunciations/?limit=5&offset=10&language=en',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      'https://api.gradium.ai/api/pronunciations/dict%2F123',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      'https://api.gradium.ai/api/pronunciations/',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Brand names',
+          language: 'en',
+          rules: [{ original: 'Gradium', rewrite: 'Grad-ium' }],
+        }),
+      }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      4,
+      'https://api.gradium.ai/api/pronunciations/dict%2F123',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      5,
+      'https://api.gradium.ai/api/pronunciations/dict%2F123',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('gets credits and surfaces helper API errors', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          remaining_credits: 42,
+          allocated_credits: 100,
+          billing_period: 'monthly',
+          plan_name: 'Team',
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ error: { message: 'forbidden' } }, { status: 403 }),
+      ) as unknown as typeof fetch;
+    const gradium = createGradium({ apiKey: 'test-key', fetch: fetchSpy });
+
+    await expect(gradium.credits.get()).resolves.toMatchObject({
+      remaining_credits: 42,
+    });
+    await expect(gradium.voices.list()).rejects.toThrow(/forbidden/);
+  });
+});

--- a/packages/gradium/src/gradium-pronunciations.ts
+++ b/packages/gradium/src/gradium-pronunciations.ts
@@ -1,0 +1,180 @@
+import { combineHeaders } from '@ai-sdk/provider-utils';
+import { cleanHeaders, type GradiumConfig } from './gradium-config';
+import { gradiumFailedResponseHandler } from './gradium-error';
+
+export interface GradiumPronunciationRule {
+  original: string;
+  rewrite: string;
+  case_sensitive?: boolean;
+}
+
+export interface GradiumPronunciationDictionary {
+  uid: string;
+  org_uid: string;
+  name: string;
+  description?: string | null;
+  language: string;
+  rules: GradiumPronunciationRule[];
+  created_at: string;
+}
+
+export interface GradiumPronunciationListResponse {
+  dictionaries: GradiumPronunciationDictionary[];
+  total: number;
+}
+
+export interface GradiumPronunciationListOptions {
+  limit?: number;
+  offset?: number;
+  language?: string;
+}
+
+export interface GradiumPronunciationCreateOptions {
+  name: string;
+  language: string;
+  description?: string;
+  rules?: GradiumPronunciationRule[];
+}
+
+export interface GradiumPronunciationUpdateOptions {
+  name?: string | null;
+  description?: string | null;
+  language?: string | null;
+  rules?: GradiumPronunciationRule[] | null;
+}
+
+/** Surface presented as `gradium.pronunciations` on the provider object. */
+export interface GradiumPronunciationsAPI {
+  list(
+    options?: GradiumPronunciationListOptions,
+  ): Promise<GradiumPronunciationListResponse>;
+  get(uid: string): Promise<GradiumPronunciationDictionary>;
+  create(
+    options: GradiumPronunciationCreateOptions,
+  ): Promise<GradiumPronunciationDictionary>;
+  update(
+    uid: string,
+    options: GradiumPronunciationUpdateOptions,
+  ): Promise<GradiumPronunciationDictionary>;
+  delete(uid: string): Promise<void>;
+}
+
+async function ensureOk(response: Response, url: string): Promise<void> {
+  if (response.ok) return;
+  const errorResult = await gradiumFailedResponseHandler({
+    response,
+    url,
+    requestBodyValues: undefined,
+  });
+  throw errorResult.value;
+}
+
+export function createGradiumPronunciationsAPI(
+  config: GradiumConfig,
+): GradiumPronunciationsAPI {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  const baseHeaders = () => config.headers();
+  const jsonHeaders = () =>
+    cleanHeaders(
+      combineHeaders(baseHeaders(), { 'content-type': 'application/json' }),
+    );
+
+  return {
+    async list({ limit, offset, language } = {}) {
+      const url = new URL(
+        config.url({ path: '/pronunciations/', modelId: '' }),
+      );
+      if (limit != null) url.searchParams.set('limit', String(limit));
+      if (offset != null) url.searchParams.set('offset', String(offset));
+      if (language) url.searchParams.set('language', language);
+      const res = await fetchImpl(url.toString(), {
+        method: 'GET',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url.toString());
+      return (await res.json()) as GradiumPronunciationListResponse;
+    },
+
+    async get(uid: string) {
+      const url = config.url({
+        path: `/pronunciations/${encodeURIComponent(uid)}`,
+        modelId: '',
+      });
+      const res = await fetchImpl(url, {
+        method: 'GET',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumPronunciationDictionary;
+    },
+
+    async create(options: GradiumPronunciationCreateOptions) {
+      const url = config.url({ path: '/pronunciations/', modelId: '' });
+      const res = await fetchImpl(url, {
+        method: 'POST',
+        headers: jsonHeaders(),
+        body: JSON.stringify(options),
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumPronunciationDictionary;
+    },
+
+    async update(uid: string, options: GradiumPronunciationUpdateOptions) {
+      const url = config.url({
+        path: `/pronunciations/${encodeURIComponent(uid)}`,
+        modelId: '',
+      });
+      const res = await fetchImpl(url, {
+        method: 'PUT',
+        headers: jsonHeaders(),
+        body: JSON.stringify(options),
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumPronunciationDictionary;
+    },
+
+    async delete(uid: string) {
+      const url = config.url({
+        path: `/pronunciations/${encodeURIComponent(uid)}`,
+        modelId: '',
+      });
+      const res = await fetchImpl(url, {
+        method: 'DELETE',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url);
+    },
+  };
+}
+
+export interface GradiumCreditsSummary {
+  remaining_credits: number;
+  allocated_credits: number;
+  billing_period: string;
+  next_rollover_date?: string | null;
+  plan_name?: string;
+}
+
+export interface GradiumCreditsAPI {
+  /** Get the authenticated user's current billing-period credit balance. */
+  get(): Promise<GradiumCreditsSummary>;
+}
+
+export function createGradiumCreditsAPI(
+  config: GradiumConfig,
+): GradiumCreditsAPI {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  const baseHeaders = () => config.headers();
+
+  return {
+    async get(): Promise<GradiumCreditsSummary> {
+      const url = config.url({ path: '/usages/credits', modelId: '' });
+      const res = await fetchImpl(url, {
+        method: 'GET',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumCreditsSummary;
+    },
+  };
+}

--- a/packages/gradium/src/gradium-provider.ts
+++ b/packages/gradium/src/gradium-provider.ts
@@ -1,0 +1,217 @@
+import {
+  NoSuchModelError,
+  type ProviderV4,
+  type SpeechModelV4,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
+import {
+  type FetchFunction,
+  loadApiKey,
+  withUserAgentSuffix,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+import type { GradiumConfig } from './gradium-config';
+import { GradiumSpeechModel } from './gradium-speech-model';
+import type { GradiumSpeechModelId } from './gradium-speech-options';
+import { GradiumTranscriptionModel } from './gradium-transcription-model';
+import type { GradiumTranscriptionModelId } from './gradium-transcription-options';
+import {
+  createGradiumCreditsAPI,
+  createGradiumPronunciationsAPI,
+  type GradiumCreditsAPI,
+  type GradiumPronunciationsAPI,
+} from './gradium-pronunciations';
+import {
+  createGradiumVoicesAPI,
+  type GradiumVoicesAPI,
+} from './gradium-voices';
+import { VERSION } from './version';
+
+const DEFAULT_BASE_URL = 'https://api.gradium.ai/api';
+
+export interface GradiumProviderSettings {
+  /**
+   * Base URL of the Gradium API. No trailing slash.
+   * @default `https://api.gradium.ai/api`
+   */
+  baseURL?: string;
+
+  /**
+   * Gradium API key. Defaults to the `GRADIUM_API_KEY` environment variable.
+   * Sent as the `x-api-key` header on every request.
+   */
+  apiKey?: string;
+
+  /**
+   * Custom headers merged into every request.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. Useful for proxying, testing, and request
+   * inspection. Defaults to the global `fetch`.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface GradiumProvider extends ProviderV4 {
+  (
+    modelId?: GradiumTranscriptionModelId,
+    settings?: {},
+  ): {
+    transcription: GradiumTranscriptionModel;
+  };
+
+  /**
+   * Create a Gradium speech (text-to-speech) model.
+   *
+   * @example
+   * ```ts
+   * import { gradium } from '@ai-sdk/gradium';
+   * import { experimental_generateSpeech as generateSpeech } from 'ai';
+   *
+   * const { audio } = await generateSpeech({
+   *   model: gradium.speech('default'),
+   *   text: 'Hello from Gradium.',
+   *   voice: 'YTpq7expH9539ERJ',
+   * });
+   * ```
+   */
+  speech(modelId?: GradiumSpeechModelId): SpeechModelV4;
+
+  /**
+   * Create a Gradium transcription (speech-to-text) model.
+   *
+   * @example
+   * ```ts
+   * import { gradium } from '@ai-sdk/gradium';
+   * import { experimental_transcribe as transcribe } from 'ai';
+   * import { readFile } from 'node:fs/promises';
+   *
+   * const { text } = await transcribe({
+   *   model: gradium.transcription('default'),
+   *   audio: await readFile('./input.wav'),
+   *   mediaType: 'audio/wav',
+   * });
+   * ```
+   */
+  transcription(modelId?: GradiumTranscriptionModelId): TranscriptionModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+
+  /** Voice management: list, create, get, update, delete. */
+  voices: GradiumVoicesAPI;
+
+  /** Pronunciation dictionary management: list, create, get, update, delete. */
+  pronunciations: GradiumPronunciationsAPI;
+
+  /** Billing-period credit balance. */
+  credits: GradiumCreditsAPI;
+}
+
+export function createGradium(
+  options: GradiumProviderSettings = {},
+): GradiumProvider {
+  const baseURL = withoutTrailingSlash(options.baseURL ?? DEFAULT_BASE_URL)!;
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        'x-api-key': loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'GRADIUM_API_KEY',
+          description: 'Gradium',
+        }),
+        ...options.headers,
+      },
+      `ai-sdk/gradium/${VERSION}`,
+    );
+
+  const speechConfig: GradiumConfig = {
+    provider: 'gradium.speech',
+    url: ({ path }) => `${baseURL}${path}`,
+    headers: getHeaders,
+    fetch: options.fetch,
+  };
+
+  const transcriptionConfig: GradiumConfig = {
+    provider: 'gradium.transcription',
+    url: ({ path }) => `${baseURL}${path}`,
+    headers: getHeaders,
+    fetch: options.fetch,
+  };
+
+  const restConfig: GradiumConfig = {
+    provider: 'gradium',
+    url: ({ path }) => `${baseURL}${path}`,
+    headers: getHeaders,
+    fetch: options.fetch,
+  };
+
+  const createSpeechModel = (
+    modelId: GradiumSpeechModelId = 'default',
+  ): GradiumSpeechModel => new GradiumSpeechModel(modelId, speechConfig);
+
+  const createTranscriptionModel = (
+    modelId: GradiumTranscriptionModelId = 'default',
+  ): GradiumTranscriptionModel =>
+    new GradiumTranscriptionModel(modelId, transcriptionConfig);
+
+  const provider = function (modelId: GradiumTranscriptionModelId = 'default') {
+    return {
+      transcription: createTranscriptionModel(modelId),
+    };
+  };
+
+  provider.specificationVersion = 'v4' as const;
+
+  // Convenience aliases for idiomatic AI SDK community usage.
+  provider.speech = createSpeechModel;
+  provider.transcription = createTranscriptionModel;
+
+  // ProviderV4 standardised method names.
+  provider.speechModel = createSpeechModel;
+  provider.transcriptionModel = createTranscriptionModel;
+
+  // Gradium-specific helper APIs, outside the ProviderV4 contract.
+  provider.voices = createGradiumVoicesAPI(restConfig);
+  provider.pronunciations = createGradiumPronunciationsAPI(restConfig);
+  provider.credits = createGradiumCreditsAPI(restConfig);
+
+  // ProviderV4 requires these; Gradium does not ship LLMs/embeddings/images.
+  provider.languageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'languageModel',
+      message: 'Gradium does not provide language models',
+    });
+  };
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+      message: 'Gradium does not provide embedding models',
+    });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'imageModel',
+      message: 'Gradium does not provide image models',
+    });
+  };
+
+  return provider as GradiumProvider;
+}
+
+/**
+ * Default Gradium provider instance.
+ *
+ * Uses the `GRADIUM_API_KEY` environment variable.
+ * Call `createGradium({...})` for custom configuration.
+ */
+export const gradium: GradiumProvider = createGradium();

--- a/packages/gradium/src/gradium-speech-model-options.ts
+++ b/packages/gradium/src/gradium-speech-model-options.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod/v4';
+import { GRADIUM_TTS_OUTPUT_FORMATS } from './gradium-api-types';
+
+/**
+ * Provider-specific options for `generateSpeech()` calls against Gradium.
+ *
+ * Set these via `providerOptions: { gradium: { ... } }`. AI SDK top-level
+ * `voice`, `outputFormat`, `language`, and `speed` are auto-mapped. These
+ * options are for overrides and Gradium-specific knobs.
+ *
+ * @see https://api.gradium.ai/api/post/speech/tts
+ */
+export const gradiumSpeechModelOptionsSchema = z.object({
+  /**
+   * Override the voice ID. Takes precedence over the AI SDK top-level
+   * `voice` argument. Accepts any Gradium library voice ID
+   * (e.g. `"YTpq7expH9539ERJ"`) or a custom voice clone ID.
+   */
+  voiceId: z.string().nullish(),
+
+  /**
+   * Override the output format. Takes precedence over the AI SDK
+   * top-level `outputFormat` argument. Use this to access telephony
+   * (`ulaw_8000`, `mulaw_8000`, `alaw_8000`) and explicit-rate PCM
+   * (`pcm_8000`, `pcm_16000`, ..., `pcm_48000`) variants.
+   */
+  outputFormat: z.enum(GRADIUM_TTS_OUTPUT_FORMATS).nullish(),
+
+  /**
+   * Raw `json_config` string forwarded verbatim. Use when Gradium exposes
+   * a new option before this provider has a typed convenience field. When
+   * set, top-level `speed`, `language`, and structured Gradium settings are
+   * ignored to avoid conflicts.
+   */
+  jsonConfig: z.string().nullish(),
+
+  /**
+   * Extra pause duration between spoken chunks. Lower values, including
+   * negative values, make speech feel faster; higher values add spacing.
+   * Takes precedence over the AI SDK top-level `speed` mapping.
+   */
+  paddingBonus: z.number().min(-4).max(4).nullish(),
+
+  /**
+   * Voice-similarity coefficient (1.0-4.0). Higher values track the
+   * cloned voice more closely; default is 2.0. Synthesised into
+   * `json_config` when `jsonConfig` is not set explicitly.
+   */
+  cfgCoef: z.number().min(1).max(4).nullish(),
+
+  /** Sampling temperature for generation. */
+  temperature: z.number().min(0).max(2).nullish(),
+
+  /**
+   * Text-rewrite rules applied before synthesis. Stored in `json_config`.
+   * Pass a language code (`"en"`, `"fr"`, `"de"`, `"es"`, `"pt"`) to
+   * enable the recommended rules for that language, or a comma-separated
+   * list of explicit rule names.
+   */
+  rewriteRules: z.string().nullish(),
+
+  /** Pronunciation dictionary ID to apply during synthesis. */
+  pronunciationDictionary: z.string().nullish(),
+
+  /**
+   * If true (default), the response body is the raw audio stream. If
+   * false, the response is JSON containing timing metadata and base64
+   * audio chunks. Audio extraction is handled inside the provider when
+   * this is `false`.
+   */
+  onlyAudio: z.boolean().nullish(),
+});
+
+export type GradiumSpeechModelOptions = z.infer<
+  typeof gradiumSpeechModelOptionsSchema
+>;
+
+/** @deprecated Renamed to `gradiumSpeechModelOptionsSchema`. */
+export const gradiumSpeechProviderOptionsSchema =
+  gradiumSpeechModelOptionsSchema;
+
+/** @deprecated Renamed to `GradiumSpeechModelOptions`. */
+export type GradiumSpeechProviderOptions = GradiumSpeechModelOptions;
+
+/** @deprecated Renamed to `gradiumSpeechModelOptionsSchema`. */
+export const gradiumProviderOptionsSchema = gradiumSpeechModelOptionsSchema;
+
+/** @deprecated Renamed to `GradiumSpeechModelOptions`. */
+export type GradiumProviderOptions = GradiumSpeechModelOptions;

--- a/packages/gradium/src/gradium-speech-model.test.ts
+++ b/packages/gradium/src/gradium-speech-model.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SpeechModelV4 } from '@ai-sdk/provider';
+import { createGradium } from './index';
+
+const FAKE_AUDIO = new Uint8Array([0x52, 0x49, 0x46, 0x46]); // "RIFF"
+
+type Captured = { url?: string; init?: RequestInit };
+
+type GenerateSpeechOptions = Parameters<SpeechModelV4['doGenerate']>[0] & {
+  model: SpeechModelV4;
+};
+
+async function generateSpeech({ model, ...options }: GenerateSpeechOptions) {
+  return model.doGenerate(options);
+}
+
+function fakeFetch(captured: Captured, response?: Response) {
+  return vi.fn(async (url: string, init: RequestInit) => {
+    captured.url = url;
+    captured.init = init;
+    return (
+      response ??
+      new Response(FAKE_AUDIO, {
+        status: 200,
+        headers: { 'content-type': 'audio/wav' },
+      })
+    );
+  }) as unknown as typeof fetch;
+}
+
+function bodyOf(captured: Captured): Record<string, unknown> {
+  return JSON.parse(captured.init!.body as string);
+}
+
+function jsonConfigOf(captured: Captured): Record<string, unknown> {
+  return JSON.parse(bodyOf(captured).json_config as string);
+}
+
+function b64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+describe('GradiumSpeechModel', () => {
+  it('sends a well-formed POST to the unified TTS endpoint', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    const { audio } = await generateSpeech({
+      model: gradium.speech('default'),
+      text: 'Hello from Gradium.',
+      voice: 'YTpq7expH9539ERJ',
+    });
+
+    expect(captured.url).toBe('https://api.gradium.ai/api/post/speech/tts');
+    expect(
+      (captured.init!.headers as Record<string, string>)['x-api-key'],
+    ).toBe('test-key');
+
+    expect(bodyOf(captured)).toMatchObject({
+      text: 'Hello from Gradium.',
+      voice_id: 'YTpq7expH9539ERJ',
+      output_format: 'wav',
+      only_audio: true,
+    });
+
+    expect(audio.slice(0, 4)).toEqual(FAKE_AUDIO);
+  });
+
+  it('also exposes speechModel(modelId) per ProviderV4', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    const model = gradium.speechModel!('default');
+    expect(model.specificationVersion).toBe('v4');
+
+    await generateSpeech({ model, text: 'via speechModel' });
+    expect(bodyOf(captured).text).toBe('via speechModel');
+  });
+
+  it('baseURL overrides default and strips trailing slash', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      baseURL: 'https://proxy.example.com/gradium/',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({ model: gradium.speech(), text: 'proxy' });
+
+    expect(captured.url).toBe(
+      'https://proxy.example.com/gradium/post/speech/tts',
+    );
+  });
+
+  it('merges custom headers with the api-key header', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      headers: { 'x-team': 'voice-platform' },
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({ model: gradium.speech(), text: 'headers' });
+
+    const headers = captured.init!.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('test-key');
+    expect(headers['x-team']).toBe('voice-platform');
+  });
+
+  it('falls back to the default voice when none is supplied', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({ model: gradium.speech(), text: 'no voice' });
+
+    expect(bodyOf(captured).voice_id).toBe('YTpq7expH9539ERJ');
+  });
+
+  it('forwards providerOptions.gradium.voiceId and rewriteRules', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'Bonjour le monde.',
+      providerOptions: {
+        gradium: { voiceId: 'custom-clone-id', rewriteRules: 'fr' },
+      },
+    });
+
+    const body = bodyOf(captured);
+    expect(body.voice_id).toBe('custom-clone-id');
+    expect(JSON.parse(body.json_config as string)).toEqual({
+      rewrite_rules: 'fr',
+    });
+  });
+
+  it('maps top-level speed into json_config.padding_bonus', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'speedy',
+      speed: 1.25,
+    });
+
+    const body = bodyOf(captured);
+    expect(typeof body.json_config).toBe('string');
+    expect(JSON.parse(body.json_config as string)).toEqual({
+      padding_bonus: -0.25,
+    });
+  });
+
+  it('maps cfgCoef into json_config.cfg_coef', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'coefficient',
+      providerOptions: { gradium: { cfgCoef: 2.4 } },
+    });
+
+    expect(jsonConfigOf(captured)).toEqual({ cfg_coef: 2.4 });
+  });
+
+  it('maps typed Gradium TTS options into json_config', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'advanced',
+      providerOptions: {
+        gradium: {
+          paddingBonus: -1.2,
+          temperature: 0.35,
+          pronunciationDictionary: 'dict_123',
+          rewriteRules: 'custom_rule',
+        },
+      },
+    });
+
+    expect(jsonConfigOf(captured)).toEqual({
+      padding_bonus: -1.2,
+      temp: 0.35,
+      pronunciation_dictionary: 'dict_123',
+      rewrite_rules: 'custom_rule',
+    });
+  });
+
+  it('warns when jsonConfig conflicts with mapped options', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    const { warnings } = await generateSpeech({
+      model: gradium.speech(),
+      text: 'conflict',
+      speed: 1.1,
+      providerOptions: {
+        gradium: {
+          jsonConfig: '{"padding_bonus": -1.2}',
+          cfgCoef: 2.0,
+          rewriteRules: 'fr',
+        },
+      },
+    });
+
+    expect(bodyOf(captured).json_config).toBe('{"padding_bonus": -1.2}');
+    expect(warnings.some(w => w.type === 'other')).toBe(true);
+  });
+
+  it('emits an unsupported warning for free-form instructions', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch({}),
+    });
+
+    const { warnings } = await generateSpeech({
+      model: gradium.speech(),
+      text: 'with instructions',
+      instructions: 'Speak in a warm, slow tone.',
+    });
+
+    expect(
+      warnings.some(
+        w => w.type === 'unsupported' && w.feature === 'instructions',
+      ),
+    ).toBe(true);
+  });
+
+  it('warns when an unsupported output format is requested', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch({}),
+    });
+
+    const { warnings } = await generateSpeech({
+      model: gradium.speech(),
+      text: 'mp3 fallback',
+      outputFormat: 'mp3',
+    });
+
+    expect(
+      warnings.some(
+        w => w.type === 'unsupported' && w.feature === 'outputFormat',
+      ),
+    ).toBe(true);
+  });
+
+  it('passes through Gradium-specific output formats via providerOptions', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'telephony',
+      providerOptions: { gradium: { outputFormat: 'ulaw_8000' } },
+    });
+
+    expect(bodyOf(captured).output_format).toBe('ulaw_8000');
+  });
+
+  it('forwards language as json_config.rewrite_rules when none is set', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'Bonjour',
+      language: 'fr',
+    });
+
+    expect(jsonConfigOf(captured).rewrite_rules).toBe('fr');
+  });
+
+  it('does not overwrite explicit rewriteRules when language is also given', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech(),
+      text: 'Bonjour',
+      language: 'fr',
+      providerOptions: { gradium: { rewriteRules: 'custom_rule' } },
+    });
+
+    expect(jsonConfigOf(captured).rewrite_rules).toBe('custom_rule');
+  });
+
+  it('parses providerOptions.gradium.onlyAudio = false JSON messages into audio', async () => {
+    const captured: Captured = {};
+    const first = new Uint8Array([0x52, 0x49]);
+    const second = new Uint8Array([0x46, 0x46]);
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        captured,
+        new Response(
+          [
+            JSON.stringify({
+              type: 'text',
+              text: 'Hello',
+              start_s: 0.1,
+              stop_s: 0.3,
+            }),
+            JSON.stringify({ type: 'audio', audio: b64(first) }),
+            JSON.stringify({ type: 'audio', audio: b64(second) }),
+          ].join('\n'),
+          { status: 200, headers: { 'content-type': 'application/x-ndjson' } },
+        ),
+      ),
+    });
+
+    const { audio } = await generateSpeech({
+      model: gradium.speech(),
+      text: 'json mode',
+      providerOptions: { gradium: { onlyAudio: false } },
+    });
+
+    expect(bodyOf(captured).only_audio).toBe(false);
+    expect(audio).toEqual(FAKE_AUDIO);
+  });
+
+  it('surfaces provider metadata for onlyAudio = false', async () => {
+    const model = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        {},
+        new Response(
+          [
+            JSON.stringify({
+              type: 'text',
+              text: 'Hello',
+              start_s: 0.1,
+              stop_s: 0.3,
+            }),
+            JSON.stringify({ type: 'audio', audio: b64(FAKE_AUDIO) }),
+          ].join('\n'),
+          { status: 200, headers: { 'content-type': 'application/x-ndjson' } },
+        ),
+      ),
+    }).speech('default');
+
+    const result = await model.doGenerate({
+      text: 'json mode',
+      providerOptions: { gradium: { onlyAudio: false } },
+    });
+
+    expect(result.audio).toEqual(FAKE_AUDIO);
+    expect(result.providerMetadata?.gradium).toMatchObject({
+      messageCount: 2,
+      text: [{ text: 'Hello', startSecond: 0.1, endSecond: 0.3 }],
+    });
+  });
+
+  it('surfaces onlyAudio = false JSON error messages', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        {},
+        new Response(
+          JSON.stringify({ type: 'error', message: 'synthesis failed' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    });
+
+    await expect(
+      generateSpeech({
+        model: gradium.speech(),
+        text: 'json error',
+        providerOptions: { gradium: { onlyAudio: false } },
+      }),
+    ).rejects.toThrow(/synthesis failed/);
+  });
+
+  it('sends model_name when modelId is not "default"', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({
+      model: gradium.speech('experimental-v2'),
+      text: 'pick a model',
+    });
+
+    expect(bodyOf(captured).model_name).toBe('experimental-v2');
+  });
+
+  it('omits model_name for the "default" modelId', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await generateSpeech({ model: gradium.speech('default'), text: 'd' });
+
+    expect('model_name' in bodyOf(captured)).toBe(false);
+  });
+
+  it('uses GRADIUM_API_KEY env var when no apiKey is passed', async () => {
+    const previous = process.env.GRADIUM_API_KEY;
+    process.env.GRADIUM_API_KEY = 'env-key';
+    try {
+      const captured: Captured = {};
+      const gradium = createGradium({ fetch: fakeFetch(captured) });
+
+      await generateSpeech({ model: gradium.speech(), text: 'env' });
+
+      expect(
+        (captured.init!.headers as Record<string, string>)['x-api-key'],
+      ).toBe('env-key');
+    } finally {
+      if (previous === undefined) delete process.env.GRADIUM_API_KEY;
+      else process.env.GRADIUM_API_KEY = previous;
+    }
+  });
+});

--- a/packages/gradium/src/gradium-speech-model.test.ts
+++ b/packages/gradium/src/gradium-speech-model.test.ts
@@ -341,6 +341,7 @@ describe('GradiumSpeechModel', () => {
               stop_s: 0.3,
             }),
             JSON.stringify({ type: 'audio', audio: b64(first) }),
+            '',
             JSON.stringify({ type: 'audio', audio: b64(second) }),
           ].join('\n'),
           { status: 200, headers: { 'content-type': 'application/x-ndjson' } },

--- a/packages/gradium/src/gradium-speech-model.ts
+++ b/packages/gradium/src/gradium-speech-model.ts
@@ -124,15 +124,18 @@ function parseJsonMessages(body: string): GradiumTTSMessage[] {
     return parsed as GradiumTTSMessage[];
   }
 
-  return trimmed.split(/\r?\n/).map(line => {
-    try {
-      return JSON.parse(line) as GradiumTTSMessage;
-    } catch {
-      throw new Error(
-        `Gradium returned a malformed TTS JSON message: ${line.slice(0, 200)}`,
-      );
-    }
-  });
+  return trimmed
+    .split(/\r?\n/)
+    .filter(line => line.length > 0)
+    .map(line => {
+      try {
+        return JSON.parse(line) as GradiumTTSMessage;
+      } catch {
+        throw new Error(
+          `Gradium returned a malformed TTS JSON message: ${line.slice(0, 200)}`,
+        );
+      }
+    });
 }
 
 function createGradiumTTSJsonResponseHandler(): ResponseHandler<GradiumTTSJsonResponse> {

--- a/packages/gradium/src/gradium-speech-model.ts
+++ b/packages/gradium/src/gradium-speech-model.ts
@@ -1,0 +1,381 @@
+import {
+  APICallError,
+  type SpeechModelV4,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createBinaryResponseHandler,
+  extractResponseHeaders,
+  parseProviderOptions,
+  postJsonToApi,
+  type ResponseHandler,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import {
+  GRADIUM_TTS_OUTPUT_FORMATS,
+  type GradiumTTSJsonConfig,
+  type GradiumTTSMessage,
+  type GradiumTTSOutputFormat,
+  type GradiumTTSRequestBody,
+} from './gradium-api-types';
+import type { GradiumConfig } from './gradium-config';
+import { gradiumFailedResponseHandler } from './gradium-error';
+import type { GradiumSpeechModelId } from './gradium-speech-options';
+import { gradiumSpeechModelOptionsSchema } from './gradium-speech-model-options';
+
+// Default voice from Gradium's library — used when neither the AI SDK
+// top-level `voice` nor `providerOptions.gradium.voiceId` is supplied.
+const DEFAULT_VOICE_ID = 'YTpq7expH9539ERJ';
+
+type GradiumTTSJsonResponse = {
+  audio: Uint8Array;
+  body: string;
+  messages: GradiumTTSMessage[];
+  text: Array<{ text: string; startSecond?: number; endSecond?: number }>;
+};
+
+/**
+ * Map the AI SDK's free-form `outputFormat` to one of Gradium's
+ * canonical formats. Gradium also accepts telephony / explicit-rate PCM
+ * formats — those are exposed via `providerOptions.gradium.outputFormat`.
+ */
+function mapOutputFormat(requested: string | undefined): {
+  format: GradiumTTSOutputFormat;
+  warnings: SharedV4Warning[];
+} {
+  if (!requested) return { format: 'wav', warnings: [] };
+  const lowered = requested.toLowerCase();
+
+  if ((GRADIUM_TTS_OUTPUT_FORMATS as readonly string[]).includes(lowered)) {
+    return { format: lowered as GradiumTTSOutputFormat, warnings: [] };
+  }
+
+  if (lowered === 'mp3' || lowered === 'flac' || lowered === 'aac') {
+    return {
+      format: 'wav',
+      warnings: [
+        {
+          type: 'unsupported',
+          feature: 'outputFormat',
+          details: `Gradium does not natively support ${lowered}; falling back to wav. Re-encode client-side if needed.`,
+        },
+      ],
+    };
+  }
+
+  return { format: 'wav', warnings: [] };
+}
+
+function mapSpeedToPaddingBonus(speed: number): number {
+  // AI SDK speed uses 1 as neutral and larger values as faster. Gradium's
+  // padding bonus uses 0 as neutral and negative values as less spacing.
+  return Math.max(-4, Math.min(4, 1 - speed));
+}
+
+function hasStructuredJsonConfigOptions(options: {
+  cfgCoef?: number | null;
+  paddingBonus?: number | null;
+  temperature?: number | null;
+  rewriteRules?: string | null;
+  pronunciationDictionary?: string | null;
+}): boolean {
+  return (
+    options.cfgCoef != null ||
+    options.paddingBonus != null ||
+    options.temperature != null ||
+    options.rewriteRules != null ||
+    options.pronunciationDictionary != null
+  );
+}
+
+function fromBase64(base64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(base64, 'base64'));
+  }
+  const binary = atob(base64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+function parseJsonMessages(body: string): GradiumTTSMessage[] {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return [];
+
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Gradium returned JSON, but not a message array.');
+    }
+    return parsed as GradiumTTSMessage[];
+  }
+
+  return trimmed.split(/\r?\n/).map(line => {
+    try {
+      return JSON.parse(line) as GradiumTTSMessage;
+    } catch {
+      throw new Error(
+        `Gradium returned a malformed TTS JSON message: ${line.slice(0, 200)}`,
+      );
+    }
+  });
+}
+
+function createGradiumTTSJsonResponseHandler(): ResponseHandler<GradiumTTSJsonResponse> {
+  return async ({ response, url, requestBodyValues }) => {
+    const responseHeaders = extractResponseHeaders(response);
+    const body = await response.text();
+
+    try {
+      const messages = parseJsonMessages(body);
+      const audioChunks = messages
+        .filter(
+          (message): message is Extract<GradiumTTSMessage, { type: 'audio' }> =>
+            message.type === 'audio' && typeof message.audio === 'string',
+        )
+        .map(message => fromBase64(message.audio));
+      const text = messages
+        .filter(
+          (message): message is Extract<GradiumTTSMessage, { type: 'text' }> =>
+            message.type === 'text' && typeof message.text === 'string',
+        )
+        .map(message => ({
+          text: message.text,
+          startSecond: message.start_s,
+          endSecond: message.stop_s,
+        }));
+
+      const error = messages.find(
+        (message): message is Extract<GradiumTTSMessage, { type: 'error' }> =>
+          message.type === 'error' && typeof message.message === 'string',
+      );
+      if (error) {
+        throw new APICallError({
+          message: error.message,
+          url,
+          requestBodyValues,
+          statusCode: response.status,
+          responseHeaders,
+          responseBody: body,
+          isRetryable: false,
+          data: error,
+        });
+      }
+
+      return {
+        responseHeaders,
+        value: {
+          audio: concatBytes(audioChunks),
+          body,
+          messages,
+          text,
+        },
+      };
+    } catch (error) {
+      if (APICallError.isInstance(error)) throw error;
+      throw new APICallError({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Failed to parse Gradium TTS JSON response',
+        url,
+        requestBodyValues,
+        statusCode: response.status,
+        responseHeaders,
+        responseBody: body,
+        cause: error,
+      });
+    }
+  };
+}
+
+export class GradiumSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: GradiumSpeechModelId;
+
+  private readonly config: GradiumConfig;
+
+  static [WORKFLOW_SERIALIZE](model: GradiumSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: GradiumSpeechModelId;
+    config: GradiumConfig;
+  }) {
+    return new GradiumSpeechModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: GradiumSpeechModelId, config: GradiumConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  /**
+   * Build the Gradium TTS POST body from the unified AI SDK
+   * `doGenerate` arguments plus any `providerOptions.gradium.*` overrides.
+   */
+  private async getArgs({
+    text,
+    voice,
+    outputFormat,
+    speed,
+    language,
+    instructions,
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+
+    const gradiumOpts =
+      (await parseProviderOptions({
+        provider: 'gradium',
+        providerOptions,
+        schema: gradiumSpeechModelOptionsSchema,
+      })) ?? {};
+
+    let format: GradiumTTSOutputFormat;
+    if (gradiumOpts.outputFormat) {
+      // Explicit Gradium-side override beats the AI SDK top-level format.
+      format = gradiumOpts.outputFormat;
+    } else {
+      const mapped = mapOutputFormat(outputFormat);
+      format = mapped.format;
+      warnings.push(...mapped.warnings);
+    }
+
+    if (instructions) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'Gradium does not currently support free-form instructions. Use a different voice_id or providerOptions.gradium.rewriteRules instead.',
+      });
+    }
+
+    // Synthesise json_config from typed options when caller didn't pass
+    // a raw jsonConfig string. If both are supplied, raw wins and we warn.
+    let jsonConfig: string | undefined = gradiumOpts.jsonConfig ?? undefined;
+    if (jsonConfig == null) {
+      const cfg: GradiumTTSJsonConfig = {};
+      if (gradiumOpts.cfgCoef != null) cfg.cfg_coef = gradiumOpts.cfgCoef;
+      if (gradiumOpts.temperature != null) cfg.temp = gradiumOpts.temperature;
+      if (gradiumOpts.paddingBonus != null) {
+        cfg.padding_bonus = gradiumOpts.paddingBonus;
+        if (speed != null) {
+          warnings.push({
+            type: 'other',
+            message:
+              'providerOptions.gradium.paddingBonus was provided; top-level `speed` was ignored to avoid conflicts.',
+          });
+        }
+      } else if (speed != null) {
+        cfg.padding_bonus = mapSpeedToPaddingBonus(speed);
+      }
+      if (gradiumOpts.rewriteRules) {
+        cfg.rewrite_rules = gradiumOpts.rewriteRules;
+      } else if (language) {
+        cfg.rewrite_rules = language;
+      }
+      if (gradiumOpts.pronunciationDictionary) {
+        cfg.pronunciation_dictionary = gradiumOpts.pronunciationDictionary;
+      }
+      if (Object.keys(cfg).length > 0) jsonConfig = JSON.stringify(cfg);
+    } else if (
+      speed != null ||
+      language != null ||
+      hasStructuredJsonConfigOptions(gradiumOpts)
+    ) {
+      warnings.push({
+        type: 'other',
+        message:
+          'providerOptions.gradium.jsonConfig was provided; top-level `speed`, `language`, and structured Gradium options were ignored to avoid conflicts.',
+      });
+    }
+
+    const body: GradiumTTSRequestBody = {
+      text,
+      voice_id: gradiumOpts.voiceId ?? voice ?? DEFAULT_VOICE_ID,
+      output_format: format,
+      only_audio: gradiumOpts.onlyAudio ?? true,
+    };
+
+    if (this.modelId !== 'default') body.model_name = this.modelId;
+    if (jsonConfig) body.json_config = jsonConfig;
+
+    return { body, warnings, format };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const { body, warnings, format } = await this.getArgs(options);
+
+    const url = this.config.url({
+      path: '/post/speech/tts',
+      modelId: this.modelId,
+    });
+
+    const responseHandler: ResponseHandler<
+      Uint8Array | GradiumTTSJsonResponse
+    > =
+      body.only_audio === false
+        ? createGradiumTTSJsonResponseHandler()
+        : createBinaryResponseHandler();
+
+    const { value, responseHeaders, rawValue } = await postJsonToApi({
+      url,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: gradiumFailedResponseHandler,
+      successfulResponseHandler: responseHandler,
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const audio = value instanceof Uint8Array ? value : value.audio;
+
+    return {
+      audio,
+      warnings,
+      request: { body: JSON.stringify(rawValue ?? body) },
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: value instanceof Uint8Array ? audio : value.body,
+      },
+      providerMetadata: {
+        gradium: {
+          outputFormat: format,
+          ...(value instanceof Uint8Array
+            ? {}
+            : {
+                messageCount: value.messages.length,
+                text: value.text,
+              }),
+        },
+      },
+    };
+  }
+}

--- a/packages/gradium/src/gradium-speech-options.ts
+++ b/packages/gradium/src/gradium-speech-options.ts
@@ -1,0 +1,11 @@
+/**
+ * Gradium TTS model IDs.
+ *
+ * `'default'` is the production model; passing any other string forwards
+ * it as `model_name` for early-access or A/B-tested models. The
+ * `(string & {})` suffix preserves the literal hint while allowing
+ * arbitrary strings.
+ *
+ * @see https://gradium.ai/api_docs.html
+ */
+export type GradiumSpeechModelId = 'default' | (string & {});

--- a/packages/gradium/src/gradium-transcription-model-options.ts
+++ b/packages/gradium/src/gradium-transcription-model-options.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod/v4';
+import { GRADIUM_STT_INPUT_FORMATS } from './gradium-api-types';
+
+/**
+ * Provider-specific options for `transcribe()` calls against Gradium.
+ *
+ * Set these via `providerOptions: { gradium: { ... } }`. The AI SDK
+ * top-level `mediaType` is mapped automatically. These options expose
+ * Gradium-specific knobs that are not in the unified API.
+ *
+ * @see https://api.gradium.ai/api/post/speech/asr
+ */
+export const gradiumTranscriptionModelOptionsSchema = z.object({
+  /**
+   * Override the input format detected from `mediaType`. Pass
+   * `"wav"`, `"pcm"`, `"opus"`, or any of the explicit-rate / telephony
+   * variants (`"pcm_16000"`, `"ulaw_8000"`, ...).
+   */
+  inputFormat: z.enum(GRADIUM_STT_INPUT_FORMATS).nullish(),
+
+  /**
+   * BCP-47 / ISO 639-1 language hint passed inside `json_config.language`
+   * (e.g. `"en"`, `"fr"`). Gradium otherwise auto-detects.
+   */
+  language: z.string().nullish(),
+
+  /**
+   * Raw `json_config` string forwarded verbatim as the `?json_config=`
+   * query parameter. Use for advanced knobs like `temp`, `padding_bonus`,
+   * or `delay_in_frames`. When set, top-level `language` is ignored.
+   */
+  jsonConfig: z.string().nullish(),
+});
+
+export type GradiumTranscriptionModelOptions = z.infer<
+  typeof gradiumTranscriptionModelOptionsSchema
+>;
+
+/** @deprecated Renamed to `gradiumTranscriptionModelOptionsSchema`. */
+export const gradiumTranscriptionProviderOptionsSchema =
+  gradiumTranscriptionModelOptionsSchema;
+
+/** @deprecated Renamed to `GradiumTranscriptionModelOptions`. */
+export type GradiumTranscriptionProviderOptions =
+  GradiumTranscriptionModelOptions;

--- a/packages/gradium/src/gradium-transcription-model.test.ts
+++ b/packages/gradium/src/gradium-transcription-model.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TranscriptionModelV4 } from '@ai-sdk/provider';
+import { createGradium } from './index';
+
+const SAMPLE_AUDIO = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00,
+]); // tiny WAV-ish header
+
+type Captured = { url?: string; init?: RequestInit };
+
+type TranscribeOptions = Parameters<TranscriptionModelV4['doGenerate']>[0] & {
+  model: TranscriptionModelV4;
+};
+
+async function transcribe({ model, ...options }: TranscribeOptions) {
+  return model.doGenerate(options);
+}
+
+function ndjson(...messages: unknown[]): string {
+  return messages.map(m => JSON.stringify(m)).join('\n') + '\n';
+}
+
+function fakeFetch(captured: Captured, response?: Response) {
+  return vi.fn(async (url: string, init: RequestInit) => {
+    captured.url = url;
+    captured.init = init;
+    return (
+      response ??
+      new Response(
+        ndjson(
+          { type: 'text', text: 'Hello', start_s: 0.5, stream_id: 0 },
+          { type: 'end_text', stop_s: 0.9, stream_id: 0 },
+          { type: 'text', text: 'world', start_s: 1.0, stream_id: 0 },
+          { type: 'end_text', stop_s: 1.4, stream_id: 0 },
+        ),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/x-ndjson' },
+        },
+      )
+    );
+  }) as unknown as typeof fetch;
+}
+
+describe('GradiumTranscriptionModel', () => {
+  it('POSTs audio bytes to /post/speech/asr with the right Content-Type', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await transcribe({
+      model: gradium.transcription('default'),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+    });
+
+    expect(captured.url).toBe('https://api.gradium.ai/api/post/speech/asr');
+    const headers = captured.init!.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('test-key');
+    expect(headers['content-type']).toBe('audio/wav');
+    expect(captured.init!.method).toBe('POST');
+    expect(captured.init!.body).toBeInstanceOf(Uint8Array);
+  });
+
+  it('also exposes transcriptionModel(modelId) per ProviderV4', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    const model = gradium.transcriptionModel!('default');
+    expect(model.specificationVersion).toBe('v4');
+
+    await transcribe({
+      model,
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+    });
+    expect(captured.url).toContain('/post/speech/asr');
+  });
+
+  it('joins NDJSON text segments and exposes per-segment timing', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch({}),
+    });
+
+    const result = await transcribe({
+      model: gradium.transcription('default'),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.text).toBe('Hello world');
+    expect(result.segments).toEqual([
+      { text: 'Hello', startSecond: 0.5, endSecond: 0.9 },
+      { text: 'world', startSecond: 1.0, endSecond: 1.4 },
+    ]);
+    expect(result.durationInSeconds).toBe(1.4);
+  });
+
+  it('passes ?model= query parameter when modelId is not "default"', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await transcribe({
+      model: gradium.transcription('experimental-v2'),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+    });
+
+    expect(captured.url).toContain('model=experimental-v2');
+  });
+
+  it('passes language hint via json_config when no raw jsonConfig is supplied', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await transcribe({
+      model: gradium.transcription(),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+      providerOptions: { gradium: { language: 'en' } },
+    });
+
+    const u = new URL(captured.url!);
+    expect(u.searchParams.get('json_config')).toBe('{"language":"en"}');
+  });
+
+  it('honours providerOptions.gradium.inputFormat override', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    await transcribe({
+      model: gradium.transcription(),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+      providerOptions: { gradium: { inputFormat: 'pcm_16000' } },
+    });
+
+    const u = new URL(captured.url!);
+    expect(u.searchParams.get('input_format')).toBe('pcm_16000');
+  });
+
+  it('warns when an mp3 mediaType is provided (Gradium does not accept it)', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch({}),
+    });
+
+    const { warnings } = await transcribe({
+      model: gradium.transcription(),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/mpeg',
+    });
+
+    expect(
+      warnings.some(w => w.type === 'unsupported' && w.feature === 'mediaType'),
+    ).toBe(true);
+  });
+
+  it('surfaces a plain-text error from a non-2xx response', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        {},
+        new Response(
+          'error from server Some(1008): API key is revoked or expired',
+          { status: 500, headers: { 'content-type': 'text/plain' } },
+        ),
+      ),
+    });
+
+    await expect(
+      transcribe({
+        model: gradium.transcription(),
+        audio: SAMPLE_AUDIO,
+        mediaType: 'audio/wav',
+      }),
+    ).rejects.toThrow(/API key is revoked/);
+  });
+
+  it('surfaces an in-stream error message as a warning', async () => {
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(
+        {},
+        new Response(
+          ndjson(
+            { type: 'text', text: 'Partial', start_s: 0.0 },
+            { type: 'end_text', stop_s: 0.4 },
+            { type: 'error', message: 'pipeline crashed at frame 12' },
+          ),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/x-ndjson' },
+          },
+        ),
+      ),
+    });
+
+    const { text, warnings } = await transcribe({
+      model: gradium.transcription(),
+      audio: SAMPLE_AUDIO,
+      mediaType: 'audio/wav',
+    });
+
+    expect(text).toBe('Partial');
+    expect(
+      warnings.some(
+        w => w.type === 'other' && /pipeline crashed/.test(w.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts base64 string input and decodes to bytes', async () => {
+    const captured: Captured = {};
+    const gradium = createGradium({
+      apiKey: 'test-key',
+      fetch: fakeFetch(captured),
+    });
+
+    const base64 = Buffer.from(SAMPLE_AUDIO).toString('base64');
+
+    await transcribe({
+      model: gradium.transcription(),
+      audio: base64,
+      mediaType: 'audio/wav',
+    });
+
+    expect(captured.init!.body).toBeInstanceOf(Uint8Array);
+    expect((captured.init!.body as Uint8Array).slice(0, 4)).toEqual(
+      SAMPLE_AUDIO.slice(0, 4),
+    );
+  });
+});

--- a/packages/gradium/src/gradium-transcription-model.ts
+++ b/packages/gradium/src/gradium-transcription-model.ts
@@ -1,0 +1,282 @@
+import type { TranscriptionModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  parseProviderOptions,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import type { GradiumSTTMessage } from './gradium-api-types';
+import { cleanHeaders, type GradiumConfig } from './gradium-config';
+import { gradiumFailedResponseHandler } from './gradium-error';
+import type { GradiumTranscriptionModelId } from './gradium-transcription-options';
+import { gradiumTranscriptionModelOptionsSchema } from './gradium-transcription-model-options';
+
+/**
+ * Map an IANA media type to the value Gradium expects for `Content-Type`.
+ * Gradium accepts `audio/wav`, `audio/pcm`, `audio/ogg`, `audio/opus`.
+ * Anything else is sent through as-is — Gradium will reject unsupported
+ * types with a 500 + plain-text error which our error handler surfaces.
+ */
+function mapMediaType(mediaType: string): {
+  contentType: string;
+  warnings: SharedV4Warning[];
+} {
+  const lowered = mediaType.toLowerCase();
+  if (
+    lowered === 'audio/wav' ||
+    lowered === 'audio/x-wav' ||
+    lowered === 'audio/wave'
+  ) {
+    return { contentType: 'audio/wav', warnings: [] };
+  }
+  if (lowered === 'audio/pcm') {
+    return { contentType: 'audio/pcm', warnings: [] };
+  }
+  if (lowered === 'audio/ogg' || lowered === 'audio/opus') {
+    return { contentType: 'audio/ogg', warnings: [] };
+  }
+  if (lowered === 'audio/mpeg' || lowered === 'audio/mp3') {
+    return {
+      contentType: lowered,
+      warnings: [
+        {
+          type: 'unsupported',
+          feature: 'mediaType',
+          details: `Gradium does not currently accept ${lowered}. Re-encode to wav/pcm/opus client-side; the request will fail otherwise.`,
+        },
+      ],
+    };
+  }
+  return { contentType: mediaType, warnings: [] };
+}
+
+/**
+ * Decode `audio` (base64 string or `Uint8Array`) into a `Uint8Array`.
+ * The AI SDK accepts either form for transcription input.
+ */
+function toUint8Array(audio: Uint8Array | string): Uint8Array {
+  if (audio instanceof Uint8Array) return audio;
+  // Base64 → Uint8Array. Works in both Node 16+ and edge runtimes.
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(audio, 'base64'));
+  }
+  const binary = atob(audio);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Parse Gradium's NDJSON STT response into a flat list of messages.
+ * Empty lines are skipped; malformed lines are surfaced as a thrown
+ * error since Gradium's stream contract guarantees one JSON per line.
+ */
+function parseNdjson(body: string): GradiumSTTMessage[] {
+  const out: GradiumSTTMessage[] = [];
+  for (const line of body.split(/\r?\n/)) {
+    if (line.length === 0) continue;
+    try {
+      out.push(JSON.parse(line) as GradiumSTTMessage);
+    } catch {
+      throw new Error(
+        `Gradium returned a malformed NDJSON line: ${line.slice(0, 200)}`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Fold a list of NDJSON messages into the AI SDK transcription result
+ * shape. `text` segments pair with their following `end_text` to form
+ * a `{ text, startSecond, endSecond }` segment; segments without an
+ * end_text get `endSecond = startSecond` so they're still useful.
+ */
+function foldMessages(messages: GradiumSTTMessage[]): {
+  text: string;
+  segments: Array<{ text: string; startSecond: number; endSecond: number }>;
+  errorMessage?: string;
+} {
+  const segments: Array<{
+    text: string;
+    startSecond: number;
+    endSecond: number;
+  }> = [];
+  let pending: { text: string; startSecond: number } | null = null;
+  let errorMessage: string | undefined;
+
+  for (const msg of messages) {
+    if (msg.type === 'text') {
+      if (pending) {
+        // Previous segment never got an explicit end_text; close it
+        // off using its own start time as the end.
+        segments.push({
+          text: pending.text,
+          startSecond: pending.startSecond,
+          endSecond: pending.startSecond,
+        });
+      }
+      pending = { text: msg.text, startSecond: msg.start_s };
+    } else if (msg.type === 'end_text' && pending) {
+      segments.push({
+        text: pending.text,
+        startSecond: pending.startSecond,
+        endSecond: msg.stop_s,
+      });
+      pending = null;
+    } else if (msg.type === 'error') {
+      errorMessage = msg.message;
+    }
+  }
+  if (pending) {
+    segments.push({
+      text: pending.text,
+      startSecond: pending.startSecond,
+      endSecond: pending.startSecond,
+    });
+  }
+
+  return {
+    text: segments.map(s => s.text).join(' '),
+    segments,
+    errorMessage,
+  };
+}
+
+export class GradiumTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: GradiumTranscriptionModelId;
+
+  private readonly config: GradiumConfig;
+
+  static [WORKFLOW_SERIALIZE](model: GradiumTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: GradiumTranscriptionModelId;
+    config: GradiumConfig;
+  }) {
+    return new GradiumTranscriptionModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: GradiumTranscriptionModelId, config: GradiumConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    const warnings: SharedV4Warning[] = [];
+
+    const gradiumOpts =
+      (await parseProviderOptions({
+        provider: 'gradium',
+        providerOptions: options.providerOptions,
+        schema: gradiumTranscriptionModelOptionsSchema,
+      })) ?? {};
+
+    const { contentType, warnings: ctWarnings } = mapMediaType(
+      options.mediaType,
+    );
+    warnings.push(...ctWarnings);
+
+    // Build query string — model + input_format + json_config.
+    const url = new URL(
+      this.config.url({
+        path: '/post/speech/asr',
+        modelId: this.modelId,
+      }),
+    );
+    if (this.modelId !== 'default') {
+      url.searchParams.set('model', this.modelId);
+    }
+    if (gradiumOpts.inputFormat) {
+      url.searchParams.set('input_format', gradiumOpts.inputFormat);
+    }
+    let jsonConfig = gradiumOpts.jsonConfig ?? undefined;
+    if (jsonConfig == null && gradiumOpts.language) {
+      jsonConfig = JSON.stringify({ language: gradiumOpts.language });
+    } else if (jsonConfig != null && gradiumOpts.language) {
+      warnings.push({
+        type: 'other',
+        message:
+          'providerOptions.gradium.jsonConfig was provided; `language` was ignored to avoid conflicts.',
+      });
+    }
+    if (jsonConfig) url.searchParams.set('json_config', jsonConfig);
+
+    const audioBytes = toUint8Array(options.audio);
+
+    const requestHeaders = combineHeaders(
+      this.config.headers(),
+      { 'content-type': contentType },
+      options.headers,
+    );
+
+    const fetchImpl = this.config.fetch ?? globalThis.fetch;
+    const response = await fetchImpl(url.toString(), {
+      method: 'POST',
+      headers: cleanHeaders(requestHeaders),
+      // Cast around TS 5.x's tighter Uint8Array<ArrayBuffer> constraint.
+      body: audioBytes as unknown as BodyInit,
+      signal: options.abortSignal,
+    });
+
+    if (!response.ok) {
+      const errorResult = await gradiumFailedResponseHandler({
+        response,
+        url: url.toString(),
+        requestBodyValues: { mediaType: options.mediaType },
+      });
+      throw errorResult.value;
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    const body = await response.text();
+    const messages = parseNdjson(body);
+    const { text, segments, errorMessage } = foldMessages(messages);
+
+    if (errorMessage) {
+      // Mid-stream error — surface as a regular `unsupported` warning
+      // alongside whatever partial transcript came through.
+      warnings.push({ type: 'other', message: errorMessage });
+    }
+
+    return {
+      text,
+      segments,
+      language: gradiumOpts.language ?? undefined,
+      durationInSeconds:
+        segments.length > 0
+          ? segments[segments.length - 1]!.endSecond
+          : undefined,
+      warnings,
+      request: { body: undefined },
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body,
+      },
+      providerMetadata: {
+        gradium: {
+          messageCount: messages.length,
+        },
+      },
+    };
+  }
+}

--- a/packages/gradium/src/gradium-transcription-options.ts
+++ b/packages/gradium/src/gradium-transcription-options.ts
@@ -1,0 +1,9 @@
+/**
+ * Gradium STT model IDs.
+ *
+ * `'default'` is the production model; any other string is forwarded as
+ * the `?model=` query parameter for early-access or A/B-tested models.
+ *
+ * @see https://api.gradium.ai/api/post/speech/asr
+ */
+export type GradiumTranscriptionModelId = 'default' | (string & {});

--- a/packages/gradium/src/gradium-voices.ts
+++ b/packages/gradium/src/gradium-voices.ts
@@ -1,0 +1,187 @@
+import { combineHeaders } from '@ai-sdk/provider-utils';
+import { cleanHeaders, type GradiumConfig } from './gradium-config';
+import { gradiumFailedResponseHandler } from './gradium-error';
+
+export interface GradiumVoiceTag {
+  category?: string | null;
+  value: string;
+}
+
+export interface GradiumVoice {
+  uid: string;
+  name: string;
+  description?: string | null;
+  filename?: string | null;
+  start_s?: number | null;
+  is_catalog: boolean;
+  is_pro_clone: boolean;
+  language?: string | null;
+  tags: GradiumVoiceTag[];
+}
+
+export interface GradiumVoiceListOptions {
+  /** Pagination offset. */
+  skip?: number;
+  /** Page size. Default 100. */
+  limit?: number;
+  /** Include Gradium's curated catalog voices alongside org-owned voices. */
+  includeCatalog?: boolean;
+}
+
+export interface GradiumVoiceCreateOptions {
+  /** Display name for the voice. */
+  name: string;
+  /** Audio sample. Pass a `Blob` (browser/edge) or a `Uint8Array` (node). */
+  audioFile: Blob | Uint8Array;
+  /**
+   * Optional filename hint when passing `Uint8Array`. Determines the
+   * `audio_file` part name and helps Gradium infer `input_format`.
+   */
+  audioFileName?: string;
+  /** Audio MIME type (e.g. `'audio/wav'`). Optional when filename is set. */
+  audioContentType?: string;
+  /** Override the input format inferred from filename (`wav`/`pcm`/`opus`). */
+  inputFormat?: string;
+  /** Free-form description shown alongside the voice. */
+  description?: string;
+  /** Voice language hint (ISO 639-1, e.g. `'en'`). */
+  language?: string;
+  /** Trim audio before this many seconds. Default 0. */
+  startSeconds?: number;
+  /** Cap analysis at this many seconds. Default 10. */
+  timeoutSeconds?: number;
+}
+
+export interface GradiumVoiceUpdateOptions {
+  name?: string | null;
+  description?: string | null;
+  language?: string | null;
+}
+
+/** Surface presented as `gradium.voices` on the provider object. */
+export interface GradiumVoicesAPI {
+  list(options?: GradiumVoiceListOptions): Promise<GradiumVoice[]>;
+  get(voiceUid: string): Promise<GradiumVoice>;
+  create(options: GradiumVoiceCreateOptions): Promise<GradiumVoice>;
+  update(
+    voiceUid: string,
+    options: GradiumVoiceUpdateOptions,
+  ): Promise<GradiumVoice>;
+  delete(voiceUid: string): Promise<void>;
+}
+
+async function ensureOk(response: Response, url: string): Promise<void> {
+  if (response.ok) return;
+  const errorResult = await gradiumFailedResponseHandler({
+    response,
+    url,
+    requestBodyValues: undefined,
+  });
+  throw errorResult.value;
+}
+
+export function createGradiumVoicesAPI(
+  config: GradiumConfig,
+): GradiumVoicesAPI {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  const baseHeaders = () => config.headers();
+
+  return {
+    async list({ skip, limit, includeCatalog } = {}): Promise<GradiumVoice[]> {
+      const url = new URL(config.url({ path: '/voices/', modelId: '' }));
+      if (skip != null) url.searchParams.set('skip', String(skip));
+      if (limit != null) url.searchParams.set('limit', String(limit));
+      if (includeCatalog != null) {
+        url.searchParams.set('include_catalog', String(includeCatalog));
+      }
+      const res = await fetchImpl(url.toString(), {
+        method: 'GET',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url.toString());
+      return (await res.json()) as GradiumVoice[];
+    },
+
+    async get(voiceUid: string): Promise<GradiumVoice> {
+      const url = config.url({
+        path: `/voices/${encodeURIComponent(voiceUid)}`,
+        modelId: '',
+      });
+      const res = await fetchImpl(url, {
+        method: 'GET',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumVoice;
+    },
+
+    async create(options: GradiumVoiceCreateOptions): Promise<GradiumVoice> {
+      const url = config.url({ path: '/voices/', modelId: '' });
+
+      const form = new FormData();
+      const filename = options.audioFileName ?? 'voice.wav';
+      const contentType = options.audioContentType ?? 'audio/wav';
+
+      const blob =
+        options.audioFile instanceof Blob
+          ? options.audioFile
+          : new Blob([options.audioFile as unknown as BlobPart], {
+              type: contentType,
+            });
+
+      form.append('audio_file', blob, filename);
+      form.append('name', options.name);
+      if (options.inputFormat) form.append('input_format', options.inputFormat);
+      if (options.description) form.append('description', options.description);
+      if (options.language) form.append('language', options.language);
+      if (options.startSeconds != null) {
+        form.append('start_s', String(options.startSeconds));
+      }
+      if (options.timeoutSeconds != null) {
+        form.append('timeout_s', String(options.timeoutSeconds));
+      }
+
+      // Don't set Content-Type — fetch will add the multipart boundary.
+      const res = await fetchImpl(url, {
+        method: 'POST',
+        headers: baseHeaders(),
+        body: form,
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumVoice;
+    },
+
+    async update(
+      voiceUid: string,
+      options: GradiumVoiceUpdateOptions,
+    ): Promise<GradiumVoice> {
+      const url = config.url({
+        path: `/voices/${encodeURIComponent(voiceUid)}`,
+        modelId: '',
+      });
+      const res = await fetchImpl(url, {
+        method: 'PUT',
+        headers: cleanHeaders(
+          combineHeaders(baseHeaders(), {
+            'content-type': 'application/json',
+          }),
+        ),
+        body: JSON.stringify(options),
+      });
+      await ensureOk(res, url);
+      return (await res.json()) as GradiumVoice;
+    },
+
+    async delete(voiceUid: string): Promise<void> {
+      const url = config.url({
+        path: `/voices/${encodeURIComponent(voiceUid)}`,
+        modelId: '',
+      });
+      const res = await fetchImpl(url, {
+        method: 'DELETE',
+        headers: baseHeaders(),
+      });
+      await ensureOk(res, url);
+    },
+  };
+}

--- a/packages/gradium/src/index.ts
+++ b/packages/gradium/src/index.ts
@@ -1,0 +1,64 @@
+export { createGradium, gradium } from './gradium-provider';
+export type {
+  GradiumProvider,
+  GradiumProviderSettings,
+} from './gradium-provider';
+
+// Speech (TTS)
+export type { GradiumSpeechModelId } from './gradium-speech-options';
+export {
+  gradiumSpeechModelOptionsSchema,
+  gradiumSpeechProviderOptionsSchema,
+  gradiumProviderOptionsSchema,
+} from './gradium-speech-model-options';
+export type {
+  GradiumSpeechModelOptions,
+  GradiumSpeechProviderOptions,
+  GradiumProviderOptions,
+} from './gradium-speech-model-options';
+
+// Transcription (STT)
+export type { GradiumTranscriptionModelId } from './gradium-transcription-options';
+export {
+  gradiumTranscriptionModelOptionsSchema,
+  gradiumTranscriptionProviderOptionsSchema,
+} from './gradium-transcription-model-options';
+export type {
+  GradiumTranscriptionModelOptions,
+  GradiumTranscriptionProviderOptions,
+} from './gradium-transcription-model-options';
+
+// Wire types — useful for typing extension code.
+export type {
+  GradiumTTSOutputFormat,
+  GradiumSTTInputFormat,
+  GradiumTTSJsonConfig,
+  GradiumTTSMessage,
+  GradiumTTSRequestBody,
+  GradiumSTTMessage,
+} from './gradium-api-types';
+export {
+  GRADIUM_TTS_OUTPUT_FORMATS,
+  GRADIUM_STT_INPUT_FORMATS,
+} from './gradium-api-types';
+
+// Helper APIs (voices, pronunciations, credits).
+export type {
+  GradiumVoicesAPI,
+  GradiumVoice,
+  GradiumVoiceTag,
+  GradiumVoiceListOptions,
+  GradiumVoiceCreateOptions,
+  GradiumVoiceUpdateOptions,
+} from './gradium-voices';
+export type {
+  GradiumPronunciationsAPI,
+  GradiumPronunciationDictionary,
+  GradiumPronunciationRule,
+  GradiumPronunciationListOptions,
+  GradiumPronunciationListResponse,
+  GradiumPronunciationCreateOptions,
+  GradiumPronunciationUpdateOptions,
+  GradiumCreditsAPI,
+  GradiumCreditsSummary,
+} from './gradium-pronunciations';

--- a/packages/gradium/src/version.ts
+++ b/packages/gradium/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/gradium/tsconfig.build.json
+++ b/packages/gradium/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/gradium/tsconfig.json
+++ b/packages/gradium/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    }
+  ]
+}

--- a/packages/gradium/tsup.config.ts
+++ b/packages/gradium/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/gradium/turbo.json
+++ b/packages/gradium/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/dist/**"]
+    }
+  }
+}

--- a/packages/gradium/vitest.edge.config.js
+++ b/packages/gradium/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/gradium/vitest.node.config.js
+++ b/packages/gradium/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2300,6 +2300,34 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/gradium:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.0)(typescript@5.6.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/groq:
     dependencies:
       '@ai-sdk/provider':
@@ -3344,7 +3372,7 @@ importers:
         version: 5.8.3
       workflow:
         specifier: 4.2.4
-        version: 4.2.4(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(typescript@5.8.3)
+        version: 4.2.4(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(typescript@5.8.3)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -3739,6 +3767,7 @@ packages:
   '@aws-sdk/core@3.974.11':
     resolution: {integrity: sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==}
     engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/credential-provider-web-identity@3.972.13':
     resolution: {integrity: sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==}
@@ -29711,7 +29740,7 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/next@4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))':
+  '@workflow/next@4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
@@ -29720,7 +29749,7 @@ snapshots:
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -36012,15 +36041,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0):
+  next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001792
       postcss: 8.4.31
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(react@19.2.6)
+      react: 19.0.0-rc-cc1ec60d0d-20240607
+      react-dom: 19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607)
+      styled-jsx: 5.1.6(react@19.0.0-rc-cc1ec60d0d-20240607)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.18
       '@next/swc-darwin-x64': 15.5.18
@@ -38932,12 +38961,6 @@ snapshots:
       client-only: 0.0.1
       react: 19.0.0-rc.1
 
-  styled-jsx@5.1.6(react@19.2.6):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.6
-    optional: true
-
   stylehacks@7.0.11(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
@@ -41190,14 +41213,14 @@ snapshots:
       - supports-color
       - typescript
 
-  workflow@4.2.4(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(typescript@5.8.3):
+  workflow@4.2.4(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(typescript@5.8.3):
     dependencies:
       '@workflow/astro': 4.0.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/cli': 4.2.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/core': 4.2.4(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.1.1
       '@workflow/nest': 0.0.4(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
-      '@workflow/next': 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))
+      '@workflow/next': 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))
       '@workflow/nitro': 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/nuxt': 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.3)
       '@workflow/rollup': 4.0.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)


### PR DESCRIPTION
## Background

Adds Gradium as an AI SDK provider for speech generation and transcription.

## Summary

Added `@ai-sdk/gradium` with:

- `ProviderV4` support.
- Speech via `gradium.speech()` / `gradium.speechModel()`.
- Transcription via `gradium.transcription()` / `gradium.transcriptionModel()`.
- Gradium provider options for voice IDs, formats, `json_config`, rewrite rules, pronunciation dictionaries, and STT controls.
- Helper APIs for voices, pronunciation dictionaries, and credits.
- Node/Edge tests, docs, model listings, and a changeset.

## Manual Verification

Verified the complete voice flow with live smoke-test snippets through the AI SDK:

- Generated speech with `experimental_generateSpeech` + `gradium.speech('default')`.
- Transcribed the generated audio with `experimental_transcribe` + `gradium.transcription('default')`.

Result:

- Successful TTS and STT outputs for all requests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Gradium realtime WebSocket APIs support semantic VAD, adaptive delay, and flush-driven turn-taking. This PR documents those capabilities, while the provider focuses on the AI SDK speech/transcription request-response interfaces.

## Related Issues

Fixes #15596
