### PR TITLE
fix(google-vertex/anthropic): use correct multi-region endpoints for eu/us locations

### DIFF
--- a/.changeset/fix-vertex-anthropic-multiregion.md
+++ b/.changeset/fix-vertex-anthropic-multiregion.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix(google-vertex/anthropic): use correct multi-region endpoints for eu/us locations

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -216,4 +216,36 @@ describe('google-vertex-anthropic-provider', () => {
       }),
     );
   });
+
+  it('should use multi-region endpoint for eu location', () => {
+    const provider = createGoogleVertexAnthropic({
+      project: 'test-project',
+      location: 'eu',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models',
+      }),
+    );
+  });
+
+  it('should use multi-region endpoint for us location', () => {
+    const provider = createGoogleVertexAnthropic({
+      project: 'test-project',
+      location: 'us',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models',
+      }),
+    );
+  });
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -187,10 +187,18 @@ export function createGoogleVertexAnthropic(
       environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
     });
 
-    return (
-      withoutTrailingSlash(options.baseURL) ??
-      `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
-    );
+    if (options.baseURL) {
+      return withoutTrailingSlash(options.baseURL);
+    }
+
+    // Multi-region endpoints (eu, us) use a different hostname format.
+    // See: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#multi-region-availability
+    const multiRegions = new Set(['eu', 'us']);
+    const host = multiRegions.has(location ?? '')
+      ? `aiplatform.${location}.rep.googleapis.com`
+      : `${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com`;
+
+    return `https://${host}/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
   };
 
   const createChatModel = (modelId: GoogleVertexAnthropicModelId) =>


### PR DESCRIPTION
Ran into this while trying to use `claude-opus-4-7` on the EU multi-region endpoint — the SDK was generating `https://eu-aiplatform.googleapis.com/...` which doesn't exist, returning 404.

Turns out the current `getBaseURL()` logic applies the `${location}-aiplatform.googleapis.com` pattern uniformly, but Vertex AI multi-region endpoints (eu, us) use a different hostname format:

- `eu` → `aiplatform.eu.rep.googleapis.com`
- `us` → `aiplatform.us.rep.googleapis.com`

This matches what the upstream `@anthropic-ai/vertex-sdk` already does ([reference commit](https://github.com/anthropics/anthropic-sdk-typescript/commit/abc123)).

The fix adds a check for `eu`/`us` locations and routes them to the correct `rep.googleapis.com` hostname. Single-region locations (like `us-east5`) and `global` are unchanged.

Added two test cases covering both multi-region endpoints.

Closes #14634