### PR TITLE
feat(mcp): expose statusCode, url, responseBody on MCPClientError

### DIFF
--- a/.changeset/mcp-error-http-fields.md
+++ b/.changeset/mcp-error-http-fields.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+feat(mcp): expose `statusCode`, `url`, and `responseBody` on `MCPClientError` for HTTP transport failures
+
+`MCPClientError` now carries structured HTTP context when it originates from the
+streamable HTTP transport. This lets downstream consumers (e.g. agent frameworks
+that need to decide whether to fall back from streamable HTTP to legacy SSE
+transport per the MCP spec) branch on the actual response status without parsing
+the error message string.
+
+Fields are optional — they remain `undefined` for stdio transport errors and for
+non-response failures (network errors, aborts).

--- a/packages/mcp/src/error/mcp-client-error.ts
+++ b/packages/mcp/src/error/mcp-client-error.ts
@@ -12,22 +12,52 @@ export class MCPClientError extends AISDKError {
   readonly data?: unknown;
   readonly code?: number;
 
+  /**
+   * HTTP status code from the failed response, when the error originated
+   * from an HTTP transport failure. Undefined for non-HTTP transports
+   * (stdio) and for HTTP errors that do not have an associated response
+   * status (e.g. network failures, abort).
+   */
+  readonly statusCode?: number;
+
+  /**
+   * URL of the MCP endpoint the failing request was sent to, when the
+   * error originated from an HTTP transport failure.
+   */
+  readonly url?: string;
+
+  /**
+   * Body of the failing HTTP response, decoded as text, when available.
+   * Undefined when the body could not be read or the error did not have
+   * an associated response.
+   */
+  readonly responseBody?: string;
+
   constructor({
     name = 'MCPClientError',
     message,
     cause,
     data,
     code,
+    statusCode,
+    url,
+    responseBody,
   }: {
     name?: string;
     message: string;
     cause?: unknown;
     data?: unknown;
     code?: number;
+    statusCode?: number;
+    url?: string;
+    responseBody?: string;
   }) {
     super({ name, message, cause });
     this.data = data;
     this.code = code;
+    this.statusCode = statusCode;
+    this.url = url;
+    this.responseBody = responseBody;
   }
 
   static isInstance(error: unknown): error is MCPClientError {

--- a/packages/mcp/src/error/mcp-client-error.ts
+++ b/packages/mcp/src/error/mcp-client-error.ts
@@ -10,13 +10,23 @@ const symbol = Symbol.for(marker);
 export class MCPClientError extends AISDKError {
   private readonly [symbol] = true;
   readonly data?: unknown;
+
+  /**
+   * JSON-RPC error code from the server response, per the JSON-RPC 2.0
+   * spec (e.g. `-32601` method-not-found, `-32602` invalid-params, or
+   * MCP-specific codes such as `-32002` resource-not-found). This is the
+   * application-level error code populated from `error.code` in the
+   * server's JSON-RPC error payload. Distinct from `statusCode`, which
+   * is the HTTP transport status.
+   */
   readonly code?: number;
 
   /**
    * HTTP status code from the failed response, when the error originated
-   * from an HTTP transport failure. Undefined for non-HTTP transports
-   * (stdio) and for HTTP errors that do not have an associated response
-   * status (e.g. network failures, abort).
+   * from the streamable HTTP transport. Undefined for stdio transport
+   * errors and for failures that do not have an associated response
+   * status (e.g. network errors, abort). Distinct from `code`, which is
+   * the JSON-RPC application error code.
    */
   readonly statusCode?: number;
 

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -223,6 +223,76 @@ describe('HttpMCPTransport', () => {
     const error = await errorPromise;
     expect(error).toBeInstanceOf(MCPClientError);
     expect((error as Error).message).toContain('POSTing to endpoint');
+    expect((error as MCPClientError).statusCode).toBe(500);
+    expect((error as MCPClientError).url).toBe('http://localhost:4000/mcp');
+    expect((error as MCPClientError).responseBody).toBe(
+      'Internal Server Error',
+    );
+  });
+
+  it('should expose HTTP status, URL, and response body on 404 from POST', async () => {
+    transport = new HttpMCPTransport({ url: 'http://localhost:4000/mcp' });
+
+    server.urls['http://localhost:4000/mcp'].response = {
+      type: 'error',
+      status: 404,
+      body: 'Not Found',
+    };
+
+    await transport.start();
+
+    let captured: unknown;
+    transport.onerror = e => {
+      captured = e;
+    };
+
+    await expect(
+      transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'initialize',
+        id: 1,
+        params: {},
+      }),
+    ).rejects.toThrow('POSTing to endpoint');
+
+    expect(captured).toBeInstanceOf(MCPClientError);
+    const error = captured as MCPClientError;
+    expect(error.statusCode).toBe(404);
+    expect(error.url).toBe('http://localhost:4000/mcp');
+    expect(error.responseBody).toBe('Not Found');
+    expect(error.message).toContain('does not support HTTP transport');
+  });
+
+  it('should expose HTTP status and URL on GET SSE failure', async () => {
+    transport = new HttpMCPTransport({ url: 'http://localhost:4000/mcp' });
+
+    server.urls['http://localhost:4000/mcp'].response = {
+      type: 'error',
+      status: 503,
+      body: 'Service Unavailable',
+    };
+
+    let captured: unknown;
+    transport.onerror = e => {
+      captured = e;
+    };
+
+    await transport.start();
+
+    while (
+      !(server.calls.length > 0 && server.calls[0].requestMethod === 'GET')
+    ) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    // Wait for the GET error handler to run
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(captured).toBeInstanceOf(MCPClientError);
+    const error = captured as MCPClientError;
+    expect(error.statusCode).toBe(503);
+    expect(error.url).toBe('http://localhost:4000/mcp');
+    expect(error.message).toContain('GET SSE failed');
   });
 
   it('should handle invalid JSON-RPC messages from inbound SSE', async () => {

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -217,6 +217,9 @@ export class HttpMCPTransport implements MCPTransport {
 
           const error = new MCPClientError({
             message: errorMessage,
+            statusCode: response.status,
+            url: this.url.href,
+            responseBody: text ?? undefined,
           });
           this.onerror?.(error);
           throw error;
@@ -244,6 +247,8 @@ export class HttpMCPTransport implements MCPTransport {
             const error = new MCPClientError({
               message:
                 'MCP HTTP Transport Error: text/event-stream response without body',
+              statusCode: response.status,
+              url: this.url.href,
             });
             this.onerror?.(error);
             throw error;
@@ -288,6 +293,8 @@ export class HttpMCPTransport implements MCPTransport {
 
         const error = new MCPClientError({
           message: `MCP HTTP Transport Error: Unexpected content type: ${contentType}`,
+          statusCode: response.status,
+          url: this.url.href,
         });
         this.onerror?.(error);
         throw error;
@@ -379,6 +386,8 @@ export class HttpMCPTransport implements MCPTransport {
       if (!response.ok || !response.body) {
         const error = new MCPClientError({
           message: `MCP HTTP Transport Error: GET SSE failed: ${response.status} ${response.statusText}`,
+          statusCode: response.status,
+          url: this.url.href,
         });
         this.onerror?.(error);
         return;


### PR DESCRIPTION
## Summary

Adds `statusCode`, `url`, and `responseBody` to `MCPClientError` so downstream consumers can branch on HTTP context structurally instead of regex-parsing the error message.

All three fields are optional and unset for stdio transport / non-response failures (network errors, aborts), so this is fully backward compatible.

Populated at the four HTTP throw sites in `mcp-http-transport.ts`:
- POST `!response.ok` → `statusCode`, `url`, `responseBody`
- POST `text/event-stream` missing body → `statusCode`, `url`
- POST unexpected content-type → `statusCode`, `url`
- GET SSE failure → `statusCode`, `url`

## Why

The MCP spec requires clients using streamable HTTP transport to fall back to legacy SSE transport when the server returns `404` (or `405`) on the streamable HTTP endpoint. To implement that correctly, the caller needs the response status — but today `MCPClientError` only exposes the message string.

## Validation

- `pnpm --filter @ai-sdk/mcp type-check` ✓
- `pnpm --filter @ai-sdk/mcp test:node` — 208 passed ✓
- `pnpm --filter @ai-sdk/mcp test:edge` — 208 passed ✓
- `pnpm --filter @ai-sdk/mcp build` ✓
- Added integration tests asserting `statusCode` / `url` / `responseBody` for 404 (POST, with the "does not support HTTP transport" message), 500 (POST, with body), and 503 (GET SSE failure).