### PR TITLE
chore: add new Vertex examples for function call ID usage

### DIFF
--- a/examples/ai-functions/src/generate-text/google/vertex-express-mode-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-express-mode-tool-call.ts
@@ -1,0 +1,21 @@
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
+import { generateText, isStepCount } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const googleVertex = createGoogleVertex({
+    apiKey: process.env.GOOGLE_VERTEX_API_KEY,
+  });
+
+  const result = await generateText({
+    model: googleVertex('gemini-3.5-flash'),
+    prompt:
+      'Use the weather tool to get the weather for London, then answer with the result.',
+    tools: { weather: weatherTool },
+    toolChoice: 'required',
+    stopWhen: isStepCount(2),
+  });
+
+  console.log(result.text);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-function-call-id-2.5.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-function-call-id-2.5.ts
@@ -1,0 +1,50 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { generateText, isStepCount, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+/*
+ * Tool-call round-trip on Vertex AI with gemini-2.5-flash. Mirrors the Gemini
+ * API example. Pre-Gemini-3 models do not emit `id` on `functionCall`, so the
+ * SDK falls back to a locally generated tool call id. This example confirms
+ * whether the Vertex endpoint accepts that locally generated id on the
+ * outbound `functionCall`/`functionResponse` parts in turn 2.
+ */
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  const turn1 = await generateText({
+    model: googleVertex('gemini-2.5-flash'),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  console.log('Turn 1 tool call IDs:');
+  for (const call of turn1.toolCalls) {
+    console.log(`  - ${call.toolCallId} (${call.toolName})`);
+  }
+
+  messages.push(...turn1.finalStep.response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  const turn2 = await generateText({
+    model: googleVertex('gemini-2.5-flash'),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log('\nTurn 2 text:', turn2.text);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-function-call-id-3.5.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-function-call-id-3.5.ts
@@ -1,0 +1,49 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { generateText, isStepCount, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+/*
+ * Tool-call round-trip on Vertex AI with gemini-3.5-flash. Mirrors the Gemini
+ * API example. Gemini 3 emits an `id` on each `functionCall` part; the
+ * matching `functionResponse` parts we send back in turn 2 should carry the
+ * same `id` so the model can correlate parallel calls.
+ */
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  const turn1 = await generateText({
+    model: googleVertex('gemini-3.5-flash'),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  console.log('Turn 1 tool call IDs:');
+  for (const call of turn1.toolCalls) {
+    console.log(`  - ${call.toolCallId} (${call.toolName})`);
+  }
+
+  messages.push(...turn1.finalStep.response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  const turn2 = await generateText({
+    model: googleVertex('gemini-3-flash-preview'),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log('\nTurn 2 text:', turn2.text);
+});

--- a/examples/ai-functions/src/stream-text/google/interactions-function-call-id.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-function-call-id.ts
@@ -1,0 +1,86 @@
+import { google } from '@ai-sdk/google';
+import { isStepCount, streamText, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+type GoogleInteractionsModelId = Parameters<typeof google.interactions>[0];
+
+/*
+ * Same scenario as `function-call-id.ts` but routed through the Gemini
+ * Interactions API instead of the native Gemini API. Exercises parallel
+ * function calling and the tool-result round-trip for both pre-Gemini-3 and
+ * Gemini 3 models.
+ */
+async function exerciseRoundTrip({
+  turn1Model,
+  turn2Model,
+}: {
+  turn1Model: GoogleInteractionsModelId;
+  turn2Model: GoogleInteractionsModelId;
+}) {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  const turn1 = streamText({
+    model: google.interactions(turn1Model),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  for await (const part of turn1.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log(
+        `Turn 1 tool call (${turn1Model}) (${part.toolCallId}): ${part.toolName}`,
+        JSON.stringify(part.input),
+      );
+    } else if (part.type === 'tool-result') {
+      console.log(
+        `Turn 1 tool result (${turn1Model}) (${part.toolCallId}):`,
+        JSON.stringify(part.output),
+      );
+    }
+  }
+
+  messages.push(...(await turn1.finalStep).response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  const turn2 = streamText({
+    model: google.interactions(turn2Model),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log(`\nTurn 2 text (${turn2Model}):`);
+  for await (const part of turn2.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+  console.log();
+}
+
+run(async () => {
+  console.log('--- gemini-2.5-flash ---');
+  await exerciseRoundTrip({
+    turn1Model: 'gemini-2.5-flash',
+    turn2Model: 'gemini-2.5-flash',
+  });
+
+  console.log('\n--- gemini-3.5-flash ---');
+  await exerciseRoundTrip({
+    turn1Model: 'gemini-3.5-flash',
+    turn2Model: 'gemini-3-flash-preview',
+  });
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-function-call-id-2.5.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-function-call-id-2.5.ts
@@ -1,0 +1,65 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { isStepCount, streamText, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+/*
+ * Tool-call round-trip on Vertex AI with gemini-2.5-flash via streaming.
+ * Pre-Gemini-3 models do not emit `id` on `functionCall`, so the SDK falls
+ * back to a locally generated tool call id. This example confirms whether
+ * the Vertex endpoint accepts that locally generated id on the outbound
+ * `functionCall`/`functionResponse` parts in turn 2.
+ */
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  const turn1 = streamText({
+    model: googleVertex('gemini-2.5-flash'),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  for await (const part of turn1.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log(
+        `Turn 1 tool call (${part.toolCallId}): ${part.toolName}`,
+        JSON.stringify(part.input),
+      );
+    } else if (part.type === 'tool-result') {
+      console.log(
+        `Turn 1 tool result (${part.toolCallId}):`,
+        JSON.stringify(part.output),
+      );
+    }
+  }
+
+  messages.push(...(await turn1.finalStep).response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  const turn2 = streamText({
+    model: googleVertex('gemini-2.5-flash'),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log('\nTurn 2 text:');
+  for await (const part of turn2.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+  console.log();
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-function-call-id-3.5.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-function-call-id-3.5.ts
@@ -1,0 +1,64 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { isStepCount, streamText, type ModelMessage } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+/*
+ * Tool-call round-trip on Vertex AI with gemini-3.5-flash via streaming.
+ * Gemini 3 emits an `id` on each `functionCall` part; the matching
+ * `functionResponse` parts we send back in turn 2 should carry the same `id`
+ * so the model can correlate parallel calls.
+ */
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'In parallel, get the weather for San Francisco, London, and Tokyo. ' +
+        'Call the weather tool three times, one per city.',
+    },
+  ];
+
+  const turn1 = streamText({
+    model: googleVertex('gemini-3.5-flash'),
+    tools: { weather: weatherTool },
+    messages,
+    stopWhen: isStepCount(1),
+  });
+
+  for await (const part of turn1.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log(
+        `Turn 1 tool call (${part.toolCallId}): ${part.toolName}`,
+        JSON.stringify(part.input),
+      );
+    } else if (part.type === 'tool-result') {
+      console.log(
+        `Turn 1 tool result (${part.toolCallId}):`,
+        JSON.stringify(part.output),
+      );
+    }
+  }
+
+  messages.push(...(await turn1.finalStep).response.messages);
+  messages.push({
+    role: 'user',
+    content:
+      'Now summarize those three results in a single sentence, sorted from ' +
+      'coldest to warmest.',
+  });
+
+  const turn2 = streamText({
+    model: googleVertex('gemini-3-flash-preview'),
+    tools: { weather: weatherTool },
+    messages,
+  });
+
+  console.log('\nTurn 2 text:');
+  for await (const part of turn2.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+  console.log();
+});


### PR DESCRIPTION
## Background

There have been reports of Vertex specific errors for function call and function response `id` being flagged as invalid. Related to #15317.

## Summary

<!-- What did you change? -->

## Manual Verification

Run the examples.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
