### PR TITLE
docs: remove experimental telemetry warning

### DIFF
--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -5,10 +5,6 @@ description: Using OpenTelemetry with AI SDK Core
 
 # Telemetry
 
-<Note type="warning">
-  AI SDK Telemetry is experimental and may change in the future.
-</Note>
-
 The AI SDK uses [OpenTelemetry](https://opentelemetry.io/) to collect telemetry data.
 OpenTelemetry is an open-source observability framework designed to provide
 standardized instrumentation for collecting telemetry data.
@@ -125,7 +121,7 @@ In this example, telemetry integrations receive `runtimeContext` as `{ requestId
 Tool-specific context can also contain values that are useful during execution but should not be sent to telemetry providers, such as API keys or access tokens.
 Use `telemetry.includeToolsContext` to include selected top-level properties from a tool's `context` in telemetry:
 
-```ts highlight="18-24"
+```ts highlight="16-20,23-28"
 const weatherTool = tool({
   inputSchema: z.object({
     location: z.string(),


### PR DESCRIPTION
## Background

Telemetry is going stable in v7 and the docs needed to be updated

## Summary

remove warning + code highlighting change