### PR TITLE
fix(mcp): handle Response-like inputs from other realms in parseErrorResponse

### DIFF
--- a/.changeset/fix-mcp-parse-error-response-cross-realm.md
+++ b/.changeset/fix-mcp-parse-error-response-cross-realm.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+`parseErrorResponse` now uses a `typeof input !== 'string'` check instead of `instanceof Response` to decide whether to read `status` and `await text()`. The previous `instanceof` check silently failed when the caller passed a `Response` produced in a different module realm (common when the SDK is consumed via undici-backed fetches in a Node application), which surfaced as an unhelpful `"[object Response]"` thrown from OAuth error paths and broke the SDK's built-in 401-driven token refresh.

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -9,6 +9,7 @@ import {
   refreshAuthorization,
   registerClient,
   auth,
+  parseErrorResponse,
   type OAuthClientProvider,
   type AuthResult,
 } from './oauth';
@@ -2348,5 +2349,49 @@ describe('OAuth state validation', () => {
 
     expect(result).toBe('REDIRECT');
     expect(saveState).toHaveBeenCalledWith('MY_STATE_VALUE');
+  });
+});
+
+
+describe('parseErrorResponse', () => {
+  it('parses a same-realm Response (instanceof check would pass)', async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: 'invalid_client',
+        error_description: 'unknown',
+      }),
+      { status: 401 },
+    );
+
+    const err = await parseErrorResponse(response);
+    expect(err.message).toBe('unknown');
+  });
+
+  it('parses a Response-shaped object from a different realm where instanceof Response is false', async () => {
+    // Simulate a Response produced in another realm (different module graph)
+    // by handing in an object that quacks like Response but is not the
+    // global Response constructor. `instanceof Response` returns false here;
+    // the duck-typed implementation must still extract status + body.
+    const crossRealmResponse: unknown = {
+      status: 401,
+      async text() {
+        return JSON.stringify({
+          error: 'invalid_grant',
+          error_description: 'expired',
+        });
+      },
+    };
+
+    expect(crossRealmResponse instanceof Response).toBe(false);
+
+    const err = await parseErrorResponse(crossRealmResponse as Response);
+    expect(err.message).toBe('expired');
+  });
+
+  it('parses a raw body string when given one', async () => {
+    const err = await parseErrorResponse(
+      JSON.stringify({ error: 'invalid_request' }),
+    );
+    expect(err).toBeDefined();
   });
 });

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -586,8 +586,14 @@ function applyPublicAuth(clientId: string, params: URLSearchParams): void {
 export async function parseErrorResponse(
   input: Response | string,
 ): Promise<MCPClientOAuthError> {
-  const statusCode = input instanceof Response ? input.status : undefined;
-  const body = input instanceof Response ? await input.text() : input;
+  // Use a string-vs-not check rather than `instanceof Response` because the
+  // Response constructor differs across Node.js realms (e.g. when the caller
+  // hands us a Response produced by undici inside a different module
+  // graph). `instanceof Response` then silently returns false and we end up
+  // serialising the Response as the literal string "[object Response]".
+  const isResponse = typeof input !== 'string';
+  const statusCode = isResponse ? (input as Response).status : undefined;
+  const body = isResponse ? await (input as Response).text() : input;
 
   try {
     const result = OAuthErrorResponseSchema.parse(


### PR DESCRIPTION
## Summary

`parseErrorResponse` in `packages/mcp/src/tool/oauth.ts:586-590` uses `instanceof Response` to decide whether to read `status` / `await text()`. When the SDK is consumed inside a Node application that runs `fetch` from a different module realm (e.g. undici from a separate module graph, or a downstream `fetchFn` that re-wraps the Response), `instanceof Response` silently returns false. The Response is then serialised as the literal string `"[object Response]"`, the OAuth error parsing throws, and - more importantly - the SDK's built-in 401-driven token-refresh path inside `HttpMCPTransport` bubbles `UnauthorizedError` instead of completing the refresh.

Switching to a `typeof input !== "string"` check treats any Response-shaped object as a Response, preserving the existing string overload.

## Why this matters

This is the proximate cause of the `UnauthorizedError: [object Response]` reports that show up when an MCP server returns 401 on an HTTP call: the SDK already implements the right refresh-and-retry flow inside `HttpMCPTransport`, but `parseErrorResponse` collapses the 401 body into an opaque string, the refresh attempt then fails to parse the upstream's error response, and the caller sees a 401 that should have been transparently refreshed.

I hit this in production via a `DatabaseOAuthClientProvider` whose `tokens()` reads from Postgres; a 5 ms artificial token expiry was enough to reproduce the broken refresh path on `main`. With this patch the same flow auto-refreshes and rotates the stored access token.

## Test plan

- [x] Unit tests in `packages/mcp/src/tool/oauth.test.ts` cover three cases:
  1. Same-realm `Response` (where `instanceof Response` would also pass).
  2. Response-shaped object where `instanceof Response` returns `false` - proves the duck-typed path.
  3. Raw string body (preserves the existing overload).
- [x] Verified end-to-end against a real OAuth-protected MCP server: with the patch, a 401 on an MCP request triggers refresh + retry and rotates the stored access token transparently; without it the same flow surfaces `UnauthorizedError: [object Response]`.
- [x] Changeset added (`patch` to `@ai-sdk/mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
