### PR TITLE
feat(ai): introduce onAbort hook to close telemetry spans

### DIFF
--- a/.changeset/thin-trees-pay.md
+++ b/.changeset/thin-trees-pay.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+feat(ai): introduce onAbort hook to close telemetry spans

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -298,6 +298,10 @@ class MyIntegration implements Telemetry {
   async onEnd(event) {
     console.log('Done. Total tokens:', event.usage.totalTokens);
   }
+
+  async onAbort(event) {
+    console.log('Stream aborted after', event.steps.length, 'finished steps');
+  }
 }
 
 export function myIntegration(): Telemetry {
@@ -363,6 +367,12 @@ export function myIntegration(): Telemetry {
       type: '(event: GenerateTextEndEvent) => void | PromiseLike<void>',
       description:
         'Called when the entire generation completes (all steps finished).',
+    },
+    {
+      name: 'onAbort',
+      type: '(event: GenerateTextAbortEvent) => void | PromiseLike<void>',
+      description:
+        'Called when a streaming text generation operation is aborted before it completes.',
     },
   ]}
 />

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -285,6 +285,26 @@ export type GenerateTextEndEvent<
   readonly finalStep: StepResult<TOOLS, RUNTIME_CONTEXT>;
 };
 
+/**
+ * Event passed to the telemetry `onAbort` callback.
+ *
+ * Called when a streaming text generation operation is aborted before it
+ * completes.
+ */
+export type GenerateTextAbortEvent<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = {
+  /** Unique identifier for this generation call, used to correlate events. */
+  readonly callId: string;
+
+  /** Details for all previously finished steps. */
+  readonly steps: StepResult<TOOLS, RUNTIME_CONTEXT>[];
+
+  /** The abort reason from the AbortSignal, when one is available. */
+  readonly reason?: unknown;
+};
+
 /** @deprecated Use `GenerateTextStartEvent` instead. */
 export type OnStartEvent<
   TOOLS extends ToolSet = ToolSet,
@@ -367,6 +387,19 @@ export type GenerateTextOnEndCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
 > = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
+
+/**
+ * Callback that is set using the telemetry `onAbort` option.
+ *
+ * Called when a streaming text generation operation is aborted before it
+ * completes.
+ *
+ * @param event - The abort event, including finished steps and abort reason.
+ */
+export type GenerateTextOnAbortCallback<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = Callback<GenerateTextAbortEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Callback that is set using the `onFinish` option.

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -3,6 +3,8 @@ export type { ContentPart } from './content-part';
 export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tools';
 export { generateText, type GenerateTextInclude } from './generate-text';
 export type {
+  GenerateTextAbortEvent,
+  GenerateTextOnAbortCallback,
   GenerateTextEndEvent,
   GenerateTextOnFinishCallback,
   GenerateTextOnEndCallback,

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test.ts
@@ -319,6 +319,30 @@ describe('createRestrictedTelemetryDispatcher', () => {
     expect(step.toolsContext).toEqual(toolsContext);
   });
 
+  it('includes configured runtimeContext for abort events and all steps without mutating source steps', async () => {
+    const onAbort = vi.fn();
+    const telemetryDispatcher = createRestrictedTelemetryDispatcher({
+      telemetry: { integrations: { onAbort } },
+      includeRuntimeContext,
+    });
+    const step = createStepResult();
+
+    await telemetryDispatcher.onAbort?.({
+      callId: 'call-1',
+      steps: [step],
+      reason: 'manual abort',
+    });
+
+    const telemetryEvent = onAbort.mock.calls[0][0];
+
+    expect(telemetryEvent.reason).toBe('manual abort');
+    expect(telemetryEvent.steps[0].runtimeContext).toEqual({
+      requestId: 'request-123',
+    });
+    expect(telemetryEvent.steps[0].text).toBe('Hello');
+    expect(step.runtimeContext).toEqual(runtimeContext);
+  });
+
   it('filters tool execution start events without mutating the source event', async () => {
     const onToolExecutionStart = vi.fn();
     const telemetryDispatcher = createRestrictedTelemetryDispatcher({

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.ts
@@ -12,6 +12,7 @@ import type {
   TelemetryOptions,
 } from '../telemetry/telemetry-options';
 import type {
+  GenerateTextOnAbortCallback,
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
   GenerateTextOnStepFinishCallback,
@@ -38,6 +39,7 @@ export type RestrictedTelemetryDispatcher<
   | 'onStepStart'
   | 'onStepFinish'
   | 'onEnd'
+  | 'onAbort'
   | 'onToolExecutionStart'
   | 'onToolExecutionEnd'
 > & {
@@ -45,6 +47,7 @@ export type RestrictedTelemetryDispatcher<
   onStepStart: GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
   onStepFinish: GenerateTextOnStepFinishCallback<TOOLS, RUNTIME_CONTEXT>;
   onEnd: GenerateTextOnEndCallback<TOOLS, RUNTIME_CONTEXT>;
+  onAbort?: GenerateTextOnAbortCallback<TOOLS, RUNTIME_CONTEXT>;
   onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
   onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
 };
@@ -249,6 +252,17 @@ export function createRestrictedTelemetryDispatcher<
           ),
         ),
       ),
+    onAbort: event =>
+      telemetryDispatcher.onAbort?.({
+        ...event,
+        steps: event.steps.map(step =>
+          restrictStepResult({
+            step,
+            includeRuntimeContext,
+            includeToolsContext,
+          }),
+        ),
+      }),
     onToolExecutionStart: event =>
       telemetryDispatcher.onToolExecutionStart?.({
         ...event,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -42,7 +42,7 @@ import {
 } from 'vitest';
 import { mockSandboxFileStubs } from '../test/mock-sandbox';
 import { z } from 'zod/v4';
-import { Output, type LanguageModelCallEndEvent } from '..';
+import { Output, type LanguageModelCallEndEvent, type Telemetry } from '..';
 import * as logWarningsModule from '../logger/log-warnings';
 import type { Instructions } from '../prompt';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
@@ -21212,13 +21212,26 @@ describe('streamText', () => {
       let result: StreamTextResult<ToolSet, any, never>;
       let onErrorCalls: Array<{ error: unknown }> = [];
       let onAbortCalls: Array<{ steps: StepResult<ToolSet, any>[] }> = [];
+      let telemetryCalls: Array<{ name: string; event?: unknown }> = [];
 
       beforeEach(() => {
         onErrorCalls = [];
         onAbortCalls = [];
+        telemetryCalls = [];
 
         const abortController = new AbortController();
         let pullCalls = 0;
+        const telemetryIntegration: Telemetry = {
+          onAbort: event => {
+            telemetryCalls.push({ name: 'onAbort', event });
+          },
+          onEnd: event => {
+            telemetryCalls.push({ name: 'onEnd', event });
+          },
+          onError: event => {
+            telemetryCalls.push({ name: 'onError', event });
+          },
+        };
 
         result = streamText({
           abortSignal: abortController.signal,
@@ -21227,6 +21240,12 @@ describe('streamText', () => {
           },
           onAbort: event => {
             onAbortCalls.push(event);
+          },
+          telemetry: {
+            integrations: telemetryIntegration,
+          },
+          _internal: {
+            generateCallId: () => 'test-telemetry-call-id',
           },
           model: new MockLanguageModelV4({
             doStream: async () => ({
@@ -21280,6 +21299,25 @@ describe('streamText', () => {
         expect(onAbortCalls).toMatchInlineSnapshot(`
           [
             {
+              "callId": "test-telemetry-call-id",
+              "reason": [AbortError: This operation was aborted],
+              "steps": [],
+            },
+          ]
+        `);
+      });
+
+      it('should call telemetry onAbort but not onEnd or onError when the abort signal is triggered', async () => {
+        await result.consumeStream();
+        expect(
+          telemetryCalls.map(({ name, event }) => ({
+            name,
+            steps: (event as { steps?: unknown[] }).steps,
+          })),
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "name": "onAbort",
               "steps": [],
             },
           ]
@@ -21511,6 +21549,8 @@ describe('streamText', () => {
         expect(onAbortCalls).toMatchInlineSnapshot(`
           [
             {
+              "callId": "test-telemetry-call-id",
+              "reason": [AbortError: This operation was aborted],
               "steps": [
                 DefaultStepResult {
                   "callId": "test-telemetry-call-id",
@@ -21865,6 +21905,8 @@ describe('streamText', () => {
         expect(onAbortCalls).toMatchInlineSnapshot(`
           [
             {
+              "callId": "test-telemetry-call-id",
+              "reason": [AbortError: This operation was aborted],
               "steps": [],
             },
           ]

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1305,8 +1305,17 @@ class DefaultStreamTextResult<
 
       async pull(controller) {
         // abort handling:
-        function abort() {
-          onAbort?.({ steps: recordedSteps });
+        async function abort() {
+          await notify({
+            event: {
+              callId,
+              steps: recordedSteps,
+              ...(abortSignal?.reason !== undefined
+                ? { reason: abortSignal.reason }
+                : {}),
+            },
+            callbacks: [onAbort, telemetryDispatcher.onAbort],
+          });
           controller.enqueue({
             type: 'abort',
             // The `reason` is usually of type DOMException, but it can also be of any type,
@@ -1328,14 +1337,14 @@ class DefaultStreamTextResult<
           }
 
           if (abortSignal?.aborted) {
-            abort();
+            await abort();
             return;
           }
 
           controller.enqueue(value);
         } catch (error) {
           if (isAbortError(error) && abortSignal?.aborted) {
-            abort();
+            await abort();
           } else {
             controller.error(error);
           }

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -33,6 +33,7 @@ describe('createTelemetryDispatcher', () => {
     expect(telemetry.onRerankStart).toBeDefined();
     expect(telemetry.onRerankEnd).toBeDefined();
     expect(telemetry.onEnd).toBeDefined();
+    expect(telemetry.onAbort).toBeDefined();
     expect(telemetry.onError).toBeDefined();
     expect(telemetry.executeLanguageModelCall).toBeUndefined();
     expect(telemetry.executeTool).toBeUndefined();
@@ -153,6 +154,7 @@ describe('createTelemetryDispatcher', () => {
       onRerankStart: vi.fn(),
       onRerankEnd: vi.fn(),
       onEnd: vi.fn(),
+      onAbort: vi.fn(),
       onError: vi.fn(),
     };
 
@@ -174,6 +176,7 @@ describe('createTelemetryDispatcher', () => {
     await telemetry.onRerankStart!(dummyEvent);
     await telemetry.onRerankEnd!(dummyEvent);
     await telemetry.onEnd!(dummyEvent);
+    await telemetry.onAbort!(dummyEvent);
     await telemetry.onError!(dummyEvent);
 
     expect(integration.onStart).toHaveBeenCalledOnce();
@@ -190,6 +193,7 @@ describe('createTelemetryDispatcher', () => {
     expect(integration.onRerankStart).toHaveBeenCalledOnce();
     expect(integration.onRerankEnd).toHaveBeenCalledOnce();
     expect(integration.onEnd).toHaveBeenCalledOnce();
+    expect(integration.onAbort).toHaveBeenCalledOnce();
     expect(integration.onError).toHaveBeenCalledOnce();
   });
 
@@ -219,6 +223,7 @@ describe('createTelemetryDispatcher', () => {
         onRerankStart: vi.fn(),
         onRerankEnd: vi.fn(),
         onEnd: vi.fn(),
+        onAbort: vi.fn(),
         onError: vi.fn(),
         executeLanguageModelCall: async ({ execute }) => execute(),
         executeTool: async ({ execute }) => execute(),
@@ -240,6 +245,7 @@ describe('createTelemetryDispatcher', () => {
       expect(telemetry.onRerankStart).toBeUndefined();
       expect(telemetry.onRerankEnd).toBeUndefined();
       expect(telemetry.onEnd).toBeUndefined();
+      expect(telemetry.onAbort).toBeUndefined();
       expect(telemetry.onError).toBeUndefined();
       expect(telemetry.executeLanguageModelCall).toBeUndefined();
       expect(telemetry.executeTool).toBeUndefined();

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -138,6 +138,7 @@ export function createTelemetryDispatcher({
     onRerankStart: mergeTelemetryCallback('onRerankStart'),
     onRerankEnd: mergeTelemetryCallback('onRerankEnd'),
     onEnd: mergeTelemetryCallback('onEnd'),
+    onAbort: mergeTelemetryCallback('onAbort'),
     onError: mergeTelemetryCallback('onError'),
 
     executeLanguageModelCall:

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -15,6 +15,7 @@ export type TelemetryDiagnosticEventType =
   | 'onRerankStart'
   | 'onRerankEnd'
   | 'onEnd'
+  | 'onAbort'
   | 'onError';
 
 export type TelemetryDiagnosticChannelMessage<EVENT = unknown> = {

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -12,6 +12,7 @@ import type {
   GenerateObjectStepStartEvent,
 } from '../generate-object/structured-output-events';
 import type {
+  GenerateTextAbortEvent,
   GenerateTextEndEvent,
   GenerateTextStartEvent,
   GenerateTextStepEndEvent,
@@ -69,6 +70,7 @@ export interface TelemetryDispatcher {
   onRerankStart?: Callback<RerankingModelCallStartEvent>;
   onRerankEnd?: Callback<RerankingModelCallEndEvent>;
   onEnd?: Callback<OperationEndEvent>;
+  onAbort?: Callback<GenerateTextAbortEvent<ToolSet>>;
   onError?: Callback<unknown>;
   executeLanguageModelCall?: Telemetry['executeLanguageModelCall'];
   executeTool?: Telemetry['executeTool'];
@@ -192,6 +194,12 @@ export interface Telemetry {
    * Use the event shape or `operationId` to distinguish between operation types.
    */
   onEnd?: Callback<InferTelemetryEvent<OperationEndEvent>>;
+
+  /**
+   * Called when a streaming text generation operation is aborted before it
+   * completes.
+   */
+  onAbort?: Callback<InferTelemetryEvent<GenerateTextAbortEvent<ToolSet>>>;
 
   /**
    * Called when an unrecoverable error occurs during the generation lifecycle.

--- a/packages/otel/src/legacy-open-telemetry.test.ts
+++ b/packages/otel/src/legacy-open-telemetry.test.ts
@@ -989,6 +989,82 @@ describe('LegacyOpenTelemetry', () => {
     });
   });
 
+  describe('onAbort', () => {
+    it('closes streamText spans when AbortController aborts the stream', async () => {
+      const abortController = new AbortController();
+      let pullCalls = 0;
+
+      const result = streamText({
+        abortSignal: abortController.signal,
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({
+                      type: 'stream-start',
+                      warnings: [],
+                    });
+                    break;
+                  case 1:
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: '1',
+                    });
+                    break;
+                  case 2:
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: '1',
+                      delta: 'Hello',
+                    });
+                    break;
+                  case 3:
+                    abortController.abort();
+                    controller.error(
+                      new DOMException(
+                        'The user aborted a request.',
+                        'AbortError',
+                      ),
+                    );
+                    break;
+                }
+              },
+            }),
+          }),
+        }),
+        prompt: 'test-input',
+        telemetry: {
+          integrations: otelIntegration,
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(
+        tracer.spans.map(span => ({
+          name: span.name,
+          ended: span.ended,
+          status: span.status,
+        })),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "ended": true,
+            "name": "ai.streamText",
+            "status": undefined,
+          },
+          {
+            "ended": true,
+            "name": "ai.streamText.doStream",
+            "status": undefined,
+          },
+        ]
+      `);
+    });
+  });
+
   describe('telemetry disabled / recordInputs / recordOutputs', () => {
     it('does not record input attributes when recordInputs is false', () => {
       otelIntegration.onStart!(makeOnStartEvent({ recordInputs: false }));

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -19,6 +19,7 @@ import type {
   GenerateObjectStartEvent,
   GenerateObjectStepEndEvent,
   GenerateObjectStepStartEvent,
+  GenerateTextAbortEvent,
   GenerateTextEndEvent,
   GenerateTextStartEvent,
   GenerateTextStepEndEvent,
@@ -1084,6 +1085,35 @@ export class LegacyOpenTelemetry implements Telemetry {
 
     span.end();
     state.rerankSpan = undefined;
+  }
+
+  onAbort(event: GenerateTextAbortEvent<ToolSet>): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan) return;
+
+    for (const { span: toolSpan } of state.toolSpans.values()) {
+      toolSpan.end();
+    }
+    state.toolSpans.clear();
+
+    if (state.stepSpan) {
+      state.stepSpan.end();
+      state.stepSpan = undefined;
+      state.stepContext = undefined;
+    }
+
+    for (const { span: embedSpan } of state.embedSpans.values()) {
+      embedSpan.end();
+    }
+    state.embedSpans.clear();
+
+    if (state.rerankSpan) {
+      state.rerankSpan.span.end();
+      state.rerankSpan = undefined;
+    }
+
+    state.rootSpan.end();
+    this.cleanupCallState(event.callId);
   }
 
   onError(error: unknown): void {

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -7,7 +7,8 @@ import {
   type SpanOptions,
   type Tracer,
 } from '@opentelemetry/api';
-import type { GenerateTextEndEvent, Telemetry } from 'ai';
+import { streamText, type GenerateTextEndEvent, type Telemetry } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
 import { OpenTelemetry, type EnrichSpan } from './open-telemetry';
 
 type MockSpan = Span & {
@@ -1467,6 +1468,83 @@ describe('OpenTelemetry', () => {
               "code": 2,
               "message": "something went wrong",
             },
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('abort', () => {
+    it('closes streamText spans when AbortController aborts the stream', async () => {
+      const abortController = new AbortController();
+      let pullCalls = 0;
+
+      const result = streamText({
+        abortSignal: abortController.signal,
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({
+                      type: 'stream-start',
+                      warnings: [],
+                    });
+                    break;
+                  case 1:
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: '1',
+                    });
+                    break;
+                  case 2:
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: '1',
+                      delta: 'Hello',
+                    });
+                    break;
+                  case 3:
+                    abortController.abort();
+                    controller.error(
+                      new DOMException(
+                        'The user aborted a request.',
+                        'AbortError',
+                      ),
+                    );
+                    break;
+                }
+              },
+            }),
+          }),
+        }),
+        prompt: 'test-input',
+        telemetry: {
+          integrations: integration,
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(
+        tracer.spans.map(span => ({
+          name: span.name,
+          ended: span.ended,
+        })),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "ended": true,
+            "name": "invoke_agent mock-model-id",
+          },
+          {
+            "ended": true,
+            "name": "step 1",
+          },
+          {
+            "ended": true,
+            "name": "chat mock-model-id",
           },
         ]
       `);

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -18,6 +18,7 @@ import type {
   GenerateObjectStartEvent,
   GenerateObjectStepEndEvent,
   GenerateObjectStepStartEvent,
+  GenerateTextAbortEvent,
   GenerateTextEndEvent,
   GenerateTextStartEvent,
   GenerateTextStepEndEvent,
@@ -1218,6 +1219,41 @@ export class OpenTelemetry implements Telemetry {
 
     span.end();
     state.rerankSpan = undefined;
+  }
+
+  onAbort(event: GenerateTextAbortEvent<ToolSet>): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan) return;
+
+    for (const { span: toolSpan } of state.toolSpans.values()) {
+      toolSpan.end();
+    }
+    state.toolSpans.clear();
+
+    if (state.inferenceSpan) {
+      state.inferenceSpan.end();
+      state.inferenceSpan = undefined;
+      state.inferenceContext = undefined;
+    }
+
+    if (state.stepSpan) {
+      state.stepSpan.end();
+      state.stepSpan = undefined;
+      state.stepContext = undefined;
+    }
+
+    for (const { span: embedSpan } of state.embedSpans.values()) {
+      embedSpan.end();
+    }
+    state.embedSpans.clear();
+
+    if (state.rerankSpan) {
+      state.rerankSpan.span.end();
+      state.rerankSpan = undefined;
+    }
+
+    state.rootSpan.end();
+    this.cleanupCallState(event.callId);
   }
 
   onError(error: unknown): void {


### PR DESCRIPTION
## Background

created as an alternate to https://github.com/vercel/ai/pull/15477

when aborting a request using AbortController, neither onEnd or onError (telemetry specific, not user facing) are called via the telemetry dispatcher., resulting in traces that are marked as indeterminate

## Summary

introduced an `onAbort` hook in the telemetry api that helps close out existing spans in the case of a stream abort

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)