### PR TITLE
feat: `result.stream`

### DIFF
--- a/.changeset/bright-streams-flow.md
+++ b/.changeset/bright-streams-flow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Deprecate `streamText` result `fullStream` in favor of `stream`.

--- a/.changeset/bright-streams-flow.md
+++ b/.changeset/bright-streams-flow.md
@@ -1,5 +1,6 @@
 ---
 'ai': patch
+'@ai-sdk/groq': patch
 ---
 
 Deprecate `streamText` result `fullStream` in favor of `stream`.

--- a/content/cookbook/00-guides/23-gpt-5.mdx
+++ b/content/cookbook/00-guides/23-gpt-5.mdx
@@ -199,7 +199,7 @@ const result = streamText({
 });
 
 // Stream reasoning and text separately
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     console.log(part.textDelta);
   } else if (part.type === 'text-delta') {

--- a/content/cookbook/01-next/85-custom-stream-format.mdx
+++ b/content/cookbook/01-next/85-custom-stream-format.mdx
@@ -8,7 +8,7 @@ tags: ['next', 'streaming', 'tool use']
 
 Create a custom stream to control the streaming format and structure of tool calls instead of using the built-in AI SDK data stream format (`toUIMessageStream()`).
 
-`fullStream` (on `StreamTextResult`) gives you direct access to all model events. You can transform, filter, and structure these events into your own streaming format. This gives you the benefits of the AI SDK's unified provider interface without prescribing how you consume the stream.
+`stream` (on `StreamTextResult`) gives you direct access to all model events. You can transform, filter, and structure these events into your own streaming format. This gives you the benefits of the AI SDK's unified provider interface without prescribing how you consume the stream.
 
 You can:
 
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
     },
   });
 
-  return new Response(result.fullStream.pipeThrough(transformStream), {
+  return new Response(result.stream.pipeThrough(transformStream), {
     headers: { 'Content-Type': 'text/event-stream' },
   });
 }

--- a/content/cookbook/05-node/55-manual-agent-loop.mdx
+++ b/content/cookbook/05-node/55-manual-agent-loop.mdx
@@ -51,7 +51,7 @@ async function main() {
     });
 
     // Stream the response (only necessary for providing updates to the user)
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of result.stream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }

--- a/content/docs/02-foundations/06-provider-options.mdx
+++ b/content/docs/02-foundations/06-provider-options.mdx
@@ -106,7 +106,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     console.log(`Reasoning: ${part.textDelta}`);
   } else if (part.type === 'text-delta') {

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -279,7 +279,7 @@ const result = streamText({
 
 When using `streamText`, you can provide an `onChunk` callback that is triggered for each chunk of the stream.
 
-It receives all stream part types from `fullStream`, including:
+It receives all stream part types from `stream`, including:
 
 - `start`
 - `start-step`
@@ -422,11 +422,11 @@ The available lifecycle callbacks are:
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
 - **`onStepFinish`**: Called after each step finishes. Receives the finish reason, usage, and other step details.
 
-### `fullStream` property
+### `stream` property
 
-You can read a stream with all events using the `fullStream` property.
+You can read a stream with all events using the `stream` property.
 This can be useful if you want to implement your own UI or handle the stream in a different way.
-Here is an example of how to use the `fullStream` property:
+Here is an example of how to use the `stream` property:
 
 ```tsx
 import { streamText } from 'ai';
@@ -446,7 +446,7 @@ const result = streamText({
   prompt: 'What are some San Francisco tourist attractions?',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'start': {
       // handle start of stream
@@ -735,7 +735,7 @@ for (const source of result.sources) {
 }
 ```
 
-When you use `streamText`, you can access the sources using the `fullStream` property:
+When you use `streamText`, you can access the sources using the `stream` property:
 
 ```tsx
 const result = streamText({
@@ -746,7 +746,7 @@ const result = streamText({
   prompt: 'List the top 5 San Francisco news from the past week.',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'source' && part.sourceType === 'url') {
     console.log('ID:', part.id);
     console.log('Title:', part.title);

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -1178,7 +1178,7 @@ toolErrors.forEach(toolError => {
 
 ### `streamText`
 
-`streamText` sends errors as part of the full stream. Tool execution errors appear as `tool-error` parts, while other errors appear as `error` parts.
+`streamText` sends errors as part of the `stream` result. Tool execution errors appear as `tool-error` parts, while other errors appear as `error` parts.
 
 When using `toUIMessageStreamResponse`, you can pass an `onError` function to extract the error message from the error part and forward it as part of the stream response:
 

--- a/content/docs/03-ai-sdk-core/26-reasoning.mdx
+++ b/content/docs/03-ai-sdk-core/26-reasoning.mdx
@@ -44,7 +44,7 @@ const result = streamText({
   prompt: 'Explain the Riemann hypothesis in simple terms.',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     process.stdout.write(part.textDelta);
   } else if (part.type === 'text-delta') {

--- a/content/docs/03-ai-sdk-core/50-error-handling.mdx
+++ b/content/docs/03-ai-sdk-core/50-error-handling.mdx
@@ -51,7 +51,7 @@ try {
 
 ## Handling streaming errors (streaming with `error` support)
 
-Full streams support error parts.
+The `stream` result supports error parts.
 You can handle those parts similar to other parts.
 It is recommended to also add a try-catch block for errors that
 happen outside of the streaming.
@@ -61,12 +61,12 @@ import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
 try {
-  const { fullStream } = streamText({
+  const { stream } = streamText({
     model: __MODEL__,
     prompt: 'Write a vegetarian lasagna recipe for 4 people.',
   });
 
-  for await (const part of fullStream) {
+  for await (const part of stream) {
     switch (part.type) {
       // ... handle other part types
 
@@ -131,12 +131,12 @@ You can also handle abort events directly in the stream:
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
-const { fullStream } = streamText({
+const { stream } = streamText({
   model: __MODEL__,
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 
-for await (const chunk of fullStream) {
+for await (const chunk of stream) {
   switch (chunk.type) {
     case 'abort': {
       // Handle abort directly in stream

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -123,7 +123,7 @@ This is particularly useful for:
 You can also handle abort events directly in the stream using the `abort` stream part:
 
 ```tsx highlight="8-12"
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'text-delta':
       // Handle text delta content

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -907,7 +907,7 @@ To see `streamText` in action, check out [these examples](#examples).
               name: 'chunk',
               type: 'TextStreamPart<TOOLS>',
               description:
-                'The stream part. This is the same union as `fullStream` and includes `start`, `start-step`, `text-start`, `text-delta`, `text-end`, `reasoning-start`, `reasoning-delta`, `reasoning-end`, `custom`, `source`, `file`, `reasoning-file`, `tool-call`, `tool-input-start`, `tool-input-delta`, `tool-input-end`, `tool-result`, `tool-error`, `tool-output-denied`, `tool-approval-request`, `tool-approval-response`, `finish-step`, `finish`, `abort`, `error`, and `raw`.',
+                'The stream part. This is the same union as `stream` and includes `start`, `start-step`, `text-start`, `text-delta`, `text-end`, `reasoning-start`, `reasoning-delta`, `reasoning-end`, `custom`, `source`, `file`, `reasoning-file`, `tool-call`, `tool-input-start`, `tool-input-delta`, `tool-input-end`, `tool-result`, `tool-error`, `tool-output-denied`, `tool-approval-request`, `tool-approval-response`, `finish-step`, `finish`, `abort`, `error`, and `raw`.',
               properties: [
                 {
                   type: 'TextStreamPart',
@@ -3186,7 +3186,7 @@ To see `streamText` in action, check out [these examples](#examples).
         'The final step. This is a shortcut for `steps.at(-1)`. Automatically consumes the stream.',
     },
     {
-      name: 'fullStream',
+      name: 'stream',
       type: 'AsyncIterable<TextStreamPart<TOOLS>> & ReadableStream<TextStreamPart<TOOLS>>',
       description:
         'A stream with all events, including text deltas, tool calls, tool results, and errors. You can use it as either an AsyncIterable or a ReadableStream. Only errors that stop the stream, such as network errors, are thrown.',
@@ -3862,6 +3862,12 @@ To see `streamText` in action, check out [these examples](#examples).
           ],
         },
       ],
+    },
+    {
+      name: 'fullStream',
+      type: 'AsyncIterable<TextStreamPart<TOOLS>> & ReadableStream<TextStreamPart<TOOLS>>',
+      description:
+        'Deprecated. Use `stream` instead. A stream with all events, including text deltas, tool calls, tool results, and errors.',
     },
     {
       name: 'partialOutputStream',

--- a/content/docs/07-reference/01-ai-sdk-core/67-simulate-streaming-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/67-simulate-streaming-middleware.mdx
@@ -56,7 +56,7 @@ const result = streamText({
 });
 
 // Now you can use the streaming interface
-for await (const chunk of result.fullStream) {
+for await (const chunk of result.stream) {
   // Process streaming chunks
 }
 ```

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -243,6 +243,36 @@ The same rename applies to `streamText`, `Agent.generate()`,
 accepted as a deprecated alias. When both `onEnd` and `onFinish` are provided,
 `onEnd` takes precedence.
 
+#### `StreamTextResult.fullStream` Renamed to `stream`
+
+The full event stream returned by `streamText` has been renamed from
+`fullStream` to `stream`.
+
+```tsx filename="AI SDK 6"
+const result = streamText({
+  model: yourModel,
+  prompt: 'Hello!',
+});
+
+for await (const part of result.fullStream) {
+  console.log(part);
+}
+```
+
+```tsx filename="AI SDK 7"
+const result = streamText({
+  model: yourModel,
+  prompt: 'Hello!',
+});
+
+for await (const part of result.stream) {
+  console.log(part);
+}
+```
+
+The `fullStream` property is still available as a deprecated alias for
+`stream`.
+
 ### Prompt Messages: System Messages in `prompt` or `messages` Are Rejected by Default
 
 AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `instructions` option.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -325,7 +325,7 @@ console.log(`Prompt tokens: ${generation.promptTokens}`);
 console.log(`Completion tokens: ${generation.completionTokens}`);
 ```
 
-With `streamText`, you can capture the generation ID from the first chunk via `fullStream`:
+With `streamText`, you can capture the generation ID from the first chunk via `stream`:
 
 ```ts
 import { gateway, streamText } from 'ai';
@@ -337,7 +337,7 @@ const result = streamText({
 
 let generationId: string | undefined;
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (!generationId && part.providerMetadata?.gateway?.generationId) {
     generationId = part.providerMetadata.gateway.generationId as string;
     console.log(`Generation ID (early): ${generationId}`);
@@ -548,7 +548,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'text-delta':
       process.stdout.write(part.text);
@@ -653,7 +653,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'text-delta':
       process.stdout.write(part.text);

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -408,7 +408,7 @@ You can combine multiple server-side tools for comprehensive research:
 import { xai } from '@ai-sdk/xai';
 import { streamText } from 'ai';
 
-const { fullStream } = streamText({
+const { stream } = streamText({
   model: xai.responses('grok-4.20-non-reasoning'),
   prompt: 'Research AI safety developments and calculate risk metrics',
   tools: {
@@ -425,7 +425,7 @@ const { fullStream } = streamText({
   },
 });
 
-for await (const part of fullStream) {
+for await (const part of stream) {
   if (part.type === 'text-delta') {
     process.stdout.write(part.text);
   } else if (part.type === 'source' && part.sourceType === 'url') {

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -317,7 +317,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     console.log(`Reasoning: ${part.textDelta}`);
   } else if (part.type === 'text-delta') {
@@ -609,7 +609,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type == 'tool-result' && !part.dynamic) {
     const base64Image = part.output.result;
   }
@@ -1161,7 +1161,7 @@ const result = streamText({
   prompt: 'Write a SQL query to get all users older than 25.',
 });
 
-for await (const chunk of result.fullStream) {
+for await (const chunk of result.stream) {
   if (chunk.type === 'tool-call') {
     console.log(`Tool: ${chunk.toolName}`);
     console.log(`Input: ${chunk.input}`);
@@ -1576,7 +1576,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'text-start': {
       const isCompaction = part.providerMetadata?.openai?.type === 'compaction';

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -506,7 +506,7 @@ When compaction occurs, the model generates a summary of the earlier context. Th
 When using `streamText`, you can detect compaction summaries by checking the `providerMetadata` on `text-start` events:
 
 ```ts
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'text-start': {
       const isCompaction =

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -376,7 +376,7 @@ const result = streamText({
   toolChoice: 'required',
 });
 
-for await (const delta of result.fullStream) {
+for await (const delta of result.stream) {
   if (delta.type === 'text-delta') {
     process.stdout.write(delta.text);
   }

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -517,7 +517,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   switch (part.type) {
     case 'tool-input-start':
       console.log(`Tool call started: ${part.toolName}`);
@@ -581,7 +581,7 @@ const result = streamText({
   prompt: 'Explain quantum computing in simple terms.',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     process.stdout.write(`THOUGHT: ${part.textDelta}\n`);
   } else if (part.type === 'text-delta') {

--- a/content/providers/01-ai-sdk-providers/170-huggingface.mdx
+++ b/content/providers/01-ai-sdk-providers/170-huggingface.mdx
@@ -151,7 +151,7 @@ const result = streamText({
   },
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     console.log(`Reasoning: ${part.textDelta}`);
   } else if (part.type === 'text-delta') {

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -139,7 +139,7 @@ const result = streamText({
   prompt: 'How many "r"s are in the word "strawberry"?',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     // This is the reasoning text
     console.log('Reasoning:', part.text);

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -117,7 +117,7 @@ const result = streamText({
   prompt: 'How many "r"s are in the word "strawberry"?',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'reasoning') {
     console.log('Reasoning:', part.text);
   } else if (part.type === 'text-delta') {

--- a/contributing/codemods.md
+++ b/contributing/codemods.md
@@ -36,7 +36,7 @@ const result = await streamText({
   prompt: 'Generate an image',
 });
 
-for await (const delta of result.fullStream) {
+for await (const delta of result.stream) {
   switch (delta.type) {
     case 'file': {
       console.log('Media type:', delta.file.mediaType);
@@ -57,7 +57,7 @@ const result = await streamText({
   prompt: 'Generate an image',
 });
 
-for await (const delta of result.fullStream) {
+for await (const delta of result.stream) {
   switch (delta.type) {
     case 'file': {
       console.log('Media type:', delta.mediaType);

--- a/examples/ai-functions/src/e2e/feature-test-suite.ts
+++ b/examples/ai-functions/src/e2e/feature-test-suite.ts
@@ -696,7 +696,7 @@ export function createFeatureTestSuite({
                 });
 
                 const parts = [];
-                for await (const part of result.fullStream) {
+                for await (const part of result.stream) {
                   parts.push(part);
                 }
 

--- a/examples/ai-functions/src/e2e/raw-chunks.test.ts
+++ b/examples/ai-functions/src/e2e/raw-chunks.test.ts
@@ -26,7 +26,7 @@ describe('Raw Chunks E2E Tests', () => {
         });
 
         const chunks = [];
-        for await (const chunk of result.fullStream) {
+        for await (const chunk of result.stream) {
           chunks.push(chunk);
         }
 
@@ -43,7 +43,7 @@ describe('Raw Chunks E2E Tests', () => {
         });
 
         const chunks = [];
-        for await (const chunk of result.fullStream) {
+        for await (const chunk of result.stream) {
           chunks.push(chunk);
         }
 
@@ -60,7 +60,7 @@ describe('Raw Chunks E2E Tests', () => {
         });
 
         const chunks = [];
-        for await (const chunk of result.fullStream) {
+        for await (const chunk of result.stream) {
           chunks.push(chunk);
         }
 

--- a/examples/ai-functions/src/generate-text/anthropic/tool-schema-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/tool-schema-telemetry.ts
@@ -41,7 +41,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'tool-input-start':
         console.log(`\n[tool-input-start] ${part.toolName} (${part.id})`);

--- a/examples/ai-functions/src/lib/print-full-stream.ts
+++ b/examples/ai-functions/src/lib/print-full-stream.ts
@@ -5,7 +5,7 @@ export async function printFullStream({
 }: {
   result: StreamTextResult<any, any, any>;
 }) {
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'tool-call': {
         console.log(

--- a/examples/ai-functions/src/lib/save-raw-chunks.ts
+++ b/examples/ai-functions/src/lib/save-raw-chunks.ts
@@ -9,7 +9,7 @@ export async function saveRawChunks({
   filename: string;
 }) {
   const rawChunks: unknown[] = [];
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'raw') {
       rawChunks.push(chunk.rawValue);
     }

--- a/examples/ai-functions/src/stream-text/alibaba/disable-parallel-tools.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/disable-parallel-tools.ts
@@ -38,7 +38,7 @@ run(async () => {
 
   let toolCallOrder: string[] = [];
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'tool-call':
         toolCallOrder.push(part.toolName);

--- a/examples/ai-functions/src/stream-text/alibaba/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/reasoning.ts
@@ -11,7 +11,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/alibaba/thinking-budget.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/thinking-budget.ts
@@ -14,7 +14,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-start':
         console.log('--- Reasoning Process ---');

--- a/examples/ai-functions/src/stream-text/alibaba/thinking.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/thinking.ts
@@ -15,7 +15,7 @@ run(async () => {
 
   let inReasoning = false;
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-start': {
         console.log('\n--- Reasoning Process ---');

--- a/examples/ai-functions/src/stream-text/alibaba/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/tool-call.ts
@@ -30,7 +30,7 @@ run(async () => {
   });
 
   // Show tool calls and text as they happen
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'tool-call':
         console.log(`\nTool call: ${part.toolName}`);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/activetools.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/activetools.ts
@@ -29,7 +29,7 @@ run(async () => {
     prompt: 'What is the weather in Toronto, Calgary, and Vancouver?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'start-step':
         console.log('Step started');

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-bash.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-bash.ts
@@ -35,7 +35,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-bash.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-bash.ts
@@ -26,7 +26,7 @@ README.md     build         data          node_modules  package.json  src       
     stopWhen: isStepCount(2),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     } else if (part.type === 'tool-call') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-computer.ts
@@ -46,7 +46,7 @@ run(async () => {
     stopWhen: isStepCount(3),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     } else if (part.type === 'tool-call') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-editor.ts
@@ -34,7 +34,7 @@ This is a sample README file for testing the text editor tool.
     stopWhen: isStepCount(5),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     } else if (part.type === 'tool-call') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-fine-grained-tool-streaming.ts
@@ -61,7 +61,7 @@ run(async () => {
 
   ts('stream started');
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-start':
         ts('[text-start]');

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-fullstream.ts
@@ -9,7 +9,7 @@ run(async () => {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-multiple-tools.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-multiple-tools.ts
@@ -35,7 +35,7 @@ run(async () => {
       'What is the weather in Tokyo? Also, what is the stock price of GOOGL?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-output-array-tools.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-output-array-tools.ts
@@ -32,7 +32,7 @@ run(async () => {
     prompt: 'What is the weather in New York, Los Angeles, and Chicago?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-reasoning-partial-config.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-reasoning-partial-config.ts
@@ -23,7 +23,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-reasoning.ts
@@ -20,7 +20,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-stop-sequence.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-stop-sequence.ts
@@ -10,7 +10,7 @@ run(async () => {
     stopSequences: ['5'],
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-tool-call.ts
@@ -22,7 +22,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-tool-search-bm25.ts
@@ -69,7 +69,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-tool-search-regex.ts
@@ -69,7 +69,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-websearch.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-websearch.ts
@@ -34,7 +34,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/cache-point-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/cache-point-tool-call.ts
@@ -144,7 +144,7 @@ run(async () => {
 
   let fullResponse = '';
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/fullstream.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/fullstream.ts
@@ -27,7 +27,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta': {
         if (!enteredReasoning) {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/reasoning-chatbot.ts
@@ -55,7 +55,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'reasoning-delta') {
         process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
       } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/reasoning-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/reasoning-fullstream.ts
@@ -25,7 +25,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta': {
         if (!enteredReasoning) {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/reasoning.ts
@@ -15,7 +15,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/tool-call-empty-description.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/tool-call-empty-description.ts
@@ -24,7 +24,7 @@ run(async () => {
     prompt: 'Use the tool to get weather for San Francisco',
   });
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         process.stdout.write(delta.text);

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/tool-call.ts
@@ -28,7 +28,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/anthropic/advisor-20260301.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/advisor-20260301.ts
@@ -21,7 +21,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/code-execution-20250825-downloads.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/code-execution-20250825-downloads.ts
@@ -15,7 +15,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/code-execution-20250825.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/code-execution-20250825.ts
@@ -13,7 +13,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/code-execution-20260120.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/code-execution-20260120.ts
@@ -13,7 +13,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/code-execution-file-upload.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/code-execution-file-upload.ts
@@ -46,7 +46,7 @@ run(async () => {
     filename: 'anthropic-code-execution-file-upload.1',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/compaction-metadata.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/compaction-metadata.ts
@@ -40,7 +40,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-start': {
         const isCompaction =

--- a/examples/ai-functions/src/stream-text/anthropic/compaction.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/compaction.ts
@@ -266,7 +266,7 @@ run(async () => {
 
   console.log('=== Streaming Response ===\n');
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-start': {
         const isCompaction =

--- a/examples/ai-functions/src/stream-text/anthropic/computer-use-zoom.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/computer-use-zoom.ts
@@ -65,7 +65,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/context-management.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/context-management.ts
@@ -268,7 +268,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }

--- a/examples/ai-functions/src/stream-text/anthropic/disable-parallel-tools.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/disable-parallel-tools.ts
@@ -27,7 +27,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/fine-grained-tool-streaming.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/fine-grained-tool-streaming.ts
@@ -60,7 +60,7 @@ async function main() {
 
   ts('stream started');
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-start':
         ts('[reasoning-start]');

--- a/examples/ai-functions/src/stream-text/anthropic/fullstream.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/memory-20250818.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/memory-20250818.ts
@@ -16,7 +16,7 @@ Acknowledge by saying "stored".
     stopWhen: isStepCount(10),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/pdf-sources.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/pdf-sources.ts
@@ -32,7 +32,7 @@ run(async () => {
     ],
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/reasoning-chatbot.ts
@@ -55,7 +55,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'reasoning-delta') {
         process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
       } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/anthropic/reasoning-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/reasoning-fullstream.ts
@@ -40,7 +40,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta': {
         if (!enteredReasoning) {

--- a/examples/ai-functions/src/stream-text/anthropic/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/reasoning.ts
@@ -14,7 +14,7 @@ run(async () => {
     maxRetries: 0,
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
 

--- a/examples/ai-functions/src/stream-text/anthropic/text-citations.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/text-citations.ts
@@ -31,7 +31,7 @@ run(async () => {
 
   let citationCount = 0;
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/anthropic/tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/tool-search-bm25.ts
@@ -68,7 +68,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/tool-search-regex.ts
@@ -68,7 +68,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/web-fetch-20260209-pdf.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/web-fetch-20260209-pdf.ts
@@ -13,7 +13,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/web-fetch-20260209-wikipedia.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/web-fetch-20260209-wikipedia.ts
@@ -12,7 +12,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/web-fetch-tool-pdf.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/web-fetch-tool-pdf.ts
@@ -13,7 +13,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/web-fetch-tool-wikipedia.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/web-fetch-tool-wikipedia.ts
@@ -12,7 +12,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/web-search-20260209.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/web-search-20260209.ts
@@ -19,7 +19,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/web-search-tool.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/web-search-tool.ts
@@ -19,7 +19,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/anthropic/xhigh-effort.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/xhigh-effort.ts
@@ -18,7 +18,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/azure/fullstream-logprobs.ts
+++ b/examples/ai-functions/src/stream-text/azure/fullstream-logprobs.ts
@@ -14,7 +14,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/azure/fullstream.ts
+++ b/examples/ai-functions/src/stream-text/azure/fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/azure/image-generation-tool.ts
+++ b/examples/ai-functions/src/stream-text/azure/image-generation-tool.ts
@@ -23,7 +23,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type == 'tool-result' && !part.dynamic) {
       await presentImages([
         {

--- a/examples/ai-functions/src/stream-text/azure/model-router.ts
+++ b/examples/ai-functions/src/stream-text/azure/model-router.ts
@@ -11,7 +11,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     console.log(`[CHUNK ${chunk.type}]`, chunk);
   }
 

--- a/examples/ai-functions/src/stream-text/azure/provider-options-name-openai-compatible.ts
+++ b/examples/ai-functions/src/stream-text/azure/provider-options-name-openai-compatible.ts
@@ -57,7 +57,7 @@ run(async () => {
     ],
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'reasoning-start':
         process.stdout.write('\x1b[34m');

--- a/examples/ai-functions/src/stream-text/azure/reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/stream-text/azure/reasoning-encrypted-content.ts
@@ -19,7 +19,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'reasoning-start':
         process.stdout.write('\x1b[34m');

--- a/examples/ai-functions/src/stream-text/azure/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/azure/reasoning.ts
@@ -18,7 +18,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'reasoning-start':
         process.stdout.write('\x1b[34m');

--- a/examples/ai-functions/src/stream-text/azure/responses-code-interpreter.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-code-interpreter.ts
@@ -38,7 +38,7 @@ run(async () => {
     containerId: string;
     fileId: string;
   }[] = [];
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-end') {
       const providerMetadata = part.providerMetadata as
         | AzureResponsesTextProviderMetadata

--- a/examples/ai-functions/src/stream-text/azure/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-reasoning-summary.ts
@@ -18,7 +18,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/azure/responses-web-search-preview.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-web-search-preview.ts
@@ -29,7 +29,7 @@ run(async () => {
   console.log(await result.toolCalls);
   console.log(await result.toolResults);
   console.log('\n=== Web Search Preview Annotations ===');
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-end':
         {

--- a/examples/ai-functions/src/stream-text/baseten/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/baseten/reasoning.ts
@@ -13,7 +13,7 @@ run(async () => {
     prompt: 'What is notable about Sonoran food?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/cerebras/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/cerebras/reasoning.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'What is notable about Sonoran food?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/cerebras/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/cerebras/tool-call.ts
@@ -28,7 +28,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/cohere/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/cohere/raw-chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/cohere/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/cohere/reasoning.ts
@@ -12,7 +12,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/cohere/tool-call-empty-params.ts
+++ b/examples/ai-functions/src/stream-text/cohere/tool-call-empty-params.ts
@@ -33,7 +33,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     console.log(delta);
 
     switch (delta.type) {

--- a/examples/ai-functions/src/stream-text/cohere/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/cohere/tool-call.ts
@@ -27,7 +27,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     console.log(delta);
 
     switch (delta.type) {

--- a/examples/ai-functions/src/stream-text/deepseek/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/deepseek/reasoning.ts
@@ -11,7 +11,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/fireworks/kimi-k2-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/kimi-k2-tool-call.ts
@@ -27,7 +27,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/fireworks/reasoning-effort.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/reasoning-effort.ts
@@ -11,7 +11,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/fireworks/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/reasoning.ts
@@ -16,7 +16,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -48,7 +48,7 @@ async function main() {
     stopWhen: isStepCount(2),
   });
 
-  for await (const chunk of turn1.fullStream) {
+  for await (const chunk of turn1.stream) {
     if (chunk.type === 'text-delta') {
       process.stdout.write(chunk.text);
     }
@@ -97,7 +97,7 @@ async function main() {
       stopWhen: isStepCount(2),
     });
 
-    for await (const chunk of scenarioA.fullStream) {
+    for await (const chunk of scenarioA.stream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }
@@ -154,7 +154,7 @@ async function main() {
       stopWhen: isStepCount(2),
     });
 
-    for await (const chunk of scenarioB.fullStream) {
+    for await (const chunk of scenarioB.stream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }
@@ -196,7 +196,7 @@ async function main() {
         stopWhen: isStepCount(2),
       });
 
-      for await (const chunk of scenarioC.fullStream) {
+      for await (const chunk of scenarioC.stream) {
         if (chunk.type === 'text-delta') {
           process.stdout.write(chunk.text);
         }

--- a/examples/ai-functions/src/stream-text/gateway/image-edit-tool.ts
+++ b/examples/ai-functions/src/stream-text/gateway/image-edit-tool.ts
@@ -20,7 +20,7 @@ run(async () => {
 
   let baseImageData: Uint8Array | null = null;
 
-  for await (const part of baseResult.fullStream) {
+  for await (const part of baseResult.stream) {
     if (part.type == 'tool-result' && !part.dynamic) {
       baseImageData = convertBase64ToUint8Array(part.output.result);
       await presentImages([
@@ -64,7 +64,7 @@ run(async () => {
     },
   });
 
-  for await (const part of editResult.fullStream) {
+  for await (const part of editResult.stream) {
     if (part.type == 'tool-result' && !part.dynamic) {
       await presentImages([
         {

--- a/examples/ai-functions/src/stream-text/gateway/tool-parallel-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-parallel-search-params.ts
@@ -23,7 +23,7 @@ async function main() {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta':
         process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);

--- a/examples/ai-functions/src/stream-text/gateway/tool-parallel-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-parallel-search.ts
@@ -10,7 +10,7 @@ async function main() {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta':
         process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);

--- a/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search-params.ts
@@ -19,7 +19,7 @@ async function main() {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta':
         process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);

--- a/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search.ts
@@ -10,7 +10,7 @@ async function main() {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-delta':
         process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);

--- a/examples/ai-functions/src/stream-text/google/chatbot-image-output.ts
+++ b/examples/ai-functions/src/stream-text/google/chatbot-image-output.ts
@@ -21,7 +21,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const delta of result.fullStream) {
+    for await (const delta of result.stream) {
       switch (delta.type) {
         case 'text-delta': {
           process.stdout.write(delta.text);

--- a/examples/ai-functions/src/stream-text/google/fullstream.ts
+++ b/examples/ai-functions/src/stream-text/google/fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/google/function-call-id.ts
+++ b/examples/ai-functions/src/stream-text/google/function-call-id.ts
@@ -29,7 +29,7 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  for await (const part of turn1.fullStream) {
+  for await (const part of turn1.stream) {
     if (part.type === 'tool-call') {
       console.log(
         `Turn 1 tool call (${part.toolCallId}): ${part.toolName}`,
@@ -61,7 +61,7 @@ run(async () => {
   });
 
   console.log('\nTurn 2 text:');
-  for await (const part of turn2.fullStream) {
+  for await (const part of turn2.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }

--- a/examples/ai-functions/src/stream-text/google/gemini-2-5-flash-lite-multi-step.ts
+++ b/examples/ai-functions/src/stream-text/google/gemini-2-5-flash-lite-multi-step.ts
@@ -22,7 +22,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/google/gemini-2.5-flash-image-preview-chatbot.ts
@@ -21,7 +21,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const delta of result.fullStream) {
+    for await (const delta of result.stream) {
       switch (delta.type) {
         case 'text-delta': {
           process.stdout.write(delta.text);

--- a/examples/ai-functions/src/stream-text/google/grounding.ts
+++ b/examples/ai-functions/src/stream-text/google/grounding.ts
@@ -11,7 +11,7 @@ run(async () => {
     prompt: 'List the top 5 San Francisco news from the past week.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }

--- a/examples/ai-functions/src/stream-text/google/image-output.ts
+++ b/examples/ai-functions/src/stream-text/google/image-output.ts
@@ -9,7 +9,7 @@ run(async () => {
     prompt: 'Generate an image of a comic cat',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/image-search.ts
+++ b/examples/ai-functions/src/stream-text/google/image-search.ts
@@ -24,7 +24,7 @@ run(async () => {
       'Search for live footage photos of the 2026 Super Bowl halftime show artist. I want an image with a close-up of them during the show, but in space.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/image-thinking-multi-step.ts
+++ b/examples/ai-functions/src/stream-text/google/image-thinking-multi-step.ts
@@ -20,7 +20,7 @@ run(async () => {
     providerOptions,
   });
 
-  for await (const part of step1.fullStream) {
+  for await (const part of step1.stream) {
     switch (part.type) {
       case 'reasoning-delta': {
         process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
@@ -59,7 +59,7 @@ run(async () => {
     providerOptions,
   });
 
-  for await (const part of step2.fullStream) {
+  for await (const part of step2.stream) {
     switch (part.type) {
       case 'reasoning-delta': {
         process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-base64.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-base64.ts
@@ -51,7 +51,7 @@ run(async () => {
     stopWhen: isStepCount(4),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-data-url.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-data-url.ts
@@ -52,7 +52,7 @@ run(async () => {
     stopWhen: isStepCount(4),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-old.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-old.ts
@@ -59,7 +59,7 @@ run(async () => {
     prompt: `Whats in this image?`,
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-url.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-url.ts
@@ -45,7 +45,7 @@ run(async () => {
     stopWhen: isStepCount(4),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/interactions-agent-abort.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-agent-abort.ts
@@ -77,7 +77,7 @@ run(async () => {
   });
 
   try {
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'reasoning-delta') {
         process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
       } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-agent-multi-turn.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-agent-multi-turn.ts
@@ -35,7 +35,7 @@ run(async () => {
       'List three foundational concepts behind transformer-based language models (one sentence each).',
     abortSignal: ac.signal,
   });
-  for await (const part of turn1.fullStream) {
+  for await (const part of turn1.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {
@@ -77,7 +77,7 @@ run(async () => {
     },
     abortSignal: ac.signal,
   });
-  for await (const part of turn2.fullStream) {
+  for await (const part of turn2.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-agent-single-turn.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-agent-single-turn.ts
@@ -34,7 +34,7 @@ run(async () => {
     abortSignal: ac.signal,
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-base-agent.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-base-agent.ts
@@ -20,7 +20,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-google-search.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-google-search.ts
@@ -13,7 +13,7 @@ run(async () => {
       'Include the date for each item you mention.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }

--- a/examples/ai-functions/src/stream-text/google/interactions-image-output-modify-stateless.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-image-output-modify-stateless.ts
@@ -32,7 +32,7 @@ run(async () => {
     },
   });
 
-  for await (const part of turn1.fullStream) {
+  for await (const part of turn1.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);
@@ -72,7 +72,7 @@ run(async () => {
     },
   });
 
-  for await (const part of turn2.fullStream) {
+  for await (const part of turn2.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/interactions-image-output-modify.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-image-output-modify.ts
@@ -20,7 +20,7 @@ run(async () => {
     },
   });
 
-  for await (const part of turn1.fullStream) {
+  for await (const part of turn1.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);
@@ -61,7 +61,7 @@ run(async () => {
     },
   });
 
-  for await (const part of turn2.fullStream) {
+  for await (const part of turn2.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/interactions-image-output.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-image-output.ts
@@ -17,7 +17,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/interactions-managed-agent-inline-source.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-managed-agent-inline-source.ts
@@ -45,7 +45,7 @@ run(async () => {
       },
     });
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'reasoning-delta') {
         process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
       } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-managed-agent-repository-source.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-managed-agent-repository-source.ts
@@ -45,7 +45,7 @@ run(async () => {
       },
     });
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'reasoning-delta') {
         process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
       } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-managed-agent.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-managed-agent.ts
@@ -34,7 +34,7 @@ run(async () => {
       },
     });
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'reasoning-delta') {
         process.stdout.write(`\x1b[2m${part.text}\x1b[0m`);
       } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-multimodal-output-response-format.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-multimodal-output-response-format.ts
@@ -24,7 +24,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/interactions-multimodal-output.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-multimodal-output.ts
@@ -18,7 +18,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/interactions-reasoning-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-reasoning-multiturn.ts
@@ -36,7 +36,7 @@ run(async () => {
       } satisfies GoogleLanguageModelInteractionsOptions,
     },
   });
-  for await (const part of turn1.fullStream) {
+  for await (const part of turn1.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {
@@ -65,7 +65,7 @@ run(async () => {
       } satisfies GoogleLanguageModelInteractionsOptions,
     },
   });
-  for await (const part of turn2.fullStream) {
+  for await (const part of turn2.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/interactions-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-tool-call.ts
@@ -11,7 +11,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco right now?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     } else if (part.type === 'tool-call') {

--- a/examples/ai-functions/src/stream-text/google/multiturn-tool-error.ts
+++ b/examples/ai-functions/src/stream-text/google/multiturn-tool-error.ts
@@ -60,7 +60,7 @@ run(async () => {
   console.log('\nturn 1 response:');
 
   let rawChunkCount = 0;
-  for await (const chunk of turn1.fullStream) {
+  for await (const chunk of turn1.stream) {
     if (chunk.type === 'text-delta') {
       process.stdout.write(chunk.text);
     } else if (chunk.type === 'raw') {
@@ -149,7 +149,7 @@ run(async () => {
 
     console.log('\nturn 2 response:');
 
-    for await (const chunk of turn2.fullStream) {
+    for await (const chunk of turn2.stream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }
@@ -230,7 +230,7 @@ run(async () => {
 
     console.log('\nturn 3 response:');
 
-    for await (const chunk of turn3.fullStream) {
+    for await (const chunk of turn3.stream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }

--- a/examples/ai-functions/src/stream-text/google/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/stream-text/google/pdf-tool-results-url.ts
@@ -45,7 +45,7 @@ run(async () => {
     stopWhen: isStepCount(4),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/google/raw-chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/google/reasoning-with-tools.ts
+++ b/examples/ai-functions/src/stream-text/google/reasoning-with-tools.ts
@@ -30,7 +30,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta':
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/google/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/google/reasoning.ts
@@ -13,7 +13,7 @@ run(async () => {
     onError: console.error,
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/search-types.ts
+++ b/examples/ai-functions/src/stream-text/google/search-types.ts
@@ -19,7 +19,7 @@ run(async () => {
       'You must include the date of each article.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }

--- a/examples/ai-functions/src/stream-text/google/tool-combination.ts
+++ b/examples/ai-functions/src/stream-text/google/tool-combination.ts
@@ -15,7 +15,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta':
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/google/tool-nested-empty-object.ts
+++ b/examples/ai-functions/src/stream-text/google/tool-nested-empty-object.ts
@@ -21,7 +21,7 @@ run(async () => {
     prompt: 'Navigate to https://example.com with default launch options',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'tool-call') {
       console.log('Tool call:', part.toolName, part.input);
     }

--- a/examples/ai-functions/src/stream-text/google/url-context.ts
+++ b/examples/ai-functions/src/stream-text/google/url-context.ts
@@ -12,7 +12,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-call.ts
@@ -28,7 +28,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-bm25.ts
@@ -68,7 +68,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-regex.ts
@@ -68,7 +68,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/google/vertex-chatbot-image-output.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-chatbot-image-output.ts
@@ -28,7 +28,7 @@ run(async () => {
 
     process.stdout.write('\nAssistant: ');
 
-    for await (const delta of result.fullStream) {
+    for await (const delta of result.stream) {
       switch (delta.type) {
         case 'reasoning-delta': {
           process.stdout.write('\x1b[34m' + delta.text + '\x1b[0m');

--- a/examples/ai-functions/src/stream-text/google/vertex-code-execution.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-code-execution.ts
@@ -24,7 +24,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/google/vertex-combined-tools.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-combined-tools.ts
@@ -27,7 +27,7 @@ run(async () => {
   });
 
   const rawChunks: unknown[] = [];
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     } else if (part.type === 'raw') {

--- a/examples/ai-functions/src/stream-text/google/vertex-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/google/vertex-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-gemini-2.5-flash-image-preview-chatbot.ts
@@ -21,7 +21,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const delta of result.fullStream) {
+    for await (const delta of result.stream) {
       switch (delta.type) {
         case 'text-delta': {
           process.stdout.write(delta.text);

--- a/examples/ai-functions/src/stream-text/google/vertex-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-reasoning.ts
@@ -18,7 +18,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/google/vertex-stream-function-call-args.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-stream-function-call-args.ts
@@ -26,7 +26,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'tool-input-start':
         console.log(`\n[tool-input-start] ${part.toolName} (${part.id})`);

--- a/examples/ai-functions/src/stream-text/google/vertex-stream-tool-call-object.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-stream-tool-call-object.ts
@@ -30,7 +30,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'tool-input-start':
         console.log(`\n[tool-input-start] ${part.toolName} (${part.id})`);

--- a/examples/ai-functions/src/stream-text/groq/browser-search.ts
+++ b/examples/ai-functions/src/stream-text/groq/browser-search.ts
@@ -17,7 +17,7 @@ run(async () => {
 
     console.log('Starting browser search...\n');
 
-    for await (const delta of result.fullStream) {
+    for await (const delta of result.stream) {
       switch (delta.type) {
         case 'text-delta': {
           process.stdout.write(delta.text);

--- a/examples/ai-functions/src/stream-text/groq/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/groq/chatbot.ts
@@ -47,7 +47,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of result.stream) {
       switch (chunk.type) {
         case 'raw':
           console.log(JSON.stringify(chunk.rawValue, null, 2));

--- a/examples/ai-functions/src/stream-text/groq/kimi-k2-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/groq/kimi-k2-tool-call.ts
@@ -27,7 +27,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/groq/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/groq/raw-chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/groq/reasoning-effort.ts
+++ b/examples/ai-functions/src/stream-text/groq/reasoning-effort.ts
@@ -11,7 +11,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/groq/reasoning-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/groq/reasoning-fullstream.ts
@@ -15,7 +15,7 @@ run(async () => {
 
   let enteredReasoning = false;
   let enteredText = false;
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/huggingface/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/huggingface/reasoning.ts
@@ -14,7 +14,7 @@ run(async () => {
   let enteredReasoning = false;
   let enteredText = false;
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'reasoning-delta':
         if (!enteredReasoning) {

--- a/examples/ai-functions/src/stream-text/huggingface/tools.ts
+++ b/examples/ai-functions/src/stream-text/huggingface/tools.ts
@@ -51,7 +51,7 @@ run(async () => {
     prompt: 'What is the weather like in my current location?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/mistral/disable-parallel-tools.ts
+++ b/examples/ai-functions/src/stream-text/mistral/disable-parallel-tools.ts
@@ -27,7 +27,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/mistral/fullstream.ts
+++ b/examples/ai-functions/src/stream-text/mistral/fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/mistral/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/mistral/raw-chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/mistral/reasoning-effort.ts
+++ b/examples/ai-functions/src/stream-text/mistral/reasoning-effort.ts
@@ -9,7 +9,7 @@ run(async () => {
     prompt: 'What is 2 + 2?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-start': {
         console.log('\n--- Reasoning ---');

--- a/examples/ai-functions/src/stream-text/mistral/reasoning-input.ts
+++ b/examples/ai-functions/src/stream-text/mistral/reasoning-input.ts
@@ -27,7 +27,7 @@ run(async () => {
     ],
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-start': {
         console.log('\n--- Reasoning ---');

--- a/examples/ai-functions/src/stream-text/mistral/reasoning-raw.ts
+++ b/examples/ai-functions/src/stream-text/mistral/reasoning-raw.ts
@@ -19,7 +19,7 @@ run(async () => {
   let enteredReasoning = false;
   let enteredText = false;
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;

--- a/examples/ai-functions/src/stream-text/mistral/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/mistral/reasoning.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'What is 2 + 2?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'reasoning-start': {
         console.log('\n--- Reasoning ---');

--- a/examples/ai-functions/src/stream-text/mock/tool-call-repair-change-tool.ts
+++ b/examples/ai-functions/src/stream-text/mock/tool-call-repair-change-tool.ts
@@ -56,7 +56,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     console.log(JSON.stringify(part, null, 2));
   }
 

--- a/examples/ai-functions/src/stream-text/moonshot/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/tool-call.ts
@@ -24,7 +24,7 @@ run(async () => {
     prompt: 'What is the weather in my current location?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/open-responses/lmstudio-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/open-responses/lmstudio-chatbot.ts
@@ -39,7 +39,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of result.stream) {
       switch (chunk.type) {
         case 'tool-call': {
           process.stdout.write('\x1b[33m');

--- a/examples/ai-functions/src/stream-text/open-responses/lmstudio-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/open-responses/lmstudio-tool-call.ts
@@ -18,7 +18,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/openai/chatbot.ts
@@ -64,7 +64,7 @@ run(async () => {
     });
 
     process.stdout.write('\nAssistant: ');
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of result.stream) {
       switch (chunk.type) {
         case 'raw':
           console.log(JSON.stringify(chunk.rawValue, null, 2));

--- a/examples/ai-functions/src/stream-text/openai/code-interpreter-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/code-interpreter-tool.ts
@@ -12,7 +12,7 @@ run(async () => {
       'Simulate rolling two dice 10000 times and return the sum of all the results.',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/compaction.ts
+++ b/examples/ai-functions/src/stream-text/openai/compaction.ts
@@ -254,7 +254,7 @@ run(async () => {
 
   console.log('=== Streaming Response ===\n');
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-start': {
         const isCompaction =

--- a/examples/ai-functions/src/stream-text/openai/compatible-abort-reason.ts
+++ b/examples/ai-functions/src/stream-text/openai/compatible-abort-reason.ts
@@ -31,7 +31,7 @@ run(async () => {
       abortController.abort('user cancelled');
     }, manualCancelTimeout);
 
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of result.stream) {
       if (chunk.type === 'abort') {
         const reason = chunk.reason;
         console.log('Abort reason:', reason);

--- a/examples/ai-functions/src/stream-text/openai/compatible-google-thought-signatures.ts
+++ b/examples/ai-functions/src/stream-text/openai/compatible-google-thought-signatures.ts
@@ -82,7 +82,7 @@ run(async () => {
   });
 
   console.log('Turn 1 response:');
-  for await (const chunk of turn1.fullStream) {
+  for await (const chunk of turn1.stream) {
     if (chunk.type === 'text-delta') {
       process.stdout.write(chunk.text);
     } else if (chunk.type === 'tool-call') {
@@ -167,7 +167,7 @@ run(async () => {
     });
 
     console.log('Turn 2 response:');
-    for await (const chunk of turn2.fullStream) {
+    for await (const chunk of turn2.stream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }
@@ -215,7 +215,7 @@ run(async () => {
   });
 
   console.log('Parallel test response:');
-  for await (const chunk of parallelTest.fullStream) {
+  for await (const chunk of parallelTest.stream) {
     if (chunk.type === 'text-delta') {
       process.stdout.write(chunk.text);
     }

--- a/examples/ai-functions/src/stream-text/openai/compatible-raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/openai/compatible-raw-chunks.ts
@@ -23,7 +23,7 @@ run(async () => {
   let rawChunkCount = 0;
   let otherChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     console.log('Chunk type:', chunk.type, 'Chunk:', JSON.stringify(chunk));
 
     if (chunk.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/openai/compatible-togetherai-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/compatible-togetherai-tool-call.ts
@@ -38,7 +38,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/openai/custom-fetch-inject-error.ts
+++ b/examples/ai-functions/src/stream-text/openai/custom-fetch-inject-error.ts
@@ -50,7 +50,7 @@ run(async () => {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     process.stdout.write(JSON.stringify(part));
   }
 

--- a/examples/ai-functions/src/stream-text/openai/dynamic-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/dynamic-tool-call.ts
@@ -30,7 +30,7 @@ run(async () => {
     prompt: 'What is the weather in my current location?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/file-search-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/file-search-tool.ts
@@ -21,7 +21,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/fullstream-logprobs.ts
+++ b/examples/ai-functions/src/stream-text/openai/fullstream-logprobs.ts
@@ -20,7 +20,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/openai/fullstream-raw.ts
+++ b/examples/ai-functions/src/stream-text/openai/fullstream-raw.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     console.log(JSON.stringify(part));
   }
 });

--- a/examples/ai-functions/src/stream-text/openai/fullstream.ts
+++ b/examples/ai-functions/src/stream-text/openai/fullstream.ts
@@ -16,7 +16,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/openai/image-generation-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/image-generation-tool.ts
@@ -17,7 +17,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type == 'tool-result' && !part.dynamic) {
       await presentImages([
         {

--- a/examples/ai-functions/src/stream-text/openai/local-shell-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/local-shell-tool.ts
@@ -24,7 +24,7 @@ README.md     build         data          node_modules  package.json  src       
     stopWhen: isStepCount(2),
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/phase.ts
+++ b/examples/ai-functions/src/stream-text/openai/phase.ts
@@ -20,7 +20,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-start': {
         const phase = chunk.providerMetadata?.openai?.phase;

--- a/examples/ai-functions/src/stream-text/openai/reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/stream-text/openai/reasoning-encrypted-content.ts
@@ -19,7 +19,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'reasoning-start':
         process.stdout.write('\x1b[34m');

--- a/examples/ai-functions/src/stream-text/openai/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/openai/reasoning.ts
@@ -18,7 +18,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'reasoning-start':
         process.stdout.write('\x1b[34m');

--- a/examples/ai-functions/src/stream-text/openai/responses-allowed-tools.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-allowed-tools.ts
@@ -25,7 +25,7 @@ run(async () => {
 
   const calledTools = new Set<string>();
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-apply-patch.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-apply-patch.ts
@@ -20,7 +20,7 @@ run(async () => {
   });
 
   process.stdout.write('\n=== Model Response (Streaming) ===\n');
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         process.stdout.write(part.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-client-tool-search.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-client-tool-search.ts
@@ -97,7 +97,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-code-interpreter.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-code-interpreter.ts
@@ -31,7 +31,7 @@ run(async () => {
     containerId: string;
     fileId: string;
   }[] = [];
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-end') {
       const providerMetadata = part.providerMetadata as
         | OpenaiResponsesTextProviderMetadata

--- a/examples/ai-functions/src/stream-text/openai/responses-custom-tool-multi-turn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-custom-tool-multi-turn.ts
@@ -23,7 +23,7 @@ run(async () => {
     stopWhen: isStepCount(3),
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'tool-call': {
         console.log(`Tool call: ${chunk.toolName}`);

--- a/examples/ai-functions/src/stream-text/openai/responses-custom-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-custom-tool.ts
@@ -19,7 +19,7 @@ run(async () => {
     prompt: 'Write a SQL query to get all users older than 25.',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'tool-call': {
         console.log(

--- a/examples/ai-functions/src/stream-text/openai/responses-namespace.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-namespace.ts
@@ -35,7 +35,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'tool-input-end') {
       console.log(
         `tool-input-end providerMetadata.openai: ${JSON.stringify(part.providerMetadata?.openai)}`,

--- a/examples/ai-functions/src/stream-text/openai/responses-raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-raw-chunks.ts
@@ -26,7 +26,7 @@ run(async () => {
   let fullText = '';
   let fullReasoning = '';
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'raw') {
       rawChunkCount++;
       console.log(

--- a/examples/ai-functions/src/stream-text/openai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-reasoning-summary.ts
@@ -21,7 +21,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/openai/responses-reasoning-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-reasoning-tool-call.ts
@@ -46,7 +46,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'start':
         console.log('START');

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-container-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-container-multiturn.ts
@@ -33,7 +33,7 @@ run(async () => {
     ],
   });
 
-  for await (const chunk of result2.fullStream) {
+  for await (const chunk of result2.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-container-skills.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-container-skills.ts
@@ -34,7 +34,7 @@ run(async () => {
       'You are trapped and lost on a lonely island in 1895. Find a way to get rescued!',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-container.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-container.ts
@@ -16,7 +16,7 @@ run(async () => {
       'Print "Hello from container!" and show the system info using uname -a',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-local-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-local-multiturn.ts
@@ -46,7 +46,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const chunk of result2.fullStream) {
+  for await (const chunk of result2.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-local-skills.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-local-skills.ts
@@ -35,7 +35,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-tool.ts
@@ -23,7 +23,7 @@ run(async () => {
     stopWhen: isStepCount(5),
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-tool-call.ts
@@ -32,7 +32,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/responses-tool-search.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-tool-search.ts
@@ -68,7 +68,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/step-performance.ts
+++ b/examples/ai-functions/src/stream-text/openai/step-performance.ts
@@ -21,7 +21,7 @@ run(async () => {
     prompt: 'What is the weather in my current location?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-approval.ts
@@ -70,7 +70,7 @@ run(async () => {
       stopWhen: isStepCount(5),
     });
 
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of result.stream) {
       switch (chunk.type) {
         case 'text-start': {
           process.stdout.write('\nAssistant:\n');

--- a/examples/ai-functions/src/stream-text/openai/tool-call-raw-json-schema.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-call-raw-json-schema.ts
@@ -34,7 +34,7 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'text-delta': {
         console.log('Text:', part.text);

--- a/examples/ai-functions/src/stream-text/openai/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-call.ts
@@ -24,7 +24,7 @@ run(async () => {
     prompt: 'What is the weather in my current location?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/tool-output-stream.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-output-stream.ts
@@ -52,7 +52,7 @@ run(async () => {
     prompt: 'What is the weather in New York?',
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/openai/tool-timeout-error.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-timeout-error.ts
@@ -29,7 +29,7 @@ run(async () => {
     prompt: 'Search for "hello world"',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'tool-call') {
       console.log(`tool-call: ${part.toolName}(${JSON.stringify(part.input)})`);
     }

--- a/examples/ai-functions/src/stream-text/openai/web-search-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/web-search-tool.ts
@@ -14,7 +14,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/perplexity/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/perplexity/raw-chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/raw/chunks.ts
+++ b/examples/ai-functions/src/stream-text/raw/chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/togetherai/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/togetherai/tool-call.ts
@@ -28,7 +28,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/vercel/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/vercel/tool-call.ts
@@ -27,7 +27,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/xai/code-execution.ts
+++ b/examples/ai-functions/src/stream-text/xai/code-execution.ts
@@ -14,7 +14,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of response.fullStream) {
+  for await (const chunk of response.stream) {
     console.dir(chunk, { depth: null });
   }
 });

--- a/examples/ai-functions/src/stream-text/xai/logprobs.ts
+++ b/examples/ai-functions/src/stream-text/xai/logprobs.ts
@@ -17,7 +17,7 @@ run(async () => {
     },
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'raw') {
       console.log('raw:', JSON.stringify(part.rawValue));
       continue;

--- a/examples/ai-functions/src/stream-text/xai/mcp-server.ts
+++ b/examples/ai-functions/src/stream-text/xai/mcp-server.ts
@@ -3,7 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const { fullStream } = streamText({
+  const { stream } = streamText({
     model: xai.responses('grok-4-1-fast-reasoning'),
     tools: {
       mcp_server: xai.tools.mcpServer({
@@ -18,7 +18,7 @@ run(async () => {
 
   let toolCallCount = 0;
 
-  for await (const event of fullStream) {
+  for await (const event of stream) {
     if (event.type === 'tool-call') {
       toolCallCount++;
       console.log(

--- a/examples/ai-functions/src/stream-text/xai/openai-compat-file-search.ts
+++ b/examples/ai-functions/src/stream-text/xai/openai-compat-file-search.ts
@@ -19,7 +19,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);

--- a/examples/ai-functions/src/stream-text/xai/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/xai/raw-chunks.ts
@@ -14,7 +14,7 @@ run(async () => {
   let textChunkCount = 0;
   let rawChunkCount = 0;
 
-  for await (const chunk of result.fullStream) {
+  for await (const chunk of result.stream) {
     if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);

--- a/examples/ai-functions/src/stream-text/xai/responses-encrypted-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-encrypted-reasoning.ts
@@ -23,7 +23,7 @@ run(async () => {
     let encryptedContent: string | undefined;
     let itemId: string | undefined;
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       if (part.type === 'text-delta') {
         textContent += part.text || '';
       }

--- a/examples/ai-functions/src/stream-text/xai/responses-grok-code-fast-1.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-grok-code-fast-1.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
     } else if (part.type === 'text-delta') {

--- a/examples/ai-functions/src/stream-text/xai/responses-reasoning-effort.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-reasoning-effort.ts
@@ -12,7 +12,7 @@ run(async () => {
   let inReasoning = false;
   let inText = false;
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!inReasoning) {
         console.log('Reasoning:');

--- a/examples/ai-functions/src/stream-text/xai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-reasoning-summary.ts
@@ -17,7 +17,7 @@ run(async () => {
   let inReasoning = false;
   let inText = false;
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'reasoning-delta') {
       if (!inReasoning) {
         console.log('Reasoning:');

--- a/examples/ai-functions/src/stream-text/xai/responses-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-tool-call.ts
@@ -18,7 +18,7 @@ run(async () => {
       'What is the weather in San Francisco and what attractions should I visit?',
   });
 
-  for await (const event of result.fullStream) {
+  for await (const event of result.stream) {
     switch (event.type) {
       case 'text-delta': {
         process.stdout.write(event.text);

--- a/examples/ai-functions/src/stream-text/xai/responses-tools.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-tools.ts
@@ -3,7 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const { fullStream } = streamText({
+  const { stream } = streamText({
     model: xai.responses('grok-4-fast-non-reasoning'),
     tools: {
       web_search: xai.tools.webSearch(),
@@ -15,7 +15,7 @@ run(async () => {
 
   let toolCallCount = 0;
 
-  for await (const event of fullStream) {
+  for await (const event of stream) {
     if (event.type === 'tool-call') {
       toolCallCount++;
       console.log(

--- a/examples/ai-functions/src/stream-text/xai/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/xai/tool-call.ts
@@ -28,7 +28,7 @@ run(async () => {
   const toolCalls: ToolCallPart[] = [];
   const toolResponses: ToolResultPart[] = [];
 
-  for await (const delta of result.fullStream) {
+  for await (const delta of result.stream) {
     switch (delta.type) {
       case 'text-delta': {
         fullResponse += delta.text;

--- a/examples/ai-functions/src/stream-text/xai/web-search-image-understanding.ts
+++ b/examples/ai-functions/src/stream-text/xai/web-search-image-understanding.ts
@@ -3,7 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const { fullStream } = streamText({
+  const { stream } = streamText({
     model: xai.responses('grok-4-fast-non-reasoning'),
     tools: {
       web_search: xai.tools.webSearch({
@@ -17,7 +17,7 @@ run(async () => {
 
   console.log('searching x.ai with image understanding...\n');
 
-  for await (const part of fullStream) {
+  for await (const part of stream) {
     switch (part.type) {
       case 'tool-call':
         if (part.providerExecuted) {

--- a/examples/ai-functions/src/stream-text/xai/x-search-video-understanding.ts
+++ b/examples/ai-functions/src/stream-text/xai/x-search-video-understanding.ts
@@ -3,7 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const { fullStream } = streamText({
+  const { stream } = streamText({
     model: xai.responses('grok-4-fast-non-reasoning'),
     tools: {
       x_search: xai.tools.xSearch({
@@ -18,7 +18,7 @@ run(async () => {
 
   console.log('searching x for videos and images from xai...\n');
 
-  for await (const part of fullStream) {
+  for await (const part of stream) {
     switch (part.type) {
       case 'tool-call':
         if (part.providerExecuted) {

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -212,286 +212,6 @@ exports[`streamText > result.files > should contain files 1`] = `
 ]
 `;
 
-exports[`streamText > result.fullStream > should send delayed asynchronous tool results 1`] = `
-[
-  {
-    "type": "start",
-  },
-  {
-    "request": {
-      "body": undefined,
-      "messages": undefined,
-    },
-    "type": "start-step",
-    "warnings": [],
-  },
-  {
-    "input": {
-      "value": "value",
-    },
-    "providerExecuted": undefined,
-    "providerMetadata": undefined,
-    "title": "Tool 1",
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-call",
-  },
-  {
-    "dynamic": false,
-    "input": {
-      "value": "value",
-    },
-    "output": "value-result",
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-result",
-  },
-  {
-    "finishReason": "stop",
-    "performance": {
-      "effectiveOutputTokensPerSecond": 0,
-      "effectiveTotalTokensPerSecond": 0,
-      "inputTokensPerSecond": 0,
-      "outputTokensPerSecond": 0,
-      "responseTimeMs": 0,
-      "stepTimeMs": 60,
-      "timeBetweenOutputChunksMs": undefined,
-      "timeToFirstOutputMs": 0,
-      "toolExecutionMs": {
-        "call-1": 60,
-      },
-    },
-    "providerMetadata": undefined,
-    "rawFinishReason": "stop",
-    "response": {
-      "headers": undefined,
-      "id": "id-0",
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "type": "finish-step",
-    "usage": {
-      "inputTokenDetails": {
-        "cacheReadTokens": undefined,
-        "cacheWriteTokens": undefined,
-        "noCacheTokens": 3,
-      },
-      "inputTokens": 3,
-      "outputTokenDetails": {
-        "reasoningTokens": undefined,
-        "textTokens": 10,
-      },
-      "outputTokens": 10,
-      "raw": undefined,
-      "totalTokens": 13,
-    },
-  },
-  {
-    "finishReason": "stop",
-    "rawFinishReason": "stop",
-    "totalUsage": {
-      "inputTokenDetails": {
-        "cacheReadTokens": undefined,
-        "cacheWriteTokens": undefined,
-        "noCacheTokens": 3,
-      },
-      "inputTokens": 3,
-      "outputTokenDetails": {
-        "reasoningTokens": undefined,
-        "textTokens": 10,
-      },
-      "outputTokens": 10,
-      "totalTokens": 13,
-    },
-    "type": "finish",
-  },
-]
-`;
-
-exports[`streamText > result.fullStream > should send tool calls 1`] = `
-[
-  {
-    "type": "start",
-  },
-  {
-    "request": {
-      "body": undefined,
-      "messages": undefined,
-    },
-    "type": "start-step",
-    "warnings": [],
-  },
-  {
-    "input": {
-      "value": "value",
-    },
-    "providerExecuted": undefined,
-    "providerMetadata": {
-      "testProvider": {
-        "signature": "sig",
-      },
-    },
-    "title": "Tool 1",
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-call",
-  },
-  {
-    "finishReason": "stop",
-    "performance": {
-      "effectiveOutputTokensPerSecond": 0,
-      "effectiveTotalTokensPerSecond": 0,
-      "inputTokensPerSecond": 0,
-      "outputTokensPerSecond": 0,
-      "responseTimeMs": 0,
-      "stepTimeMs": 0,
-      "timeBetweenOutputChunksMs": undefined,
-      "timeToFirstOutputMs": 0,
-      "toolExecutionMs": {},
-    },
-    "providerMetadata": undefined,
-    "rawFinishReason": "stop",
-    "response": {
-      "headers": undefined,
-      "id": "id-0",
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "type": "finish-step",
-    "usage": {
-      "inputTokenDetails": {
-        "cacheReadTokens": undefined,
-        "cacheWriteTokens": undefined,
-        "noCacheTokens": 3,
-      },
-      "inputTokens": 3,
-      "outputTokenDetails": {
-        "reasoningTokens": undefined,
-        "textTokens": 10,
-      },
-      "outputTokens": 10,
-      "raw": undefined,
-      "totalTokens": 13,
-    },
-  },
-  {
-    "finishReason": "stop",
-    "rawFinishReason": "stop",
-    "totalUsage": {
-      "inputTokenDetails": {
-        "cacheReadTokens": undefined,
-        "cacheWriteTokens": undefined,
-        "noCacheTokens": 3,
-      },
-      "inputTokens": 3,
-      "outputTokenDetails": {
-        "reasoningTokens": undefined,
-        "textTokens": 10,
-      },
-      "outputTokens": 10,
-      "totalTokens": 13,
-    },
-    "type": "finish",
-  },
-]
-`;
-
-exports[`streamText > result.fullStream > should send tool results 1`] = `
-[
-  {
-    "type": "start",
-  },
-  {
-    "request": {
-      "body": undefined,
-      "messages": undefined,
-    },
-    "type": "start-step",
-    "warnings": [],
-  },
-  {
-    "input": {
-      "value": "value",
-    },
-    "providerExecuted": undefined,
-    "providerMetadata": undefined,
-    "title": "Tool 1",
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-call",
-  },
-  {
-    "dynamic": false,
-    "input": {
-      "value": "value",
-    },
-    "output": "value-result",
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-result",
-  },
-  {
-    "finishReason": "stop",
-    "performance": {
-      "effectiveOutputTokensPerSecond": 0,
-      "effectiveTotalTokensPerSecond": 0,
-      "inputTokensPerSecond": 0,
-      "outputTokensPerSecond": 0,
-      "responseTimeMs": 0,
-      "stepTimeMs": 0,
-      "timeBetweenOutputChunksMs": undefined,
-      "timeToFirstOutputMs": 0,
-      "toolExecutionMs": {
-        "call-1": 0,
-      },
-    },
-    "providerMetadata": undefined,
-    "rawFinishReason": "stop",
-    "response": {
-      "headers": undefined,
-      "id": "id-0",
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "type": "finish-step",
-    "usage": {
-      "inputTokenDetails": {
-        "cacheReadTokens": undefined,
-        "cacheWriteTokens": undefined,
-        "noCacheTokens": 3,
-      },
-      "inputTokens": 3,
-      "outputTokenDetails": {
-        "reasoningTokens": undefined,
-        "textTokens": 10,
-      },
-      "outputTokens": 10,
-      "raw": undefined,
-      "totalTokens": 13,
-    },
-  },
-  {
-    "finishReason": "stop",
-    "rawFinishReason": "stop",
-    "totalUsage": {
-      "inputTokenDetails": {
-        "cacheReadTokens": undefined,
-        "cacheWriteTokens": undefined,
-        "noCacheTokens": 3,
-      },
-      "inputTokens": 3,
-      "outputTokenDetails": {
-        "reasoningTokens": undefined,
-        "textTokens": 10,
-      },
-      "outputTokens": 10,
-      "totalTokens": 13,
-    },
-    "type": "finish",
-  },
-]
-`;
-
 exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error messages by default 1`] = `
 [
   "data: {"type":"start"}
@@ -615,6 +335,286 @@ exports[`streamText > result.sources > should contain sources 1`] = `
     "title": "Example 2",
     "type": "source",
     "url": "https://example.com/2",
+  },
+]
+`;
+
+exports[`streamText > result.stream > should send delayed asynchronous tool results 1`] = `
+[
+  {
+    "type": "start",
+  },
+  {
+    "request": {
+      "body": undefined,
+      "messages": undefined,
+    },
+    "type": "start-step",
+    "warnings": [],
+  },
+  {
+    "input": {
+      "value": "value",
+    },
+    "providerExecuted": undefined,
+    "providerMetadata": undefined,
+    "title": "Tool 1",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "dynamic": false,
+    "input": {
+      "value": "value",
+    },
+    "output": "value-result",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-result",
+  },
+  {
+    "finishReason": "stop",
+    "performance": {
+      "effectiveOutputTokensPerSecond": 0,
+      "effectiveTotalTokensPerSecond": 0,
+      "inputTokensPerSecond": 0,
+      "outputTokensPerSecond": 0,
+      "responseTimeMs": 0,
+      "stepTimeMs": 60,
+      "timeBetweenOutputChunksMs": undefined,
+      "timeToFirstOutputMs": 0,
+      "toolExecutionMs": {
+        "call-1": 60,
+      },
+    },
+    "providerMetadata": undefined,
+    "rawFinishReason": "stop",
+    "response": {
+      "headers": undefined,
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish-step",
+    "usage": {
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "raw": undefined,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "finishReason": "stop",
+    "rawFinishReason": "stop",
+    "totalUsage": {
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "totalTokens": 13,
+    },
+    "type": "finish",
+  },
+]
+`;
+
+exports[`streamText > result.stream > should send tool calls 1`] = `
+[
+  {
+    "type": "start",
+  },
+  {
+    "request": {
+      "body": undefined,
+      "messages": undefined,
+    },
+    "type": "start-step",
+    "warnings": [],
+  },
+  {
+    "input": {
+      "value": "value",
+    },
+    "providerExecuted": undefined,
+    "providerMetadata": {
+      "testProvider": {
+        "signature": "sig",
+      },
+    },
+    "title": "Tool 1",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "finishReason": "stop",
+    "performance": {
+      "effectiveOutputTokensPerSecond": 0,
+      "effectiveTotalTokensPerSecond": 0,
+      "inputTokensPerSecond": 0,
+      "outputTokensPerSecond": 0,
+      "responseTimeMs": 0,
+      "stepTimeMs": 0,
+      "timeBetweenOutputChunksMs": undefined,
+      "timeToFirstOutputMs": 0,
+      "toolExecutionMs": {},
+    },
+    "providerMetadata": undefined,
+    "rawFinishReason": "stop",
+    "response": {
+      "headers": undefined,
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish-step",
+    "usage": {
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "raw": undefined,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "finishReason": "stop",
+    "rawFinishReason": "stop",
+    "totalUsage": {
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "totalTokens": 13,
+    },
+    "type": "finish",
+  },
+]
+`;
+
+exports[`streamText > result.stream > should send tool results 1`] = `
+[
+  {
+    "type": "start",
+  },
+  {
+    "request": {
+      "body": undefined,
+      "messages": undefined,
+    },
+    "type": "start-step",
+    "warnings": [],
+  },
+  {
+    "input": {
+      "value": "value",
+    },
+    "providerExecuted": undefined,
+    "providerMetadata": undefined,
+    "title": "Tool 1",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "dynamic": false,
+    "input": {
+      "value": "value",
+    },
+    "output": "value-result",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-result",
+  },
+  {
+    "finishReason": "stop",
+    "performance": {
+      "effectiveOutputTokensPerSecond": 0,
+      "effectiveTotalTokensPerSecond": 0,
+      "inputTokensPerSecond": 0,
+      "outputTokensPerSecond": 0,
+      "responseTimeMs": 0,
+      "stepTimeMs": 0,
+      "timeBetweenOutputChunksMs": undefined,
+      "timeToFirstOutputMs": 0,
+      "toolExecutionMs": {
+        "call-1": 0,
+      },
+    },
+    "providerMetadata": undefined,
+    "rawFinishReason": "stop",
+    "response": {
+      "headers": undefined,
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish-step",
+    "usage": {
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "raw": undefined,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "finishReason": "stop",
+    "rawFinishReason": "stop",
+    "totalUsage": {
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "totalTokens": 13,
+    },
+    "type": "finish",
   },
 ]
 `;

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -306,6 +306,16 @@ export interface StreamTextResult<
    * You can use it as either an AsyncIterable or a ReadableStream.
    * Only errors that stop the stream, such as network errors, are thrown.
    */
+  readonly stream: AsyncIterableStream<TextStreamPart<TOOLS>>;
+
+  /**
+   * A stream with all events, including text deltas, tool calls, tool results, and
+   * errors.
+   * You can use it as either an AsyncIterable or a ReadableStream.
+   * Only errors that stop the stream, such as network errors, are thrown.
+   *
+   * @deprecated Use `stream` instead.
+   */
   readonly fullStream: AsyncIterableStream<TextStreamPart<TOOLS>>;
 
   /**

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -215,6 +215,21 @@ describe('streamText types', () => {
     });
   });
 
+  describe('stream', () => {
+    it('should infer stream part type', () => {
+      const result = streamText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello, world!',
+      });
+
+      const stream: AsyncIterableStream<unknown> = result.stream;
+
+      expectTypeOf<typeof stream>().toEqualTypeOf<
+        AsyncIterableStream<unknown>
+      >();
+    });
+  });
+
   describe('elementStream', () => {
     it('should infer element type for array output', async () => {
       const result = streamText({

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -596,7 +596,44 @@ describe('streamText', () => {
     });
   });
 
-  describe('result.fullStream', () => {
+  describe('result.fullStream (deprecated)', () => {
+    it('should expose the same stream parts as result.stream', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        prompt: 'test-input',
+      });
+
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+
+      expect(parts.map(part => part.type)).toStrictEqual([
+        'start',
+        'start-step',
+        'text-start',
+        'text-delta',
+        'text-end',
+        'finish-step',
+        'finish',
+      ]);
+      expect(parts.find(part => part.type === 'text-delta')).toMatchObject({
+        text: 'Hello',
+      });
+    });
+  });
+
+  describe('result.stream', () => {
     it('should send text deltas', async () => {
       const result = streamText({
         model: new MockLanguageModelV4({
@@ -634,7 +671,7 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -748,7 +785,7 @@ describe('streamText', () => {
         ...defaultSettings(),
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -995,7 +1032,7 @@ describe('streamText', () => {
         ...defaultSettings(),
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -1114,7 +1151,7 @@ describe('streamText', () => {
         ...defaultSettings(),
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -1218,7 +1255,7 @@ describe('streamText', () => {
         ...defaultSettings(),
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -1340,7 +1377,7 @@ describe('streamText', () => {
         ...defaultSettings(),
       });
 
-      const parts = await convertAsyncIterableToArray(result.fullStream);
+      const parts = await convertAsyncIterableToArray(result.stream);
       const fileParts = parts.filter(p => p.type === 'file');
 
       expect(fileParts).toMatchInlineSnapshot(`
@@ -1379,7 +1416,7 @@ describe('streamText', () => {
         ...defaultSettings(),
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -1548,7 +1585,7 @@ describe('streamText', () => {
         },
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -1723,7 +1760,7 @@ describe('streamText', () => {
       });
 
       expect(
-        await convertAsyncIterableToArray(result.fullStream),
+        await convertAsyncIterableToArray(result.stream),
       ).toMatchSnapshot();
     });
 
@@ -1772,9 +1809,9 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
+      const stream = await convertAsyncIterableToArray(result.stream);
 
-      expect(fullStream).toContainEqual(
+      expect(stream).toContainEqual(
         expect.objectContaining({
           type: 'tool-call',
           toolCallId: 'call-1',
@@ -1782,7 +1819,7 @@ describe('streamText', () => {
           input: { value: 'raw' },
         }),
       );
-      expect(fullStream).toContainEqual(
+      expect(stream).toContainEqual(
         expect.objectContaining({
           type: 'tool-result',
           toolCallId: 'call-1',
@@ -1876,7 +1913,7 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -2064,7 +2101,7 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      const chunks = await convertAsyncIterableToArray(result.fullStream);
+      const chunks = await convertAsyncIterableToArray(result.stream);
       const toolInputStart = chunks.find(
         (c): c is Extract<typeof c, { type: 'tool-input-start' }> =>
           c.type === 'tool-input-start',
@@ -2115,7 +2152,7 @@ describe('streamText', () => {
       });
 
       expect(
-        await convertAsyncIterableToArray(result.fullStream),
+        await convertAsyncIterableToArray(result.stream),
       ).toMatchSnapshot();
     });
 
@@ -2156,7 +2193,7 @@ describe('streamText', () => {
       });
 
       expect(
-        await convertAsyncIterableToArray(result.fullStream),
+        await convertAsyncIterableToArray(result.stream),
       ).toMatchSnapshot();
     });
 
@@ -2189,7 +2226,7 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -2326,9 +2363,7 @@ describe('streamText', () => {
         onError: () => {},
       });
 
-      expect(
-        await convertAsyncIterableToArray(result.fullStream),
-      ).toStrictEqual([
+      expect(await convertAsyncIterableToArray(result.stream)).toStrictEqual([
         {
           type: 'start',
         },
@@ -4900,13 +4935,13 @@ describe('streamText', () => {
 
       expect({
         textStream: await convertAsyncIterableToArray(result.textStream),
-        fullStream: await convertAsyncIterableToArray(result.fullStream),
+        stream: await convertAsyncIterableToArray(result.stream),
         uiMessageStream: await convertReadableStreamToArray(
           result.toUIMessageStream(),
         ),
       }).toMatchInlineSnapshot(`
         {
-          "fullStream": [
+          "stream": [
             {
               "type": "start",
             },
@@ -10899,9 +10934,7 @@ describe('streamText', () => {
         onError: () => {},
       });
 
-      expect(
-        await convertAsyncIterableToArray(result.fullStream),
-      ).toStrictEqual([
+      expect(await convertAsyncIterableToArray(result.stream)).toStrictEqual([
         {
           type: 'start',
         },
@@ -11290,7 +11323,7 @@ describe('streamText', () => {
       });
 
       it('should contain assistant response message and tool message from all steps', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -13434,7 +13467,7 @@ describe('streamText', () => {
       });
 
       it('should contain assistant response message and tool message from all steps', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -15348,7 +15381,7 @@ describe('streamText', () => {
       });
 
       it('should include provider-executed tool call and result in the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -15936,7 +15969,7 @@ describe('streamText', () => {
       });
 
       it('should include dynamic tool call and result in the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -16238,7 +16271,7 @@ describe('streamText', () => {
         abortSignal: abortController.signal,
       });
 
-      await convertAsyncIterableToArray(result.fullStream);
+      await convertAsyncIterableToArray(result.stream);
 
       abortController.abort();
 
@@ -17083,7 +17116,7 @@ describe('streamText', () => {
       });
 
       expect(
-        await convertAsyncIterableToArray(result.fullStream),
+        await convertAsyncIterableToArray(result.stream),
       ).toMatchSnapshot();
     });
   });
@@ -17174,7 +17207,7 @@ describe('streamText', () => {
     });
 
     it('should include tool error part in the full stream', async () => {
-      expect(await convertAsyncIterableToArray(result.fullStream))
+      expect(await convertAsyncIterableToArray(result.stream))
         .toMatchInlineSnapshot(`
           [
             {
@@ -19017,7 +19050,7 @@ describe('streamText', () => {
           experimental_transform: stopWordTransform(),
         });
 
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -20393,7 +20426,7 @@ describe('streamText', () => {
         },
       });
 
-      const chunks = await convertAsyncIterableToArray(result.fullStream);
+      const chunks = await convertAsyncIterableToArray(result.stream);
 
       expect(chunks.filter(chunk => chunk.type === 'raw'))
         .toMatchInlineSnapshot(`
@@ -20445,7 +20478,7 @@ describe('streamText', () => {
         },
       });
 
-      const chunks = await convertAsyncIterableToArray(result.fullStream);
+      const chunks = await convertAsyncIterableToArray(result.stream);
 
       expect(chunks.filter(chunk => chunk.type === 'raw')).toHaveLength(0);
     });
@@ -20891,7 +20924,7 @@ describe('streamText', () => {
       });
 
       it('should return the full stream with the correct parts', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -21289,7 +21322,7 @@ describe('streamText', () => {
       it.skipIf(isNodeVersionAtLeast(24, 15))(
         'should only stream initial chunks in full stream',
         async () => {
-          expect(await convertAsyncIterableToArray(result.fullStream))
+          expect(await convertAsyncIterableToArray(result.stream))
             .toMatchInlineSnapshot(`
               [
                 {
@@ -21367,7 +21400,7 @@ describe('streamText', () => {
           prompt: 'test-input',
         });
 
-        expect(await convertAsyncIterableToArray(resultWithReason.fullStream))
+        expect(await convertAsyncIterableToArray(resultWithReason.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -21625,7 +21658,7 @@ describe('streamText', () => {
       });
 
       it('should only stream initial chunks in full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -21872,7 +21905,7 @@ describe('streamText', () => {
       });
 
       it('should end full stream with abort part', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -22321,7 +22354,7 @@ describe('streamText', () => {
       });
 
       it('should add tool call and result error parts to the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -22580,7 +22613,7 @@ describe('streamText', () => {
       });
 
       it('should include preliminary tool results in full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -23003,7 +23036,7 @@ describe('streamText', () => {
       });
 
       it('should set dynamic and providerExecuted in full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -24371,9 +24404,9 @@ describe('streamText', () => {
         });
       });
 
-      describe('fullStream events', () => {
+      describe('stream events', () => {
         it('should emit correct stream parts including tool calls and deferred results', async () => {
-          expect(await convertAsyncIterableToArray(result.fullStream))
+          expect(await convertAsyncIterableToArray(result.stream))
             .toMatchInlineSnapshot(`
               [
                 {
@@ -25311,7 +25344,7 @@ describe('streamText', () => {
       });
 
       it('should add tool approval requests to the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -26109,7 +26142,7 @@ describe('streamText', () => {
       });
 
       it('should add tool approval requests to the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -26734,7 +26767,7 @@ describe('streamText', () => {
       });
 
       it('should include the tool result in the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -27165,7 +27198,7 @@ describe('streamText', () => {
       });
 
       it('should include the tool result in the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -27510,7 +27543,7 @@ describe('streamText', () => {
       });
 
       it('should include the tool denied in the full stream', async () => {
-        expect(await convertAsyncIterableToArray(result.fullStream))
+        expect(await convertAsyncIterableToArray(result.stream))
           .toMatchInlineSnapshot(`
             [
               {
@@ -27689,7 +27722,7 @@ describe('streamText', () => {
         });
 
         it('should add provider-executed tool approval request to full stream', async () => {
-          expect(await convertAsyncIterableToArray(result.fullStream))
+          expect(await convertAsyncIterableToArray(result.stream))
             .toMatchInlineSnapshot(`
               [
                 {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2248,7 +2248,7 @@ class DefaultStreamTextResult<
     );
   }
 
-  get fullStream(): AsyncIterableStream<TextStreamPart<TOOLS>> {
+  get stream(): AsyncIterableStream<TextStreamPart<TOOLS>> {
     return createAsyncIterableStream(
       this.teeStream().pipeThrough(
         new TransformStream<
@@ -2263,10 +2263,14 @@ class DefaultStreamTextResult<
     );
   }
 
+  get fullStream(): AsyncIterableStream<TextStreamPart<TOOLS>> {
+    return this.stream;
+  }
+
   async consumeStream(options?: ConsumeStreamOptions): Promise<void> {
     try {
       await consumeStream({
-        stream: this.fullStream,
+        stream: this.stream,
         onError: options?.onError,
       });
     } catch (error) {
@@ -2358,7 +2362,7 @@ class DefaultStreamTextResult<
       return tool?.type === 'dynamic' ? true : undefined;
     };
 
-    const baseStream = this.fullStream.pipeThrough(
+    const baseStream = this.stream.pipeThrough(
       new TransformStream<
         TextStreamPart<TOOLS>,
         UIMessageChunk<

--- a/packages/ai/src/middleware/extract-json-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.test.ts
@@ -409,8 +409,8 @@ describe('extractJsonMiddleware', () => {
         prompt: 'Generate JSON',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
-      const toolInputStart = fullStream.find(
+      const stream = await convertAsyncIterableToArray(result.stream);
+      const toolInputStart = stream.find(
         chunk => chunk.type === 'tool-input-start',
       );
       expect(toolInputStart).toBeDefined();
@@ -455,10 +455,8 @@ describe('extractJsonMiddleware', () => {
         prompt: 'Generate JSON',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
-      const textDeltas = fullStream.filter(
-        chunk => chunk.type === 'text-delta',
-      );
+      const stream = await convertAsyncIterableToArray(result.stream);
+      const textDeltas = stream.filter(chunk => chunk.type === 'text-delta');
 
       const allText = textDeltas.map(d => d.text).join('');
       expect(allText).toContain('{"first": true}');
@@ -497,10 +495,8 @@ describe('extractJsonMiddleware', () => {
         prompt: 'Generate JSON',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
-      const textDeltas = fullStream.filter(
-        chunk => chunk.type === 'text-delta',
-      );
+      const stream = await convertAsyncIterableToArray(result.stream);
+      const textDeltas = stream.filter(chunk => chunk.type === 'text-delta');
       expect(textDeltas.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -537,11 +533,9 @@ describe('extractJsonMiddleware', () => {
         prompt: 'Generate JSON',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
-      const textStarts = fullStream.filter(
-        chunk => chunk.type === 'text-start',
-      );
-      const textEnds = fullStream.filter(chunk => chunk.type === 'text-end');
+      const stream = await convertAsyncIterableToArray(result.stream);
+      const textStarts = stream.filter(chunk => chunk.type === 'text-start');
+      const textEnds = stream.filter(chunk => chunk.type === 'text-end');
 
       expect(textStarts.length).toBe(1);
       expect(textEnds.length).toBe(1);
@@ -740,14 +734,14 @@ describe('extractJsonMiddleware', () => {
         prompt: 'Generate JSON',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
+      const stream = await convertAsyncIterableToArray(result.stream);
 
-      expect(fullStream.find(c => c.type === 'start')).toBeDefined();
-      expect(fullStream.find(c => c.type === 'text-start')).toBeDefined();
-      expect(fullStream.find(c => c.type === 'text-end')).toBeDefined();
-      expect(fullStream.find(c => c.type === 'finish')).toBeDefined();
+      expect(stream.find(c => c.type === 'start')).toBeDefined();
+      expect(stream.find(c => c.type === 'text-start')).toBeDefined();
+      expect(stream.find(c => c.type === 'text-end')).toBeDefined();
+      expect(stream.find(c => c.type === 'finish')).toBeDefined();
 
-      const textDeltas = fullStream.filter(c => c.type === 'text-delta');
+      const textDeltas = stream.filter(c => c.type === 'text-delta');
       const combinedText = textDeltas.map(d => d.text).join('');
       expect(combinedText).toBe('{"value": "test"}');
     });

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -24,7 +24,7 @@ const testUsage: LanguageModelV4Usage = {
   },
 };
 
-function normalizeFullStreamPerformance(parts: Array<TextStreamPart<any>>) {
+function normalizeStreamPerformance(parts: Array<TextStreamPart<any>>) {
   return parts.map(part =>
     part.type === 'finish-step'
       ? {
@@ -307,8 +307,8 @@ describe('extractReasoningMiddleware', () => {
       });
 
       expect(
-        normalizeFullStreamPerformance(
-          await convertAsyncIterableToArray(result.fullStream),
+        normalizeStreamPerformance(
+          await convertAsyncIterableToArray(result.stream),
         ),
       ).toMatchInlineSnapshot(`
         [
@@ -461,8 +461,8 @@ describe('extractReasoningMiddleware', () => {
       });
 
       expect(
-        normalizeFullStreamPerformance(
-          await convertAsyncIterableToArray(result.fullStream),
+        normalizeStreamPerformance(
+          await convertAsyncIterableToArray(result.stream),
         ),
       ).toMatchInlineSnapshot(`
         [
@@ -623,8 +623,8 @@ describe('extractReasoningMiddleware', () => {
       });
 
       expect(
-        normalizeFullStreamPerformance(
-          await convertAsyncIterableToArray(result.fullStream),
+        normalizeStreamPerformance(
+          await convertAsyncIterableToArray(result.stream),
         ),
       ).toMatchInlineSnapshot(`
         [
@@ -775,8 +775,8 @@ describe('extractReasoningMiddleware', () => {
       });
 
       expect(
-        normalizeFullStreamPerformance(
-          await convertAsyncIterableToArray(resultTrue.fullStream),
+        normalizeStreamPerformance(
+          await convertAsyncIterableToArray(resultTrue.stream),
         ),
       ).toMatchInlineSnapshot(`
         [
@@ -886,8 +886,8 @@ describe('extractReasoningMiddleware', () => {
       `);
 
       expect(
-        normalizeFullStreamPerformance(
-          await convertAsyncIterableToArray(resultFalse.fullStream),
+        normalizeStreamPerformance(
+          await convertAsyncIterableToArray(resultFalse.stream),
         ),
       ).toMatchInlineSnapshot(`
         [
@@ -1028,8 +1028,8 @@ describe('extractReasoningMiddleware', () => {
       });
 
       expect(
-        normalizeFullStreamPerformance(
-          await convertAsyncIterableToArray(result.fullStream),
+        normalizeStreamPerformance(
+          await convertAsyncIterableToArray(result.stream),
         ),
       ).toMatchInlineSnapshot(`
         [
@@ -1151,13 +1151,13 @@ describe('extractReasoningMiddleware', () => {
         prompt: 'Test prompt',
       });
 
-      const fullStream = await convertAsyncIterableToArray(result.fullStream);
+      const stream = await convertAsyncIterableToArray(result.stream);
 
       // Find the reasoning events
-      const reasoningStartIndex = fullStream.findIndex(
+      const reasoningStartIndex = stream.findIndex(
         part => part.type === 'reasoning-start' && part.id === 'reasoning-0',
       );
-      const reasoningEndIndex = fullStream.findIndex(
+      const reasoningEndIndex = stream.findIndex(
         part => part.type === 'reasoning-end' && part.id === 'reasoning-0',
       );
 

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -77,7 +77,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream))
+    expect(await convertAsyncIterableToArray(result.stream))
       .toMatchInlineSnapshot(`
         [
           {
@@ -193,7 +193,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream))
+    expect(await convertAsyncIterableToArray(result.stream))
       .toMatchInlineSnapshot(`
         [
           {
@@ -343,7 +343,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream))
+    expect(await convertAsyncIterableToArray(result.stream))
       .toMatchInlineSnapshot(`
         [
           {
@@ -524,7 +524,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream))
+    expect(await convertAsyncIterableToArray(result.stream))
       .toMatchInlineSnapshot(`
         [
           {
@@ -705,7 +705,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream))
+    expect(await convertAsyncIterableToArray(result.stream))
       .toMatchInlineSnapshot(`
         [
           {
@@ -844,7 +844,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream))
+    expect(await convertAsyncIterableToArray(result.stream))
       .toMatchInlineSnapshot(`
         [
           {
@@ -957,9 +957,7 @@ describe('simulateStreamingMiddleware', () => {
       ...DEFAULT_SETTINGs,
     });
 
-    expect(
-      await convertAsyncIterableToArray(result.fullStream),
-    ).toMatchSnapshot();
+    expect(await convertAsyncIterableToArray(result.stream)).toMatchSnapshot();
   });
 
   it('should pass through warnings from the model', async () => {

--- a/packages/groq/README.md
+++ b/packages/groq/README.md
@@ -76,7 +76,7 @@ const result = streamText({
   toolChoice: 'required',
 });
 
-for await (const delta of result.fullStream) {
+for await (const delta of result.stream) {
   if (delta.type === 'text-delta') {
     process.stdout.write(delta.text);
   }


### PR DESCRIPTION
## Background

In preparation of https://github.com/vercel/ai/pull/14652
Follow up to https://github.com/vercel/ai/commit/b095aef28f21c44377fcbe227264c3fa99c05a80

## Summary

- introduces `response.stream` as a replacement for `response.fullStream`
- deprecates `response.fullStream`

Note: I didn't update `streamObject` since it's deprecated and due to be removed anyway.

## Manual Verification

Ran examples

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

https://github.com/vercel/ai/pull/14652

## Related Issues

https://github.com/vercel/ai/pull/14652