### PR TITLE
fix(otel): ensure nested context object creates separate attribute

### DIFF
--- a/.changeset/mighty-drinks-sniff.md
+++ b/.changeset/mighty-drinks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/otel": patch
+---
+
+fix(otel): ensure nested context object creates separate attribute

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider-utils": "workspace:*",
+    "@opentelemetry/sdk-trace-base": "2.7.1",
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",

--- a/packages/otel/src/get-base-telemetry-attributes.ts
+++ b/packages/otel/src/get-base-telemetry-attributes.ts
@@ -1,5 +1,6 @@
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import type { LanguageModelCallOptions } from 'ai';
+import { getRuntimeContextAttributes } from './supplemental-attributes';
 
 export function getBaseTelemetryAttributes({
   model,
@@ -23,12 +24,7 @@ export function getBaseTelemetryAttributes({
     }, {} as Attributes),
 
     // add context as attributes:
-    ...Object.entries(context ?? {}).reduce((attributes, [key, value]) => {
-      if (value != undefined) {
-        attributes[`ai.settings.context.${key}`] = value as AttributeValue;
-      }
-      return attributes;
-    }, {} as Attributes),
+    ...(getRuntimeContextAttributes(context) as Attributes),
 
     // request headers
     ...Object.entries(headers ?? {}).reduce((attributes, [key, value]) => {

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -7,6 +7,11 @@ import {
   type SpanOptions,
   type Tracer,
 } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import type { GenerateTextEndEvent, Telemetry } from 'ai';
 import { OpenTelemetry, type EnrichSpan } from './open-telemetry';
 
@@ -77,6 +82,24 @@ function createMockTracer(): MockTracer {
     startActiveSpan: vi.fn() as Tracer['startActiveSpan'],
   };
   return tracer;
+}
+
+function createSdkTracer() {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+
+  return {
+    exporter,
+    tracer: provider.getTracer('test-tracer'),
+  };
+}
+
+function getExportedSpan(exporter: InMemorySpanExporter, name: string) {
+  const span = exporter.getFinishedSpans().find(span => span.name === name);
+  expect(span).toBeDefined();
+  return span!;
 }
 
 function getStartSpanAttributes(
@@ -1118,6 +1141,56 @@ describe('OpenTelemetry', () => {
   });
 
   describe('supplemental attributes', () => {
+    it('exports flat runtime context attribute keys', () => {
+      const sdkTrace = createSdkTracer();
+      integration = new OpenTelemetry({
+        tracer: sdkTrace.tracer,
+        runtimeContext: true,
+      });
+
+      integration.onStart!(
+        makeOnStartEvent({
+          runtimeContext: { 'foo.bar': 'baz' },
+        }),
+      );
+      integration.onEnd!(makeFinishEvent());
+
+      const rootSpan = getExportedSpan(sdkTrace.exporter, 'invoke_agent gpt-4');
+      expect({
+        'ai.settings.context.foo.bar':
+          rootSpan.attributes['ai.settings.context.foo.bar'],
+      }).toMatchInlineSnapshot(`
+        {
+          "ai.settings.context.foo.bar": "baz",
+        }
+      `);
+    });
+
+    it('exports nested runtime context attributes', () => {
+      const sdkTrace = createSdkTracer();
+      integration = new OpenTelemetry({
+        tracer: sdkTrace.tracer,
+        runtimeContext: true,
+      });
+
+      integration.onStart!(
+        makeOnStartEvent({
+          runtimeContext: { foo: { bar: 'baz' } },
+        }),
+      );
+      integration.onEnd!(makeFinishEvent());
+
+      const rootSpan = getExportedSpan(sdkTrace.exporter, 'invoke_agent gpt-4');
+      expect({
+        'ai.settings.context.foo.bar':
+          rootSpan.attributes['ai.settings.context.foo.bar'],
+      }).toMatchInlineSnapshot(`
+        {
+          "ai.settings.context.foo.bar": "baz",
+        }
+      `);
+    });
+
     it('emits supplemental AI SDK attributes on existing spans when enabled', () => {
       integration = new OpenTelemetry({
         tracer,

--- a/packages/otel/src/supplemental-attributes.ts
+++ b/packages/otel/src/supplemental-attributes.ts
@@ -1,6 +1,10 @@
 import type { Attributes, Tracer } from '@opentelemetry/api';
 import type { TelemetryOptions } from 'ai';
-import { selectAttributes, type AttributeSpecMap } from './select-attributes';
+import {
+  selectAttributes,
+  type AttributeSpec,
+  type AttributeSpecMap,
+} from './select-attributes';
 
 type SupplementalAttributeOption =
   | 'usage'
@@ -115,11 +119,36 @@ export function normalizeSupplementalAttributes(
 export function getRuntimeContextAttributes(
   context: Record<string, unknown> | undefined,
 ): AttributeSpecMap {
-  return Object.fromEntries(
-    Object.entries(context ?? {})
-      .filter(([, value]) => value != null)
-      .map(([key, value]) => [`ai.settings.context.${key}`, value]),
-  ) as AttributeSpecMap;
+  const attributes: AttributeSpecMap = {};
+
+  for (const [key, value] of Object.entries(context ?? {})) {
+    addRuntimeContextAttribute(attributes, `ai.settings.context.${key}`, value);
+  }
+
+  return attributes;
+}
+
+/**
+ * Flattens nested runtime context objects into OTel-compatible attribute keys.
+ * Arrays are preserved because OTel supports primitive array attribute values.
+ */
+function addRuntimeContextAttribute(
+  attributes: AttributeSpecMap,
+  key: string,
+  value: unknown,
+): void {
+  if (value == null) {
+    return;
+  }
+
+  if (Array.isArray(value) || typeof value !== 'object') {
+    attributes[key] = value as AttributeSpec;
+    return;
+  }
+
+  for (const [nestedKey, nestedValue] of Object.entries(value)) {
+    addRuntimeContextAttribute(attributes, `${key}.${nestedKey}`, nestedValue);
+  }
 }
 
 export function getHeaderAttributes(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2710,6 +2710,9 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19


### PR DESCRIPTION
## Background

for a nested runtime context defined as

```ts
runtimeContext: {
  userId: 'user-123',
  metadata: {
    tenant: 'acme',
    plan: 'pro',
  },
}
```

the spans we produced looked like

```
{
  'ai.settings.context.userId': 'user-123',
  'ai.settings.context.metadata': { tenant: 'acme', plan: 'pro' },
}
```

but the second attribute, which is an object, is not a valid OpenTelemetry span attribute value, so real OTel exporters drop it. Which would result in traces like

```
{
  'ai.settings.context.userId': 'user-123',
}
``` 

## Summary

After the change, nested context is flattened into valid primitive attributes:

```
{
  'ai.settings.context.userId': 'user-123',
  'ai.settings.context.metadata.tenant': 'acme',
  'ai.settings.context.metadata.plan': 'pro',
}
```

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)