### PR TITLE
feat(openai): forward web_search_call.action.queries from Responses API

### DIFF
--- a/.changeset/openai-responses-web-search-queries.md
+++ b/.changeset/openai-responses-web-search-queries.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(openai): forward `web_search_call.action.queries` from Responses API

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -750,6 +750,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
                 z.object({
                   type: z.literal('search'),
                   query: z.string().nullish(),
+                  queries: z.array(z.string()).nullish(),
                   sources: z
                     .array(
                       z.discriminatedUnion('type', [
@@ -1147,6 +1148,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
                   z.object({
                     type: z.literal('search'),
                     query: z.string().nullish(),
+                    queries: z.array(z.string()).nullish(),
                     sources: z
                       .array(
                         z.discriminatedUnion('type', [

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -4003,6 +4003,93 @@ describe('OpenAIResponsesLanguageModel', () => {
           result: {},
         });
       });
+
+      it('should forward web_search_call.action.queries to tool-result', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_queries',
+            object: 'response',
+            created_at: 1741631111,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            instructions: null,
+            max_output_tokens: null,
+            model: 'gpt-4o',
+            output: [
+              {
+                type: 'web_search_call',
+                id: 'ws_queries',
+                status: 'completed',
+                action: {
+                  type: 'search',
+                  query: 'sf news',
+                  queries: ['sf news', 'bay area tech'],
+                },
+              },
+              {
+                type: 'message',
+                id: 'msg_done',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Here is what I found.',
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+            usage: {
+              input_tokens: 10,
+              output_tokens: 5,
+              total_tokens: 15,
+            },
+            previous_response_id: null,
+            parallel_tool_calls: true,
+            reasoning: { effort: null, summary: null },
+            store: true,
+            temperature: 0,
+            text: { format: { type: 'text' } },
+            tool_choice: 'auto',
+            tools: [{ type: 'web_search', search_context_size: 'medium' }],
+            top_p: 1,
+            truncation: 'disabled',
+            user: null,
+            metadata: {},
+          },
+        };
+
+        const result = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'openai.web_search',
+              name: 'webSearch',
+              args: {},
+            },
+          ],
+        });
+
+        const webSearchResultPart = result.content.find(
+          part => part.type === 'tool-result',
+        );
+
+        expect(webSearchResultPart).toMatchObject({
+          type: 'tool-result',
+          toolName: 'webSearch',
+          result: {
+            action: {
+              type: 'search',
+              query: 'sf news',
+              queries: ['sf news', 'bay area tech'],
+            },
+          },
+        });
+      });
     });
 
     describe('mcp tool', () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -2302,7 +2302,11 @@ function mapWebSearchOutput(
   switch (action.type) {
     case 'search':
       return {
-        action: { type: 'search', query: action.query ?? undefined },
+        action: {
+          type: 'search',
+          query: action.query ?? undefined,
+          ...(action.queries != null && { queries: action.queries }),
+        },
         // include sources when provided by the Responses API (behind include flag)
         ...(action.sources != null && { sources: action.sources }),
       };

--- a/packages/openai/src/tool/web-search.ts
+++ b/packages/openai/src/tool/web-search.ts
@@ -80,8 +80,7 @@ export const webSearchToolFactory = createProviderExecutedToolFactory<
           /**
            * The search query.
            *
-           * @deprecated Use `queries` instead. The OpenAI Responses API marks
-           * this single-query field as deprecated in favor of `queries`.
+           * @deprecated Use `queries` instead.
            */
           query?: string;
 

--- a/packages/openai/src/tool/web-search.ts
+++ b/packages/openai/src/tool/web-search.ts
@@ -36,6 +36,7 @@ export const webSearchOutputSchema = lazySchema(() =>
           z.object({
             type: z.literal('search'),
             query: z.string().optional(),
+            queries: z.array(z.string()).optional(),
           }),
           z.object({
             type: z.literal('openPage'),
@@ -78,8 +79,16 @@ export const webSearchToolFactory = createProviderExecutedToolFactory<
 
           /**
            * The search query.
+           *
+           * @deprecated Use `queries` instead. The OpenAI Responses API marks
+           * this single-query field as deprecated in favor of `queries`.
            */
           query?: string;
+
+          /**
+           * The search queries the model used.
+           */
+          queries?: string[];
         }
       | {
           /**


### PR DESCRIPTION
## Background

The OpenAI Responses API returns both `action.query` and `action.queries` on `web_search_call` items:

```yaml
WebSearchActionSearch:
  properties:
    query: { type: string, description: "[DEPRECATED] The search query." }
    queries: { type: array, items: { type: string }, description: "The search queries." }
  required:
    - type
    - query
```

(from [`openai/openai-openapi`](https://github.com/openai/openai-openapi))

The current Zod schemas in this package only parse `query`. When OpenAI emits a multi-query search, the array is dropped on the floor before it reaches consumers via `tool-result`. The Vercel AI Gateway hit this gap building OpenResponses-compatible responses for Grok CLI — when a downstream client expected the spec-current `queries` field, it had to fabricate it from the deprecated `query` string, which is lossy for multi-query searches.

## Changes

- Adds `queries: z.array(z.string()).nullish()` to the `web_search_call.action.search` discriminator in both the non-streaming response schema and the streaming `output_item.done` schema (`openai-responses-api.ts`).
- Adds `queries?: string[]` to `webSearchOutputSchema` and the tool factory's TypeScript output type (`tool/web-search.ts`). Marks the existing `query` field as `@deprecated` in JSDoc, matching the upstream API's annotation.
- Updates `mapWebSearchOutput` in `openai-responses-language-model.ts` to forward `queries` to the tool-result when present.
- New test: asserts that `queries: ['sf news', 'bay area tech']` from OpenAI is preserved on the resulting `tool-result.result.action.queries`.

## Test plan

- [x] `pnpm --filter @ai-sdk/openai test:node` (715 tests pass)