### PR TITLE
fix(google): round-trip provider code execution parts

### DIFF
--- a/.changeset/fix-google-code-execution-roundtrip.md
+++ b/.changeset/fix-google-code-execution-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Fix Google message conversion to replay provider-executed code execution calls and results as `executableCode` and `codeExecutionResult` parts.

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -1458,6 +1458,98 @@ describe('tool results with thought signatures', () => {
 });
 
 describe('server tool combination round-trip', () => {
+  it('should convert provider-executed code execution parts back to code execution wire format', () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'code-execution-1',
+            toolName: 'code_execution',
+            input: JSON.stringify({
+              language: 'PYTHON',
+              code: 'print(2 + 2)',
+            }),
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'code-execution-1',
+            toolName: 'code_execution',
+            output: {
+              type: 'json',
+              value: {
+                outcome: 'OUTCOME_OK',
+                output: '4\n',
+              },
+            },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'list-items-1',
+            toolName: 'listItems',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'list-items-1',
+            toolName: 'listItems',
+            output: { type: 'json', value: { items: ['a', 'b'] } },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents).toEqual([
+      {
+        role: 'model',
+        parts: [
+          {
+            executableCode: {
+              language: 'PYTHON',
+              code: 'print(2 + 2)',
+            },
+          },
+          {
+            codeExecutionResult: {
+              outcome: 'OUTCOME_OK',
+              output: '4\n',
+            },
+          },
+          {
+            functionCall: {
+              id: 'list-items-1',
+              name: 'listItems',
+              args: {},
+            },
+            thoughtSignature: undefined,
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'list-items-1',
+              name: 'listItems',
+              response: {
+                name: 'listItems',
+                content: { items: ['a', 'b'] },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should convert assistant tool-call with serverToolCallId to toolCall wire format', () => {
     const result = convertToGoogleMessages([
       {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -189,6 +189,66 @@ function appendLegacyToolResultParts(
   }
 }
 
+function parsePotentialJsonValue(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function asExecutableCode(value: unknown):
+  | {
+      language: string;
+      code: string;
+    }
+  | undefined {
+  const parsedValue = parsePotentialJsonValue(value);
+
+  if (
+    parsedValue != null &&
+    typeof parsedValue === 'object' &&
+    'language' in parsedValue &&
+    typeof parsedValue.language === 'string' &&
+    'code' in parsedValue &&
+    typeof parsedValue.code === 'string'
+  ) {
+    return {
+      language: parsedValue.language,
+      code: parsedValue.code,
+    };
+  }
+
+  return undefined;
+}
+
+function asCodeExecutionResult(
+  output: LanguageModelV4ToolResultOutput,
+): { outcome: string; output: string } | undefined {
+  const value = output.type === 'json' ? output.value : undefined;
+
+  if (
+    value != null &&
+    typeof value === 'object' &&
+    'outcome' in value &&
+    typeof value.outcome === 'string'
+  ) {
+    return {
+      outcome: value.outcome,
+      output:
+        'output' in value && typeof value.output === 'string'
+          ? value.output
+          : '',
+    };
+  }
+
+  return undefined;
+}
+
 export function convertToGoogleMessages(
   prompt: LanguageModelV4Prompt,
   options?: {
@@ -448,6 +508,17 @@ export function convertToGoogleMessages(
                 }
 
                 case 'tool-call': {
+                  if (
+                    part.providerExecuted === true &&
+                    part.toolName === 'code_execution'
+                  ) {
+                    const executableCode = asExecutableCode(part.input);
+
+                    if (executableCode != null) {
+                      return { executableCode };
+                    }
+                  }
+
                   const serverToolCallId =
                     providerOpts?.serverToolCallId != null
                       ? String(providerOpts.serverToolCallId)
@@ -489,6 +560,16 @@ export function convertToGoogleMessages(
                 }
 
                 case 'tool-result': {
+                  if (part.toolName === 'code_execution') {
+                    const codeExecutionResult = asCodeExecutionResult(
+                      part.output,
+                    );
+
+                    if (codeExecutionResult != null) {
+                      return { codeExecutionResult };
+                    }
+                  }
+
                   const serverToolCallId =
                     providerOpts?.serverToolCallId != null
                       ? String(providerOpts.serverToolCallId)

--- a/packages/google/src/google-prompt.ts
+++ b/packages/google/src/google-prompt.ts
@@ -32,6 +32,12 @@ export type GoogleContentPart =
       thoughtSignature?: string;
     }
   | {
+      executableCode: { language: string; code: string };
+    }
+  | {
+      codeExecutionResult: { outcome: string; output: string };
+    }
+  | {
       functionResponse: {
         id?: string;
         name: string;


### PR DESCRIPTION
## Summary

Closes #15613.

Fixes Google message conversion so provider-executed `code_execution` calls and results are replayed as Gemini code execution content parts instead of being converted to a regular `functionCall` or dropped.

## Details

- Converts provider-executed `code_execution` tool calls back to `executableCode` parts.
- Converts persisted `code_execution` tool results back to `codeExecutionResult` parts.
- Keeps regular client tool calls/results on the existing `functionCall` / `functionResponse` path.
- Adds a patch changeset for `@ai-sdk/google`.

## Tests

- `pnpm --filter @ai-sdk/google test`
- `pnpm --filter @ai-sdk/google type-check`
- `pnpm --filter @ai-sdk/google build`
- `pnpm exec oxfmt --check packages/google/src/convert-to-google-messages.ts packages/google/src/convert-to-google-messages.test.ts packages/google/src/google-prompt.ts`
- `git diff --check`