### PR TITLE
fix(google): omit function ids for vertex requests

### DIFF
--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -138,7 +138,6 @@ describe('thought signatures with vertex providerOptionsName', () => {
                   "args": {
                     "location": "London",
                   },
-                  "id": "call1",
                   "name": "getWeather",
                 },
                 "thoughtSignature": "sig3",
@@ -176,7 +175,6 @@ describe('thought signatures with vertex providerOptionsName', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
-        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
@@ -207,7 +205,6 @@ describe('thought signatures with vertex providerOptionsName', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
-        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -75,6 +75,7 @@ function appendToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  includeToolCallId = true,
 ): void {
   const functionResponseParts: GoogleFunctionResponsePart[] = [];
   const responseTextParts: string[] = [];
@@ -117,7 +118,7 @@ function appendToolResultParts(
 
   parts.push({
     functionResponse: {
-      ...(toolCallId != null ? { id: toolCallId } : {}),
+      ...(includeToolCallId && toolCallId != null ? { id: toolCallId } : {}),
       name: toolName,
       response: {
         name: toolName,
@@ -146,13 +147,16 @@ function appendLegacyToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  includeToolCallId = true,
 ): void {
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
       case 'text':
         parts.push({
           functionResponse: {
-            ...(toolCallId != null ? { id: toolCallId } : {}),
+            ...(includeToolCallId && toolCallId != null
+              ? { id: toolCallId }
+              : {}),
             name: toolName,
             response: {
               name: toolName,
@@ -213,6 +217,7 @@ export function convertToGoogleMessages(
   const onWarning = options?.onWarning;
   const providerOptionsNames = options?.providerOptionsNames ?? ['google'];
   const isVertexLike = !providerOptionsNames.includes('google');
+  const includeFunctionCallIds = !isVertexLike;
   const supportsFunctionResponseParts =
     options?.supportsFunctionResponseParts ?? true;
 
@@ -478,7 +483,7 @@ export function convertToGoogleMessages(
 
                   return {
                     functionCall: {
-                      ...(part.toolCallId != null
+                      ...(includeFunctionCallIds && part.toolCallId != null
                         ? { id: part.toolCallId }
                         : {}),
                       name: part.toolName,
@@ -572,6 +577,7 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                includeFunctionCallIds,
               );
             } else {
               appendLegacyToolResultParts(
@@ -579,12 +585,15 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                includeFunctionCallIds,
               );
             }
           } else {
             parts.push({
               functionResponse: {
-                ...(part.toolCallId != null ? { id: part.toolCallId } : {}),
+                ...(includeFunctionCallIds && part.toolCallId != null
+                  ? { id: part.toolCallId }
+                  : {}),
                 name: part.toolName,
                 response: {
                   name: part.toolName,

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -656,6 +656,94 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should omit functionCall and functionResponse ids on Vertex', async () => {
+    prepareJsonResponse({ content: 'test response' });
+
+    const vertexModel = new GoogleLanguageModel('gemini-pro', {
+      provider: 'google.vertex.chat',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await vertexModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the weather?' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'weather',
+              input: { location: 'Stockholm' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'weather',
+              output: {
+                type: 'json',
+                value: { temperature: 21 },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody).toMatchObject({
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'What is the weather?' }],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'weather',
+                args: { location: 'Stockholm' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'weather',
+                response: {
+                  name: 'weather',
+                  content: { temperature: 21 },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(requestBody.contents[1].parts[0].functionCall).not.toHaveProperty(
+      'id',
+    );
+    expect(
+      requestBody.contents[2].parts[0].functionResponse,
+    ).not.toHaveProperty('id');
+  });
+
   it('should warn and drop serviceTier on Vertex provider', async () => {
     prepareJsonResponse({ content: 'test response' });
 


### PR DESCRIPTION
Closes #15664

## Summary

Vertex native `generateContent` rejects `functionCall.id` and `functionResponse.id`, but the Google message serializer was sending AI SDK `toolCallId` values into those fields for Vertex requests.

This keeps the ids for Gemini Developer API requests and omits them only when serializing through the Vertex provider path.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [ai-sdk-vertex-function-id](https://stackblitz.com/github/onmax/repros/tree/repro/ai-sdk-vertex-function-id/ai-sdk-vertex-function-id?startScript=repro) | Fails with Vertex schema error |
| Fix | [ai-sdk-vertex-function-id-fix](https://stackblitz.com/github/onmax/repros/tree/repro/ai-sdk-vertex-function-id/ai-sdk-vertex-function-id-fix?startScript=repro) | Request omits unsupported function ids |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/ai-sdk-vertex-function-id https://github.com/onmax/repros.git
cd repros && git sparse-checkout set ai-sdk-vertex-function-id
cd ai-sdk-vertex-function-id && pnpm i
VERTEX_API_KEY=... pnpm repro
```

## Verify fix

```bash
git sparse-checkout add ai-sdk-vertex-function-id-fix
cd ../ai-sdk-vertex-function-id-fix && pnpm i
VERTEX_API_KEY=... pnpm repro
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related

- https://github.com/vercel/ai/issues/15664

## Checks

```bash
pnpm --filter @ai-sdk/google test:node
pnpm --filter @ai-sdk/google type-check
```
