### PR TITLE
fix(docs): correct OpenRouter documentation link path

### DIFF
--- a/content/providers/03-community-providers/01-custom-providers.mdx
+++ b/content/providers/03-community-providers/01-custom-providers.mdx
@@ -9,7 +9,7 @@ The AI SDK provides a [Language Model Specification](https://github.com/vercel/a
 
 ## Publishing Your Provider
 
-Please publish your custom provider in your own GitHub repository and as an NPM package. You are responsible for hosting and maintaining your provider. Once published, you can submit a PR to the AI SDK repository to add your provider to the [Community Providers](/providers/community-providers) documentation section. Use the [OpenRouter provider documentation](https://github.com/vercel/ai/blob/main/content/providers/03-community-providers/13-openrouter.mdx) as a template for your documentation.
+Please publish your custom provider in your own GitHub repository and as an NPM package. You are responsible for hosting and maintaining your provider. Once published, you can submit a PR to the AI SDK repository to add your provider to the [Community Providers](/providers/community-providers) documentation section. Use the [OpenRouter provider documentation](https://github.com/vercel/ai/blob/main/content/providers/03-community-providers/32-openrouter.mdx) as a template for your documentation.
 
 ## Why the Language Model Specification?
 


### PR DESCRIPTION
#### Found this while reading the docs to register a custom provider as a community provider.
The OpenRouter provider doc was renamed from 13-openrouter.mdx to 32-openrouter.mdx when community providers were reordered alphabetically (#11788), but the reference link in 01-custom-providers.mdx wasn't updated.
