### PR TITLE
fix(chat): replace non-null assertion with optional chaining on activeResponse

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -757,7 +757,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     } finally {
       try {
         this.onFinish?.({
-          message: this.activeResponse!.state.message,
+          message: this.activeResponse?.state.message,
           messages: this.state.messages,
           isAbort,
           isDisconnect,


### PR DESCRIPTION
**Issue**: #15668

`Chat.makeRequest`'s `finally` block builds the `onFinish` argument using `this.activeResponse!.state.message`, but `this.activeResponse` can be `undefined` when a trigger like `'resume-stream'` overlaps another `makeRequest` call that clears the shared `this.activeResponse`. This throws:

```
Cannot read properties of undefined (reading 'state')
  at Chat.makeRequest (packages/ai/src/ui/chat.ts:760)
```

The very next line `this.activeResponse?.state.finishReason` already uses optional chaining, so the non-null assertion appears to be an oversight.

**Fix**: Change `!` to `?` — `this.activeResponse?.state.message`.