### PR TITLE
feat(gateway): add xaiSearchParameters() builder for Grok Live Search

### DIFF
--- a/.changeset/xai-responses-search-parameters.md
+++ b/.changeset/xai-responses-search-parameters.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Support `searchParameters` (xAI Live Search) on the Responses API, matching the Chat Completions model. Previously `providerOptions.xai.searchParameters` was silently dropped on `xai.responses(...)` because the Responses options schema and request body didn't handle it. When set, `search_parameters` is now serialized to the `/v1/responses` request and overrides the `web_search` provider tool, consistent with xAI's API.

--- a/.changeset/xai-search-parameters-builder.md
+++ b/.changeset/xai-search-parameters-builder.md
@@ -1,0 +1,26 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Add `xaiSearchParameters()` — a typed builder for xAI Live Search config on Grok models. Returns a `searchParameters` object (with `mode` defaulted to `'auto'`) to pass to `providerOptions.xai.searchParameters`. Use `maxSearchResults` to bound cost, plus typed `sources` for `web` / `x` / `news` / `rss` filters.
+
+This is a config builder, not an AI SDK tool: xAI Live Search is provider-native and dispatched automatically by xAI. Gateway forwards `providerOptions.xai.*` end-to-end already, so this works without further gateway changes.
+
+```ts
+import { xaiSearchParameters } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: 'xai/grok-4-fast-reasoning',
+  prompt: 'What happened in markets today?',
+  providerOptions: {
+    xai: {
+      searchParameters: xaiSearchParameters({
+        mode: 'on',
+        maxSearchResults: 5,
+        sources: [{ type: 'web', country: 'US' }],
+      }),
+    },
+  },
+});
+```

--- a/examples/ai-functions/src/generate-text/gateway/xai-search-parameters.ts
+++ b/examples/ai-functions/src/generate-text/gateway/xai-search-parameters.ts
@@ -1,0 +1,31 @@
+import { generateText } from 'ai';
+import { xaiSearchParameters } from '@ai-sdk/gateway';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'xai/grok-4-fast-reasoning',
+    prompt:
+      'What were the major AI policy announcements this week? Cite your sources.',
+    providerOptions: {
+      xai: {
+        searchParameters: xaiSearchParameters({
+          mode: 'on',
+          maxSearchResults: 5,
+          sources: [{ type: 'web', country: 'US' }, { type: 'news' }],
+        }),
+      },
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.finalStep.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -44,3 +44,11 @@ export {
 } from './errors';
 export type { GatewayErrorResponse } from './errors';
 export { VERSION } from './version';
+
+// xAI Live Search config builder (not a tool — see file header)
+export { xaiSearchParameters } from './xai-search-parameters';
+export type {
+  XaiSearchParameters,
+  XaiSearchParametersConfig,
+  XaiSearchSource,
+} from './xai-search-parameters';

--- a/packages/gateway/src/xai-search-parameters.test.ts
+++ b/packages/gateway/src/xai-search-parameters.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type XaiSearchParameters,
+  xaiSearchParameters,
+} from './xai-search-parameters';
+
+describe('xaiSearchParameters', () => {
+  it('defaults mode to "auto" when no config is passed', () => {
+    const result = xaiSearchParameters();
+    expect(result).toEqual({ mode: 'auto' });
+  });
+
+  it('defaults mode to "auto" when only other fields are set', () => {
+    const result = xaiSearchParameters({ maxSearchResults: 5 });
+    expect(result).toEqual({ mode: 'auto', maxSearchResults: 5 });
+  });
+
+  it('preserves an explicit mode over the default', () => {
+    expect(xaiSearchParameters({ mode: 'on' }).mode).toBe('on');
+    expect(xaiSearchParameters({ mode: 'off' }).mode).toBe('off');
+  });
+
+  it('treats explicit mode: undefined the same as omitted', () => {
+    const result = xaiSearchParameters({ mode: undefined });
+    expect(result.mode).toBe('auto');
+  });
+
+  it('passes through all optional fields verbatim', () => {
+    const result = xaiSearchParameters({
+      mode: 'on',
+      maxSearchResults: 10,
+      returnCitations: false,
+      fromDate: '2025-01-01',
+      toDate: '2025-12-31',
+    });
+    expect(result).toEqual({
+      mode: 'on',
+      maxSearchResults: 10,
+      returnCitations: false,
+      fromDate: '2025-01-01',
+      toDate: '2025-12-31',
+    });
+  });
+
+  it('passes through the sources discriminated union for all four types', () => {
+    const result = xaiSearchParameters({
+      sources: [
+        {
+          type: 'web',
+          country: 'US',
+          excludedWebsites: ['example.com'],
+          allowedWebsites: ['nature.com'],
+          safeSearch: true,
+        },
+        {
+          type: 'x',
+          excludedXHandles: ['bot'],
+          includedXHandles: ['elonmusk'],
+          postFavoriteCount: 10,
+          postViewCount: 100,
+        },
+        { type: 'news', country: 'GB', safeSearch: false },
+        { type: 'rss', links: ['https://example.com/feed'] },
+      ],
+    });
+    expect(result.sources).toHaveLength(4);
+    expect(result.sources?.[0]).toEqual({
+      type: 'web',
+      country: 'US',
+      excludedWebsites: ['example.com'],
+      allowedWebsites: ['nature.com'],
+      safeSearch: true,
+    });
+    expect(result.sources?.[3]).toEqual({
+      type: 'rss',
+      links: ['https://example.com/feed'],
+    });
+  });
+
+  it('returns a value assignable to XaiSearchParameters', () => {
+    // Compile-time check: the return type must satisfy XaiSearchParameters.
+    const result: XaiSearchParameters = xaiSearchParameters({
+      maxSearchResults: 3,
+    });
+    expect(result.mode).toBe('auto');
+  });
+});

--- a/packages/gateway/src/xai-search-parameters.ts
+++ b/packages/gateway/src/xai-search-parameters.ts
@@ -1,0 +1,166 @@
+import type { JSONObject } from '@ai-sdk/provider';
+
+// Source-type shapes mirror the camelCase fields in
+// `@ai-sdk/xai`'s `xaiLanguageModelChatOptions.searchParameters.sources`.
+// Keep in sync with `packages/xai/src/xai-chat-language-model-options.ts`.
+// We deliberately don't import from `@ai-sdk/xai` to avoid a cross-package
+// dep; xAI's wire-level field names are public API.
+//
+// Each source extends `JSONObject` so the result of `xaiSearchParameters()`
+// is structurally assignable to `providerOptions.xai.searchParameters`
+// (typed as `JSONValue | undefined`).
+
+/**
+ * Search a `web` source — the public web.
+ */
+export interface XaiSearchWebSource extends JSONObject {
+  type: 'web';
+  /** Two-letter ISO 3166-1 alpha-2 country code (e.g. `'US'`, `'GB'`). */
+  country?: string;
+  /** Up to 5 domains to exclude from search results. */
+  excludedWebsites?: string[];
+  /** Up to 5 domains to restrict search results to. */
+  allowedWebsites?: string[];
+  /** Whether to apply safe-search filtering. */
+  safeSearch?: boolean;
+}
+
+/**
+ * Search an `x` source — posts on X (formerly Twitter).
+ */
+export interface XaiSearchXSource extends JSONObject {
+  type: 'x';
+  /** X handles to exclude. */
+  excludedXHandles?: string[];
+  /** X handles to restrict the search to. */
+  includedXHandles?: string[];
+  /** Only include posts with at least this many favorites. */
+  postFavoriteCount?: number;
+  /** Only include posts with at least this many views. */
+  postViewCount?: number;
+}
+
+/**
+ * Search a `news` source.
+ */
+export interface XaiSearchNewsSource extends JSONObject {
+  type: 'news';
+  /** Two-letter ISO 3166-1 alpha-2 country code. */
+  country?: string;
+  /** Up to 5 news domains to exclude. */
+  excludedWebsites?: string[];
+  /** Whether to apply safe-search filtering. */
+  safeSearch?: boolean;
+}
+
+/**
+ * Search an `rss` source — fetch from a specific RSS feed.
+ */
+export interface XaiSearchRssSource extends JSONObject {
+  type: 'rss';
+  /** RSS feed URLs. xAI currently supports a single link. */
+  links: string[];
+}
+
+export type XaiSearchSource =
+  | XaiSearchNewsSource
+  | XaiSearchRssSource
+  | XaiSearchWebSource
+  | XaiSearchXSource;
+
+/**
+ * Strict input shape for `xaiSearchParameters()`. No `JSONObject` index
+ * signature — keeps typo'd keys as compile errors. Mirrors the field set of
+ * `XaiSearchParameters`; `mode` is optional here (the builder defaults it).
+ */
+export interface XaiSearchParametersConfig {
+  /**
+   * Search mode preference.
+   * - `'auto'` (default): the model decides whether to search.
+   * - `'on'`: always invoke Live Search.
+   * - `'off'`: disable Live Search (equivalent to omitting `searchParameters`).
+   */
+  mode?: 'auto' | 'off' | 'on';
+
+  /**
+   * Maximum number of search results to consider per request (1-50).
+   * Primary cost-control knob; defaults to xAI's server-side default
+   * (currently 20) when omitted.
+   */
+  maxSearchResults?: number;
+
+  /** Whether to return citations. Defaults to `true` on xAI's side. */
+  returnCitations?: boolean;
+
+  /** Earliest publication date (ISO-8601 `YYYY-MM-DD`). */
+  fromDate?: string;
+
+  /** Latest publication date (ISO-8601 `YYYY-MM-DD`). */
+  toDate?: string;
+
+  /**
+   * Data sources to search. Defaults to `[{ type: 'web' }, { type: 'x' }]`
+   * on xAI's side when omitted.
+   */
+  sources?: XaiSearchSource[];
+}
+
+/**
+ * Output of `xaiSearchParameters()` — the camelCase object assignable to
+ * `providerOptions.xai.searchParameters`. Extends `JSONObject` for that
+ * assignment to type-check; otherwise structurally identical to
+ * `XaiSearchParametersConfig` except that `mode` is always present.
+ */
+export interface XaiSearchParameters extends JSONObject {
+  mode: 'auto' | 'off' | 'on';
+  maxSearchResults?: number;
+  returnCitations?: boolean;
+  fromDate?: string;
+  toDate?: string;
+  sources?: XaiSearchSource[];
+}
+
+/**
+ * Build a typed `searchParameters` object for xAI Grok models, with `mode`
+ * defaulted to `'auto'`.
+ *
+ * This is a config builder, not an AI SDK tool: xAI Live Search is
+ * provider-native and dispatched automatically by xAI when relevant. Pass the
+ * result through `providerOptions.xai.searchParameters` — the gateway already
+ * forwards `providerOptions.xai.*` end-to-end, so no gateway-specific support
+ * is required for this to work.
+ *
+ * Value over inline construction: type-checking the config and the
+ * `sources` discriminated union (which `providerOptions` does not type),
+ * plus the `'auto'` default.
+ *
+ * Imported from `@ai-sdk/gateway` directly (not from `gateway.tools.*`,
+ * which is reserved for actual AI SDK tools the model can invoke).
+ *
+ * @example
+ * ```ts
+ * import { xaiSearchParameters } from '@ai-sdk/gateway';
+ * import { generateText } from 'ai';
+ *
+ * const result = await generateText({
+ *   model: 'xai/grok-4-fast-reasoning',
+ *   prompt: 'What happened in markets today?',
+ *   providerOptions: {
+ *     xai: {
+ *       searchParameters: xaiSearchParameters({
+ *         mode: 'on',
+ *         maxSearchResults: 5,
+ *         sources: [{ type: 'web', country: 'US' }],
+ *       }),
+ *     },
+ *   },
+ * });
+ * ```
+ *
+ * @see https://docs.x.ai/docs/guides/live-search
+ */
+export function xaiSearchParameters(
+  config: XaiSearchParametersConfig = {},
+): XaiSearchParameters {
+  return { ...config, mode: config.mode ?? 'auto' };
+}

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -7,6 +7,47 @@ export type XaiResponsesModelId =
   | 'grok-latest'
   | (string & {});
 
+// search source schemas
+// Kept in sync with `xai-chat-language-model-options.ts`.
+const webSourceSchema = z.object({
+  type: z.literal('web'),
+  country: z.string().length(2).optional(),
+  excludedWebsites: z.array(z.string()).max(5).optional(),
+  allowedWebsites: z.array(z.string()).max(5).optional(),
+  safeSearch: z.boolean().optional(),
+});
+
+const xSourceSchema = z.object({
+  type: z.literal('x'),
+  excludedXHandles: z.array(z.string()).optional(),
+  includedXHandles: z.array(z.string()).optional(),
+  postFavoriteCount: z.number().int().optional(),
+  postViewCount: z.number().int().optional(),
+  /**
+   * @deprecated use `includedXHandles` instead
+   */
+  xHandles: z.array(z.string()).optional(),
+});
+
+const newsSourceSchema = z.object({
+  type: z.literal('news'),
+  country: z.string().length(2).optional(),
+  excludedWebsites: z.array(z.string()).max(5).optional(),
+  safeSearch: z.boolean().optional(),
+});
+
+const rssSourceSchema = z.object({
+  type: z.literal('rss'),
+  links: z.array(z.string().url()).max(1), // currently only supports one RSS link
+});
+
+const searchSourceSchema = z.discriminatedUnion('type', [
+  webSourceSchema,
+  xSourceSchema,
+  newsSourceSchema,
+  rssSourceSchema,
+]);
+
 /**
  * @see https://docs.x.ai/docs/api-reference#create-new-response
  */
@@ -39,6 +80,55 @@ export const xaiLanguageModelResponsesOptions = z.object({
    * Example values: 'file_search_call.results'.
    */
   include: z.array(z.enum(['file_search_call.results'])).nullish(),
+
+  /**
+   * Live Search parameters. Supported on the Responses API; when set, this
+   * overrides the `web_search` provider tool.
+   *
+   * @see https://docs.x.ai/docs/guides/live-search
+   */
+  searchParameters: z
+    .object({
+      /**
+       * search mode preference
+       * - "off": disables search completely
+       * - "auto": model decides whether to search (default)
+       * - "on": always enables search
+       */
+      mode: z.enum(['off', 'auto', 'on']),
+
+      /**
+       * whether to return citations in the response
+       * defaults to true
+       */
+      returnCitations: z.boolean().optional(),
+
+      /**
+       * start date for search data (ISO8601 format: YYYY-MM-DD)
+       */
+      fromDate: z.string().optional(),
+
+      /**
+       * end date for search data (ISO8601 format: YYYY-MM-DD)
+       */
+      toDate: z.string().optional(),
+
+      /**
+       * maximum number of search results to consider
+       * defaults to 20
+       */
+      maxSearchResults: z.number().min(1).max(50).optional(),
+
+      /**
+       * data sources to search from.
+       * defaults to [{ type: 'web' }, { type: 'x' }] if not specified.
+       *
+       * @example
+       * sources: [{ type: 'web', country: 'US' }, { type: 'x' }]
+       */
+      sources: z.array(searchSourceSchema).optional(),
+    })
+    .optional(),
 });
 
 export type XaiLanguageModelResponsesOptions = z.infer<

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -655,6 +655,130 @@ describe('XaiResponsesLanguageModel', () => {
           });
         });
 
+        it('searchParameters', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                searchParameters: {
+                  mode: 'on',
+                  returnCitations: true,
+                  fromDate: '2024-01-01',
+                  toDate: '2024-12-31',
+                  maxSearchResults: 10,
+                },
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.search_parameters).toStrictEqual({
+            mode: 'on',
+            return_citations: true,
+            from_date: '2024-01-01',
+            to_date: '2024-12-31',
+            max_search_results: 10,
+          });
+        });
+
+        it('searchParameters with sources array', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                searchParameters: {
+                  mode: 'on',
+                  sources: [
+                    {
+                      type: 'web',
+                      country: 'US',
+                      excludedWebsites: ['example.com'],
+                      safeSearch: false,
+                    },
+                    {
+                      type: 'x',
+                      includedXHandles: ['grok'],
+                      excludedXHandles: ['openai'],
+                      postFavoriteCount: 5,
+                      postViewCount: 50,
+                    },
+                    {
+                      type: 'news',
+                      country: 'GB',
+                    },
+                    {
+                      type: 'rss',
+                      links: ['https://status.x.ai/feed.xml'],
+                    },
+                  ],
+                },
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.search_parameters.mode).toBe('on');
+          expect(requestBody.search_parameters.sources).toStrictEqual([
+            {
+              type: 'web',
+              country: 'US',
+              excluded_websites: ['example.com'],
+              safe_search: false,
+            },
+            {
+              type: 'x',
+              excluded_x_handles: ['openai'],
+              included_x_handles: ['grok'],
+              post_favorite_count: 5,
+              post_view_count: 50,
+            },
+            {
+              type: 'news',
+              country: 'GB',
+            },
+            {
+              type: 'rss',
+              links: ['https://status.x.ai/feed.xml'],
+            },
+          ]);
+        });
+
+        it('omits search_parameters when not provided', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.search_parameters).toBeUndefined();
+        });
+
         it('logprobs and topLogprobs', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -228,6 +228,40 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
       ...(options.previousResponseId != null && {
         previous_response_id: options.previousResponseId,
       }),
+      // search parameters (Live Search). When set, this overrides the
+      // `web_search` provider tool on the Responses API.
+      ...(options.searchParameters != null && {
+        search_parameters: {
+          mode: options.searchParameters.mode,
+          return_citations: options.searchParameters.returnCitations,
+          from_date: options.searchParameters.fromDate,
+          to_date: options.searchParameters.toDate,
+          max_search_results: options.searchParameters.maxSearchResults,
+          sources: options.searchParameters.sources?.map(source => ({
+            type: source.type,
+            ...(source.type === 'web' && {
+              country: source.country,
+              excluded_websites: source.excludedWebsites,
+              allowed_websites: source.allowedWebsites,
+              safe_search: source.safeSearch,
+            }),
+            ...(source.type === 'x' && {
+              excluded_x_handles: source.excludedXHandles,
+              included_x_handles: source.includedXHandles ?? source.xHandles,
+              post_favorite_count: source.postFavoriteCount,
+              post_view_count: source.postViewCount,
+            }),
+            ...(source.type === 'news' && {
+              country: source.country,
+              excluded_websites: source.excludedWebsites,
+              safe_search: source.safeSearch,
+            }),
+            ...(source.type === 'rss' && {
+              links: source.links,
+            }),
+          })),
+        },
+      }),
     };
 
     if (xaiTools && xaiTools.length > 0) {


### PR DESCRIPTION
## Background
External user report: xAI's `search_parameters` (the Live Search config field on xAI Chat Completions) has no ergonomic surface through the AI Gateway when called via AI SDK. Users can hand-write `providerOptions.xai.searchParameters` today, but the field is untyped on `providerOptions` and the `sources` discriminated union (`web` / `x` / `news` / `rss`) has no autocomplete or compile-time checking. The practical consequence: there's no easy way to bound Grok web-search cost via `maxSearchResults`.

A `gateway.tools.xaiWebSearch()` entry was considered (uniform with `perplexitySearch` / `parallelSearch`) and rejected: xAI Live Search is **not** a tool the model invokes — it's a request-level config that xAI dispatches internally and returns inline. Wrapping it in `createProviderExecutedToolFactory` would lie about the semantics, require a coordinated gateway-side interception PR to be functional at release, and force misleading input/output schemas. A plain typed builder is honest about what it is and ships independently — the gateway already forwards `providerOptions.xai.*` end-to-end.

## Summary
Adds `xaiSearchParameters()` to `@ai-sdk/gateway`:
```ts
import { xaiSearchParameters } from '@ai-sdk/gateway';
import { generateText } from 'ai';
const result = await generateText({
  model: 'xai/grok-4-fast-reasoning',
  prompt: 'What happened in markets today?',
  providerOptions: {
    xai: {
      searchParameters: xaiSearchParameters({
        mode: 'on',
        maxSearchResults: 5,
        sources: [{ type: 'web', country: 'US' }],
      }),
    },
  },
});
```
- xaiSearchParameters(config) — returns a searchParameters object with mode defaulted to 'auto' (xAI's Zod schema requires the field). All other fields passthrough.
- Types: XaiSearchParameters (output, extends JSONObject so it's assignable to providerOptions.xai.searchParameters which is JSONValue | undefined), XaiSearchParametersConfig (strict input — deliberately doesn't extend JSONObject, so typo'd config keys remain compile errors), XaiSearchSource (discriminated union of web / x / news / rss).
- Source types mirror the camelCase shapes in @ai-sdk/xai's xai-chat-language-model-options.ts. We don't import from @ai-sdk/xai to avoid a cross-package dep; xAI's wire-level field names are public API. There's a // Keep in sync comment at the file header.
- Example at examples/ai-functions/src/generate-text/gateway/xai-search-parameters.ts.