### PR TITLE
fix: use regional endpoint for Vertex MaaS

### DIFF
--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -77,7 +77,7 @@ describe('google-vertex-maas-provider', () => {
       expect.objectContaining({
         name: 'vertex.maas',
         baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
+          'https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
       }),
     );
   });
@@ -181,7 +181,7 @@ describe('google-vertex-maas-provider', () => {
     expect(createOpenAICompatible).toHaveBeenCalledWith(
       expect.objectContaining({
         baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
+          'https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
       }),
     );
   });

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -75,12 +75,18 @@ export function createGoogleVertexMaas(
       description: 'Google Vertex project',
     });
 
-  // Construct base URL: https://aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi
+  // Construct base URL:
+  // - global: https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi
+  // - regional: https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi
   const constructBaseURL = () => {
     const projectId = loadProject();
     const location = loadLocation() ?? 'global';
+    const host =
+      location === 'global'
+        ? 'aiplatform.googleapis.com'
+        : `${location}-aiplatform.googleapis.com`;
 
-    return `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/endpoints/openapi`;
+    return `https://${host}/v1/projects/${projectId}/locations/${location}/endpoints/openapi`;
   };
 
   const loadBaseURL = () =>


### PR DESCRIPTION
## Summary

Fixes #15684.

Updates the Google Vertex MaaS provider default base URL so regional locations use the regional Vertex AI host, for example:

`https://us-central1-aiplatform.googleapis.com/v1/projects/{project}/locations/us-central1/endpoints/openapi`

The global location still uses:

`https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi`

This lets `createVertexMaas({ project, location })` work out of the box for regional MaaS models without requiring callers to override `baseURL`.

## Tests

- `pnpm --filter @ai-sdk/google-vertex... build`
- `pnpm --dir packages/google-vertex exec vitest --config vitest.node.config.js --run src/maas/google-vertex-maas-provider.test.ts`
- `pnpm --dir packages/google-vertex test:node`
- `pnpm --dir packages/google-vertex type-check`
- `pnpm --dir packages/google-vertex test:edge`
- `pnpm --dir packages/google-vertex build`
- `pnpm exec ultracite check packages/google-vertex/src/maas/google-vertex-maas-provider.ts packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts`
