### PR TITLE
fix(google-vertex): default Llama MaaS max tokens

### DIFF
--- a/.changeset/vertex-maas-llama-max-tokens.md
+++ b/.changeset/vertex-maas-llama-max-tokens.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Add a default `max_tokens` value for Vertex MaaS Llama 4 chat requests when no max token setting is provided.

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -154,6 +154,95 @@ describe('google-vertex-maas-provider', () => {
     );
   });
 
+  it('should add default max_tokens for Llama 4 models when no max token setting is provided', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('meta/llama-4-scout-17b-16e-instruct-maas');
+
+    const [{ transformRequestBody }] = vi.mocked(createOpenAICompatible).mock
+      .calls[0];
+
+    expect(
+      transformRequestBody?.({
+        model: 'meta/llama-4-scout-17b-16e-instruct-maas',
+        messages: [],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "max_tokens": 4096,
+        "messages": [],
+        "model": "meta/llama-4-scout-17b-16e-instruct-maas",
+      }
+    `);
+  });
+
+  it('should preserve explicit max token settings for Llama 4 models', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('meta/llama-4-maverick-17b-128e-instruct-maas');
+
+    const [{ transformRequestBody }] = vi.mocked(createOpenAICompatible).mock
+      .calls[0];
+
+    expect(
+      transformRequestBody?.({
+        model: 'meta/llama-4-maverick-17b-128e-instruct-maas',
+        max_tokens: 1024,
+        messages: [],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "max_tokens": 1024,
+        "messages": [],
+        "model": "meta/llama-4-maverick-17b-128e-instruct-maas",
+      }
+    `);
+
+    expect(
+      transformRequestBody?.({
+        model: 'meta/llama-4-maverick-17b-128e-instruct-maas',
+        max_completion_tokens: 2048,
+        messages: [],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "max_completion_tokens": 2048,
+        "messages": [],
+        "model": "meta/llama-4-maverick-17b-128e-instruct-maas",
+      }
+    `);
+  });
+
+  it('should not add default max_tokens for non-Llama 4 models', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('deepseek-ai/deepseek-v3.2-maas');
+
+    const [{ transformRequestBody }] = vi.mocked(createOpenAICompatible).mock
+      .calls[0];
+
+    expect(
+      transformRequestBody?.({
+        model: 'deepseek-ai/deepseek-v3.2-maas',
+        messages: [],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "messages": [],
+        "model": "deepseek-ai/deepseek-v3.2-maas",
+      }
+    `);
+  });
+
   it('should construct correct URL with trailing slash removed from baseURL', () => {
     const provider = createGoogleVertexMaas({
       project: 'test-project',

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -11,6 +11,26 @@ import {
 } from '@ai-sdk/provider-utils';
 import type { GoogleVertexMaasModelId } from './google-vertex-maas-options';
 
+const DEFAULT_LLAMA_4_MAX_TOKENS = 4096;
+
+function transformGoogleVertexMaasRequestBody(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    typeof args.model === 'string' &&
+    args.model.startsWith('meta/llama-4-') &&
+    args.max_tokens == null &&
+    args.max_completion_tokens == null
+  ) {
+    return {
+      ...args,
+      max_tokens: DEFAULT_LLAMA_4_MAX_TOKENS,
+    };
+  }
+
+  return args;
+}
+
 export interface GoogleVertexMaasProvider extends OpenAICompatibleProvider<
   GoogleVertexMaasModelId,
   string,
@@ -92,6 +112,7 @@ export function createGoogleVertexMaas(
       name: 'vertex.maas',
       baseURL: loadBaseURL(),
       fetch: options.fetch,
+      transformRequestBody: transformGoogleVertexMaasRequestBody,
     }));
 
   const provider = (modelId: GoogleVertexMaasModelId) => getProvider()(modelId);


### PR DESCRIPTION
## Summary

- Adds a Vertex MaaS request-body transform that supplies a conservative `max_tokens` default for Llama 4 chat requests when callers do not provide `max_tokens` or `max_completion_tokens`.
- Preserves explicit caller-provided max token settings.
- Leaves non-Llama 4 MaaS models unchanged.

Closes #15685.

## Tests

- `pnpm exec vitest --config vitest.node.config.js --run src/maas/google-vertex-maas-provider.test.ts`
- `pnpm --filter @ai-sdk/google-vertex type-check`
- `pnpm --filter @ai-sdk/google-vertex build`
- `pnpm --filter @ai-sdk/google-vertex test:node`
- `pnpm --filter @ai-sdk/google-vertex test:edge`
- `pnpm exec ultracite check packages/google-vertex/src/maas/google-vertex-maas-provider.ts packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts .changeset/vertex-maas-llama-max-tokens.md`
