### PR TITLE
fix(openai-compatible): preserve Vertex MaaS Scout stream text

### DIFF
--- a/.changeset/vertex-maas-scout-streaming.md
+++ b/.changeset/vertex-maas-scout-streaming.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Fix Vertex MaaS Llama 4 Scout streaming when answer fragments arrive in reasoning deltas.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -1825,6 +1825,44 @@ describe('doStream', () => {
     ]);
   });
 
+  it('should treat Vertex MaaS Llama 4 Scout reasoning_content deltas as text', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1702657020,"model":"meta/llama-4-scout-17b-16e-instruct-maas",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":"stream"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1702657020,"model":"meta/llama-4-scout-17b-16e-instruct-maas",` +
+          `"choices":[{"index":0,"delta":{"content":"-ok"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1702657020,"model":"meta/llama-4-scout-17b-16e-instruct-maas",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const model = new OpenAICompatibleChatLanguageModel(
+      'meta/llama-4-scout-17b-16e-instruct-maas',
+      {
+        provider: 'vertex.maas.chat',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+      },
+    );
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const textDeltas = (await convertReadableStreamToArray(stream)).filter(
+      e => e.type === 'text-delta',
+    );
+
+    expect(textDeltas).toStrictEqual([
+      { type: 'text-delta', delta: 'stream', id: 'txt-0' },
+      { type: 'text-delta', delta: '-ok', id: 'txt-0' },
+    ]);
+  });
+
   it('should respect the includeUsage option', async () => {
     prepareStreamResponse({
       content: ['Hello', ', ', 'World!'],

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -169,6 +169,13 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     );
   }
 
+  private shouldTreatReasoningAsText(): boolean {
+    return (
+      this.provider === 'vertex.maas.chat' &&
+      this.modelId === 'meta/llama-4-scout-17b-16e-instruct-maas'
+    );
+  }
+
   private async getArgs({
     prompt,
     maxOutputTokens,
@@ -532,6 +539,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     let isFirstChunk = true;
     let isActiveReasoning = false;
     let isActiveText = false;
+    const shouldTreatReasoningAsText = this.shouldTreatReasoningAsText();
     const convertUsage = (
       usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
     ) => this.convertUsage(usage);
@@ -621,7 +629,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
 
             // enqueue reasoning before text deltas:
             const reasoningContent = delta.reasoning_content ?? delta.reasoning;
-            if (reasoningContent) {
+            if (reasoningContent && !shouldTreatReasoningAsText) {
               if (!isActiveReasoning) {
                 controller.enqueue({
                   type: 'reasoning-start',
@@ -637,7 +645,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               });
             }
 
-            if (delta.content) {
+            const textContent =
+              delta.content ||
+              (shouldTreatReasoningAsText ? reasoningContent : undefined);
+
+            if (textContent) {
               // end active reasoning block before text starts
               if (isActiveReasoning) {
                 controller.enqueue({
@@ -655,7 +667,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({
                 type: 'text-delta',
                 id: 'txt-0',
-                delta: delta.content,
+                delta: textContent,
               });
             }
 


### PR DESCRIPTION
## Summary

Fixes #15686.

This preserves streamed text for Vertex MaaS Llama 4 Scout when the model emits answer fragments in `reasoning_content` before normal `content` deltas. Without this handling, consumers of `streamText().textStream` can receive only a suffix of the model response.

## Tests

- `pnpm --filter @ai-sdk/openai-compatible test:node -- src/chat/openai-compatible-chat-language-model.test.ts -t "Vertex MaaS Llama 4 Scout"`
- `pnpm --filter @ai-sdk/openai-compatible test:node`
- `pnpm --filter @ai-sdk/openai-compatible type-check`
- `pnpm exec ultracite check packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts`
- `pnpm --filter @ai-sdk/openai-compatible build`
