### PR TITLE
fix(vertex): disable tools for MaaS Llama Scout

### DIFF
--- a/.changeset/vertex-maas-scout-tools.md
+++ b/.changeset/vertex-maas-scout-tools.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/openai-compatible': patch
+---
+
+Add model-specific tool support gating for OpenAI-compatible providers and disable tool calls for Vertex MaaS Llama 4 Scout.

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -2124,6 +2124,12 @@ The following models are available through the MaaS provider. You can also pass 
 | `moonshotai/kimi-k2-thinking-maas`             | Moonshot |
 
 <Note>
+  `meta/llama-4-scout-17b-16e-instruct-maas` does not support AI SDK tool calls
+  through the Vertex MaaS OpenAI-compatible endpoint. Tool definitions are
+  omitted for this model, and a warning is returned when tools are provided.
+</Note>
+
+<Note>
   Model availability depends on your Google Cloud project and region. Check the
   [Vertex AI Model
   Garden](https://console.cloud.google.com/vertex-ai/model-garden) for the

--- a/packages/google-vertex/README.md
+++ b/packages/google-vertex/README.md
@@ -287,6 +287,8 @@ const { text } = await generateText({
 });
 ```
 
+`meta/llama-4-scout-17b-16e-instruct-maas` does not support AI SDK tool calls through the Vertex MaaS OpenAI-compatible endpoint. Tool definitions are omitted for this model, and a warning is returned when tools are provided.
+
 ## Documentation
 
 Please check out the **[Google Vertex provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex)** for more information.

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -154,6 +154,40 @@ describe('google-vertex-maas-provider', () => {
     );
   });
 
+  it('should disable tools for Llama 4 Scout', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+    });
+
+    provider('meta/llama-4-scout-17b-16e-instruct-maas');
+
+    const [{ supportsTools }] = vi.mocked(createOpenAICompatible).mock.calls[0];
+    if (typeof supportsTools !== 'function') {
+      throw new Error('Expected supportsTools to be a function');
+    }
+
+    expect(supportsTools('meta/llama-4-scout-17b-16e-instruct-maas')).toBe(
+      false,
+    );
+  });
+
+  it('should keep tools enabled for Llama 4 Maverick', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+    });
+
+    provider('meta/llama-4-maverick-17b-128e-instruct-maas');
+
+    const [{ supportsTools }] = vi.mocked(createOpenAICompatible).mock.calls[0];
+    if (typeof supportsTools !== 'function') {
+      throw new Error('Expected supportsTools to be a function');
+    }
+
+    expect(supportsTools('meta/llama-4-maverick-17b-128e-instruct-maas')).toBe(
+      true,
+    );
+  });
+
   it('should construct correct URL with trailing slash removed from baseURL', () => {
     const provider = createGoogleVertexMaas({
       project: 'test-project',

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -11,6 +11,10 @@ import {
 } from '@ai-sdk/provider-utils';
 import type { GoogleVertexMaasModelId } from './google-vertex-maas-options';
 
+const modelsWithoutToolSupport = new Set<string>([
+  'meta/llama-4-scout-17b-16e-instruct-maas',
+]);
+
 export interface GoogleVertexMaasProvider extends OpenAICompatibleProvider<
   GoogleVertexMaasModelId,
   string,
@@ -92,6 +96,7 @@ export function createGoogleVertexMaas(
       name: 'vertex.maas',
       baseURL: loadBaseURL(),
       fetch: options.fetch,
+      supportsTools: modelId => !modelsWithoutToolSupport.has(modelId),
     }));
 
   const provider = (modelId: GoogleVertexMaasModelId) => getProvider()(modelId);

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -786,6 +786,61 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should omit tools and warn when tools are not supported', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const provider = createOpenAICompatible({
+      baseURL: 'https://my.api.com/v1/',
+      name: 'test-provider',
+      supportsTools: false,
+    });
+
+    const result = await provider('grok-3').doGenerate({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      toolChoice: {
+        type: 'tool',
+        toolName: 'test-tool',
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello",
+            "role": "user",
+          },
+        ],
+        "model": "grok-3",
+      }
+    `);
+    expect(result.warnings).toMatchInlineSnapshot(`
+      [
+        {
+          "feature": "tools",
+          "type": "unsupported",
+        },
+        {
+          "feature": "toolChoice",
+          "type": "unsupported",
+        },
+      ]
+    `);
+  });
+
   it('should pass headers', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -73,6 +73,11 @@ export type OpenAICompatibleChatConfig = {
   supportsStructuredOutputs?: boolean;
 
   /**
+   * Whether the model supports tools.
+   */
+  supportsTools?: boolean;
+
+  /**
    * The supported URLs for the model.
    */
   supportedUrls?: () => LanguageModelV4['supportedUrls'];
@@ -247,14 +252,30 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
       });
     }
 
-    const {
-      tools: openaiTools,
-      toolChoice: openaiToolChoice,
-      toolWarnings,
-    } = prepareTools({
-      tools,
-      toolChoice,
-    });
+    const supportsTools = this.config.supportsTools ?? true;
+
+    let openaiTools: ReturnType<typeof prepareTools>['tools'] | undefined;
+    let openaiToolChoice:
+      | ReturnType<typeof prepareTools>['toolChoice']
+      | undefined;
+    let toolWarnings: SharedV4Warning[] = [];
+
+    if (supportsTools) {
+      const preparedTools = prepareTools({
+        tools,
+        toolChoice,
+      });
+      openaiTools = preparedTools.tools;
+      openaiToolChoice = preparedTools.toolChoice;
+      toolWarnings = preparedTools.toolWarnings;
+    } else {
+      if (tools?.length) {
+        warnings.push({ type: 'unsupported', feature: 'tools' });
+      }
+      if (toolChoice != null) {
+        warnings.push({ type: 'unsupported', feature: 'toolChoice' });
+      }
+    }
 
     const metadataKey = resolveProviderOptionsKey(
       this.providerOptionsName,

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -92,6 +92,11 @@ export interface OpenAICompatibleProviderSettings {
   supportsStructuredOutputs?: boolean;
 
   /**
+   * Whether chat models support tools. Defaults to true.
+   */
+  supportsTools?: boolean | ((modelId: string) => boolean);
+
+  /**
    * Optional function to transform the request body before sending it to the API.
    * This is useful for proxy providers that may require a different request format
    * than the official OpenAI API.
@@ -172,6 +177,10 @@ export function createOpenAICompatible<
       ...getCommonModelConfig('chat'),
       includeUsage: options.includeUsage,
       supportsStructuredOutputs: options.supportsStructuredOutputs,
+      supportsTools:
+        typeof options.supportsTools === 'function'
+          ? options.supportsTools(modelId)
+          : options.supportsTools,
       supportedUrls: options.supportedUrls,
       transformRequestBody: options.transformRequestBody,
       metadataExtractor: options.metadataExtractor,


### PR DESCRIPTION
## Summary

Fixes #15687 by preventing the Vertex MaaS provider from sending tool definitions to Llama 4 Scout, which does not return OpenAI-compatible `tool_calls` for those requests.

This adds a small model-specific tool support gate to the OpenAI-compatible provider configuration, applies it to Vertex MaaS Scout, and documents the behavior so users get a normal unsupported-tools warning instead of a misleading plain-text JSON response.

## Tests

- `pnpm --dir packages/openai-compatible test:node src/chat/openai-compatible-chat-language-model.test.ts`
- `pnpm --dir packages/openai-compatible test:edge src/chat/openai-compatible-chat-language-model.test.ts`
- `pnpm --dir packages/google-vertex test:node src/maas/google-vertex-maas-provider.test.ts`
- `pnpm --dir packages/google-vertex test:edge src/maas/google-vertex-maas-provider.test.ts`
- `pnpm --dir packages/openai-compatible type-check`
- `pnpm --dir packages/google-vertex type-check`
- `pnpm -F @ai-sdk/openai-compatible... -F @ai-sdk/google-vertex... build`
- `pnpm exec ultracite check packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts packages/openai-compatible/src/openai-compatible-provider.ts packages/google-vertex/src/maas/google-vertex-maas-provider.ts packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts content/providers/01-ai-sdk-providers/16-google-vertex.mdx packages/google-vertex/README.md .changeset/vertex-maas-scout-tools.md`
