### PR TITLE
fix(ai): do not re-validate tool input for output-error parts in validateUIMessages

### DIFF
--- a/.changeset/sixty-deers-hug.md
+++ b/.changeset/sixty-deers-hug.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): do not re-validate tool input for output-error parts in validateUIMessages

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1185,7 +1185,10 @@ describe('validateUIMessages', () => {
       });
     });
 
-    it('should validate tool input when state is output-error and there is input', async () => {
+    it('should not re-validate tool input when state is output-error', async () => {
+      // A tool call that failed with an invalid-input error keeps its (invalid)
+      // input. Re-validating it on replay would throw a TypeValidationError and
+      // crash follow-up messages, so output-error input is intentionally skipped.
       const messages = await validateUIMessages<TestMessage>({
         messages: [
           {
@@ -1196,9 +1199,9 @@ describe('validateUIMessages', () => {
                 type: 'tool-foo',
                 toolCallId: '1',
                 state: 'output-error',
-                input: { foo: 'bar' },
-                errorText: 'Tool execution failed',
-                providerExecuted: true,
+                input: { foo: 123 } as unknown as { foo: string },
+                errorText: 'AI_InvalidToolInputError',
+                providerExecuted: false,
               },
             ],
           },
@@ -1215,11 +1218,11 @@ describe('validateUIMessages', () => {
             "id": "1",
             "parts": [
               {
-                "errorText": "Tool execution failed",
+                "errorText": "AI_InvalidToolInputError",
                 "input": {
-                  "foo": "bar",
+                  "foo": 123,
                 },
-                "providerExecuted": true,
+                "providerExecuted": false,
                 "state": "output-error",
                 "toolCallId": "1",
                 "type": "tool-foo",

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -474,11 +474,13 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
             }
 
             // Tool input validation
+            // Note: input is intentionally not re-validated for `output-error`
+            // states. A tool call that failed with an invalid-input error keeps
+            // its (invalid) input, and re-validating it on replay would throw a
+            // TypeValidationError that crashes follow-up messages.
             if (
               toolPart.state === 'input-available' ||
-              toolPart.state === 'output-available' ||
-              (toolPart.state === 'output-error' &&
-                toolPart.input !== undefined)
+              toolPart.state === 'output-available'
             ) {
               await validateTypes({
                 value: toolPart.input,


### PR DESCRIPTION
## background

when a tool call fails with `AI_InvalidToolInputError` (the model produced input that doesn't match the tool's schema), the resulting UI message part is stored in `output-error` state with the invalid input preserved. on any follow-up message, `validateUIMessages` re-runs over the conversation history, hits that errored part, and re-validates the already-known-bad input against the schema, throwing `AI_TypeValidationError` and crashing the follow-up.

reported internally against a production agent service hitting `AI_TypeValidationError` on continuation messages.

## summary

the input-validation condition in `safeValidateUIMessages` validated tool input for `input-available`, `output-available`, and `output-error` (when input was defined) states. the `output-error` case is wrong: a tool call that already errored shouldn't have its input re-validated on replay. if the input was valid the re-validation is wasted work, and if it was invalid (the reason it errored) the re-validation throws and breaks the whole conversation.

fix: drop `output-error` from the input-validation condition, leaving `input-available || output-available`. tool output validation (gated on `output-available`) and the no-schema skip branch are unchanged. dynamic tools were never affected (they hit the `!tool` early return).

this continues the direction of #11393, which already narrowed this path to skip undefined input but didn't cover defined-but-invalid input.

## verification

<details>
<summary>before fix: invalid input in output-error throws</summary>

```
AI_TypeValidationError: Type validation failed for messages[0].parts[0].input (foo, id: "1"): Value: {"foo":123}.
```

</details>

after fix: an `output-error` part carrying schema-invalid input passes through `validateUIMessages` unchanged, no throw. added a regression test covering this case (repurposed the prior "validate output-error input" test, which only passed because its fixture input happened to be valid).

## related

- introduced in #8065, narrowed in #11393