### PR TITLE
fix(anthropic): respect disableParallelToolUse in jsonTool mode

### DIFF
--- a/.changeset/sharp-ants-remember.md
+++ b/.changeset/sharp-ants-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Respect explicit `disableParallelToolUse` overrides when using `jsonTool` structured output mode.

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -1888,6 +1888,105 @@ describe('AnthropicLanguageModel', () => {
       });
     });
 
+    it('should default disableParallelToolUse to true for json tool responses with other tools', async () => {
+      prepareJsonFixtureResponse('anthropic-json-other-tool.1');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'get-weather',
+            description: 'Get the weather in a location',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+              },
+              required: ['location'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        providerOptions: {
+          anthropic: {
+            structuredOutputMode: 'jsonTool',
+          } satisfies AnthropicLanguageModelOptions,
+        },
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              weather: { type: 'string' },
+              temperature: { type: 'number' },
+            },
+            required: ['weather', 'temperature'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        tool_choice: {
+          type: 'any',
+          disable_parallel_tool_use: true,
+        },
+      });
+    });
+
+    it('should respect disableParallelToolUse false for json tool responses with other tools', async () => {
+      prepareJsonFixtureResponse('anthropic-json-other-tool.1');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'get-weather',
+            description: 'Get the weather in a location',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+              },
+              required: ['location'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        providerOptions: {
+          anthropic: {
+            structuredOutputMode: 'jsonTool',
+            disableParallelToolUse: false,
+          } satisfies AnthropicLanguageModelOptions,
+        },
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              weather: { type: 'string' },
+              temperature: { type: 'number' },
+            },
+            required: ['weather', 'temperature'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        tool_choice: {
+          type: 'any',
+          disable_parallel_tool_use: false,
+        },
+      });
+    });
+
     it('should pass headers', async () => {
       prepareJsonFixtureResponse('anthropic-text');
 

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -729,7 +729,8 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
         ? {
             tools: [...(tools ?? []), jsonResponseTool],
             toolChoice: { type: 'required' },
-            disableParallelToolUse: true,
+            disableParallelToolUse:
+              anthropicOptions?.disableParallelToolUse ?? true,
             cacheControlValidator,
             supportsStructuredOutput: false,
             supportsStrictTools,


### PR DESCRIPTION
## Summary

Closes #15652.

Respect explicit `disableParallelToolUse` overrides when Anthropic structured output uses the `jsonTool` fallback. The json tool path still defaults to disabling parallel tool use, but a user-provided `false` is now passed through to Anthropic instead of being overwritten.

## Details

- Keeps the existing `jsonTool` default of `disable_parallel_tool_use: true`.
- Preserves `disableParallelToolUse: false` when users explicitly opt into parallel tool use with json tool responses and other tools.
- Adds regression coverage for both the default and explicit override cases.
- Adds a patch changeset for `@ai-sdk/anthropic`.

## Tests

- `pnpm --filter @ai-sdk/anthropic test:node -- anthropic-language-model.test.ts -t "disableParallelToolUse"`
- `pnpm exec oxfmt --check packages/anthropic/src/anthropic-language-model.ts packages/anthropic/src/anthropic-language-model.test.ts .changeset/sharp-ants-remember.md`
- `pnpm exec ultracite fix packages/anthropic/src/anthropic-language-model.ts packages/anthropic/src/anthropic-language-model.test.ts`
- `pnpm exec ultracite check packages/anthropic/src/anthropic-language-model.ts packages/anthropic/src/anthropic-language-model.test.ts`
- `git diff --check`
- `pnpm --filter @ai-sdk/anthropic test`
- `pnpm --filter @ai-sdk/anthropic type-check`
- `pnpm --filter @ai-sdk/anthropic build`
