### PR TITLE
backport v6: feat(provider/xai): expose `enableImageSearch` on the Web Search tool

### DIFF
--- a/.changeset/xai-enable-image-search.md
+++ b/.changeset/xai-enable-image-search.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): add `enableImageSearch` to the xAI Web Search tool
+
+The xAI Responses API supports `enable_image_search` on Web Search tools. `xai.tools.webSearch()` now accepts `enableImageSearch` and sends it through to the API as `enable_image_search`.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -210,9 +210,13 @@ console.log('Citations:', sources);
 
   Exclude specified domains from search (max 5). Cannot be used with `allowedDomains`.
 
+- **enableImageSearch** _boolean_
+
+  Allow the model to perform image search as a separate Web Search mode when images are useful for the answer. The model can choose between regular web search and image search; responses can include Markdown image embeds when relevant.
+
 - **enableImageUnderstanding** _boolean_
 
-  Enable the model to view and analyze images found during search. Increases token usage.
+  Enable the model to view and analyze images found during search. Increases token usage. To allow explicitly searching for images, use `enableImageSearch`.
 
 ### X Search Tool
 

--- a/examples/ai-functions/src/generate-text/xai/responses-web-search-image-search.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-web-search-image-search.ts
@@ -1,0 +1,36 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai.responses('grok-4.3'),
+    tools: {
+      web_search: xai.tools.webSearch({ enableImageSearch: true }),
+    },
+    prompt: 'Show me images of SpaceX Starship on the launch pad.',
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls made:');
+  for (const content of result.content) {
+    if (content.type === 'tool-call') {
+      console.log(
+        `  - ${content.toolName} (providerExecuted: ${content.providerExecuted})`,
+      );
+    }
+  }
+
+  console.log();
+  console.log('Sources cited:');
+  for (const content of result.content) {
+    if (content.type === 'source' && content.sourceType === 'url') {
+      console.log(`  - ${content.url}`);
+    }
+  }
+
+  console.log();
+  console.log('Finish reason:', result.finishReason);
+  console.log('Usage:', result.usage);
+});

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -78,6 +78,7 @@ export type XaiResponsesTool =
       type: 'web_search';
       allowed_domains?: string[];
       excluded_domains?: string[];
+      enable_image_search?: boolean;
       enable_image_understanding?: boolean;
     }
   | {

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -865,13 +865,14 @@ describe('XaiResponsesLanguageModel', () => {
               name: 'web_search',
               args: {
                 allowedDomains: ['wikipedia.org'],
+                enableImageSearch: true,
                 enableImageUnderstanding: true,
               },
             },
           ],
         });
 
-        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        expect(await server.calls[1].requestBodyJson).toMatchInlineSnapshot(`
           {
             "input": [
               {
@@ -887,6 +888,11 @@ describe('XaiResponsesLanguageModel', () => {
             "model": "grok-4-fast-non-reasoning",
             "tools": [
               {
+                "allowed_domains": [
+                  "wikipedia.org",
+                ],
+                "enable_image_search": true,
+                "enable_image_understanding": true,
                 "type": "web_search",
               },
             ],

--- a/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
@@ -22,6 +22,7 @@ describe('prepareResponsesTools', () => {
           "tools": [
             {
               "allowed_domains": undefined,
+              "enable_image_search": undefined,
               "enable_image_understanding": undefined,
               "excluded_domains": undefined,
               "type": "web_search",
@@ -52,6 +53,7 @@ describe('prepareResponsesTools', () => {
               "wikipedia.org",
               "example.com",
             ],
+            "enable_image_search": undefined,
             "enable_image_understanding": undefined,
             "excluded_domains": undefined,
             "type": "web_search",
@@ -78,10 +80,38 @@ describe('prepareResponsesTools', () => {
         [
           {
             "allowed_domains": undefined,
+            "enable_image_search": undefined,
             "enable_image_understanding": undefined,
             "excluded_domains": [
               "spam.com",
             ],
+            "type": "web_search",
+          },
+        ]
+      `);
+    });
+
+    it('should prepare web_search tool with image search', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'xai.web_search',
+            name: 'web_search',
+            args: {
+              enableImageSearch: true,
+            },
+          },
+        ],
+      });
+
+      expect(result.tools).toMatchInlineSnapshot(`
+        [
+          {
+            "allowed_domains": undefined,
+            "enable_image_search": true,
+            "enable_image_understanding": undefined,
+            "excluded_domains": undefined,
             "type": "web_search",
           },
         ]
@@ -106,6 +136,7 @@ describe('prepareResponsesTools', () => {
         [
           {
             "allowed_domains": undefined,
+            "enable_image_search": undefined,
             "enable_image_understanding": true,
             "excluded_domains": undefined,
             "type": "web_search",

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -54,6 +54,7 @@ export async function prepareResponsesTools({
             type: 'web_search',
             allowed_domains: args.allowedDomains,
             excluded_domains: args.excludedDomains,
+            enable_image_search: args.enableImageSearch,
             enable_image_understanding: args.enableImageUnderstanding,
           });
           break;

--- a/packages/xai/src/tool/web-search.ts
+++ b/packages/xai/src/tool/web-search.ts
@@ -10,6 +10,7 @@ export const webSearchArgsSchema = lazySchema(() =>
     z.object({
       allowedDomains: z.array(z.string()).max(5).optional(),
       excludedDomains: z.array(z.string()).max(5).optional(),
+      enableImageSearch: z.boolean().optional(),
       enableImageUnderstanding: z.boolean().optional(),
     }),
   ),
@@ -43,6 +44,7 @@ const webSearchToolFactory = createProviderToolFactoryWithOutputSchema<
   {
     allowedDomains?: string[];
     excludedDomains?: string[];
+    enableImageSearch?: boolean;
     enableImageUnderstanding?: boolean;
   }
 >({


### PR DESCRIPTION
backport of #15662