### PR TITLE
fix(mcp): await addClientAuthentication in token exchange and refresh

### DIFF
--- a/.changeset/brave-feet-hide.md
+++ b/.changeset/brave-feet-hide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): await addClientAuthentication in token exchange and refresh

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1124,6 +1124,36 @@ describe('exchangeAuthorization', () => {
     const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
     expect(body.get('resource')).toBe('https://mcp.example.com');
   });
+
+  it('awaits async addClientAuthentication before dispatching token request', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validTokens,
+    });
+
+    const addClientAuthentication = async (
+      _headers: Headers,
+      params: URLSearchParams,
+    ) => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      params.set('client_id', 'set-by-async-provider');
+      params.set('client_secret', 'secret-by-async-provider');
+    };
+
+    await exchangeAuthorization('https://auth.example.com', {
+      metadata: validMetadata as AuthorizationServerMetadata,
+      clientInformation: validClientInfo,
+      authorizationCode: 'code123',
+      codeVerifier: 'verifier123',
+      redirectUri: 'http://localhost:3000/callback',
+      addClientAuthentication,
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('client_id')).toBe('set-by-async-provider');
+    expect(body.get('client_secret')).toBe('secret-by-async-provider');
+  });
 });
 
 describe('refreshAuthorization', () => {
@@ -1316,6 +1346,34 @@ describe('refreshAuthorization', () => {
 
     const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
     expect(body.get('resource')).toBe('https://mcp.example.com');
+  });
+
+  it('awaits async addClientAuthentication before dispatching refresh request', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validTokens,
+    });
+
+    const addClientAuthentication = async (
+      _headers: Headers,
+      params: URLSearchParams,
+    ) => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      params.set('client_id', 'set-by-async-provider');
+      params.set('client_secret', 'secret-by-async-provider');
+    };
+
+    await refreshAuthorization('https://auth.example.com', {
+      metadata: validMetadata as AuthorizationServerMetadata,
+      clientInformation: validClientInfo,
+      refreshToken: 'refresh123',
+      addClientAuthentication,
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('client_id')).toBe('set-by-async-provider');
+    expect(body.get('client_secret')).toBe('secret-by-async-provider');
   });
 });
 

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -667,7 +667,12 @@ export async function exchangeAuthorization(
   });
 
   if (addClientAuthentication) {
-    addClientAuthentication(headers, params, authorizationServerUrl, metadata);
+    await addClientAuthentication(
+      headers,
+      params,
+      authorizationServerUrl,
+      metadata,
+    );
   } else {
     const supportedMethods =
       metadata?.token_endpoint_auth_methods_supported ?? [];
@@ -754,7 +759,12 @@ export async function refreshAuthorization(
   });
 
   if (addClientAuthentication) {
-    addClientAuthentication(headers, params, authorizationServerUrl, metadata);
+    await addClientAuthentication(
+      headers,
+      params,
+      authorizationServerUrl,
+      metadata,
+    );
   } else {
     const supportedMethods =
       metadata?.token_endpoint_auth_methods_supported ?? [];


### PR DESCRIPTION
## Background

added as a substitute for https://github.com/vercel/ai/pull/15591 because of signed commits

`OAuthClientProvider.addClientAuthentication?(...)` is typed `void | Promise<void>`, but the two call sites in `exchangeAuthorization` and `refreshAuthorization` invoke it without `await`

## Summary

`await` the function calls

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Co-authored-by: MesoX <frantisek.spacek@morosystems.cz>