### PR TITLE
docs: update onEnd lifecycle callback examples

### DIFF
--- a/content/cookbook/01-next/73-mcp-tools.mdx
+++ b/content/cookbook/01-next/73-mcp-tools.mdx
@@ -88,7 +88,7 @@ export async function POST(req: Request) {
       tools,
       prompt,
       // When streaming, the client should be closed after the response is finished:
-      onFinish: async () => {
+      onEnd: async () => {
         await stdioClient.close();
         await httpClient.close();
         await sseClient.close();

--- a/content/cookbook/05-node/45-stream-object-record-token-usage.mdx
+++ b/content/cookbook/05-node/45-stream-object-record-token-usage.mdx
@@ -9,9 +9,9 @@ tags: ['node', 'streaming', 'structured data', 'observability']
 When you're streaming structured data with `streamText` and `Output`,
 you may want to record the token usage for billing purposes.
 
-## `onFinish` Callback
+## `onEnd` Callback
 
-You can use the `onFinish` callback to record token usage.
+You can use the `onEnd` callback to record token usage.
 It is called when the stream is finished.
 
 ```ts file='index.ts' highlight={"15-17"}
@@ -30,7 +30,7 @@ const result = streamText({
     }),
   }),
   prompt: 'Generate a lasagna recipe.',
-  onFinish({ usage }) {
+  onEnd({ usage }) {
     console.log('Token usage:', usage);
   },
 });

--- a/content/cookbook/05-node/46-stream-object-record-final-object.mdx
+++ b/content/cookbook/05-node/46-stream-object-record-final-object.mdx
@@ -8,9 +8,9 @@ tags: ['node', 'streaming', 'structured data']
 
 When you're streaming structured data, you may want to record the final object for logging or other purposes.
 
-## `onFinish` and `output`
+## `onEnd` and `output`
 
-Use `onFinish` for metadata like token usage and await `result.output` for the final structured object.
+Use `onEnd` for metadata like token usage and await `result.output` for the final structured object.
 
 ```ts file='index.ts' highlight={"15-29"}
 import { streamText, Output } from 'ai';
@@ -28,7 +28,7 @@ const result = streamText({
     }),
   }),
   prompt: 'Generate a lasagna recipe.',
-  onFinish({ usage }) {
+  onEnd({ usage }) {
     console.log('Token usage:', usage);
   },
 });

--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -118,7 +118,7 @@ You can see a full example of caching with Redis in a Next.js application in our
 
 ## Using Lifecycle Callbacks
 
-Alternatively, each AI SDK Core function has special lifecycle callbacks you can use. The one of interest is likely `onFinish`, which is called when the generation is complete. This is where you can cache the full response.
+Alternatively, each AI SDK Core function has special lifecycle callbacks you can use. The one of interest is likely `onEnd`, which is called when the generation is complete. This is where you can cache the full response.
 
 Here's an example of how you can implement caching using Vercel KV and Next.js to cache the OpenAI response for 1 hour:
 
@@ -156,7 +156,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    async onFinish({ text }) {
+    async onEnd({ text }) {
       // Cache the response text:
       await redis.set(key, text);
       await redis.expire(key, 60 * 60);

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -391,7 +391,7 @@ const result = streamText({
   tools: {
     // ...
   },
-  onFinish: () => wsFetch.close(), // close the WebSocket when done
+  onEnd: () => wsFetch.close(), // close the WebSocket when done
 });
 ```
 

--- a/examples/ai-functions/src/agent/openai/generate-on-end.ts
+++ b/examples/ai-functions/src/agent/openai/generate-on-end.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 const agent = new ToolLoopAgent({
   model: openai('gpt-4o'),
   instructions: 'You are a helpful assistant.',
-  onFinish({ text }) {
+  onEnd({ text }) {
     console.log(text);
   },
 });

--- a/examples/ai-functions/src/agent/openai/generate-runtime-context-call-options.ts
+++ b/examples/ai-functions/src/agent/openai/generate-runtime-context-call-options.ts
@@ -44,8 +44,8 @@ const agent = new ToolLoopAgent({
       },
     };
   },
-  onFinish: ({ runtimeContext }) => {
-    console.log('onFinish runtimeContext:', runtimeContext);
+  onEnd: ({ runtimeContext }) => {
+    console.log('onEnd runtimeContext:', runtimeContext);
   },
   instructions: 'You are a helpful assistant.',
 });

--- a/examples/ai-functions/src/agent/openai/generate-runtime-context.ts
+++ b/examples/ai-functions/src/agent/openai/generate-runtime-context.ts
@@ -33,8 +33,8 @@ const agent = new ToolLoopAgent({
       },
     };
   },
-  onFinish: ({ runtimeContext }) => {
-    console.log('onFinish runtimeContext:', runtimeContext);
+  onEnd: ({ runtimeContext }) => {
+    console.log('onEnd runtimeContext:', runtimeContext);
   },
   instructions: 'You are a helpful assistant.',
 });

--- a/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
+++ b/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
@@ -55,8 +55,8 @@ async function main() {
       console.log('Input tokens:', event.usage.inputTokens);
       console.log('Output tokens:', event.usage.outputTokens);
     },
-    onFinish: event => {
-      console.log('\n--- onFinish ---');
+    onEnd: event => {
+      console.log('\n--- onEnd ---');
       console.log('Total steps:', event.steps.length);
       console.log('Total input tokens:', event.usage.inputTokens);
       console.log('Total output tokens:', event.usage.outputTokens);

--- a/examples/ai-functions/src/generate-text/openai/on-end.ts
+++ b/examples/ai-functions/src/generate-text/openai/on-end.ts
@@ -6,7 +6,7 @@ run(async () => {
   await generateText({
     model: openai('gpt-4o'),
     prompt: 'Invent a new holiday and describe its traditions.',
-    onFinish(event) {
+    onEnd(event) {
       console.dir(event, { depth: Infinity });
     },
   });

--- a/examples/ai-functions/src/generate-text/openai/tool-call-with-runtime-context.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-call-with-runtime-context.ts
@@ -34,8 +34,8 @@ run(async () => {
         },
       };
     },
-    onFinish: ({ runtimeContext }) => {
-      console.log('onFinish runtimeContext:', runtimeContext);
+    onEnd: ({ runtimeContext }) => {
+      console.log('onEnd runtimeContext:', runtimeContext);
     },
     prompt: 'What is the weather in San Francisco?',
   });

--- a/examples/ai-functions/src/stream-text/anthropic/cache-control.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/cache-control.ts
@@ -35,9 +35,9 @@ run(async () => {
         ],
       },
     ],
-    onFinish({ finalStep }) {
+    onEnd({ finalStep }) {
       console.log();
-      console.log('=== onFinish ===');
+      console.log('=== onEnd ===');
       console.log(finalStep.providerMetadata?.anthropic);
     },
   });

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-cache-control.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-cache-control.ts
@@ -33,9 +33,9 @@ run(async () => {
         ],
       },
     ],
-    onFinish({ finalStep }) {
+    onEnd({ finalStep }) {
       console.log();
-      console.log('=== onFinish ===');
+      console.log('=== onEnd ===');
       console.log(finalStep.providerMetadata?.anthropic);
     },
   });

--- a/examples/ai-functions/src/stream-text/openai/cached-prompt-tokens.ts
+++ b/examples/ai-functions/src/stream-text/openai/cached-prompt-tokens.ts
@@ -149,7 +149,7 @@ function createCompletion() {
         maxCompletionTokens: 100,
       } satisfies OpenAILanguageModelChatOptions,
     },
-    onFinish: ({ finalStep }) => {
+    onEnd: ({ finalStep }) => {
       console.log(`metadata:`, finalStep.providerMetadata);
     },
   });

--- a/examples/ai-functions/src/stream-text/openai/on-end-response-messages.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-end-response-messages.ts
@@ -16,8 +16,8 @@ run(async () => {
       }),
     },
     stopWhen: isStepCount(5),
-    onFinish({ steps }) {
-      console.log(JSON.stringify(steps, null, 2));
+    onEnd({ responseMessages }) {
+      console.log(JSON.stringify(responseMessages, null, 2));
     },
     prompt: 'What is the current weather in San Francisco?',
   });

--- a/examples/ai-functions/src/stream-text/openai/on-end-steps.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-end-steps.ts
@@ -16,8 +16,8 @@ run(async () => {
       }),
     },
     stopWhen: isStepCount(5),
-    onFinish({ responseMessages }) {
-      console.log(JSON.stringify(responseMessages, null, 2));
+    onEnd({ steps }) {
+      console.log(JSON.stringify(steps, null, 2));
     },
     prompt: 'What is the current weather in San Francisco?',
   });

--- a/examples/ai-functions/src/stream-text/openai/on-end.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-end.ts
@@ -6,9 +6,9 @@ run(async () => {
   const result = streamText({
     model: openai('gpt-4o'),
     prompt: 'Invent a new holiday and describe its traditions.',
-    onFinish({ usage, finishReason, text }) {
+    onEnd({ usage, finishReason, text }) {
       console.log();
-      console.log('onFinish');
+      console.log('onEnd');
       console.log('Token usage:', usage);
       console.log('Finish reason:', finishReason);
       console.log('Text:', text);

--- a/examples/ai-functions/src/stream-text/openai/output-object-on-end.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-object-on-end.ts
@@ -21,9 +21,9 @@ run(async () => {
     }),
     prompt:
       'Generate 3 character descriptions for a fantasy role playing game.',
-    onFinish({ usage }) {
+    onEnd({ usage }) {
       console.log();
-      console.log('onFinish');
+      console.log('onEnd');
       console.log('Token usage:', usage);
     },
   });

--- a/examples/ai-functions/src/stream-text/openai/tool-call-with-runtime-context.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-call-with-runtime-context.ts
@@ -35,8 +35,8 @@ run(async () => {
         },
       };
     },
-    onFinish: ({ runtimeContext }) => {
-      console.log('onFinish runtimeContext:', runtimeContext);
+    onEnd: ({ runtimeContext }) => {
+      console.log('onEnd runtimeContext:', runtimeContext);
     },
     prompt: 'What is the weather in San Francisco?',
   });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -76,7 +76,7 @@ const result = streamText({
   model: 'openai/gpt-5.4',
   tools: await mcpClient.tools(),
   prompt: 'Use the available tools to answer the user question.',
-  onFinish: async () => {
+  onEnd: async () => {
     await mcpClient.close();
   },
 });


### PR DESCRIPTION
### Summary

Closes #15663.

Updates stale AI SDK Core lifecycle callback examples from the deprecated `onFinish` alias to `onEnd` after the AI SDK 7 rename. This covers docs, cookbook recipes, the MCP README, and runnable `ai-functions` examples.

Example filenames that explicitly referenced `on-finish` were renamed to `on-end` as well. AI SDK UI callbacks were intentionally left unchanged because they use a separate `onFinish` API.

### Validation

- `git diff --check`
- confirmed no `onFinish` / `on-finish` references remain in the touched Core docs and example scopes
- pre-commit `ultracite fix` passed
- `pnpm --filter @example/ai-functions type-check` could not complete in a fresh clone because multiple workspace provider packages are not built yet (`TS2307` missing module errors such as `@ai-sdk/alibaba`, `@ai-sdk/baseten`, and `@ai-sdk/huggingface`)
