### PR TITLE
fix(provider-utils): include object type in default tool schema

### DIFF
--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import * as z4 from 'zod/v4';
 import { safeParseJSON } from './parse-json';
 import { asSchema, zodSchema, type StandardSchema } from './schema';
+
+describe('asSchema', () => {
+  it('should create an object schema when no schema is provided', async () => {
+    const schema = asSchema(undefined);
+
+    expect(await schema.jsonSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+});
+
 describe('zodSchema', () => {
   describe('zod/v4', () => {
     describe('json schema conversion', () => {

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -136,7 +136,11 @@ export function asSchema<OBJECT>(
   schema: FlexibleSchema<OBJECT> | undefined,
 ): Schema<OBJECT> {
   return schema == null
-    ? jsonSchema({ properties: {}, additionalProperties: false })
+    ? jsonSchema({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      })
     : isSchema(schema)
       ? schema
       : '~standard' in schema


### PR DESCRIPTION
## Summary
- Add `type: object` to the default schema returned by `asSchema(undefined)` in `@ai-sdk/provider-utils`.
- Add regression test asserting empty tool input schema shape includes `type`, `properties`, and `additionalProperties`.
- Add a patch changeset for the package.

## Validation
- `pnpm --filter @ai-sdk/provider-utils test`