### PR TITLE
Fix(google-vertex): support for eu/us multi region gemini endpoints

### DIFF
--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -378,4 +378,42 @@ describe('google-vertex-provider-base', () => {
       }),
     );
   });
+
+  it('should use multi-region REP URL for us location', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'us',
+    });
+    provider('test-model-id');
+
+    expect(GoogleLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        provider: 'google.vertex.chat',
+        baseURL:
+          'https://aiplatform.us.rep.googleapis.com/v1beta1/projects/test-project/locations/us/publishers/google',
+        headers: expect.any(Function),
+        generateId: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should use multi-region REP URL for eu location', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'eu',
+    });
+    provider('test-model-id');
+
+    expect(GoogleLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        provider: 'google.vertex.chat',
+        baseURL:
+          'https://aiplatform.eu.rep.googleapis.com/v1beta1/projects/test-project/locations/eu/publishers/google',
+        headers: expect.any(Function),
+        generateId: expect.any(Function),
+      }),
+    );
+  });
 });

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -164,11 +164,19 @@ export function createGoogleVertex(
 
     // For global region, use aiplatform.googleapis.com directly
     // For other regions, use region-aiplatform.googleapis.com
-    const baseHost = `${region === 'global' ? '' : region + '-'}aiplatform.googleapis.com`;
+    const getHost = () => {
+      if (region === 'global') {
+        return 'aiplatform.googleapis.com';
+      } else if (region === 'eu' || region === 'us') {
+        return `aiplatform.${region}.rep.googleapis.com`;
+      } else {
+        return `${region}-aiplatform.googleapis.com`;
+      }
+    };
 
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${baseHost}/v1beta1/projects/${project}/locations/${region}/publishers/google`
+      `https://${getHost()}/v1beta1/projects/${project}/locations/${region}/publishers/google`
     );
   };
 


### PR DESCRIPTION
## fix(google-vertex): use REP hostname for `us`/`eu` multi-region locations

When `location` is set to `us` or `eu`, the provider was generating an invalid
hostname (`us-aiplatform.googleapis.com`) that returns 404. These are multi-region
locations that require Vertex AI's Representative Endpoint (REP) format.

Added a `getHost()` helper that maps:
- `global` → `aiplatform.googleapis.com`
- `us` / `eu` → `aiplatform.{region}.rep.googleapis.com`
- everything else → `{region}-aiplatform.googleapis.com`

