### PR TITLE
fix(ai): return validated elements from array output parseCompleteOutput

### DIFF
--- a/.changeset/green-ravens-enjoy.md
+++ b/.changeset/green-ravens-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Return validated elements from generateText array output

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -352,6 +352,36 @@ describe('Output.array', () => {
         });
       }
     });
+
+    it('should return schema-validated values (with transforms applied)', async () => {
+      const arrayWithTransform = array({
+        element: z
+          .object({ content: z.string() })
+          .transform(val => ({ ...val, extra: true })),
+      });
+
+      const result = await arrayWithTransform.parseCompleteOutput(
+        { text: `{ "elements": [{ "content": "hello" }] }` },
+        context,
+      );
+
+      expect(result).toStrictEqual([{ content: 'hello', extra: true }]);
+    });
+
+    it('should return validated values for multiple elements', async () => {
+      const result = await array1.parseCompleteOutput(
+        {
+          text: `{ "elements": [{ "content": "a" }, { "content": "b" }, { "content": "c" }] }`,
+        },
+        context,
+      );
+
+      expect(result).toStrictEqual([
+        { content: 'a' },
+        { content: 'b' },
+        { content: 'c' },
+      ]);
+    });
   });
 
   describe('array.parsePartialOutput', () => {

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -278,6 +278,7 @@ export const array = <ELEMENT>({
         });
       }
 
+      const validatedElements: Array<ELEMENT> = [];
       for (const element of outerValue.elements) {
         const validationResult = await safeValidateTypes({
           value: element,
@@ -294,9 +295,11 @@ export const array = <ELEMENT>({
             finishReason: context.finishReason,
           });
         }
+
+        validatedElements.push(validationResult.value);
       }
 
-      return outerValue.elements as Array<ELEMENT>;
+      return validatedElements;
     },
 
     async parsePartialOutput({ text }: { text: string }) {


### PR DESCRIPTION
## Background

When using `generateText` with `output: Output.array(...)`, the `parseCompleteOutput` method validated each element with `safeValidateTypes` but discarded `validationResult.value`, returning the raw parsed JSON (`outerValue.elements`) instead. This silently dropped any schema transforms (`.transform()`), coercions (`.coerce`), and defaults (`.default()`), causing the TypeScript return type `Array<ELEMENT>` to be incorrect at runtime.

## Summary

- Collect `validationResult.value` during the validation loop and return the validated array instead of `outerValue.elements`
- Remove the unsafe `as Array<ELEMENT>` type assertion
- Add regression tests including one with a `.transform()` schema that proves returned values come from validation, not raw JSON

## Manual Verification

Ran the `output.test.ts` test suite — all 62 tests pass, including the new transform test which would fail on the old code (it would return `{ content: "hello" }` instead of `{ content: "hello", extra: true }`).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15708