### PR TITLE
Expose Google Vertex model id type

### DIFF
--- a/.changeset/expose-google-vertex-model-id.md
+++ b/.changeset/expose-google-vertex-model-id.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Expose the Google Vertex model id type from package entrypoints.

--- a/packages/google-vertex/src/edge/index.ts
+++ b/packages/google-vertex/src/edge/index.ts
@@ -1,3 +1,4 @@
+export type { GoogleVertexModelId } from '../google-vertex-options';
 export {
   createGoogleVertex,
   /** @deprecated Use `createGoogleVertex` instead. */

--- a/packages/google-vertex/src/index.ts
+++ b/packages/google-vertex/src/index.ts
@@ -10,6 +10,7 @@ export type {
   GoogleVertexVideoModelOptions as GoogleVertexVideoProviderOptions,
 } from './google-vertex-video-model-options';
 export type { GoogleVertexVideoModelId } from './google-vertex-video-settings';
+export type { GoogleVertexModelId } from './google-vertex-options';
 export {
   createGoogleVertex,
   /** @deprecated Use `createGoogleVertex` instead. */


### PR DESCRIPTION
## Background

`GoogleVertexModelId` is already the model id type used by `createGoogleVertex`, but the package entrypoints do not export it. Consumers that type wrappers around Vertex models currently need to work around that with inference:

```ts
type GoogleVertexModelId = Parameters<ReturnType<typeof createGoogleVertex>>[0]
```

## Summary

Exports `GoogleVertexModelId` from both the main and edge `@ai-sdk/google-vertex` entrypoints so consumers can import the type directly. Adds the corresponding patch changeset for `@ai-sdk/google-vertex`.

## Manual Verification

This is a type-only export; no runtime manual verification is needed.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)