### PR TITLE
docs(minimax): add MiniMax-M3 and M2.7 to the model table

### DIFF
--- a/content/providers/03-community-providers/28-minimax.mdx
+++ b/content/providers/03-community-providers/28-minimax.mdx
@@ -5,7 +5,7 @@ description: Learn how to use MiniMax provider with the AI SDK.
 
 # MiniMax Provider
 
-[vercel-minimax-ai-provider](https://github.com/MiniMax-AI/vercel-minimax-ai-provider) is a community provider that provides access to the latest [MiniMax-M2 model](https://platform.minimax.io/docs/guides/text-generation) from [MiniMax](https://www.minimax.io/).
+[vercel-minimax-ai-provider](https://github.com/MiniMax-AI/vercel-minimax-ai-provider) is a community provider that provides access to the latest [MiniMax models](https://platform.minimax.io/docs/guides/text-generation), including the flagship MiniMax-M3, from [MiniMax](https://www.minimax.io/).
 
 API keys can be obtained from the [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key).
 
@@ -102,10 +102,13 @@ Both formats access the same MiniMax models with the same capabilities.
 
 ## Model Capabilities
 
-| Model               | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
-| ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `MiniMax-M2`        | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `MiniMax-M2-Stable` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Model                     | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
+| ------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `MiniMax-M3`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2.7`           | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2.7-highspeed` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2`             | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2-Stable`      | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   Please see the [MiniMax


### PR DESCRIPTION
## Summary

Updates the MiniMax community provider docs (`vercel-minimax-ai-provider`) to list MiniMax's current models. The page's model table previously only listed `MiniMax-M2` / `MiniMax-M2-Stable`.

Added rows:
- **`MiniMax-M3`** — flagship, with native multimodal **image input** (✓), 512K context, reasoning
- **`MiniMax-M2.7`** and **`MiniMax-M2.7-highspeed`** — current text models

Also refreshed the intro line to reference M3 rather than M2.

## Notes

- Docs-only change to `content/providers/03-community-providers/28-minimax.mdx`.
- The provider already accepts any model ID as a string (the page's existing forward-compatibility note still applies); this just documents the current lineup.
- Companion change to the provider package itself: MiniMax-AI/vercel-minimax-ai-provider#3