### PR TITLE
feat(azure): support Microsoft Entra ID auth

### DIFF
--- a/.changeset/azure-ad-token-provider.md
+++ b/.changeset/azure-ad-token-provider.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure': patch
+---
+
+Add Microsoft Entra ID token provider authentication for Azure OpenAI.

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -46,6 +46,26 @@ const azure = createAzure({
 });
 ```
 
+For Microsoft Entra ID authentication, you can provide an Azure AD token provider.
+Install `@azure/identity` separately if you want to use its credential helpers:
+
+```ts
+import { createAzure } from '@ai-sdk/azure';
+import {
+  DefaultAzureCredential,
+  getBearerTokenProvider,
+} from '@azure/identity';
+
+const credential = new DefaultAzureCredential();
+const scope = 'https://cognitiveservices.azure.com/.default';
+const azureADTokenProvider = getBearerTokenProvider(credential, scope);
+
+const azure = createAzure({
+  resourceName: 'your-resource-name',
+  azureADTokenProvider,
+});
+```
+
 You can use the following optional settings to customize the OpenAI provider instance:
 
 - **resourceName** _string_
@@ -60,6 +80,11 @@ You can use the following optional settings to customize the OpenAI provider ins
 
   API key that is being sent using the `api-key` header.
   It defaults to the `AZURE_API_KEY` environment variable.
+
+- **azureADTokenProvider** _() => Promise&lt;string&gt;_
+
+  Microsoft Entra ID token provider that returns an access token to be sent using the `Authorization` header.
+  When provided, this is used instead of `apiKey`.
 
 - **apiVersion** _string_
 

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -46,7 +46,7 @@ const azure = createAzure({
 });
 ```
 
-For Microsoft Entra ID authentication, you can provide an Azure AD token provider.
+For Microsoft Entra ID authentication, you can provide a token provider.
 Install `@azure/identity` separately if you want to use its credential helpers:
 
 ```ts
@@ -58,11 +58,11 @@ import {
 
 const credential = new DefaultAzureCredential();
 const scope = 'https://cognitiveservices.azure.com/.default';
-const azureADTokenProvider = getBearerTokenProvider(credential, scope);
+const tokenProvider = getBearerTokenProvider(credential, scope);
 
 const azure = createAzure({
   resourceName: 'your-resource-name',
-  azureADTokenProvider,
+  tokenProvider,
 });
 ```
 
@@ -81,7 +81,7 @@ You can use the following optional settings to customize the OpenAI provider ins
   API key that is being sent using the `api-key` header.
   It defaults to the `AZURE_API_KEY` environment variable.
 
-- **azureADTokenProvider** _() => Promise&lt;string&gt;_
+- **tokenProvider** _() => Promise&lt;string&gt;_
 
   Microsoft Entra ID token provider that returns an access token to be sent using the `Authorization` header.
   When provided, this is used instead of `apiKey`.

--- a/examples/ai-functions/src/e2e/azure.test.ts
+++ b/examples/ai-functions/src/e2e/azure.test.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
-import { expect } from 'vitest';
-import { azure as provider } from '@ai-sdk/azure';
-import type { APICallError } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { azure as provider, createAzure } from '@ai-sdk/azure';
+import { generateText, type APICallError } from 'ai';
 import {
   createFeatureTestSuite,
   createLanguageModelWithCapabilities,
@@ -37,3 +37,21 @@ createFeatureTestSuite({
     },
   },
 })();
+
+describe.skipIf(
+  !process.env.AZURE_RESOURCE_NAME || !process.env.AZURE_OPENAI_AD_TOKEN,
+)('Azure OpenAI Microsoft Entra ID E2E Tests', () => {
+  it('should generate text with azureADTokenProvider', async () => {
+    const azure = createAzure({
+      resourceName: process.env.AZURE_RESOURCE_NAME!,
+      azureADTokenProvider: async () => process.env.AZURE_OPENAI_AD_TOKEN!,
+    });
+
+    const result = await generateText({
+      model: azure(process.env.AZURE_OPENAI_DEPLOYMENT_NAME ?? 'gpt-4o'),
+      prompt: 'Write one short sentence about TypeScript.',
+    });
+
+    expect(result.text).toBeTruthy();
+  });
+});

--- a/examples/ai-functions/src/e2e/azure.test.ts
+++ b/examples/ai-functions/src/e2e/azure.test.ts
@@ -41,10 +41,10 @@ createFeatureTestSuite({
 describe.skipIf(
   !process.env.AZURE_RESOURCE_NAME || !process.env.AZURE_OPENAI_AD_TOKEN,
 )('Azure OpenAI Microsoft Entra ID E2E Tests', () => {
-  it('should generate text with azureADTokenProvider', async () => {
+  it('should generate text with tokenProvider', async () => {
     const azure = createAzure({
       resourceName: process.env.AZURE_RESOURCE_NAME!,
-      azureADTokenProvider: async () => process.env.AZURE_OPENAI_AD_TOKEN!,
+      tokenProvider: async () => process.env.AZURE_OPENAI_AD_TOKEN!,
     });
 
     const result = await generateText({

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -187,12 +187,12 @@ describe('responses (default language model)', () => {
       );
     });
 
-    it('should use azureADTokenProvider for Microsoft Entra ID auth', async () => {
+    it('should use tokenProvider for Microsoft Entra ID auth', async () => {
       prepareJsonResponse();
 
       const provider = createAzure({
         resourceName: 'test-resource',
-        azureADTokenProvider: async () => 'test-azure-ad-token',
+        tokenProvider: async () => 'test-azure-ad-token',
       });
 
       await provider('test-deployment').doGenerate({
@@ -210,14 +210,14 @@ describe('responses (default language model)', () => {
       );
     });
 
-    it('should call azureADTokenProvider for every request', async () => {
+    it('should call tokenProvider for every request', async () => {
       prepareJsonResponse();
 
       let tokenCount = 0;
-      const azureADTokenProvider = vi.fn(async () => `token-${++tokenCount}`);
+      const tokenProvider = vi.fn(async () => `token-${++tokenCount}`);
       const provider = createAzure({
         resourceName: 'test-resource',
-        azureADTokenProvider,
+        tokenProvider,
       });
 
       await provider('test-deployment').doGenerate({
@@ -227,7 +227,7 @@ describe('responses (default language model)', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(azureADTokenProvider).toHaveBeenCalledTimes(2);
+      expect(tokenProvider).toHaveBeenCalledTimes(2);
       expect(server.calls[0].requestHeaders.authorization).toBe(
         'Bearer token-1',
       );
@@ -236,15 +236,15 @@ describe('responses (default language model)', () => {
       );
     });
 
-    it('should reject explicit apiKey with azureADTokenProvider', () => {
+    it('should reject explicit apiKey with tokenProvider', () => {
       expect(() =>
         createAzure({
           resourceName: 'test-resource',
           apiKey: 'test-api-key',
-          azureADTokenProvider: async () => 'test-azure-ad-token',
+          tokenProvider: async () => 'test-azure-ad-token',
         }),
       ).toThrow(
-        'Both apiKey and azureADTokenProvider were provided. Please use only one authentication method.',
+        'Both apiKey and tokenProvider were provided. Please use only one authentication method.',
       );
     });
 

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -187,6 +187,67 @@ describe('responses (default language model)', () => {
       );
     });
 
+    it('should use azureADTokenProvider for Microsoft Entra ID auth', async () => {
+      prepareJsonResponse();
+
+      const provider = createAzure({
+        resourceName: 'test-resource',
+        azureADTokenProvider: async () => 'test-azure-ad-token',
+      });
+
+      await provider('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+        {
+          "authorization": "Bearer test-azure-ad-token",
+          "content-type": "application/json",
+        }
+      `);
+      expect(server.calls[0].requestUserAgent).toContain(
+        `ai-sdk/azure/0.0.0-test`,
+      );
+    });
+
+    it('should call azureADTokenProvider for every request', async () => {
+      prepareJsonResponse();
+
+      let tokenCount = 0;
+      const azureADTokenProvider = vi.fn(async () => `token-${++tokenCount}`);
+      const provider = createAzure({
+        resourceName: 'test-resource',
+        azureADTokenProvider,
+      });
+
+      await provider('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+      await provider('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(azureADTokenProvider).toHaveBeenCalledTimes(2);
+      expect(server.calls[0].requestHeaders.authorization).toBe(
+        'Bearer token-1',
+      );
+      expect(server.calls[1].requestHeaders.authorization).toBe(
+        'Bearer token-2',
+      );
+    });
+
+    it('should reject explicit apiKey with azureADTokenProvider', () => {
+      expect(() =>
+        createAzure({
+          resourceName: 'test-resource',
+          apiKey: 'test-api-key',
+          azureADTokenProvider: async () => 'test-azure-ad-token',
+        }),
+      ).toThrow(
+        'Both apiKey and azureADTokenProvider were provided. Please use only one authentication method.',
+      );
+    });
+
     it('should use the baseURL correctly', async () => {
       prepareJsonResponse();
 

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -7,17 +7,19 @@ import {
   OpenAISpeechModel,
   OpenAITranscriptionModel,
 } from '@ai-sdk/openai/internal';
-import type {
-  EmbeddingModelV4,
-  LanguageModelV4,
-  ProviderV4,
-  ImageModelV4,
-  SpeechModelV4,
-  TranscriptionModelV4,
+import {
+  InvalidArgumentError,
+  type EmbeddingModelV4,
+  type LanguageModelV4,
+  type ProviderV4,
+  type ImageModelV4,
+  type SpeechModelV4,
+  type TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   loadApiKey,
   loadSetting,
+  normalizeHeaders,
   withUserAgentSuffix,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
@@ -115,6 +117,13 @@ export interface AzureOpenAIProviderSettings {
   apiKey?: string;
 
   /**
+   * A function that returns an access token for Microsoft Entra
+   * (formerly known as Azure Active Directory), which will be invoked
+   * on every request.
+   */
+  azureADTokenProvider?: (() => Promise<string>) | undefined;
+
+  /**
    * Custom headers to include in the requests.
    */
   headers?: Record<string, string>;
@@ -144,17 +153,50 @@ export interface AzureOpenAIProviderSettings {
 export function createAzure(
   options: AzureOpenAIProviderSettings = {},
 ): AzureOpenAIProvider {
+  const azureADTokenProvider = options.azureADTokenProvider;
+
+  if (options.apiKey && azureADTokenProvider) {
+    throw new InvalidArgumentError({
+      argument: 'apiKey/azureADTokenProvider',
+      message:
+        'Both apiKey and azureADTokenProvider were provided. Please use only one authentication method.',
+    });
+  }
+
   const getHeaders = () => {
-    const baseHeaders = {
-      'api-key': loadApiKey({
-        apiKey: options.apiKey,
-        environmentVariableName: 'AZURE_API_KEY',
-        description: 'Azure OpenAI',
-      }),
-      ...options.headers,
-    };
-    return withUserAgentSuffix(baseHeaders, `ai-sdk/azure/${VERSION}`);
+    const authHeaders = azureADTokenProvider
+      ? {}
+      : {
+          'api-key': loadApiKey({
+            apiKey: options.apiKey,
+            environmentVariableName: 'AZURE_API_KEY',
+            description: 'Azure OpenAI',
+          }),
+        };
+
+    return withUserAgentSuffix(
+      {
+        ...authHeaders,
+        ...options.headers,
+      },
+      `ai-sdk/azure/${VERSION}`,
+    );
   };
+
+  const fetch: FetchFunction | undefined = azureADTokenProvider
+    ? async (input, init) => {
+        const headers = normalizeHeaders(init?.headers);
+
+        if (headers.authorization == null) {
+          headers.authorization = `Bearer ${await azureADTokenProvider()}`;
+        }
+
+        return (options.fetch ?? globalThis.fetch)(input, {
+          ...init,
+          headers,
+        });
+      }
+    : options.fetch;
 
   const getResourceName = () =>
     loadSetting({
@@ -188,7 +230,7 @@ export function createAzure(
       provider: 'azure.chat',
       url,
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch,
     });
 
   const createCompletionModel = (modelId: string) =>
@@ -196,7 +238,7 @@ export function createAzure(
       provider: 'azure.completion',
       url,
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch,
     });
 
   const createEmbeddingModel = (modelId: string) =>
@@ -204,7 +246,7 @@ export function createAzure(
       provider: 'azure.embeddings',
       headers: getHeaders,
       url,
-      fetch: options.fetch,
+      fetch,
     });
 
   const createResponsesModel = (modelId: string) =>
@@ -212,7 +254,7 @@ export function createAzure(
       provider: 'azure.responses',
       url,
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch,
       // Soft-deprecated. TODO: remove in v8
       fileIdPrefixes: ['assistant-'],
     });
@@ -222,7 +264,7 @@ export function createAzure(
       provider: 'azure.image',
       url,
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch,
     });
 
   const createTranscriptionModel = (modelId: string) =>
@@ -230,7 +272,7 @@ export function createAzure(
       provider: 'azure.transcription',
       url,
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch,
     });
 
   const createSpeechModel = (modelId: string) =>
@@ -238,7 +280,7 @@ export function createAzure(
       provider: 'azure.speech',
       url,
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch,
     });
 
   const provider = function (deploymentId: string) {

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -121,7 +121,7 @@ export interface AzureOpenAIProviderSettings {
    * (formerly known as Azure Active Directory), which will be invoked
    * on every request.
    */
-  azureADTokenProvider?: (() => Promise<string>) | undefined;
+  tokenProvider?: (() => Promise<string>) | undefined;
 
   /**
    * Custom headers to include in the requests.
@@ -153,18 +153,18 @@ export interface AzureOpenAIProviderSettings {
 export function createAzure(
   options: AzureOpenAIProviderSettings = {},
 ): AzureOpenAIProvider {
-  const azureADTokenProvider = options.azureADTokenProvider;
+  const tokenProvider = options.tokenProvider;
 
-  if (options.apiKey && azureADTokenProvider) {
+  if (options.apiKey && tokenProvider) {
     throw new InvalidArgumentError({
-      argument: 'apiKey/azureADTokenProvider',
+      argument: 'apiKey/tokenProvider',
       message:
-        'Both apiKey and azureADTokenProvider were provided. Please use only one authentication method.',
+        'Both apiKey and tokenProvider were provided. Please use only one authentication method.',
     });
   }
 
   const getHeaders = () => {
-    const authHeaders = azureADTokenProvider
+    const authHeaders = tokenProvider
       ? {}
       : {
           'api-key': loadApiKey({
@@ -183,12 +183,12 @@ export function createAzure(
     );
   };
 
-  const fetch: FetchFunction | undefined = azureADTokenProvider
+  const fetch: FetchFunction | undefined = tokenProvider
     ? async (input, init) => {
         const headers = normalizeHeaders(init?.headers);
 
         if (headers.authorization == null) {
-          headers.authorization = `Bearer ${await azureADTokenProvider()}`;
+          headers.authorization = `Bearer ${await tokenProvider()}`;
         }
 
         return (options.fetch ?? globalThis.fetch)(input, {


### PR DESCRIPTION
## Background

Azure OpenAI users need Microsoft Entra ID bearer-token auth in environments where API-key auth is disabled.

## Summary

Adds `azureADTokenProvider` to `@ai-sdk/azure`; when provided, the provider omits the `api-key` header and injects `Authorization: Bearer <token>` on each request.

## Manual Verification

- `pnpm test` in `packages/azure`
- `pnpm build` in `packages/azure`
- Live Azure OpenAI smoke test with real Microsoft Entra credentials.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
