### PR TITLE
chore(ci): set top-level permissions on workflows

### DIFF
--- a/.github/workflows/ai-provider-api-changes.yml
+++ b/.github/workflows/ai-provider-api-changes.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [ai-provider-api-change]
 
+permissions:
+  contents: read
+
 jobs:
   create-issue:
     name: 'Create Issue for Provider API Change'

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - '.changeset/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   verify-changesets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes.

Setting `contents: read` explicitly on `.github/workflows/ai-provider-api-changes.yml`, `.github/workflows/verify-changesets.yml` keeps the workflow token scoped to what the job actually uses. If a third-party action or transitive dependency in the run were ever compromised, a read-only token limits the damage (no pushes, no releases, no token-backed writes). The change is mechanical and does not alter any step.