### PR TITLE
Backport: feat (provider/amazon-bedrock): add bedrock mantle provider (#14246)

### DIFF
--- a/.changeset/bedrock-mantle-provider.md
+++ b/.changeset/bedrock-mantle-provider.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+added bedrock mantle provider

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -1641,6 +1641,163 @@ on how to integrate reasoning into your chatbot.
   Connector which are not supported on Bedrock.
 </Note>
 
+## Bedrock Mantle Provider Usage
+
+The Bedrock Mantle provider offers access to OpenAI-compatible models through Amazon Bedrock's Mantle API at `https://bedrock-mantle.{region}.api.aws/v1`. This endpoint supports the Chat Completions API and the Responses API, and provides access to models that may only be available through the Mantle endpoint (such as `openai.gpt-oss-120b`).
+
+### Provider Instance
+
+You can import the default provider instance `bedrockMantle` from `@ai-sdk/amazon-bedrock/mantle`:
+
+```typescript
+import { bedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+```
+
+If you need a customized setup, you can import `createBedrockMantle` from `@ai-sdk/amazon-bedrock/mantle` and create a provider instance with your settings:
+
+```typescript
+import { createBedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+
+const bedrockMantle = createBedrockMantle({
+  region: 'us-east-1', // optional
+  accessKeyId: 'xxxxxxxxx', // optional
+  secretAccessKey: 'xxxxxxxxx', // optional
+  sessionToken: 'xxxxxxxxx', // optional
+});
+```
+
+#### Provider Settings
+
+You can use the following optional settings to customize the Bedrock Mantle provider instance:
+
+- **region** _string_
+
+  The AWS region that you want to use for the API calls.
+  It uses the `AWS_REGION` environment variable by default.
+
+- **accessKeyId** _string_
+
+  The AWS access key ID that you want to use for the API calls.
+  It uses the `AWS_ACCESS_KEY_ID` environment variable by default.
+
+- **secretAccessKey** _string_
+
+  The AWS secret access key that you want to use for the API calls.
+  It uses the `AWS_SECRET_ACCESS_KEY` environment variable by default.
+
+- **sessionToken** _string_
+
+  Optional. The AWS session token that you want to use for the API calls.
+  It uses the `AWS_SESSION_TOKEN` environment variable by default.
+
+- **apiKey** _string_
+
+  API key for authenticating requests using Bearer token authentication.
+  When provided, this will be used instead of AWS SigV4 authentication.
+  It uses the `AWS_BEARER_TOKEN_BEDROCK` environment variable by default.
+
+- **baseURL** _string_
+
+  Base URL for the Bedrock Mantle API calls.
+  Defaults to `https://bedrock-mantle.{region}.api.aws/v1`.
+
+- **headers** _Record&lt;string, string | undefined&gt;_
+
+  Headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
+- **credentialProvider** _() => PromiseLike&lt;BedrockCredentials&gt;_
+
+  The AWS credential provider to use for the Bedrock provider to get dynamic
+  credentials similar to the AWS SDK. Setting a provider here will cause its
+  credential values to be used instead of the `accessKeyId`, `secretAccessKey`,
+  and `sessionToken` settings.
+
+### Language Models
+
+You can create models using the Mantle provider instance. By default, the provider creates models using the Chat Completions API, which has the broadest model support on Mantle:
+
+```ts
+const model = bedrockMantle('openai.gpt-oss-120b');
+```
+
+You can also explicitly select the Chat Completions API or the Responses API:
+
+```ts
+const chatModel = bedrockMantle.chat('openai.gpt-oss-120b');
+const responsesModel = bedrockMantle.responses('openai.gpt-oss-120b');
+```
+
+Note that not all Mantle models support the Responses API. See the model capabilities table below.
+
+You can use Bedrock Mantle language models to generate text with the `generateText` function:
+
+```ts
+import { bedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: bedrockMantle('openai.gpt-oss-120b'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+Or stream text with the `streamText` function:
+
+```ts
+import { bedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: bedrockMantle('openai.gpt-oss-120b'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+### Provider Options
+
+Since the Mantle API is OpenAI-compatible, provider options are passed under the `openai` namespace:
+
+```ts
+import { bedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: bedrockMantle('openai.gpt-oss-120b'),
+  prompt: 'Hello!',
+  providerOptions: {
+    openai: {
+      // OpenAI-compatible provider options
+    },
+  },
+});
+```
+
+### Model Capabilities
+
+| Model                           | Chat Completions    | Responses API       |
+| ------------------------------- | ------------------- | ------------------- |
+| `openai.gpt-oss-20b`            | <Check size={18} /> | <Check size={18} /> |
+| `openai.gpt-oss-120b`           | <Check size={18} /> | <Check size={18} /> |
+| `openai.gpt-oss-safeguard-20b`  | <Check size={18} /> | <Cross size={18} /> |
+| `openai.gpt-oss-safeguard-120b` | <Check size={18} /> | <Cross size={18} /> |
+
+<Note>
+  The Bedrock Mantle provider uses the OpenAI-compatible API format. Models
+  available through the Mantle endpoint may differ from those available through
+  the Bedrock Converse API. Use the Mantle endpoint's model listing API to
+  discover all available models.
+</Note>
+
 ## Migrating to `@ai-sdk/amazon-bedrock` 2.x
 
 The Amazon Bedrock provider was rewritten in version 2.x to remove the

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/bedrock-mantle-chat.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/bedrock-mantle-chat.ts
@@ -1,0 +1,20 @@
+import { createBedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const bedrockMantle = createBedrockMantle({
+    region: 'us-east-1',
+  });
+
+  const result = await generateText({
+    model: bedrockMantle.chat('openai.gpt-oss-120b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log('Response headers:', result.response.headers);
+});

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/bedrock-mantle.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/bedrock-mantle.ts
@@ -1,0 +1,16 @@
+import { bedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrockMantle('openai.gpt-oss-20b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log('Response headers:', result.response.headers);
+});

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/bedrock-mantle-chat.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/bedrock-mantle-chat.ts
@@ -1,0 +1,23 @@
+import { createBedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const bedrockMantle = createBedrockMantle({
+    region: 'us-east-1',
+  });
+
+  const result = streamText({
+    model: bedrockMantle.chat('openai.gpt-oss-20b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log('Response headers:', (await result.response).headers);
+});

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/bedrock-mantle.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/bedrock-mantle.ts
@@ -1,0 +1,19 @@
+import { bedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: bedrockMantle('openai.gpt-oss-20b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log('Response headers:', (await result.response).headers);
+});

--- a/packages/amazon-bedrock/mantle/index.d.ts
+++ b/packages/amazon-bedrock/mantle/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/mantle';

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -16,7 +16,8 @@
     "!src/**/__fixtures__",
     "CHANGELOG.md",
     "README.md",
-    "anthropic/index.d.ts"
+    "anthropic/index.d.ts",
+    "mantle/index.d.ts"
   ],
   "directories": {
     "doc": "./docs"
@@ -45,10 +46,16 @@
       "types": "./dist/anthropic/index.d.ts",
       "import": "./dist/anthropic/index.mjs",
       "require": "./dist/anthropic/index.js"
+    },
+    "./mantle": {
+      "types": "./dist/mantle/index.d.ts",
+      "import": "./dist/mantle/index.mjs",
+      "require": "./dist/mantle/index.js"
     }
   },
   "dependencies": {
     "@ai-sdk/anthropic": "workspace:*",
+    "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
     "@smithy/eventstream-codec": "^4.0.1",

--- a/packages/amazon-bedrock/src/bedrock-sigv4-fetch.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-sigv4-fetch.test.ts
@@ -19,11 +19,14 @@ vi.mock('@ai-sdk/provider-utils', async () => {
 });
 
 // Mock AwsV4Signer so that no real crypto calls are made.
+// Capture constructor options for test assertions.
+let lastSignerOptions: any = null;
 vi.mock('aws4fetch', () => {
   class MockAwsV4Signer {
     options: any;
     constructor(options: any) {
       this.options = options;
+      lastSignerOptions = options;
     }
     async sign() {
       // Return a fake Headers instance with predetermined signing headers.
@@ -130,7 +133,7 @@ describe('createSigV4FetchFunction', () => {
     expect(calledInit.body).toEqual('{"test": "data"}');
   });
 
-  it('shold handle a POST request with a Request object', async () => {
+  it('should handle a POST request with a Request object', async () => {
     const dummyResponse = new Response('Signed', { status: 200 });
     const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
     const fetchFn = createFetchFunction(dummyFetch);
@@ -378,6 +381,53 @@ describe('createSigV4FetchFunction', () => {
 
     // The underlying fetch should not be called
     expect(dummyFetch).not.toHaveBeenCalled();
+  });
+
+  it('should use default service name "bedrock" when no service parameter is provided', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    lastSignerOptions = null;
+
+    const fetchFn = createSigV4FetchFunction(
+      () => ({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret',
+      }),
+      dummyFetch,
+    );
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(lastSignerOptions).not.toBeNull();
+    expect(lastSignerOptions.service).toBe('bedrock');
+  });
+
+  it('should use custom service name when service parameter is provided', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    lastSignerOptions = null;
+
+    const fetchFn = createSigV4FetchFunction(
+      () => ({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret',
+      }),
+      dummyFetch,
+      'bedrock-mantle',
+    );
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(lastSignerOptions).not.toBeNull();
+    expect(lastSignerOptions.service).toBe('bedrock-mantle');
   });
 });
 

--- a/packages/amazon-bedrock/src/bedrock-sigv4-fetch.ts
+++ b/packages/amazon-bedrock/src/bedrock-sigv4-fetch.ts
@@ -20,11 +20,13 @@ export interface BedrockCredentials {
  *
  * @param getCredentials - Function that returns the AWS credentials to use when signing.
  * @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+ * @param service - The AWS service name to use for SigV4 signing scope. Defaults to 'bedrock'.
  * @returns A FetchFunction that signs requests before passing them to the underlying fetch.
  */
 export function createSigV4FetchFunction(
   getCredentials: () => BedrockCredentials | PromiseLike<BedrockCredentials>,
   fetch?: FetchFunction,
+  service: string = 'bedrock',
 ): FetchFunction {
   return async (
     input: RequestInfo | URL,
@@ -77,7 +79,7 @@ export function createSigV4FetchFunction(
       accessKeyId: credentials.accessKeyId,
       secretAccessKey: credentials.secretAccessKey,
       sessionToken: credentials.sessionToken,
-      service: 'bedrock',
+      service,
     });
 
     const signingResult = await signer.sign();

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-options.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-options.ts
@@ -1,0 +1,15 @@
+export type BedrockMantleChatModelId =
+  | 'openai.gpt-oss-20b'
+  | 'openai.gpt-oss-120b'
+  | 'openai.gpt-oss-safeguard-20b'
+  | 'openai.gpt-oss-safeguard-120b'
+  | (string & {});
+
+export type BedrockMantleResponsesModelId =
+  | 'openai.gpt-oss-20b'
+  | 'openai.gpt-oss-120b'
+  | (string & {});
+
+export type BedrockMantleModelId =
+  | BedrockMantleChatModelId
+  | BedrockMantleResponsesModelId;

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.test.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.test.ts
@@ -1,0 +1,278 @@
+import { createBedrockMantle } from './bedrock-mantle-provider';
+import { NoSuchModelError } from '@ai-sdk/provider';
+import {
+  OpenAIChatLanguageModel,
+  OpenAIResponsesLanguageModel,
+} from '@ai-sdk/openai/internal';
+import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
+import {
+  createApiKeyFetchFunction,
+  createSigV4FetchFunction,
+} from '../bedrock-sigv4-fetch';
+import { vi, describe, beforeEach, it, expect } from 'vitest';
+
+vi.mock('@ai-sdk/provider-utils', async importOriginal => {
+  const actual = await importOriginal<typeof ProviderUtilsModule>();
+  return {
+    ...actual,
+    loadOptionalSetting: vi.fn().mockImplementation(({ settingValue }) => {
+      // Return undefined for API key to test SigV4 flow
+      if (settingValue === undefined) return undefined;
+      return settingValue;
+    }),
+    loadSetting: vi.fn().mockImplementation(({ settingValue, settingName }) => {
+      if (settingValue) return settingValue;
+      // Return mock values for required settings
+      if (settingName === 'region') return 'us-east-1';
+      if (settingName === 'accessKeyId') return 'mock-access-key';
+      if (settingName === 'secretAccessKey') return 'mock-secret-key';
+      return settingValue;
+    }),
+    withoutTrailingSlash: vi.fn().mockImplementation(url => url),
+    withUserAgentSuffix: vi.fn().mockImplementation((headers, suffix) => ({
+      ...headers,
+      'user-agent': suffix,
+    })),
+  };
+});
+
+vi.mock('@ai-sdk/openai/internal', async () => {
+  const originalModule = await vi.importActual('@ai-sdk/openai/internal');
+  return {
+    ...originalModule,
+    OpenAIChatLanguageModel: vi.fn(),
+    OpenAIResponsesLanguageModel: vi.fn(),
+  };
+});
+
+vi.mock('../bedrock-sigv4-fetch', () => ({
+  createSigV4FetchFunction: vi.fn().mockReturnValue(vi.fn()),
+  createApiKeyFetchFunction: vi.fn().mockReturnValue(vi.fn()),
+}));
+
+describe('bedrock-mantle-provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a chat model with default settings', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('openai.gpt-oss-20b');
+
+    expect(OpenAIChatLanguageModel).toHaveBeenCalledWith(
+      'openai.gpt-oss-20b',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.chat',
+        url: expect.any(Function),
+        headers: expect.any(Function),
+        fetch: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should create a chat model via .chat()', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider.chat('openai.gpt-oss-20b');
+
+    expect(OpenAIChatLanguageModel).toHaveBeenCalledWith(
+      'openai.gpt-oss-20b',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.chat',
+        url: expect.any(Function),
+        headers: expect.any(Function),
+        fetch: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should alias .languageModel() to chat model', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider.languageModel('test-model');
+
+    expect(OpenAIChatLanguageModel).toHaveBeenCalledWith(
+      'test-model',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.chat',
+      }),
+    );
+  });
+
+  it('should create a responses model via .responses()', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider.responses('test-model');
+
+    expect(OpenAIResponsesLanguageModel).toHaveBeenCalledWith(
+      'test-model',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.responses',
+      }),
+    );
+  });
+
+  it('should throw an error when using new keyword', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(() => new (provider as any)('test-model-id')).toThrow(
+      'The Bedrock Mantle model function cannot be called with the new keyword.',
+    );
+  });
+
+  it('should use default base URL with region', () => {
+    const provider = createBedrockMantle({
+      region: 'us-west-2',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model');
+
+    const constructorCall = vi.mocked(OpenAIChatLanguageModel).mock.calls[
+      vi.mocked(OpenAIChatLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const generatedUrl = config.url({
+      path: '/responses',
+      modelId: 'test-model',
+    });
+    expect(generatedUrl).toBe(
+      'https://bedrock-mantle.us-west-2.api.aws/v1/responses',
+    );
+  });
+
+  it('should pass custom baseURL to the model when created', () => {
+    const customBaseURL = 'https://custom-mantle.example.com/v1';
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      baseURL: customBaseURL,
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model');
+
+    const constructorCall = vi.mocked(OpenAIChatLanguageModel).mock.calls[
+      vi.mocked(OpenAIChatLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const generatedUrl = config.url({
+      path: '/chat/completions',
+      modelId: 'test-model',
+    });
+    expect(generatedUrl).toBe(
+      'https://custom-mantle.example.com/v1/chat/completions',
+    );
+  });
+
+  it('should include custom headers with user-agent suffix', () => {
+    const customHeaders = { 'Custom-Header': 'custom-value' };
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      headers: customHeaders,
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model');
+
+    const constructorCall = vi.mocked(OpenAIChatLanguageModel).mock.calls[
+      vi.mocked(OpenAIChatLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const resolvedHeaders = config.headers!();
+    expect(resolvedHeaders).toMatchObject(customHeaders);
+    expect(resolvedHeaders['user-agent']).toContain('ai-sdk/amazon-bedrock/');
+  });
+
+  it('should use createApiKeyFetchFunction when apiKey is provided', () => {
+    createBedrockMantle({
+      region: 'us-east-1',
+      apiKey: 'test-api-key',
+    });
+
+    expect(createApiKeyFetchFunction).toHaveBeenCalledWith(
+      'test-api-key',
+      undefined,
+    );
+    expect(createSigV4FetchFunction).not.toHaveBeenCalled();
+  });
+
+  it('should use createSigV4FetchFunction with bedrock-mantle service when no apiKey', () => {
+    createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(createSigV4FetchFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      'bedrock-mantle',
+    );
+    expect(createApiKeyFetchFunction).not.toHaveBeenCalled();
+  });
+
+  it('should throw NoSuchModelError for embeddingModel', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(() => provider.embeddingModel('invalid-model-id')).toThrow(
+      NoSuchModelError,
+    );
+  });
+
+  it('should throw NoSuchModelError for imageModel', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(() => provider.imageModel('invalid-model-id')).toThrow(
+      NoSuchModelError,
+    );
+  });
+
+  it('should have correct specificationVersion', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(provider.specificationVersion).toBe('v3');
+  });
+
+  it('should provide languageModel as alias for responses', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(provider.languageModel).toBeDefined();
+    expect(typeof provider.languageModel).toBe('function');
+  });
+});

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.ts
@@ -1,0 +1,281 @@
+import {
+  OpenAIChatLanguageModel,
+  OpenAIResponsesLanguageModel,
+} from '@ai-sdk/openai/internal';
+import {
+  NoSuchModelError,
+  type LanguageModelV3,
+  type ProviderV3,
+} from '@ai-sdk/provider';
+import {
+  loadOptionalSetting,
+  loadSetting,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import {
+  createApiKeyFetchFunction,
+  createSigV4FetchFunction,
+  type BedrockCredentials,
+} from '../bedrock-sigv4-fetch';
+import type {
+  BedrockMantleChatModelId,
+  BedrockMantleResponsesModelId,
+} from './bedrock-mantle-options';
+import { VERSION } from '../version';
+
+export interface BedrockMantleProvider extends ProviderV3 {
+  /**
+   * Creates a model for text generation using the Chat Completions API.
+   * Chat Completions has the broadest model support on Mantle.
+   */
+  (modelId: BedrockMantleChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a model for text generation using the Chat Completions API.
+   */
+  languageModel(modelId: BedrockMantleChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a model for text generation using the Chat Completions API.
+   */
+  chat(modelId: BedrockMantleChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a model for text generation using the Responses API.
+   * Not all Mantle models support this API. Notably, gpt-oss-safeguard models
+   * are Chat-only.
+   */
+  responses(modelId: BedrockMantleResponsesModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Mantle does not support embedding models.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export interface BedrockMantleProviderSettings {
+  /**
+   * The AWS region to use for the Bedrock Mantle endpoint. Defaults to the value of the
+   * `AWS_REGION` environment variable.
+   */
+  region?: string;
+
+  /**
+   * API key for authenticating requests using Bearer token authentication.
+   * When provided, this will be used instead of AWS SigV4 authentication.
+   * Defaults to the value of the `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * The AWS access key ID to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_ACCESS_KEY_ID` environment variable.
+   */
+  accessKeyId?: string;
+
+  /**
+   * The AWS secret access key to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SECRET_ACCESS_KEY` environment variable.
+   */
+  secretAccessKey?: string;
+
+  /**
+   * The AWS session token to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SESSION_TOKEN` environment variable.
+   */
+  sessionToken?: string;
+
+  /**
+   * Base URL for the Bedrock Mantle API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string | undefined>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+
+  /**
+   * The AWS credential provider to use for SigV4 authentication to get dynamic
+   * credentials similar to the AWS SDK. Setting a provider here will cause its
+   * credential values to be used instead of the `accessKeyId`, `secretAccessKey`,
+   * and `sessionToken` settings.
+   */
+  credentialProvider?: () => PromiseLike<Omit<BedrockCredentials, 'region'>>;
+}
+
+/**
+ * Create an Amazon Bedrock Mantle provider instance.
+ * This provider uses the OpenAI-compatible Mantle API for models that are
+ * only available through the Mantle endpoint (e.g. openai.gpt-oss-20b).
+ */
+export function createBedrockMantle(
+  options: BedrockMantleProviderSettings = {},
+): BedrockMantleProvider {
+  // Check for API key authentication first
+  const rawApiKey = loadOptionalSetting({
+    settingValue: options.apiKey,
+    environmentVariableName: 'AWS_BEARER_TOKEN_BEDROCK',
+  });
+
+  // Only use API key if it's a non-empty, non-whitespace string
+  const apiKey =
+    rawApiKey && rawApiKey.trim().length > 0 ? rawApiKey.trim() : undefined;
+
+  // Use API key authentication if available, otherwise fall back to SigV4
+  const fetchFunction = apiKey
+    ? createApiKeyFetchFunction(apiKey, options.fetch)
+    : createSigV4FetchFunction(
+        async () => {
+          const region = loadSetting({
+            settingValue: options.region,
+            settingName: 'region',
+            environmentVariableName: 'AWS_REGION',
+            description: 'AWS region',
+          });
+
+          // If a credential provider is provided, use it to get the credentials.
+          if (options.credentialProvider) {
+            try {
+              return {
+                ...(await options.credentialProvider()),
+                region,
+              };
+            } catch (error) {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error);
+              throw new Error(
+                `AWS credential provider failed: ${errorMessage}. ` +
+                  'Please ensure your credential provider returns valid AWS credentials ' +
+                  'with accessKeyId and secretAccessKey properties.',
+              );
+            }
+          }
+
+          try {
+            return {
+              region,
+              accessKeyId: loadSetting({
+                settingValue: options.accessKeyId,
+                settingName: 'accessKeyId',
+                environmentVariableName: 'AWS_ACCESS_KEY_ID',
+                description: 'AWS access key ID',
+              }),
+              secretAccessKey: loadSetting({
+                settingValue: options.secretAccessKey,
+                settingName: 'secretAccessKey',
+                environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
+                description: 'AWS secret access key',
+              }),
+              sessionToken: loadOptionalSetting({
+                settingValue: options.sessionToken,
+                environmentVariableName: 'AWS_SESSION_TOKEN',
+              }),
+            };
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            if (
+              errorMessage.includes('AWS_ACCESS_KEY_ID') ||
+              errorMessage.includes('accessKeyId')
+            ) {
+              throw new Error(
+                'AWS SigV4 authentication requires AWS credentials. Please provide either:\n' +
+                  '1. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables\n' +
+                  '2. Provide accessKeyId and secretAccessKey in options\n' +
+                  '3. Use a credentialProvider function\n' +
+                  '4. Use API key authentication with AWS_BEARER_TOKEN_BEDROCK or apiKey option\n' +
+                  `Original error: ${errorMessage}`,
+              );
+            }
+            if (
+              errorMessage.includes('AWS_SECRET_ACCESS_KEY') ||
+              errorMessage.includes('secretAccessKey')
+            ) {
+              throw new Error(
+                'AWS SigV4 authentication requires both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. ' +
+                  'Please ensure both credentials are provided.\n' +
+                  `Original error: ${errorMessage}`,
+              );
+            }
+            throw error;
+          }
+        },
+        options.fetch,
+        'bedrock-mantle',
+      );
+
+  const getBaseURL = (): string =>
+    withoutTrailingSlash(
+      options.baseURL ??
+        `https://bedrock-mantle.${loadSetting({
+          settingValue: options.region,
+          settingName: 'region',
+          environmentVariableName: 'AWS_REGION',
+          description: 'AWS region',
+        })}.api.aws/v1`,
+    ) ?? 'https://bedrock-mantle.us-east-1.api.aws/v1';
+
+  const getHeaders = (): Record<string, string | undefined> =>
+    withUserAgentSuffix(
+      options.headers ?? {},
+      `ai-sdk/amazon-bedrock/${VERSION}`,
+    );
+
+  const url = ({ path }: { path: string; modelId: string }): string =>
+    `${getBaseURL()}${path}`;
+
+  const createChatModel = (modelId: BedrockMantleChatModelId) =>
+    new OpenAIChatLanguageModel(modelId, {
+      provider: 'bedrock-mantle.chat',
+      url,
+      headers: getHeaders,
+      fetch: fetchFunction,
+    });
+
+  const createResponsesModel = (modelId: BedrockMantleResponsesModelId) =>
+    new OpenAIResponsesLanguageModel(modelId, {
+      provider: 'bedrock-mantle.responses',
+      url,
+      headers: getHeaders,
+      fetch: fetchFunction,
+    });
+
+  const provider = function (modelId: BedrockMantleChatModelId) {
+    if (new.target) {
+      throw new Error(
+        'The Bedrock Mantle model function cannot be called with the new keyword.',
+      );
+    }
+
+    return createChatModel(modelId);
+  };
+
+  provider.specificationVersion = 'v3' as const;
+  provider.languageModel = createChatModel;
+  provider.chat = createChatModel;
+  provider.responses = createResponsesModel;
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider as BedrockMantleProvider;
+}
+
+/**
+ * Default Bedrock Mantle provider instance.
+ */
+export const bedrockMantle = createBedrockMantle();

--- a/packages/amazon-bedrock/src/mantle/index.ts
+++ b/packages/amazon-bedrock/src/mantle/index.ts
@@ -1,0 +1,6 @@
+export { bedrockMantle, createBedrockMantle } from './bedrock-mantle-provider';
+export type {
+  BedrockMantleProvider,
+  BedrockMantleProviderSettings,
+} from './bedrock-mantle-provider';
+export type { BedrockMantleModelId } from './bedrock-mantle-options';

--- a/packages/amazon-bedrock/tsconfig.json
+++ b/packages/amazon-bedrock/tsconfig.json
@@ -10,17 +10,24 @@
     "build",
     "node_modules",
     "tsup.config.ts",
-    "anthropic/index.d.ts"
+    "anthropic/index.d.ts",
+    "mantle/index.d.ts"
   ],
   "references": [
     {
       "path": "../anthropic"
     },
     {
+      "path": "../openai"
+    },
+    {
       "path": "../provider"
     },
     {
       "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
     }
   ]
 }

--- a/packages/amazon-bedrock/tsup.config.ts
+++ b/packages/amazon-bedrock/tsup.config.ts
@@ -26,4 +26,17 @@ export default defineConfig([
       ),
     },
   },
+  {
+    entry: ['src/mantle/index.ts'],
+    outDir: 'dist/mantle',
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1422,6 +1422,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: workspace:*
         version: link:../anthropic
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../openai
       '@ai-sdk/provider':
         specifier: workspace:*
         version: link:../provider


### PR DESCRIPTION
## Background

Manual backport of #14246 (which added the Bedrock Mantle provider on `main`/v7) to the `release-v6.0` line.

Mantle is Amazon Bedrock's OpenAI-compatible endpoint (`bedrock-mantle.{region}.api.aws`), used to serve OpenAI models (gpt-oss, and the new GPT-5.x) on Bedrock via the OpenAI Chat Completions / Responses APIs. The existing Converse-based Bedrock provider can't reach these, so this adds a dedicated `@ai-sdk/amazon-bedrock/mantle` sub-provider that wraps the OpenAI chat + responses language models with Bedrock SigV4 / Bearer (`AWS_BEARER_TOKEN_BEDROCK`) auth.

## Summary

- New `@ai-sdk/amazon-bedrock/mantle` export: `createBedrockMantle` / `bedrockMantle` with `.chat()`, `.languageModel()`, and `.responses()`
- Extends `createSigV4FetchFunction` with an optional `service` param (default `'bedrock'`) so Mantle can sign with the `'bedrock-mantle'` scope — additive, existing callers unchanged
- Examples, docs (`08-amazon-bedrock.mdx`), and changeset

## Adaptations from the v7 PR

- `ProviderV4`/`LanguageModelV4` → `ProviderV3`/`LanguageModelV3`; `specificationVersion` `'v4'` → `'v3'` (matches the v6 OpenAI models)
- SigV4 fetch import path/type updated to the v6 names (`bedrock-sigv4-fetch`, `BedrockCredentials`)

## Verification

- Build (emits `dist/mantle/`), `tsc --build`, oxlint + oxfmt: clean
- `@ai-sdk/amazon-bedrock` tests: passing (node + edge), incl. the new mantle provider tests and the SigV4 `service`-param tests

## Notes

- Default base URL is `bedrock-mantle.{region}.api.aws/v1`, carried over verbatim from the v7 PR. Consumers can override via `baseURL`.