### PR TITLE
fix: handle image URL tool results for Vertex

### DIFF
--- a/.changeset/hungry-badgers-scream.md
+++ b/.changeset/hungry-badgers-scream.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/google": patch
+"ai": patch
+---
+
+Fix Google/Vertex handling of URL-backed image tool results.

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1334,6 +1334,83 @@ describe('convertToLanguageModelPrompt', () => {
         ]
       `);
     });
+
+    it('should download legacy image-url tool result content when only a top-level media type is known', async () => {
+      const mockDownload = vi.fn().mockImplementation(requestedDownloads =>
+        requestedDownloads.map(() => ({
+          data: new Uint8Array([8, 9, 10, 11]),
+          mediaType: 'image/png',
+        })),
+      );
+
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId',
+                  toolName: 'toolName',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'image-url',
+                        url: 'https://example.com/preview',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {
+          '*': [/^https?:\/\/.*$/],
+        },
+        download: mockDownload,
+      });
+
+      expect(mockDownload).toHaveBeenCalledOnce();
+      expect(mockDownload).toHaveBeenCalledWith([
+        {
+          url: new URL('https://example.com/preview'),
+          isUrlSupportedByModel: false,
+        },
+      ]);
+
+      expect(result[1].role).toBe('tool');
+      expect(result[1].content[0]).toMatchObject({
+        type: 'tool-result',
+        output: {
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: {
+                type: 'data',
+                data: new Uint8Array([8, 9, 10, 11]),
+              },
+            },
+          ],
+        },
+      });
+    });
   });
 });
 
@@ -3048,6 +3125,7 @@ describe('convertToLanguageModelMessage', () => {
                       "type": "url",
                       "url": "https://example.com/image.png",
                     },
+                    "filename": undefined,
                     "mediaType": "image/png",
                     "providerOptions": undefined,
                     "type": "file",
@@ -3087,6 +3165,7 @@ describe('convertToLanguageModelMessage', () => {
                       "type": "url",
                       "url": "https://example.com/image.png",
                     },
+                    "filename": undefined,
                     "mediaType": "image",
                     "providerOptions": undefined,
                     "type": "file",

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -423,8 +423,56 @@ function convertImagePartToFilePart(
   };
 }
 
+function collectToolResultFileParts(
+  output: ToolResultOutput,
+): Array<{ part: FilePart; forceDownload: boolean }> {
+  if (output.type !== 'content') {
+    return [];
+  }
+
+  return output.value.flatMap(item => {
+    switch (item.type) {
+      case 'file':
+        return [
+          {
+            part: item,
+            forceDownload: !isFullMediaType(item.mediaType),
+          },
+        ];
+      case 'file-url': {
+        const mediaType = item.mediaType ?? getMediaTypeFromUrl(item.url);
+        return [
+          {
+            part: {
+              type: 'file' as const,
+              data: { type: 'url' as const, url: new URL(item.url) },
+              mediaType,
+              providerOptions: item.providerOptions,
+            },
+            forceDownload: !isFullMediaType(mediaType),
+          },
+        ];
+      }
+      case 'image-url':
+        return [
+          {
+            part: {
+              type: 'file' as const,
+              data: { type: 'url' as const, url: new URL(item.url) },
+              mediaType: 'image',
+              providerOptions: item.providerOptions,
+            },
+            forceDownload: true,
+          },
+        ];
+      default:
+        return [];
+    }
+  });
+}
+
 /**
- * Downloads files from URLs in the user messages.
+ * Downloads URL-backed file parts before provider conversion when needed.
  */
 async function downloadAssets(
   messages: ModelMessage[],
@@ -440,9 +488,13 @@ async function downloadAssets(
   type UrlTaggedFile = {
     mediaType: string | undefined;
     data: { type: 'url'; url: URL };
+    forceDownload: boolean;
   };
 
-  const downloadableFiles: FilePart[] = [];
+  const downloadableFiles: Array<{
+    part: FilePart;
+    forceDownload: boolean;
+  }> = [];
 
   for (const message of messages) {
     if (message.role === 'user' && Array.isArray(message.content)) {
@@ -450,7 +502,7 @@ async function downloadAssets(
         const filePart = convertImagePartToFilePart(part);
 
         if (filePart.type === 'file') {
-          downloadableFiles.push(filePart);
+          downloadableFiles.push({ part: filePart, forceDownload: false });
         }
       }
     }
@@ -461,15 +513,7 @@ async function downloadAssets(
           continue;
         }
 
-        if (part.output.type !== 'content') {
-          continue;
-        }
-
-        for (const contentPart of part.output.value) {
-          if (contentPart.type === 'file') {
-            downloadableFiles.push(contentPart);
-          }
-        }
+        downloadableFiles.push(...collectToolResultFileParts(part.output));
       }
     }
 
@@ -478,28 +522,29 @@ async function downloadAssets(
         if (part.type !== 'tool-result') {
           continue;
         }
-        if (part.output.type !== 'content') {
-          continue;
-        }
-        for (const contentPart of part.output.value) {
-          if (contentPart.type === 'file') {
-            downloadableFiles.push(contentPart);
-          }
-        }
+        downloadableFiles.push(...collectToolResultFileParts(part.output));
       }
     }
   }
 
   const plannedDownloads = downloadableFiles
-    .map((part): ConvertedFile => {
-      const mediaType = part.mediaType;
-      const { data } = convertToLanguageModelV4FilePart(part.data);
-      return { mediaType, data };
-    })
+    .map(
+      ({
+        part,
+        forceDownload,
+      }): ConvertedFile & {
+        forceDownload: boolean;
+      } => {
+        const mediaType = part.mediaType;
+        const { data } = convertToLanguageModelV4FilePart(part.data);
+        return { mediaType, data, forceDownload };
+      },
+    )
     .filter((part): part is UrlTaggedFile => part.data.type === 'url')
     .map(part => ({
       url: part.data.url,
       isUrlSupportedByModel:
+        !part.forceDownload &&
         part.mediaType != null &&
         isUrlSupported({
           url: part.data.url.toString(),
@@ -592,6 +637,22 @@ function convertPartToLanguageModelPart(
   };
 }
 
+function convertToolResultFilePart(
+  part: FilePart,
+  downloadedAssets: Record<
+    string,
+    { mediaType: string | undefined; data: Uint8Array }
+  >,
+): LanguageModelV4FilePart {
+  const convertedPart = convertPartToLanguageModelPart(part, downloadedAssets);
+
+  if (convertedPart.type !== 'file') {
+    throw new Error('Expected tool result file content to convert to file.');
+  }
+
+  return convertedPart;
+}
+
 function mapToolResultOutput({
   output,
   // `provider` is only needed here to convert legacy "file-id" and "image-file-id" types to provider references, in case they are using string ID values.
@@ -617,18 +678,7 @@ function mapToolResultOutput({
     value: output.value.map(item => {
       switch (item.type) {
         case 'file': {
-          const convertedPart = convertPartToLanguageModelPart(
-            item,
-            downloadedAssets,
-          );
-
-          if (convertedPart.type !== 'file') {
-            throw new Error(
-              'Expected tool result file content to convert to file.',
-            );
-          }
-
-          return convertedPart;
+          return convertToolResultFilePart(item, downloadedAssets);
         }
         case 'file-data': {
           warnings.push({
@@ -659,12 +709,15 @@ function mapToolResultOutput({
             setting: '"tool-result" content of type "file-url"',
             message,
           });
-          return {
-            type: 'file' as const,
-            data: { type: 'url' as const, url: new URL(item.url) },
-            mediaType,
-            providerOptions: item.providerOptions,
-          };
+          return convertToolResultFilePart(
+            {
+              type: 'file' as const,
+              data: { type: 'url' as const, url: new URL(item.url) },
+              mediaType,
+              providerOptions: item.providerOptions,
+            },
+            downloadedAssets,
+          );
         }
         case 'file-id': {
           warnings.push({
@@ -722,12 +775,15 @@ function mapToolResultOutput({
             setting: '"tool-result" content of type "image-url"',
             message: `The "image-url" type for tool result content is deprecated. Use the "file" type with mediaType 'image' (or a specific image/* subtype) and { type: 'url', url } instead.`,
           });
-          return {
-            type: 'file' as const,
-            data: { type: 'url' as const, url: new URL(item.url) },
-            mediaType: 'image',
-            providerOptions: item.providerOptions,
-          };
+          return convertToolResultFilePart(
+            {
+              type: 'file' as const,
+              data: { type: 'url' as const, url: new URL(item.url) },
+              mediaType: 'image',
+              providerOptions: item.providerOptions,
+            },
+            downloadedAssets,
+          );
         }
         case 'image-file-id': {
           warnings.push({

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -808,6 +808,60 @@ describe('tool messages', () => {
     });
   });
 
+  it('should convert Vertex tool result content with URL files into functionResponse fileData parts', async () => {
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'imageGenerator',
+              toolCallId: 'testCallId',
+              output: {
+                type: 'content',
+                value: [
+                  {
+                    type: 'text',
+                    text: 'Here is the generated image:',
+                  },
+                  {
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/image.png'),
+                    },
+                    mediaType: 'image/png',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      { providerOptionsNames: ['googleVertex', 'vertex'] },
+    );
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionResponse: {
+        id: 'testCallId',
+        name: 'imageGenerator',
+        response: {
+          name: 'imageGenerator',
+          content: 'Here is the generated image:',
+        },
+        parts: [
+          {
+            fileData: {
+              mimeType: 'image/png',
+              fileUri: 'https://example.com/image.png',
+            },
+          },
+        ],
+      },
+    });
+  });
+
   it('should forward non-data image-url tool result parts as text content', async () => {
     const result = convertToGoogleMessages([
       {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -29,6 +29,14 @@ export const SKIP_THOUGHT_SIGNATURE_VALIDATOR =
 
 const dataUrlRegex = /^data:([^;,]+);base64,(.+)$/s;
 
+type ToolResultFilePart = Extract<
+  Extract<
+    LanguageModelV4ToolResultOutput,
+    { type: 'content' }
+  >['value'][number],
+  { type: 'file' }
+>;
+
 function parseBase64DataUrl(
   value: string,
 ): { mediaType: string; data: string } | undefined {
@@ -43,23 +51,52 @@ function parseBase64DataUrl(
   };
 }
 
-function convertUrlToolResultPart(
-  url: string,
-): GoogleFunctionResponsePart | undefined {
-  // Per https://ai.google.dev/api/caching#FunctionResponsePart, only inline data is supported.
-  // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling#functionresponsepart suggests that this
-  // may be different for Vertex, but this needs to be confirmed and further tested for both APIs.
+function convertUrlToolResultPart({
+  url,
+  mediaType,
+  displayName,
+  supportsFileData,
+}: {
+  url: string;
+  mediaType?: string;
+  displayName?: string;
+  supportsFileData: boolean;
+}): GoogleFunctionResponsePart | undefined {
+  // Gemini API tool-result URLs are only represented when they are already data URLs.
+  // Vertex functionResponse parts can also reference URL-backed files via fileData.
   const parsedDataUrl = parseBase64DataUrl(url);
-  if (parsedDataUrl == null) {
+  if (parsedDataUrl != null) {
+    return {
+      inlineData: {
+        mimeType: parsedDataUrl.mediaType,
+        data: parsedDataUrl.data,
+      },
+    };
+  }
+
+  if (!supportsFileData || mediaType == null) {
     return undefined;
   }
 
   return {
-    inlineData: {
-      mimeType: parsedDataUrl.mediaType,
-      data: parsedDataUrl.data,
+    fileData: {
+      mimeType: mediaType,
+      fileUri: url,
+      ...(displayName != null ? { displayName } : {}),
     },
   };
+}
+
+function tryResolveFullMediaType(part: ToolResultFilePart): string | undefined {
+  try {
+    return resolveFullMediaType({ part });
+  } catch (error) {
+    if (!UnsupportedFunctionalityError.isInstance(error)) {
+      throw error;
+    }
+
+    return undefined;
+  }
 }
 
 /*
@@ -75,9 +112,11 @@ function appendToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  options: { supportsUrlFileData?: boolean } = {},
 ): void {
   const functionResponseParts: GoogleFunctionResponsePart[] = [];
   const responseTextParts: string[] = [];
+  const supportsUrlFileData = options.supportsUrlFileData ?? false;
 
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
@@ -94,9 +133,14 @@ function appendToolResultParts(
             },
           });
         } else if (contentPart.data.type === 'url') {
-          const functionResponsePart = convertUrlToolResultPart(
-            contentPart.data.url.toString(),
-          );
+          const functionResponsePart = convertUrlToolResultPart({
+            url: contentPart.data.url.toString(),
+            mediaType: supportsUrlFileData
+              ? tryResolveFullMediaType(contentPart)
+              : undefined,
+            displayName: contentPart.filename,
+            supportsFileData: supportsUrlFileData,
+          });
 
           if (functionResponsePart != null) {
             functionResponseParts.push(functionResponsePart);
@@ -572,6 +616,7 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                { supportsUrlFileData: isVertexLike },
               );
             } else {
               appendLegacyToolResultParts(

--- a/packages/google/src/google-prompt.ts
+++ b/packages/google/src/google-prompt.ts
@@ -61,9 +61,13 @@ export type GoogleContentPart =
       thoughtSignature?: string;
     };
 
-export type GoogleFunctionResponsePart = {
-  inlineData: { mimeType: string; data: string };
-};
+export type GoogleFunctionResponsePart =
+  | {
+      inlineData: { mimeType: string; data: string };
+    }
+  | {
+      fileData: { mimeType: string; fileUri: string; displayName?: string };
+    };
 
 export type GoogleGroundingMetadata = GroundingMetadataSchema;
 


### PR DESCRIPTION
## Background

Fixes #15671 

Google/Vertex tool results can include multimodal content, but URL-backed image tool-result content was not being surfaced to Vertex as model-visible image content. In the reported case, a tool returned legacy `image-url` content, and the model only saw text/JSON context instead of the image.

## Summary

This PR updates tool-result file handling so URL-backed image outputs are preserved through the prompt conversion path and serialized as Vertex-compatible file content.

Changes include:

- collecting tool-result file content, including legacy `image-url` and `file-url`, during asset download planning
- forcing download for legacy `image-url` tool-result content when the media type is incomplete
- mapping legacy URL tool-result content through the same file conversion path as modern `file` parts
- allowing Vertex-like Google message conversion to serialize URL-backed tool-result files as `functionResponse.parts[].fileData`
- preserving existing conservative behavior for non-Vertex Google paths
- adding regression coverage for the core prompt conversion path and Google/Vertex message conversion path

## Manual Verification

I did not run a live Vertex/Gemini request because that requires provider credentials.

The targeted regression tests cover the two conversion boundaries involved in the bug: legacy `image-url` tool-result content is normalized/downloaded by the `ai` prompt conversion path, and Vertex-like Google message conversion serializes URL-backed image file results as `functionResponse.parts[].fileData` instead of falling back to text/JSON-only context.

I manually verified the branch contents before opening the PR:

- `git status --short --branch`
- `git log --oneline upstream/main..HEAD`
- `git diff --name-status upstream/main...HEAD`
- `git diff --check upstream/main...HEAD`

I also verified the changeset includes patch bumps for both affected packages:

- `sed -n '1,40p' .changeset/hungry-badgers-scream.md`

Automated checks run locally:

- `pnpm --filter ai type-check`
- `pnpm --filter @ai-sdk/google type-check`
- `pnpm --filter ai test:node`
- `pnpm --filter ai test:edge`
- `pnpm --filter @ai-sdk/google test:node`
- `pnpm --filter @ai-sdk/google test:edge`
- `pnpm --filter ai build`
- `pnpm --filter @ai-sdk/google build`
- `git diff --check`

No docs update included because this fixes internal tool-result image conversion for Vertex rather than introducing a new public API.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Live provider verification against Vertex/Gemini with real credentials would be useful follow-up validation, but this PR keeps the fix scoped to prompt conversion and request serialization.

## Related Issues

#15671.