### PR TITLE
feat(langchain): emit source-url/source-document parts from citations

### DIFF
--- a/.changeset/langchain-source-parts.md
+++ b/.changeset/langchain-source-parts.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/langchain": patch
+---
+
+Surface LangChain citation annotations as spec-compliant `source-url` / `source-document` UI message parts. Previously, citations attached to text content blocks (e.g. from web search or RAG) were dropped entirely instead of being emitted as AI SDK source parts. Citation metadata (`citedText`, `startIndex`, `endIndex`, `source`) is preserved under `providerMetadata.langchain`.

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -1954,6 +1954,62 @@ describe('toUIMessageStream with streamEvents', () => {
       ]
     `);
   });
+
+  it('should emit source-url parts for citation annotations and dedupe them', async () => {
+    const inputStream = convertArrayToReadableStream([
+      {
+        event: 'on_chat_model_stream',
+        data: {
+          chunk: {
+            id: 'src-msg-1',
+            content: [
+              {
+                type: 'text',
+                text: 'Answer',
+                annotations: [
+                  {
+                    type: 'citation',
+                    url: 'https://example.com',
+                    title: 'Example',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+      {
+        event: 'on_chat_model_stream',
+        data: {
+          chunk: {
+            id: 'src-msg-1',
+            content: [
+              {
+                type: 'text',
+                text: ' continued',
+                annotations: [
+                  { type: 'citation', url: 'https://example.com' },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ]);
+
+    const result = await convertReadableStreamToArray(
+      toUIMessageStream(inputStream),
+    );
+
+    expect(result.filter(c => c.type === 'source-url')).toEqual([
+      {
+        type: 'source-url',
+        sourceId: 'https://example.com',
+        url: 'https://example.com',
+        title: 'Example',
+      },
+    ]);
+  });
 });
 
 describe('toUIMessageStream LangGraph finish events', () => {

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -1987,9 +1987,7 @@ describe('toUIMessageStream with streamEvents', () => {
               {
                 type: 'text',
                 text: ' continued',
-                annotations: [
-                  { type: 'citation', url: 'https://example.com' },
-                ],
+                annotations: [{ type: 'citation', url: 'https://example.com' }],
               },
             ],
           },

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -18,6 +18,8 @@ import {
   parseLangGraphEvent,
   isToolResultPart,
   extractReasoningFromContentBlocks,
+  extractCitationsFromContentBlocks,
+  emitSourceChunks,
 } from './utils';
 import type { LangGraphEventState } from './types';
 import type { StreamCallbacks } from './stream-callbacks';
@@ -132,6 +134,7 @@ function processStreamEventsEvent(
     textStarted: boolean;
     textMessageId: string | null;
     reasoningMessageId: string | null;
+    emittedSourceIds: Set<string>;
   },
   controller: ReadableStreamDefaultController<UIMessageChunk>,
 ): void {
@@ -240,6 +243,16 @@ function processStreamEventsEvent(
             delta: text,
             id: state.textMessageId ?? state.messageId,
           });
+        }
+
+        const citations = extractCitationsFromContentBlocks(chunk);
+        if (citations.length > 0) {
+          emitSourceChunks(
+            citations,
+            state.messageId,
+            state.emittedSourceIds,
+            controller,
+          );
         }
       }
       break;
@@ -378,6 +391,7 @@ export function toUIMessageStream<TState = unknown>(
     textMessageId: null as string | null,
     /** Track the ID used for reasoning-start to ensure reasoning-end uses the same ID */
     reasoningMessageId: null as string | null,
+    emittedSourceIds: new Set<string>(),
   };
 
   /**
@@ -399,6 +413,7 @@ export function toUIMessageStream<TState = unknown>(
     >,
     currentStep: null as number | null,
     emittedToolCallsByKey: new Map<string, string>(),
+    emittedSourceIds: new Set<string>(),
   };
 
   /**

--- a/packages/langchain/src/types.ts
+++ b/packages/langchain/src/types.ts
@@ -28,6 +28,20 @@ export interface LangGraphEventState {
   currentStep: number | null;
   /** Maps tool call key (name:argsJson) to tool call ID for HITL interrupt handling */
   emittedToolCallsByKey: Map<string, string>;
+  /** Tracks source IDs already emitted to avoid duplicates across messages/values events */
+  emittedSourceIds: Set<string>;
+}
+
+/**
+ * A LangChain citation projected to the fields the AI SDK source parts can carry.
+ */
+export interface NormalizedCitation {
+  url?: string;
+  title?: string;
+  source?: string;
+  citedText?: string;
+  startIndex?: number;
+  endIndex?: number;
 }
 
 /**

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -24,7 +24,11 @@ import {
   isImageGenerationOutput,
   extractImageOutputs,
   processLangGraphEvent,
+  isCitationContentBlock,
+  extractCitationsFromContentBlocks,
+  emitSourceChunks,
 } from './utils';
+import type { NormalizedCitation } from './types';
 
 /**
  * Creates a mock ReadableStreamDefaultController for testing
@@ -947,6 +951,7 @@ describe('processLangGraphEvent', () => {
     >,
     currentStep: null as number | null,
     emittedToolCallsByKey: new Map<string, string>(),
+    emittedSourceIds: new Set<string>(),
   });
 
   it('should handle custom events without type field (fallback to data-custom)', () => {
@@ -2051,5 +2056,386 @@ describe('processLangGraphEvent', () => {
       approvalId: toolCallId,
       toolCallId: toolCallId,
     });
+  });
+});
+
+describe('isCitationContentBlock', () => {
+  it('should return true for a citation block', () => {
+    expect(isCitationContentBlock({ type: 'citation', url: 'x' })).toBe(true);
+  });
+
+  it('should return false for non-citation blocks', () => {
+    expect(isCitationContentBlock({ type: 'text', text: 'hi' })).toBe(false);
+    expect(isCitationContentBlock(null)).toBe(false);
+    expect(isCitationContentBlock('citation')).toBe(false);
+  });
+});
+
+describe('extractCitationsFromContentBlocks', () => {
+  it('should extract citation annotations from text content blocks', () => {
+    const msg = new AIMessageChunk({
+      content: [
+        {
+          type: 'text',
+          text: 'The sky is blue.',
+          annotations: [
+            {
+              type: 'citation',
+              url: 'https://example.com/sky',
+              title: 'Why the sky is blue',
+              citedText: 'Rayleigh scattering',
+              startIndex: 0,
+              endIndex: 16,
+            },
+          ],
+        },
+      ],
+      id: 'msg-1',
+    });
+
+    const citations = extractCitationsFromContentBlocks(msg);
+
+    expect(citations).toEqual([
+      {
+        url: 'https://example.com/sky',
+        title: 'Why the sky is blue',
+        source: undefined,
+        citedText: 'Rayleigh scattering',
+        startIndex: 0,
+        endIndex: 16,
+      },
+    ]);
+  });
+
+  it('should return an empty array when annotations are empty', () => {
+    const msg = new AIMessageChunk({
+      content: [{ type: 'text', text: 'No sources.', annotations: [] }],
+      id: 'msg-1',
+    });
+
+    expect(extractCitationsFromContentBlocks(msg)).toEqual([]);
+  });
+
+  it('should return an empty array for plain string content', () => {
+    const msg = new AIMessageChunk({ content: 'just text', id: 'msg-1' });
+
+    expect(extractCitationsFromContentBlocks(msg)).toEqual([]);
+  });
+
+  it('should ignore non-citation annotations', () => {
+    const msg = new AIMessageChunk({
+      content: [
+        {
+          type: 'text',
+          text: 'Hi',
+          annotations: [{ type: 'something-else', value: 1 }],
+        },
+      ],
+      id: 'msg-1',
+    });
+
+    expect(extractCitationsFromContentBlocks(msg)).toEqual([]);
+  });
+
+  it('should extract from serialized LangChain messages (kwargs)', () => {
+    const serialized = {
+      lc: 1,
+      type: 'constructor',
+      id: ['langchain_core', 'messages', 'AIMessageChunk'],
+      kwargs: {
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            annotations: [{ type: 'citation', url: 'https://example.com' }],
+          },
+        ],
+      },
+    };
+
+    expect(extractCitationsFromContentBlocks(serialized)).toEqual([
+      {
+        url: 'https://example.com',
+        title: undefined,
+        source: undefined,
+        citedText: undefined,
+        startIndex: undefined,
+        endIndex: undefined,
+      },
+    ]);
+  });
+});
+
+describe('emitSourceChunks', () => {
+  it('should emit a source-url chunk for citations with a url', () => {
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+    const citations: NormalizedCitation[] = [
+      {
+        url: 'https://example.com/doc',
+        title: 'Doc Title',
+        citedText: 'excerpt',
+        startIndex: 5,
+        endIndex: 12,
+        source: 'web',
+      },
+    ];
+
+    emitSourceChunks(citations, 'msg-1', new Set(), controller);
+
+    expect(chunks).toEqual([
+      {
+        type: 'source-url',
+        sourceId: 'https://example.com/doc',
+        url: 'https://example.com/doc',
+        title: 'Doc Title',
+        providerMetadata: {
+          langchain: {
+            citedText: 'excerpt',
+            startIndex: 5,
+            endIndex: 12,
+            source: 'web',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should emit a source-document chunk for url-less citations with a title', () => {
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+    const citations: NormalizedCitation[] = [
+      { title: 'Local Doc', citedText: 'quoted text' },
+    ];
+
+    emitSourceChunks(citations, 'msg-1', new Set(), controller);
+
+    expect(chunks).toEqual([
+      {
+        type: 'source-document',
+        sourceId: 'msg-1:Local Doc:quoted text::',
+        mediaType: 'text/plain',
+        title: 'Local Doc',
+        providerMetadata: {
+          langchain: { citedText: 'quoted text' },
+        },
+      },
+    ]);
+  });
+
+  it('should skip url-less citations that have no title or source', () => {
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    emitSourceChunks(
+      [{ citedText: 'orphan excerpt' }],
+      'msg-1',
+      new Set(),
+      controller,
+    );
+
+    expect(chunks).toEqual([]);
+  });
+
+  it('should not collide url-less source ids across differing citation orders', () => {
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+    const emittedSourceIds = new Set<string>();
+
+    emitSourceChunks(
+      [{ title: 'A' }, { title: 'B' }],
+      'msg-1',
+      emittedSourceIds,
+      controller,
+    );
+    // 'B' alone, at index 0 this time: must still be deduped, 'A' must not reappear.
+    emitSourceChunks([{ title: 'B' }], 'msg-1', emittedSourceIds, controller);
+
+    const docs = chunks.filter(
+      c => (c as { type: string }).type === 'source-document',
+    ) as Array<{ title: string }>;
+    expect(docs.map(d => d.title)).toEqual(['A', 'B']);
+  });
+
+  it('should omit providerMetadata when there are no extra fields', () => {
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    emitSourceChunks(
+      [{ url: 'https://example.com' }],
+      'msg-1',
+      new Set(),
+      controller,
+    );
+
+    expect(chunks).toEqual([
+      {
+        type: 'source-url',
+        sourceId: 'https://example.com',
+        url: 'https://example.com',
+      },
+    ]);
+  });
+
+  it('should dedupe by sourceId across calls', () => {
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+    const emittedSourceIds = new Set<string>();
+    const citation: NormalizedCitation = { url: 'https://example.com' };
+
+    emitSourceChunks([citation], 'msg-1', emittedSourceIds, controller);
+    emitSourceChunks([citation], 'msg-1', emittedSourceIds, controller);
+
+    expect(
+      chunks.filter(c => (c as { type: string }).type === 'source-url'),
+    ).toHaveLength(1);
+  });
+});
+
+describe('processModelChunk - sources', () => {
+  it('should emit source-url after text for citation annotations', () => {
+    const chunk = new AIMessageChunk({
+      content: [
+        {
+          type: 'text',
+          text: 'Answer',
+          annotations: [
+            { type: 'citation', url: 'https://example.com', title: 'Ex' },
+          ],
+        },
+      ],
+      id: 'msg-1',
+    });
+    const state = {
+      started: false,
+      messageId: 'default',
+      reasoningStarted: false,
+      textStarted: false,
+    };
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    processModelChunk(chunk, state, controller);
+
+    expect(
+      chunks.filter(c => (c as { type: string }).type.startsWith('source-')),
+    ).toEqual([
+      {
+        type: 'source-url',
+        sourceId: 'https://example.com',
+        url: 'https://example.com',
+        title: 'Ex',
+      },
+    ]);
+    // source must come after the text-delta
+    const textIdx = chunks.findIndex(
+      c => (c as { type: string }).type === 'text-delta',
+    );
+    const sourceIdx = chunks.findIndex(
+      c => (c as { type: string }).type === 'source-url',
+    );
+    expect(sourceIdx).toBeGreaterThan(textIdx);
+  });
+
+  it('should emit no source chunks when annotations are empty', () => {
+    const chunk = new AIMessageChunk({
+      content: [{ type: 'text', text: 'Answer', annotations: [] }],
+      id: 'msg-1',
+    });
+    const state = {
+      started: false,
+      messageId: 'default',
+      reasoningStarted: false,
+      textStarted: false,
+    };
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    processModelChunk(chunk, state, controller);
+
+    expect(
+      chunks.filter(c =>
+        (c as { type: string }).type.startsWith('source-'),
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe('processLangGraphEvent - sources', () => {
+  const createMockState = () => ({
+    messageSeen: {} as Record<
+      string,
+      { text?: boolean; reasoning?: boolean; tool?: Record<string, boolean> }
+    >,
+    messageConcat: {} as Record<string, AIMessageChunk>,
+    emittedToolCalls: new Set<string>(),
+    emittedImages: new Set<string>(),
+    emittedReasoningIds: new Set<string>(),
+    messageReasoningIds: {} as Record<string, string>,
+    toolCallInfoByIndex: {} as Record<
+      string,
+      Record<number, { id: string; name: string }>
+    >,
+    currentStep: null as number | null,
+    emittedToolCallsByKey: new Map<string, string>(),
+    emittedSourceIds: new Set<string>(),
+  });
+
+  it('should emit source-url for citations in a messages event', () => {
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    const msg = new AIMessageChunk({
+      content: [
+        {
+          type: 'text',
+          text: 'Hello',
+          annotations: [{ type: 'citation', url: 'https://example.com' }],
+        },
+      ],
+      id: 'msg-1',
+    });
+
+    processLangGraphEvent(['messages', [msg, {}]], state, controller);
+
+    const sourceChunks = chunks.filter(c =>
+      (c as { type: string }).type.startsWith('source-'),
+    );
+    expect(sourceChunks).toEqual([
+      {
+        type: 'source-url',
+        sourceId: 'https://example.com',
+        url: 'https://example.com',
+      },
+    ]);
+  });
+
+  it('should not double-emit a source seen in both messages and values', () => {
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    const msg = new AIMessageChunk({
+      content: [
+        {
+          type: 'text',
+          text: 'Hello',
+          annotations: [{ type: 'citation', url: 'https://example.com' }],
+        },
+      ],
+      id: 'msg-1',
+    });
+
+    processLangGraphEvent(['messages', [msg, {}]], state, controller);
+    processLangGraphEvent(
+      ['values', { messages: [msg] }],
+      state,
+      controller,
+    );
+
+    expect(
+      chunks.filter(c => (c as { type: string }).type === 'source-url'),
+    ).toHaveLength(1);
   });
 });

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -2354,9 +2354,7 @@ describe('processModelChunk - sources', () => {
     processModelChunk(chunk, state, controller);
 
     expect(
-      chunks.filter(c =>
-        (c as { type: string }).type.startsWith('source-'),
-      ),
+      chunks.filter(c => (c as { type: string }).type.startsWith('source-')),
     ).toHaveLength(0);
   });
 });
@@ -2428,11 +2426,7 @@ describe('processLangGraphEvent - sources', () => {
     });
 
     processLangGraphEvent(['messages', [msg, {}]], state, controller);
-    processLangGraphEvent(
-      ['values', { messages: [msg] }],
-      state,
-      controller,
-    );
+    processLangGraphEvent(['values', { messages: [msg] }], state, controller);
 
     expect(
       chunks.filter(c => (c as { type: string }).type === 'source-url'),

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -1463,7 +1463,12 @@ export function processLangGraphEvent(
 
         const citations = extractCitationsFromContentBlocks(msg);
         if (citations.length > 0) {
-          emitSourceChunks(citations, msgId, state.emittedSourceIds, controller);
+          emitSourceChunks(
+            citations,
+            msgId,
+            state.emittedSourceIds,
+            controller,
+          );
         }
       } else if (isToolMessageType(msg)) {
         // Handle both direct properties and serialized messages (kwargs)

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -14,6 +14,8 @@ import type {
   ToolResultPart,
   AssistantContent,
   UserContent,
+  ProviderMetadata,
+  JSONValue,
 } from 'ai';
 
 import type {
@@ -22,6 +24,7 @@ import type {
   ThinkingContentBlock,
   GPT5ReasoningOutput,
   ImageGenerationOutput,
+  NormalizedCitation,
 } from './types';
 
 /**
@@ -433,6 +436,7 @@ export function processModelChunk(
     /** Track the ID used for text-start to ensure text-end uses the same ID */
     textMessageId?: string | null;
     emittedImages?: Set<string>;
+    emittedSourceIds?: Set<string>;
   },
   controller: ReadableStreamDefaultController<UIMessageChunk>,
 ): void {
@@ -441,6 +445,10 @@ export function processModelChunk(
    */
   if (!state.emittedImages) {
     state.emittedImages = new Set<string>();
+  }
+
+  if (!state.emittedSourceIds) {
+    state.emittedSourceIds = new Set<string>();
   }
 
   /**
@@ -545,6 +553,16 @@ export function processModelChunk(
       delta: text,
       id: state.textMessageId ?? state.messageId,
     });
+  }
+
+  const citations = extractCitationsFromContentBlocks(chunk);
+  if (citations.length > 0) {
+    emitSourceChunks(
+      citations,
+      state.messageId,
+      state.emittedSourceIds,
+      controller,
+    );
   }
 }
 
@@ -964,6 +982,152 @@ export function extractReasoningFromValuesMessage(
   return undefined;
 }
 
+export function isCitationContentBlock(
+  obj: unknown,
+): obj is ContentBlock.Citation {
+  return (
+    obj != null &&
+    typeof obj === 'object' &&
+    'type' in obj &&
+    (obj as { type: unknown }).type === 'citation'
+  );
+}
+
+/**
+ * LangChain Core standardizes citations as `{ type: 'citation', ... }` entries in
+ * the `annotations` array of a text content block. The text extractors elsewhere
+ * in this file only read the `text` field, so without this the citations would be
+ * dropped instead of surfaced as AI SDK source parts.
+ *
+ * Handles both class instances and serialized LangChain message objects.
+ */
+export function extractCitationsFromContentBlocks(
+  msg: unknown,
+): NormalizedCitation[] {
+  if (msg == null || typeof msg !== 'object') return [];
+
+  const msgObj = msg as Record<string, unknown>;
+  const kwargs =
+    msgObj.kwargs && typeof msgObj.kwargs === 'object'
+      ? (msgObj.kwargs as Record<string, unknown>)
+      : msgObj;
+
+  // `contentBlocks` is the normalized view derived from `content`; reading both
+  // would double-count annotations, so prefer it and only fall back to `content`.
+  const contentBlocks = (kwargs as { contentBlocks?: unknown }).contentBlocks;
+  const content = (kwargs as { content?: unknown }).content;
+  const blockSources: unknown[] = Array.isArray(contentBlocks)
+    ? contentBlocks
+    : Array.isArray(content)
+      ? content
+      : [];
+
+  const citations: NormalizedCitation[] = [];
+
+  for (const block of blockSources) {
+    if (block == null || typeof block !== 'object') continue;
+
+    const annotations = (block as { annotations?: unknown }).annotations;
+    if (!Array.isArray(annotations)) continue;
+
+    for (const annotation of annotations) {
+      if (!isCitationContentBlock(annotation)) continue;
+
+      citations.push({
+        url: annotation.url,
+        title: annotation.title,
+        source: annotation.source,
+        citedText: annotation.citedText,
+        startIndex: annotation.startIndex,
+        endIndex: annotation.endIndex,
+      });
+    }
+  }
+
+  return citations;
+}
+
+function buildSourceProviderMetadata(
+  citation: NormalizedCitation,
+): ProviderMetadata | undefined {
+  const langchain: Record<string, JSONValue> = {};
+
+  if (typeof citation.citedText === 'string') {
+    langchain.citedText = citation.citedText;
+  }
+  if (typeof citation.startIndex === 'number') {
+    langchain.startIndex = citation.startIndex;
+  }
+  if (typeof citation.endIndex === 'number') {
+    langchain.endIndex = citation.endIndex;
+  }
+  if (typeof citation.source === 'string') {
+    langchain.source = citation.source;
+  }
+
+  if (Object.keys(langchain).length === 0) {
+    return undefined;
+  }
+
+  return { langchain };
+}
+
+/**
+ * Emits AI SDK source chunks (`source-url` / `source-document`) for the given
+ * citations.
+ *
+ * Citations with a `url` become `source-url` parts keyed by that url; the rest
+ * become `source-document` parts. Citation metadata that the source parts cannot
+ * represent natively (`citedText`, `startIndex`, `endIndex`, `source`) is preserved
+ * under `providerMetadata.langchain`.
+ *
+ * `emittedSourceIds` dedupes across the LangGraph messages and values events, which
+ * can each surface the same citation. URL-less citations are keyed by their content
+ * rather than position, so a differing citation subset/order between those two events
+ * does not cause an id collision.
+ */
+export function emitSourceChunks(
+  citations: NormalizedCitation[],
+  messageId: string,
+  emittedSourceIds: Set<string>,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+): void {
+  for (const citation of citations) {
+    if (citation.url) {
+      if (emittedSourceIds.has(citation.url)) continue;
+      emittedSourceIds.add(citation.url);
+
+      const providerMetadata = buildSourceProviderMetadata(citation);
+      controller.enqueue({
+        type: 'source-url',
+        sourceId: citation.url,
+        url: citation.url,
+        ...(citation.title ? { title: citation.title } : {}),
+        ...(providerMetadata ? { providerMetadata } : {}),
+      });
+      continue;
+    }
+
+    // A citation with no url and no human-readable label carries no information a
+    // UI could render, so skip it rather than emit a placeholder source.
+    const title = citation.title ?? citation.source;
+    if (!title) continue;
+
+    const sourceId = `${messageId}:${title}:${citation.citedText ?? ''}:${citation.startIndex ?? ''}:${citation.endIndex ?? ''}`;
+    if (emittedSourceIds.has(sourceId)) continue;
+    emittedSourceIds.add(sourceId);
+
+    const providerMetadata = buildSourceProviderMetadata(citation);
+    controller.enqueue({
+      type: 'source-document',
+      sourceId,
+      mediaType: 'text/plain',
+      title,
+      ...(providerMetadata ? { providerMetadata } : {}),
+    });
+  }
+}
+
 /**
  * Checks if an object is an image generation output
  *
@@ -1296,6 +1460,11 @@ export function processLangGraphEvent(
             id: msgId,
           });
         }
+
+        const citations = extractCitationsFromContentBlocks(msg);
+        if (citations.length > 0) {
+          emitSourceChunks(citations, msgId, state.emittedSourceIds, controller);
+        }
       } else if (isToolMessageType(msg)) {
         // Handle both direct properties and serialized messages (kwargs)
         const msgObj = msg as unknown as Record<string, unknown>;
@@ -1574,6 +1743,16 @@ export function processLangGraphEvent(
                 controller.enqueue({ type: 'reasoning-end', id: msgId });
                 emittedReasoningIds.add(reasoningId);
               }
+            }
+
+            const valuesCitations = extractCitationsFromContentBlocks(msg);
+            if (valuesCitations.length > 0) {
+              emitSourceChunks(
+                valuesCitations,
+                msgId,
+                state.emittedSourceIds,
+                controller,
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary

The `@ai-sdk/langchain` adapter previously dropped LangChain citation annotations entirely. Models that return citations through LangChain (web search, RAG, etc.) produced no source information in a `useChat` UI, even though the same models surface `source-url` parts when used through native AI SDK providers.

This change maps LangChain citation annotations to spec-compliant [`source-url` / `source-document`](https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#source-parts) UI message stream parts.

- LangChain Core standardizes citations as `{ type: 'citation', url?, title?, source?, citedText?, startIndex?, endIndex? }` entries in the `annotations` array of a text content block. The adapter's text extractors only read `.text`, so these were silently discarded.
- Citations with a `url` become `source-url` parts (keyed by url); url-less citations with a `title`/`source` become `source-document` parts. Url-less citations with no human-readable label are skipped rather than emitted as a placeholder.
- Wired into all three stream paths: direct model streams (`processModelChunk`), `streamEvents` (`on_chat_model_stream`), and LangGraph (`messages` + `values`).
- Citation metadata that the source parts can't represent natively (`citedText`, `startIndex`, `endIndex`, `source`) is preserved under `providerMetadata.langchain`, so the projection is lossless.
- Sources are deduped by `sourceId`. Url-less citations are keyed by content (not position) so that differing citation subsets/orderings between the `messages` and `values` events don't cause id collisions.

## Test plan

- [x] Unit tests for `extractCitationsFromContentBlocks` (array content, serialized `kwargs` messages, empty annotations, plain-string content).
- [x] Unit tests for `emitSourceChunks`: `source-url`, `source-document`, `providerMetadata` round-trip + omission, dedupe across calls, url-less id collision regression, and skipping label-less citations.
- [x] Integration tests across the model, `streamEvents`, and LangGraph (messages + values dedupe) paths.
- [x] `pnpm --filter @ai-sdk/langchain test` (node + edge) — 208 passing.
- [x] `tsc --noEmit` clean for the package.

## Notes

- `patch` changeset included.
- No public API changes; this is additive behavior in the adapter.

Made with [Cursor](https://cursor.com)