### PR TITLE
chore: modify run function to record fixtures

### DIFF
--- a/examples/ai-functions/src/generate-text/anthropic/basic.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/basic.ts
@@ -8,10 +8,15 @@ run(async () => {
     model: anthropic('claude-sonnet-4-0'),
     prompt: 'Invent a new holiday and describe its traditions.',
     maxRetries: 0,
+    include: {
+      responseBody: true,
+    },
   });
 
   print('Content:', result.content);
   print('Usage:', result.usage);
   print('Finish reason:', result.finishReason);
   print('Raw finish reason:', result.rawFinishReason);
+
+  return result;
 });

--- a/examples/ai-functions/src/lib/record-fixture.ts
+++ b/examples/ai-functions/src/lib/record-fixture.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+
+interface StreamResult {
+  fullStream: AsyncIterable<{ type: string; rawValue?: unknown }>;
+}
+
+interface GenerateResult {
+  steps: ReadonlyArray<{ response: { body?: unknown } }>;
+}
+
+type RecordableResult = StreamResult | GenerateResult;
+
+export function isRecordableResult(value: unknown): value is RecordableResult {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    ('fullStream' in value || 'steps' in value)
+  );
+}
+
+function isStreamResult(result: RecordableResult): result is StreamResult {
+  return 'fullStream' in result;
+}
+
+// e.g. ".../stream-text/anthropic/basic.ts" -> "basic"
+function fixtureBaseName() {
+  return path.basename(process.argv[1]).replace(/\.[jt]s$/, '');
+}
+
+// Records a test fixture for the example currently being run. The file is named
+// after the example file, with a per-request index (`.1`, `.2`, ...): raw stream
+// chunks as `<name>.<n>.chunks.txt` for `streamText`, or the raw response body as
+// `<name>.<n>.json` for `generateText`.
+export async function recordFixture(result: RecordableResult) {
+  const name = fixtureBaseName();
+
+  if (isStreamResult(result)) {
+    const steps: string[][] = [];
+    for await (const chunk of result.fullStream) {
+      if (chunk.type === 'start-step') {
+        steps.push([]);
+      }
+      if (chunk.type === 'raw') {
+        steps.at(-1)?.push(JSON.stringify(chunk.rawValue));
+      }
+    }
+    steps.forEach((chunks, i) =>
+      fs.writeFileSync(`output/${name}.${i + 1}.chunks.txt`, chunks.join('\n')),
+    );
+  } else {
+    result.steps.forEach((step, i) =>
+      fs.writeFileSync(
+        `output/${name}.${i + 1}.json`,
+        JSON.stringify(step.response.body, null, 2),
+      ),
+    );
+  }
+}

--- a/examples/ai-functions/src/lib/record-fixture.ts
+++ b/examples/ai-functions/src/lib/record-fixture.ts
@@ -11,6 +11,8 @@ interface GenerateResult {
 
 type RecordableResult = StreamResult | GenerateResult;
 
+const OUTPUT_DIR = 'output';
+
 export function isRecordableResult(value: unknown): value is RecordableResult {
   return (
     value != null &&
@@ -35,6 +37,9 @@ function fixtureBaseName() {
 export async function recordFixture(result: RecordableResult) {
   const name = fixtureBaseName();
 
+  // The output directory is gitignored, so it may not exist on a fresh checkout.
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
   if (isStreamResult(result)) {
     const steps: string[][] = [];
     for await (const chunk of result.fullStream) {
@@ -46,12 +51,15 @@ export async function recordFixture(result: RecordableResult) {
       }
     }
     steps.forEach((chunks, i) =>
-      fs.writeFileSync(`output/${name}.${i + 1}.chunks.txt`, chunks.join('\n')),
+      fs.writeFileSync(
+        path.join(OUTPUT_DIR, `${name}.${i + 1}.chunks.txt`),
+        chunks.join('\n'),
+      ),
     );
   } else {
     result.steps.forEach((step, i) =>
       fs.writeFileSync(
-        `output/${name}.${i + 1}.json`,
+        path.join(OUTPUT_DIR, `${name}.${i + 1}.json`),
         JSON.stringify(step.response.body, null, 2),
       ),
     );

--- a/examples/ai-functions/src/lib/run.ts
+++ b/examples/ai-functions/src/lib/run.ts
@@ -1,15 +1,22 @@
 import 'dotenv/config';
 import { APICallError } from 'ai';
 import { print } from './print';
+import { isRecordableResult, recordFixture } from './record-fixture';
 
-export function run(fn: () => Promise<void>) {
-  fn().catch(error => {
-    console.error(error);
+export function run(fn: () => Promise<unknown>) {
+  fn()
+    .then(result => {
+      if (isRecordableResult(result)) {
+        return recordFixture(result);
+      }
+    })
+    .catch(error => {
+      console.error(error);
 
-    if (APICallError.isInstance(error)) {
-      console.log();
-      print('Request body:', error.requestBodyValues);
-      print('Response body:', error.responseBody);
-    }
-  });
+      if (APICallError.isInstance(error)) {
+        console.log();
+        print('Request body:', error.requestBodyValues);
+        print('Response body:', error.responseBody);
+      }
+    });
 }

--- a/examples/ai-functions/src/stream-text/anthropic/basic.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/basic.ts
@@ -9,6 +9,9 @@ run(async () => {
     model: anthropic('claude-haiku-4-5'),
     prompt: 'Invent a new holiday and describe its traditions.',
     maxRetries: 0,
+    include: {
+      rawChunks: true,
+    },
   });
 
   printFullStream({ result });
@@ -16,4 +19,6 @@ run(async () => {
   print('Usage:', await result.usage);
   print('Finish reason:', await result.finishReason);
   print('Raw finish reason:', await result.rawFinishReason);
+
+  return result;
 });


### PR DESCRIPTION
## Background

before, we needed to add a separate save chunks function at the end of the example file to record fixtures / copy the response body from the terminal for json fixtures. 

## Summary

- changed the `run()` function so that fixtures are recorded automatically and saved.
- only change needed is that the fixture needs to return the result

## Manual Verification

verified by running the basic examples for generate/streamText

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)