### PR TITLE
ENG-8511 normalize UI data URL file parts

### DIFF
--- a/.changeset/eng-8511-data-url-file-parts.md
+++ b/.changeset/eng-8511-data-url-file-parts.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Normalize data URL file parts to base64 data in `convertToModelMessages`.

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -193,6 +193,36 @@ describe('convertToModelMessages', () => {
       ]);
     });
 
+    it('should convert user data URL file parts to base64 data', async () => {
+      const result = await convertToModelMessages([
+        {
+          role: 'user',
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/jpeg',
+              url: 'data:image/jpeg;base64,/9j/3Q==',
+            },
+            { type: 'text', text: 'Check this image' },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/jpeg',
+              data: '/9j/3Q==',
+            },
+            { type: 'text', text: 'Check this image' },
+          ],
+        },
+      ]);
+    });
+
     it('should handle user message file parts with provider metadata', async () => {
       const result = await convertToModelMessages([
         {
@@ -474,7 +504,7 @@ describe('convertToModelMessages', () => {
             {
               type: 'file',
               mediaType: 'image/png',
-              data: 'data:image/png;base64,dGVzdA==',
+              data: 'dGVzdA==',
             },
           ],
         },
@@ -503,7 +533,7 @@ describe('convertToModelMessages', () => {
             {
               type: 'file',
               mediaType: 'image/png',
-              data: 'data:image/png;base64,dGVzdA==',
+              data: 'dGVzdA==',
               filename: 'test.png',
             },
           ],
@@ -535,7 +565,7 @@ describe('convertToModelMessages', () => {
             {
               type: 'file',
               mediaType: 'image/png',
-              data: 'data:image/png;base64,dGVzdA==',
+              data: 'dGVzdA==',
               providerOptions: {
                 testProvider: { signature: 'test-signature' },
               },

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -11,6 +11,7 @@ import {
 import type { ToolSet } from '@ai-sdk/provider-utils';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import { MessageConversionError } from '../prompt/message-conversion-error';
+import { splitDataUrl } from '../prompt/split-data-url';
 import {
   CustomContentUIPart,
   DataUIPart,
@@ -32,6 +33,32 @@ import {
   ToolUIPart,
   UIMessage,
 } from './ui-messages';
+
+function convertFileUIPartToModelFilePart(part: FileUIPart): FilePart {
+  let mediaType = part.mediaType;
+  let data: FilePart['data'] = part.providerReference ?? part.url;
+
+  if (part.providerReference == null && part.url.startsWith('data:')) {
+    const { mediaType: dataUrlMediaType, base64Content } = splitDataUrl(
+      part.url,
+    );
+
+    if (dataUrlMediaType != null && base64Content != null) {
+      mediaType = dataUrlMediaType;
+      data = base64Content;
+    }
+  }
+
+  return {
+    type: 'file' as const,
+    mediaType,
+    filename: part.filename,
+    data,
+    ...(part.providerMetadata != null
+      ? { providerOptions: part.providerMetadata }
+      : {}),
+  };
+}
 
 /**
  * Converts an array of UI messages from useChat into an array of ModelMessages that can be used
@@ -110,15 +137,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
 
               // Process file parts
               if (isFileUIPart(part)) {
-                return {
-                  type: 'file' as const,
-                  mediaType: part.mediaType,
-                  filename: part.filename,
-                  data: part.providerReference ?? part.url,
-                  ...(part.providerMetadata != null
-                    ? { providerOptions: part.providerMetadata }
-                    : {}),
-                };
+                return convertFileUIPartToModelFilePart(part);
               }
 
               // Process data parts with converter if provided
@@ -172,15 +191,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     : {}),
                 } satisfies CustomPart);
               } else if (isFileUIPart(part)) {
-                content.push({
-                  type: 'file' as const,
-                  mediaType: part.mediaType,
-                  filename: part.filename,
-                  data: part.providerReference ?? part.url,
-                  ...(part.providerMetadata != null
-                    ? { providerOptions: part.providerMetadata }
-                    : {}),
-                });
+                content.push(convertFileUIPartToModelFilePart(part));
               } else if (isReasoningFileUIPart(part)) {
                 content.push({
                   type: 'reasoning-file' as const,


### PR DESCRIPTION
## Summary

- Normalize `FileUIPart.url` data URLs to raw base64 data during `convertToModelMessages`.
- Reuse the parsed data URL media type for the resulting model file part.
- Add regression coverage for user and assistant file parts that use data URLs.

## Why

UI `FileUIPart` allows data URLs, but preserving the full `data:image/...;base64,...` string in model messages can cause provider serializers or downstream code to treat it as a URL. Anthropic then rejects it with `URL scheme must be http or https, got data:`. Normalizing during UI conversion makes the model message provider-safe earlier.

## Validation

- `pnpm --filter ai test:node src/ui/convert-to-model-messages.test.ts`
- `pnpm type-check:full`
- `pnpm check`