### PR TITLE
fix (provider/amazon-bedrock): correct mantle subpath exports

### DIFF
--- a/.changeset/fix-provider-amazon-bedrock-correct-mantle-subpath-exports.md
+++ b/.changeset/fix-provider-amazon-bedrock-correct-mantle-subpath-exports.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix (provider/amazon-bedrock): correct mantle subpath exports

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -49,8 +49,8 @@
     },
     "./mantle": {
       "types": "./dist/mantle/index.d.ts",
-      "import": "./dist/mantle/index.mjs",
-      "require": "./dist/mantle/index.js"
+      "import": "./dist/mantle/index.js",
+      "require": "./dist/mantle/index.cjs"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

The `@ai-sdk/amazon-bedrock/mantle` subpath export points at files that the build doesn't produce:

```jsonc
"./mantle": {
  "import": "./dist/mantle/index.mjs",  // ❌ not emitted
  "require": "./dist/mantle/index.js"    // this is actually the ESM build
}
```

The `amazon-bedrock` package is `"type": "module"`, so the build emits `index.js` (ESM) and `index.cjs` (CJS) — there is no `index.mjs`. As a result, any consumer that imports the subpath over ESM fails to resolve it:

```
Cannot find package '@ai-sdk/amazon-bedrock/mantle' (ERR_MODULE_NOT_FOUND)
```

The sibling `./anthropic` export is already correct (`import` → `index.js`); `mantle` was added with the older `.mjs` convention. The package's own tests import the source directly (`./bedrock-mantle-provider`), so the broken built export wasn't caught.

## Fix

Point the export conditions at the files actually emitted, matching the `./anthropic` entry:

```jsonc
"./mantle": {
  "import": "./dist/mantle/index.js",
  "require": "./dist/mantle/index.cjs"
}
```

## Verification

Built `@ai-sdk/amazon-bedrock` and resolved the subpath both ways via Node self-reference:

- `import('@ai-sdk/amazon-bedrock/mantle')` → `{ bedrockMantle, createBedrockMantle }`
- `require('@ai-sdk/amazon-bedrock/mantle')` → `{ bedrockMantle, createBedrockMantle }`

Existing mantle tests pass (14/14).