### PR TITLE
Expose request metadata in OpenAI Responses

### DIFF
--- a/.changeset/eight-hounds-juggle.md
+++ b/.changeset/eight-hounds-juggle.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(provider/openai): expose request metadata in Responses providerMetadata

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -487,6 +487,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       toolNameMapping,
       providerOptionsName,
       isShellProviderExecuted,
+      metadata: openaiOptions?.metadata ?? undefined,
     };
   }
 
@@ -500,6 +501,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       toolNameMapping,
       providerOptionsName,
       isShellProviderExecuted,
+      metadata,
     } = await this.getArgs(options);
     const url = this.config.url({
       path: '/responses',
@@ -1039,6 +1041,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
         ...(typeof response.service_tier === 'string'
           ? { serviceTier: response.service_tier }
           : {}),
+        ...(metadata != null ? { metadata } : {}),
       } satisfies ResponsesProviderMetadata,
     };
 
@@ -1076,6 +1079,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       webSearchToolName,
       toolNameMapping,
       store,
+      metadata: requestMetadata,
       providerOptionsName,
       isShellProviderExecuted,
     } = await this.getArgs(options);
@@ -2168,6 +2172,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                 responseId: responseId,
                 ...(logprobs.length > 0 ? { logprobs } : {}),
                 ...(serviceTier !== undefined ? { serviceTier } : {}),
+                ...(requestMetadata != null
+                  ? { metadata: requestMetadata }
+                  : {}),
               } satisfies ResponsesProviderMetadata,
             };
 

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -15,6 +15,7 @@ export type ResponsesProviderMetadata = {
   responseId: string | null | undefined;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
+  metadata?: Record<string, string>;
 };
 
 export type ResponsesReasoningProviderMetadata = {


### PR DESCRIPTION
## Summary

Reflect request metadata from OpenAI Responses provider options onto response-side `providerMetadata`.

Today, `providerOptions.openai.metadata` is forwarded to the OpenAI/Azure Responses API request but is not surfaced back to the caller. This makes it difficult for clients to associate returned `itemId`s with the provider/model/region that produced them.

This change mirrors request metadata onto:

```ts
providerMetadata.<provider>.metadata
```

allowing it to flow through the existing providerMetadata pipeline and become available on UI message parts.

## Changes

* Add `metadata?: Record<string, string>` to `ResponsesProviderMetadata`
* Reflect request metadata into response `providerMetadata` for:

  * `doGenerate()`
  * `doStream()`
* Preserve existing provider metadata fields (`responseId`, `itemId`, `logprobs`, `serviceTier`, etc.)
* Only include `metadata` when provided on the request

## Example

Request:

```ts
providerOptions: {
  openai: {
    metadata: {
      providerId: 'openai.responses',
      modelId: 'gpt-4o',
    },
  },
}
```

Response:

```ts
providerMetadata: {
  openai: {
    responseId: 'resp_...',
    metadata: {
      providerId: 'openai.responses',
      modelId: 'gpt-4o',
    },
  },
}
```

## Motivation

This enables applications that use multiple providers, deployments, or regions to attach provenance information (e.g. `providerId`, `modelId`, `region`) to response parts and access it later on the client.

The implementation follows the approach proposed in the linked issue by reflecting request metadata into `providerMetadata.<provider>.metadata`.

## Tests

Added coverage for:

* `doGenerate()` metadata reflection
* `doStream()` metadata reflection

Both tests fail on the current main branch and pass with this change.
