### PR TITLE
fix(vertex-anthropic): support eu/us multi-region anthropic endpoints

### DIFF
--- a/.changeset/proud-eyes-camp.md
+++ b/.changeset/proud-eyes-camp.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(vertex-anthropic): support eu/us multi-region anthropic endpoints

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-eu-multi-region.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-eu-multi-region.ts
@@ -1,0 +1,17 @@
+import { createGoogleVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+const vertexAnthropic = createGoogleVertexAnthropic({
+  location: 'eu',
+});
+
+run(async () => {
+  const result = await generateText({
+    model: vertexAnthropic('claude-opus-4-7'),
+    prompt: 'Say hello in one sentence.',
+    maxRetries: 0,
+  });
+
+  console.log(result.text);
+});

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -198,6 +198,40 @@ describe('google-vertex-anthropic-provider', () => {
     );
   });
 
+  it('should use multi-region URL for eu location', () => {
+    const provider = createGoogleVertexAnthropic({
+      project: 'test-project',
+      location: 'eu',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
+  it('should use multi-region URL for us location', () => {
+    const provider = createGoogleVertexAnthropic({
+      project: 'test-project',
+      location: 'us',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
   it('should support combining tools with structured outputs (inherited from Anthropic)', () => {
     const provider = createGoogleVertexAnthropic({
       project: 'test-project',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -205,14 +205,20 @@ describe('google-vertex-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
-      'test-model-id',
-      expect.objectContaining({
-        baseURL:
-          'https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models',
-        provider: 'vertex.anthropic.messages',
-      }),
-    );
+    expect(vi.mocked(AnthropicLanguageModel).mock.calls[0][1])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models",
+          "buildRequestUrl": [Function],
+          "fetch": undefined,
+          "headers": {},
+          "provider": "googleVertex.anthropic.messages",
+          "supportedUrls": [Function],
+          "supportsNativeStructuredOutput": false,
+          "supportsStrictTools": false,
+          "transformRequestBody": [Function],
+        }
+      `);
   });
 
   it('should use multi-region URL for us location', () => {
@@ -222,14 +228,20 @@ describe('google-vertex-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
-      'test-model-id',
-      expect.objectContaining({
-        baseURL:
-          'https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models',
-        provider: 'vertex.anthropic.messages',
-      }),
-    );
+    expect(vi.mocked(AnthropicLanguageModel).mock.calls[0][1])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models",
+          "buildRequestUrl": [Function],
+          "fetch": undefined,
+          "headers": {},
+          "provider": "googleVertex.anthropic.messages",
+          "supportedUrls": [Function],
+          "supportsNativeStructuredOutput": false,
+          "supportsStrictTools": false,
+          "transformRequestBody": [Function],
+        }
+      `);
   });
 
   it('should support combining tools with structured outputs (inherited from Anthropic)', () => {

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -187,9 +187,19 @@ export function createGoogleVertexAnthropic(
       environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
     });
 
+    const getHost = () => {
+      if (location === 'global') {
+        return 'aiplatform.googleapis.com';
+      } else if (location === 'eu' || location === 'us') {
+        return `aiplatform.${location}.rep.googleapis.com`;
+      } else {
+        return `${location}-aiplatform.googleapis.com`;
+      }
+    };
+
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
+      `https://${getHost()}/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
     );
   };
 


### PR DESCRIPTION
## Background

added as an alternate to https://github.com/vercel/ai/pull/14744 (because of signed commits); resolves https://github.com/vercel/ai/issues/14634

The Anthropic Vertex provider currently builds the base URL as:

`https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/...`

This produces 404s for location: 'eu' and location: 'us', because Vertex's multi-region endpoints use different hostnames

## Summary

adds a `getHost()` helper that selects the correct hostname based on the location value

## Manual Verification

verified by running the example `examples/ai-functions/src/generate-text/google/vertex-anthropic-eu-multi-region.ts` - 404s before and runs after!

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14634 

Co-authored-by: Christian-Sidak <csidak@users.noreply.github.com>