### PR TITLE
fix(google-vertex): support for eu/us multi region gemini endpoints

### DIFF
--- a/.changeset/sixty-ads-provide.md
+++ b/.changeset/sixty-ads-provide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(google-vertex): support for eu/us multi region gemini endpoints

--- a/examples/ai-functions/src/generate-text/google/vertex-eu-multi-region.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-eu-multi-region.ts
@@ -1,0 +1,17 @@
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+const vertex = createGoogleVertex({
+  location: 'us',
+});
+
+run(async () => {
+  const result = await generateText({
+    model: vertex('gemini-3.5-flash'),
+    prompt: 'Say hello in one word.',
+    maxRetries: 0,
+  });
+
+  console.log(result.text);
+});

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -279,6 +279,46 @@ describe('google-vertex-provider-base', () => {
     );
   });
 
+  it('should use multi-region REP URL for us location', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'us',
+    });
+    provider('test-model-id');
+
+    expect(vi.mocked(GoogleLanguageModel).mock.calls[0][1])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.us.rep.googleapis.com/v1beta1/projects/test-project/locations/us/publishers/google",
+          "fetch": undefined,
+          "generateId": [MockFunction],
+          "headers": [Function],
+          "provider": "google.vertex.chat",
+          "supportedUrls": [Function],
+        }
+      `);
+  });
+
+  it('should use multi-region REP URL for eu location', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'eu',
+    });
+    provider('test-model-id');
+
+    expect(vi.mocked(GoogleLanguageModel).mock.calls[0][1])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1beta1/projects/test-project/locations/eu/publishers/google",
+          "fetch": undefined,
+          "generateId": [MockFunction],
+          "headers": [Function],
+          "provider": "google.vertex.chat",
+          "supportedUrls": [Function],
+        }
+      `);
+  });
+
   it('should use express mode base URL when apiKey is provided', () => {
     const provider = createGoogleVertex({
       apiKey: 'test-api-key',

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -162,13 +162,19 @@ export function createGoogleVertex(
     const region = loadGoogleVertexLocation();
     const project = loadGoogleVertexProject();
 
-    // For global region, use aiplatform.googleapis.com directly
-    // For other regions, use region-aiplatform.googleapis.com
-    const baseHost = `${region === 'global' ? '' : region + '-'}aiplatform.googleapis.com`;
+    const getHost = () => {
+      if (region === 'global') {
+        return 'aiplatform.googleapis.com';
+      } else if (region === 'eu' || region === 'us') {
+        return `aiplatform.${region}.rep.googleapis.com`;
+      } else {
+        return `${region}-aiplatform.googleapis.com`;
+      }
+    };
 
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${baseHost}/v1beta1/projects/${project}/locations/${region}/publishers/google`
+      `https://${getHost()}/v1beta1/projects/${project}/locations/${region}/publishers/google`
     );
   };
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15722

similar to the change we made in https://github.com/vercel/ai/pull/15772 for anthropic vertex endpoints, the change was also needed in the base google-vertex provider in order to support multi-regions

this PR improves on https://github.com/vercel/ai/pull/15728 (signed commits, example + changeset)

## Summary

Added a `getHost()` helper that maps:

- global -> `aiplatform.googleapis.com`
- us / eu -> `aiplatform.{region}.rep.googleapis.com`
- everything else -> `{region}-aiplatform.googleapis.com`

## Manual Verification

verified by running the example `examples/ai-functions/src/generate-text/google/vertex-eu-multi-region.ts` 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15722

Co-authored-by: shubhamgore2468 <shubhamgore2468@gmail.com>