### PR TITLE
fix(google-vertex): support regional endpoints for vertex MaaS

### DIFF
--- a/.changeset/polite-phones-do.md
+++ b/.changeset/polite-phones-do.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(google-vertex): support regional endpoints for vertex MaaS

--- a/examples/ai-functions/src/generate-text/google/vertex-maas-eu-multi-region.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-maas-eu-multi-region.ts
@@ -1,0 +1,20 @@
+import { createVertexMaas } from '@ai-sdk/google-vertex/maas';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+const project = process.env.GOOGLE_VERTEX_PROJECT!;
+
+const vertexMaas = createVertexMaas({
+  location: 'us-east5',
+  project,
+});
+
+run(async () => {
+  const result = await generateText({
+    model: vertexMaas('meta/llama-4-maverick-17b-128e-instruct-maas'),
+    prompt: 'Say hello in one word.',
+    maxRetries: 0,
+  });
+
+  console.log(result.text);
+});

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -56,13 +56,14 @@ describe('google-vertex-maas-provider', () => {
     // Trigger lazy init
     provider('test-model');
 
-    expect(createOpenAICompatible).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'vertex.maas',
-        baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi',
-      }),
-    );
+    expect(vi.mocked(createOpenAICompatible).mock.calls[0][0])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi",
+          "fetch": undefined,
+          "name": "vertex.maas",
+        }
+      `);
   });
 
   it('should create a provider with correct base URL for regional location', () => {
@@ -73,13 +74,32 @@ describe('google-vertex-maas-provider', () => {
 
     provider('test-model');
 
-    expect(createOpenAICompatible).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'vertex.maas',
-        baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
-      }),
-    );
+    expect(vi.mocked(createOpenAICompatible).mock.calls[0][0])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi",
+          "fetch": undefined,
+          "name": "vertex.maas",
+        }
+      `);
+  });
+
+  it('should create a provider with correct base URL for multi-region location', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+      location: 'eu',
+    });
+
+    provider('test-model');
+
+    expect(vi.mocked(createOpenAICompatible).mock.calls[0][0])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/endpoints/openapi",
+          "fetch": undefined,
+          "name": "vertex.maas",
+        }
+      `);
   });
 
   it('should default to global location when not specified', () => {
@@ -181,7 +201,7 @@ describe('google-vertex-maas-provider', () => {
     expect(createOpenAICompatible).toHaveBeenCalledWith(
       expect.objectContaining({
         baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
+          'https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
       }),
     );
   });

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -75,12 +75,21 @@ export function createGoogleVertexMaas(
       description: 'Google Vertex project',
     });
 
-  // Construct base URL: https://aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi
+  const getHost = (location: string) => {
+    if (location === 'global') {
+      return 'aiplatform.googleapis.com';
+    } else if (location === 'eu' || location === 'us') {
+      return `aiplatform.${location}.rep.googleapis.com`;
+    } else {
+      return `${location}-aiplatform.googleapis.com`;
+    }
+  };
+
   const constructBaseURL = () => {
     const projectId = loadProject();
     const location = loadLocation() ?? 'global';
 
-    return `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/endpoints/openapi`;
+    return `https://${getHost(location)}/v1/projects/${projectId}/locations/${location}/endpoints/openapi`;
   };
 
   const loadBaseURL = () =>


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15684

alternate to https://github.com/vercel/ai/pull/15688 (but needed an example + edge case for US and EU endpoints)

--

`createVertexMaas` appears to default to the global `aiplatform.googleapis.com` host:

```text
https://aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi
```

For Vertex MaaS Llama 4 models, that host returns 404 for us even when `location` is set to the region where the model works

## Summary

apply the similar `getHost()` function fix to detect location and change the base URL as done in https://github.com/vercel/ai/pull/15772 and https://github.com/vercel/ai/pull/15777

## Manual Verification

verified via the example `examples/ai-functions/src/generate-text/google/vertex-maas-eu-multi-region.ts` - the model only works in that location

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15684