### PR TITLE
fix(ai/ui): guard approval access for output-denied tool parts in convertToModelMessages

### DIFF
--- a/.changeset/fix-convert-to-model-messages-denied-no-approval.md
+++ b/.changeset/fix-convert-to-model-messages-denied-no-approval.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai/ui): avoid crash in `convertToModelMessages` when an `output-denied` tool part has no `approval`
+
+`convertToModelMessages` read `toolPart.approval.reason` unguarded for tool parts in the `output-denied` state. A tool part can legitimately be in `output-denied` without an `approval` object (e.g. denied tool history rehydrated from storage), which threw `TypeError: Cannot read properties of undefined (reading 'reason')`. Use optional chaining so it falls back to the default denial message instead of crashing.

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -2320,6 +2320,82 @@ describe('convertToModelMessages', () => {
       `);
     });
 
+    it('should not throw when an output-denied tool part has no approval (falls back to default message)', async () => {
+      // Regression: a tool part can be in `output-denied` state without an
+      // `approval` object (e.g. denied history rehydrated from storage).
+      // `toolPart.approval.reason` previously threw
+      // "Cannot read properties of undefined (reading 'reason')".
+      const result = await convertToModelMessages([
+        {
+          parts: [
+            {
+              text: 'What is the weather in Tokyo?',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          parts: [
+            {
+              type: 'step-start',
+            },
+            {
+              input: {
+                city: 'Tokyo',
+              },
+              state: 'output-denied',
+              toolCallId: 'call-1',
+              type: 'tool-weather',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "What is the weather in Tokyo?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "city": "Tokyo",
+                },
+                "providerExecuted": undefined,
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Tool call execution denied.",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+    });
+
     it('should convert tool output result with approval and follow up text (static tool)', async () => {
       const result = await convertToModelMessages([
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -346,7 +346,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                         output: {
                           type: 'error-text' as const,
                           value:
-                            toolPart.approval.reason ??
+                            toolPart.approval?.reason ??
                             'Tool call execution denied.',
                         },
                         ...(toolPart.callProviderMetadata != null


### PR DESCRIPTION
## Background

`convertToModelMessages` crashes with `TypeError: Cannot read properties of undefined (reading 'reason')` when a tool part is in the `output-denied` state but has no `approval` object — for example when denied tool history is persisted and rehydrated from storage (the approval request/response parts are not always round-tripped with the result). The `output-denied` branch reads `toolPart.approval.reason` without optional chaining, while the adjacent approval-response branch already guards with `toolPart.approval?.approved`.

## Summary

Optional-chain `approval` in the `output-denied` case of `convertToModelMessages` (`toolPart.approval.reason` → `toolPart.approval?.reason`), so a denied tool part without an `approval` falls back to the default `'Tool call execution denied.'` message instead of throwing.

## Manual Verification

Reproduced against the published `ai` build:

```ts
import { convertToModelMessages } from 'ai';

convertToModelMessages([
  { role: 'user', parts: [{ type: 'text', text: 'hi' }] },
  {
    role: 'assistant',
    parts: [{
      type: 'tool-myTool',
      toolCallId: 'call_1',
      state: 'output-denied',
      input: { foo: 'bar' },
      output: { type: 'execution-denied' },
      // no `approval` field
    }],
  },
]);
// before: TypeError: Cannot read properties of undefined (reading 'reason')
// after:  tool-result with output { type: 'error-text', value: 'Tool call execution denied.' }
```

Note: I verified the runtime fix against the published `ai` build (shown above) but couldn't run the package's snapshot suite locally — building the workspace deps fails in my environment with `ERR_REQUIRE_ESM` (tsup 8.5.1 `require()`-ing the ESM-only tinyexec), which is unrelated to this change. The inline snapshot in the test was written to match the existing `output-denied` test format; please rely on CI / `pnpm test:node` to confirm it.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15787.

