### PR TITLE
fix(openai): send client-executed tool calls as full function_call items in the Responses API

### DIFF
--- a/.changeset/spicy-pandas-pair.md
+++ b/.changeset/spicy-pandas-pair.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): send client-executed tool calls as full function_call items in the Responses API so they pair with their function_call_output by call_id

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1247,7 +1247,6 @@ describe('convertToOpenAIResponsesInput', () => {
           {
             "arguments": "{}",
             "call_id": "call_123",
-            "id": undefined,
             "name": "search",
             "type": "function_call",
           },
@@ -1255,7 +1254,7 @@ describe('convertToOpenAIResponsesInput', () => {
       `);
     });
 
-    it('should convert messages with tool call parts that have ids', async () => {
+    it('should convert text parts with ids to item_reference but not client-executed tool calls', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,
         prompt: [
@@ -1297,8 +1296,10 @@ describe('convertToOpenAIResponsesInput', () => {
             "type": "item_reference",
           },
           {
-            "id": "id_456",
-            "type": "item_reference",
+            "arguments": "{"query":"weather in San Francisco"}",
+            "call_id": "call_123",
+            "name": "search",
+            "type": "function_call",
           },
         ]
       `);
@@ -1343,6 +1344,156 @@ describe('convertToOpenAIResponsesInput', () => {
           call_id: 'call_456',
           name: 'calculator',
           arguments: JSON.stringify({ expression: '2 + 2' }),
+        },
+      ]);
+    });
+
+    // A client-executed function_call_output can only reference its call by
+    // call_id (call_...). The model-assigned item id (fc_...) cannot be used
+    // to pair them, so the function_call must be sent in full without the item
+    // id and without an item_reference. Otherwise the API rejects follow-up
+    // requests with "No tool call found for function call output with call_id",
+    // most visibly with parallel tool calls across multiple steps.
+    it('should send client-executed tool calls as function_call items without item id (store: false)', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_a',
+                toolName: 'search',
+                input: { query: 'first' },
+                providerOptions: { openai: { itemId: 'fc_a' } },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call_b',
+                toolName: 'search',
+                input: { query: 'second' },
+                providerOptions: { openai: { itemId: 'fc_b' } },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_a',
+                toolName: 'search',
+                output: { type: 'json', value: { results: [] } },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_b',
+                toolName: 'search',
+                output: { type: 'json', value: { results: ['x'] } },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: false,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call',
+          call_id: 'call_a',
+          name: 'search',
+          arguments: JSON.stringify({ query: 'first' }),
+        },
+        {
+          type: 'function_call',
+          call_id: 'call_b',
+          name: 'search',
+          arguments: JSON.stringify({ query: 'second' }),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_a',
+          output: JSON.stringify({ results: [] }),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_b',
+          output: JSON.stringify({ results: ['x'] }),
+        },
+      ]);
+    });
+
+    it('should not use item_reference for client-executed tool calls (store: true)', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_a',
+                toolName: 'search',
+                input: { query: 'first' },
+                providerOptions: { openai: { itemId: 'fc_a' } },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call_b',
+                toolName: 'search',
+                input: { query: 'second' },
+                providerOptions: { openai: { itemId: 'fc_b' } },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_a',
+                toolName: 'search',
+                output: { type: 'json', value: { results: [] } },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_b',
+                toolName: 'search',
+                output: { type: 'json', value: { results: ['x'] } },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call',
+          call_id: 'call_a',
+          name: 'search',
+          arguments: JSON.stringify({ query: 'first' }),
+        },
+        {
+          type: 'function_call',
+          call_id: 'call_b',
+          name: 'search',
+          arguments: JSON.stringify({ query: 'second' }),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_a',
+          output: JSON.stringify({ results: [] }),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_b',
+          output: JSON.stringify({ results: ['x'] }),
         },
       ]);
     });
@@ -3992,7 +4143,6 @@ describe('convertToOpenAIResponsesInput', () => {
             {
               "arguments": "{"a":1,"b":2}",
               "call_id": "call-1",
-              "id": undefined,
               "name": "calculator",
               "type": "function_call",
             },
@@ -5227,7 +5377,6 @@ describe('convertToOpenAIResponsesInput', () => {
           {
             "arguments": ""SELECT 1"",
             "call_id": "call_custom_001",
-            "id": undefined,
             "name": "write_sql",
             "type": "function_call",
           },

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -309,10 +309,29 @@ export async function convertToOpenAIResponsesInput({
                 break;
               }
 
-              if (store && id != null) {
-                if (hasPreviousResponseId) {
-                  break;
-                }
+              // When chaining with a previous response id, items already part
+              // of that response chain must not be resent.
+              if (hasPreviousResponseId && store && id != null) {
+                break;
+              }
+
+              // Provider-defined tool calls (local_shell, shell, apply_patch,
+              // and custom tools) are stored by the API and can be sent as an
+              // `item_reference` to reduce payload size. Plain client-executed
+              // function calls must NOT be: the matching `function_call_output`
+              // can only reference the call by `call_id` (`call_...`), which
+              // the API cannot reconcile with an item id (`fc_...`) or an
+              // `item_reference`. Sending either breaks call/output pairing and
+              // makes follow-up requests fail with "No tool call found for
+              // function call output with call_id", most visibly with parallel
+              // tool calls across multiple steps.
+              const isProviderDefinedToolCall =
+                (hasLocalShellTool && resolvedToolName === 'local_shell') ||
+                (hasShellTool && resolvedToolName === 'shell') ||
+                (hasApplyPatchTool && resolvedToolName === 'apply_patch') ||
+                (customProviderToolNames?.has(resolvedToolName) ?? false);
+
+              if (store && id != null && isProviderDefinedToolCall) {
                 input.push({ type: 'item_reference', id });
                 break;
               }
@@ -394,7 +413,6 @@ export async function convertToOpenAIResponsesInput({
                 call_id: part.toolCallId,
                 name: resolvedToolName,
                 arguments: serializeToolCallArguments(part.input),
-                id,
               });
               break;
             }


### PR DESCRIPTION
## Summary

- Fixes a 400 error (`No tool call found for function call output with call_id ...`) that can abort multi-step tool-calling conversations on the OpenAI Responses API
- Affects client-executed (user-defined) tools, and is most visible with parallel tool calls across several steps
- No behavior change for provider-executed or provider-defined tools

## Problem

When the OpenAI Responses API runs a multi-step conversation that uses client-executed (user-defined) tools, follow-up requests can fail with:

```
No tool call found for function call output with call_id call_XXX
```

Each prior tool call in the serialized history is referenced by its model-assigned item id (`fc_...`) — either as an `item_reference` (when `store: true`) or by including that id on the `function_call` item. But a `function_call_output` can only reference its call by `call_id` (`call_...`). The API cannot reconcile the item id with the call id, so the output is treated as orphaned and the request is rejected.

This surfaces most often with parallel tool calls across multiple steps, where several calls and their outputs have to be paired within a single request. Provider-executed tools (e.g. web search) are unaffected, because the API runs them and stores both the call and its result.

## Changes

Client-executed function calls are now serialized as full `function_call` items identified only by `call_id`, with no `item_reference` and no item id. This lets the API pair every `function_call_output` with its `function_call` by `call_id`, independent of `store`.

Provider-defined tool calls (`local_shell`, `shell`, `apply_patch`, and custom tools) are intentionally left unchanged and still use `item_reference` when `store: true`. This keeps the fix scoped to the client-executed function calls in the report; those tools were not reported as affected, and re-sending their stored call items in full could risk duplicate-item errors.

Fixes #8216. Ports the fix @CalebBarnes proposed in #11114 (which targeted the `release-v5.0` branch) to the current line, and credits them as co-author.
