### PR TITLE
Fix ByteDance first-frame video payload role

### DIFF
--- a/.changeset/fix-bytedance-first-frame-role.md
+++ b/.changeset/fix-bytedance-first-frame-role.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+Fix ByteDance video payloads to tag the prompt image as the first frame when a last frame image is provided.

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -601,6 +601,7 @@ describe('ByteDanceVideoModel', () => {
         {
           type: 'image_url',
           image_url: { url: 'https://example.com/first-frame.png' },
+          role: 'first_frame',
         },
         {
           type: 'image_url',

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -179,6 +179,9 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
       content.push({
         type: 'image_url',
         image_url: { url: convertImageModelFileToDataUri(options.image) },
+        ...(byteDanceOptions?.lastFrameImage != null
+          ? { role: 'first_frame' }
+          : {}),
       });
     }
 


### PR DESCRIPTION
## Background

ByteDance Ark rejects first+last-frame video payloads when the prompt image is not tagged with `role: first_frame`. Direct ByteDance provider calls and Gateway calls both use this provider payload construction.

## Summary

Adds `role: first_frame` to the ByteDance video prompt image only when `lastFrameImage` is provided. Updates the existing first+last-frame payload test and adds a patch changeset for `@ai-sdk/bytedance`.

## Manual Verification

Ran `pnpm --filter @ai-sdk/test-server build`, `pnpm --filter @ai-sdk/bytedance test:node -- bytedance-video-model.test.ts`, `pnpm --filter @ai-sdk/bytedance type-check`, and `git diff --check`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)