### PR TITLE
feat(aliababa): add embedding model support

### DIFF
--- a/.changeset/seven-grapes-invite.md
+++ b/.changeset/seven-grapes-invite.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/alibaba": patch
+---
+
+feat(aliababa): add embedding model support

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -299,7 +299,7 @@ Alibaba embedding models support additional provider options that can be passed 
   Differentiates query text from document text for asymmetric retrieval tasks.
   Defaults to `document`.
 
-- **dimension** _64 | 128 | 256 | 512 | 768 | 1024 | 1536 | 2048_
+- **dimension** _number_
 
   The dimension of the output embedding vectors. Defaults to 1024.
   `text-embedding-v4` also supports 1536 and 2048 dimensions.

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -314,10 +314,10 @@ Alibaba embedding models support additional provider options that can be passed 
 
 ### Embedding Model Capabilities
 
-| Model               | Default Dimensions | Flexible Dimensions                              | Max Values per Call |
-| ------------------- | ------------------ | ------------------------------------------------ | ------------------- |
-| `text-embedding-v4` | 1024               | 64, 128, 256, 512, 768, 1024, 1536, 2048         | 10                  |
-| `text-embedding-v3` | 1024               | 512, 768, 1024                                   | 10                  |
+| Model               | Default Dimensions | Flexible Dimensions                      | Max Values per Call |
+| ------------------- | ------------------ | ---------------------------------------- | ------------------- |
+| `text-embedding-v4` | 1024               | 64, 128, 256, 512, 768, 1024, 1536, 2048 | 10                  |
+| `text-embedding-v3` | 1024               | 512, 768, 1024                           | 10                  |
 
 <Note>
   The tables above list currently documented Alibaba text embedding models. You

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -59,6 +59,12 @@ You can use the following optional settings to customize the Alibaba provider in
   native endpoint (not the OpenAI-compatible endpoint).
   The default prefix is `https://dashscope-intl.aliyuncs.com`.
 
+- **embeddingBaseURL** _string_
+
+  Use a different URL prefix for embedding API calls. The embedding API uses the DashScope
+  native endpoint (not the OpenAI-compatible endpoint).
+  The default prefix is `https://dashscope-intl.aliyuncs.com/api/v1`.
+
 - **apiKey** _string_
 
   API key that is being sent using the `Authorization` header. It defaults to
@@ -232,6 +238,91 @@ const { text, usage } = await generateText({
 ```
 
 **Note:** The minimum content length for a cache block is 1,024 tokens.
+
+## Embedding Models
+
+You can create text embedding models using the `.embedding()` factory method.
+For more on embeddings with the AI SDK see [`embed()`](/docs/reference/ai-sdk-core/embed)
+and [`embedMany()`](/docs/reference/ai-sdk-core/embed-many).
+
+```ts
+const model = alibaba.embedding('text-embedding-v4');
+```
+
+You can use Alibaba embedding models to generate embeddings with the `embed` function:
+
+```ts
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embed } from 'ai';
+
+const { embedding, usage } = await embed({
+  model: alibaba.embedding('text-embedding-v4'),
+  value: 'sunny day at the beach',
+  providerOptions: {
+    alibaba: {
+      textType: 'document',
+      dimension: 1024,
+      outputType: 'dense',
+    } satisfies AlibabaEmbeddingModelOptions,
+  },
+});
+```
+
+Use `embedMany` to embed multiple text values. Alibaba text embedding models support
+up to 10 values per API call; larger batches are split automatically by `embedMany`.
+
+```ts
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embedMany } from 'ai';
+
+const { embeddings } = await embedMany({
+  model: alibaba.embedding('text-embedding-v4'),
+  values: [
+    'sunny day at the beach',
+    'rainy afternoon in the city',
+    'snowy night in the mountains',
+  ],
+  providerOptions: {
+    alibaba: {
+      textType: 'document',
+      dimension: 1024,
+    } satisfies AlibabaEmbeddingModelOptions,
+  },
+});
+```
+
+Alibaba embedding models support additional provider options that can be passed via
+`providerOptions.alibaba`:
+
+- **textType** _'query' | 'document'_
+
+  Differentiates query text from document text for asymmetric retrieval tasks.
+  Defaults to `document`.
+
+- **dimension** _64 | 128 | 256 | 512 | 768 | 1024 | 1536 | 2048_
+
+  The dimension of the output embedding vectors. Defaults to 1024.
+  `text-embedding-v4` also supports 1536 and 2048 dimensions.
+
+- **outputType** _'dense' | 'sparse' | 'dense&sparse'_
+
+  Specifies the output vector type. Defaults to `dense`.
+  The AI SDK embedding interface returns dense `number[]` vectors, so sparse-only
+  output is not supported and will throw. Use `dense&sparse` to receive dense
+  embeddings in `embedding`/`embeddings` and sparse vectors in
+  `providerMetadata.alibaba.sparseEmbeddings`.
+
+### Embedding Model Capabilities
+
+| Model               | Default Dimensions | Flexible Dimensions                              | Max Values per Call |
+| ------------------- | ------------------ | ------------------------------------------------ | ------------------- |
+| `text-embedding-v4` | 1024               | 64, 128, 256, 512, 768, 1024, 1536, 2048         | 10                  |
+| `text-embedding-v3` | 1024               | 512, 768, 1024                                   | 10                  |
+
+<Note>
+  The tables above list currently documented Alibaba text embedding models. You
+  can also pass any available provider model ID as a string if needed.
+</Note>
 
 ## Video Models
 

--- a/examples/ai-functions/src/embed-many/alibaba/basic.ts
+++ b/examples/ai-functions/src/embed-many/alibaba/basic.ts
@@ -1,0 +1,25 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embedMany } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embeddings, usage, warnings } = await embedMany({
+    model: alibaba.embedding('text-embedding-v4'),
+    values: [
+      'sunny day at the beach',
+      'rainy afternoon in the city',
+      'snowy night in the mountains',
+    ],
+    providerOptions: {
+      alibaba: {
+        textType: 'document',
+        dimension: 1024,
+        outputType: 'dense',
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts
+++ b/examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts
@@ -1,0 +1,34 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embedMany } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embeddings, providerMetadata, usage, warnings } = await embedMany({
+    model: alibaba.embedding('text-embedding-v4'),
+    values: [
+      'sunny day at the beach',
+      'rainy afternoon in the city',
+      'snowy night in the mountains',
+      'quiet morning in the library',
+      'busy market with fresh fruit',
+      'calm lake beside pine trees',
+      'crowded train station at dusk',
+      'warm soup on a winter evening',
+      'bright flowers in a spring garden',
+      'long walk through an old town',
+      'fresh coffee in a small cafe',
+    ],
+    providerOptions: {
+      alibaba: {
+        textType: 'document',
+        dimension: 1024,
+        outputType: 'dense&sparse',
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embeddings);
+  console.log(providerMetadata?.alibaba);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts
+++ b/examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts
@@ -16,7 +16,6 @@ run(async () => {
       'warm soup on a winter evening',
       'bright flowers in a spring garden',
       'long walk through an old town',
-      'fresh coffee in a small cafe',
     ],
     providerOptions: {
       alibaba: {

--- a/examples/ai-functions/src/embed/alibaba/basic.ts
+++ b/examples/ai-functions/src/embed/alibaba/basic.ts
@@ -1,0 +1,22 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embed } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embedding, providerMetadata, usage, warnings } = await embed({
+    model: alibaba.embedding('text-embedding-v4'),
+    value: 'sunny day at the beach',
+    providerOptions: {
+      alibaba: {
+        textType: 'document',
+        dimension: 1024,
+        outputType: 'dense',
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embedding);
+  console.log(providerMetadata?.alibaba?.sparseEmbeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/packages/alibaba/README.md
+++ b/packages/alibaba/README.md
@@ -1,6 +1,6 @@
 # AI SDK - Alibaba Provider
 
-The **[Alibaba provider](https://ai-sdk.dev/providers/ai-sdk-providers/alibaba)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for [Alibaba Cloud Model Studio](https://modelstudio.console.alibabacloud.com/), including the Qwen model series with advanced reasoning capabilities.
+The **[Alibaba provider](https://ai-sdk.dev/providers/ai-sdk-providers/alibaba)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model, embedding model, and video model support for [Alibaba Cloud Model Studio](https://modelstudio.console.alibabacloud.com/), including the Qwen model series with advanced reasoning capabilities.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Alibaba (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 
@@ -61,6 +61,28 @@ const { text, reasoningText } = await generateText({
 
 console.log('Reasoning:', reasoningText);
 console.log('Answer:', text);
+```
+
+## Embedding Model Example
+
+```ts
+import {
+  alibaba,
+  type AlibabaEmbeddingModelOptions,
+} from '@ai-sdk/alibaba';
+import { embed } from 'ai';
+
+const { embedding, usage } = await embed({
+  model: alibaba.embedding('text-embedding-v4'),
+  value: 'sunny day at the beach',
+  providerOptions: {
+    alibaba: {
+      textType: 'document',
+      dimension: 1024,
+      outputType: 'dense',
+    } satisfies AlibabaEmbeddingModelOptions,
+  },
+});
 ```
 
 ## Tool Calling Example

--- a/packages/alibaba/README.md
+++ b/packages/alibaba/README.md
@@ -66,10 +66,7 @@ console.log('Answer:', text);
 ## Embedding Model Example
 
 ```ts
-import {
-  alibaba,
-  type AlibabaEmbeddingModelOptions,
-} from '@ai-sdk/alibaba';
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
 import { embed } from 'ai';
 
 const { embedding, usage } = await embed({

--- a/packages/alibaba/src/alibaba-embedding-model-options.ts
+++ b/packages/alibaba/src/alibaba-embedding-model-options.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+
+export type AlibabaEmbeddingModelId =
+  | 'text-embedding-v4'
+  | 'text-embedding-v3'
+  | (string & {});
+
+export const alibabaEmbeddingModelOptions = z.object({
+  /**
+   * Differentiates query text from document text for asymmetric retrieval tasks.
+   * Defaults to `document`.
+   */
+  textType: z.enum(['query', 'document']).optional(),
+
+  /**
+   * The dimension of the output embedding vectors. Defaults to 1024.
+   *
+   * `text-embedding-v4` also supports 1536 and 2048 dimensions.
+   */
+  dimension: z
+    .union([
+      z.literal(64),
+      z.literal(128),
+      z.literal(256),
+      z.literal(512),
+      z.literal(768),
+      z.literal(1024),
+      z.literal(1536),
+      z.literal(2048),
+    ])
+    .optional(),
+
+  /**
+   * The output vector type. Defaults to `dense`.
+   *
+   * Sparse-only output is not supported by the AI SDK embedding interface,
+   * which requires dense number arrays.
+   */
+  outputType: z.enum(['dense', 'sparse', 'dense&sparse']).optional(),
+});
+
+export type AlibabaEmbeddingModelOptions = z.infer<
+  typeof alibabaEmbeddingModelOptions
+>;

--- a/packages/alibaba/src/alibaba-embedding-model-options.ts
+++ b/packages/alibaba/src/alibaba-embedding-model-options.ts
@@ -17,18 +17,7 @@ export const alibabaEmbeddingModelOptions = z.object({
    *
    * `text-embedding-v4` also supports 1536 and 2048 dimensions.
    */
-  dimension: z
-    .union([
-      z.literal(64),
-      z.literal(128),
-      z.literal(256),
-      z.literal(512),
-      z.literal(768),
-      z.literal(1024),
-      z.literal(1536),
-      z.literal(2048),
-    ])
-    .optional(),
+  dimension: z.number().optional(),
 
   /**
    * The output vector type. Defaults to `dense`.

--- a/packages/alibaba/src/alibaba-embedding-model.test.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.test.ts
@@ -1,0 +1,235 @@
+import {
+  TooManyEmbeddingValuesForCallError,
+  UnsupportedFunctionalityError,
+  type EmbeddingModelV4Embedding,
+} from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { createAlibaba } from './alibaba-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const testValues = ['sunny day at the beach', 'rainy day in the city'];
+const dummyEmbeddings: EmbeddingModelV4Embedding[] = [
+  [0.1, 0.2, 0.3],
+  [0.4, 0.5, 0.6],
+];
+
+const provider = createAlibaba({ apiKey: 'test-api-key' });
+const model = provider.embedding('text-embedding-v4');
+
+const server = createTestServer({
+  'https://dashscope-intl.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding':
+    {},
+});
+
+function prepareJsonResponse({
+  embeddings = dummyEmbeddings,
+  usage = { total_tokens: 8 },
+  headers,
+  reverseOrder = false,
+  sparse = false,
+}: {
+  embeddings?: EmbeddingModelV4Embedding[];
+  usage?: { total_tokens: number } | null;
+  headers?: Record<string, string>;
+  reverseOrder?: boolean;
+  sparse?: boolean;
+} = {}) {
+  const data = embeddings.map((embedding, textIndex) => ({
+    embedding,
+    text_index: textIndex,
+    ...(sparse
+      ? {
+          sparse_embedding: [
+            { index: textIndex + 100, value: 0.8, token: `token-${textIndex}` },
+          ],
+        }
+      : {}),
+  }));
+
+  server.urls[
+    'https://dashscope-intl.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding'
+  ].response = {
+    type: 'json-value',
+    headers,
+    body: {
+      output: {
+        embeddings: reverseOrder ? [...data].reverse() : data,
+      },
+      ...(usage === null ? {} : { usage }),
+    },
+  };
+}
+
+describe('doEmbed', () => {
+  it('should extract embeddings in input order', async () => {
+    prepareJsonResponse({ reverseOrder: true });
+
+    const { embeddings } = await model.doEmbed({ values: testValues });
+
+    expect(embeddings).toStrictEqual(dummyEmbeddings);
+  });
+
+  it('should extract usage', async () => {
+    prepareJsonResponse({ usage: { total_tokens: 20 } });
+
+    const { usage } = await model.doEmbed({ values: testValues });
+
+    expect(usage).toStrictEqual({ tokens: 20 });
+  });
+
+  it('should omit usage when the response does not include usage', async () => {
+    prepareJsonResponse({ usage: null });
+
+    const { usage } = await model.doEmbed({ values: testValues });
+
+    expect(usage).toBeUndefined();
+  });
+
+  it('should expose the raw response', async () => {
+    prepareJsonResponse({
+      headers: { 'test-header': 'test-value' },
+    });
+
+    const { response } = await model.doEmbed({ values: testValues });
+
+    expect(response?.headers).toMatchObject({
+      'content-type': 'application/json',
+      'test-header': 'test-value',
+    });
+    expect(response?.body).toStrictEqual({
+      output: {
+        embeddings: [
+          { embedding: [0.1, 0.2, 0.3], text_index: 0 },
+          { embedding: [0.4, 0.5, 0.6], text_index: 1 },
+        ],
+      },
+      usage: { total_tokens: 8 },
+    });
+  });
+
+  it('should pass the model and values', async () => {
+    prepareJsonResponse();
+
+    await model.doEmbed({ values: testValues });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'text-embedding-v4',
+      input: {
+        texts: testValues,
+      },
+      parameters: {},
+    });
+  });
+
+  it('should pass provider options', async () => {
+    prepareJsonResponse();
+
+    await model.doEmbed({
+      values: testValues,
+      providerOptions: {
+        alibaba: {
+          textType: 'query',
+          dimension: 768,
+          outputType: 'dense&sparse',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'text-embedding-v4',
+      input: {
+        texts: testValues,
+      },
+      parameters: {
+        text_type: 'query',
+        dimension: 768,
+        output_type: 'dense&sparse',
+      },
+    });
+  });
+
+  it('should extract sparse embeddings into provider metadata', async () => {
+    prepareJsonResponse({ sparse: true });
+
+    const { providerMetadata } = await model.doEmbed({
+      values: testValues,
+      providerOptions: {
+        alibaba: {
+          outputType: 'dense&sparse',
+        },
+      },
+    });
+
+    expect(providerMetadata).toStrictEqual({
+      alibaba: {
+        sparseEmbeddings: [
+          {
+            textIndex: 0,
+            sparseEmbedding: [{ index: 100, value: 0.8, token: 'token-0' }],
+          },
+          {
+            textIndex: 1,
+            sparseEmbedding: [{ index: 101, value: 0.8, token: 'token-1' }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('should reject sparse-only output', async () => {
+    await expect(
+      model.doEmbed({
+        values: testValues,
+        providerOptions: {
+          alibaba: {
+            outputType: 'sparse',
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
+
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it('should reject too many values', async () => {
+    await expect(
+      model.doEmbed({
+        values: Array.from({ length: 11 }, (_, index) => `value-${index}`),
+      }),
+    ).rejects.toBeInstanceOf(TooManyEmbeddingValuesForCallError);
+
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it('should pass headers', async () => {
+    prepareJsonResponse();
+
+    const provider = createAlibaba({
+      apiKey: 'test-api-key',
+      headers: {
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await provider.embedding('text-embedding-v4').doEmbed({
+      values: testValues,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(server.calls[0].requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain(
+      'ai-sdk/alibaba/0.0.0-test',
+    );
+  });
+});

--- a/packages/alibaba/src/alibaba-embedding-model.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.ts
@@ -1,0 +1,177 @@
+import {
+  TooManyEmbeddingValuesForCallError,
+  UnsupportedFunctionalityError,
+  type EmbeddingModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  alibabaEmbeddingModelOptions,
+  type AlibabaEmbeddingModelId,
+} from './alibaba-embedding-model-options';
+import type { AlibabaConfig } from './alibaba-config';
+
+const alibabaEmbeddingFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: z.object({
+    code: z.string().nullish(),
+    message: z.string(),
+    request_id: z.string().nullish(),
+  }),
+  errorToMessage: data => data.message,
+});
+
+export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: AlibabaEmbeddingModelId;
+  readonly maxEmbeddingsPerCall = 10;
+  readonly supportsParallelCalls = false;
+
+  private readonly config: AlibabaConfig;
+
+  static [WORKFLOW_SERIALIZE](model: AlibabaEmbeddingModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: AlibabaEmbeddingModelId;
+    config: AlibabaConfig;
+  }) {
+    return new AlibabaEmbeddingModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: AlibabaEmbeddingModelId, config: AlibabaConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  async doEmbed({
+    values,
+    headers,
+    abortSignal,
+    providerOptions,
+  }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
+    Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
+  > {
+    if (values.length > this.maxEmbeddingsPerCall) {
+      throw new TooManyEmbeddingValuesForCallError({
+        provider: this.provider,
+        modelId: this.modelId,
+        maxEmbeddingsPerCall: this.maxEmbeddingsPerCall,
+        values,
+      });
+    }
+
+    const alibabaOptions = await parseProviderOptions({
+      provider: 'alibaba',
+      providerOptions,
+      schema: alibabaEmbeddingModelOptions,
+    });
+
+    // TODO: Explore first-class sparse embedding support in AI SDK core.
+    if (alibabaOptions?.outputType === 'sparse') {
+      throw new UnsupportedFunctionalityError({
+        functionality: "Alibaba embedding outputType 'sparse'",
+        message:
+          "Alibaba embedding outputType 'sparse' is not supported because AI SDK embeddings require dense number arrays. Use 'dense' or 'dense&sparse' instead.",
+      });
+    }
+
+    const {
+      responseHeaders,
+      value: response,
+      rawValue,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/services/embeddings/text-embedding/text-embedding`,
+      headers: combineHeaders(this.config.headers?.(), headers),
+      body: {
+        model: this.modelId,
+        input: {
+          texts: values,
+        },
+        parameters: {
+          text_type: alibabaOptions?.textType,
+          dimension: alibabaOptions?.dimension,
+          output_type: alibabaOptions?.outputType,
+        },
+      },
+      failedResponseHandler: alibabaEmbeddingFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        alibabaTextEmbeddingResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const sortedEmbeddings = response.output.embeddings.sort(
+      (a, b) => a.text_index - b.text_index,
+    );
+    const sparseEmbeddings = sortedEmbeddings
+      .map(item =>
+        item.sparse_embedding == null
+          ? undefined
+          : {
+              textIndex: item.text_index,
+              sparseEmbedding: item.sparse_embedding,
+            },
+      )
+      .filter(item => item != null);
+
+    return {
+      warnings: [],
+      embeddings: sortedEmbeddings.map(item => item.embedding),
+      usage: response.usage
+        ? { tokens: response.usage.total_tokens }
+        : undefined,
+      providerMetadata:
+        sparseEmbeddings.length > 0
+          ? {
+              alibaba: {
+                sparseEmbeddings,
+              },
+            }
+          : undefined,
+      response: { headers: responseHeaders, body: rawValue },
+    };
+  }
+}
+
+const alibabaTextEmbeddingSparseEmbeddingSchema = z.object({
+  index: z.number(),
+  value: z.number(),
+  token: z.string().nullish(),
+});
+
+const alibabaTextEmbeddingResponseSchema = z.object({
+  output: z.object({
+    embeddings: z.array(
+      z.object({
+        embedding: z.array(z.number()),
+        text_index: z.number(),
+        sparse_embedding: z
+          .array(alibabaTextEmbeddingSparseEmbeddingSchema)
+          .nullish(),
+      }),
+    ),
+  }),
+  usage: z
+    .object({
+      total_tokens: z.number(),
+    })
+    .nullish(),
+});

--- a/packages/alibaba/src/alibaba-embedding-model.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.ts
@@ -20,6 +20,7 @@ import {
 } from './alibaba-embedding-model-options';
 import type { AlibabaConfig } from './alibaba-config';
 
+// TODO: Add Alibaba multimodal embedding support in a follow-up change.
 const alibabaEmbeddingFailedResponseHandler = createJsonErrorResponseHandler({
   errorSchema: z.object({
     code: z.string().nullish(),

--- a/packages/alibaba/src/alibaba-provider.test.ts
+++ b/packages/alibaba/src/alibaba-provider.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { createAlibaba } from './alibaba-provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { AlibabaChatLanguageModel } from './alibaba-chat-language-model';
+import { AlibabaEmbeddingModel } from './alibaba-embedding-model';
 import { AlibabaVideoModel } from './alibaba-video-model';
 
 const AlibabaChatLanguageModelMock =
   AlibabaChatLanguageModel as unknown as Mock;
+const AlibabaEmbeddingModelMock = AlibabaEmbeddingModel as unknown as Mock;
 const AlibabaVideoModelMock = AlibabaVideoModel as unknown as Mock;
 
 vi.mock('./alibaba-chat-language-model', () => {
@@ -35,6 +37,21 @@ vi.mock('./alibaba-video-model', () => {
   });
   return {
     AlibabaVideoModel: mockConstructor,
+  };
+});
+
+vi.mock('./alibaba-embedding-model', () => {
+  const mockConstructor = vi.fn().mockImplementation(function (
+    this: any,
+    modelId: string,
+    settings: any,
+  ) {
+    this.provider = 'alibaba.embedding';
+    this.modelId = modelId;
+    this.settings = settings;
+  });
+  return {
+    AlibabaEmbeddingModel: mockConstructor,
   };
 });
 
@@ -136,6 +153,77 @@ describe('AlibabaProvider', () => {
       const model = provider.languageModel(modelId);
 
       expect(model).toBeInstanceOf(AlibabaChatLanguageModel);
+    });
+  });
+
+  describe('embedding', () => {
+    it('should construct an embedding model with correct provider', () => {
+      const provider = createAlibaba();
+      const model = provider.embedding('text-embedding-v4');
+
+      expect(model).toBeInstanceOf(AlibabaEmbeddingModel);
+      const constructorCall = AlibabaEmbeddingModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('text-embedding-v4');
+      expect(constructorCall[1].provider).toBe('alibaba.embedding');
+    });
+
+    it('should use default embeddingBaseURL', () => {
+      const provider = createAlibaba();
+      provider.embedding('text-embedding-v4');
+
+      const constructorCall = AlibabaEmbeddingModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe(
+        'https://dashscope-intl.aliyuncs.com/api/v1',
+      );
+    });
+
+    it('should use custom embeddingBaseURL', () => {
+      const provider = createAlibaba({
+        embeddingBaseURL: 'https://custom-embedding.example.com/api/v1',
+      });
+      provider.embedding('text-embedding-v4');
+
+      const constructorCall = AlibabaEmbeddingModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe(
+        'https://custom-embedding.example.com/api/v1',
+      );
+    });
+
+    it('should pass custom fetch to embedding model', () => {
+      const customFetch = vi.fn();
+      const provider = createAlibaba({ fetch: customFetch });
+      provider.embedding('text-embedding-v4');
+
+      const constructorCall = AlibabaEmbeddingModelMock.mock.calls[0];
+      expect(constructorCall[1].fetch).toBe(customFetch);
+    });
+
+    it('should pass headers function to embedding model', () => {
+      const provider = createAlibaba({
+        apiKey: 'test-key',
+        headers: { 'X-Custom': 'value' },
+      });
+      provider.embedding('text-embedding-v4');
+
+      const constructorCall = AlibabaEmbeddingModelMock.mock.calls[0];
+      const headers = constructorCall[1].headers();
+
+      expect(headers).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'x-custom': 'value',
+      });
+    });
+  });
+
+  describe('embeddingModel', () => {
+    it('should construct an embedding model with correct configuration', () => {
+      const provider = createAlibaba();
+      const model = provider.embeddingModel('text-embedding-v3');
+
+      expect(model).toBeInstanceOf(AlibabaEmbeddingModel);
+      const constructorCall = AlibabaEmbeddingModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('text-embedding-v3');
+      expect(constructorCall[1].provider).toBe('alibaba.embedding');
     });
   });
 

--- a/packages/alibaba/src/alibaba-provider.ts
+++ b/packages/alibaba/src/alibaba-provider.ts
@@ -1,5 +1,6 @@
 import {
   NoSuchModelError,
+  type EmbeddingModelV4,
   type Experimental_VideoModelV4,
   type LanguageModelV4,
   type ProviderV4,
@@ -12,6 +13,8 @@ import {
 } from '@ai-sdk/provider-utils';
 import { AlibabaChatLanguageModel } from './alibaba-chat-language-model';
 import type { AlibabaChatModelId } from './alibaba-chat-language-model-options';
+import { AlibabaEmbeddingModel } from './alibaba-embedding-model';
+import type { AlibabaEmbeddingModelId } from './alibaba-embedding-model-options';
 import { AlibabaVideoModel } from './alibaba-video-model';
 import type { AlibabaVideoModelId } from './alibaba-video-settings';
 import { VERSION } from './version';
@@ -31,6 +34,16 @@ export interface AlibabaProvider extends ProviderV4 {
    * Creates a chat model for text generation.
    */
   chatModel(modelId: AlibabaChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a model for text embeddings.
+   */
+  embedding(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * Creates a model for text embeddings.
+   */
+  embeddingModel(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * Creates a model for video generation.
@@ -56,6 +69,13 @@ export interface AlibabaProviderSettings {
    * The default prefix is `https://dashscope-intl.aliyuncs.com`.
    */
   videoBaseURL?: string;
+
+  /**
+   * Use a different URL prefix for embedding API calls.
+   * The embedding API uses the DashScope native endpoint (not the OpenAI-compatible endpoint).
+   * The default prefix is `https://dashscope-intl.aliyuncs.com/api/v1`.
+   */
+  embeddingBaseURL?: string;
 
   /**
    * API key that is being sent using the `Authorization` header.
@@ -97,6 +117,10 @@ export function createAlibaba(
     withoutTrailingSlash(options.videoBaseURL) ??
     'https://dashscope-intl.aliyuncs.com';
 
+  const embeddingBaseURL =
+    withoutTrailingSlash(options.embeddingBaseURL) ??
+    'https://dashscope-intl.aliyuncs.com/api/v1';
+
   const getHeaders = () =>
     withUserAgentSuffix(
       {
@@ -117,6 +141,14 @@ export function createAlibaba(
       headers: getHeaders,
       fetch: options.fetch,
       includeUsage: options.includeUsage ?? true,
+    });
+
+  const createEmbeddingModel = (modelId: AlibabaEmbeddingModelId) =>
+    new AlibabaEmbeddingModel(modelId, {
+      provider: 'alibaba.embedding',
+      baseURL: embeddingBaseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
     });
 
   const createVideoModel = (modelId: AlibabaVideoModelId) =>
@@ -140,15 +172,13 @@ export function createAlibaba(
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chatModel = createLanguageModel;
+  provider.embedding = createEmbeddingModel;
+  provider.embeddingModel = createEmbeddingModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
-  };
-
-  provider.embeddingModel = (modelId: string) => {
-    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
 
   return provider;

--- a/packages/alibaba/src/index.ts
+++ b/packages/alibaba/src/index.ts
@@ -7,6 +7,10 @@ export type {
   AlibabaLanguageModelChatOptions as AlibabaProviderOptions,
 } from './alibaba-chat-language-model-options';
 export type { AlibabaCacheControl } from './alibaba-chat-prompt';
+export type {
+  AlibabaEmbeddingModelId,
+  AlibabaEmbeddingModelOptions,
+} from './alibaba-embedding-model-options';
 export {
   type AlibabaProvider,
   type AlibabaProviderSettings,


### PR DESCRIPTION
## Background

asked in https://github.com/vercel/ai/issues/14644

Alibaba added support for embedding models (both text and multimodal) and the AISDK didn't have support for it yet

## Summary

added embedding model support for:
- text  
- multimodal input (will be continued in https://github.com/vercel/ai/pull/15804)

## Manual Verification

done by running the examples: 
- `examples/ai-functions/src/embed-many/alibaba/basic.ts`
- `examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts`
- `examples/ai-functions/src/embed/alibaba/basic.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- look into adding support for sparse embedding output in aisdk core
- add multimodal suppoprt once api key access is obtained

## Related Issues

fixes #14644