### PR TITLE
feat(provider-utils): add `env` option to `spawn` and `run` methods of `Experimental_SandboxSession`

### DIFF
--- a/.changeset/tame-gorillas-add.md
+++ b/.changeset/tame-gorillas-add.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+feat(provider-utils): add `env` option to `spawn` and `run` methods of `Experimental_SandboxSession`

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -951,9 +951,10 @@ const result = await generateText({
 The experimental sandbox description is not added to the model prompt automatically. If the model should know about details such as the root directory, exposed ports, or public hostname, include `experimental_sandbox.description` in your system prompt,
 instructions, user-visible context, or a tool description function.
 
-`run` also accepts an optional `workingDirectory` and `abortSignal`.
+`run` also accepts an optional `workingDirectory`, `env`, and `abortSignal`.
 Use `workingDirectory` when a tool needs to run a command from a directory other
-than the experimental sandbox implementation's default working directory. Forward
+than the experimental sandbox implementation's default working directory. Use `env`
+to set environment variables for the command. Forward
 `abortSignal` from the tool execution options so the experimental sandbox can cancel the command if the overall operation is aborted or times out.
 
 The AI SDK forwards your experimental sandbox object but does not create or isolate one for you.

--- a/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
@@ -33,6 +33,7 @@ type Experimental_SandboxSession = {
   readonly run: (options: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }) => PromiseLike<{
     exitCode: number;
@@ -54,7 +55,7 @@ type Experimental_SandboxSession = {
     },
     {
       name: 'run',
-      type: '(options: { command: string; workingDirectory?: string; abortSignal?: AbortSignal }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
+      type: '(options: { command: string; workingDirectory?: string; env?: Record<string, string>; abortSignal?: AbortSignal }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
       description:
         'Executes a command in the experimental sandbox and resolves with the command exit code, standard output, and standard error.',
       properties: [
@@ -72,6 +73,12 @@ type Experimental_SandboxSession = {
               type: 'string | undefined',
               description:
                 'Optional working directory to execute the command in. If omitted, the experimental sandbox implementation uses its default working directory.',
+            },
+            {
+              name: 'env',
+              type: 'Record<string, string> | undefined',
+              description:
+                'Optional environment variables to set for the command. Merged with the experimental sandbox default environment, with these values taking precedence. Passing secrets here instead of inlining them into the command avoids leaking them in logs. Implementations that cannot set environment variables reject this option.',
             },
             {
               name: 'abortSignal',

--- a/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
+++ b/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
@@ -41,15 +41,18 @@ export class VercelSandboxSession implements SandboxSession {
   async run({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }) {
     const proc = await this.spawn({
       command,
       workingDirectory,
+      env,
       abortSignal,
     });
 
@@ -65,10 +68,12 @@ export class VercelSandboxSession implements SandboxSession {
   async spawn({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }): Promise<Experimental_SandboxProcess> {
     abortSignal?.throwIfAborted();
@@ -77,6 +82,7 @@ export class VercelSandboxSession implements SandboxSession {
       cmd: 'bash',
       args: ['-c', command],
       cwd: workingDirectory ?? rootDirectory,
+      env,
       detached: true,
     });
 

--- a/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
@@ -26,15 +26,18 @@ export class JustBashSandboxSession implements SandboxSession {
   async run({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }) {
     const proc = await this.spawn({
       command,
       workingDirectory,
+      env,
       abortSignal,
     });
 
@@ -50,10 +53,12 @@ export class JustBashSandboxSession implements SandboxSession {
   async spawn({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }): Promise<Experimental_SandboxProcess> {
     abortSignal?.throwIfAborted();
@@ -63,6 +68,7 @@ export class JustBashSandboxSession implements SandboxSession {
       args: ['-c', command],
       detached: true,
       ...(workingDirectory !== undefined ? { cwd: workingDirectory } : {}),
+      ...(env !== undefined ? { env } : {}),
       ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
     });
 

--- a/examples/ai-functions/src/sandbox/local-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/local-sandbox.ts
@@ -43,15 +43,18 @@ export class LocalSandboxSession implements SandboxSession {
   async run({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }) {
     const proc = await this.spawn({
       command,
       workingDirectory,
+      env,
       abortSignal,
     });
 
@@ -67,13 +70,19 @@ export class LocalSandboxSession implements SandboxSession {
   async spawn({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }): Promise<Experimental_SandboxProcess> {
     abortSignal?.throwIfAborted();
+
+    if (env != null && Object.keys(env).length > 0) {
+      throw new Error('LocalSandboxSession does not support the `env` option.');
+    }
 
     const child = spawn('bash', ['-c', command], {
       cwd: workingDirectory ?? this.rootDirectory,

--- a/examples/ai-functions/src/sandbox/vercel-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/vercel-sandbox.ts
@@ -28,15 +28,18 @@ export class VercelSandboxSession implements SandboxSession {
   async run({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }) {
     const proc = await this.spawn({
       command,
       workingDirectory,
+      env,
       abortSignal,
     });
 
@@ -52,10 +55,12 @@ export class VercelSandboxSession implements SandboxSession {
   async spawn({
     command,
     workingDirectory,
+    env,
     abortSignal,
   }: {
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }): Promise<Experimental_SandboxProcess> {
     abortSignal?.throwIfAborted();
@@ -64,6 +69,7 @@ export class VercelSandboxSession implements SandboxSession {
       cmd: 'bash',
       args: ['-c', command],
       cwd: workingDirectory ?? rootDirectory,
+      env,
       detached: true,
     });
 

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -32,8 +32,8 @@ export type { ModelMessage } from './model-message';
 export type { ProviderOptions } from './provider-options';
 export type { ProviderReference } from './provider-reference';
 export type {
-  Experimental_SandboxSession,
-  Experimental_SandboxProcess,
+  SandboxSession as Experimental_SandboxSession,
+  SandboxProcess as Experimental_SandboxProcess,
 } from './sandbox';
 export type { SystemModelMessage } from './system-model-message';
 export {

--- a/packages/provider-utils/src/types/sandbox.test-d.ts
+++ b/packages/provider-utils/src/types/sandbox.test-d.ts
@@ -1,37 +1,30 @@
 import { expectTypeOf, test } from 'vitest';
-import type {
-  Experimental_SandboxSession,
-  Experimental_SandboxProcess,
-} from './sandbox';
+import type { SandboxSession, SandboxProcess } from './sandbox';
 
-test('Experimental_SandboxSession exposes spawn returning a process handle', () => {
-  expectTypeOf<Experimental_SandboxSession['spawn']>().toBeFunction();
-  expectTypeOf<
-    Parameters<Experimental_SandboxSession['spawn']>[0]
-  >().toEqualTypeOf<{
+test('SandboxSession exposes spawn returning a process handle', () => {
+  expectTypeOf<SandboxSession['spawn']>().toBeFunction();
+  expectTypeOf<Parameters<SandboxSession['spawn']>[0]>().toEqualTypeOf<{
     command: string;
     workingDirectory?: string;
     abortSignal?: AbortSignal;
   }>();
   expectTypeOf<
-    Awaited<ReturnType<Experimental_SandboxSession['spawn']>>
-  >().toEqualTypeOf<Experimental_SandboxProcess>();
+    Awaited<ReturnType<SandboxSession['spawn']>>
+  >().toEqualTypeOf<SandboxProcess>();
 });
 
-test('Experimental_SandboxProcess exposes the expected handle shape', () => {
-  expectTypeOf<Experimental_SandboxProcess['pid']>().toEqualTypeOf<
-    number | undefined
-  >();
-  expectTypeOf<Experimental_SandboxProcess['stdout']>().toEqualTypeOf<
+test('SandboxProcess exposes the expected handle shape', () => {
+  expectTypeOf<SandboxProcess['pid']>().toEqualTypeOf<number | undefined>();
+  expectTypeOf<SandboxProcess['stdout']>().toEqualTypeOf<
     ReadableStream<Uint8Array>
   >();
-  expectTypeOf<Experimental_SandboxProcess['stderr']>().toEqualTypeOf<
+  expectTypeOf<SandboxProcess['stderr']>().toEqualTypeOf<
     ReadableStream<Uint8Array>
   >();
+  expectTypeOf<Awaited<ReturnType<SandboxProcess['wait']>>>().toEqualTypeOf<{
+    exitCode: number;
+  }>();
   expectTypeOf<
-    Awaited<ReturnType<Experimental_SandboxProcess['wait']>>
-  >().toEqualTypeOf<{ exitCode: number }>();
-  expectTypeOf<
-    Awaited<ReturnType<Experimental_SandboxProcess['kill']>>
+    Awaited<ReturnType<SandboxProcess['kill']>>
   >().toEqualTypeOf<void>();
 });

--- a/packages/provider-utils/src/types/sandbox.test-d.ts
+++ b/packages/provider-utils/src/types/sandbox.test-d.ts
@@ -6,6 +6,7 @@ test('SandboxSession exposes spawn returning a process handle', () => {
   expectTypeOf<Parameters<SandboxSession['spawn']>[0]>().toEqualTypeOf<{
     command: string;
     workingDirectory?: string;
+    env?: Record<string, string>;
     abortSignal?: AbortSignal;
   }>();
   expectTypeOf<

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -13,6 +13,14 @@ type SandboxProcessOptions = {
   workingDirectory?: string;
 
   /**
+   * Environment variables to set for this command. Merged with the
+   * sandbox's default environment; values here take precedence.
+   * Supporting environment variables as an option is preferable from a
+   * security perspective, e.g. to avoid them leaking in logs.
+   */
+  env?: Record<string, string>;
+
+  /**
    * Signal that can be used to abort the command. When aborted, the running
    * process is killed; for `spawn`, `wait()` rejects with the abort reason.
    */

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -1,4 +1,61 @@
 /**
+ * Options for executing a command in the sandbox via `run` or `spawn`.
+ */
+type SandboxProcessOptions = {
+  /**
+   * Command to execute in the sandbox.
+   */
+  command: string;
+
+  /**
+   * Working directory to execute the command in.
+   */
+  workingDirectory?: string;
+
+  /**
+   * Signal that can be used to abort the command. When aborted, the running
+   * process is killed; for `spawn`, `wait()` rejects with the abort reason.
+   */
+  abortSignal?: AbortSignal;
+};
+
+/**
+ * Options for reading a file from the sandbox.
+ */
+type ReadFileOptions = {
+  /**
+   * Path of the file to read.
+   */
+  path: string;
+
+  /**
+   * Signal that can be used to abort the read.
+   */
+  abortSignal?: AbortSignal;
+};
+
+/**
+ * Options for writing a file to the sandbox. `CONTENT` is the payload written
+ * to the file: a byte stream, raw bytes, or a string.
+ */
+type WriteFileOptions<CONTENT> = {
+  /**
+   * Path of the file to write.
+   */
+  path: string;
+
+  /**
+   * Content to write to the file.
+   */
+  content: CONTENT;
+
+  /**
+   * Signal that can be used to abort the write.
+   */
+  abortSignal?: AbortSignal;
+};
+
+/**
  * Sandbox session that can execute commands and read/write files.
  */
 export type Experimental_SandboxSession = {
@@ -10,24 +67,100 @@ export type Experimental_SandboxSession = {
   readonly description: string;
 
   /**
+   * Read one file from the sandbox as a stream of bytes. Resolves to `null`
+   * when the file does not exist.
+   *
+   * Relative path handling is implementation-defined. This is the lowest-level
+   * read primitive; prefer `readBinaryFile` or `readTextFile` unless you need
+   * to stream bytes.
+   */
+  readonly readFile: (
+    options: ReadFileOptions,
+  ) => PromiseLike<ReadableStream<Uint8Array> | null>;
+
+  /**
+   * Read one file from the sandbox as raw bytes. Resolves to `null` when the
+   * file does not exist.
+   */
+  readonly readBinaryFile: (
+    options: ReadFileOptions,
+  ) => PromiseLike<Uint8Array | null>;
+
+  /**
+   * Read one text file from the sandbox, decoded using the requested encoding.
+   * Resolves to `null` when the file does not exist.
+   *
+   * Line ranges are 1-based and inclusive. When `endLine` is past EOF the read
+   * returns through EOF without error.
+   */
+  readonly readTextFile: (
+    options: ReadFileOptions & {
+      /**
+       * Text encoding used to decode the file bytes. Defaults to `"utf-8"`.
+       */
+      encoding?: string;
+
+      /**
+       * 1-based inclusive start line. Defaults to 1.
+       */
+      startLine?: number;
+
+      /**
+       * 1-based inclusive end line. When past the file's line count, the read
+       * returns through EOF without error.
+       */
+      endLine?: number;
+    },
+  ) => PromiseLike<string | null>;
+
+  /**
+   * Write one file to the sandbox from a stream of bytes. Creates parent
+   * directories recursively and overwrites any existing file.
+   *
+   * This is the lowest-level write primitive; prefer `writeBinaryFile` or
+   * `writeTextFile` when the full content is already materialized in memory.
+   */
+  readonly writeFile: (
+    options: WriteFileOptions<ReadableStream<Uint8Array>>,
+  ) => PromiseLike<void>;
+
+  /**
+   * Write one file to the sandbox from raw bytes. Creates parent directories
+   * recursively and overwrites any existing file.
+   */
+  readonly writeBinaryFile: (
+    options: WriteFileOptions<Uint8Array>,
+  ) => PromiseLike<void>;
+
+  /**
+   * Write one file to the sandbox from a string, encoded using the requested
+   * encoding. Creates parent directories recursively and overwrites any
+   * existing file.
+   */
+  readonly writeTextFile: (
+    options: WriteFileOptions<string> & {
+      /**
+       * Text encoding used to encode the string to bytes. Defaults to `"utf-8"`.
+       */
+      encoding?: string;
+    },
+  ) => PromiseLike<void>;
+
+  /**
+   * Spawn a long-running process in the sandbox. Returns immediately with a
+   * handle that streams stdout/stderr, can be waited on, and can be killed.
+   *
+   * `run` is conceptually a thin wrapper over this primitive: spawn,
+   * collect both streams to strings, await `wait()`, return the result.
+   */
+  readonly spawn: (
+    options: SandboxProcessOptions,
+  ) => PromiseLike<Experimental_SandboxProcess>;
+
+  /**
    * Run a command in the sandbox.
    */
-  readonly run: (options: {
-    /**
-     * Command to execute in the sandbox.
-     */
-    command: string;
-
-    /**
-     * Working directory to execute the command in.
-     */
-    workingDirectory?: string;
-
-    /**
-     * Signal that can be used to abort the command.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<{
+  readonly run: (options: SandboxProcessOptions) => PromiseLike<{
     /**
      * Exit code returned by the command.
      */
@@ -43,174 +176,6 @@ export type Experimental_SandboxSession = {
      */
     stderr: string;
   }>;
-
-  /**
-   * Read one file from the sandbox as a stream of bytes. Resolves to `null`
-   * when the file does not exist.
-   *
-   * Relative path handling is implementation-defined. This is the lowest-level
-   * read primitive; prefer `readBinaryFile` or `readTextFile` unless you need
-   * to stream bytes.
-   */
-  readonly readFile: (options: {
-    /**
-     * Path of the file to read.
-     */
-    path: string;
-
-    /**
-     * Signal that can be used to abort the read.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<ReadableStream<Uint8Array> | null>;
-
-  /**
-   * Read one file from the sandbox as raw bytes. Resolves to `null` when the
-   * file does not exist.
-   */
-  readonly readBinaryFile: (options: {
-    /**
-     * Path of the file to read.
-     */
-    path: string;
-
-    /**
-     * Signal that can be used to abort the read.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<Uint8Array | null>;
-
-  /**
-   * Read one text file from the sandbox, decoded using the requested encoding.
-   * Resolves to `null` when the file does not exist.
-   *
-   * Line ranges are 1-based and inclusive. When `endLine` is past EOF the read
-   * returns through EOF without error.
-   */
-  readonly readTextFile: (options: {
-    /**
-     * Path of the file to read.
-     */
-    path: string;
-
-    /**
-     * Text encoding used to decode the file bytes. Defaults to `"utf-8"`.
-     */
-    encoding?: string;
-
-    /**
-     * 1-based inclusive start line. Defaults to 1.
-     */
-    startLine?: number;
-
-    /**
-     * 1-based inclusive end line. When past the file's line count, the read
-     * returns through EOF without error.
-     */
-    endLine?: number;
-
-    /**
-     * Signal that can be used to abort the read.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<string | null>;
-
-  /**
-   * Write one file to the sandbox from a stream of bytes. Creates parent
-   * directories recursively and overwrites any existing file.
-   *
-   * This is the lowest-level write primitive; prefer `writeBinaryFile` or
-   * `writeTextFile` when the full content is already materialized in memory.
-   */
-  readonly writeFile: (options: {
-    /**
-     * Path of the file to write.
-     */
-    path: string;
-
-    /**
-     * Stream of bytes to write.
-     */
-    content: ReadableStream<Uint8Array>;
-
-    /**
-     * Signal that can be used to abort the write.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<void>;
-
-  /**
-   * Write one file to the sandbox from raw bytes. Creates parent directories
-   * recursively and overwrites any existing file.
-   */
-  readonly writeBinaryFile: (options: {
-    /**
-     * Path of the file to write.
-     */
-    path: string;
-
-    /**
-     * Raw bytes to write.
-     */
-    content: Uint8Array;
-
-    /**
-     * Signal that can be used to abort the write.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<void>;
-
-  /**
-   * Write one file to the sandbox from a string, encoded using the requested
-   * encoding. Creates parent directories recursively and overwrites any
-   * existing file.
-   */
-  readonly writeTextFile: (options: {
-    /**
-     * Path of the file to write.
-     */
-    path: string;
-
-    /**
-     * Text content to write.
-     */
-    content: string;
-
-    /**
-     * Text encoding used to encode the string to bytes. Defaults to `"utf-8"`.
-     */
-    encoding?: string;
-
-    /**
-     * Signal that can be used to abort the write.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<void>;
-
-  /**
-   * Spawn a long-running process in the sandbox. Returns immediately with a
-   * handle that streams stdout/stderr, can be waited on, and can be killed.
-   *
-   * `run` is conceptually a thin wrapper over this primitive: spawn,
-   * collect both streams to strings, await `wait()`, return the result.
-   */
-  readonly spawn: (options: {
-    /**
-     * Command to execute in the sandbox.
-     */
-    command: string;
-
-    /**
-     * Working directory to execute the command in.
-     */
-    workingDirectory?: string;
-
-    /**
-     * Signal that can be used to abort the process. When aborted, the process
-     * is killed and `wait()` rejects with the abort reason.
-     */
-    abortSignal?: AbortSignal;
-  }) => PromiseLike<Experimental_SandboxProcess>;
 };
 
 /**

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -58,7 +58,7 @@ type WriteFileOptions<CONTENT> = {
 /**
  * Sandbox session that can execute commands and read/write files.
  */
-export type Experimental_SandboxSession = {
+export type SandboxSession = {
   /**
    * Description of the sandbox environment that can be added to the agent's instructions
    * so that the agent knows about relevant details such as the root directory, exposed
@@ -155,7 +155,7 @@ export type Experimental_SandboxSession = {
    */
   readonly spawn: (
     options: SandboxProcessOptions,
-  ) => PromiseLike<Experimental_SandboxProcess>;
+  ) => PromiseLike<SandboxProcess>;
 
   /**
    * Run a command in the sandbox.
@@ -179,9 +179,9 @@ export type Experimental_SandboxSession = {
 };
 
 /**
- * Handle to a long-running process started via `Experimental_SandboxSession.spawn`.
+ * Handle to a long-running process started via `SandboxSession.spawn`.
  */
-export type Experimental_SandboxProcess = {
+export type SandboxProcess = {
   /**
    * Process identifier, if the sandbox implementation exposes one.
    */

--- a/packages/provider-utils/src/types/tool-execute-function.test-d.ts
+++ b/packages/provider-utils/src/types/tool-execute-function.test-d.ts
@@ -22,6 +22,7 @@ describe('tool execute function types', () => {
     expectTypeOf<Parameters<SandboxSession['run']>[0]>().toEqualTypeOf<{
       command: string;
       workingDirectory?: string;
+      env?: Record<string, string>;
       abortSignal?: AbortSignal;
     }>();
   });

--- a/packages/provider-utils/src/types/tool-execute-function.test-d.ts
+++ b/packages/provider-utils/src/types/tool-execute-function.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import type { Context } from './context';
 import type { ModelMessage } from './model-message';
-import type { Experimental_SandboxSession as SandboxSession } from './sandbox';
+import type { SandboxSession } from './sandbox';
 import type {
   ToolExecuteFunction,
   ToolExecutionOptions,

--- a/packages/provider-utils/src/types/tool-execute-function.ts
+++ b/packages/provider-utils/src/types/tool-execute-function.ts
@@ -1,6 +1,6 @@
 import type { Context } from './context';
 import type { ModelMessage } from './model-message';
-import type { Experimental_SandboxSession as SandboxSession } from './sandbox';
+import type { SandboxSession } from './sandbox';
 
 /**
  * Additional options that are sent into each tool execution.

--- a/packages/provider-utils/src/types/tool.test-d.ts
+++ b/packages/provider-utils/src/types/tool.test-d.ts
@@ -5,7 +5,7 @@ import type { ToolResultOutput } from './content-part';
 import type { Context } from './context';
 import type { ExecutableTool } from './executable-tool';
 import type { ModelMessage } from './model-message';
-import type { Experimental_SandboxSession as SandboxSession } from './sandbox';
+import type { SandboxSession } from './sandbox';
 import {
   dynamicTool,
   tool,

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -10,7 +10,7 @@ import type {
   ToolExecutionOptions,
 } from './tool-execute-function';
 import type { ToolNeedsApprovalFunction } from './tool-needs-approval-function';
-import type { Experimental_SandboxSession as SandboxSession } from './sandbox';
+import type { SandboxSession } from './sandbox';
 
 /**
  * Helper type to determine the outputSchema and execute function properties of a tool.


### PR DESCRIPTION
## Background

Sandbox sessions had no first-class way to pass environment variables to executed commands — callers had to inline them into the command string, which risks leaking secrets into logs.

## Summary

Adds an optional `env` to the shared command options used by both `spawn` and `run` on `Experimental_SandboxSession`. Implementations forward it where the underlying runtime supports it and reject it where it doesn't. The branch also includes an internal cleanup of the sandbox type definitions with no public API change.

- Add `env?: Record<string, string>` to the `spawn`/`run` options of `Experimental_SandboxSession`.
- Forward `env` through `VercelSandboxSession` and `JustBashSandboxSession` (both support it natively).
- `LocalSandboxSession` throws when `env` values are passed, since it can't isolate them.
- Internal cleanup only:
    - extract reusable option types instead of duplicating inline shapes
    - confine the `Experimental_` prefix to the package export seam rather than throughout everywhere in the package, to keep diffs small in the future (exported names are unchanged externally)

## Manual Verification

N/A

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
