### PR TITLE
feat(alibaba): add multimodal embedding support

### DIFF
--- a/examples/ai-functions/src/embed-many/alibaba/basic.ts
+++ b/examples/ai-functions/src/embed-many/alibaba/basic.ts
@@ -1,0 +1,25 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embedMany } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embeddings, usage, warnings } = await embedMany({
+    model: alibaba.embedding('text-embedding-v4'),
+    values: [
+      'sunny day at the beach',
+      'rainy afternoon in the city',
+      'snowy night in the mountains',
+    ],
+    providerOptions: {
+      alibaba: {
+        textType: 'document',
+        dimension: 1024,
+        outputType: 'dense',
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts
+++ b/examples/ai-functions/src/embed-many/alibaba/dense-sparse.ts
@@ -1,0 +1,34 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embedMany } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embeddings, providerMetadata, usage, warnings } = await embedMany({
+    model: alibaba.embedding('text-embedding-v4'),
+    values: [
+      'sunny day at the beach',
+      'rainy afternoon in the city',
+      'snowy night in the mountains',
+      'quiet morning in the library',
+      'busy market with fresh fruit',
+      'calm lake beside pine trees',
+      'crowded train station at dusk',
+      'warm soup on a winter evening',
+      'bright flowers in a spring garden',
+      'long walk through an old town',
+      'fresh coffee in a small cafe',
+    ],
+    providerOptions: {
+      alibaba: {
+        textType: 'document',
+        dimension: 1024,
+        outputType: 'dense&sparse',
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embeddings);
+  console.log(providerMetadata?.alibaba);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed/alibaba/basic.ts
+++ b/examples/ai-functions/src/embed/alibaba/basic.ts
@@ -1,0 +1,22 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embed } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embedding, providerMetadata, usage, warnings } = await embed({
+    model: alibaba.embedding('text-embedding-v4'),
+    value: 'sunny day at the beach',
+    providerOptions: {
+      alibaba: {
+        textType: 'document',
+        dimension: 1024,
+        outputType: 'dense',
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embedding);
+  console.log(providerMetadata?.alibaba?.sparseEmbeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed/alibaba/multimodal-fused.ts
+++ b/examples/ai-functions/src/embed/alibaba/multimodal-fused.ts
@@ -1,0 +1,28 @@
+import { alibaba, type AlibabaEmbeddingModelOptions } from '@ai-sdk/alibaba';
+import { embed } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embedding, providerMetadata, usage, warnings } = await embed({
+    model: alibaba.embedding('qwen3-vl-embedding'),
+    value: 'White sports shoes, lightweight and breathable.',
+    providerOptions: {
+      alibaba: {
+        content: [
+          {
+            type: 'image',
+            image:
+              'https://dashscope.oss-cn-beijing.aliyuncs.com/images/256_1.png',
+          },
+        ],
+        dimension: 1024,
+        enableFusion: true,
+      } satisfies AlibabaEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embedding);
+  console.log(providerMetadata);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/packages/alibaba/src/alibaba-config.ts
+++ b/packages/alibaba/src/alibaba-config.ts
@@ -3,6 +3,7 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 export interface AlibabaConfig {
   provider: string;
   baseURL: string;
+  multimodalBaseURL?: string;
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
   includeUsage?: boolean;

--- a/packages/alibaba/src/alibaba-embedding-model-options.ts
+++ b/packages/alibaba/src/alibaba-embedding-model-options.ts
@@ -3,7 +3,32 @@ import { z } from 'zod/v4';
 export type AlibabaEmbeddingModelId =
   | 'text-embedding-v4'
   | 'text-embedding-v3'
+  | 'qwen3-vl-embedding'
+  | 'qwen2.5-vl-embedding'
+  | 'tongyi-embedding-vision-plus'
+  | 'tongyi-embedding-vision-flash'
+  | 'multimodal-embedding-v1'
+  | 'tongyi-embedding-vision-plus-2026-03-06'
   | (string & {});
+
+const alibabaEmbeddingContentSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('text'),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal('image'),
+    image: z.string(),
+  }),
+  z.object({
+    type: z.literal('video'),
+    video: z.string(),
+  }),
+  z.object({
+    type: z.literal('multiImages'),
+    images: z.array(z.string()).min(1).max(8),
+  }),
+]);
 
 export const alibabaEmbeddingModelOptions = z.object({
   /**
@@ -15,7 +40,7 @@ export const alibabaEmbeddingModelOptions = z.object({
   /**
    * The dimension of the output embedding vectors. Defaults to 1024.
    *
-   * `text-embedding-v4` also supports 1536 and 2048 dimensions.
+   * Supported values vary by model.
    */
   dimension: z
     .union([
@@ -25,8 +50,10 @@ export const alibabaEmbeddingModelOptions = z.object({
       z.literal(512),
       z.literal(768),
       z.literal(1024),
+      z.literal(1152),
       z.literal(1536),
       z.literal(2048),
+      z.literal(2560),
     ])
     .optional(),
 
@@ -37,6 +64,42 @@ export const alibabaEmbeddingModelOptions = z.object({
    * which requires dense number arrays.
    */
   outputType: z.enum(['dense', 'sparse', 'dense&sparse']).optional(),
+
+  /**
+   * Additional multimodal content to embed with the text value.
+   * Images can be public URLs or Base64 data URIs. Videos must be public URLs.
+   */
+  content: z.array(alibabaEmbeddingContentSchema).optional(),
+
+  /**
+   * Video frame extraction rate. Lower values extract fewer frames.
+   *
+   * @default 1
+   */
+  fps: z.number().min(0).max(1).optional(),
+
+  /**
+   * Custom task description to guide query intent.
+   */
+  instruct: z.string().optional(),
+
+  /**
+   * Whether to fuse all multimodal content into a single embedding.
+   * Supported by `qwen3-vl-embedding`; `qwen2.5-vl-embedding` is fused-only.
+   */
+  enableFusion: z.boolean().optional(),
+
+  /**
+   * Resolution level for `tongyi-embedding-vision-plus-2026-03-06`.
+   */
+  resLevel: z
+    .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)])
+    .optional(),
+
+  /**
+   * Maximum number of sampled video frames for `tongyi-embedding-vision-plus-2026-03-06`.
+   */
+  maxVideoFrames: z.number().int().positive().max(64).optional(),
 });
 
 export type AlibabaEmbeddingModelOptions = z.infer<

--- a/packages/alibaba/src/alibaba-embedding-model-options.ts
+++ b/packages/alibaba/src/alibaba-embedding-model-options.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+
+export type AlibabaEmbeddingModelId =
+  | 'text-embedding-v4'
+  | 'text-embedding-v3'
+  | (string & {});
+
+export const alibabaEmbeddingModelOptions = z.object({
+  /**
+   * Differentiates query text from document text for asymmetric retrieval tasks.
+   * Defaults to `document`.
+   */
+  textType: z.enum(['query', 'document']).optional(),
+
+  /**
+   * The dimension of the output embedding vectors. Defaults to 1024.
+   *
+   * `text-embedding-v4` also supports 1536 and 2048 dimensions.
+   */
+  dimension: z
+    .union([
+      z.literal(64),
+      z.literal(128),
+      z.literal(256),
+      z.literal(512),
+      z.literal(768),
+      z.literal(1024),
+      z.literal(1536),
+      z.literal(2048),
+    ])
+    .optional(),
+
+  /**
+   * The output vector type. Defaults to `dense`.
+   *
+   * Sparse-only output is not supported by the AI SDK embedding interface,
+   * which requires dense number arrays.
+   */
+  outputType: z.enum(['dense', 'sparse', 'dense&sparse']).optional(),
+});
+
+export type AlibabaEmbeddingModelOptions = z.infer<
+  typeof alibabaEmbeddingModelOptions
+>;

--- a/packages/alibaba/src/alibaba-embedding-model.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.ts
@@ -1,0 +1,177 @@
+import {
+  TooManyEmbeddingValuesForCallError,
+  UnsupportedFunctionalityError,
+  type EmbeddingModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  alibabaEmbeddingModelOptions,
+  type AlibabaEmbeddingModelId,
+} from './alibaba-embedding-model-options';
+import type { AlibabaConfig } from './alibaba-config';
+
+const alibabaEmbeddingFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: z.object({
+    code: z.string().nullish(),
+    message: z.string(),
+    request_id: z.string().nullish(),
+  }),
+  errorToMessage: data => data.message,
+});
+
+export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: AlibabaEmbeddingModelId;
+  readonly maxEmbeddingsPerCall = 10;
+  readonly supportsParallelCalls = false;
+
+  private readonly config: AlibabaConfig;
+
+  static [WORKFLOW_SERIALIZE](model: AlibabaEmbeddingModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: AlibabaEmbeddingModelId;
+    config: AlibabaConfig;
+  }) {
+    return new AlibabaEmbeddingModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: AlibabaEmbeddingModelId, config: AlibabaConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  async doEmbed({
+    values,
+    headers,
+    abortSignal,
+    providerOptions,
+  }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
+    Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
+  > {
+    if (values.length > this.maxEmbeddingsPerCall) {
+      throw new TooManyEmbeddingValuesForCallError({
+        provider: this.provider,
+        modelId: this.modelId,
+        maxEmbeddingsPerCall: this.maxEmbeddingsPerCall,
+        values,
+      });
+    }
+
+    const alibabaOptions = await parseProviderOptions({
+      provider: 'alibaba',
+      providerOptions,
+      schema: alibabaEmbeddingModelOptions,
+    });
+
+    // TODO: Explore first-class sparse embedding support in AI SDK core.
+    if (alibabaOptions?.outputType === 'sparse') {
+      throw new UnsupportedFunctionalityError({
+        functionality: "Alibaba embedding outputType 'sparse'",
+        message:
+          "Alibaba embedding outputType 'sparse' is not supported because AI SDK embeddings require dense number arrays. Use 'dense' or 'dense&sparse' instead.",
+      });
+    }
+
+    const {
+      responseHeaders,
+      value: response,
+      rawValue,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/services/embeddings/text-embedding/text-embedding`,
+      headers: combineHeaders(this.config.headers?.(), headers),
+      body: {
+        model: this.modelId,
+        input: {
+          texts: values,
+        },
+        parameters: {
+          text_type: alibabaOptions?.textType,
+          dimension: alibabaOptions?.dimension,
+          output_type: alibabaOptions?.outputType,
+        },
+      },
+      failedResponseHandler: alibabaEmbeddingFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        alibabaTextEmbeddingResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const sortedEmbeddings = response.output.embeddings.sort(
+      (a, b) => a.text_index - b.text_index,
+    );
+    const sparseEmbeddings = sortedEmbeddings
+      .map(item =>
+        item.sparse_embedding == null
+          ? undefined
+          : {
+              textIndex: item.text_index,
+              sparseEmbedding: item.sparse_embedding,
+            },
+      )
+      .filter(item => item != null);
+
+    return {
+      warnings: [],
+      embeddings: sortedEmbeddings.map(item => item.embedding),
+      usage: response.usage
+        ? { tokens: response.usage.total_tokens }
+        : undefined,
+      providerMetadata:
+        sparseEmbeddings.length > 0
+          ? {
+              alibaba: {
+                sparseEmbeddings,
+              },
+            }
+          : undefined,
+      response: { headers: responseHeaders, body: rawValue },
+    };
+  }
+}
+
+const alibabaTextEmbeddingSparseEmbeddingSchema = z.object({
+  index: z.number(),
+  value: z.number(),
+  token: z.string().nullish(),
+});
+
+const alibabaTextEmbeddingResponseSchema = z.object({
+  output: z.object({
+    embeddings: z.array(
+      z.object({
+        embedding: z.array(z.number()),
+        text_index: z.number(),
+        sparse_embedding: z
+          .array(alibabaTextEmbeddingSparseEmbeddingSchema)
+          .nullish(),
+      }),
+    ),
+  }),
+  usage: z
+    .object({
+      total_tokens: z.number(),
+    })
+    .nullish(),
+});

--- a/packages/alibaba/src/alibaba-embedding-model.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.ts
@@ -16,6 +16,7 @@ import {
 import { z } from 'zod/v4';
 import {
   alibabaEmbeddingModelOptions,
+  type AlibabaEmbeddingModelOptions,
   type AlibabaEmbeddingModelId,
 } from './alibaba-embedding-model-options';
 import type { AlibabaConfig } from './alibaba-config';
@@ -29,10 +30,54 @@ const alibabaEmbeddingFailedResponseHandler = createJsonErrorResponseHandler({
   errorToMessage: data => data.message,
 });
 
+const multimodalEmbeddingModelIds = new Set<string>([
+  'qwen3-vl-embedding',
+  'qwen2.5-vl-embedding',
+  'tongyi-embedding-vision-plus',
+  'tongyi-embedding-vision-flash',
+  'multimodal-embedding-v1',
+  'tongyi-embedding-vision-plus-2026-03-06',
+]);
+
+function isMultimodalEmbeddingModel(modelId: string): boolean {
+  return multimodalEmbeddingModelIds.has(modelId);
+}
+
+function isMultimodalEmbeddingCall({
+  modelId,
+  options,
+}: {
+  modelId: string;
+  options: AlibabaEmbeddingModelOptions | undefined;
+}): boolean {
+  return (
+    isMultimodalEmbeddingModel(modelId) ||
+    options?.content != null ||
+    options?.enableFusion != null ||
+    options?.fps != null ||
+    options?.resLevel != null ||
+    options?.maxVideoFrames != null
+  );
+}
+
+function convertToAlibabaMultimodalContent(
+  content: NonNullable<AlibabaEmbeddingModelOptions['content']>[number],
+): Record<string, unknown> {
+  switch (content.type) {
+    case 'text':
+      return { text: content.text };
+    case 'image':
+      return { image: content.image };
+    case 'video':
+      return { video: content.video };
+    case 'multiImages':
+      return { multi_images: content.images };
+  }
+}
+
 export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
   readonly specificationVersion = 'v4';
   readonly modelId: AlibabaEmbeddingModelId;
-  readonly maxEmbeddingsPerCall = 10;
   readonly supportsParallelCalls = false;
 
   private readonly config: AlibabaConfig;
@@ -58,6 +103,10 @@ export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
 
   get provider(): string {
     return this.config.provider;
+  }
+
+  get maxEmbeddingsPerCall(): number {
+    return isMultimodalEmbeddingModel(this.modelId) ? 1 : 10;
   }
 
   async doEmbed({
@@ -89,6 +138,39 @@ export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
         functionality: "Alibaba embedding outputType 'sparse'",
         message:
           "Alibaba embedding outputType 'sparse' is not supported because AI SDK embeddings require dense number arrays. Use 'dense' or 'dense&sparse' instead.",
+      });
+    }
+
+    const isMultimodalCall = isMultimodalEmbeddingCall({
+      modelId: this.modelId,
+      options: alibabaOptions,
+    });
+
+    if (isMultimodalCall) {
+      if (values.length > 1) {
+        throw new UnsupportedFunctionalityError({
+          functionality: 'Alibaba multimodal embeddings with multiple values',
+          message:
+            'Alibaba multimodal embeddings are limited to one AI SDK embedding value per provider call.',
+        });
+      }
+
+      if (
+        alibabaOptions?.outputType != null &&
+        alibabaOptions.outputType !== 'dense'
+      ) {
+        throw new UnsupportedFunctionalityError({
+          functionality: `Alibaba multimodal embedding outputType '${alibabaOptions.outputType}'`,
+          message:
+            "Alibaba multimodal embeddings only support outputType 'dense'.",
+        });
+      }
+
+      return this.doMultimodalEmbed({
+        values,
+        headers,
+        abortSignal,
+        alibabaOptions,
       });
     }
 
@@ -149,6 +231,86 @@ export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
       response: { headers: responseHeaders, body: rawValue },
     };
   }
+
+  private async doMultimodalEmbed({
+    values,
+    headers,
+    abortSignal,
+    alibabaOptions,
+  }: {
+    values: string[];
+    headers: Parameters<EmbeddingModelV4['doEmbed']>[0]['headers'];
+    abortSignal: Parameters<EmbeddingModelV4['doEmbed']>[0]['abortSignal'];
+    alibabaOptions: AlibabaEmbeddingModelOptions | undefined;
+  }): Promise<Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>> {
+    const content = alibabaOptions?.content;
+    const contents = [
+      ...(values[0] !== '' || content == null ? [{ text: values[0] }] : []),
+      ...(content?.map(convertToAlibabaMultimodalContent) ?? []),
+    ];
+
+    const {
+      responseHeaders,
+      value: response,
+      rawValue,
+    } = await postJsonToApi({
+      url: `${
+        this.config.multimodalBaseURL ?? this.config.baseURL
+      }/services/embeddings/multimodal-embedding/multimodal-embedding`,
+      headers: combineHeaders(this.config.headers?.(), headers),
+      body: {
+        model: this.modelId,
+        input: {
+          contents,
+        },
+        parameters: {
+          output_type: alibabaOptions?.outputType,
+          dimension: alibabaOptions?.dimension,
+          fps: alibabaOptions?.fps,
+          instruct: alibabaOptions?.instruct,
+          enable_fusion: alibabaOptions?.enableFusion,
+          res_level: alibabaOptions?.resLevel,
+          max_video_frames: alibabaOptions?.maxVideoFrames,
+        },
+      },
+      failedResponseHandler: alibabaEmbeddingFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        alibabaMultimodalEmbeddingResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const sortedEmbeddings = response.output.embeddings.sort(
+      (a, b) => a.index - b.index,
+    );
+
+    if (sortedEmbeddings.length !== values.length) {
+      // TODO: Add core AI SDK support for one embedding input returning multiple independent embeddings.
+      throw new UnsupportedFunctionalityError({
+        functionality: 'Alibaba multimodal independent embeddings',
+        message:
+          `Alibaba returned ${sortedEmbeddings.length} embeddings for ` +
+          `${values.length} AI SDK embedding value. Use fused embedding mode or ` +
+          'pass a single multimodal content item.',
+      });
+    }
+
+    return {
+      warnings: [],
+      embeddings: sortedEmbeddings.map(item => item.embedding),
+      usage: response.usage
+        ? { tokens: response.usage.total_tokens }
+        : undefined,
+      providerMetadata: {
+        alibaba: {
+          requestId: response.request_id,
+          embeddingTypes: sortedEmbeddings.map(item => item.type),
+        },
+      },
+      response: { headers: responseHeaders, body: rawValue },
+    };
+  }
 }
 
 const alibabaTextEmbeddingSparseEmbeddingSchema = z.object({
@@ -172,6 +334,35 @@ const alibabaTextEmbeddingResponseSchema = z.object({
   usage: z
     .object({
       total_tokens: z.number(),
+    })
+    .nullish(),
+});
+
+const alibabaMultimodalEmbeddingResponseSchema = z.object({
+  request_id: z.string().nullish(),
+  output: z.object({
+    embeddings: z.array(
+      z.object({
+        index: z.number(),
+        embedding: z.array(z.number()),
+        type: z.string(),
+      }),
+    ),
+  }),
+  usage: z
+    .object({
+      total_tokens: z.number(),
+      input_tokens: z.number().nullish(),
+      output_tokens: z.number().nullish(),
+      input_tokens_details: z
+        .object({
+          image_tokens: z.number().nullish(),
+          text_tokens: z.number().nullish(),
+        })
+        .nullish(),
+      image_tokens: z.number().nullish(),
+      image_count: z.number().nullish(),
+      duration: z.number().nullish(),
     })
     .nullish(),
 });

--- a/packages/alibaba/src/alibaba-provider.ts
+++ b/packages/alibaba/src/alibaba-provider.ts
@@ -78,6 +78,13 @@ export interface AlibabaProviderSettings {
   embeddingBaseURL?: string;
 
   /**
+   * Use a different URL prefix for multimodal embedding API calls.
+   * The multimodal embedding API is only available in the China (Beijing) region.
+   * The default prefix is `https://dashscope.aliyuncs.com/api/v1`.
+   */
+  multimodalEmbeddingBaseURL?: string;
+
+  /**
    * API key that is being sent using the `Authorization` header.
    * It defaults to the `ALIBABA_API_KEY` environment variable.
    */
@@ -121,6 +128,10 @@ export function createAlibaba(
     withoutTrailingSlash(options.embeddingBaseURL) ??
     'https://dashscope-intl.aliyuncs.com/api/v1';
 
+  const multimodalEmbeddingBaseURL =
+    withoutTrailingSlash(options.multimodalEmbeddingBaseURL) ??
+    'https://dashscope.aliyuncs.com/api/v1';
+
   const getHeaders = () =>
     withUserAgentSuffix(
       {
@@ -147,6 +158,7 @@ export function createAlibaba(
     new AlibabaEmbeddingModel(modelId, {
       provider: 'alibaba.embedding',
       baseURL: embeddingBaseURL,
+      multimodalBaseURL: multimodalEmbeddingBaseURL,
       headers: getHeaders,
       fetch: options.fetch,
     });

--- a/packages/alibaba/src/alibaba-provider.ts
+++ b/packages/alibaba/src/alibaba-provider.ts
@@ -1,5 +1,6 @@
 import {
   NoSuchModelError,
+  type EmbeddingModelV4,
   type Experimental_VideoModelV4,
   type LanguageModelV4,
   type ProviderV4,
@@ -12,6 +13,8 @@ import {
 } from '@ai-sdk/provider-utils';
 import { AlibabaChatLanguageModel } from './alibaba-chat-language-model';
 import type { AlibabaChatModelId } from './alibaba-chat-language-model-options';
+import { AlibabaEmbeddingModel } from './alibaba-embedding-model';
+import type { AlibabaEmbeddingModelId } from './alibaba-embedding-model-options';
 import { AlibabaVideoModel } from './alibaba-video-model';
 import type { AlibabaVideoModelId } from './alibaba-video-settings';
 import { VERSION } from './version';
@@ -31,6 +34,16 @@ export interface AlibabaProvider extends ProviderV4 {
    * Creates a chat model for text generation.
    */
   chatModel(modelId: AlibabaChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a model for text embeddings.
+   */
+  embedding(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * Creates a model for text embeddings.
+   */
+  embeddingModel(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * Creates a model for video generation.
@@ -56,6 +69,13 @@ export interface AlibabaProviderSettings {
    * The default prefix is `https://dashscope-intl.aliyuncs.com`.
    */
   videoBaseURL?: string;
+
+  /**
+   * Use a different URL prefix for embedding API calls.
+   * The embedding API uses the DashScope native endpoint (not the OpenAI-compatible endpoint).
+   * The default prefix is `https://dashscope-intl.aliyuncs.com/api/v1`.
+   */
+  embeddingBaseURL?: string;
 
   /**
    * API key that is being sent using the `Authorization` header.
@@ -97,6 +117,10 @@ export function createAlibaba(
     withoutTrailingSlash(options.videoBaseURL) ??
     'https://dashscope-intl.aliyuncs.com';
 
+  const embeddingBaseURL =
+    withoutTrailingSlash(options.embeddingBaseURL) ??
+    'https://dashscope-intl.aliyuncs.com/api/v1';
+
   const getHeaders = () =>
     withUserAgentSuffix(
       {
@@ -117,6 +141,14 @@ export function createAlibaba(
       headers: getHeaders,
       fetch: options.fetch,
       includeUsage: options.includeUsage ?? true,
+    });
+
+  const createEmbeddingModel = (modelId: AlibabaEmbeddingModelId) =>
+    new AlibabaEmbeddingModel(modelId, {
+      provider: 'alibaba.embedding',
+      baseURL: embeddingBaseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
     });
 
   const createVideoModel = (modelId: AlibabaVideoModelId) =>
@@ -140,15 +172,13 @@ export function createAlibaba(
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chatModel = createLanguageModel;
+  provider.embedding = createEmbeddingModel;
+  provider.embeddingModel = createEmbeddingModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
-  };
-
-  provider.embeddingModel = (modelId: string) => {
-    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
 
   return provider;

--- a/packages/alibaba/src/index.ts
+++ b/packages/alibaba/src/index.ts
@@ -7,6 +7,10 @@ export type {
   AlibabaLanguageModelChatOptions as AlibabaProviderOptions,
 } from './alibaba-chat-language-model-options';
 export type { AlibabaCacheControl } from './alibaba-chat-prompt';
+export type {
+  AlibabaEmbeddingModelId,
+  AlibabaEmbeddingModelOptions,
+} from './alibaba-embedding-model-options';
 export {
   type AlibabaProvider,
   type AlibabaProviderSettings,


### PR DESCRIPTION
## Background

this PR builds on https://github.com/vercel/ai/pull/15802

multimodal support is only available in the region of China [[docs here](https://www.alibabacloud.com/help/en/model-studio/multimodal-embedding-api-reference?spm=a2c63.p38356.help-menu-2400256.d_2_11_0.48904199Uk5e4k&scm=20140722.H_2712517._.OR_help-T_intl~en-V_1)]

so for now, this is kept as a draft. when we have proper testing keys, this can be merged

this still has a gap - `embedMany` with multimodal values will only work in the current aisdk core when `enable_fusion` is enabled. this is because the core only allows one embedding result for a particular value

## Summary

add multimodal embedding support
- new base url
- additional model options
- `enable_fusion` is currently opt-in but should maybe be enabled by default

## Manual Verification

added the example `examples/ai-functions/src/embed/alibaba/multimodal-fused.ts` to verify but unable to do so because of lack of api key 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

see if we can get an api key + make additional aisdk core changes to sup[port embedMany with multimodal individual embedddings
