### PR TITLE
feat(provider/google-vertex): add Chirp speech-to-text (transcription) model support

### DIFF
--- a/.changeset/google-vertex-chirp-transcription.md
+++ b/.changeset/google-vertex-chirp-transcription.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google-vertex': patch
 ---
 
-feat(provider/google-vertex): add Chirp speech-to-text (transcription) model support
+feat(provider/google-vertex): add Google Cloud Speech-to-Text transcription model support

--- a/.changeset/google-vertex-chirp-transcription.md
+++ b/.changeset/google-vertex-chirp-transcription.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat(provider/google-vertex): add Chirp speech-to-text (transcription) model support

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -198,30 +198,32 @@ try {
 
 ## Transcription Models
 
-| Provider                                                                  | Model                    |
-| ------------------------------------------------------------------------- | ------------------------ |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `whisper-1`              |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `gpt-4o-transcribe`      |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `gpt-4o-mini-transcribe` |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models) | `scribe_v1`              |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models) | `scribe_v1_experimental` |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `whisper-large-v3-turbo` |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `whisper-large-v3`       |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `whisper-1`              |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `gpt-4o-transcribe`      |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `gpt-4o-mini-transcribe` |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `machine`                |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `low_cost`               |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `fusion`                 |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `base` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `enhanced` (+ variants)  |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-2` (+ variants)    |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-3` (+ variants)    |
-| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)         | `default`                |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `best`                   |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `nano`                   |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)               | `whisper`                |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)               | `wizper`                 |
+| Provider                                                                        | Model                    |
+| ------------------------------------------------------------------------------- | ------------------------ |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `whisper-1`              |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `gpt-4o-transcribe`      |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `gpt-4o-mini-transcribe` |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v1`              |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v1_experimental` |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                   | `whisper-large-v3-turbo` |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                   | `whisper-large-v3`       |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `whisper-1`              |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `gpt-4o-transcribe`      |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `gpt-4o-mini-transcribe` |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                | `machine`                |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                | `low_cost`               |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                | `fusion`                 |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `base` (+ variants)      |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `enhanced` (+ variants)  |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `nova` (+ variants)      |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `nova-2` (+ variants)    |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `nova-3` (+ variants)    |
+| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)               | `default`                |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)       | `best`                   |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)       | `nano`                   |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `whisper`                |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `wizper`                 |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -225,5 +225,6 @@ try {
 | [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `wizper`                 |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1334,6 +1334,79 @@ rate is reported in `result.providerMetadata.google.sampleRate`.
 | `gemini-2.5-flash-lite-preview-tts` | <Check size={18} /> | <Check size={18} />    |
 | `gemini-3.1-flash-tts-preview`      | <Check size={18} /> | <Check size={18} />    |
 
+### Transcription Models (Chirp)
+
+You can transcribe audio with Google Cloud [Chirp](https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3)
+speech-to-text models using the `.transcription()` factory method together with
+[`transcribe()`](/docs/reference/ai-sdk-core/transcribe).
+
+```ts
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+
+const result = await transcribe({
+  model: googleVertex.transcription('chirp_2'),
+  audio: await readFile('audio.wav'),
+});
+```
+
+Chirp uses standard Google Cloud credentials (OAuth, Application Default
+Credentials, or a service account) and calls the Cloud Speech-to-Text API.
+Express Mode API keys are not supported for transcription models. Set
+`GOOGLE_VERTEX_LOCATION` (or `providerOptions.googleVertex.region`) to a
+Speech-to-Text region: `chirp_2` is available in `us-central1`, `europe-west4`,
+and `asia-southeast1`; `chirp_3` in the `us` and `eu` multi-regions. Chirp is
+not available in the `global` Speech-to-Text location, and these regions differ
+from Vertex AI regions.
+
+The synchronous API transcribes audio up to one minute or 10 MB, whichever is
+reached first. The spoken language is auto-detected by default; pass
+`languageCodes` to restrict it.
+
+```ts
+const result = await transcribe({
+  model: googleVertex.transcription('chirp_3'),
+  audio: await readFile('audio.wav'),
+  providerOptions: {
+    googleVertex: {
+      region: 'us',
+      languageCodes: ['en-US'],
+    },
+  },
+});
+```
+
+The following provider options are available:
+
+- **languageCodes** _string[]_
+
+  BCP-47 language codes to recognize, or `['auto']` to detect the spoken
+  language. Defaults to `['auto']`. Multiple explicit language codes require a
+  multi-region Speech-to-Text endpoint such as `us` or `eu`.
+
+- **enableAutomaticPunctuation** _boolean_
+
+  Whether to add punctuation to the transcript. Defaults to `true`.
+
+- **enableWordTimeOffsets** _boolean_
+
+  Whether to include word-level timestamps in `result.segments`. Defaults to
+  `true`. Google notes that enabling word-level timestamps can reduce
+  transcription quality and speed.
+
+- **region** _string_
+
+  The Speech-to-Text region for the request. Defaults to the provider
+  `location`.
+
+#### Transcription Model Capabilities
+
+| Model     | Word timestamps                                           | Auto language detection |
+| --------- | --------------------------------------------------------- | ----------------------- |
+| `chirp_2` | Available with a potential quality and speed tradeoff     | <Check size={18} />     |
+| `chirp_3` | Available with a potential transcription quality tradeoff | <Check size={18} />     |
+
 ## Google Vertex Anthropic Provider Usage
 
 The Google Vertex Anthropic provider for the [AI SDK](/docs) offers support for Anthropic's Claude models through the Google Vertex AI APIs. This section provides details on how to set up and use the Google Vertex Anthropic provider.

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1334,10 +1334,10 @@ rate is reported in `result.providerMetadata.google.sampleRate`.
 | `gemini-2.5-flash-lite-preview-tts` | <Check size={18} /> | <Check size={18} />    |
 | `gemini-3.1-flash-tts-preview`      | <Check size={18} /> | <Check size={18} />    |
 
-### Transcription Models (Chirp)
+### Transcription Models
 
-You can transcribe audio with Google Cloud [Chirp](https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3)
-speech-to-text models using the `.transcription()` factory method together with
+You can transcribe audio with Google Cloud Speech-to-Text models using the
+`.transcription()` factory method together with
 [`transcribe()`](/docs/reference/ai-sdk-core/transcribe).
 
 ```ts
@@ -1351,18 +1351,22 @@ const result = await transcribe({
 });
 ```
 
-Chirp uses standard Google Cloud credentials (OAuth, Application Default
+The provider supports [Chirp](https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3)
+models `chirp_2` and `chirp_3`, plus `telephony` for phone-call audio.
+Speech-to-Text uses standard Google Cloud credentials (OAuth, Application Default
 Credentials, or a service account) and calls the Cloud Speech-to-Text API.
 Express Mode API keys are not supported for transcription models. Set
 `GOOGLE_VERTEX_LOCATION` (or `providerOptions.googleVertex.region`) to a
-Speech-to-Text region: `chirp_2` is available in `us-central1`, `europe-west4`,
-and `asia-southeast1`; `chirp_3` in the `us` and `eu` multi-regions. Chirp is
-not available in the `global` Speech-to-Text location, and these regions differ
-from Vertex AI regions.
+Speech-to-Text region. For Chirp, `chirp_2` is available in `us-central1`,
+`europe-west4`, and `asia-southeast1`; `chirp_3` in the `us` and `eu`
+multi-regions. Chirp is not available in the `global` Speech-to-Text location,
+and these regions differ from Vertex AI regions. `telephony` availability
+depends on the selected Speech-to-Text region and language.
 
 The synchronous API transcribes audio up to one minute or 10 MB, whichever is
 reached first. The spoken language is auto-detected by default; pass
-`languageCodes` to restrict it.
+`languageCodes` to restrict it. For `telephony`, pass a supported language code
+such as `['en-US']`.
 
 ```ts
 const result = await transcribe({
@@ -1402,10 +1406,11 @@ The following provider options are available:
 
 #### Transcription Model Capabilities
 
-| Model     | Word timestamps                                           | Auto language detection |
-| --------- | --------------------------------------------------------- | ----------------------- |
-| `chirp_2` | Available with a potential quality and speed tradeoff     | <Check size={18} />     |
-| `chirp_3` | Available with a potential transcription quality tradeoff | <Check size={18} />     |
+| Model       | Word timestamps                                           | Language detection                                                             |
+| ----------- | --------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `chirp_2`   | Available with a potential quality and speed tradeoff     | Auto detection with `['auto']`                                                 |
+| `chirp_3`   | Available with a potential transcription quality tradeoff | Auto detection with `['auto']`                                                 |
+| `telephony` | Available                                                 | Explicit supported language codes, with alternative language detection support |
 
 ## Google Vertex Anthropic Provider Usage
 

--- a/examples/ai-functions/src/transcribe/google-vertex/basic.ts
+++ b/examples/ai-functions/src/transcribe/google-vertex/basic.ts
@@ -1,0 +1,20 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    // Chirp uses Cloud Speech-to-Text regions: set GOOGLE_VERTEX_LOCATION to a
+    // Speech region (e.g. `us-central1`) or pass `providerOptions.googleVertex.region`.
+    model: googleVertex.transcription('chirp_2'),
+    audio: await readFile('data/galileo.mp3'),
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/ai-functions/src/transcribe/google-vertex/telephony.ts
+++ b/examples/ai-functions/src/transcribe/google-vertex/telephony.ts
@@ -1,0 +1,26 @@
+import {
+  googleVertex,
+  type GoogleVertexTranscriptionModelOptions,
+} from '@ai-sdk/google-vertex';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: googleVertex.transcription('telephony'),
+    audio: await readFile('data/galileo.mp3'),
+    providerOptions: {
+      googleVertex: {
+        languageCodes: ['en-US'],
+      } satisfies GoogleVertexTranscriptionModelOptions,
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -8,6 +8,7 @@ import {
 import { GoogleVertexEmbeddingModel } from './google-vertex-embedding-model';
 import { GoogleVertexImageModel } from './google-vertex-image-model';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
+import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
 
 // Mock the imported modules
 vi.mock('@ai-sdk/provider-utils', async importOriginal => {
@@ -58,6 +59,10 @@ vi.mock('./google-vertex-image-model', () => ({
 
 vi.mock('./google-vertex-video-model', () => ({
   GoogleVertexVideoModel: vi.fn(),
+}));
+
+vi.mock('./google-vertex-transcription-model', () => ({
+  GoogleVertexTranscriptionModel: vi.fn(),
 }));
 
 describe('google-vertex-provider-base', () => {
@@ -143,6 +148,47 @@ describe('google-vertex-provider-base', () => {
     expect(GoogleSpeechModel).toHaveBeenCalledWith(
       'gemini-2.5-pro-tts',
       expect.objectContaining({ provider: 'google.vertex.speech' }),
+    );
+  });
+
+  it('should create a transcription model with correct settings', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'us-central1',
+    });
+    provider.transcription('chirp_2');
+
+    expect(GoogleVertexTranscriptionModel).toHaveBeenCalledWith(
+      'chirp_2',
+      expect.objectContaining({
+        provider: 'google.vertex.transcription',
+        project: 'test-project',
+        location: 'us-central1',
+        headers: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should create a transcription model via transcriptionModel()', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'us-central1',
+    });
+    provider.transcriptionModel('chirp_3');
+
+    expect(GoogleVertexTranscriptionModel).toHaveBeenCalledWith(
+      'chirp_3',
+      expect.objectContaining({ provider: 'google.vertex.transcription' }),
+    );
+  });
+
+  it('should reject Express Mode for transcription models', () => {
+    const provider = createGoogleVertex({
+      apiKey: 'test-api-key',
+    });
+
+    expect(() => provider.transcription('chirp_3')).toThrow(
+      'Google Vertex transcription models do not support Express Mode API keys. Use standard Google Cloud credentials instead.',
     );
   });
 

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -8,6 +8,7 @@ import type {
   LanguageModelV4,
   ProviderV4,
   SpeechModelV4,
+  TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -28,6 +29,8 @@ import { GoogleVertexImageModel } from './google-vertex-image-model';
 import type { GoogleVertexImageModelId } from './google-vertex-image-settings';
 import type { GoogleVertexModelId } from './google-vertex-options';
 import { googleVertexTools } from './google-vertex-tools';
+import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
+import type { GoogleVertexTranscriptionModelId } from './google-vertex-transcription-model-options';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
 import type { GoogleVertexVideoModelId } from './google-vertex-video-settings';
 import type { GoogleVertexSpeechModelId } from './google-vertex-speech-model-options';
@@ -98,6 +101,20 @@ export interface GoogleVertexProvider extends ProviderV4 {
    * Creates a model for speech generation (text-to-speech).
    */
   speechModel(modelId: GoogleVertexSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates a model for transcription (speech-to-text) using Chirp.
+   */
+  transcription(
+    modelId: GoogleVertexTranscriptionModelId,
+  ): TranscriptionModelV4;
+
+  /**
+   * Creates a model for transcription (speech-to-text) using Chirp.
+   */
+  transcriptionModel(
+    modelId: GoogleVertexTranscriptionModelId,
+  ): TranscriptionModelV4;
 }
 
 export interface GoogleVertexProviderSettings {
@@ -245,6 +262,27 @@ export function createGoogleVertex(
   const createSpeechModel = (modelId: GoogleVertexSpeechModelId) =>
     new GoogleSpeechModel(modelId, createConfig('speech'));
 
+  // Chirp (Cloud Speech-to-Text) reuses the Vertex auth headers from
+  // createConfig, but targets the Speech-to-Text API.
+  const createTranscriptionModel = (
+    modelId: GoogleVertexTranscriptionModelId,
+  ) => {
+    if (apiKey) {
+      throw new Error(
+        'Google Vertex transcription models do not support Express Mode API keys. Use standard Google Cloud credentials instead.',
+      );
+    }
+
+    const config = createConfig('transcription');
+    return new GoogleVertexTranscriptionModel(modelId, {
+      provider: config.provider,
+      headers: config.headers,
+      fetch: config.fetch,
+      project: loadGoogleVertexProject(),
+      location: loadGoogleVertexLocation(),
+    });
+  };
+
   const provider = function (modelId: GoogleVertexModelId) {
     if (new.target) {
       throw new Error(
@@ -265,6 +303,8 @@ export function createGoogleVertex(
   provider.videoModel = createVideoModel;
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;
+  provider.transcription = createTranscriptionModel;
+  provider.transcriptionModel = createTranscriptionModel;
   provider.tools = googleVertexTools;
 
   return provider;

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -103,14 +103,14 @@ export interface GoogleVertexProvider extends ProviderV4 {
   speechModel(modelId: GoogleVertexSpeechModelId): SpeechModelV4;
 
   /**
-   * Creates a model for transcription (speech-to-text) using Chirp.
+   * Creates a model for transcription (speech-to-text).
    */
   transcription(
     modelId: GoogleVertexTranscriptionModelId,
   ): TranscriptionModelV4;
 
   /**
-   * Creates a model for transcription (speech-to-text) using Chirp.
+   * Creates a model for transcription (speech-to-text).
    */
   transcriptionModel(
     modelId: GoogleVertexTranscriptionModelId,
@@ -262,8 +262,8 @@ export function createGoogleVertex(
   const createSpeechModel = (modelId: GoogleVertexSpeechModelId) =>
     new GoogleSpeechModel(modelId, createConfig('speech'));
 
-  // Chirp (Cloud Speech-to-Text) reuses the Vertex auth headers from
-  // createConfig, but targets the Speech-to-Text API.
+  // Cloud Speech-to-Text reuses the Vertex auth headers from createConfig, but
+  // targets the Speech-to-Text API.
   const createTranscriptionModel = (
     modelId: GoogleVertexTranscriptionModelId,
   ) => {

--- a/packages/google-vertex/src/google-vertex-transcription-model-options.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model-options.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+
+// Google Cloud Speech-to-Text "Chirp" transcription models (Speech-to-Text v2).
+// https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3
+export type GoogleVertexTranscriptionModelId =
+  | 'chirp_2'
+  | 'chirp_3'
+  | (string & {});
+
+export const googleVertexTranscriptionProviderOptionsSchema = z.object({
+  /**
+   * BCP-47 language codes to recognize (e.g. `['en-US']`), or `['auto']` to let
+   * Chirp auto-detect the spoken language. Defaults to `['auto']`.
+   */
+  languageCodes: z.array(z.string()).optional(),
+
+  /**
+   * Whether to add punctuation to the transcript. Defaults to `true`.
+   */
+  enableAutomaticPunctuation: z.boolean().optional(),
+
+  /**
+   * Whether to include word-level timestamps. Defaults to `true` so the
+   * transcription result can include segments.
+   *
+   * Enabling word-level timestamps can reduce transcription quality and speed
+   * for Chirp models.
+   */
+  enableWordTimeOffsets: z.boolean().optional(),
+
+  /**
+   * The Cloud Speech-to-Text region for the request (e.g. `'us'`, `'eu'`,
+   * `'us-central1'`). Defaults to the provider `location`.
+   *
+   * Note: Speech-to-Text regions differ from Vertex AI regions. Chirp is only
+   * available in specific Speech-to-Text regions and is not available in the
+   * `global` location.
+   */
+  region: z.string().optional(),
+});
+
+export type GoogleVertexTranscriptionModelOptions = z.infer<
+  typeof googleVertexTranscriptionProviderOptionsSchema
+>;

--- a/packages/google-vertex/src/google-vertex-transcription-model-options.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model-options.ts
@@ -1,16 +1,18 @@
 import { z } from 'zod/v4';
 
-// Google Cloud Speech-to-Text "Chirp" transcription models (Speech-to-Text v2).
-// https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3
+// Google Cloud Speech-to-Text transcription models (Speech-to-Text v2).
+// https://docs.cloud.google.com/speech-to-text/docs/transcription-model
 export type GoogleVertexTranscriptionModelId =
   | 'chirp_2'
   | 'chirp_3'
+  | 'telephony'
   | (string & {});
 
 export const googleVertexTranscriptionProviderOptionsSchema = z.object({
   /**
    * BCP-47 language codes to recognize (e.g. `['en-US']`), or `['auto']` to let
-   * Chirp auto-detect the spoken language. Defaults to `['auto']`.
+   * Chirp auto-detect the spoken language. Defaults to `['auto']`. For
+   * `telephony`, pass a supported explicit language code.
    */
   languageCodes: z.array(z.string()).optional(),
 

--- a/packages/google-vertex/src/google-vertex-transcription-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model.test.ts
@@ -1,0 +1,356 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { createGoogleVertex } from './google-vertex-provider-base';
+import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createGoogleVertex({
+  project: 'test-project',
+  location: 'us-central1',
+});
+const model = provider.transcription('chirp_2');
+
+// 8 bytes of audio; base64 -> 'AQIDBAUGBwg='.
+const audioData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+const AUDIO_BASE64 = 'AQIDBAUGBwg=';
+
+const url =
+  'https://us-central1-speech.googleapis.com/v2/projects/test-project/locations/us-central1/recognizers/_:recognize';
+const usUrl =
+  'https://us-speech.googleapis.com/v2/projects/test-project/locations/us/recognizers/_:recognize';
+const globalUrl =
+  'https://speech.googleapis.com/v2/projects/test-project/locations/global/recognizers/_:recognize';
+
+const defaultBody = {
+  results: [
+    {
+      alternatives: [
+        {
+          transcript: 'hello world',
+          words: [
+            { word: 'hello', startOffset: '0s', endOffset: '0.500s' },
+            { word: 'world', startOffset: '0.500s', endOffset: '1s' },
+          ],
+        },
+      ],
+      languageCode: 'en-US',
+    },
+  ],
+  metadata: { totalBilledDuration: '1s' },
+};
+
+const server = createTestServer({
+  [url]: {},
+  [usUrl]: {},
+  [globalUrl]: {},
+});
+
+function prepareJsonResponse({
+  headers,
+}: {
+  headers?: Record<string, string>;
+} = {}) {
+  server.urls[url].response = {
+    type: 'json-value',
+    headers,
+    body: defaultBody,
+  };
+}
+
+describe('doGenerate', () => {
+  it('should send the model, languageCodes, features and base64 content', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({ audio: audioData, mediaType: 'audio/wav' });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      config: {
+        model: 'chirp_2',
+        languageCodes: ['auto'],
+        autoDecodingConfig: {},
+        features: {
+          enableWordTimeOffsets: true,
+          enableAutomaticPunctuation: true,
+        },
+      },
+      content: AUDIO_BASE64,
+    });
+  });
+
+  it('should target the regional Speech-to-Text endpoint', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({ audio: audioData, mediaType: 'audio/wav' });
+
+    expect(server.calls[0].requestUrl).toBe(url);
+  });
+
+  it('should extract text, segments, language and duration', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.text).toBe('hello world');
+    expect(result.segments).toEqual([
+      { text: 'hello', startSecond: 0, endSecond: 0.5 },
+      { text: 'world', startSecond: 0.5, endSecond: 1 },
+    ]);
+    // BCP-47 `en-US` is reduced to the ISO-639-1 `en`.
+    expect(result.language).toBe('en');
+    expect(result.durationInSeconds).toBe(1);
+  });
+
+  it('should accept a base64 string audio input directly', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({ audio: AUDIO_BASE64, mediaType: 'audio/wav' });
+
+    expect((await server.calls[0].requestBodyJson).content).toBe(AUDIO_BASE64);
+  });
+
+  it('should pass languageCodes and features from provider options', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        googleVertex: {
+          languageCodes: ['en-US', 'fr-FR'],
+          enableAutomaticPunctuation: false,
+          enableWordTimeOffsets: false,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      config: {
+        languageCodes: ['en-US', 'fr-FR'],
+        features: {
+          enableAutomaticPunctuation: false,
+          enableWordTimeOffsets: false,
+        },
+      },
+    });
+  });
+
+  it('should accept the legacy vertex provider options key', async () => {
+    server.urls[usUrl].response = { type: 'json-value', body: defaultBody };
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: { vertex: { region: 'us' } },
+    });
+
+    expect(server.calls[0].requestUrl).toBe(usUrl);
+  });
+
+  it('should accept the google provider options key', async () => {
+    server.urls[usUrl].response = { type: 'json-value', body: defaultBody };
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: { google: { region: 'us' } },
+    });
+
+    expect(server.calls[0].requestUrl).toBe(usUrl);
+  });
+
+  it('should prefer googleVertex provider options', async () => {
+    server.urls[usUrl].response = { type: 'json-value', body: defaultBody };
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        googleVertex: { region: 'us' },
+        vertex: { region: 'eu' },
+        google: { region: 'asia-southeast1' },
+      },
+    });
+
+    expect(server.calls[0].requestUrl).toBe(usUrl);
+  });
+
+  it('should route to a region override from provider options', async () => {
+    server.urls[usUrl].response = { type: 'json-value', body: defaultBody };
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: { googleVertex: { region: 'us' } },
+    });
+
+    expect(server.calls[0].requestUrl).toBe(usUrl);
+  });
+
+  it('should use the unprefixed host for the global location', async () => {
+    server.urls[globalUrl].response = { type: 'json-value', body: defaultBody };
+
+    await provider.transcription('latest_long').doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: { googleVertex: { region: 'global' } },
+    });
+
+    expect(server.calls[0].requestUrl).toBe(globalUrl);
+  });
+
+  it('should pass headers and user agent', async () => {
+    prepareJsonResponse();
+
+    const providerWithHeaders = createGoogleVertex({
+      project: 'test-project',
+      location: 'us-central1',
+      headers: { 'Custom-Provider-Header': 'provider-header-value' },
+    });
+
+    await providerWithHeaders.transcription('chirp_2').doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      headers: { 'Custom-Request-Header': 'request-header-value' },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain(
+      'ai-sdk/google-vertex/0.0.0-test',
+    );
+  });
+
+  it('should return empty text and segments when there are no results', async () => {
+    server.urls[url].response = { type: 'json-value', body: {} };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.text).toBe('');
+    expect(result.segments).toEqual([]);
+    expect(result.language).toBeUndefined();
+    expect(result.durationInSeconds).toBeUndefined();
+  });
+
+  it('should omit segments without word time offsets', async () => {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        results: [
+          {
+            alternatives: [
+              {
+                transcript: 'hello world',
+                words: [{ word: 'hello' }, { word: 'world' }],
+              },
+            ],
+            languageCode: 'en-US',
+          },
+        ],
+      },
+    };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.segments).toEqual([]);
+  });
+
+  it('should canonicalize detected languages to ISO-639-1', async () => {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        results: [
+          {
+            alternatives: [{ transcript: '你好' }],
+            languageCode: 'cmn-Hans-CN',
+          },
+        ],
+      },
+    };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.language).toBe('zh');
+  });
+
+  it('should omit detected languages without an ISO-639-1 code', async () => {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        results: [
+          {
+            alternatives: [{ transcript: 'hello world' }],
+            languageCode: 'ast-ES',
+          },
+        ],
+      },
+    };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.language).toBeUndefined();
+  });
+
+  it('should parse billed duration', async () => {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        results: [
+          {
+            alternatives: [{ transcript: 'hello world' }],
+            languageCode: 'en-US',
+          },
+        ],
+        metadata: { totalBilledDuration: '1.250s' },
+      },
+    };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.durationInSeconds).toBe(1.25);
+  });
+
+  it('should include response data with timestamp, modelId and headers', async () => {
+    prepareJsonResponse({ headers: { 'x-request-id': 'test-request-id' } });
+
+    const testDate = new Date(0);
+    const customModel = new GoogleVertexTranscriptionModel('chirp_2', {
+      provider: 'google.vertex.transcription',
+      project: 'test-project',
+      location: 'us-central1',
+      headers: () => ({}),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.response.timestamp.getTime()).toBe(testDate.getTime());
+    expect(result.response.modelId).toBe('chirp_2');
+    expect(result.response.headers?.['x-request-id']).toBe('test-request-id');
+  });
+});

--- a/packages/google-vertex/src/google-vertex-transcription-model.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model.ts
@@ -1,0 +1,231 @@
+import type { SharedV4Warning, TranscriptionModelV4 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertUint8ArrayToBase64,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { googleVertexFailedResponseHandler } from './google-vertex-error';
+import {
+  googleVertexTranscriptionProviderOptionsSchema,
+  type GoogleVertexTranscriptionModelId,
+  type GoogleVertexTranscriptionModelOptions,
+} from './google-vertex-transcription-model-options';
+
+interface GoogleVertexTranscriptionModelConfig {
+  provider: string;
+  /** Google Cloud project id. */
+  project: string;
+  /** Default Speech-to-Text region (overridable via provider options). */
+  location: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+// Speech-to-Text Durations are strings like `"1.200s"`; parse to seconds.
+function parseDurationSeconds(
+  value: string | null | undefined,
+): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const seconds = Number.parseFloat(value);
+  return Number.isFinite(seconds) ? seconds : undefined;
+}
+
+function convertBcp47ToIso6391(
+  value: string | null | undefined,
+): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  try {
+    const language = new Intl.Locale(value).language;
+    return language.length === 2 ? language : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export class GoogleVertexTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: GoogleVertexTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: GoogleVertexTranscriptionModelId;
+    config: GoogleVertexTranscriptionModelConfig;
+  }) {
+    return new GoogleVertexTranscriptionModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: GoogleVertexTranscriptionModelId,
+    private readonly config: GoogleVertexTranscriptionModelConfig,
+  ) {}
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+
+    // Provider options may be passed under `googleVertex`, `vertex`, or `google`
+    // (matching the Vertex language + embedding models).
+    let googleOptions: GoogleVertexTranscriptionModelOptions | undefined;
+    for (const provider of ['googleVertex', 'vertex', 'google'] as const) {
+      googleOptions = await parseProviderOptions({
+        provider,
+        providerOptions: options.providerOptions,
+        schema: googleVertexTranscriptionProviderOptionsSchema,
+      });
+      if (googleOptions != null) {
+        break;
+      }
+    }
+
+    const region = googleOptions?.region ?? this.config.location;
+    const languageCodes = googleOptions?.languageCodes ?? ['auto'];
+
+    // The recognize API takes base64-encoded audio in the `content` field. A
+    // string audio input is already base64-encoded per the spec.
+    const content =
+      typeof options.audio === 'string'
+        ? options.audio
+        : convertUint8ArrayToBase64(options.audio);
+
+    const requestBody = {
+      config: {
+        model: this.modelId,
+        languageCodes,
+        // Let Chirp auto-detect the audio encoding (wav/mp3/flac/…).
+        autoDecodingConfig: {},
+        features: {
+          // Word timing populates `segments`.
+          enableWordTimeOffsets: googleOptions?.enableWordTimeOffsets ?? true,
+          enableAutomaticPunctuation:
+            googleOptions?.enableAutomaticPunctuation ?? true,
+        },
+      },
+      content,
+    };
+
+    const host =
+      region === 'global'
+        ? 'speech.googleapis.com'
+        : `${region}-speech.googleapis.com`;
+
+    const url =
+      `https://${host}/v2/projects/` +
+      `${this.config.project}/locations/${region}/recognizers/_:recognize`;
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: googleVertexFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleVertexTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    // Results are sequential portions of the audio; concatenate their primary
+    // alternatives into the full transcript and collect word-level segments.
+    const results = response.results ?? [];
+    const text = results
+      .map(result => result.alternatives?.[0]?.transcript ?? '')
+      .join(' ')
+      .trim();
+    const segments = results.flatMap(
+      result =>
+        result.alternatives?.[0]?.words?.flatMap(word => {
+          const startSecond = parseDurationSeconds(word.startOffset);
+          const endSecond = parseDurationSeconds(word.endOffset);
+
+          return word.word == null || startSecond == null || endSecond == null
+            ? []
+            : [{ text: word.word, startSecond, endSecond }];
+        }) ?? [],
+    );
+    const language = convertBcp47ToIso6391(results[0]?.languageCode);
+
+    return {
+      text,
+      segments,
+      language,
+      durationInSeconds: parseDurationSeconds(
+        response.metadata?.totalBilledDuration,
+      ),
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}
+
+// Minimal schema: only the fields the implementation reads, with `.nullish()`
+// so provider API changes don't break parsing.
+const googleVertexTranscriptionResponseSchema = z.object({
+  results: z
+    .array(
+      z.object({
+        alternatives: z
+          .array(
+            z.object({
+              transcript: z.string().nullish(),
+              words: z
+                .array(
+                  z.object({
+                    word: z.string().nullish(),
+                    startOffset: z.string().nullish(),
+                    endOffset: z.string().nullish(),
+                  }),
+                )
+                .nullish(),
+            }),
+          )
+          .nullish(),
+        languageCode: z.string().nullish(),
+      }),
+    )
+    .nullish(),
+  metadata: z
+    .object({
+      totalBilledDuration: z.string().nullish(),
+    })
+    .nullish(),
+});

--- a/packages/google-vertex/src/google-vertex-transcription-model.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model.ts
@@ -119,7 +119,7 @@ export class GoogleVertexTranscriptionModel implements TranscriptionModelV4 {
       config: {
         model: this.modelId,
         languageCodes,
-        // Let Chirp auto-detect the audio encoding (wav/mp3/flac/…).
+        // Let Speech-to-Text auto-detect the audio encoding (wav/mp3/flac/…).
         autoDecodingConfig: {},
         features: {
           // Word timing populates `segments`.

--- a/packages/google-vertex/src/index.ts
+++ b/packages/google-vertex/src/index.ts
@@ -1,5 +1,9 @@
 export type { GoogleVertexEmbeddingModelOptions } from './google-vertex-embedding-model-options';
 export type {
+  GoogleVertexTranscriptionModelId,
+  GoogleVertexTranscriptionModelOptions,
+} from './google-vertex-transcription-model-options';
+export type {
   GoogleVertexImageModelOptions,
   /** @deprecated Use `GoogleVertexImageModelOptions` instead. */
   GoogleVertexImageModelOptions as GoogleVertexImageProviderOptions,


### PR DESCRIPTION
## Background

`@ai-sdk/google-vertex` supports Google Vertex generative models but did not expose Google Cloud Chirp speech-to-text through the AI SDK transcription interface. Chirp uses the Cloud Speech-to-Text v2 API and the same standard Google Cloud credentials, but it calls Speech-to-Text endpoints rather than Vertex `aiplatform` endpoints.

## Summary

- Add a `TranscriptionModelV4` implementation for `chirp_2` and `chirp_3`.
- Expose `googleVertex.transcription()` and `googleVertex.transcriptionModel()`.
- Reuse Google Vertex OAuth/service-account headers while routing requests to the correct Speech-to-Text regional or global host.
- Support `googleVertex`, legacy `vertex`, and cross-namespace `google` provider options.
- Add provider options for language codes, punctuation, word time offsets, and Speech-to-Text region.
- Normalize Google BCP-47 language tags to ISO-639-1 where possible and omit incomplete word segments.
- Reject Vertex Express Mode API keys with a clear error because Cloud Speech-to-Text requires standard Google Cloud authentication.
- Add unit tests, an `ai-functions` example, provider/core docs, and a patch changeset.

## Manual Verification

- Ran the local `examples/gemini-tts-demo` against a real Google Cloud project with Cloud Speech-to-Text enabled.
- Transcribed `examples/ai-functions/data/galileo.mp3` successfully with:
  - `chirp_2` in `us-central1`
  - `chirp_3` in `us`
- Verified text, detected language, and duration are returned end-to-end.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Add `batchRecognize` support for audio longer than the synchronous API limit.
- Add streaming recognition support when the AI SDK transcription interface supports streaming.
