### PR TITLE
fix(gateway): classify unrecognized error responses by HTTP status code

### DIFF
--- a/.changeset/gateway-error-status-fallback.md
+++ b/.changeset/gateway-error-status-fallback.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(provider/gateway): classify unrecognized error responses by HTTP status code instead of always GatewayInternalServerError, so relayed provider errors surface as the correct error class (e.g. GatewayInvalidRequestError for 4xx, GatewayRateLimitError for 429, GatewayTimeoutError for 408/504)

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -7,6 +7,7 @@ import {
   GatewayModelNotFoundError,
   GatewayInternalServerError,
   GatewayResponseError,
+  GatewayTimeoutError,
   type GatewayErrorResponse,
 } from './index';
 describe('Valid error responses', () => {
@@ -139,6 +140,88 @@ describe('Valid error responses', () => {
     expect(error).toBeInstanceOf(GatewayInternalServerError);
     expect(error.message).toBe('Unknown error occurred');
     expect(error.statusCode).toBe(500);
+  });
+
+  it('should create GatewayTimeoutError for timeout type', async () => {
+    const error = await createGatewayErrorFromResponse({
+      response: { error: { message: 'Request timed out', type: 'timeout' } },
+      statusCode: 504,
+    });
+
+    expect(error).toBeInstanceOf(GatewayTimeoutError);
+    expect(error.statusCode).toBe(504);
+  });
+});
+
+// When the Gateway sends an error type the client doesn't have an explicit
+// case for (e.g. a relayed provider error surfaced as "AI_APICallError", or a
+// newer Gateway type), classify by HTTP status code instead of collapsing
+// everything to GatewayInternalServerError. This keeps `instanceof` checks and
+// `isRetryable` meaningful for the most common error category.
+describe('status-code fallback for unrecognized error types', () => {
+  it('should map a relayed provider 400 (AI_APICallError) to GatewayInvalidRequestError', async () => {
+    const error = await createGatewayErrorFromResponse({
+      response: {
+        error: {
+          message:
+            'No tool call found for function call output with call_id call_x.',
+          type: 'AI_APICallError',
+        },
+      },
+      statusCode: 400,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInvalidRequestError);
+    expect(error.statusCode).toBe(400);
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should map an unrecognized 429 to GatewayRateLimitError (retryable)', async () => {
+    const error = await createGatewayErrorFromResponse({
+      response: { error: { message: 'slow down', type: 'AI_APICallError' } },
+      statusCode: 429,
+    });
+
+    expect(error).toBeInstanceOf(GatewayRateLimitError);
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should map an unrecognized 408/504 to GatewayTimeoutError', async () => {
+    const error408 = await createGatewayErrorFromResponse({
+      response: { error: { message: 'timed out', type: 'AI_APICallError' } },
+      statusCode: 408,
+    });
+    const error504 = await createGatewayErrorFromResponse({
+      response: { error: { message: 'gateway timeout', type: 'some_type' } },
+      statusCode: 504,
+    });
+
+    expect(error408).toBeInstanceOf(GatewayTimeoutError);
+    expect(error504).toBeInstanceOf(GatewayTimeoutError);
+  });
+
+  it('should map an unrecognized 5xx to GatewayInternalServerError (retryable)', async () => {
+    const error = await createGatewayErrorFromResponse({
+      response: {
+        error: { message: 'upstream boom', type: 'AI_APICallError' },
+      },
+      statusCode: 503,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInternalServerError);
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should map other unrecognized 4xx to GatewayInvalidRequestError (not retryable)', async () => {
+    const error = await createGatewayErrorFromResponse({
+      response: {
+        error: { message: 'unprocessable', type: 'AI_APICallError' },
+      },
+      statusCode: 422,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInvalidRequestError);
+    expect(error.isRetryable).toBe(false);
   });
 });
 

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -223,6 +223,30 @@ describe('status-code fallback for unrecognized error types', () => {
     expect(error).toBeInstanceOf(GatewayInvalidRequestError);
     expect(error.isRetryable).toBe(false);
   });
+
+  // Deliberate: a relayed provider 401/403/404 is bucketed as
+  // GatewayInvalidRequestError, NOT GatewayAuthenticationError /
+  // GatewayModelNotFoundError. Those classes describe Gateway-level auth and
+  // model resolution; the Gateway already emits the matching recognized types
+  // (authentication_error / model_not_found) for genuine cases via its own
+  // paths. Inferring them from a bare upstream status would mislead (a provider
+  // 401 isn't the caller's Gateway key being wrong). isRetryable stays correct
+  // either way since it derives from the status code.
+  it.each([401, 403, 404])(
+    'maps an unrecognized %i to GatewayInvalidRequestError (not Auth/ModelNotFound)',
+    async statusCode => {
+      const error = await createGatewayErrorFromResponse({
+        response: {
+          error: { message: 'upstream rejected', type: 'AI_APICallError' },
+        },
+        statusCode,
+      });
+
+      expect(error).toBeInstanceOf(GatewayInvalidRequestError);
+      expect(error.statusCode).toBe(statusCode);
+      expect(error.isRetryable).toBe(false);
+    },
+  );
 });
 
 describe('Error response edge cases', () => {

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -9,6 +9,7 @@ import {
 } from './gateway-model-not-found-error';
 import { GatewayInternalServerError } from './gateway-internal-server-error';
 import { GatewayResponseError } from './gateway-response-error';
+import { GatewayTimeoutError } from './gateway-timeout-error';
 import {
   lazySchema,
   safeValidateTypes,
@@ -101,14 +102,77 @@ export async function createGatewayErrorFromResponse({
         cause,
         generationId,
       });
+    case 'timeout':
+      return new GatewayTimeoutError({
+        message,
+        statusCode,
+        cause,
+        generationId,
+      });
     default:
-      return new GatewayInternalServerError({
+      // The Gateway can return an error type this client has no explicit case
+      // for - a relayed upstream provider error (surfaced as e.g.
+      // "AI_APICallError"), or a newer Gateway error type. Classify by HTTP
+      // status code so `instanceof` checks and `isRetryable` stay meaningful,
+      // instead of collapsing every such error to GatewayInternalServerError.
+      return createGatewayErrorFromStatusCode({
         message,
         statusCode,
         cause,
         generationId,
       });
   }
+}
+
+function createGatewayErrorFromStatusCode({
+  message,
+  statusCode,
+  cause,
+  generationId,
+}: {
+  message: string;
+  statusCode: number;
+  cause?: unknown;
+  generationId?: string;
+}): GatewayError {
+  if (statusCode === 429) {
+    return new GatewayRateLimitError({
+      message,
+      statusCode,
+      cause,
+      generationId,
+    });
+  }
+  if (statusCode === 408 || statusCode === 504) {
+    return new GatewayTimeoutError({
+      message,
+      statusCode,
+      cause,
+      generationId,
+    });
+  }
+  if (statusCode >= 500) {
+    return new GatewayInternalServerError({
+      message,
+      statusCode,
+      cause,
+      generationId,
+    });
+  }
+  if (statusCode >= 400) {
+    return new GatewayInvalidRequestError({
+      message,
+      statusCode,
+      cause,
+      generationId,
+    });
+  }
+  return new GatewayInternalServerError({
+    message,
+    statusCode,
+    cause,
+    generationId,
+  });
 }
 
 const gatewayErrorResponseSchema = lazySchema(() =>


### PR DESCRIPTION
## Problem

When the AI Gateway returns an error whose `type` this client doesn't explicitly handle — most commonly a relayed upstream provider error, but also newer Gateway error types — `createGatewayErrorFromResponse` falls through to `GatewayInternalServerError` regardless of the actual HTTP status. So a relayed 400 / 429 / 408 surfaces to application code as `GatewayInternalServerError`, and `instanceof GatewayInvalidRequestError` / `GatewayRateLimitError` / `GatewayTimeoutError` checks never match for those errors.

Retry behavior is unaffected — `isRetryable` is derived from the status code on the base `GatewayError`, and the status code is already preserved. This is specifically about the error class being accurate for `instanceof` handling.

## Changes

- Add an explicit `timeout` type case → `GatewayTimeoutError`.
- For an unrecognized `type`, classify by HTTP status code instead of always returning `GatewayInternalServerError`:
  - `429` → `GatewayRateLimitError`
  - `408` / `504` → `GatewayTimeoutError`
  - `>= 500` → `GatewayInternalServerError`
  - other `4xx` → `GatewayInvalidRequestError`

`statusCode` and `isRetryable` are unchanged; only the resolved error class is corrected.
