### PR TITLE
fix(providers): use secureJsonParse instead of raw JSON.parse in production code

### DIFF
--- a/.changeset/secure-json-parse-provider-code.md
+++ b/.changeset/secure-json-parse-provider-code.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/google': patch
+'@ai-sdk/gateway': patch
+---
+
+fix(providers): use `secureJsonParse` instead of raw `JSON.parse` in production code
+
+Several provider files parsed untrusted strings (tool call inputs, tool error results, and API error response bodies) with raw `JSON.parse`, leaving a prototype-pollution vector open. `secureJsonParse` (which rejects `__proto__` / `constructor.prototype` keys) is now exported from `@ai-sdk/provider-utils` and used at these call sites in `@ai-sdk/google`, `@ai-sdk/anthropic`, and `@ai-sdk/gateway`.

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -28,6 +28,7 @@ import {
   postJsonToApi,
   resolve,
   resolveProviderReference,
+  secureJsonParse,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -2105,7 +2106,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                         contentBlock.input === '' ? '{}' : contentBlock.input;
                       if (contentBlock.providerToolName === 'code_execution') {
                         try {
-                          const parsed = JSON.parse(finalInput);
+                          const parsed = secureJsonParse(finalInput);
                           if (
                             parsed != null &&
                             typeof parsed === 'object' &&

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -12,6 +12,7 @@ import {
   parseProviderOptions,
   resolveFullMediaType,
   resolveProviderReference,
+  secureJsonParse,
   validateTypes,
   isNonNullable,
   type ToolNameMapping,
@@ -48,7 +49,7 @@ function convertBytesDataToString(data: Uint8Array | string): string {
 function extractErrorValue(value: unknown): { errorCode?: string } {
   try {
     if (typeof value === 'string') {
-      return JSON.parse(value);
+      return secureJsonParse(value);
     } else if (typeof value === 'object' && value !== null) {
       return value as { errorCode?: string };
     }
@@ -844,7 +845,7 @@ export async function convertToAnthropicPrompt({
                     let errorInfo: { type?: string; errorCode?: string } = {};
                     try {
                       if (typeof output.value === 'string') {
-                        errorInfo = JSON.parse(output.value);
+                        errorInfo = secureJsonParse(output.value);
                       } else if (
                         typeof output.value === 'object' &&
                         output.value !== null

--- a/packages/gateway/src/errors/extract-api-call-response.test.ts
+++ b/packages/gateway/src/errors/extract-api-call-response.test.ts
@@ -267,4 +267,44 @@ describe('extractResponseFromAPICallError', () => {
       expect(result).toEqual(arrayData);
     });
   });
+
+  describe('prototype pollution protection', () => {
+    it('should not parse a responseBody containing a __proto__ key', () => {
+      const malicious = '{"__proto__":{"polluted":true}}';
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: malicious,
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      // secureJsonParse rejects the payload, so we fall back to the raw string
+      // rather than returning an attacker-influenced object.
+      expect(result).toBe(malicious);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('should not parse a responseBody containing a constructor.prototype key', () => {
+      const malicious = '{"constructor":{"prototype":{"polluted":true}}}';
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: malicious,
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(malicious);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
 });

--- a/packages/gateway/src/errors/extract-api-call-response.ts
+++ b/packages/gateway/src/errors/extract-api-call-response.ts
@@ -1,4 +1,5 @@
 import type { APICallError } from '@ai-sdk/provider';
+import { secureJsonParse } from '@ai-sdk/provider-utils';
 
 export function extractApiCallResponse(error: APICallError): unknown {
   if (error.data !== undefined) {
@@ -6,7 +7,7 @@ export function extractApiCallResponse(error: APICallError): unknown {
   }
   if (error.responseBody != null) {
     try {
-      return JSON.parse(error.responseBody);
+      return secureJsonParse(error.responseBody);
     } catch {
       return error.responseBody;
     }

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -10,6 +10,7 @@ import {
   isFullMediaType,
   resolveFullMediaType,
   resolveProviderReference,
+  secureJsonParse,
 } from '@ai-sdk/provider-utils';
 import type {
   GoogleContent,
@@ -468,7 +469,7 @@ export function convertToGoogleMessages(
                         toolType: serverToolType,
                         args:
                           typeof part.input === 'string'
-                            ? JSON.parse(part.input)
+                            ? secureJsonParse(part.input)
                             : part.input,
                         id: serverToolCallId,
                       },

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -858,6 +858,40 @@ describe('convertToGoogleInteractionsInput', () => {
       expect(fnCall?.arguments).toEqual({ location: 'Boston' });
     });
 
+    it('rejects a stringified tool-call input with a __proto__ key instead of parsing it', () => {
+      const malicious = '{"__proto__":{"polluted":true}}';
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hi' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_abc',
+              toolName: 'getWeather',
+              input: malicious,
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+      const steps = result.input as Array<{
+        type: string;
+        arguments?: Record<string, unknown>;
+      }>;
+      const fnCall = steps.find(step => step.type === 'function_call');
+
+      // secureJsonParse rejects the prototype-pollution payload, so the helper
+      // falls back to wrapping the raw string instead of returning a parsed
+      // object with an attacker-controlled `__proto__` entry.
+      expect(fnCall?.arguments).toEqual({ value: malicious });
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
     it('round-trips a function_call signature via providerMetadata.google.signature', () => {
       const prompt: LanguageModelV4Prompt = [
         {

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -10,6 +10,7 @@ import {
   isFullMediaType,
   resolveFullMediaType,
   resolveProviderReference,
+  secureJsonParse,
 } from '@ai-sdk/provider-utils';
 import type {
   GoogleInteractionsContent,
@@ -376,7 +377,7 @@ function compactPromptForPreviousInteraction({
 
 function safeParseToolArgs(input: string): Record<string, unknown> {
   try {
-    const parsed = JSON.parse(input);
+    const parsed = secureJsonParse(input);
     if (
       parsed != null &&
       typeof parsed === 'object' &&

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -78,6 +78,7 @@ export {
   type Schema,
   type ValidationResult,
 } from './schema';
+export { secureJsonParse } from './secure-json-parse';
 export { serializeModelOptions } from './serialize-model-options';
 export {
   StreamingToolCallTracker,


### PR DESCRIPTION
Several production provider files parse untrusted strings with raw `JSON.parse`. These strings come from model output and upstream API responses — tool-call inputs, provider tool error results, and API error response bodies — all of which can be influenced by prompt injection or a misbehaving/malicious upstream.

This violates the project coding standard ("Never use `JSON.parse` directly in production code to prevent security risks") and leaves a prototype-pollution vector open: a payload such as `{"__proto__":{"polluted":true}}` parses without complaint and can pollute objects during later recursive merges.

The repo already ships `secureJsonParse` (`packages/provider-utils/src/secure-json-parse.ts`), which rejects `__proto__` / `constructor.prototype` keys. However it was **not exported** from `@ai-sdk/provider-utils`, and the public `parseJSON` / `safeParseJSON` helpers are async, so these synchronous call sites had no safe option.

## Summary

- **`@ai-sdk/provider-utils`**: export `secureJsonParse` from the package entry point.
- Replace raw `JSON.parse` with `secureJsonParse` at six call sites (all already wrapped in `try/catch`, so error handling is unchanged — a rejected payload now falls back instead of being parsed):

  | Package | File | Parses |
  |---|---|---|
  | `@ai-sdk/google` | `src/interactions/convert-to-google-interactions-input.ts` | tool-call input string |
  | `@ai-sdk/google` | `src/convert-to-google-messages.ts` | server tool-call args |
  | `@ai-sdk/anthropic` | `src/convert-to-anthropic-prompt.ts` (×2) | provider tool error result values |
  | `@ai-sdk/anthropic` | `src/anthropic-language-model.ts` | `code_execution` tool input |
  | `@ai-sdk/gateway` | `src/errors/extract-api-call-response.ts` | API error response body |

- Add regression tests that fail on the previous `JSON.parse` implementation:
  - `@ai-sdk/gateway`: `__proto__` and `constructor.prototype` payloads fall back to the raw response string.
  - `@ai-sdk/google`: a malicious stringified tool-call input is rejected and wrapped safely instead of parsed.

## Manual Verification

Targeted test suites (all pass):

```
pnpm --filter @ai-sdk/gateway   exec vitest run src/errors/extract-api-call-response.test.ts          # 16 passed
pnpm --filter @ai-sdk/google    exec vitest run src/interactions/convert-to-google-interactions-input.test.ts \
                                              src/convert-to-google-messages.test.ts                   # 95 passed
pnpm --filter @ai-sdk/anthropic exec vitest run src/convert-to-anthropic-prompt.test.ts               # 75 passed
pnpm --filter @ai-sdk/anthropic exec vitest run src/anthropic-language-model.test.ts                  # 250 passed
pnpm --filter @ai-sdk/provider-utils exec vitest run src/secure-json-parse.test.ts src/parse-json.test.ts  # 27 passed
```

Additional checks:

- `npx ultracite check <changed files>` — clean (formatting + lint).
- `npx tsc --build packages/provider-utils packages/google packages/anthropic packages/gateway` — exit 0.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) — n/a, internal-only change
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Audit remaining raw `JSON.parse` usages in other production packages (e.g. `@ai-sdk/langchain`) and migrate any that handle untrusted input to `secureJsonParse`.

## Related Issues

Fixes #15812
