### PR TITLE
fix(ai): throw InvalidResponseDataError when audio format cannot be d…

### DIFF
--- a/.changeset/audio-file-sdk-error.md
+++ b/.changeset/audio-file-sdk-error.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): throw `InvalidResponseDataError` instead of a generic `Error` when an audio format cannot be determined
+
+`DefaultGeneratedAudioFile` previously threw a plain `Error` when it could not derive a format from the media type, so callers could not detect it with `AISDKError.isInstance`. It now throws `InvalidResponseDataError` (an `AISDKError`), consistent with the rest of the SDK's error handling.

--- a/packages/ai/src/generate-speech/generated-audio-file.test.ts
+++ b/packages/ai/src/generate-speech/generated-audio-file.test.ts
@@ -1,0 +1,58 @@
+import { AISDKError, InvalidResponseDataError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { DefaultGeneratedAudioFile } from './generated-audio-file';
+
+describe('DefaultGeneratedAudioFile', () => {
+  it('derives the format from the media type subtype', () => {
+    const file = new DefaultGeneratedAudioFile({
+      data: 'AQID',
+      mediaType: 'audio/wav',
+    });
+
+    expect(file.format).toBe('wav');
+  });
+
+  it('keeps the format as mp3 for audio/mpeg', () => {
+    const file = new DefaultGeneratedAudioFile({
+      data: 'AQID',
+      mediaType: 'audio/mpeg',
+    });
+
+    expect(file.format).toBe('mp3');
+  });
+
+  it('defaults the format to mp3 when the media type has no subtype', () => {
+    const file = new DefaultGeneratedAudioFile({
+      data: 'AQID',
+      mediaType: 'audio',
+    });
+
+    expect(file.format).toBe('mp3');
+  });
+
+  it('throws an InvalidResponseDataError when the format cannot be determined', () => {
+    expect(
+      () =>
+        new DefaultGeneratedAudioFile({
+          data: 'AQID',
+          mediaType: 'audio/',
+        }),
+    ).toThrow(InvalidResponseDataError);
+  });
+
+  it('throws an AISDKError (not a plain Error) carrying the offending media type', () => {
+    const createWithInvalidMediaType = () =>
+      new DefaultGeneratedAudioFile({ data: 'AQID', mediaType: 'audio/' });
+
+    let error: unknown;
+    try {
+      createWithInvalidMediaType();
+    } catch (e) {
+      error = e;
+    }
+
+    expect(AISDKError.isInstance(error)).toBe(true);
+    expect(InvalidResponseDataError.isInstance(error)).toBe(true);
+    expect((error as InvalidResponseDataError).data).toBe('audio/');
+  });
+});

--- a/packages/ai/src/generate-speech/generated-audio-file.ts
+++ b/packages/ai/src/generate-speech/generated-audio-file.ts
@@ -1,3 +1,4 @@
+import { InvalidResponseDataError } from '@ai-sdk/provider';
 import {
   DefaultGeneratedFile,
   type GeneratedFile,
@@ -41,10 +42,10 @@ export class DefaultGeneratedAudioFile
     }
 
     if (!format) {
-      // TODO this should be an AI SDK error
-      throw new Error(
-        'Audio format must be provided or determinable from media type',
-      );
+      throw new InvalidResponseDataError({
+        data: mediaType,
+        message: `Could not determine audio format from media type: ${mediaType}`,
+      });
     }
 
     this.format = format;


### PR DESCRIPTION
`DefaultGeneratedAudioFile` (`packages/ai/src/generate-speech/generated-audio-file.ts`) threw a plain JavaScript `Error` when it could not derive an audio format from the provider's media type — it even carried a `// TODO this should be an AI SDK error` comment.

Because the error did not extend `AISDKError`, callers could not distinguish it from an unexpected runtime error via `AISDKError.isInstance(...)`, and it was inconsistent with the rest of the SDK's error handling. The path is reachable when a provider returns audio with a malformed media type (e.g. `audio/` — an empty subtype), which leaves the derived format empty.

## Summary

- Replace the generic `Error` with `InvalidResponseDataError` from `@ai-sdk/provider`, passing the offending media type as `data` and a clearer message.
- Remove the stale `// TODO this should be an AI SDK error` comment.
- Add `generated-audio-file.test.ts` covering format derivation and the new error behavior.

## Manual Verification

```
pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-speech/generated-audio-file.test.ts   # 5 passed
pnpm --filter ai exec vitest --config vitest.edge.config.js --run src/generate-speech/generated-audio-file.test.ts   # 5 passed
pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-speech/generate-speech.test.ts        # 8 passed (no regressions)
```

Additional checks:

- `npx ultracite check <changed files>` — clean (formatting + lint).
- `npx tsc --build packages/ai` — exit 0.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) — n/a, internal-only change
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15814
