### PR TITLE
docs(provider): add Latitude observability provider v6

### DIFF
--- a/content/providers/05-observability/index.mdx
+++ b/content/providers/05-observability/index.mdx
@@ -15,6 +15,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [LangSmith](/providers/observability/langsmith)
 - [Laminar](/providers/observability/laminar)
 - [LangWatch](/providers/observability/langwatch)
+- [Latitude](/providers/observability/latitude)
 - [MLflow](/providers/observability/mlflow)
 - [Maxim](/providers/observability/maxim)
 - [PostHog](/providers/observability/posthog)

--- a/content/providers/05-observability/latitude.mdx
+++ b/content/providers/05-observability/latitude.mdx
@@ -1,0 +1,74 @@
+---
+title: Latitude
+description: Monitor and debug your AI SDK application with Latitude
+---
+
+# Latitude Observability
+
+[Latitude](https://latitude.so) ([GitHub](https://github.com/latitude-dev/latitude-llm)) is an open-source MIT-licensed platform for AI agent observability with semantic trace search and issue tracking. It integrates with the AI SDK to capture:
+
+- Traces of every `generateText`, `streamText`, and tool call
+- Token usage and latency per call
+- Errors and failure patterns grouped as recurring issues
+
+## Setup
+
+Latitude ships an SDK that wires up OpenTelemetry under the hood. The AI SDK emits spans through its `experimental_telemetry` flag and Latitude collects them.
+
+Install the SDK:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @latitude-data/telemetry" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @latitude-data/telemetry" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @latitude-data/telemetry" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @latitude-data/telemetry" dark />
+  </Tab>
+</Tabs>
+
+Sign in at [app.latitude.so](https://app.latitude.so) and grab your API key and project slug from the dashboard. Set them in your environment:
+
+```bash filename=".env"
+LATITUDE_API_KEY="..."
+LATITUDE_PROJECT_SLUG="..."
+```
+
+Initialize Latitude once at startup and set `experimental_telemetry.isEnabled` to `true` on AI SDK calls:
+
+```ts
+import { Latitude, capture } from '@latitude-data/telemetry';
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
+});
+
+await capture('generate-support-reply', async () => {
+  const { text } = await generateText({
+    model: openai('gpt-4o'),
+    prompt: 'Hello',
+    experimental_telemetry: {
+      isEnabled: true,
+    },
+  });
+  return text;
+});
+
+await latitude.shutdown();
+```
+
+The `capture()` wrapper groups all AI SDK calls inside the callback under a single named trace. `shutdown()` flushes pending spans before the process exits.
+
+## Resources
+
+- [Latitude Vercel AI SDK guide](https://docs.latitude.so/telemetry/frameworks/vercel-ai-sdk)
+- [Latitude documentation](https://docs.latitude.so)
+- [GitHub repository](https://github.com/latitude-dev/latitude-llm)


### PR DESCRIPTION
Adds Latitude as an observability provider for the AI SDK.

Latitude is an open-source, MIT-licensed platform for AI agent observability with semantic trace search and issue tracking. It ships an SDK that picks up OpenTelemetry spans emitted by the AI SDK's `experimental_telemetry` flag.

Two file changes:

- New `content/providers/05-observability/latitude.mdx` with install, env setup, and a minimal `generateText` example
- `content/providers/05-observability/index.mdx` updated to list Latitude alphabetically between LangWatch and MLflow

Links:

- Site: https://latitude.so
- Vercel AI SDK guide on Latitude docs: https://docs.latitude.so/telemetry/frameworks/vercel-ai-sdk
- Repo: https://github.com/latitude-dev/latitude-llm