### PR TITLE
backport: chore: update TypeScript references and fix `pnpm update-references` script

### DIFF
--- a/examples/ai-core/tsconfig.json
+++ b/examples/ai-core/tsconfig.json
@@ -4,9 +4,14 @@
     "declaration": true,
     "sourceMap": true,
     "target": "es2022",
-    "lib": ["es2022", "dom"],
+    "lib": [
+      "es2022",
+      "dom"
+    ],
     "module": "esnext",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "Bundler",
@@ -15,10 +20,15 @@
     "skipLibCheck": true,
     "composite": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "references": [
     {
       "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/alibaba"
     },
     {
       "path": "../../packages/amazon-bedrock"
@@ -27,7 +37,13 @@
       "path": "../../packages/anthropic"
     },
     {
+      "path": "../../packages/assemblyai"
+    },
+    {
       "path": "../../packages/azure"
+    },
+    {
+      "path": "../../packages/baseten"
     },
     {
       "path": "../../packages/black-forest-labs"
@@ -36,43 +52,31 @@
       "path": "../../packages/cerebras"
     },
     {
-      "path": "../../packages/elevenlabs"
-    },
-    {
-      "path": "../../packages/revai"
-    },
-    {
       "path": "../../packages/cohere"
     },
     {
       "path": "../../packages/deepgram"
     },
     {
-      "path": "../../packages/revai"
-    },
-    {
       "path": "../../packages/deepinfra"
-    },
-    {
-      "path": "../../packages/gladia"
-    },
-    {
-      "path": "../../packages/lmnt"
     },
     {
       "path": "../../packages/deepseek"
     },
     {
-      "path": "../../packages/hume"
+      "path": "../../packages/elevenlabs"
     },
     {
       "path": "../../packages/fal"
     },
     {
-      "path": "../../packages/assemblyai"
+      "path": "../../packages/fireworks"
     },
     {
-      "path": "../../packages/fireworks"
+      "path": "../../packages/gateway"
+    },
+    {
+      "path": "../../packages/gladia"
     },
     {
       "path": "../../packages/google"
@@ -82,6 +86,15 @@
     },
     {
       "path": "../../packages/groq"
+    },
+    {
+      "path": "../../packages/huggingface"
+    },
+    {
+      "path": "../../packages/hume"
+    },
+    {
+      "path": "../../packages/lmnt"
     },
     {
       "path": "../../packages/luma"
@@ -111,13 +124,16 @@
       "path": "../../packages/replicate"
     },
     {
-      "path": "../../packages/test-server"
+      "path": "../../packages/revai"
     },
     {
       "path": "../../packages/togetherai"
     },
     {
       "path": "../../packages/valibot"
+    },
+    {
+      "path": "../../packages/vercel"
     },
     {
       "path": "../../packages/xai"

--- a/examples/angular/tsconfig.json
+++ b/examples/angular/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "files": [],
   "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.server.json" }
+    {
+      "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/angular"
+    },
+    {
+      "path": "../../packages/openai"
+    }
   ]
 }

--- a/examples/mcp/tsconfig.json
+++ b/examples/mcp/tsconfig.json
@@ -4,9 +4,14 @@
     "declaration": true,
     "sourceMap": true,
     "target": "es2022",
-    "lib": ["es2022", "dom"],
+    "lib": [
+      "es2022",
+      "dom"
+    ],
     "module": "esnext",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "Bundler",
@@ -20,6 +25,9 @@
   "references": [
     {
       "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/mcp"
     },
     {
       "path": "../../packages/openai"

--- a/examples/next-agent/tsconfig.json
+++ b/examples/next-agent/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,17 +23,31 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"],
-      "@util/*": ["./util/*"]
+      "@/*": [
+        "./*"
+      ],
+      "@util/*": [
+        "./util/*"
+      ]
     },
     "composite": true,
     "noEmit": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
   "references": [
     {
       "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/openai"
     },
     {
       "path": "../../packages/react"

--- a/examples/next-fastapi/tsconfig.json
+++ b/examples/next-fastapi/tsconfig.json
@@ -45,9 +45,6 @@
     },
     {
       "path": "../../packages/react"
-    },
-    {
-      "path": "../../packages/ai"
     }
   ]
 }

--- a/examples/next-langchain/tsconfig.json
+++ b/examples/next-langchain/tsconfig.json
@@ -44,10 +44,10 @@
       "path": "../../packages/ai"
     },
     {
-      "path": "../../packages/react"
+      "path": "../../packages/langchain"
     },
     {
-      "path": "../../packages/langchain"
+      "path": "../../packages/react"
     }
   ]
 }

--- a/examples/next-openai/tsconfig.json
+++ b/examples/next-openai/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,24 +23,40 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"],
-      "@component/*": ["./component/*"],
-      "@util/*": ["./util/*"]
+      "@/*": [
+        "./*"
+      ],
+      "@component/*": [
+        "./component/*"
+      ],
+      "@util/*": [
+        "./util/*"
+      ]
     },
     "composite": true,
     "noEmit": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
   "references": [
     {
       "path": "../../packages/ai"
     },
     {
-      "path": "../../packages/rsc"
+      "path": "../../packages/amazon-bedrock"
     },
     {
       "path": "../../packages/anthropic"
+    },
+    {
+      "path": "../../packages/cohere"
     },
     {
       "path": "../../packages/deepseek"
@@ -51,13 +71,31 @@
       "path": "../../packages/google-vertex"
     },
     {
+      "path": "../../packages/groq"
+    },
+    {
+      "path": "../../packages/mcp"
+    },
+    {
+      "path": "../../packages/mistral"
+    },
+    {
       "path": "../../packages/openai"
     },
     {
       "path": "../../packages/perplexity"
     },
     {
+      "path": "../../packages/provider-utils"
+    },
+    {
       "path": "../../packages/react"
+    },
+    {
+      "path": "../../packages/rsc"
+    },
+    {
+      "path": "../../packages/xai"
     }
   ]
 }

--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -19,6 +19,7 @@
     "@sveltejs/adapter-vercel": "5.5.2",
     "@sveltejs/kit": "2.16.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@types/node": "22.19.19",
     "ai": "workspace:*",
     "autoprefixer": "^10.4.20",
     "bits-ui": "^1.3.9",

--- a/examples/sveltekit-openai/tsconfig.json
+++ b/examples/sveltekit-openai/tsconfig.json
@@ -27,9 +27,6 @@
     },
     {
       "path": "../../packages/svelte"
-    },
-    {
-      "path": "../../packages/ai"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "turbo clean",
     "dev": "turbo dev --no-cache --concurrency 16 --continue",
     "prepare": "husky install",
-    "update-references": "update-ts-references",
+    "update-references": "update-ts-references && node tools/split-ts-references.mjs",
     "type-check": "tsc --build",
     "type-check:full": "tsc --build tsconfig.with-examples.json",
     "check": "ultracite check",

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -3,8 +3,14 @@
   "compilerOptions": {
     "target": "ES2018",
     "stripInternal": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "types": ["@types/node"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "types": [
+      "@types/node"
+    ],
     "composite": true,
     "rootDir": ".",
     "outDir": "dist"
@@ -19,13 +25,13 @@
   ],
   "references": [
     {
+      "path": "../gateway"
+    },
+    {
       "path": "../provider"
     },
     {
       "path": "../provider-utils"
-    },
-    {
-      "path": "../gateway"
     },
     {
       "path": "../test-server"

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -11,14 +11,19 @@
     "skipLibCheck": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules"],
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
   "references": [
     {
-      "path": "../provider-utils"
+      "path": "../ai"
     },
     {
-      "path": "../ai"
+      "path": "../provider-utils"
     },
     {
       "path": "../test-server"

--- a/packages/baseten/tsconfig.json
+++ b/packages/baseten/tsconfig.json
@@ -5,7 +5,12 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
   "references": [
     {
       "path": "../openai-compatible"
@@ -15,9 +20,6 @@
     },
     {
       "path": "../provider-utils"
-    },
-    {
-      "path": "../ai"
     }
   ]
 }

--- a/packages/deepseek/tsconfig.json
+++ b/packages/deepseek/tsconfig.json
@@ -13,13 +13,13 @@
   ],
   "references": [
     {
-      "path": "../openai-compatible"
-    },
-    {
       "path": "../provider"
     },
     {
       "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
     }
   ]
 }

--- a/packages/langchain/tsconfig.json
+++ b/packages/langchain/tsconfig.json
@@ -8,7 +8,7 @@
       "dom",
       "dom.iterable",
       "esnext"
-    ],
+    ]
   },
   "exclude": [
     "dist",
@@ -19,9 +19,6 @@
   "references": [
     {
       "path": "../ai"
-    },
-    {
-      "path": "../provider-utils"
     }
   ]
 }

--- a/packages/llamaindex/tsconfig.json
+++ b/packages/llamaindex/tsconfig.json
@@ -8,7 +8,7 @@
       "dom",
       "dom.iterable",
       "esnext"
-    ],
+    ]
   },
   "exclude": [
     "dist",
@@ -19,9 +19,6 @@
   "references": [
     {
       "path": "../ai"
-    },
-    {
-      "path": "../provider-utils"
     }
   ]
 }

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -15,11 +15,14 @@
     "tsup.config.ts"
   ],
   "references": [
-      {
+    {
       "path": "../provider"
-      },
-      {
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
       "path": "../test-server"
-      }
+    }
   ]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -15,10 +15,10 @@
   ],
   "references": [
     {
-      "path": "../provider-utils"
+      "path": "../ai"
     },
     {
-      "path": "../ai"
+      "path": "../provider-utils"
     }
   ]
 }

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -17,17 +17,21 @@
     "stripInternal": true,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
-    "lib": ["esnext", "dom", "dom.iterable"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable"
+    ],
     "types": [],
     "rootDir": "src",
     "outDir": "dist"
   },
   "references": [
     {
-      "path": "../provider-utils"
+      "path": "../ai"
     },
     {
-      "path": "../ai"
+      "path": "../provider-utils"
     },
     {
       "path": "../test-server"

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -13,10 +13,10 @@
   ],
   "references": [
     {
-      "path": "../provider-utils"
+      "path": "../ai"
     },
     {
-      "path": "../ai"
+      "path": "../provider-utils"
     },
     {
       "path": "../test-server"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.6.2
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.7.4)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
 
   examples/ai-core:
     dependencies:
@@ -1227,13 +1227,16 @@ importers:
         version: link:../../packages/svelte
       '@sveltejs/adapter-vercel':
         specifier: 5.5.2
-        version: 5.5.2(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(encoding@0.1.13)(rollup@4.59.0)
+        version: 5.5.2(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(encoding@0.1.13)(rollup@4.59.0)
       '@sveltejs/kit':
         specifier: 2.16.0
-        version: 2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        version: 2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        version: 5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -1260,19 +1263,19 @@ importers:
         version: 3.5.0
       tailwind-variants:
         specifier: ^1.0.0
-        version: 1.0.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3)))
+        version: 1.0.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)))
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3))
+        version: 3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+        version: 6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -2820,7 +2823,7 @@ importers:
         version: link:../../tools/tsconfig
       '@vitejs/plugin-vue':
         specifier: 5.2.0
-        version: 5.2.0(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.3))
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
@@ -2835,7 +2838,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
 
   packages/xai:
     dependencies:
@@ -10188,8 +10191,8 @@ packages:
   '@types/node@20.17.24':
     resolution: {integrity: sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==}
 
-  '@types/node@22.7.4':
-    resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -18357,6 +18360,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
@@ -23326,11 +23332,11 @@ snapshots:
       '@inquirer/type': 3.0.1(@types/node@20.17.24)
       '@types/node': 20.17.24
 
-  '@inquirer/confirm@5.0.2(@types/node@22.7.4)':
+  '@inquirer/confirm@5.0.2(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 10.1.0(@types/node@22.7.4)
-      '@inquirer/type': 3.0.1(@types/node@22.7.4)
-      '@types/node': 22.7.4
+      '@inquirer/core': 10.1.0(@types/node@22.19.19)
+      '@inquirer/type': 3.0.1(@types/node@22.19.19)
+      '@types/node': 22.19.19
     optional: true
 
   '@inquirer/confirm@5.1.14(@types/node@20.17.24)':
@@ -23361,10 +23367,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@inquirer/core@10.1.0(@types/node@22.7.4)':
+  '@inquirer/core@10.1.0(@types/node@22.19.19)':
     dependencies:
       '@inquirer/figures': 1.0.8
-      '@inquirer/type': 3.0.1(@types/node@22.7.4)
+      '@inquirer/type': 3.0.1(@types/node@22.19.19)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -23499,9 +23505,9 @@ snapshots:
     dependencies:
       '@types/node': 20.17.24
 
-  '@inquirer/type@3.0.1(@types/node@22.7.4)':
+  '@inquirer/type@3.0.1(@types/node@22.19.19)':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.19.19
     optional: true
 
   '@inquirer/type@3.0.10(@types/node@20.17.24)':
@@ -23548,7 +23554,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -23561,14 +23567,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.24)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -23593,7 +23599,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -23611,7 +23617,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -23633,7 +23639,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.29
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -23703,7 +23709,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -27676,9 +27682,9 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(encoding@0.1.13)(rollup@4.59.0)':
+  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(encoding@0.1.13)(rollup@4.59.0)':
     dependencies:
-      '@sveltejs/kit': 2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@sveltejs/kit': 2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       '@vercel/nft': 0.27.10(encoding@0.1.13)(rollup@4.59.0)
       esbuild: 0.24.2
     transitivePeerDependencies:
@@ -27686,9 +27692,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.6.4
@@ -27701,7 +27707,7 @@ snapshots:
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
       svelte: 5.53.6
-      vite: 6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
   '@sveltejs/package@2.5.7(svelte@5.53.6)(typescript@5.9.3)':
     dependencies:
@@ -27723,12 +27729,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       debug: 4.4.3(supports-color@9.4.0)
       svelte: 5.53.6
-      vite: 6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27745,16 +27751,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(svelte@5.53.6)(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.53.6
-      vite: 6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
-      vitefu: 1.0.6(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      vite: 6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vitefu: 1.0.6(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -27902,15 +27908,15 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/bunyan@1.8.9':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/chai@5.2.3':
     dependencies:
@@ -27919,20 +27925,20 @@ snapshots:
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.0.0
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/cookie@0.6.0': {}
 
@@ -28081,14 +28087,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
   '@types/express-serve-static-core@5.0.0':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -28117,7 +28123,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/hast@3.0.4':
     dependencies:
@@ -28129,7 +28135,7 @@ snapshots:
 
   '@types/http-proxy@1.17.15':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -28161,7 +28167,7 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/methods@1.1.4': {}
 
@@ -28175,20 +28181,20 @@ snapshots:
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       form-data: 4.0.5
 
   '@types/node-forge@1.3.13':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/node@12.20.55': {}
 
@@ -28200,10 +28206,9 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.7.4':
+  '@types/node@22.19.19':
     dependencies:
-      undici-types: 6.19.8
-    optional: true
+      undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -28217,13 +28222,13 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       pg-protocol: 1.12.0
       pg-types: 2.2.0
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       pg-protocol: 1.12.0
       pg-types: 2.2.0
 
@@ -28261,7 +28266,7 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -28270,19 +28275,19 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       '@types/send': 0.17.4
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       '@types/send': 0.17.4
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/shimmer@1.0.5': {}
 
@@ -28290,7 +28295,7 @@ snapshots:
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/stack-utils@2.0.3': {}
 
@@ -28302,7 +28307,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       form-data: 4.0.0
 
   '@types/supertest@6.0.3':
@@ -28312,7 +28317,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -28326,7 +28331,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -28499,9 +28504,9 @@ snapshots:
       vite: 5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
       vue: 3.5.13(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@5.2.0(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.8.3)
 
   '@vitest/expect@2.1.4':
@@ -28566,23 +28571,23 @@ snapshots:
       msw: 2.12.10(@types/node@20.17.24)(typescript@5.9.3)
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.10(@types/node@22.7.4)(typescript@5.8.3)
-      vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      msw: 2.12.10(@types/node@22.19.19)(typescript@5.8.3)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  '@vitest/mocker@4.1.0(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.0(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.6.4(@types/node@20.17.24)(typescript@5.8.3)
-      vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
   '@vitest/pretty-format@2.1.4':
     dependencies:
@@ -32863,7 +32868,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1
@@ -32933,6 +32938,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.19
+      ts-node: 10.9.2(@types/node@20.17.24)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -32957,7 +32993,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -32967,7 +33003,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -33006,7 +33042,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -33041,7 +33077,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -33069,7 +33105,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -33115,7 +33151,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -33134,7 +33170,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -33143,13 +33179,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -34934,9 +34970,9 @@ snapshots:
       - '@types/node'
     optional: true
 
-  msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3):
+  msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3):
     dependencies:
-      '@inquirer/confirm': 5.0.2(@types/node@22.7.4)
+      '@inquirer/confirm': 5.0.2(@types/node@22.19.19)
       '@mswjs/interceptors': 0.41.3
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -36229,13 +36265,13 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@20.17.24)(typescript@5.9.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@types/node@22.7.4)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
 
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
@@ -36506,7 +36542,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.17.24
+      '@types/node': 22.19.19
       long: 5.2.3
 
   protocols@2.0.1: {}
@@ -38083,18 +38119,18 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwind-variants@1.0.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3))):
+  tailwind-variants@1.0.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))):
     dependencies:
       tailwind-merge: 3.0.2
-      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3))
+      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.3))):
     dependencies:
       tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.3))
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))):
     dependencies:
-      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3))
+      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
 
   tailwindcss@3.4.15(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3)):
     dependencies:
@@ -38231,7 +38267,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3)):
+  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -38250,7 +38286,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -38595,14 +38631,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.7.4)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.7.4
+      '@types/node': 22.19.19
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3
@@ -38877,6 +38913,8 @@ snapshots:
       unplugin: 1.11.0
 
   undici-types@6.19.8: {}
+
+  undici-types@6.21.0: {}
 
   undici@5.28.4:
     dependencies:
@@ -39357,7 +39395,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0):
+  vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -39366,7 +39404,7 @@ snapshots:
       rollup: 4.34.9
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.19.19
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.4.0
@@ -39414,7 +39452,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0):
+  vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -39423,7 +39461,7 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.19.19
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.4.0
@@ -39437,9 +39475,9 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  vitefu@1.0.6(vite@6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitefu@1.0.6(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 6.4.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
   vitest@2.1.4(@edge-runtime/vm@5.0.0)(@types/node@20.17.24)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1):
     dependencies:
@@ -39553,10 +39591,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/mocker': 4.1.0(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -39573,7 +39611,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -39643,10 +39681,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.7.4)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -39663,12 +39701,12 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.7.4
+      '@types/node': 22.19.19
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw

--- a/tools/split-ts-references.mjs
+++ b/tools/split-ts-references.mjs
@@ -1,0 +1,51 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/*
+ * `update-ts-references` derives project references from the pnpm workspace,
+ * which means it writes a reference for every workspace package — including
+ * `examples/*` and `tools/*` — into the root `tsconfig.json`. There is no
+ * option to scope which workspaces land in the root config.
+ *
+ * The desired layout is:
+ *   - `tsconfig.json`               -> only `packages/*` references
+ *   - `tsconfig.with-examples.json` -> the root config plus `examples/*`
+ *
+ * This script runs right after `update-ts-references` and re-partitions the
+ * references the tool produced into those two configs, dropping everything
+ * that is neither a package nor an included example (e.g. `tools/*`).
+ */
+
+const ROOT_CONFIG = 'tsconfig.json';
+const WITH_EXAMPLES_CONFIG = 'tsconfig.with-examples.json';
+
+/*
+ * Examples that cannot be type-checked by `tsc --build` and are therefore kept
+ * out of `tsconfig.with-examples.json`. `sveltekit-openai` imports `.svelte`
+ * components, whose types are only resolvable via `svelte-check` (which the
+ * example runs as its own `type-check` script); under plain `tsc` those imports
+ * resolve to the ambient `*.svelte` module and fail.
+ */
+const EXCLUDED_EXAMPLES = new Set(['examples/sveltekit-openai']);
+
+const isPackageReference = reference =>
+  /^packages\/[^/]+$/.test(reference.path);
+const isExampleReference = reference =>
+  /^examples\/[^/]+$/.test(reference.path) &&
+  !EXCLUDED_EXAMPLES.has(reference.path);
+
+const readConfig = file => JSON.parse(readFileSync(file, 'utf8'));
+const writeConfig = (file, config) =>
+  writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+
+const rootConfig = readConfig(ROOT_CONFIG);
+const allReferences = rootConfig.references ?? [];
+
+rootConfig.references = allReferences.filter(isPackageReference);
+writeConfig(ROOT_CONFIG, rootConfig);
+
+const withExamplesConfig = readConfig(WITH_EXAMPLES_CONFIG);
+withExamplesConfig.references = [
+  { path: './' },
+  ...allReferences.filter(isExampleReference),
+];
+writeConfig(WITH_EXAMPLES_CONFIG, withExamplesConfig);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,53 +1,152 @@
 {
   "references": [
-    { "path": "packages/ai" },
-    { "path": "packages/mcp" },
-    { "path": "packages/alibaba" },
-    { "path": "packages/amazon-bedrock" },
-    { "path": "packages/angular" },
-    { "path": "packages/anthropic" },
-    { "path": "packages/assemblyai" },
-    { "path": "packages/azure" },
-    { "path": "packages/black-forest-labs" },
-    { "path": "packages/baseten" },
-    { "path": "packages/cerebras" },
-    { "path": "packages/codemod" },
-    { "path": "packages/cohere" },
-    { "path": "packages/deepgram" },
-    { "path": "packages/deepinfra" },
-    { "path": "packages/deepseek" },
-    { "path": "packages/elevenlabs" },
-    { "path": "packages/fal" },
-    { "path": "packages/fireworks" },
-    { "path": "packages/gateway" },
-    { "path": "packages/gladia" },
-    { "path": "packages/google" },
-    { "path": "packages/google-vertex" },
-    { "path": "packages/groq" },
-    { "path": "packages/huggingface" },
-    { "path": "packages/hume" },
-    { "path": "packages/langchain" },
-    { "path": "packages/llamaindex" },
-    { "path": "packages/lmnt" },
-    { "path": "packages/luma" },
-    { "path": "packages/mistral" },
-    { "path": "packages/moonshotai" },
-    { "path": "packages/openai" },
-    { "path": "packages/openai-compatible" },
-    { "path": "packages/perplexity" },
-    { "path": "packages/provider" },
-    { "path": "packages/provider-utils" },
-    { "path": "packages/react" },
-    { "path": "packages/replicate" },
-    { "path": "packages/revai" },
-    { "path": "packages/rsc" },
-    { "path": "packages/svelte" },
-    { "path": "packages/test-server" },
-    { "path": "packages/togetherai" },
-    { "path": "packages/valibot" },
-    { "path": "packages/vercel" },
-    { "path": "packages/vue" },
-    { "path": "packages/xai" }
+    {
+      "path": "packages/ai"
+    },
+    {
+      "path": "packages/alibaba"
+    },
+    {
+      "path": "packages/amazon-bedrock"
+    },
+    {
+      "path": "packages/angular"
+    },
+    {
+      "path": "packages/anthropic"
+    },
+    {
+      "path": "packages/assemblyai"
+    },
+    {
+      "path": "packages/azure"
+    },
+    {
+      "path": "packages/baseten"
+    },
+    {
+      "path": "packages/black-forest-labs"
+    },
+    {
+      "path": "packages/cerebras"
+    },
+    {
+      "path": "packages/codemod"
+    },
+    {
+      "path": "packages/cohere"
+    },
+    {
+      "path": "packages/deepgram"
+    },
+    {
+      "path": "packages/deepinfra"
+    },
+    {
+      "path": "packages/deepseek"
+    },
+    {
+      "path": "packages/elevenlabs"
+    },
+    {
+      "path": "packages/fal"
+    },
+    {
+      "path": "packages/fireworks"
+    },
+    {
+      "path": "packages/gateway"
+    },
+    {
+      "path": "packages/gladia"
+    },
+    {
+      "path": "packages/google-vertex"
+    },
+    {
+      "path": "packages/google"
+    },
+    {
+      "path": "packages/groq"
+    },
+    {
+      "path": "packages/huggingface"
+    },
+    {
+      "path": "packages/hume"
+    },
+    {
+      "path": "packages/langchain"
+    },
+    {
+      "path": "packages/llamaindex"
+    },
+    {
+      "path": "packages/lmnt"
+    },
+    {
+      "path": "packages/luma"
+    },
+    {
+      "path": "packages/mcp"
+    },
+    {
+      "path": "packages/mistral"
+    },
+    {
+      "path": "packages/moonshotai"
+    },
+    {
+      "path": "packages/openai-compatible"
+    },
+    {
+      "path": "packages/openai"
+    },
+    {
+      "path": "packages/perplexity"
+    },
+    {
+      "path": "packages/prodia"
+    },
+    {
+      "path": "packages/provider-utils"
+    },
+    {
+      "path": "packages/provider"
+    },
+    {
+      "path": "packages/react"
+    },
+    {
+      "path": "packages/replicate"
+    },
+    {
+      "path": "packages/revai"
+    },
+    {
+      "path": "packages/rsc"
+    },
+    {
+      "path": "packages/svelte"
+    },
+    {
+      "path": "packages/test-server"
+    },
+    {
+      "path": "packages/togetherai"
+    },
+    {
+      "path": "packages/valibot"
+    },
+    {
+      "path": "packages/vercel"
+    },
+    {
+      "path": "packages/vue"
+    },
+    {
+      "path": "packages/xai"
+    }
   ],
   "include": []
 }

--- a/tsconfig.with-examples.json
+++ b/tsconfig.with-examples.json
@@ -28,7 +28,7 @@
       "path": "examples/nest"
     },
     {
-      "path": "examples/next"
+      "path": "examples/next-agent"
     },
     {
       "path": "examples/next-fastapi"
@@ -38,9 +38,6 @@
     },
     {
       "path": "examples/next-langchain"
-    },
-    {
-      "path": "examples/next-openai"
     },
     {
       "path": "examples/next-openai-kasada-bot-protection"
@@ -56,6 +53,12 @@
     },
     {
       "path": "examples/next-openai-upstash-rate-limits"
+    },
+    {
+      "path": "examples/next-openai"
+    },
+    {
+      "path": "examples/next"
     },
     {
       "path": "examples/node-http-server"


### PR DESCRIPTION
## Summary

Manual backport of #15830, which is itself a backport of #15828.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
