### PR TITLE
release @ai-sdk/policy-opa

### DIFF
--- a/.changeset/release-policy-opa-provenance.md
+++ b/.changeset/release-policy-opa-provenance.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/policy-opa': patch
+---
+
+Initial release


### PR DESCRIPTION
Re-release `@ai-sdk/policy-opa`. The previous publish failed because the
package was not yet configured for npm provenance. Provenance is now enabled, so this bump triggers a fresh publish.