### PR TITLE
docs(contributing): document the Experimental_ prefix seam convention

### DIFF
--- a/contributing/naming-conventions.md
+++ b/contributing/naming-conventions.md
@@ -59,7 +59,7 @@ For non-lifecycle events, use the most specific verb that applies:
 
 New features that are explored outside of a major release cycle are marked as experimental using prefixes: `Experimental_*` for types and classes, `experimental_*` for functions and values. See `project-philosophies.md` for when to introduce an experimental feature.
 
-**Keep the experimental prefix at the import and export seams only.** Declare the symbol with its plain, unprefixed name and apply the prefix as an _alias_ where the symbol crosses a package boundary:
+**For exported experimental symbols, keep the experimental prefix at the import and export seams only.** Declare the symbol with its plain, unprefixed name and apply the prefix as an _alias_ where the symbol crosses a package boundary:
 
 - In the package that owns the feature, name every declaration without the prefix and add the `Experimental_*` / `experimental_*` alias only in the public export (typically the package's `index.ts`).
 - In packages that consume the feature, import the prefixed symbol under its unprefixed alias and use the unprefixed name throughout the file.

--- a/contributing/naming-conventions.md
+++ b/contributing/naming-conventions.md
@@ -54,3 +54,37 @@ For non-lifecycle events, use the most specific verb that applies:
 | `denied`    | A request was rejected               | `tool-output-denied`                            |
 
 > **Note:** There are existing violations of these conventions (`start-step` and `finish-step` in UI message stream chunks). These should be migrated to `step-start` and `step-end` when possible.
+
+## Experimental Prefixes
+
+New features that are explored outside of a major release cycle are marked as experimental using prefixes: `Experimental_*` for types and classes, `experimental_*` for functions and values. See `project-philosophies.md` for when to introduce an experimental feature.
+
+**Keep the experimental prefix at the import and export seams only.** Declare the symbol with its plain, unprefixed name and apply the prefix as an _alias_ where the symbol crosses a package boundary:
+
+- In the package that owns the feature, name every declaration without the prefix and add the `Experimental_*` / `experimental_*` alias only in the public export (typically the package's `index.ts`).
+- In packages that consume the feature, import the prefixed symbol under its unprefixed alias and use the unprefixed name throughout the file.
+
+```ts
+// realtime-session.ts — declare with the plain name
+export abstract class AbstractRealtimeSession {
+  /* … */
+}
+
+// index.ts — apply the prefix only at the export seam
+export { AbstractRealtimeSession as Experimental_AbstractRealtimeSession } from './realtime-session';
+```
+
+```ts
+// consumer.ts — import under the unprefixed alias, then use the plain name
+import { Experimental_AbstractRealtimeSession as AbstractRealtimeSession } from 'ai';
+
+class RealtimeStore extends AbstractRealtimeSession {
+  /* … */
+}
+```
+
+Why this matters:
+
+- **Smaller diff when promoting to stable.** Removing the prefix only touches the export and import lines, not every reference throughout the implementation.
+- **Harder to leak unprefixed.** Because the public surface is a single, explicit list of aliases, a new experimental symbol can't accidentally be exported without its prefix.
+- **Implementation reads cleanly.** Internal code stays free of prefixes, so it reads the same way it will once the feature is stable.

--- a/contributing/project-philosophies.md
+++ b/contributing/project-philosophies.md
@@ -38,6 +38,7 @@
   - Non-experimental types must NEVER include references to experimental types (e.g., do not add a reference to something like `Experimental_VideoModelV4` to `ProviderV4`).
   - Experimental features must remain fully isolated until they are promoted to stable.
   - Adding a new experimental feature requires broad consensus between the maintainers. Use it with caution. Do not use experimental code as a way out when you're unsure about stability.
+  - Confine the prefix to the import and export seams: declare symbols with their unprefixed names and apply the `Experimental_*` / `experimental_*` alias only where they cross a package boundary. See `naming-conventions.md` for the exact pattern.
 
 - **Clear, accurate naming.** When in doubt, prefer longer, more explicit names that are unambiguous and correct (e.g. `.languageModel(id)` over `.chat(id)`).
   - Optimize for clarity for both developers and coding agents, not brevity.


### PR DESCRIPTION
## Summary

Documents the convention for introducing experimental features: the `Experimental_*` / `experimental_*` prefix should live **only at import and export seams**, not at declaration sites.

- Adds an **Experimental Prefixes** section to `contributing/naming-conventions.md` with the rule, a worked example (declare unprefixed → alias at the export seam → consumers import under unprefixed aliases), and the rationale (smaller diff on promotion to stable, harder to leak unprefixed exports, cleaner implementation code).
- Cross-references it from the experimental-features bullet in `contributing/project-philosophies.md`.

## Background

This came out of review feedback on #13893 (realtime API), where @felixarntz pointed out the seam-only pattern that's already used elsewhere in the SDK (e.g. `@ai-sdk/provider` declares `RealtimeFactoryV4` and exports it as `Experimental_RealtimeFactoryV4`). The realtime code in #13893 was updated to follow it; this PR captures the convention so it's discoverable for future features.

Docs only — no code or public API changes.