### PR TITLE
fix(ai): return transformed array output elements

### DIFF
--- a/.changeset/clean-arrays-parse.md
+++ b/.changeset/clean-arrays-parse.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Return transformed element values from generateObject array output.

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -906,6 +906,33 @@ describe('generateObject', () => {
       }
     `);
     });
+
+    it('should return transformed element values', async () => {
+      const model = new MockLanguageModelV4({
+        doGenerate: {
+          ...dummyResponseValues,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                elements: [{ content: 'element 1' }],
+              }),
+            },
+          ],
+        },
+      });
+
+      const result = await generateObject({
+        model,
+        schema: z.object({
+          content: z.string().transform(value => value.toUpperCase()),
+        }),
+        output: 'array',
+        prompt: 'prompt',
+      });
+
+      expect(result.object).toEqual([{ content: 'ELEMENT 1' }]);
+    });
   });
 
   describe('output = "enum"', () => {

--- a/packages/ai/src/generate-object/output-strategy.ts
+++ b/packages/ai/src/generate-object/output-strategy.ts
@@ -239,6 +239,7 @@ const arrayOutputStrategy = <ELEMENT>(
       }
 
       const inputArray = value.elements as Array<JSONObject>;
+      const resultArray: Array<ELEMENT> = [];
 
       // check that each element in the array is of the correct type:
       for (const element of inputArray) {
@@ -246,9 +247,11 @@ const arrayOutputStrategy = <ELEMENT>(
         if (!result.success) {
           return result;
         }
+
+        resultArray.push(result.value);
       }
 
-      return { success: true, value: inputArray as Array<ELEMENT> };
+      return { success: true, value: resultArray };
     },
 
     createElementStream(


### PR DESCRIPTION
## Summary
- return validated array elements from `generateObject({ output: "array" })`
- return validated array elements from `Output.array().parseCompleteOutput`
- add regression coverage for schema transforms in both final array paths

Fixes #15707.
Fixes #15708.

## To verify
- `pnpm install --frozen-lockfile --filter ai...`
- `pnpm --filter ai test:node -- src/generate-text/output.test.ts src/generate-object/generate-object.test.ts`
- `pnpm --filter ai type-check`
- `pnpm exec ultracite check packages/ai/src/generate-text/output.ts packages/ai/src/generate-text/output.test.ts packages/ai/src/generate-object/output-strategy.ts packages/ai/src/generate-object/generate-object.test.ts`
- `git diff --check`
