### PR TITLE
feat(ai): rename onStepFinish to onStepEnd

### DIFF
--- a/.changeset/calm-cars-deliver.md
+++ b/.changeset/calm-cars-deliver.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/devtools": patch
+"@ai-sdk/workflow": patch
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+feat(ai): rename onStepFinish to onStepEnd

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -212,7 +212,7 @@ async function main(prompt: string) {
       }),
     },
     // log out intermediate steps
-    onStepFinish: ({ toolResults }) => {
+    onStepEnd: ({ toolResults }) => {
       if (toolResults.length > 0) {
         console.log('Tool results:');
         console.dir(toolResults, { depth: null });

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -427,7 +427,7 @@ export async function POST(req: Request) {
         },
       }),
     },
-    onStepFinish: ({ toolResults }) => {
+    onStepEnd: ({ toolResults }) => {
       console.log(toolResults);
     },
   });
@@ -441,7 +441,7 @@ export async function POST(req: Request) {
 In this updated code:
 
 1. You set `stopWhen` to be when `isStepCount` 5, allowing the model to use up to 5 "steps" for any given generation.
-2. You add an `onStepFinish` callback to log any `toolResults` from each step of the interaction, helping you understand the model's tool usage.
+2. You add an `onStepEnd` callback to log any `toolResults` from each step of the interaction, helping you understand the model's tool usage.
 
 Head back to the browser and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -379,7 +379,7 @@ async function main() {
         }),
       },
       stopWhen: isStepCount(5),
-      onStepFinish: async ({ toolResults }) => {
+      onStepEnd: async ({ toolResults }) => {
         if (toolResults.length) {
           console.log(JSON.stringify(toolResults, null, 2));
         }
@@ -404,7 +404,7 @@ main().catch(console.error);
 In this updated code:
 
 1. You set `stopWhen` to be when `isStepCount` 5, allowing the agent to use up to 5 "steps" for any given generation.
-2. You add an `onStepFinish` callback to log any `toolResults` from each step of the interaction, helping you understand the agent's tool usage. This means we can also delete the `toolCall` and `toolResult` `console.log` statements from the previous example.
+2. You add an `onStepEnd` callback to log any `toolResults` from each step of the interaction, helping you understand the agent's tool usage. This means we can also delete the `toolCall` and `toolResult` `console.log` statements from the previous example.
 
 Now, when you ask about the weather in a location, you should see the agent using the weather tool results to answer your question.
 
@@ -469,7 +469,7 @@ async function main() {
         }),
       },
       stopWhen: isStepCount(5),
-      onStepFinish: async ({ toolResults }) => {
+      onStepEnd: async ({ toolResults }) => {
         if (toolResults.length) {
           console.log(JSON.stringify(toolResults, null, 2));
         }

--- a/content/docs/02-getting-started/09-coding-agents.mdx
+++ b/content/docs/02-getting-started/09-coding-agents.mdx
@@ -152,7 +152,7 @@ const result = streamText({
     }),
   },
   stopWhen: isStepCount(5),
-  onStepFinish: async ({ toolResults }) => {
+  onStepEnd: async ({ toolResults }) => {
     if (toolResults.length) {
       console.log(JSON.stringify(toolResults, null, 2));
     }
@@ -160,7 +160,7 @@ const result = streamText({
 });
 ```
 
-The `onStepFinish` callback fires after each LLM step and prints any tool results to your terminal — useful for quick debugging without opening the DevTools UI.
+The `onStepEnd` callback fires after each LLM step and prints any tool results to your terminal — useful for quick debugging without opening the DevTools UI.
 
 <Note>
   DevTools stores all AI interactions in a local `.devtools/generations.json`

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -492,7 +492,7 @@ const result = await myAgent.generate({
     );
   },
 
-  onStepFinish({ stepNumber, usage, performance, finishReason, toolCalls }) {
+  onStepEnd({ stepNumber, usage, performance, finishReason, toolCalls }) {
     console.log(`Step ${stepNumber} completed:`, {
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
@@ -518,7 +518,7 @@ The available lifecycle callbacks are:
 - **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
 - **`onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and `toolContext`.
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
-- **`onStepFinish`**: Called after each step finishes. Receives step results including usage, performance, finish reason, and tool calls.
+- **`onStepEnd`**: Called after each step finishes. Receives step results including usage, performance, finish reason, and tool calls.
 - **`onEnd`**: Called when all steps are finished and the response is complete. Receives all step results, total usage, and `runtimeContext`.
 
 #### Constructor vs. Method Callbacks
@@ -528,7 +528,7 @@ All lifecycle callbacks can be defined in the constructor for agent-wide trackin
 ```ts
 const agent = new ToolLoopAgent({
   model: __MODEL__,
-  onStepFinish: async ({ stepNumber, usage }) => {
+  onStepEnd: async ({ stepNumber, usage }) => {
     // Agent-wide logging
     console.log(`Agent step ${stepNumber}:`, usage.totalTokens);
   },
@@ -537,7 +537,7 @@ const agent = new ToolLoopAgent({
 // Method-level callback runs after constructor callback
 const result = await agent.generate({
   prompt: 'Hello',
-  onStepFinish: async ({ stepNumber, usage }) => {
+  onStepEnd: async ({ stepNumber, usage }) => {
     // Per-call tracking (e.g., for billing)
     await trackUsage(stepNumber, usage);
   },

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -501,7 +501,7 @@ const agent = new WorkflowAgent({
     console.log(`Tool finished: ${toolCall.toolName}`);
   },
 
-  onStepFinish({ usage, finishReason }) {
+  onStepEnd({ usage, finishReason }) {
     console.log('Step done:', { finishReason });
   },
 
@@ -660,7 +660,7 @@ whether approval is required (see [Tool Approval](#tool-approval) above).
 
 ### Everything else
 
-Other options carry over with the same names: `prepareStep`, `onStepFinish`, `onEnd`, `onError`, `toolChoice`, `activeTools`, `timeout`, `experimental_repairToolCall`, and the usual generation settings (`temperature`, `maxOutputTokens`, `topP`, …). `WorkflowAgent` additionally adds `prepareCall` (runs once before the loop) and the `experimental_onStart` / `experimental_onStepStart` / `onToolExecutionStart` / `onToolExecutionEnd` lifecycle callbacks documented above.
+Other options carry over with the same names: `prepareStep`, `onStepEnd`, `onEnd`, `onError`, `toolChoice`, `activeTools`, `timeout`, `experimental_repairToolCall`, and the usual generation settings (`temperature`, `maxOutputTokens`, `topP`, …). `WorkflowAgent` additionally adds `prepareCall` (runs once before the loop) and the `experimental_onStart` / `experimental_onStepStart` / `onToolExecutionStart` / `onToolExecutionEnd` lifecycle callbacks documented above.
 
 ## Next Steps
 

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -172,7 +172,7 @@ const result = await generateText({
     );
   },
 
-  onStepFinish({ stepNumber, finishReason, usage, performance }) {
+  onStepEnd({ stepNumber, finishReason, usage, performance }) {
     console.log(`Step ${stepNumber} finished`, {
       finishReason,
       usage,
@@ -190,7 +190,7 @@ The available lifecycle callbacks are:
 - **`experimental_onLanguageModelCallEnd`**: Called after the model response has been normalized and parsed, but before any client-side tool execution begins. Receives the model-call content parts, usage, and finish reason.
 - **`onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and `toolContext`.
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
-- **`onStepFinish`**: Called after each step finishes. Includes `stepNumber` (zero-based index of the completed step).
+- **`onStepEnd`**: Called after each step finishes. Includes `stepNumber` (zero-based index of the completed step).
 
 ## `streamText`
 
@@ -406,7 +406,7 @@ const result = streamText({
     );
   },
 
-  onStepFinish({ finishReason, usage }) {
+  onStepEnd({ finishReason, usage }) {
     console.log('Step finished', { finishReason, usage });
   },
 });
@@ -420,7 +420,7 @@ The available lifecycle callbacks are:
 - **`experimental_onLanguageModelCallEnd`**: Called after the model response has been normalized and parsed, but before any client-side tool execution begins. Receives the model-call content parts, usage, and finish reason.
 - **`onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and `toolContext`.
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
-- **`onStepFinish`**: Called after each step finishes. Receives the finish reason, usage, and other step details.
+- **`onStepEnd`**: Called after each step finishes. Receives the finish reason, usage, and other step details.
 
 ### `stream` property
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -461,9 +461,9 @@ const { steps } = await generateText({
 const allToolCalls = steps.flatMap(step => step.toolCalls);
 ```
 
-### `onStepFinish` callback
+### `onStepEnd` callback
 
-When using `generateText` or `streamText`, you can provide an `onStepFinish` callback that
+When using `generateText` or `streamText`, you can provide an `onStepEnd` callback that
 is triggered when a step is finished,
 i.e. all text deltas, tool calls, and tool results for the step are available.
 When you have multiple steps, the callback is triggered for each step.
@@ -475,7 +475,7 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   // ...
-  onStepFinish({
+  onStepEnd({
     stepNumber,
     text,
     toolCalls,
@@ -708,7 +708,7 @@ const result = await generateText({
       /* ... */
     }),
   },
-  onStepFinish: ({ toolCalls, toolResults }) => {
+  onStepEnd: ({ toolCalls, toolResults }) => {
     // Type-safe iteration
     for (const toolCall of toolCalls) {
       if (toolCall.dynamic) {

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -274,7 +274,7 @@ class MyIntegration implements Telemetry {
     console.log('Generation started:', event.modelId);
   }
 
-  async onStepFinish(event) {
+  async onStepEnd(event) {
     console.log(
       `Step ${event.stepNumber} done:`,
       event.usage.totalTokens,
@@ -348,7 +348,7 @@ export function myIntegration(): Telemetry {
       description: "Called when a tool's execute function completes or errors.",
     },
     {
-      name: 'onStepFinish',
+      name: 'onStepEnd',
       type: '(event: GenerateTextStepEndEvent) => void | PromiseLike<void>',
       description: 'Called when a step (LLM call) completes.',
     },

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -66,7 +66,7 @@ const result = await generateText({
       description: "Called when a tool's execute function completes or errors.",
     },
     {
-      name: 'onStepFinish',
+      name: 'onStepEnd',
       type: '(event: GenerateTextStepEndEvent) => void | Promise<void>',
       description: 'Called when a step (LLM call) completes.',
     },
@@ -81,7 +81,7 @@ const result = await generateText({
 
 For multi-step text generations that use tools, the callback order is typically
 `experimental_onStepStart` -> `experimental_onLanguageModelCallStart` ->
-`experimental_onLanguageModelCallEnd` -> tool execution callbacks -> `onStepFinish`.
+`experimental_onLanguageModelCallEnd` -> tool execution callbacks -> `onStepEnd`.
 
 ### `embed` / `embedMany`
 
@@ -704,7 +704,7 @@ const result = await generateText({
   ]}
 />
 
-#### `onStepFinish`
+#### `onStepEnd`
 
 Called after each step (LLM call) completes. Provides the full `StepResult`.
 
@@ -712,13 +712,17 @@ Called after each step (LLM call) completes. Provides the full `StepResult`.
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
-  onStepFinish: event => {
+  onStepEnd: event => {
     console.log('Step:', event.stepNumber);
     console.log('Finish reason:', event.finishReason);
     console.log('Tokens:', event.usage.totalTokens);
   },
 });
 ```
+
+<Note>
+  `onStepFinish` is deprecated. Use `onStepEnd` for new code.
+</Note>
 
 <PropertiesTable
   content={[
@@ -1352,7 +1356,7 @@ const result = await generateText({
       provider: event.provider,
     });
   },
-  onStepFinish: event => {
+  onStepEnd: event => {
     console.log(
       `[${new Date().toISOString()}] Step ${event.stepNumber} finished`,
       {

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -720,9 +720,7 @@ const result = await generateText({
 });
 ```
 
-<Note>
-  `onStepFinish` is deprecated. Use `onStepEnd` for new code.
-</Note>
+<Note>`onStepFinish` is deprecated. Use `onStepEnd` for new code.</Note>
 
 <PropertiesTable
   content={[

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1528,11 +1528,11 @@ To see `generateText` in action, check out [these examples](#examples).
         'Deprecated. Use `onToolExecutionEnd` instead. This alias is only used as a fallback when `onToolExecutionEnd` is not provided.',
     },
     {
-      name: 'onStepFinish',
+      name: 'onStepEnd',
       type: '(stepResult: StepResult<TOOLS>) => Promise<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when a step is finished. Receives a StepResult object.',
+        'Callback that is called when a step ends. Receives a StepResult object.',
       properties: [
         {
           type: 'StepResult',
@@ -1891,6 +1891,13 @@ To see `generateText` in action, check out [these examples](#examples).
           ],
         },
       ],
+    },
+    {
+      name: 'onStepFinish',
+      type: 'GenerateTextOnStepFinishCallback<TOOLS>',
+      isOptional: true,
+      description:
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1276,13 +1276,13 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'onStepFinish',
-      type: '(result: onStepFinishResult) => Promise<void> | void',
+      name: 'onStepEnd',
+      type: '(result: StepResult<TOOLS>) => Promise<void> | void',
       isOptional: true,
-      description: 'Callback that is called when a step is finished.',
+      description: 'Callback that is called when a step ends.',
       properties: [
         {
-          type: 'onStepFinishResult',
+          type: 'StepResult',
           parameters: [
             {
               name: 'stepType',
@@ -1607,6 +1607,13 @@ To see `streamText` in action, check out [these examples](#examples).
           ],
         },
       ],
+    },
+    {
+      name: 'onStepFinish',
+      type: 'GenerateTextOnStepFinishCallback<TOOLS>',
+      isOptional: true,
+      description:
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -89,7 +89,13 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
      */
     onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
     /**
-     * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     */
+    onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
+    /**
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     *
+     * @deprecated Use `onStepEnd` instead.
      */
     onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
     /**
@@ -180,7 +186,8 @@ Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS, TO
 - `experimental_onStepStart` (optional): Callback invoked when a step (LLM call) begins, before the provider is called. Experimental.
 - `onToolExecutionStart` (optional): Callback invoked right before a tool's execute function runs.
 - `onToolExecutionEnd` (optional): Callback invoked right after a tool's execute function completes or errors.
-- `onStepFinish` (optional): A callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging.
+- `onStepEnd` (optional): A callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging.
+- `onStepFinish` (optional): Deprecated alias for `onStepEnd`.
 - `onEnd` (optional): A callback invoked when all steps are finished and the response is complete.
 - `onFinish` (optional): Deprecated alias for `onEnd`.
 

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -495,11 +495,18 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'onStepEnd',
+      type: 'GenerateTextOnStepEndCallback',
+      isOptional: true,
+      description:
+        'Callback invoked after each agent step (LLM/tool call) completes. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).',
+    },
+    {
       name: 'onStepFinish',
       type: 'GenerateTextOnStepFinishCallback',
       isOptional: true,
       description:
-        'Callback invoked after each agent step (LLM/tool call) completes. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',
@@ -753,11 +760,18 @@ const result = await agent.generate({
         "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
     },
     {
+      name: 'onStepEnd',
+      type: 'GenerateTextOnStepEndCallback',
+      isOptional: true,
+      description:
+        'Callback invoked after each agent step (LLM/tool call) completes. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
+    },
+    {
       name: 'onStepFinish',
       type: 'GenerateTextOnStepFinishCallback',
       isOptional: true,
       description:
-        'Callback invoked after each agent step (LLM/tool call) completes. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',
@@ -869,11 +883,18 @@ for await (const chunk of stream.textStream) {
         "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
     },
     {
+      name: 'onStepEnd',
+      type: 'GenerateTextOnStepEndCallback',
+      isOptional: true,
+      description:
+        'Callback invoked after each agent step (LLM/tool call) completes. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
+    },
+    {
       name: 'onStepFinish',
       type: 'GenerateTextOnStepFinishCallback',
       isOptional: true,
       description:
-        'Callback invoked after each agent step (LLM/tool call) completes. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -95,11 +95,18 @@ export async function* streamAgent(
         'Optional transformations to apply to the agent output stream (experimental).',
     },
     {
+      name: 'onStepEnd',
+      type: 'GenerateTextOnStepEndCallback',
+      isRequired: false,
+      description:
+        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging intermediate steps.',
+    },
+    {
       name: 'onStepFinish',
       type: 'GenerateTextOnStepFinishCallback',
       isRequired: false,
       description:
-        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging intermediate steps.',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: '...UIMessageStreamOptions',

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -96,11 +96,18 @@ export async function POST(request: Request) {
         'Optional stream transforms to post-process text output—the same as in lower-level streaming APIs.',
     },
     {
+      name: 'onStepEnd',
+      type: 'GenerateTextOnStepEndCallback',
+      isRequired: false,
+      description:
+        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',
+    },
+    {
       name: 'onStepFinish',
       type: 'GenerateTextOnStepFinishCallback',
       isRequired: false,
       description:
-        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: '...UIMessageStreamOptions',

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -97,11 +97,18 @@ export async function handler(req, res) {
         'Optional stream text transformation(s) applied to agent output.',
     },
     {
+      name: 'onStepEnd',
+      type: 'GenerateTextOnStepEndCallback',
+      isRequired: false,
+      description:
+        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging intermediate steps.',
+    },
+    {
       name: 'onStepFinish',
       type: 'GenerateTextOnStepFinishCallback',
       isRequired: false,
       description:
-        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging intermediate steps.',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: '...UIMessageStreamResponseInit & UIMessageStreamOptions',

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -186,7 +186,7 @@ const result = await generateText({
       /* ... */
     }),
   },
-  onStepFinish: ({ toolCalls, toolResults }) => {
+  onStepEnd: ({ toolCalls, toolResults }) => {
     for (const toolCall of toolCalls) {
       if (toolCall.dynamic) {
         // Dynamic tool: input/output are 'unknown'

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -325,11 +325,18 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'onStepEnd',
+      type: 'WorkflowAgentOnStepEndCallback',
+      isOptional: true,
+      description:
+        'Callback invoked after each agent step completes. If also specified in `stream()`, both callbacks fire (constructor first).',
+    },
+    {
       name: 'onStepFinish',
       type: 'WorkflowAgentOnStepFinishCallback',
       isOptional: true,
       description:
-        'Callback invoked after each agent step completes. If also specified in `stream()`, both callbacks fire (constructor first).',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',
@@ -586,11 +593,18 @@ const result = await agent.stream({
         'Per-call onToolExecutionEnd callback. If also specified in the constructor, both fire (constructor first).',
     },
     {
+      name: 'onStepEnd',
+      type: 'WorkflowAgentOnStepEndCallback',
+      isOptional: true,
+      description:
+        'Per-call onStepEnd callback. If also specified in the constructor, both fire (constructor first).',
+    },
+    {
       name: 'onStepFinish',
       type: 'WorkflowAgentOnStepFinishCallback',
       isOptional: true,
       description:
-        'Per-call onStepFinish callback. If also specified in the constructor, both fire (constructor first).',
+        'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
       name: 'onEnd',
@@ -890,7 +904,7 @@ const agent = new WorkflowAgent({
   tools: { weather: weatherTool },
 
   // Agent-wide callbacks
-  onStepFinish({ usage }) {
+  onStepEnd({ usage }) {
     console.log('Tokens used:', usage.totalTokens);
   },
 });
@@ -899,7 +913,7 @@ const result = await agent.stream({
   messages,
 
   // Per-call callbacks (both fire)
-  onStepFinish({ usage }) {
+  onStepEnd({ usage }) {
     await trackUsage(usage);
   },
 

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -243,6 +243,39 @@ The same rename applies to `streamText`, `Agent.generate()`,
 accepted as a deprecated alias. When both `onEnd` and `onFinish` are provided,
 `onEnd` takes precedence.
 
+#### `onStepFinish` Renamed to `onStepEnd`
+
+The per-step lifecycle callback has been renamed from `onStepFinish` to
+`onStepEnd`.
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+  onStepFinish: ({ stepNumber, usage }) => {
+    console.log(`Step ${stepNumber} used ${usage.totalTokens} tokens`);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+  onStepEnd: ({ stepNumber, usage }) => {
+    console.log(`Step ${stepNumber} used ${usage.totalTokens} tokens`);
+  },
+});
+```
+
+This applies to `generateText`, `streamText`, `generateObject`,
+`streamObject`, agents, workflow agents, and UI message stream helpers.
+Telemetry integrations should implement `onStepEnd`.
+
+The `onStepFinish` option is still accepted as a deprecated alias for
+user-facing callbacks. When both `onStepEnd` and `onStepFinish` are provided,
+`onStepEnd` takes precedence.
+
 #### `StreamTextResult.fullStream` Renamed to `stream`
 
 The full event stream returned by `streamText` has been renamed from

--- a/content/providers/03-community-providers/35-react-native-apple.mdx
+++ b/content/providers/03-community-providers/35-react-native-apple.mdx
@@ -160,7 +160,7 @@ const result = await generateText({
 
 <Note>
   Since tools are executed by Apple Intelligence rather than the AI SDK,
-  multi-step features like `stopWhen`, `onStepStart`, and `onStepFinish` are not
+  multi-step features like `stopWhen`, `onStepStart`, and `onStepEnd` are not
   supported.
 </Note>
 

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -8,6 +8,7 @@ import type {
 import type {
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from '../generate-text/generate-text-events';
@@ -97,7 +98,14 @@ export type AgentCallParameters<
     onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
 
     /**
-     * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     */
+    onStepEnd?: GenerateTextOnStepEndCallback<TOOLS, RUNTIME_CONTEXT>;
+
+    /**
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     *
+     * @deprecated Use `onStepEnd` instead.
      */
     onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS, RUNTIME_CONTEXT>;
 

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -4,7 +4,10 @@ import type {
   Experimental_SandboxSession as SandboxSession,
   ToolSet,
 } from '@ai-sdk/provider-utils';
-import type { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
+import type {
+  GenerateTextOnStepEndCallback,
+  GenerateTextOnStepFinishCallback,
+} from '../generate-text/generate-text-events';
 import type { Output } from '../generate-text/output';
 import type { StreamTextTransform } from '../generate-text/stream-text';
 import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
@@ -25,7 +28,8 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  * @param experimental_sandbox - The sandbox environment that is passed through to tool execution. Optional.
  * @param options - The options for the agent. Optional.
  * @param experimental_transform - Stream transformations. Optional.
- * @param onStepFinish - Callback that is called when each step is finished. Optional.
+ * @param onStepEnd - Callback that is called when each step ends. Optional.
+ * @param onStepFinish - Deprecated alias for `onStepEnd`. Optional.
  * @param headers - Additional headers for the response. Optional.
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
@@ -53,6 +57,8 @@ export async function createAgentUIStreamResponse<
   experimental_sandbox?: SandboxSession;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
+  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
+  /** @deprecated Use `onStepEnd` instead. */
   onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -5,7 +5,10 @@ import type {
   Tool,
   ToolSet,
 } from '@ai-sdk/provider-utils';
-import type { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
+import type {
+  GenerateTextOnStepEndCallback,
+  GenerateTextOnStepFinishCallback,
+} from '../generate-text/generate-text-events';
 import type { Output } from '../generate-text/output';
 import type { StreamTextTransform } from '../generate-text/stream-text';
 import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
@@ -35,7 +38,8 @@ import type { Agent } from './agent';
  * @param experimental_sandbox - The sandbox environment that is passed through to tool execution. Optional.
  * @param options - The options for the agent.
  * @param experimental_transform - The stream transformations. Optional.
- * @param onStepFinish - Callback that is called when each step is finished. Optional.
+ * @param onStepEnd - Callback that is called when each step ends. Optional.
+ * @param onStepFinish - Deprecated alias for `onStepEnd`. Optional.
  *
  * @returns The UI message stream.
  */
@@ -55,6 +59,7 @@ export async function createAgentUIStream<
   timeout,
   experimental_sandbox: sandbox,
   experimental_transform,
+  onStepEnd,
   onStepFinish,
   ...uiMessageStreamOptions
 }: {
@@ -65,6 +70,8 @@ export async function createAgentUIStream<
   experimental_sandbox?: SandboxSession;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
+  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
+  /** @deprecated Use `onStepEnd` instead. */
   onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
   // TODO `originalMessages` is part of this for bc, omit in v7
 } & UIMessageStreamOptions<UI_MESSAGE>): Promise<
@@ -93,7 +100,7 @@ export async function createAgentUIStream<
     timeout,
     experimental_sandbox: sandbox,
     experimental_transform,
-    onStepFinish,
+    onStepEnd: onStepEnd ?? onStepFinish,
   });
 
   // TODO reading `originalMessages` is here for bc, always use `validatedMessages` in v7

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -5,7 +5,10 @@ import type {
   ToolSet,
 } from '@ai-sdk/provider-utils';
 import type { ServerResponse } from 'node:http';
-import type { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
+import type {
+  GenerateTextOnStepEndCallback,
+  GenerateTextOnStepFinishCallback,
+} from '../generate-text/generate-text-events';
 import type { Output } from '../generate-text/output';
 import type { StreamTextTransform } from '../generate-text/stream-text';
 import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
@@ -27,7 +30,8 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  * @param experimental_sandbox - The sandbox environment that is passed through to tool execution. Optional.
  * @param options - The options for the agent. Optional.
  * @param experimental_transform - Stream transformations. Optional.
- * @param onStepFinish - Callback that is called when each step is finished. Optional.
+ * @param onStepEnd - Callback that is called when each step ends. Optional.
+ * @param onStepFinish - Deprecated alias for `onStepEnd`. Optional.
  * @param headers - Additional headers for the response. Optional.
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
@@ -55,6 +59,8 @@ export async function pipeAgentUIStreamToResponse<
   experimental_sandbox?: SandboxSession;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
+  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
+  /** @deprecated Use `onStepEnd` instead. */
   onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -12,6 +12,7 @@ import type { ActiveTools } from '../generate-text/active-tools';
 import type {
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from '../generate-text/generate-text-events';
@@ -180,7 +181,17 @@ export type ToolLoopAgentSettings<
     onToolExecutionEnd?: OnToolExecutionEndCallback<NoInfer<TOOLS>>;
 
     /**
-     * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     */
+    onStepEnd?: GenerateTextOnStepEndCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>
+    >;
+
+    /**
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     *
+     * @deprecated Use `onStepEnd` instead.
      */
     onStepFinish?: GenerateTextOnStepFinishCallback<
       NoInfer<TOOLS>,
@@ -261,7 +272,7 @@ export type ToolLoopAgentSettings<
           NoInfer<TOOLS>,
           NoInfer<RUNTIME_CONTEXT>
         >,
-        'onStepFinish'
+        'onStepEnd' | 'onStepFinish'
       > &
         Pick<
           ToolLoopAgentSettings<

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -3496,8 +3496,8 @@ describe('ToolLoopAgent', () => {
               onToolExecutionEnd: async () => {
                 events.push('onToolExecutionEnd');
               },
-              onStepFinish: async () => {
-                events.push('onStepFinish');
+              onStepEnd: async () => {
+                events.push('onStepEnd');
               },
               onEnd: async () => {
                 events.push('onEnd');
@@ -3513,9 +3513,9 @@ describe('ToolLoopAgent', () => {
           'onStepStart',
           'onToolExecutionStart',
           'onToolExecutionEnd',
-          'onStepFinish',
+          'onStepEnd',
           'onStepStart',
-          'onStepFinish',
+          'onStepEnd',
           'onEnd',
         ]);
       });
@@ -3528,8 +3528,8 @@ describe('ToolLoopAgent', () => {
             onStart: async () => {
               events.push('global-onStart');
             },
-            onStepFinish: async () => {
-              events.push('global-onStepFinish');
+            onStepEnd: async () => {
+              events.push('global-onStepEnd');
             },
             onEnd: async () => {
               events.push('global-onEnd');
@@ -3551,7 +3551,7 @@ describe('ToolLoopAgent', () => {
 
         expect(events).toEqual([
           'global-onStart',
-          'global-onStepFinish',
+          'global-onStepEnd',
           'global-onEnd',
         ]);
       });
@@ -3591,7 +3591,7 @@ describe('ToolLoopAgent', () => {
                   (event as { runtimeContext: unknown }).runtimeContext,
                 );
               },
-              onStepFinish: async ({ runtimeContext }) => {
+              onStepEnd: async ({ runtimeContext }) => {
                 telemetryContexts.push(runtimeContext);
               },
               onEnd: async event => {
@@ -3642,8 +3642,8 @@ describe('ToolLoopAgent', () => {
               onStart: async () => {
                 events.push('integration-onStart');
               },
-              onStepFinish: async () => {
-                events.push('integration-onStepFinish');
+              onStepEnd: async () => {
+                events.push('integration-onStepEnd');
               },
               onEnd: async () => {
                 events.push('integration-onEnd');
@@ -3658,7 +3658,7 @@ describe('ToolLoopAgent', () => {
           'agent-onStart',
           'integration-onStart',
           'agent-onStepFinish',
-          'integration-onStepFinish',
+          'integration-onStepEnd',
           'agent-onFinish',
           'integration-onEnd',
         ]);
@@ -3678,7 +3678,7 @@ describe('ToolLoopAgent', () => {
               onStart: async () => {
                 throw new Error('integration error');
               },
-              onStepFinish: async () => {
+              onStepEnd: async () => {
                 throw new Error('integration error');
               },
               onEnd: async () => {
@@ -3789,8 +3789,8 @@ describe('ToolLoopAgent', () => {
               onToolExecutionEnd: async () => {
                 events.push('onToolExecutionEnd');
               },
-              onStepFinish: async () => {
-                events.push('onStepFinish');
+              onStepEnd: async () => {
+                events.push('onStepEnd');
               },
               onEnd: async () => {
                 events.push('onEnd');
@@ -3807,9 +3807,9 @@ describe('ToolLoopAgent', () => {
           'onStepStart',
           'onToolExecutionStart',
           'onToolExecutionEnd',
-          'onStepFinish',
+          'onStepEnd',
           'onStepStart',
-          'onStepFinish',
+          'onStepEnd',
           'onEnd',
         ]);
       });
@@ -3822,8 +3822,8 @@ describe('ToolLoopAgent', () => {
             onStart: async () => {
               events.push('global-onStart');
             },
-            onStepFinish: async () => {
-              events.push('global-onStepFinish');
+            onStepEnd: async () => {
+              events.push('global-onStepEnd');
             },
             onEnd: async () => {
               events.push('global-onEnd');
@@ -3856,7 +3856,7 @@ describe('ToolLoopAgent', () => {
 
         expect(events).toEqual([
           'global-onStart',
-          'global-onStepFinish',
+          'global-onStepEnd',
           'global-onEnd',
         ]);
       });
@@ -3906,7 +3906,7 @@ describe('ToolLoopAgent', () => {
                   (event as { runtimeContext: unknown }).runtimeContext,
                 );
               },
-              onStepFinish: async ({ runtimeContext }) => {
+              onStepEnd: async ({ runtimeContext }) => {
                 telemetryContexts.push(runtimeContext);
               },
               onEnd: async event => {
@@ -3968,8 +3968,8 @@ describe('ToolLoopAgent', () => {
               onStart: async () => {
                 events.push('integration-onStart');
               },
-              onStepFinish: async () => {
-                events.push('integration-onStepFinish');
+              onStepEnd: async () => {
+                events.push('integration-onStepEnd');
               },
               onEnd: async () => {
                 events.push('integration-onEnd');
@@ -3985,7 +3985,7 @@ describe('ToolLoopAgent', () => {
           'agent-onStart',
           'integration-onStart',
           'agent-onStepFinish',
-          'integration-onStepFinish',
+          'integration-onStepEnd',
           'agent-onFinish',
           'integration-onEnd',
         ]);
@@ -4015,7 +4015,7 @@ describe('ToolLoopAgent', () => {
               onStart: async () => {
                 throw new Error('integration error');
               },
-              onStepFinish: async () => {
+              onStepEnd: async () => {
                 throw new Error('integration error');
               },
               onEnd: async () => {

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1981,6 +1981,52 @@ describe('ToolLoopAgent', () => {
         });
       });
 
+      it('should call onStepEnd from constructor and generate method in order', async () => {
+        const onStepEndCalls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          onStepEnd: async () => {
+            onStepEndCalls.push('constructor');
+          },
+        });
+
+        await agent.generate({
+          prompt: 'Hello, world!',
+          onStepEnd: async () => {
+            onStepEndCalls.push('method');
+          },
+        });
+
+        expect(onStepEndCalls).toEqual(['constructor', 'method']);
+      });
+
+      it('should prefer onStepEnd over deprecated onStepFinish', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          onStepEnd: async () => {
+            calls.push('constructor-onStepEnd');
+          },
+          onStepFinish: async () => {
+            calls.push('constructor-onStepFinish');
+          },
+        });
+
+        await agent.generate({
+          prompt: 'Hello, world!',
+          onStepEnd: async () => {
+            calls.push('method-onStepEnd');
+          },
+          onStepFinish: async () => {
+            calls.push('method-onStepFinish');
+          },
+        });
+
+        expect(calls).toEqual(['constructor-onStepEnd', 'method-onStepEnd']);
+      });
+
       it('should call onStepFinish from constructor', async () => {
         const onStepFinishCalls: string[] = [];
 

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -91,6 +91,7 @@ export class ToolLoopAgent<
       | 'experimental_onStepStart'
       | 'onToolExecutionStart'
       | 'onToolExecutionEnd'
+      | 'onStepEnd'
       | 'onStepFinish'
       | 'onEnd'
       | 'onFinish'
@@ -114,6 +115,7 @@ export class ToolLoopAgent<
       experimental_onStepStart: _settingsOnStepStart,
       onToolExecutionStart: _settingsOnToolExecutionStart,
       onToolExecutionEnd: _settingsOnToolExecutionEnd,
+      onStepEnd: _settingsOnStepEnd,
       onStepFinish: _settingsOnStepFinish,
       onFinish: _settingsOnFinish,
       onEnd: _settingsOnEnd,
@@ -181,6 +183,7 @@ export class ToolLoopAgent<
     experimental_onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
+    onStepEnd,
     onStepFinish,
     onFinish,
     onEnd = onFinish,
@@ -217,7 +220,10 @@ export class ToolLoopAgent<
         this.settings.onToolExecutionEnd,
         onToolExecutionEnd,
       ),
-      onStepFinish: mergeCallbacks(this.settings.onStepFinish, onStepFinish),
+      onStepEnd: mergeCallbacks(
+        this.settings.onStepEnd ?? this.settings.onStepFinish,
+        onStepEnd ?? onStepFinish,
+      ),
       onEnd: mergeCallbacks(this.settings.onEnd, onEnd),
     };
 
@@ -239,6 +245,7 @@ export class ToolLoopAgent<
     experimental_onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
+    onStepEnd,
     onStepFinish,
     onFinish,
     onEnd = onFinish,
@@ -276,7 +283,10 @@ export class ToolLoopAgent<
         this.settings.onToolExecutionEnd,
         onToolExecutionEnd,
       ),
-      onStepFinish: mergeCallbacks(this.settings.onStepFinish, onStepFinish),
+      onStepEnd: mergeCallbacks(
+        this.settings.onStepEnd ?? this.settings.onStepFinish,
+        onStepEnd ?? onStepFinish,
+      ),
       onEnd: mergeCallbacks(this.settings.onEnd, onEnd),
     };
 

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -107,7 +107,8 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  *
  * @param experimental_onStart - Callback invoked when generation begins, before the LLM call.
  * @param experimental_onStepStart - Callback invoked when the model call begins.
- * @param onStepFinish - Callback invoked when the model call completes with the raw result.
+ * @param onStepEnd - Callback invoked when the model call completes with the raw result.
+ * @param onStepFinish - Deprecated alias for `onStepEnd`.
  * @param onFinish - Callback invoked when the entire operation completes with the parsed object.
  *
  * @returns
@@ -210,6 +211,14 @@ export async function generateObject<
        * Callback that is called when the model call (step) completes,
        * with the raw result before JSON parsing.
        */
+      onStepEnd?: Callback<GenerateObjectStepEndEvent>;
+
+      /**
+       * Callback that is called when the model call (step) completes,
+       * with the raw result before JSON parsing.
+       *
+       * @deprecated Use `onStepEnd` instead.
+       */
       onStepFinish?: Callback<GenerateObjectStepEndEvent>;
 
       /**
@@ -245,6 +254,7 @@ export async function generateObject<
     providerOptions,
     experimental_onStart: onStart,
     experimental_onStepStart: onStepStart,
+    onStepEnd,
     onStepFinish,
     onFinish,
     _internal: {
@@ -292,6 +302,7 @@ export async function generateObject<
   const telemetryDispatcher = createTelemetryDispatcher({
     telemetry,
   });
+  const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
 
   const jsonSchema = await outputStrategy.jsonSchema();
   const callId = generateId();
@@ -421,7 +432,7 @@ export async function generateObject<
 
     await notify({
       event: stepFinishEvent,
-      callbacks: [onStepFinish, telemetryDispatcher.onObjectStepFinish],
+      callbacks: [resolvedOnStepEnd, telemetryDispatcher.onObjectStepFinish],
     });
 
     const object = await parseAndValidateObjectResultWithRepair(

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -275,6 +275,14 @@ export function streamObject<
        * Callback that is called when the model streaming step completes,
        * with the raw accumulated text before final schema validation.
        */
+      onStepEnd?: Callback<GenerateObjectStepEndEvent>;
+
+      /**
+       * Callback that is called when the model streaming step completes,
+       * with the raw accumulated text before final schema validation.
+       *
+       * @deprecated Use `onStepEnd` instead.
+       */
       onStepFinish?: Callback<GenerateObjectStepEndEvent>;
 
       /**
@@ -329,6 +337,7 @@ export function streamObject<
     providerOptions,
     experimental_onStart: onStart,
     experimental_onStepStart: onStepStart,
+    onStepEnd,
     onStepFinish,
     onError = ({ error }: { error: unknown }) => {
       console.error(error);
@@ -384,7 +393,7 @@ export function streamObject<
     repairText,
     onStart,
     onStepStart,
-    onStepFinish,
+    onStepFinish: onStepEnd ?? onStepFinish,
     onError,
     onFinish,
     download,

--- a/packages/ai/src/generate-object/structured-output-events.ts
+++ b/packages/ai/src/generate-object/structured-output-events.ts
@@ -109,7 +109,7 @@ export interface GenerateObjectStepStartEvent {
 }
 
 /**
- * Event passed to the `onStepFinish` callback of
+ * Event passed to the `onStepEnd` callback of
  * `generateObject` and `streamObject`.
  *
  * Called when the model call (step) completes, with the raw result

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -137,7 +137,7 @@ export type GenerateTextStepStartEvent<
 } & StandardizedPrompt;
 
 /**
- * Event passed to the `onStepFinish` callback.
+ * Event passed to the `onStepEnd` callback.
  *
  * Called when a step (LLM call) completes.
  * Includes the StepResult for that step along with the call identifier.
@@ -369,17 +369,27 @@ export type GenerateTextOnStepStartCallback<
 > = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
- * Callback that is set using the `onStepFinish` option.
+ * Callback that is set using the `onStepEnd` option.
  *
  * Called when a step (LLM call) completes. The event includes all step result
  * properties (text, tool calls, usage, etc.) along with additional metadata.
  *
  * @param stepResult - The result of the step.
  */
-export type GenerateTextOnStepFinishCallback<
+export type GenerateTextOnStepEndCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
 > = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
+
+/**
+ * Callback that is set using the `onStepFinish` option.
+ *
+ * @deprecated Use `GenerateTextOnStepEndCallback` instead.
+ */
+export type GenerateTextOnStepFinishCallback<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = GenerateTextOnStepEndCallback<TOOLS, RUNTIME_CONTEXT>;
 
 /**
  * Callback that is set using the `onEnd` option.

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -387,7 +387,7 @@ describe('generateText types', () => {
             requestId: string;
           }>();
         },
-        onStepFinish: ({ runtimeContext }) => {
+        onStepEnd: ({ runtimeContext }) => {
           expectTypeOf(runtimeContext).toEqualTypeOf<{
             userId: string;
             requestId: string;

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -9016,7 +9016,7 @@ describe('generateText', () => {
             onStepStart: ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onStepFinish: ({ runtimeContext }) => {
+            onStepEnd: ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
             onEnd: event => {
@@ -9080,7 +9080,7 @@ describe('generateText', () => {
             onStepStart: ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
-            onStepFinish: ({ toolsContext }) => {
+            onStepEnd: ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
             onEnd: event => {
@@ -9139,7 +9139,7 @@ describe('generateText', () => {
             onStepStart: ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
-            onStepFinish: ({ toolsContext }) => {
+            onStepEnd: ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
             onEnd: event => {
@@ -9180,7 +9180,7 @@ describe('generateText', () => {
             onStepStart: ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onStepFinish: ({ runtimeContext }) => {
+            onStepEnd: ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
             onEnd: event => {
@@ -11846,8 +11846,8 @@ describe('generateText', () => {
             onToolExecutionEnd: async () => {
               events.push('onToolExecutionEnd');
             },
-            onStepFinish: async () => {
-              events.push('onStepFinish');
+            onStepEnd: async () => {
+              events.push('onStepEnd');
             },
             onEnd: async () => {
               events.push('onEnd');
@@ -11862,7 +11862,7 @@ describe('generateText', () => {
           "onStepStart",
           "onToolExecutionStart",
           "onToolExecutionEnd",
-          "onStepFinish",
+          "onStepEnd",
           "onEnd",
         ]
       `);
@@ -11876,8 +11876,8 @@ describe('generateText', () => {
           onStart: async () => {
             events.push('global-onStart');
           },
-          onStepFinish: async () => {
-            events.push('global-onStepFinish');
+          onStepEnd: async () => {
+            events.push('global-onStepEnd');
           },
           onEnd: async () => {
             events.push('global-onEnd');
@@ -11897,7 +11897,7 @@ describe('generateText', () => {
 
       expect(events).toEqual([
         'global-onStart',
-        'global-onStepFinish',
+        'global-onStepEnd',
         'global-onEnd',
       ]);
     });
@@ -11958,8 +11958,8 @@ describe('generateText', () => {
             onStart: async () => {
               events.push('integration-onStart');
             },
-            onStepFinish: async () => {
-              events.push('integration-onStepFinish');
+            onStepEnd: async () => {
+              events.push('integration-onStepEnd');
             },
             onEnd: async () => {
               events.push('integration-onEnd');
@@ -11972,7 +11972,7 @@ describe('generateText', () => {
         'user-onStart',
         'integration-onStart',
         'user-onStepFinish',
-        'integration-onStepFinish',
+        'integration-onStepEnd',
         'user-onFinish',
         'integration-onEnd',
       ]);
@@ -11992,7 +11992,7 @@ describe('generateText', () => {
             onStart: async () => {
               throw new Error('integration error');
             },
-            onStepFinish: async () => {
+            onStepEnd: async () => {
               throw new Error('integration error');
             },
             onEnd: async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -37,6 +37,7 @@ import { generateText } from './generate-text';
 import type {
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from './generate-text-events';
@@ -2384,6 +2385,49 @@ describe('generateText', () => {
         tool1: { label: 'updated' },
       });
       expect(recordedToolContext).toEqual({ label: 'updated' });
+    });
+  });
+
+  describe('options.onStepEnd stepNumber', () => {
+    it('should call onStepEnd with step result', async () => {
+      let stepEndEvent!: Parameters<GenerateTextOnStepEndCallback<any, any>>[0];
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        onStepEnd: async event => {
+          stepEndEvent = event;
+        },
+      });
+
+      expect(stepEndEvent.stepNumber).toBe(0);
+    });
+
+    it('should prefer onStepEnd over deprecated onStepFinish', async () => {
+      const calls: string[] = [];
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        onStepEnd: async () => {
+          calls.push('onStepEnd');
+        },
+        onStepFinish: async () => {
+          calls.push('onStepFinish');
+        },
+      });
+
+      expect(calls).toEqual(['onStepEnd']);
     });
   });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -69,6 +69,7 @@ import {
 import type {
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from './generate-text-events';
@@ -257,6 +258,7 @@ export async function generateText<
   onToolExecutionEnd,
   experimental_onToolCallStart,
   experimental_onToolCallFinish,
+  onStepEnd,
   onStepFinish,
   onFinish,
   onEnd = onFinish,
@@ -423,7 +425,17 @@ export async function generateText<
     experimental_onToolCallFinish?: OnToolExecutionEndCallback<NoInfer<TOOLS>>;
 
     /**
-     * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     */
+    onStepEnd?: GenerateTextOnStepEndCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>
+    >;
+
+    /**
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     *
+     * @deprecated Use `onStepEnd` instead.
      */
     onStepFinish?: GenerateTextOnStepFinishCallback<
       NoInfer<TOOLS>,
@@ -484,6 +496,7 @@ export async function generateText<
     onToolExecutionStart ?? experimental_onToolCallStart;
   const resolvedOnToolExecutionEnd =
     onToolExecutionEnd ?? experimental_onToolCallFinish;
+  const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
 
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
@@ -1179,7 +1192,7 @@ export async function generateText<
 
         await notify({
           event: currentStepResult,
-          callbacks: [onStepFinish, telemetryDispatcher.onStepFinish],
+          callbacks: [resolvedOnStepEnd, telemetryDispatcher.onStepEnd],
         });
       } finally {
         if (stepTimeoutId != null) {

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -9,6 +9,7 @@ export type {
   GenerateTextOnFinishCallback,
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
   GenerateTextStartEvent,

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test-d.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test-d.ts
@@ -50,6 +50,9 @@ describe('createRestrictedTelemetryDispatcher types', () => {
       | Callback<GenerateTextStepStartEvent<ToolSet, RuntimeContext, Output>>
       | undefined
     >();
+    expectTypeOf(telemetryDispatcher.onStepEnd).toMatchTypeOf<
+      Callback<GenerateTextStepEndEvent<ToolSet, RuntimeContext>> | undefined
+    >();
     expectTypeOf(telemetryDispatcher.onStepFinish).toMatchTypeOf<
       Callback<GenerateTextStepEndEvent<ToolSet, RuntimeContext>> | undefined
     >();

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.test.ts
@@ -224,17 +224,17 @@ describe('createRestrictedTelemetryDispatcher', () => {
     expect(previousStep.toolsContext).toEqual(toolsContext);
   });
 
-  it('includes configured runtimeContext for step finish events without mutating the source step', async () => {
-    const onStepFinish = vi.fn();
+  it('includes configured runtimeContext for step end events without mutating the source step', async () => {
+    const onStepEnd = vi.fn();
     const telemetryDispatcher = createRestrictedTelemetryDispatcher({
-      telemetry: { integrations: { onStepFinish } },
+      telemetry: { integrations: { onStepEnd } },
       includeRuntimeContext,
     });
     const step = createStepResult();
 
-    await telemetryDispatcher.onStepFinish?.(step as any);
+    await telemetryDispatcher.onStepEnd?.(step as any);
 
-    const telemetryEvent = onStepFinish.mock.calls[0][0];
+    const telemetryEvent = onStepEnd.mock.calls[0][0];
 
     expect(telemetryEvent.runtimeContext).toEqual({
       requestId: 'request-123',
@@ -243,18 +243,18 @@ describe('createRestrictedTelemetryDispatcher', () => {
     expect(step.runtimeContext).toEqual(runtimeContext);
   });
 
-  it('filters toolsContext for step finish events without mutating the source step', async () => {
-    const onStepFinish = vi.fn();
+  it('filters toolsContext for step end events without mutating the source step', async () => {
+    const onStepEnd = vi.fn();
     const telemetryDispatcher = createRestrictedTelemetryDispatcher({
-      telemetry: { integrations: { onStepFinish } },
+      telemetry: { integrations: { onStepEnd } },
       includeRuntimeContext: undefined,
       includeToolsContext,
     });
     const step = createStepResult({ toolContexts: toolsContext });
 
-    await telemetryDispatcher.onStepFinish?.(step as any);
+    await telemetryDispatcher.onStepEnd?.(step as any);
 
-    const telemetryEvent = onStepFinish.mock.calls[0][0];
+    const telemetryEvent = onStepEnd.mock.calls[0][0];
 
     expect(telemetryEvent.toolsContext).toEqual(filteredToolsContext);
     expect(telemetryEvent.text).toBe('Hello');

--- a/packages/ai/src/generate-text/restricted-telemetry-dispatcher.ts
+++ b/packages/ai/src/generate-text/restricted-telemetry-dispatcher.ts
@@ -15,6 +15,7 @@ import type {
   GenerateTextOnAbortCallback,
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from './generate-text-events';
@@ -37,6 +38,7 @@ export type RestrictedTelemetryDispatcher<
   TelemetryDispatcher,
   | 'onStart'
   | 'onStepStart'
+  | 'onStepEnd'
   | 'onStepFinish'
   | 'onEnd'
   | 'onAbort'
@@ -45,6 +47,8 @@ export type RestrictedTelemetryDispatcher<
 > & {
   onStart: GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
   onStepStart: GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
+  onStepEnd: GenerateTextOnStepEndCallback<TOOLS, RUNTIME_CONTEXT>;
+  /** @deprecated Use `onStepEnd` instead. */
   onStepFinish: GenerateTextOnStepFinishCallback<TOOLS, RUNTIME_CONTEXT>;
   onEnd: GenerateTextOnEndCallback<TOOLS, RUNTIME_CONTEXT>;
   onAbort?: GenerateTextOnAbortCallback<TOOLS, RUNTIME_CONTEXT>;
@@ -218,8 +222,16 @@ export function createRestrictedTelemetryDispatcher<
           includeToolsContext,
         }),
       }),
+    onStepEnd: event =>
+      telemetryDispatcher.onStepEnd?.(
+        restrictStepResult({
+          step: event,
+          includeRuntimeContext,
+          includeToolsContext,
+        }),
+      ),
     onStepFinish: event =>
-      telemetryDispatcher.onStepFinish?.(
+      telemetryDispatcher.onStepEnd?.(
         restrictStepResult({
           step: event,
           includeRuntimeContext,

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -477,7 +477,7 @@ describe('streamText types', () => {
             requestId: string;
           }>();
         },
-        onStepFinish: ({ runtimeContext }) => {
+        onStepEnd: ({ runtimeContext }) => {
           expectTypeOf(runtimeContext).toEqualTypeOf<{
             userId: string;
             requestId: string;

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -7149,7 +7149,7 @@ describe('streamText', () => {
             onStepStart: async ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onStepFinish: async ({ runtimeContext }) => {
+            onStepEnd: async ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
             onEnd: async event => {
@@ -7210,7 +7210,7 @@ describe('streamText', () => {
             onStepStart: async ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
-            onStepFinish: async ({ toolsContext }) => {
+            onStepEnd: async ({ toolsContext }) => {
               telemetryContexts.push(toolsContext);
             },
             onEnd: async event => {
@@ -7253,7 +7253,7 @@ describe('streamText', () => {
             onStepStart: async ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
-            onStepFinish: async ({ runtimeContext }) => {
+            onStepEnd: async ({ runtimeContext }) => {
               telemetryContexts.push(runtimeContext);
             },
             onEnd: async event => {
@@ -28622,8 +28622,8 @@ describe('streamText', () => {
             onToolExecutionEnd: async () => {
               events.push('onToolExecutionEnd');
             },
-            onStepFinish: async () => {
-              events.push('onStepFinish');
+            onStepEnd: async () => {
+              events.push('onStepEnd');
             },
             onEnd: async () => {
               events.push('onEnd');
@@ -28640,7 +28640,7 @@ describe('streamText', () => {
           "onStepStart",
           "onToolExecutionStart",
           "onToolExecutionEnd",
-          "onStepFinish",
+          "onStepEnd",
           "onEnd",
         ]
       `);
@@ -28654,8 +28654,8 @@ describe('streamText', () => {
           onStart: async () => {
             events.push('global-onStart');
           },
-          onStepFinish: async () => {
-            events.push('global-onStepFinish');
+          onStepEnd: async () => {
+            events.push('global-onStepEnd');
           },
           onEnd: async () => {
             events.push('global-onEnd');
@@ -28673,7 +28673,7 @@ describe('streamText', () => {
 
       expect(events).toEqual([
         'global-onStart',
-        'global-onStepFinish',
+        'global-onStepEnd',
         'global-onEnd',
       ]);
     });
@@ -28728,8 +28728,8 @@ describe('streamText', () => {
             onStart: async () => {
               events.push('integration-onStart');
             },
-            onStepFinish: async () => {
-              events.push('integration-onStepFinish');
+            onStepEnd: async () => {
+              events.push('integration-onStepEnd');
             },
             onEnd: async () => {
               events.push('integration-onEnd');
@@ -28744,7 +28744,7 @@ describe('streamText', () => {
         'user-onStart',
         'integration-onStart',
         'user-onStepFinish',
-        'integration-onStepFinish',
+        'integration-onStepEnd',
         'user-onFinish',
         'integration-onEnd',
       ]);
@@ -28760,7 +28760,7 @@ describe('streamText', () => {
             onStart: async () => {
               throw new Error('integration error');
             },
-            onStepFinish: async () => {
+            onStepEnd: async () => {
               throw new Error('integration error');
             },
             onEnd: async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -19134,6 +19134,69 @@ describe('streamText', () => {
           `);
       });
 
+      it('options.onStepEnd should be called', async () => {
+        let result!: Parameters<
+          Required<Parameters<typeof streamText>[0]>['onStepEnd']
+        >[0];
+
+        const resultObject = streamText({
+          model: createTestModel({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello, ' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+          prompt: 'test-input',
+          onStepEnd: async event => {
+            result = event as unknown as typeof result;
+          },
+          _internal: {
+            generateId: () => 'test-call-id',
+            generateCallId: () => 'test-telemetry-call-id',
+          },
+        });
+
+        await resultObject.consumeStream();
+
+        expect(result.stepNumber).toBe(0);
+      });
+
+      it('options.onStepEnd should be preferred over deprecated onStepFinish', async () => {
+        const calls: string[] = [];
+
+        const resultObject = streamText({
+          model: createTestModel({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello, ' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+          prompt: 'test-input',
+          onStepEnd: async () => {
+            calls.push('onStepEnd');
+          },
+          onStepFinish: async () => {
+            calls.push('onStepFinish');
+          },
+        });
+
+        await resultObject.consumeStream();
+
+        expect(calls).toEqual(['onStepEnd']);
+      });
+
       it('options.onStepFinish should be called', async () => {
         let result!: Parameters<
           Required<Parameters<typeof streamText>[0]>['onStepFinish']

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -93,6 +93,7 @@ import {
 import type {
   GenerateTextOnEndCallback,
   GenerateTextOnStartCallback,
+  GenerateTextOnStepEndCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from './generate-text-events';
@@ -277,7 +278,8 @@ export type StreamTextOnAbortCallback<
  * @param experimental_onToolCallStart - Deprecated alias for `onToolExecutionStart`.
  * @param onToolExecutionEnd - Callback invoked after each tool execution completes.
  * @param experimental_onToolCallFinish - Deprecated alias for `onToolExecutionEnd`.
- * @param onStepFinish - Callback that is called when each step (LLM call) is finished, including intermediate steps.
+ * @param onStepEnd - Callback that is called when each step (LLM call) ends, including intermediate steps.
+ * @param onStepFinish - Deprecated alias for `onStepEnd`.
  * @param onEnd - Callback that is called when all steps are finished and the response is complete.
  * @param onFinish - Deprecated alias for `onEnd`.
  *
@@ -323,6 +325,7 @@ export function streamText<
   onFinish,
   onEnd = onFinish,
   onAbort,
+  onStepEnd,
   onStepFinish,
   experimental_onStart: onStart,
   experimental_onStepStart: onStepStart,
@@ -511,7 +514,17 @@ export function streamText<
     >;
 
     /**
-     * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     */
+    onStepEnd?: GenerateTextOnStepEndCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>
+    >;
+
+    /**
+     * Callback that is called when each step (LLM call) ends, including intermediate steps.
+     *
+     * @deprecated Use `onStepEnd` instead.
      */
     onStepFinish?: GenerateTextOnStepFinishCallback<
       NoInfer<TOOLS>,
@@ -611,6 +624,7 @@ export function streamText<
     onToolExecutionStart ?? experimental_onToolCallStart;
   const resolvedOnToolExecutionEnd =
     onToolExecutionEnd ?? experimental_onToolCallFinish;
+  const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
   return new DefaultStreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>({
     model: resolveLanguageModel(model),
     telemetry,
@@ -652,7 +666,7 @@ export function streamText<
     onError,
     onEnd,
     onAbort,
-    onStepFinish,
+    onStepFinish: resolvedOnStepEnd,
     onStart,
     onStepStart,
     onLanguageModelCallStart,
@@ -1177,7 +1191,7 @@ class DefaultStreamTextResult<
 
           await notify({
             event: currentStepResult,
-            callbacks: [onStepFinish, telemetryDispatcher.onStepFinish],
+            callbacks: [onStepFinish, telemetryDispatcher.onStepEnd],
           });
 
           logWarnings({

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -94,6 +94,22 @@ describe('createTelemetryDispatcher', () => {
     expect(onStart2).toHaveBeenCalledWith(augmentedDummyEvent);
   });
 
+  it('fans out step-end events to deprecated onStepFinish integrations', async () => {
+    const onStepEnd = vi.fn();
+    const onStepFinish = vi.fn();
+
+    const telemetry = createTelemetryDispatcher({
+      telemetry: {
+        integrations: [{ onStepEnd }, { onStepFinish }],
+      },
+    });
+
+    await telemetry.onStepEnd!(dummyEvent);
+
+    expect(onStepEnd).toHaveBeenCalledWith(augmentedDummyEvent);
+    expect(onStepFinish).toHaveBeenCalledWith(augmentedDummyEvent);
+  });
+
   it('skips integrations that do not implement the method', async () => {
     const onStart = vi.fn();
 

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -25,7 +25,7 @@ describe('createTelemetryDispatcher', () => {
     expect(telemetry.onLanguageModelCallEnd).toBeDefined();
     expect(telemetry.onToolExecutionStart).toBeDefined();
     expect(telemetry.onToolExecutionEnd).toBeDefined();
-    expect(telemetry.onStepFinish).toBeDefined();
+    expect(telemetry.onStepEnd).toBeDefined();
     expect(telemetry.onObjectStepStart).toBeDefined();
     expect(telemetry.onObjectStepFinish).toBeDefined();
     expect(telemetry.onEmbedStart).toBeDefined();
@@ -146,7 +146,7 @@ describe('createTelemetryDispatcher', () => {
       onLanguageModelCallEnd: vi.fn(),
       onToolExecutionStart: vi.fn(),
       onToolExecutionEnd: vi.fn(),
-      onStepFinish: vi.fn(),
+      onStepEnd: vi.fn(),
       onObjectStepStart: vi.fn(),
       onObjectStepFinish: vi.fn(),
       onEmbedStart: vi.fn(),
@@ -168,7 +168,7 @@ describe('createTelemetryDispatcher', () => {
     await telemetry.onLanguageModelCallEnd!(dummyEvent);
     await telemetry.onToolExecutionStart!(dummyEvent);
     await telemetry.onToolExecutionEnd!(dummyEvent);
-    await telemetry.onStepFinish!(dummyEvent);
+    await telemetry.onStepEnd!(dummyEvent);
     await telemetry.onObjectStepStart!(dummyEvent);
     await telemetry.onObjectStepFinish!(dummyEvent);
     await telemetry.onEmbedStart!(dummyEvent);
@@ -185,7 +185,7 @@ describe('createTelemetryDispatcher', () => {
     expect(integration.onLanguageModelCallEnd).toHaveBeenCalledOnce();
     expect(integration.onToolExecutionStart).toHaveBeenCalledOnce();
     expect(integration.onToolExecutionEnd).toHaveBeenCalledOnce();
-    expect(integration.onStepFinish).toHaveBeenCalledOnce();
+    expect(integration.onStepEnd).toHaveBeenCalledOnce();
     expect(integration.onObjectStepStart).toHaveBeenCalledOnce();
     expect(integration.onObjectStepFinish).toHaveBeenCalledOnce();
     expect(integration.onEmbedStart).toHaveBeenCalledOnce();
@@ -215,7 +215,7 @@ describe('createTelemetryDispatcher', () => {
         onStepStart: vi.fn(),
         onToolExecutionStart: vi.fn(),
         onToolExecutionEnd: vi.fn(),
-        onStepFinish: vi.fn(),
+        onStepEnd: vi.fn(),
         onObjectStepStart: vi.fn(),
         onObjectStepFinish: vi.fn(),
         onEmbedStart: vi.fn(),
@@ -237,7 +237,7 @@ describe('createTelemetryDispatcher', () => {
       expect(telemetry.onStepStart).toBeUndefined();
       expect(telemetry.onToolExecutionStart).toBeUndefined();
       expect(telemetry.onToolExecutionEnd).toBeUndefined();
-      expect(telemetry.onStepFinish).toBeUndefined();
+      expect(telemetry.onStepEnd).toBeUndefined();
       expect(telemetry.onObjectStepStart).toBeUndefined();
       expect(telemetry.onObjectStepFinish).toBeUndefined();
       expect(telemetry.onEmbedStart).toBeUndefined();

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -130,7 +130,14 @@ export function createTelemetryDispatcher({
     onLanguageModelCallEnd: mergeTelemetryCallback('onLanguageModelCallEnd'),
     onToolExecutionStart: mergeTelemetryCallback('onToolExecutionStart'),
     onToolExecutionEnd: mergeTelemetryCallback('onToolExecutionEnd'),
-    onStepEnd: mergeTelemetryCallback('onStepEnd'),
+    // Fan out step-end events to both the new `onStepEnd` callback and the
+    // deprecated `onStepFinish` callback so integrations that still implement
+    // only `onStepFinish` keep receiving step-end events during the deprecation
+    // window.
+    onStepEnd: mergeCallbacks(
+      mergeTelemetryCallback('onStepEnd'),
+      mergeTelemetryCallback('onStepFinish'),
+    ),
     onObjectStepStart: mergeTelemetryCallback('onObjectStepStart'),
     onObjectStepFinish: mergeTelemetryCallback('onObjectStepFinish'),
     onEmbedStart: mergeTelemetryCallback('onEmbedStart'),

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -130,7 +130,7 @@ export function createTelemetryDispatcher({
     onLanguageModelCallEnd: mergeTelemetryCallback('onLanguageModelCallEnd'),
     onToolExecutionStart: mergeTelemetryCallback('onToolExecutionStart'),
     onToolExecutionEnd: mergeTelemetryCallback('onToolExecutionEnd'),
-    onStepFinish: mergeTelemetryCallback('onStepFinish'),
+    onStepEnd: mergeTelemetryCallback('onStepEnd'),
     onObjectStepStart: mergeTelemetryCallback('onObjectStepStart'),
     onObjectStepFinish: mergeTelemetryCallback('onObjectStepFinish'),
     onEmbedStart: mergeTelemetryCallback('onEmbedStart'),

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -7,6 +7,7 @@ export type TelemetryDiagnosticEventType =
   | 'onLanguageModelCallEnd'
   | 'onToolExecutionStart'
   | 'onToolExecutionEnd'
+  | 'onStepEnd'
   | 'onStepFinish'
   | 'onObjectStepStart'
   | 'onObjectStepFinish'

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -62,6 +62,8 @@ export interface TelemetryDispatcher {
   onLanguageModelCallEnd?: OnLanguageModelCallEndCallback;
   onToolExecutionStart?: Callback<ToolExecutionStartEvent>;
   onToolExecutionEnd?: Callback<ToolExecutionEndEvent>;
+  onStepEnd?: Callback<GenerateTextStepEndEvent>;
+  /** @deprecated Use `onStepEnd` instead. */
   onStepFinish?: Callback<GenerateTextStepEndEvent>;
   onObjectStepStart?: Callback<GenerateObjectStepStartEvent>;
   onObjectStepFinish?: Callback<GenerateObjectStepEndEvent>;
@@ -138,6 +140,13 @@ export interface Telemetry {
    * The event is a `StepResult` containing the model's response, tool calls
    * and results, usage statistics, finish reason, and optional request/response
    * bodies.
+   */
+  onStepEnd?: Callback<InferTelemetryEvent<GenerateTextStepEndEvent>>;
+
+  /**
+   * Called when an individual step (single LLM invocation) completes.
+   *
+   * @deprecated Use `onStepEnd` instead.
    */
   onStepFinish?: Callback<InferTelemetryEvent<GenerateTextStepEndEvent>>;
 

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -7,6 +7,7 @@ import type { UIMessage } from '../ui/ui-messages';
 import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
 import type { InferUIMessageChunk } from './ui-message-chunks';
 import type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+import type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 import type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 import type { UIMessageStreamWriter } from './ui-message-stream-writer';
 
@@ -17,7 +18,8 @@ import type { UIMessageStreamWriter } from './ui-message-stream-writer';
  * @param options.onError - A function that extracts an error message from an error. Defaults to `getErrorMessage`.
  * @param options.originalMessages - The original messages. If provided, persistence mode is assumed
  *   and a message ID is provided for the response message.
- * @param options.onStepFinish - A callback that is called when each step finishes. Useful for persisting intermediate messages.
+ * @param options.onStepEnd - A callback that is called when each step ends. Useful for persisting intermediate messages.
+ * @param options.onStepFinish - Deprecated alias for `onStepEnd`.
  * @param options.onFinish - A callback that is called when the stream finishes.
  * @param options.generateId - A function that generates a unique ID. Defaults to the built-in ID generator.
  *
@@ -27,6 +29,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   execute,
   onError = getErrorMessage,
   originalMessages,
+  onStepEnd,
   onStepFinish,
   onFinish,
   generateId = generateIdFunc,
@@ -43,7 +46,14 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   originalMessages?: UI_MESSAGE[];
 
   /**
-   * Callback that is called when each step finishes during multi-step agent runs.
+   * Callback that is called when each step ends during multi-step agent runs.
+   */
+  onStepEnd?: UIMessageStreamOnStepEndCallback<UI_MESSAGE>;
+
+  /**
+   * Callback that is called when each step ends during multi-step agent runs.
+   *
+   * @deprecated Use `onStepEnd` instead.
    */
   onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
@@ -138,7 +148,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
     stream,
     messageId: generateId(),
     originalMessages,
-    onStepFinish,
+    onStepEnd: onStepEnd ?? onStepFinish,
     onFinish,
     onError,
   });

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
@@ -428,6 +428,55 @@ describe('handleUIMessageStreamFinish', () => {
   });
 
   describe('onStepFinish callback', () => {
+    it('should call onStepEnd when finish-step chunk is encountered', async () => {
+      const onStepEndCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-step-end' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish({
+        stream: convertArrayToReadableStream(inputChunks as any),
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepEnd: onStepEndCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onStepEndCallback).toHaveBeenCalledTimes(1);
+      expect(onStepEndCallback.mock.calls[0][0].responseMessage.id).toBe(
+        'msg-step-end',
+      );
+    });
+
+    it('should prefer onStepEnd over deprecated onStepFinish', async () => {
+      const onStepEndCallback = vi.fn();
+      const onStepFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-step-end' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish({
+        stream: convertArrayToReadableStream(inputChunks as any),
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepEnd: onStepEndCallback,
+        onStepFinish: onStepFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onStepEndCallback).toHaveBeenCalledTimes(1);
+      expect(onStepFinishCallback).not.toHaveBeenCalled();
+    });
+
     it('should call onStepFinish when finish-step chunk is encountered', async () => {
       const onStepFinishCallback = vi.fn();
       const inputChunks: UIMessageChunk[] = [

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -7,11 +7,13 @@ import type { UIMessage } from '../ui/ui-messages';
 import type { ErrorHandler } from '../util/error-handler';
 import type { InferUIMessageChunk, UIMessageChunk } from './ui-message-chunks';
 import type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+import type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 import type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 
 export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   messageId,
   originalMessages = [],
+  onStepEnd,
   onStepFinish,
   onFinish,
   onError,
@@ -33,7 +35,14 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   onError: ErrorHandler;
 
   /**
-   * Callback that is called when each step finishes during multi-step agent runs.
+   * Callback that is called when each step ends during multi-step agent runs.
+   */
+  onStepEnd?: UIMessageStreamOnStepEndCallback<UI_MESSAGE>;
+
+  /**
+   * Callback that is called when each step ends during multi-step agent runs.
+   *
+   * @deprecated Use `onStepEnd` instead.
    */
   onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
@@ -77,7 +86,9 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   );
 
   // Only process the stream if we need to track state for callbacks
-  if (onFinish == null && onStepFinish == null) {
+  const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
+
+  if (onFinish == null && resolvedOnStepEnd == null) {
     return idInjectedStream;
   }
 
@@ -119,14 +130,14 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   };
 
   const callOnStepFinish = async () => {
-    if (!onStepFinish) {
+    if (!resolvedOnStepEnd) {
       return;
     }
 
     const isContinuation = state.message.id === lastMessage?.id;
 
     try {
-      await onStepFinish({
+      await resolvedOnStepEnd({
         isContinuation,
         responseMessage: structuredClone(state.message) as UI_MESSAGE,
         messages: [

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -15,5 +15,6 @@ export {
 } from './ui-message-chunks';
 export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 export type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+export type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 export type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 export type { UIMessageStreamWriter } from './ui-message-stream-writer';

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-step-end-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-step-end-callback.ts
@@ -1,0 +1,25 @@
+import type { UIMessage } from '../ui/ui-messages';
+
+/**
+ * Callback that is called when a step ends during streaming.
+ * This is useful for persisting intermediate UI messages during multi-step agent runs.
+ */
+export type UIMessageStreamOnStepEndCallback<UI_MESSAGE extends UIMessage> =
+  (event: {
+    /**
+     * The updated list of UI messages at the end of this step.
+     */
+    messages: UI_MESSAGE[];
+
+    /**
+     * Indicates whether the response message is a continuation of the last original message,
+     * or if a new message was created.
+     */
+    isContinuation: boolean;
+
+    /**
+     * The message that was sent to the client as a response
+     * (including the original message if it was extended).
+     */
+    responseMessage: UI_MESSAGE;
+  }) => PromiseLike<void> | void;

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-step-finish-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-step-finish-callback.ts
@@ -1,25 +1,11 @@
 import type { UIMessage } from '../ui/ui-messages';
+import type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 
 /**
  * Callback that is called when a step finishes during streaming.
  * This is useful for persisting intermediate UI messages during multi-step agent runs.
+ *
+ * @deprecated Use `UIMessageStreamOnStepEndCallback` instead.
  */
 export type UIMessageStreamOnStepFinishCallback<UI_MESSAGE extends UIMessage> =
-  (event: {
-    /**
-     * The updated list of UI messages at the end of this step.
-     */
-    messages: UI_MESSAGE[];
-
-    /**
-     * Indicates whether the response message is a continuation of the last original message,
-     * or if a new message was created.
-     */
-    isContinuation: boolean;
-
-    /**
-     * The message that was sent to the client as a response
-     * (including the original message if it was extended).
-     */
-    responseMessage: UI_MESSAGE;
-  }) => PromiseLike<void> | void;
+  UIMessageStreamOnStepEndCallback<UI_MESSAGE>;

--- a/packages/devtools/src/integration.test.ts
+++ b/packages/devtools/src/integration.test.ts
@@ -139,7 +139,7 @@ describe('DevToolsTelemetry', () => {
         }
       `);
 
-      await integration.onStepFinish!(makeStepFinishEvent());
+      await integration.onStepEnd!(makeStepFinishEvent());
       expect(mockUpdateStepResult).toHaveBeenCalledOnce();
 
       const [stepId, result] = mockUpdateStepResult.mock.calls[0];
@@ -171,7 +171,7 @@ describe('DevToolsTelemetry', () => {
 
       await integration.onStart!(makeStartEvent());
       await integration.onStepStart!(makeStepStartEvent());
-      await integration.onStepFinish!(
+      await integration.onStepEnd!(
         makeStepFinishEvent({
           request: { body: { model: 'test', prompt: 'hi' } },
           response: {
@@ -212,7 +212,7 @@ describe('DevToolsTelemetry', () => {
       );
       await integration.onStepStart!(makeStepStartEvent());
 
-      await integration.onStepFinish!(
+      await integration.onStepEnd!(
         makeStepFinishEvent({
           response: {
             id: 'resp-1',
@@ -326,7 +326,7 @@ describe('DevToolsTelemetry', () => {
 
       await integration.onStart!(makeStartEvent());
       await integration.onStepStart!(makeStepStartEvent());
-      await integration.onStepFinish!(makeStepFinishEvent());
+      await integration.onStepEnd!(makeStepFinishEvent());
       await integration.onEnd!({ callId: 'call-1' } as any);
 
       mockCreateStep.mockClear();

--- a/packages/devtools/src/integration.ts
+++ b/packages/devtools/src/integration.ts
@@ -309,7 +309,7 @@ export function DevToolsTelemetry(): Telemetry {
       });
     },
 
-    onStepFinish: async event => {
+    onStepEnd: async event => {
       const stepResult = event as GenerateTextStepEndEvent<ToolSet>;
 
       const state = callStates.get(stepResult.callId);

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -655,7 +655,7 @@ export class LegacyOpenTelemetry implements Telemetry {
     state.toolSpans.delete(event.toolCall.toolCallId);
   }
 
-  onStepFinish(event: GenerateTextStepEndEvent<ToolSet>): void {
+  onStepEnd(event: GenerateTextStepEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepSpan) return;
 
@@ -760,6 +760,11 @@ export class LegacyOpenTelemetry implements Telemetry {
     state.stepSpan.end();
     state.stepSpan = undefined;
     state.stepContext = undefined;
+  }
+
+  /** @deprecated Use `onStepEnd` instead. */
+  onStepFinish(event: GenerateTextStepEndEvent<ToolSet>): void {
+    this.onStepEnd(event);
   }
 
   onEnd(

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -825,7 +825,7 @@ export class OpenTelemetry implements Telemetry {
     state.toolSpans.delete(event.toolCall.toolCallId);
   }
 
-  onStepFinish(event: GenerateTextStepEndEvent<ToolSet>): void {
+  onStepEnd(event: GenerateTextStepEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepSpan) return;
 
@@ -845,6 +845,11 @@ export class OpenTelemetry implements Telemetry {
     state.stepSpan.end();
     state.stepSpan = undefined;
     state.stepContext = undefined;
+  }
+
+  /** @deprecated Use `onStepEnd` instead. */
+  onStepFinish(event: GenerateTextStepEndEvent<ToolSet>): void {
+    this.onStepEnd(event);
   }
 
   onEnd(

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -21,6 +21,7 @@ export {
   type WorkflowAgentOnEndCallback,
   type WorkflowAgentOnErrorCallback,
   type WorkflowAgentOnFinishCallback,
+  type WorkflowAgentOnStepEndCallback,
   type WorkflowAgentOnStepFinishCallback,
   type StreamTextTransform,
   type TelemetryOptions,

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -26,6 +26,7 @@ import type {
   GenerationSettings,
   PrepareStepCallback,
   WorkflowAgentOnErrorCallback,
+  WorkflowAgentOnStepEndCallback,
   WorkflowAgentOnStepFinishCallback,
   TelemetryOptions,
   WorkflowAgentOnStepStartCallback,
@@ -60,6 +61,7 @@ export async function* streamTextIterator({
   writable,
   model,
   stopConditions,
+  onStepEnd,
   onStepFinish,
   onStepStart,
   onError,
@@ -78,6 +80,8 @@ export async function* streamTextIterator({
   writable?: WritableStream<ModelCallStreamPart<ToolSet>>;
   model: LanguageModel;
   stopConditions?: ModelStopCondition[] | ModelStopCondition;
+  onStepEnd?: WorkflowAgentOnStepEndCallback<any>;
+  /** @deprecated Use `onStepEnd` instead. */
   onStepFinish?: WorkflowAgentOnStepFinishCallback<any>;
   onStepStart?: WorkflowAgentOnStepStartCallback;
   onError?: WorkflowAgentOnErrorCallback;
@@ -448,10 +452,11 @@ export async function* streamTextIterator({
         );
       }
 
-      if (onStepFinish) {
-        await onStepFinish(step);
+      const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
+      if (resolvedOnStepEnd) {
+        await resolvedOnStepEnd(step);
       }
-      await telemetryDispatcher.onStepFinish?.(normalizeStepForTelemetry(step));
+      await telemetryDispatcher.onStepEnd?.(normalizeStepForTelemetry(step));
     } catch (error) {
       if (onError) {
         await onError({ error });

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -814,6 +814,68 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
     });
   });
 
+  describe('onStepEnd', () => {
+    describe('stream', () => {
+      let mockModel: MockLanguageModelV4;
+
+      beforeEach(() => {
+        mockModel = new MockLanguageModelV4({
+          doStream: async () => createSimpleStreamResponse(),
+        });
+      });
+
+      it('should call onStepEnd from constructor and stream method in correct order', async () => {
+        const onStepEndCalls: string[] = [];
+
+        const agent = new WorkflowAgent({
+          model: mockModel,
+          onStepEnd: async () => {
+            onStepEndCalls.push('constructor');
+          },
+        });
+
+        const { writable } = createMockWritable();
+        await agent.stream({
+          messages: [{ role: 'user' as const, content: 'Hello, world!' }],
+          writable,
+          onStepEnd: async () => {
+            onStepEndCalls.push('method');
+          },
+        });
+
+        expect(onStepEndCalls).toEqual(['constructor', 'method']);
+      });
+
+      it('should prefer onStepEnd over deprecated onStepFinish', async () => {
+        const calls: string[] = [];
+
+        const agent = new WorkflowAgent({
+          model: mockModel,
+          onStepEnd: async () => {
+            calls.push('constructor-onStepEnd');
+          },
+          onStepFinish: async () => {
+            calls.push('constructor-onStepFinish');
+          },
+        });
+
+        const { writable } = createMockWritable();
+        await agent.stream({
+          messages: [{ role: 'user' as const, content: 'Hello, world!' }],
+          writable,
+          onStepEnd: async () => {
+            calls.push('method-onStepEnd');
+          },
+          onStepFinish: async () => {
+            calls.push('method-onStepFinish');
+          },
+        });
+
+        expect(calls).toEqual(['constructor-onStepEnd', 'method-onStepEnd']);
+      });
+    });
+  });
+
   describe('onStepFinish', () => {
     describe('stream', () => {
       let mockModel: MockLanguageModelV4;

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -1433,8 +1433,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onToolExecutionEnd: async () => {
                 events.push('onToolExecutionEnd');
               },
-              onStepFinish: async () => {
-                events.push('onStepFinish');
+              onStepEnd: async () => {
+                events.push('onStepEnd');
               },
               onEnd: async () => {
                 events.push('onEnd');
@@ -1454,9 +1454,9 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
           'onStepStart',
           'onToolExecutionStart',
           'onToolExecutionEnd',
-          'onStepFinish',
+          'onStepEnd',
           'onStepStart',
-          'onStepFinish',
+          'onStepEnd',
           'onEnd',
         ]);
       });
@@ -1547,8 +1547,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
             onStart: async () => {
               events.push('global-onStart');
             },
-            onStepFinish: async () => {
-              events.push('global-onStepFinish');
+            onStepEnd: async () => {
+              events.push('global-onStepEnd');
             },
             onEnd: async () => {
               events.push('global-onEnd');
@@ -1584,7 +1584,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
 
         expect(events).toEqual([
           'global-onStart',
-          'global-onStepFinish',
+          'global-onStepEnd',
           'global-onEnd',
         ]);
       });
@@ -1624,8 +1624,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onStart: async () => {
                 events.push('integration-onStart');
               },
-              onStepFinish: async () => {
-                events.push('integration-onStepFinish');
+              onStepEnd: async () => {
+                events.push('integration-onStepEnd');
               },
               onEnd: async () => {
                 events.push('integration-onEnd');
@@ -1644,7 +1644,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
           'agent-onStart',
           'integration-onStart',
           'agent-onStepFinish',
-          'integration-onStepFinish',
+          'integration-onStepEnd',
           'agent-onFinish',
           'integration-onEnd',
         ]);
@@ -1674,7 +1674,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onStart: async () => {
                 throw new Error('integration error');
               },
-              onStepFinish: async () => {
+              onStepEnd: async () => {
                 throw new Error('integration error');
               },
               onEnd: async () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -22,7 +22,7 @@ import {
   type ModelMessage,
   type StepResult,
   type StopCondition,
-  type GenerateTextOnStepFinishCallback,
+  type GenerateTextOnStepEndCallback,
   type ActiveTools,
   type ToolCallRepairFunction,
   type ToolChoice,
@@ -47,13 +47,24 @@ export type { CompatibleLanguageModel } from './types.js';
 
 /**
  * Callback function to be called after each step completes.
- * Alias for the AI SDK's GenerateTextOnStepFinishCallback, using
+ * Alias for the AI SDK's GenerateTextOnStepEndCallback, using
  * WorkflowAgent-consistent naming.
+ */
+export type WorkflowAgentOnStepEndCallback<
+  TTools extends ToolSet = ToolSet,
+  TRuntimeContext extends Context = Context,
+> = GenerateTextOnStepEndCallback<TTools, TRuntimeContext>;
+
+/**
+ * Callback function to be called after each step completes.
+ * Deprecated alias for `WorkflowAgentOnStepEndCallback`.
+ *
+ * @deprecated Use `WorkflowAgentOnStepEndCallback` instead.
  */
 export type WorkflowAgentOnStepFinishCallback<
   TTools extends ToolSet = ToolSet,
   TRuntimeContext extends Context = Context,
-> = GenerateTextOnStepFinishCallback<TTools, TRuntimeContext>;
+> = WorkflowAgentOnStepEndCallback<TTools, TRuntimeContext>;
 
 /**
  * Infer the type of the tools of a workflow agent.
@@ -492,6 +503,13 @@ export type WorkflowAgentOptions<
     /**
      * Callback function to be called after each step completes.
      */
+    onStepEnd?: WorkflowAgentOnStepEndCallback<TTools, TRuntimeContext>;
+
+    /**
+     * Callback function to be called after each step completes.
+     *
+     * @deprecated Use `onStepEnd` instead.
+     */
     onStepFinish?: WorkflowAgentOnStepFinishCallback<TTools, TRuntimeContext>;
 
     /**
@@ -905,6 +923,13 @@ export type WorkflowAgentStreamOptions<
     /**
      * Callback function to be called after each step completes.
      */
+    onStepEnd?: WorkflowAgentOnStepEndCallback<TTools, TRuntimeContext>;
+
+    /**
+     * Callback function to be called after each step completes.
+     *
+     * @deprecated Use `onStepEnd` instead.
+     */
     onStepFinish?: WorkflowAgentOnStepFinishCallback<TTools, TRuntimeContext>;
 
     /**
@@ -1134,7 +1159,7 @@ export class WorkflowAgent<
   private experimentalRepairToolCall?: ToolCallRepairFunction<TBaseTools>;
   private experimentalDownload?: DownloadFunction;
   private prepareStep?: PrepareStepCallback<TBaseTools, TRuntimeContext>;
-  private constructorOnStepFinish?: WorkflowAgentOnStepFinishCallback<
+  private constructorOnStepEnd?: WorkflowAgentOnStepEndCallback<
     TBaseTools,
     TRuntimeContext
   >;
@@ -1170,7 +1195,7 @@ export class WorkflowAgent<
     this.experimentalRepairToolCall = options.experimental_repairToolCall;
     this.experimentalDownload = options.experimental_download;
     this.prepareStep = options.prepareStep;
-    this.constructorOnStepFinish = options.onStepFinish;
+    this.constructorOnStepEnd = options.onStepEnd ?? options.onStepFinish;
     const { onFinish, onEnd = onFinish } = options;
     this.constructorOnEnd = onEnd;
     this.constructorOnStart = options.experimental_onStart;
@@ -1533,11 +1558,11 @@ export class WorkflowAgent<
     };
 
     // Merge constructor + stream callbacks (constructor first, then stream)
-    const mergedOnStepFinish = mergeCallbacks(
-      this.constructorOnStepFinish as
-        | WorkflowAgentOnStepFinishCallback<TTools, TRuntimeContext>
+    const mergedOnStepEnd = mergeCallbacks(
+      this.constructorOnStepEnd as
+        | WorkflowAgentOnStepEndCallback<TTools, TRuntimeContext>
         | undefined,
-      options.onStepFinish,
+      options.onStepEnd ?? options.onStepFinish,
     );
     const mergedOnEnd = mergeCallbacks(
       this.constructorOnEnd as
@@ -1857,7 +1882,7 @@ export class WorkflowAgent<
       prompt: modelPrompt,
       stopConditions: options.stopWhen ?? this.stopWhen,
 
-      onStepFinish: mergedOnStepFinish as any,
+      onStepEnd: mergedOnStepEnd as any,
       onStepStart: mergedOnStepStart as any,
       onError: options.onError,
       prepareStep: (options.prepareStep ??


### PR DESCRIPTION
## Background

as part of our renaming consistency efforts, the `onStepFinish` callback had to be renamed to `onStepEnd`

## Summary

`onStepFinish` -> `onStepEnd`

## Manual Verification



## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)