### PR TITLE
fix(gateway): base64-encode inline Uint8Array data on reasoning-file and tool-result file parts

### DIFF
--- a/.changeset/strange-carrots-hide.md
+++ b/.changeset/strange-carrots-hide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): base64-encode inline Uint8Array data on reasoning-file and tool-result file parts

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1714,4 +1714,106 @@ describe('GatewayLanguageModel', () => {
       });
     });
   });
+
+  describe('file data encoding', () => {
+    function prepareResponse() {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'test-id',
+          created: 1711115037,
+          model: 'test-model',
+          content: { type: 'text', text: '' },
+          finish_reason: 'stop',
+          usage: { prompt_tokens: 4, completion_tokens: 30 },
+        },
+      };
+    }
+
+    it('should base64-encode Uint8Array data in a reasoning-file part', async () => {
+      prepareResponse();
+      const bytes = new Uint8Array([1, 2, 3, 4]);
+      const expectedBase64 = Buffer.from(bytes).toString('base64');
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning-file',
+              data: { type: 'data', data: bytes },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ];
+
+      await createTestModel().doGenerate({ prompt });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.prompt[0].content[0].data).toEqual({
+        type: 'data',
+        data: expectedBase64,
+      });
+    });
+
+    it('should base64-encode Uint8Array data in tool-result file content', async () => {
+      prepareResponse();
+      const bytes = new Uint8Array([5, 6, 7, 8]);
+      const expectedBase64 = Buffer.from(bytes).toString('base64');
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'render',
+              output: {
+                type: 'content',
+                value: [
+                  {
+                    type: 'file',
+                    data: { type: 'data', data: bytes },
+                    mediaType: 'image/png',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+
+      await createTestModel().doGenerate({ prompt });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.prompt[0].content[0].output.value[0].data).toEqual({
+        type: 'data',
+        data: expectedBase64,
+      });
+    });
+
+    it('should not modify reasoning-file data that is a URL', async () => {
+      prepareResponse();
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning-file',
+              data: { type: 'url', url: new URL('https://example.com/a.png') },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ];
+
+      await createTestModel().doGenerate({ prompt });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.prompt[0].content[0].data).toEqual({
+        type: 'url',
+        url: 'https://example.com/a.png',
+      });
+    });
+  });
 });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -1,7 +1,6 @@
 import type {
   LanguageModelV4,
   LanguageModelV4CallOptions,
-  LanguageModelV4FilePart,
   LanguageModelV4StreamPart,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamResult,
@@ -191,30 +190,27 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     }
   }
 
-  private isFilePart(part: unknown) {
-    return (
-      part && typeof part === 'object' && 'type' in part && part.type === 'file'
-    );
-  }
-
   /**
-   * Encodes inline `Uint8Array` file part data to a base64 string in place.
+   * Encodes inline `Uint8Array` file data to a base64 string in place.
    * @param options - The options to encode.
-   * @returns The options with the file parts encoded.
+   * @returns The options with the file data encoded.
    */
   private maybeEncodeFileParts(options: LanguageModelV4CallOptions) {
     for (const message of options.prompt) {
+      if (!Array.isArray(message.content)) {
+        continue;
+      }
       for (const part of message.content) {
-        if (this.isFilePart(part)) {
-          const filePart = part as LanguageModelV4FilePart;
-          if (
-            filePart.data.type === 'data' &&
-            filePart.data.data instanceof Uint8Array
-          ) {
-            filePart.data = {
-              type: 'data',
-              data: Buffer.from(filePart.data.data).toString('base64'),
-            };
+        if (part.type === 'file' || part.type === 'reasoning-file') {
+          part.data = maybeBase64EncodeFileData(part.data);
+        } else if (
+          part.type === 'tool-result' &&
+          part.output.type === 'content'
+        ) {
+          for (const contentPart of part.output.value) {
+            if (contentPart.type === 'file') {
+              contentPart.data = maybeBase64EncodeFileData(contentPart.data);
+            }
           }
         }
       }
@@ -233,4 +229,14 @@ export class GatewayLanguageModel implements LanguageModelV4 {
       'ai-language-model-streaming': String(streaming),
     };
   }
+}
+
+function maybeBase64EncodeFileData<T extends { type: string }>(data: T): T {
+  if (data.type === 'data') {
+    const bytes = (data as { data?: unknown }).data;
+    if (bytes instanceof Uint8Array) {
+      return { ...data, data: Buffer.from(bytes).toString('base64') } as T;
+    }
+  }
+  return data;
 }


### PR DESCRIPTION
## Summary

The gateway client's `maybeEncodeFileParts` (in `gateway-language-model.ts`) only base64-encoded inline `Uint8Array` data on top-level `file` parts. Inline `Uint8Array` data on **`reasoning-file`** parts and on **`file` content inside tool results** was left as a `Uint8Array`.

That's a problem: a `Uint8Array` serializes to a bloated numeric object over JSON (`{"0":1,"1":2,...}`, ~6–10× the base64 size) and doesn't round-trip — the gateway server receives a plain object that matches neither the `string` nor `Uint8Array` branch of its file-data schema. So a `reasoning-file` carrying raw bytes would balloon the request and fail validation server-side.

## Change

Generalize the encoding pass to cover every inline-data carrier in the prompt — `file` parts, `reasoning-file` parts, and `file` content in tool-result `output` — via a single `maybeBase64EncodeFileData` helper. `url` / `text` / `reference` data and already-encoded strings are untouched.

```ts
// before: only `type: 'file'` parts were encoded
// after:  file parts + reasoning-file parts + tool-result file content
```

## Tests

Added a `file data encoding` block to `gateway-language-model.test.ts`:
- `Uint8Array` in a `reasoning-file` part → base64 over the wire
- `Uint8Array` in tool-result `file` content → base64 over the wire
- `reasoning-file` with `{ type: 'url' }` data → left untouched

Full gateway-language-model suite passes (62 tests), typecheck / oxlint / oxfmt clean.

## Context

`reasoning-file` is the new v7 content type; the AI Gateway server recently added support for accepting it in prompts, but the client never learned to encode its bytes (only `file` parts were handled). This closes that gap so binary `reasoning-file` / tool-result file data is transmitted efficiently and correctly.