### PR TITLE
chore: rm export of OutputInterface

### DIFF
--- a/.changeset/orange-apes-call.md
+++ b/.changeset/orange-apes-call.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+chore: rm export of OutputInterface

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -33,7 +33,6 @@ export type {
   OnLanguageModelCallStartCallback,
 } from './language-model-events';
 export * as Output from './output';
-export type { Output as OutputInterface } from './output';
 export type {
   InferCompleteOutput as InferGenerateOutput,
   InferPartialOutput as InferStreamOutput,

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -26,7 +26,7 @@ import type {
   GenerateTextStepStartEvent,
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
-  OutputInterface as Output,
+  Output,
   RerankingModelCallEndEvent,
   RerankEndEvent,
   RerankStartEvent,
@@ -112,7 +112,7 @@ function selectAttributes(
 interface OtelStepStartEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends AISDKContext = AISDKContext,
-  OUTPUT extends Output = Output,
+  OUTPUT extends Output.Output = Output.Output,
 > extends GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   readonly promptMessages?: LanguageModelV4Prompt;
   readonly stepTools?: ReadonlyArray<Record<string, unknown>>;


### PR DESCRIPTION
## Background

a type `OutputInterface` was introduced in https://github.com/vercel/ai/pull/13989 that wasn't really needed. the `ai` package already exported the needed types.

## Summary

rm the export `export type { Output as OutputInterface } from './output';`

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)