### PR TITLE
Serialize undefined tool output to null in UI message chunks

### DIFF
--- a/.changeset/tiny-hornets-cover.md
+++ b/.changeset/tiny-hornets-cover.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Serialize `undefined` tool output to `null` in UI message chunks

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
@@ -4,7 +4,6 @@ import * as z from 'zod/v4';
 import type { GeneratedFile } from '../generate-text';
 import type { TextStreamPart } from '../generate-text/stream-text-result';
 import type { ProviderMetadata } from '../types/provider-metadata';
-import type { UIMessage } from '../ui/ui-messages';
 import { toUIMessageChunk } from './to-ui-message-chunk';
 
 const providerMetadata: ProviderMetadata = {
@@ -501,6 +500,27 @@ describe('toUIMessageChunk', () => {
     expect(
       toUIMessageChunk<Tools>(
         {
+          type: 'tool-result',
+          toolCallId: 'call-undefined',
+          toolName: 'dynamicTool',
+          input: { value: 'input' },
+          output: undefined,
+        },
+        { tools },
+      ),
+    ).toEqual({
+      type: 'tool-output-available',
+      toolCallId: 'call-undefined',
+      // This must be `null` so that we don't lose the property when this is
+      // serialized to JSON. See the following issue for more details:
+      // https://github.com/vercel/ai/issues/15854
+      output: null,
+      dynamic: true,
+    });
+
+    expect(
+      toUIMessageChunk<Tools>(
+        {
           type: 'tool-error',
           toolCallId: 'call-2',
           toolName: 'dynamicTool',
@@ -613,6 +633,8 @@ describe('toUIMessageChunk', () => {
       providerExecuted: true,
     });
   });
+
+  it('maps ');
 
   it('maps error parts through onError', () => {
     const onError = vi.fn(() => 'handled error');

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
@@ -634,8 +634,6 @@ describe('toUIMessageChunk', () => {
     });
   });
 
-  it('maps ');
-
   it('maps error parts through onError', () => {
     const onError = vi.fn(() => 'handled error');
     const error = new Error('boom');

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -276,7 +276,9 @@ export function toUIMessageChunk<
       return {
         type: 'tool-output-available',
         toolCallId: part.toolCallId,
-        output: part.output,
+        // UI stream chunks are serialized as JSON, which drops undefined
+        // properties. Use null so tool outputs always keep the output field.
+        output: part.output === undefined ? null : part.output,
         ...(part.providerExecuted != null
           ? { providerExecuted: part.providerExecuted }
           : {}),


### PR DESCRIPTION
## Background

See https://github.com/vercel/ai/issues/15854.

## Summary

`toUIMessageChunk(...)` now coerces `undefined` tool output to `null` so that the property survives being round-tripped through JSON.

## Manual Verification

I made the change in my own application's `node_modules` and verified that the issue I described in the linked issue was resolved.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This prevents invalid data from being produced in streams, but doesn't do anything to handle bad data that was already produced. If maintainers would be onboard, I'd like to make a few more changes to make this work seamlessly for people:

- Update the `'tool-output-available'` schema in `uiMessageChunkSchema` to have a `.default(null)` on the `output` schema.
- Update the `'output-available'` schemas in `validateUIMessages` to have a `.default(null)` on the `output` schema
- Update `convertToModelMessages` to pre-normalize `undefined` tool output to `null` before `createToolModelOutput` is called.

I'd be happy to increase the scope of this PR to include this, or move it to its own PR.

As it stands, I've already stored the "bad" data in my application's database, so even if this PR is merged, I'd need application-level compatibility with old messages. It'd be great to be able to shift this into `ai` itself, and I bet others could benefit from this too. If nothing else, it'd help ensure a seamless upgrade path for others looking to move from Zod 3 to Zod 4.

## Related Issues

Fixes https://github.com/vercel/ai/issues/15854