### PR TITLE
fix(ai): preserve providerMetadata on smoothStream chunking-loop chunks

### DIFF
--- a/.changeset/fix-smoothstream-providermetadata.md
+++ b/.changeset/fix-smoothstream-providermetadata.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `smoothStream` dropping `providerMetadata` from chunks emitted by its chunking loop. Previously only the final flushed chunk retained `providerMetadata` (e.g. Anthropic extended-thinking signatures), so metadata on intermediate `text-delta`/`reasoning-delta` parts was silently lost. The loop now carries `providerMetadata`, emitted once (mirroring the flush path).

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -1549,6 +1549,41 @@ describe('smoothStream', () => {
       });
     });
 
+    it('should preserve providerMetadata on chunks emitted from the chunking loop', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'reasoning-start', id: '1' },
+        {
+          text: 'hello world ',
+          type: 'reasoning-delta',
+          id: '1',
+          providerMetadata: {
+            anthropic: { signature: 'sig_loop' },
+          },
+        },
+        { type: 'reasoning-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      const reasoningDeltas = events.filter(
+        (e: any) => e?.type === 'reasoning-delta',
+      );
+      const withMetadata = reasoningDeltas.filter(
+        (e: any) => e.providerMetadata != null,
+      );
+
+      // Metadata must survive on a loop-emitted chunk — exactly once (not dropped, not duplicated).
+      expect(withMetadata).toHaveLength(1);
+      expect(withMetadata[0].providerMetadata).toEqual({
+        anthropic: { signature: 'sig_loop' },
+      });
+    });
+
     it('should preserve providerMetadata on reasoning-start for redacted thinking', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         {

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -152,7 +152,15 @@ export function smoothStream<TOOLS extends ToolSet>({
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
+          controller.enqueue({
+            type,
+            text: match,
+            id,
+            ...(providerMetadata != null ? { providerMetadata } : {}),
+          });
+          // Emit providerMetadata once (mirroring flushBuffer) so it is neither
+          // dropped from loop-emitted chunks nor duplicated across them.
+          providerMetadata = undefined;
           buffer = buffer.slice(match.length);
 
           await delay(delayInMs);


### PR DESCRIPTION
Closes #14373.

`smoothStream`'s chunking `while` loop enqueued `{ type, text, id }` without `providerMetadata`, while `flushBuffer` correctly includes it. So when the loop drained the buffer, `providerMetadata` on intermediate `text-delta`/`reasoning-delta` parts (e.g. Anthropic extended-thinking signatures) was silently dropped — only the final flushed chunk retained it.

**Fix:** carry `providerMetadata` on loop-emitted chunks, emitted **once** (then cleared, mirroring `flushBuffer`) so it is neither dropped nor duplicated.

**Test:** added a case where a `reasoning-delta` carrying `providerMetadata` has text with a word boundary (so the chunking loop emits it), asserting exactly one emitted delta retains the metadata. Full `smooth-stream` suite: 35/35 pass, type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
