### PR TITLE
fix(gateway): add caching provider option

### DIFF
--- a/.changeset/gateway-caching-provider-options.md
+++ b/.changeset/gateway-caching-provider-options.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+Add `caching: 'auto'` to Gateway provider options.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -894,6 +894,12 @@ The following gateway provider options are available:
 
   Example: `models: ['openai/gpt-5.4-nano', 'gemini-3-flash-preview']` will try the fallback models in order if the primary model fails.
 
+- **caching** _'auto'_
+
+  Enables AI Gateway prompt caching for the request. Set `caching: 'auto'` to let AI Gateway automatically cache supported prompt content when possible.
+
+  Example: `caching: 'auto'` will enable automatic gateway caching for eligible requests.
+
 - **user** _string_
 
   Optional identifier for the end user on whose behalf the request is being made. This is used for spend tracking and attribution purposes, allowing you to track usage per end-user in your application.

--- a/packages/gateway/src/gateway-provider.test-d.ts
+++ b/packages/gateway/src/gateway-provider.test-d.ts
@@ -1,10 +1,17 @@
 import { createGateway } from './gateway-provider';
+import type { GatewayProviderOptions } from './gateway-provider-options';
 
 createGateway({ apiKey: 'vck_test-key' });
 createGateway({ apiKey: 'vca_test-token' });
 createGateway({ apiKey: 'vca_test-token', teamIdOrSlug: 'vercel' });
 createGateway({ teamIdOrSlug: 'vercel' });
 createGateway({});
+
+const gatewayProviderOptions = {
+  caching: 'auto',
+} satisfies GatewayProviderOptions;
+
+gatewayProviderOptions.caching satisfies 'auto';
 
 // @ts-expect-error token is not a supported Gateway provider setting
 createGateway({ token: 'vca_test-token' });


### PR DESCRIPTION
Fixes #14595

## Summary
- Add `caching: 'auto'` to the AI Gateway provider options schema
- Add a type-level check that `GatewayProviderOptions` accepts the caching option
- Document the caching option in the AI Gateway provider options docs
- Add a changeset for `@ai-sdk/gateway`

## Tests
- `pnpm --filter @ai-sdk/gateway type-check`
- `pnpm --filter @ai-sdk/gateway test:node -- src/gateway-provider.test.ts src/gateway-provider.test-d.ts`
- `git diff --check origin/main..HEAD`
