### PR TITLE
feat(gateway): add GatewayExplicitCacheFallbackError

### DIFF
--- a/.changeset/gateway-explicit-cache-fallback-error.md
+++ b/.changeset/gateway-explicit-cache-fallback-error.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Add `GatewayExplicitCacheFallbackError` so a Gateway refusal to serve an explicit provider cache reference (e.g. Gemini `cachedContent`) on fallback credentials surfaces as a typed, non-retryable error instead of collapsing into `GatewayInternalServerError`.

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -6,6 +6,7 @@ import {
   GatewayRateLimitError,
   GatewayModelNotFoundError,
   GatewayInternalServerError,
+  GatewayExplicitCacheFallbackError,
   GatewayResponseError,
   type GatewayErrorResponse,
 } from './index';
@@ -121,6 +122,28 @@ describe('Valid error responses', () => {
     expect(error).toBeInstanceOf(GatewayInternalServerError);
     expect(error.message).toBe('Internal server error occurred');
     expect(error.statusCode).toBe(500);
+  });
+
+  it('should create GatewayExplicitCacheFallbackError for gemini_explicit_cache_fallback_unsupported type', async () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Explicit cache reference cannot be served by fallback',
+        type: 'gemini_explicit_cache_fallback_unsupported',
+      },
+    };
+
+    const error = await createGatewayErrorFromResponse({
+      response,
+      statusCode: 424,
+    });
+
+    expect(error).toBeInstanceOf(GatewayExplicitCacheFallbackError);
+    expect(error.type).toBe('gemini_explicit_cache_fallback_unsupported');
+    expect(error.message).toBe(
+      'Explicit cache reference cannot be served by fallback',
+    );
+    expect(error.statusCode).toBe(424);
+    expect(error.isRetryable).toBe(false);
   });
 
   it('should create GatewayInternalServerError for unknown error type', async () => {

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -8,6 +8,7 @@ import {
   modelNotFoundParamSchema,
 } from './gateway-model-not-found-error';
 import { GatewayInternalServerError } from './gateway-internal-server-error';
+import { GatewayExplicitCacheFallbackError } from './gateway-explicit-cache-fallback-error';
 import { GatewayResponseError } from './gateway-response-error';
 import {
   lazySchema,
@@ -96,6 +97,13 @@ export async function createGatewayErrorFromResponse({
     }
     case 'internal_server_error':
       return new GatewayInternalServerError({
+        message,
+        statusCode,
+        cause,
+        generationId,
+      });
+    case 'gemini_explicit_cache_fallback_unsupported':
+      return new GatewayExplicitCacheFallbackError({
         message,
         statusCode,
         cause,

--- a/packages/gateway/src/errors/gateway-explicit-cache-fallback-error.ts
+++ b/packages/gateway/src/errors/gateway-explicit-cache-fallback-error.ts
@@ -1,0 +1,38 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayExplicitCacheFallbackError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * An explicit provider cache reference (e.g. Gemini `cachedContent`) could not
+ * be served by fallback credentials and was refused rather than retried
+ * without the cached prompt. Retry without the cache reference and include the
+ * full inline prompt.
+ */
+export class GatewayExplicitCacheFallbackError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'gemini_explicit_cache_fallback_unsupported';
+
+  constructor({
+    message = 'Explicit cache reference cannot be served by fallback credentials',
+    statusCode = 424,
+    cause,
+    generationId,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+    generationId?: string;
+  } = {}) {
+    super({ message, statusCode, cause, generationId });
+  }
+
+  static isInstance(
+    error: unknown,
+  ): error is GatewayExplicitCacheFallbackError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -6,6 +6,7 @@ export {
 export { extractApiCallResponse } from './extract-api-call-response';
 export { GatewayError } from './gateway-error';
 export { GatewayAuthenticationError } from './gateway-authentication-error';
+export { GatewayExplicitCacheFallbackError } from './gateway-explicit-cache-fallback-error';
 export { GatewayInternalServerError } from './gateway-internal-server-error';
 export { GatewayInvalidRequestError } from './gateway-invalid-request-error';
 export {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -36,6 +36,7 @@ export type {
 export {
   GatewayError,
   GatewayAuthenticationError,
+  GatewayExplicitCacheFallbackError,
   GatewayInvalidRequestError,
   GatewayRateLimitError,
   GatewayModelNotFoundError,


### PR DESCRIPTION
## Problem

When the AI Gateway refuses to serve an explicit provider cache reference (e.g. Gemini `cachedContent`) on fallback credentials, it responds with HTTP **424** and `type: "gemini_explicit_cache_fallback_unsupported"`.

The client error mapper in `create-gateway-error.ts` has no `case` for that type, so it falls through to `default` → `GatewayInternalServerError`. That hardcodes `type = "internal_server_error"`, so the real type is lost. Callers see a generic internal-server error and can only distinguish the refusal by the (preserved) 424 status — fragile.

## Fix

Add a dedicated `GatewayExplicitCacheFallbackError`, matching the existing one-class-per-type pattern (`GatewayAuthenticationError`, `GatewayRateLimitError`, etc.), and a `case` for it in `createGatewayErrorFromResponse`.

Now callers can:

```ts
import { GatewayExplicitCacheFallbackError } from '@ai-sdk/gateway';

try {
  await generateText({ model: gateway('google/gemini-2.5-flash'), /* ...cachedContent */ });
} catch (error) {
  if (GatewayExplicitCacheFallbackError.isInstance(error)) {
    // retry without cachedContent + include the full inline prompt
  }
}
```

- `error.type === 'gemini_explicit_cache_fallback_unsupported'`
- `error.statusCode === 424`
- `error.isRetryable === false` (derived from the status code by the base class)

## Notes

- Only adds a new `case` + exported class — the `default` path and all existing behavior/tests are untouched.
- Pairs with the Gateway-side refusal (vercel/ai-gateway#2177), which is what emits this error type.

## Tests

- New case in `create-gateway-error.test.ts` asserting the type, message, 424 status, and `isRetryable: false`.
- Full gateway suite green (429 node + 429 edge), type-check and lint clean.
