### PR TITLE
fix(ai): wrap invalid tool call input in JSON object to prevent API rejection

### DIFF
--- a/.changeset/fix-invalid-tool-call-input-object.md
+++ b/.changeset/fix-invalid-tool-call-input-object.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): wrap unparseable tool call input in a JSON object instead of storing the raw string, preventing API rejections (e.g. Amazon Bedrock) on the next step

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -345,6 +345,35 @@ describe('parseToolCall', () => {
     `);
   });
 
+  it('should wrap unparseable input in a JSON object so API stays valid', async () => {
+    // Regression: previously the raw string was stored as `input`, which causes
+    // providers like Amazon Bedrock to reject the next API call with
+    // "toolUse.input must be a JSON object".
+    const result = await parseToolCall({
+      toolCall: {
+        type: 'tool-call',
+        toolName: 'testTool',
+        toolCallId: '123',
+        input: 'this is not json',
+      },
+      tools: {
+        testTool: tool({
+          inputSchema: z.object({ param1: z.string() }),
+        }),
+      } as const,
+      repairToolCall: undefined,
+      messages: [],
+      instructions: undefined,
+    });
+
+    expect(result.invalid).toBe(true);
+    // input must be a plain object, not a raw string
+    expect(typeof result.input).toBe('object');
+    expect(result.input).toEqual({ rawInvalidInput: 'this is not json' });
+    // error is still surfaced so the model can react
+    expect(result.error).toBeDefined();
+  });
+
   describe('tool call repair', () => {
     it('should invoke repairTool when provided and use its result', async () => {
       const repairToolCall = vi.fn().mockResolvedValue({
@@ -471,7 +500,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -510,7 +541,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -92,9 +92,12 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       });
     }
   } catch (error) {
-    // use parsed input when possible
+    // use parsed input when possible; fall back to a JSON object so the
+    // conversation history remains API-valid (e.g. Bedrock rejects raw strings)
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
     const tool = tools?.[toolCall.toolName];
 
     // TODO AI SDK 6: special invalid tool call parts


### PR DESCRIPTION
Closes #14442

## Root cause

In `packages/ai/src/generate-text/parse-tool-call.ts`, the outer `catch` block that handles all tool-call parse errors contains:

```ts
const parsedInput = await safeParseJSON({ text: toolCall.input });
const input = parsedInput.success ? parsedInput.value : toolCall.input;
//                                                       ^^^^^^^^^^^^^^
//                                              raw string, not a JSON object
```

When a model emits malformed JSON for a tool call's input and `safeParseJSON` fails, the raw string is stored as `input` on the invalid tool-call result. This raw string then flows through `to-response-messages.ts` and `convert-to-language-model-prompt.ts` into the assistant message for the next API step. Providers like Amazon Bedrock require `toolUse.input` to be a JSON **object** (the Bedrock provider casts `input: part.input as JSONObject`), so the API rejects the request with:

> "The format of the value at messages.X.content.Y.toolUse.input is invalid. Provide a json object for the field and try again."

The model never sees the `tool-error` result and has no opportunity to retry.

## Fix

Wrap the fallback in a valid JSON object so conversation history stays API-valid:

```ts
const input = parsedInput.success
  ? parsedInput.value
  : { rawInvalidInput: toolCall.input };
```

The `invalid: true` flag and the original `error` are still surfaced on the tool-call result, so the model can observe the failure and retry.

## Tests

- Updated two existing inline snapshot tests that previously asserted `"input": "invalid json"` (raw string) — they now correctly assert `"input": { "rawInvalidInput": "invalid json" }`.
- Added a new regression test: `'should wrap unparseable input in a JSON object so API stays valid'` — it fails without the fix (raw string returned) and passes with it (wrapped object returned, `invalid` and `error` still set).

Verification: `pnpm --filter ai test:node src/generate-text/parse-tool-call.test.ts` — 22/22 pass with fix, 3/22 fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)