### PR TITLE
fix/fix-json-partial-unicode-escape

### DIFF
--- a/.changeset/fix-json-partial-unicode-escape.md
+++ b/.changeset/fix-json-partial-unicode-escape.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix (ai): `fixJson` now drops incomplete `\uXXXX` unicode escape sequences instead of producing invalid JSON
+
+When a streamed JSON value was truncated in the middle of a unicode escape (e.g. `{"a":"\u12`), `fixJson` previously closed the string off as `{"a":"\u12"}`, which is invalid JSON. `parsePartialJson` then returned `failed-parse` and the partial value was dropped for that chunk. The repaired output is now valid JSON (`{"a":""}`), so partial values continue to stream through.

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -3,6 +3,7 @@ type State =
   | 'FINISH'
   | 'INSIDE_STRING'
   | 'INSIDE_STRING_ESCAPE'
+  | 'INSIDE_STRING_UNICODE_ESCAPE'
   | 'INSIDE_LITERAL'
   | 'INSIDE_NUMBER'
   | 'INSIDE_OBJECT_START'
@@ -28,6 +29,8 @@ export function fixJson(input: string): string {
   const stack: State[] = ['ROOT'];
   let lastValidIndex = -1;
   let literalStart: number | null = null;
+  // Number of hex digits still expected to complete the current \uXXXX escape.
+  let unicodeEscapeRemaining = 0;
 
   function processValueStart(char: string, i: number, swapState: State) {
     {
@@ -260,7 +263,48 @@ export function fixJson(input: string): string {
 
       case 'INSIDE_STRING_ESCAPE': {
         stack.pop();
-        lastValidIndex = i;
+
+        if (char === 'u') {
+          // A unicode escape requires exactly four hex digits (\uXXXX).
+          // Do not advance lastValidIndex yet: if the input ends before all
+          // four digits have arrived, the incomplete escape must be dropped
+          // rather than closed off into invalid JSON (e.g. `"\u12"`).
+          stack.push('INSIDE_STRING_UNICODE_ESCAPE');
+          unicodeEscapeRemaining = 4;
+        } else {
+          lastValidIndex = i;
+        }
+
+        break;
+      }
+
+      case 'INSIDE_STRING_UNICODE_ESCAPE': {
+        const isHexDigit =
+          (char >= '0' && char <= '9') ||
+          (char >= 'a' && char <= 'f') ||
+          (char >= 'A' && char <= 'F');
+
+        if (isHexDigit) {
+          unicodeEscapeRemaining--;
+
+          // Only once all four hex digits are present is the escape valid and
+          // safe to include in the repaired output.
+          if (unicodeEscapeRemaining === 0) {
+            stack.pop();
+            lastValidIndex = i;
+          }
+        } else {
+          // Malformed unicode escape (already-invalid JSON, which fixJson does
+          // not repair). Leave the unicode-escape state; a closing quote still
+          // terminates the string so structural repair stays consistent with
+          // the pre-existing behavior for such inputs.
+          stack.pop();
+
+          if (char === '"') {
+            stack.pop();
+            lastValidIndex = i;
+          }
+        }
 
         break;
       }


### PR DESCRIPTION
`fixJson` repairs partial JSON during streaming so `parsePartialJson` can recover a
value from each incremental chunk (used by `streamObject`, structured output, and
streaming tool-call inputs). It already handles a string truncated on a lone
backslash (`"abc\` → `"abc"`), but it did **not** handle truncation inside a
`\uXXXX` unicode escape. Given input ending after `\u`/`\u1`/`\u12`/`\u123`, it closed
the string with the partial escape in place and produced **invalid JSON**:

```ts
fixJson('{"a":"\\u');   // before: '{"a":"\\u"}'   → JSON.parse throws
fixJson('{"a":"\\u12'); // before: '{"a":"\\u12"}' → JSON.parse throws
```

`parsePartialJson` then returned `failed-parse`, so the partial value was dropped for
that chunk — fields flicker/disappear mid-stream whenever a provider's SSE chunk
boundary lands inside an escaped character (common for emoji/CJK content, which is
streamed as `\uXXXX` surrogate pairs).

## Summary

- Model the unicode escape explicitly in the scanner with a new
  `INSIDE_STRING_UNICODE_ESCAPE` state and a `unicodeEscapeRemaining` hex-digit counter.
- A `\uXXXX` escape is only marked valid once all four hex digits arrive; if the input
  ends earlier, the partial escape is dropped (consistent with the existing
  trailing-backslash repair), so the repaired output is always valid JSON.
- Complete escapes (`"A"`, `"abcሴdef"`) are preserved unchanged, and
  already-invalid inputs (e.g. `{"a":"\u1F"}`) produce byte-for-byte identical output
  to before.

```ts
fixJson('{"a":"\\u');   // after: '{"a":""}'   ✅
fixJson('{"a":"\\u12'); // after: '{"a":""}'   ✅
```

## Manual Verification

```
pnpm --filter ai exec vitest --config vitest.node.config.js --run \
  src/util/fix-json.test.ts src/util/parse-partial-json.test.ts   # 53 passed
```

Additional checks:

- `npx ultracite check packages/ai/src/util/fix-json.ts packages/ai/src/util/fix-json.test.ts` — clean.
- `npx tsc --build packages/ai` — exit 0.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) — n/a, internal util
- [x] A _patch_ changeset for relevant packages has been added (run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

<!-- File the issue from issue.md first, then replace the number below. -->
Fixes #15865
