### PR TITLE
examples(mcp): add TWZRD Agent Intel trust verification example

### DIFF
--- a/examples/mcp/src/twzrd-trust-check/README.md
+++ b/examples/mcp/src/twzrd-trust-check/README.md
@@ -1,0 +1,41 @@
+# TWZRD Agent Intel MCP Example
+
+Demonstrates connecting to [TWZRD Agent Intel](https://intel.twzrd.xyz) — a zero-install
+remote MCP server for trust scoring and x402 payment verification of AI agents on Solana.
+
+## What it shows
+
+1. **Trust scoring** — call `score_agent` to get a 0-100 trust score for any Solana wallet
+2. **Preflight check** — call `preflight_check` before transacting with an unknown agent
+3. **LLM-driven trust gate** — use the AI SDK to let the model decide whether to trust an agent
+
+## Run it
+
+```bash
+cd examples/mcp
+pnpm install
+
+# No API key needed for TWZRD trust scoring
+# Set your OpenAI key for the LLM parts
+export OPENAI_API_KEY=sk-...
+
+pnpm tsx src/twzrd-trust-check/client.ts
+```
+
+## TWZRD MCP config
+
+```json
+{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
+```
+
+## Available tools
+
+| Tool | Description | Paid? |
+|------|-------------|-------|
+| `score_agent(wallet)` | Trust score (0-100) + reputation data | Free |
+| `resolve_agent(wallet)` | Agent identity resolution | Free |
+| `preflight_check(wallet)` | Pre-transaction safety check | Free |
+| `verify_trust_receipt(receipt)` | Verify x402 payment receipt | Free |
+| `get_trust_receipt(wallet)` | Full trust receipt (identity proof) | x402 |
+
+PyPI: `pip install twzrd-agent-intel`

--- a/examples/mcp/src/twzrd-trust-check/client.ts
+++ b/examples/mcp/src/twzrd-trust-check/client.ts
@@ -1,0 +1,64 @@
+import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { generateText, isStepCount } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import 'dotenv/config';
+
+/**
+ * Example: Trust-gated agent interactions using TWZRD Agent Intel.
+ *
+ * TWZRD Agent Intel is a zero-install remote MCP server that provides
+ * trust scoring and x402 payment verification for AI agents on Solana.
+ *
+ * MCP config: {"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
+ */
+
+const TWZRD_MCP_URL = 'https://intel.twzrd.xyz/mcp';
+
+// Example Solana agent wallet to check
+const AGENT_WALLET = 'D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi';
+const TRUST_THRESHOLD = 50;
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(new URL(TWZRD_MCP_URL));
+
+  const mcpClient: MCPClient = await createMCPClient({ transport });
+
+  try {
+    const tools = await mcpClient.tools();
+
+    // Step 1: Score the agent trust using TWZRD tools
+    const { text: trustResult } = await generateText({
+      model: openai('gpt-4o-mini'),
+      tools,
+      stopWhen: isStepCount(3),
+      onStepFinish: async ({ toolResults }) => {
+        console.log(`Tool results: ${JSON.stringify(toolResults, null, 2)}`);
+      },
+      system: `You are a trust verification agent. You have access to TWZRD Agent Intel tools.
+               Use score_agent to check the trust score for a given wallet address.
+               If the trust score is >= ${TRUST_THRESHOLD}, output "TRUSTED: <score>".
+               If the trust score is < ${TRUST_THRESHOLD}, output "UNTRUSTED: <score>".`,
+      prompt: `Check the trust score for this Solana agent wallet: ${AGENT_WALLET}`,
+    });
+
+    console.log(`\nTrust verification result: ${trustResult}`);
+
+    // Step 2: Run preflight check before any transaction
+    const { text: preflightResult } = await generateText({
+      model: openai('gpt-4o-mini'),
+      tools,
+      stopWhen: isStepCount(3),
+      system: 'Use the preflight_check tool to verify if an agent wallet is safe to transact with.',
+      prompt: `Run a preflight check on wallet: ${AGENT_WALLET}`,
+    });
+
+    console.log(`Preflight check result: ${preflightResult}`);
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await mcpClient.close();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds an MCP example demonstrating how to connect to [TWZRD Agent Intel](https://intel.twzrd.xyz) — a zero-install remote MCP server for trust scoring and x402 payment verification of AI agents on Solana.

**Files added:**
- `examples/mcp/src/twzrd-trust-check/client.ts` — working TypeScript client using `@ai-sdk/mcp`
- `examples/mcp/src/twzrd-trust-check/README.md` — usage instructions

## What it demonstrates

1. **Remote MCP connection** — `StreamableHTTPClientTransport` to `https://intel.twzrd.xyz/mcp`
2. **Trust scoring** — call `score_agent` to get a 0-100 trust score for any Solana wallet
3. **Preflight checks** — call `preflight_check` before transacting with an unknown agent
4. **LLM-driven trust gate** — use `generateText` with `stopWhen: isStepCount(3)` to let the model decide whether to trust an agent

## Why this fits here

The `examples/mcp` directory already has `http`, `sse`, `stdio`, `mcp-with-auth` etc. TWZRD represents a production remote MCP server use case — showing how to use a real third-party Streamable HTTP MCP endpoint rather than a local server.

## Running it

```bash
cd examples/mcp
pnpm install
export OPENAI_API_KEY=sk-...
pnpm tsx src/twzrd-trust-check/client.ts
```

No API key needed for TWZRD (free trust scoring). OpenAI key only needed for LLM generation steps.

## TWZRD Agent Intel

- MCP config: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
- PyPI: `pip install twzrd-agent-intel`