### PR TITLE
fix(provider): publish json schema types

### DIFF
--- a/.changeset/fix-provider-json-schema-types.md
+++ b/.changeset/fix-provider-json-schema-types.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider": patch
+---
+
+Publish json-schema type declarations as a provider dependency.

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -32,10 +32,10 @@
     }
   },
   "dependencies": {
+    "@types/json-schema": "7.0.15",
     "json-schema": "^0.4.0"
   },
   "devDependencies": {
-    "@types/json-schema": "7.0.15",
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2824,13 +2824,13 @@ importers:
 
   packages/provider:
     dependencies:
+      '@types/json-schema':
+        specifier: 7.0.15
+        version: 7.0.15
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
     devDependencies:
-      '@types/json-schema':
-        specifier: 7.0.15
-        version: 7.0.15
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19


### PR DESCRIPTION
## Summary

`@ai-sdk/provider` exports `JSONSchema7` from `json-schema` in its published declarations, but `@types/json-schema` is currently only a devDependency. Consumers that typecheck dependencies with `skipLibCheck: false` fail with TS7016 after installing the package.

This moves `@types/json-schema` into the provider package dependencies so the published declaration dependency is installed transitively.

## Verification

- Reproduced in a clean consumer with `typescript@5.9.3` and `@ai-sdk/provider@3.0.8`: `npm exec tsc -- --noEmit` fails on `node_modules/@ai-sdk/provider/dist/index.d.ts` importing `json-schema`.
- Confirmed `npm install @types/json-schema@7.0.15` makes the same consumer typecheck pass.
- `pnpm --filter @ai-sdk/provider type-check`
- `pnpm --filter @ai-sdk/provider build`
- Packed the patched provider tarball and installed it in a fresh consumer without explicitly installing `@types/json-schema`; `npm exec tsc -- --noEmit` passes and `npm ls` shows `@types/json-schema` under `@ai-sdk/provider`.