### PR TITLE
fix(ai): handle partial unicode escapes in fixJson

### DIFF
--- a/packages/ai/src/util/fix-json.test.ts
+++ b/packages/ai/src/util/fix-json.test.ts
@@ -80,6 +80,16 @@ describe('string', () => {
       '"value with unicode \u003C"',
     );
   });
+
+  test('should handle incomplete unicode escape sequences', () => {
+    assert.strictEqual(fixJson('"value with \\u'), '"value with "');
+    assert.strictEqual(fixJson('"value with \\u12'), '"value with "');
+    assert.strictEqual(fixJson('{"value":"text \\u00'), '{"value":"text "}');
+  });
+
+  test('should preserve complete unicode escape sequences', () => {
+    assert.strictEqual(fixJson('"value with \\u003C"'), '"value with \\u003C"');
+  });
 });
 
 describe('array', () => {

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -3,6 +3,7 @@ type State =
   | 'FINISH'
   | 'INSIDE_STRING'
   | 'INSIDE_STRING_ESCAPE'
+  | 'INSIDE_STRING_UNICODE_ESCAPE'
   | 'INSIDE_LITERAL'
   | 'INSIDE_NUMBER'
   | 'INSIDE_OBJECT_START'
@@ -28,6 +29,11 @@ export function fixJson(input: string): string {
   const stack: State[] = ['ROOT'];
   let lastValidIndex = -1;
   let literalStart: number | null = null;
+  let unicodeEscapeDigitCount = 0;
+
+  function isHexDigit(char: string) {
+    return /^[0-9a-fA-F]$/.test(char);
+  }
 
   function processValueStart(char: string, i: number, swapState: State) {
     {
@@ -259,8 +265,29 @@ export function fixJson(input: string): string {
       }
 
       case 'INSIDE_STRING_ESCAPE': {
-        stack.pop();
-        lastValidIndex = i;
+        if (char === 'u') {
+          stack.pop();
+          stack.push('INSIDE_STRING_UNICODE_ESCAPE');
+          unicodeEscapeDigitCount = 0;
+        } else {
+          stack.pop();
+          lastValidIndex = i;
+        }
+
+        break;
+      }
+
+      case 'INSIDE_STRING_UNICODE_ESCAPE': {
+        if (isHexDigit(char)) {
+          unicodeEscapeDigitCount++;
+
+          if (unicodeEscapeDigitCount === 4) {
+            stack.pop();
+            lastValidIndex = i;
+          }
+        } else {
+          stack.pop();
+        }
 
         break;
       }


### PR DESCRIPTION
## Summary
- Track JSON unicode string escapes until all four hex digits are present.
- Drop incomplete \uXXXX escapes from repaired partial JSON instead of emitting invalid JSON.
- Add regression coverage for incomplete and complete unicode escapes.

Closes #15865.

## Validation
- corepack pnpm exec vitest --config vitest.node.config.js --run src/util/fix-json.test.ts
- corepack pnpm exec vitest --config vitest.edge.config.js --run src/util/fix-json.test.ts
- corepack pnpm type-check
- corepack pnpm exec ultracite check packages/ai/src/util/fix-json.ts packages/ai/src/util/fix-json.test.ts