### PR TITLE
chore: update private package readme to refer to AI SDK scoped package name

### DIFF
--- a/tools/konsistent-provider/README.md
+++ b/tools/konsistent-provider/README.md
@@ -1,5 +1,7 @@
 # AI SDK - Konsistent Conventions
 
+_**Preliminary readme file.** Most of this will only be relevant once this becomes a published package._
+
 Reusable [konsistent](https://github.com/vercel-labs/konsistent) conventions for the AI SDK and its providers.
 
 This package serves two purposes:
@@ -9,29 +11,29 @@ This package serves two purposes:
 
 ## Usage in third-party provider packages
 
-Add both `konsistent` and `konsistent-provider` as dev dependencies of your provider package:
+Add both `konsistent` and `@ai-sdk/konsistent-provider` as dev dependencies of your provider package:
 
 ```bash
-pnpm add -D konsistent konsistent-provider
+pnpm add -D konsistent @ai-sdk/konsistent-provider
 ```
 
 Then run `konsistent` against the bundled config, supplying your provider's kebab-case id as the `providerId` placeholder:
 
 ```bash
-konsistent --config-package=konsistent-provider --placeholder=providerId:my-provider
+konsistent --config-package='@ai-sdk/konsistent-provider' --placeholder='providerId:my-provider'
 ```
 
 Replace `my-provider` with the actual kebab-case id you use in your package and source files. This drives the symbol-name and file-name checks (`createMyProvider`, `my-provider-provider.ts`, `MyProviderLanguageModel`, etc.).
 
 ## Usage as a convention library
 
-If you'd rather author your own `konsistent.json` and pull in only the conventions you want, declare `konsistent-provider` as a convention source and reference its conventions by name:
+If you'd rather author your own `konsistent.json` and pull in only the conventions you want, declare `@ai-sdk/konsistent-provider` as a convention source and reference its conventions by name:
 
 ```json
 {
   "version": "v1",
   "conventionSources": {
-    "aisdk": "konsistent-provider"
+    "aisdk": "@ai-sdk/konsistent-provider"
   },
   "conventions": [
     {


### PR DESCRIPTION
## Background

The `konsistent-provider` package is a private AI SDK package that's not published. It contains a preliminary readme referring to a package with that name, but if it was ever going to be published, it would be called `@ai-sdk/konsistent-provider`. We just do not use the `@ai-sdk/` scope for private repo packages.

## Summary

This PR updates the preliminary readme to refer to the eventual package name, not the current _private_ package name.

## Manual Verification

N/A

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15868 