### PR TITLE
fix(ai): normalize undefined tool output chunks

### DIFF
--- a/.changeset/fix-tool-output-undefined.md
+++ b/.changeset/fix-tool-output-undefined.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Normalize undefined tool outputs to null before emitting UI stream chunks.

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
@@ -501,6 +501,24 @@ describe('toUIMessageChunk', () => {
     expect(
       toUIMessageChunk<Tools>(
         {
+          type: 'tool-result',
+          toolCallId: 'call-undefined-output',
+          toolName: 'dynamicTool',
+          input: { value: 'input' },
+          output: undefined,
+        },
+        { tools },
+      ),
+    ).toEqual({
+      type: 'tool-output-available',
+      toolCallId: 'call-undefined-output',
+      output: null,
+      dynamic: true,
+    });
+
+    expect(
+      toUIMessageChunk<Tools>(
+        {
           type: 'tool-error',
           toolCallId: 'call-2',
           toolName: 'dynamicTool',

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -276,7 +276,7 @@ export function toUIMessageChunk<
       return {
         type: 'tool-output-available',
         toolCallId: part.toolCallId,
-        output: part.output,
+        output: part.output ?? null,
         ...(part.providerExecuted != null
           ? { providerExecuted: part.providerExecuted }
           : {}),


### PR DESCRIPTION
## Summary

- Normalize `undefined` tool-result outputs to `null` when converting to `tool-output-available` UI message chunks.
- Keep the emitted UI stream chunk valid after `JSON.stringify`, which otherwise drops `output: undefined`.
- Add a regression test and patch changeset for `ai`.

Fixes #15854.

## Validation

- `npm run validate --silent` in `fixtures/vercel-ai-tool-output-undefined-20260607T204743Z`
  - confirmed `ai@6.0.197` emits a wire payload with no `output` key for `output: undefined`
  - confirmed the same payload shape with `output: null` validates
- `pnpm exec vitest --config packages/ai/vitest.node.config.js --run packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts`
  - 1 file passed
  - 11 tests passed
  - Type errors: none

## Local Limitation

- `pnpm --filter ai type-check` did not complete locally; I terminated it after several minutes with no output.
