### PR TITLE
fix(provider-utils): ignore empty event-source chunks

### DIFF
--- a/.changeset/empty-sse-events.md
+++ b/.changeset/empty-sse-events.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+fix(provider-utils): ignore empty event-source data chunks

--- a/packages/provider-utils/src/parse-json-event-stream.ts
+++ b/packages/provider-utils/src/parse-json-event-stream.ts
@@ -21,8 +21,8 @@ export function parseJsonEventStream<T>({
     .pipeThrough(
       new TransformStream<EventSourceMessage, ParseResult<T>>({
         async transform({ data }, controller) {
-          // ignore the 'DONE' event that e.g. OpenAI sends:
-          if (data === '[DONE]') {
+          // ignore keep-alive events and the 'DONE' event that e.g. OpenAI sends:
+          if (data.trim() === '' || data === '[DONE]') {
             return;
           }
 

--- a/packages/provider-utils/src/response-handler.test.ts
+++ b/packages/provider-utils/src/response-handler.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import {
+  createEventSourceResponseHandler,
   createBinaryResponseHandler,
   createJsonResponseHandler,
   createStatusCodeErrorResponseHandler,
 } from './response-handler';
+import { convertReadableStreamToArray } from './test';
 
 describe('createJsonResponseHandler', () => {
   it('should return both parsed value and rawValue', async () => {
@@ -33,6 +35,39 @@ describe('createJsonResponseHandler', () => {
       age: 30,
     });
     expect(result.rawValue).toEqual(rawData);
+  });
+});
+
+describe('createEventSourceResponseHandler', () => {
+  it('should ignore empty data events', async () => {
+    const rawData = {
+      type: 'message',
+      value: 'ok',
+    };
+
+    const response = new Response(
+      `data:\n\ndata: ${JSON.stringify(rawData)}\n\ndata: [DONE]\n\n`,
+    );
+    const handler = createEventSourceResponseHandler(
+      z.object({
+        type: z.literal('message'),
+        value: z.string(),
+      }),
+    );
+
+    const result = await handler({
+      url: 'test-url',
+      requestBodyValues: {},
+      response,
+    });
+
+    await expect(convertReadableStreamToArray(result.value)).resolves.toEqual([
+      {
+        success: true,
+        value: rawData,
+        rawValue: rawData,
+      },
+    ]);
   });
 });
 

--- a/packages/provider-utils/src/response-handler.test.ts
+++ b/packages/provider-utils/src/response-handler.test.ts
@@ -3,10 +3,12 @@ import { z } from 'zod/v4';
 import { DEFAULT_MAX_DOWNLOAD_SIZE } from './read-response-with-size-limit';
 import {
   createJsonErrorResponseHandler,
+  createEventSourceResponseHandler,
   createBinaryResponseHandler,
   createJsonResponseHandler,
   createStatusCodeErrorResponseHandler,
 } from './response-handler';
+import { convertReadableStreamToArray } from './test';
 
 function createOversizedResponse({
   body = '{}',
@@ -107,6 +109,39 @@ describe('createJsonErrorResponseHandler', () => {
     ).rejects.toThrow('exceeded maximum size');
 
     expect(cancelled()).toBe(true);
+  });
+});
+
+describe('createEventSourceResponseHandler', () => {
+  it('should ignore empty data events', async () => {
+    const rawData = {
+      type: 'message',
+      value: 'ok',
+    };
+
+    const response = new Response(
+      `data:\n\ndata: ${JSON.stringify(rawData)}\n\ndata: [DONE]\n\n`,
+    );
+    const handler = createEventSourceResponseHandler(
+      z.object({
+        type: z.literal('message'),
+        value: z.string(),
+      }),
+    );
+
+    const result = await handler({
+      url: 'test-url',
+      requestBodyValues: {},
+      response,
+    });
+
+    await expect(convertReadableStreamToArray(result.value)).resolves.toEqual([
+      {
+        success: true,
+        value: rawData,
+        rawValue: rawData,
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- ignore empty SSE `data:` events before JSON parsing in `parseJsonEventStream`
- add a regression test through `createEventSourceResponseHandler`
- add a provider-utils patch changeset

## Validation

- `pnpm --filter @ai-sdk/provider build`
- `pnpm test:node response-handler.test.ts --reporter=dot` from `packages/provider-utils`
- `pnpm test:edge response-handler.test.ts --reporter=dot` from `packages/provider-utils`
- `pnpm type-check` from `packages/provider-utils`