### PR TITLE
fix(ai): keep chat finish tied to request

### DIFF
--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -17,6 +17,8 @@ import { lastAssistantMessageIsCompleteWithApprovalResponses } from './last-assi
 import { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
 import type { UIMessage } from './ui-messages';
 
+type TextUIPart = Extract<UIMessage['parts'][number], { type: 'text' }>;
+
 class TestChatState<
   UI_MESSAGE extends UIMessage,
 > implements ChatState<UI_MESSAGE> {
@@ -68,6 +70,33 @@ class TestChat extends AbstractChat<UIMessage> {
 
 function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
+}
+
+function createGatedChunkStream({
+  gate,
+  text,
+}: {
+  gate: Promise<void>;
+  text: string;
+}) {
+  return new ReadableStream<UIMessageChunk>({
+    async start(controller) {
+      await gate;
+
+      controller.enqueue({ type: 'start' });
+      controller.enqueue({ type: 'start-step' });
+      controller.enqueue({ type: 'text-start', id: 'text-1' });
+      controller.enqueue({
+        type: 'text-delta',
+        id: 'text-1',
+        delta: text,
+      });
+      controller.enqueue({ type: 'text-end', id: 'text-1' });
+      controller.enqueue({ type: 'finish-step' });
+      controller.enqueue({ type: 'finish', finishReason: 'stop' });
+      controller.close();
+    },
+  });
 }
 
 const server = createTestServer({
@@ -902,6 +931,64 @@ describe('Chat', () => {
         ]
       `);
     });
+  });
+
+  it('should finish overlapping requests against their own active response', async () => {
+    const firstGate = createResolvablePromise<void>();
+    const secondGate = createResolvablePromise<void>();
+    const onFinish = vi.fn();
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    let sendCount = 0;
+    const transport = {
+      sendMessages: async () => {
+        sendCount++;
+
+        return createGatedChunkStream({
+          gate: sendCount === 1 ? firstGate.promise : secondGate.promise,
+          text: sendCount === 1 ? 'first response' : 'second response',
+        });
+      },
+      reconnectToStream: async () => null,
+    };
+
+    try {
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport,
+        onFinish,
+      });
+
+      const firstRequest = chat.sendMessage({ text: 'first prompt' });
+      await Promise.resolve();
+
+      const secondRequest = chat.sendMessage({ text: 'second prompt' });
+      await Promise.resolve();
+
+      firstGate.resolve(undefined);
+      await firstRequest;
+
+      secondGate.resolve(undefined);
+      await secondRequest;
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(onFinish).toHaveBeenCalledTimes(2);
+      expect(
+        onFinish.mock.calls.map(([event]) => {
+          const message = event.message as UIMessage;
+
+          return message.parts
+            .filter((part): part is TextUIPart => part.type === 'text')
+            .map(part => part.text)
+            .join('');
+        }),
+      ).toEqual(['first response', 'second response']);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('should include the metadata of text message', async () => {

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -650,9 +650,10 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     let isAbort = false;
     let isDisconnect = false;
     let isError = false;
+    let activeResponse: ActiveResponse<UI_MESSAGE> | undefined;
 
     try {
-      const activeResponse = {
+      const response = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
           messageId: this.generateId(),
@@ -660,11 +661,13 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         abortController: new AbortController(),
       } as ActiveResponse<UI_MESSAGE>;
 
-      activeResponse.abortController.signal.addEventListener('abort', () => {
+      activeResponse = response;
+
+      response.abortController.signal.addEventListener('abort', () => {
         isAbort = true;
       });
 
-      this.activeResponse = activeResponse;
+      this.activeResponse = response;
 
       let stream: ReadableStream<UIMessageChunk>;
 
@@ -674,7 +677,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         stream = await this.transport.sendMessages({
           chatId: this.id,
           messages: this.state.messages,
-          abortSignal: activeResponse.abortController.signal,
+          abortSignal: response.abortController.signal,
           metadata,
           headers,
           body,
@@ -692,21 +695,21 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         // serialize the job execution to avoid race conditions:
         this.jobExecutor.run(() =>
           job({
-            state: activeResponse.state,
+            state: response.state,
             write: () => {
               // streaming is set on first write (before it should be "submitted")
               this.setStatus({ status: 'streaming' });
 
               const replaceLastMessage =
-                activeResponse.state.message.id === this.lastMessage?.id;
+                response.state.message.id === this.lastMessage?.id;
 
               if (replaceLastMessage) {
                 this.state.replaceMessage(
                   this.state.messages.length - 1,
-                  activeResponse.state.message,
+                  response.state.message,
                 );
               } else {
-                this.state.pushMessage(activeResponse.state.message);
+                this.state.pushMessage(response.state.message);
               }
             },
           }),
@@ -756,19 +759,23 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.setStatus({ status: 'error', error: err as Error });
     } finally {
       try {
+        const response = activeResponse;
+
         this.onFinish?.({
-          message: this.activeResponse!.state.message,
+          message: response!.state.message,
           messages: this.state.messages,
           isAbort,
           isDisconnect,
           isError,
-          finishReason: this.activeResponse?.state.finishReason,
+          finishReason: response?.state.finishReason,
         });
       } catch (err) {
         console.error(err);
       }
 
-      this.activeResponse = undefined;
+      if (this.activeResponse === activeResponse) {
+        this.activeResponse = undefined;
+      }
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true


### PR DESCRIPTION
## Summary

Fixes #15870.

`AbstractChat.makeRequest` keeps a mutable `this.activeResponse` for the currently streaming request. When two requests overlap, an older request can finish first and clear that field while the newer request is still running. The newer request then reaches `finally` and tries to read `this.activeResponse!.state.message`, which throws and gets logged as a noisy `TypeError`.

This keeps each request's response state in a local `response` reference and only clears `this.activeResponse` if it still points to the same request. That preserves the current shared field for abort/update paths without letting an older request tear down a newer one.

## Test plan

- [x] `pnpm exec oxfmt --check packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts`
- [x] `pnpm exec oxlint packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts`
- [x] `pnpm --filter ai type-check`
- [x] `pnpm test:node -- src/ui/chat.test.ts`
