### PR TITLE
fix(react): resubscribe when chat instance changes

### DIFF
--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -103,30 +103,30 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       'chat' in options ? options.chat : new Chat(optionsWithCallbacks);
   }
 
+  const chat = chatRef.current;
+
   const subscribeToMessages = useCallback(
     (update: () => void) =>
-      chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    // `chatRef.current.id` is required to trigger re-subscription when the chat ID changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [throttleWaitMs, chatRef.current.id],
+      chat['~registerMessagesCallback'](update, throttleWaitMs),
+    [chat, throttleWaitMs],
   );
 
   const messages = useSyncExternalStore(
     subscribeToMessages,
-    () => chatRef.current.messages,
-    () => chatRef.current.messages,
+    () => chat.messages,
+    () => chat.messages,
   );
 
   const status = useSyncExternalStore(
-    chatRef.current['~registerStatusCallback'],
-    () => chatRef.current.status,
-    () => chatRef.current.status,
+    chat['~registerStatusCallback'],
+    () => chat.status,
+    () => chat.status,
   );
 
   const error = useSyncExternalStore(
-    chatRef.current['~registerErrorCallback'],
-    () => chatRef.current.error,
-    () => chatRef.current.error,
+    chat['~registerErrorCallback'],
+    () => chat.error,
+    () => chat.error,
   );
 
   const setMessages = useCallback(
@@ -143,26 +143,26 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
 
   useEffect(() => {
     if (resume) {
-      chatRef.current.resumeStream();
+      chat.resumeStream();
     }
-  }, [resume, chatRef]);
+  }, [resume, chat]);
 
   return {
-    id: chatRef.current.id,
+    id: chat.id,
     messages,
     setMessages,
-    sendMessage: chatRef.current.sendMessage,
-    regenerate: chatRef.current.regenerate,
-    clearError: chatRef.current.clearError,
-    stop: chatRef.current.stop,
+    sendMessage: chat.sendMessage,
+    regenerate: chat.regenerate,
+    clearError: chat.clearError,
+    stop: chat.stop,
     error,
-    resumeStream: chatRef.current.resumeStream,
+    resumeStream: chat.resumeStream,
     status,
     /**
      * @deprecated Use `addToolOutput` instead.
      */
-    addToolResult: chatRef.current.addToolOutput,
-    addToolOutput: chatRef.current.addToolOutput,
-    addToolApprovalResponse: chatRef.current.addToolApprovalResponse,
+    addToolResult: chat.addToolOutput,
+    addToolOutput: chat.addToolOutput,
+    addToolApprovalResponse: chat.addToolApprovalResponse,
   };
 }

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -25,6 +25,35 @@ function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 
+function textMessage(id: string, text: string): UIMessage {
+  return {
+    id,
+    role: 'user',
+    parts: [{ type: 'text', text }],
+  };
+}
+
+function trackMessageSubscriptions(chat: Chat<UIMessage>) {
+  const tracker = {
+    subscribeCount: 0,
+    unsubscribeCount: 0,
+  };
+  const registerMessagesCallback = chat['~registerMessagesCallback'];
+
+  chat['~registerMessagesCallback'] = (onChange, throttleWaitMs) => {
+    tracker.subscribeCount++;
+
+    const unsubscribe = registerMessagesCallback(onChange, throttleWaitMs);
+
+    return () => {
+      tracker.unsubscribeCount++;
+      unsubscribe();
+    };
+  };
+
+  return tracker;
+}
+
 const server = createTestServer({
   '/api/chat': {},
   '/api/chat/123/stream': {},
@@ -84,6 +113,64 @@ describe('use-chat', () => {
         ]);
       });
     });
+  });
+
+  it('should resubscribe when the provided chat instance changes with the same id', async () => {
+    const firstChat = new Chat({
+      id: 'same-id',
+      messages: [textMessage('first-0', 'first chat')],
+    });
+    const secondChat = new Chat({
+      id: 'same-id',
+      messages: [textMessage('second-0', 'second chat')],
+    });
+    const firstTracker = trackMessageSubscriptions(firstChat);
+    const secondTracker = trackMessageSubscriptions(secondChat);
+
+    const TestComponent = () => {
+      const [chat, setChat] = useState(firstChat);
+      const { messages } = useChat({ chat });
+
+      return (
+        <div>
+          <div data-testid="messages">{JSON.stringify(messages)}</div>
+          <button data-testid="swap-chat" onClick={() => setChat(secondChat)} />
+        </div>
+      );
+    };
+
+    const { unmount } = render(<TestComponent />);
+
+    try {
+      expect(screen.getByTestId('messages').textContent).toContain(
+        'first chat',
+      );
+      expect(firstTracker.subscribeCount).toBe(1);
+
+      fireEvent.click(screen.getByTestId('swap-chat'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('messages').textContent).toContain(
+          'second chat',
+        );
+      });
+      await waitFor(() => {
+        expect(firstTracker.unsubscribeCount).toBe(1);
+        expect(secondTracker.subscribeCount).toBe(1);
+      });
+
+      act(() => {
+        secondChat.messages = [textMessage('second-1', 'updated second chat')];
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('messages').textContent).toContain(
+          'updated second chat',
+        );
+      });
+    } finally {
+      unmount();
+    }
   });
 
   describe('data protocol stream', () => {


### PR DESCRIPTION
## Summary

Fixes #15873.

`useChat` recreates `chatRef.current` when callers pass a new `chat` instance, but `subscribeToMessages` only depended on the chat id. If the replacement instance had the same id, `useSyncExternalStore` kept the old subscription and later message updates on the new instance were not observed.

This binds the subscription and snapshots to the current `chat` instance for the render. Same-id replacements now change the subscription function identity, so React unsubscribes from the previous instance and subscribes to the new one.

## Test plan

- [x] `pnpm exec oxfmt --check packages/react/src/use-chat.ts packages/react/src/use-chat.ui.test.tsx`
- [x] `pnpm exec oxlint packages/react/src/use-chat.ts packages/react/src/use-chat.ui.test.tsx`
- [x] `pnpm --filter @ai-sdk/react type-check`
- [x] `pnpm test -- use-chat.ui.test.tsx`
