### PR TITLE
fix(google-vertex): use embedContent for Gemini embeddings

### DIFF
--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -14,11 +14,15 @@ const testValues = ['test text one', 'test text two'];
 const DEFAULT_URL =
   'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-central1/publishers/google/models/textembedding-gecko@001:predict';
 
+const GEMINI_EMBEDDING_2_URL =
+  'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent';
+
 const CUSTOM_URL =
   'https://custom-endpoint.com/models/textembedding-gecko@001:predict';
 
 const server = createTestServer({
   [DEFAULT_URL]: {},
+  [GEMINI_EMBEDDING_2_URL]: {},
   [CUSTOM_URL]: {},
 });
 
@@ -210,6 +214,60 @@ describe('GoogleVertexEmbeddingModel', () => {
           "parameters": {},
         }
       `);
+    });
+
+    it('should use embedContent for gemini-embedding-2', async () => {
+      server.urls[GEMINI_EMBEDDING_2_URL].response = {
+        type: 'json-value',
+        body: {
+          embedding: {
+            values: [0.1, 0.2, 0.3],
+          },
+          usageMetadata: {
+            promptTokenCount: 4,
+          },
+        },
+      };
+
+      const geminiEmbeddingModel = new GoogleVertexEmbeddingModel(
+        'gemini-embedding-2',
+        mockConfig,
+      );
+
+      const result = await geminiEmbeddingModel.doEmbed({
+        values: ['test text one'],
+        providerOptions: { google: mockProviderOptions },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(GEMINI_EMBEDDING_2_URL);
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "content": {
+            "parts": [
+              {
+                "text": "test text one",
+              },
+            ],
+          },
+          "embedContentConfig": {
+            "autoTruncate": false,
+            "outputDimensionality": 768,
+            "taskType": "SEMANTIC_SIMILARITY",
+            "title": "test title",
+          },
+        }
+      `);
+      expect(result.embeddings).toStrictEqual([[0.1, 0.2, 0.3]]);
+      expect(result.usage).toStrictEqual({ tokens: 4 });
+    });
+
+    it('should limit gemini-embedding-2 to one value per call', () => {
+      const geminiEmbeddingModel = new GoogleVertexEmbeddingModel(
+        'gemini-embedding-2',
+        mockConfig,
+      );
+
+      expect(geminiEmbeddingModel.maxEmbeddingsPerCall).toBe(1);
     });
   });
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -23,7 +23,6 @@ import type { GoogleVertexConfig } from './google-vertex-config';
 export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
   readonly specificationVersion = 'v4';
   readonly modelId: GoogleVertexEmbeddingModelId;
-  readonly maxEmbeddingsPerCall = 2048;
   readonly supportsParallelCalls = true;
 
   private readonly config: GoogleVertexConfig;
@@ -44,6 +43,10 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
 
   get provider(): string {
     return this.config.provider;
+  }
+
+  get maxEmbeddingsPerCall(): number {
+    return usesEmbedContentEndpoint(this.modelId) ? 1 : 2048;
   }
 
   constructor(
@@ -99,6 +102,44 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
       this.config.headers ? await resolve(this.config.headers) : undefined,
       headers,
     );
+
+    if (usesEmbedContentEndpoint(this.modelId)) {
+      const {
+        responseHeaders,
+        value: response,
+        rawValue,
+      } = await postJsonToApi({
+        url: `${this.config.baseURL}/models/${this.modelId}:embedContent`,
+        headers: mergedHeaders,
+        body: {
+          content: {
+            parts: [{ text: values[0] }],
+          },
+          embedContentConfig: {
+            outputDimensionality: googleOptions.outputDimensionality,
+            taskType: googleOptions.taskType,
+            title: googleOptions.title,
+            autoTruncate: googleOptions.autoTruncate,
+          },
+        },
+        failedResponseHandler: googleVertexFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(
+          googleVertexEmbedContentResponseSchema,
+        ),
+        abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      return {
+        warnings: [],
+        embeddings: [response.embedding.values],
+        usage:
+          response.usageMetadata?.promptTokenCount == null
+            ? undefined
+            : { tokens: response.usageMetadata.promptTokenCount },
+        response: { headers: responseHeaders, body: rawValue },
+      };
+    }
 
     const url = `${this.config.baseURL}/models/${this.modelId}:predict`;
     const {
@@ -158,3 +199,20 @@ const googleVertexTextEmbeddingResponseSchema = z.object({
     }),
   ),
 });
+
+const googleVertexEmbedContentResponseSchema = z.object({
+  embedding: z.object({
+    values: z.array(z.number()),
+  }),
+  usageMetadata: z
+    .object({
+      promptTokenCount: z.number().optional(),
+    })
+    .optional(),
+});
+
+function usesEmbedContentEndpoint(modelId: GoogleVertexEmbeddingModelId) {
+  return (
+    modelId === 'gemini-embedding-2' || modelId === 'gemini-embedding-2-preview'
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #15853.

`gemini-embedding-2` and `gemini-embedding-2-preview` are Vertex Gemini embedding models that use the `models.embedContent` method. The current Vertex embedding implementation sends every model through `:predict`, so these models fail before returning embeddings.

This routes the Gemini embedding 2 family through `:embedContent`, parses the single-embedding response shape, and reports `maxEmbeddingsPerCall = 1` for those models so callers can split multi-value requests through the normal embedding batching path. Existing `:predict` models keep the old request body and response parsing.

## Test plan

- [x] `pnpm exec oxfmt --check packages/google-vertex/src/google-vertex-embedding-model.ts packages/google-vertex/src/google-vertex-embedding-model.test.ts`
- [x] `pnpm exec oxlint packages/google-vertex/src/google-vertex-embedding-model.ts packages/google-vertex/src/google-vertex-embedding-model.test.ts`
- [x] `pnpm --filter @ai-sdk/google-vertex type-check`
- [x] `pnpm test:node -- src/google-vertex-embedding-model.test.ts`
