### PR TITLE
fix(provider-utils): handle cumulative tool argument chunks

### DIFF
--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2901,6 +2901,72 @@ describe('doStream', () => {
     `);
   });
 
+  it('should handle providers that stream cumulative tool call arguments', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_snapshot","type":"function","function":{"name":"searchGoogle","arguments":"{\\"query\\": \\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"latest"}}]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"latest news\\"}"}}]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'searchGoogle',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    expect(result.filter(event => event.type === 'tool-input-delta')).toEqual([
+      {
+        type: 'tool-input-delta',
+        id: 'call_snapshot',
+        delta: '{"query": "',
+      },
+      {
+        type: 'tool-input-delta',
+        id: 'call_snapshot',
+        delta: 'latest',
+      },
+      {
+        type: 'tool-input-delta',
+        id: 'call_snapshot',
+        delta: ' news"}',
+      },
+    ]);
+    expect(result.find(event => event.type === 'tool-call')).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call_snapshot',
+      toolName: 'searchGoogle',
+      input: '{"query": "latest news"}',
+    });
+  });
+
   it('should stream tool call that is sent in one chunk', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2904,11 +2904,6 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
-          "delta": "",
-          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
-          "type": "tool-input-delta",
-        },
-        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },
@@ -2948,6 +2943,72 @@ describe('doStream', () => {
         },
       ]
     `);
+  });
+
+  it('should handle providers that stream cumulative tool call arguments', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_snapshot","type":"function","function":{"name":"searchGoogle","arguments":"{\\"query\\": \\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"latest"}}]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"latest news\\"}"}}]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-snapshot-args","object":"chat.completion.chunk","created":1711357598,"model":"snapshot-model",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'searchGoogle',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    expect(result.filter(event => event.type === 'tool-input-delta')).toEqual([
+      {
+        type: 'tool-input-delta',
+        id: 'call_snapshot',
+        delta: '{"query": "',
+      },
+      {
+        type: 'tool-input-delta',
+        id: 'call_snapshot',
+        delta: 'latest',
+      },
+      {
+        type: 'tool-input-delta',
+        id: 'call_snapshot',
+        delta: ' news"}',
+      },
+    ]);
+    expect(result.find(event => event.type === 'tool-call')).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call_snapshot',
+      toolName: 'searchGoogle',
+      input: '{"query": "latest news"}',
+    });
   });
 
   it('should stream tool call that is sent in one chunk', async () => {

--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -100,6 +100,47 @@ describe('StreamingToolCallTracker', () => {
       ]);
     });
 
+    it('should handle cumulative argument snapshots', () => {
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
+
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search', arguments: '{"query": "' },
+      });
+
+      parts.length = 0;
+
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: '{"query": "latest' },
+      });
+
+      expect(parts).toEqual([
+        { type: 'tool-input-delta', id: 'call_1', delta: 'latest' },
+      ]);
+
+      parts.length = 0;
+
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: '{"query": "latest news"}' },
+      });
+
+      expect(parts).toEqual([
+        { type: 'tool-input-delta', id: 'call_1', delta: ' news"}' },
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'search',
+          input: '{"query": "latest news"}',
+        },
+      ]);
+    });
+
     it('should handle multiple concurrent tool calls', () => {
       const { parts, controller } = createCollector();
       const tracker = new StreamingToolCallTracker(controller);

--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -149,6 +149,49 @@ describe('StreamingToolCallTracker', () => {
       expect(parts.filter(part => part.type === 'tool-call')).toHaveLength(1);
     });
 
+    it('should handle cumulative argument snapshots', () => {
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
+
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search', arguments: '{"query": "' },
+      });
+
+      parts.length = 0;
+
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: '{"query": "latest' },
+      });
+
+      expect(parts).toEqual([
+        { type: 'tool-input-delta', id: 'call_1', delta: 'latest' },
+      ]);
+
+      parts.length = 0;
+
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: '{"query": "latest news"}' },
+      });
+
+      tracker.flush();
+
+      expect(parts).toEqual([
+        { type: 'tool-input-delta', id: 'call_1', delta: ' news"}' },
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'search',
+          input: '{"query": "latest news"}',
+        },
+      ]);
+    });
+
     it('should handle multiple concurrent tool calls', () => {
       const { parts, controller } = createCollector();
       const tracker = new StreamingToolCallTracker(controller);

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -203,13 +203,24 @@ export class StreamingToolCallTracker<
     }
 
     if (toolCallDelta.function?.arguments != null) {
-      toolCall.function.arguments += toolCallDelta.function.arguments;
+      // Some OpenAI-compatible providers stream cumulative argument snapshots.
+      const argumentsDelta = toolCallDelta.function.arguments.startsWith(
+        toolCall.function.arguments,
+      )
+        ? toolCallDelta.function.arguments.slice(
+            toolCall.function.arguments.length,
+          )
+        : toolCallDelta.function.arguments;
 
-      this.controller.enqueue({
-        type: 'tool-input-delta',
-        id: toolCall.id,
-        delta: toolCallDelta.function.arguments,
-      });
+      toolCall.function.arguments += argumentsDelta;
+
+      if (argumentsDelta.length > 0) {
+        this.controller.enqueue({
+          type: 'tool-input-delta',
+          id: toolCall.id,
+          delta: argumentsDelta,
+        });
+      }
     }
 
     // Check if tool call is complete

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -219,13 +219,24 @@ export class StreamingToolCallTracker<
     }
 
     if (toolCallDelta.function?.arguments != null) {
-      toolCall.function.arguments += toolCallDelta.function.arguments;
+      // Some OpenAI-compatible providers stream cumulative argument snapshots.
+      const argumentsDelta = toolCallDelta.function.arguments.startsWith(
+        toolCall.function.arguments,
+      )
+        ? toolCallDelta.function.arguments.slice(
+            toolCall.function.arguments.length,
+          )
+        : toolCallDelta.function.arguments;
 
-      this.controller.enqueue({
-        type: 'tool-input-delta',
-        id: toolCall.id,
-        delta: toolCallDelta.function.arguments,
-      });
+      toolCall.function.arguments += argumentsDelta;
+
+      if (argumentsDelta.length > 0) {
+        this.controller.enqueue({
+          type: 'tool-input-delta',
+          id: toolCall.id,
+          delta: argumentsDelta,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- handle OpenAI-compatible providers that stream cumulative tool-call argument snapshots instead of suffix deltas
- emit only the new suffix as tool-input-delta while keeping the final tool-call input complete
- add provider-utils and openai-compatible regression coverage for the scenario in #12052

Fixes #12052.

## Tests
- pnpm --filter @ai-sdk/provider-utils build
- cd packages/provider-utils && pnpm exec vitest --config vitest.node.config.js --run src/streaming-tool-call-tracker.test.ts
- cd packages/openai-compatible && pnpm exec vitest --config vitest.node.config.js --run src/chat/openai-compatible-chat-language-model.test.ts