### PR TITLE
fix(openai): default Responses tool strict mode to false

### DIFF
--- a/.changeset/openai-responses-strict-false.md
+++ b/.changeset/openai-responses-strict-false.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Default OpenAI Responses function tools to `strict: false` when tool strict mode is omitted.

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -72,7 +72,7 @@ describe('prepareResponsesTools', () => {
       `);
     });
 
-    it('should not include strict mode when strict is undefined', async () => {
+    it('should default strict mode to false when strict is undefined', async () => {
       const result = await prepareResponsesTools({
         tools: [
           {
@@ -97,6 +97,7 @@ describe('prepareResponsesTools', () => {
                 "properties": {},
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],
@@ -163,6 +164,7 @@ describe('prepareResponsesTools', () => {
                 "properties": {},
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],
@@ -414,6 +416,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -798,6 +801,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -1504,6 +1508,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -1639,6 +1644,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -1728,6 +1734,7 @@ describe('prepareResponsesTools', () => {
                 ],
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -72,7 +72,7 @@ describe('prepareResponsesTools', () => {
       `);
     });
 
-    it('should not include strict mode when strict is undefined', async () => {
+    it('should default strict mode to false when strict is undefined', async () => {
       const result = await prepareResponsesTools({
         tools: [
           {
@@ -97,6 +97,7 @@ describe('prepareResponsesTools', () => {
                 "properties": {},
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],
@@ -163,6 +164,7 @@ describe('prepareResponsesTools', () => {
                 "properties": {},
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],
@@ -414,6 +416,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -804,6 +807,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -1510,6 +1514,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -1683,6 +1688,7 @@ describe('prepareResponsesTools', () => {
                 },
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
             {
@@ -1772,6 +1778,7 @@ describe('prepareResponsesTools', () => {
                 ],
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],
@@ -1872,6 +1879,7 @@ describe('prepareResponsesTools', () => {
                     ],
                     "type": "object",
                   },
+                  "strict": false,
                   "type": "function",
                 },
                 {
@@ -1911,6 +1919,7 @@ describe('prepareResponsesTools', () => {
                 ],
                 "type": "object",
               },
+              "strict": false,
               "type": "function",
             },
           ],
@@ -2095,6 +2104,7 @@ describe('prepareResponsesTools', () => {
             required: ['sku'],
             additionalProperties: false,
           },
+          strict: false,
           allowed_callers: ['programmatic'],
           output_schema: {
             type: 'object',

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -83,7 +83,7 @@ export async function prepareResponsesTools({
           name: tool.name,
           description: tool.description,
           parameters: tool.inputSchema,
-          ...(tool.strict != null ? { strict: tool.strict } : {}),
+          strict: tool.strict ?? false,
           ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
         });
         break;

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -428,7 +428,7 @@ function prepareFunctionTool({
     name: tool.name,
     description: tool.description,
     parameters: tool.inputSchema,
-    ...(tool.strict != null ? { strict: tool.strict } : {}),
+    strict: tool.strict ?? false,
     ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
     ...(options?.allowedCallers != null
       ? { allowed_callers: options.allowedCallers }


### PR DESCRIPTION
## Summary

OpenAI Responses function tools currently omit the wire-level `strict` field when an AI SDK tool does not set `strict`.

OpenAI's Responses API treats omitted function-tool strictness differently from Chat Completions: omitted `strict` can trigger Responses-side strict schema normalization, while explicit `strict: false` opts out. That matches the direct OpenAI half of #11869, where optional tool parameters are populated as empty strings unless the user explicitly sets `strict: false`.

This PR makes the OpenAI Responses provider align with AI SDK's core tool docs: tool strict mode is disabled unless a tool opts in with `strict: true`.

## Changes

- Default OpenAI Responses function tools to `strict: false` when `tool.strict` is undefined.
- Preserve explicit `strict: true` and `strict: false`.
- Update existing Responses tool preparation snapshots.
- Add a patch changeset for `@ai-sdk/openai`.

## Validation

- `corepack pnpm exec vitest --config vitest.node.config.js --run src/responses/openai-responses-prepare-tools.test.ts`
- `corepack pnpm exec vitest --config vitest.node.config.js --run src/responses/openai-responses-language-model.test.ts`
- `corepack pnpm exec vitest --config vitest.edge.config.js --run src/responses/openai-responses-prepare-tools.test.ts`
- `corepack pnpm --filter @ai-sdk/openai type-check`

## Notes

This targets the direct OpenAI Responses SDK request shape. #11869 also reports that AI Gateway still behaves strictly even when `strict: false` is set, which may require Gateway-side handling beyond this provider patch.

OpenAI docs reference: https://platform.openai.com/docs/guides/function-calling?api-mode=responses

Addresses the direct OpenAI Responses portion of #11869.
