### PR TITLE
fix(provider/amazon-bedrock): expose request body metadata

### DIFF
--- a/.changeset/bedrock-request-body-metadata.md
+++ b/.changeset/bedrock-request-body-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Expose request body metadata from Bedrock chat generation and streaming results.

--- a/packages/amazon-bedrock/src/__snapshots__/amazon-bedrock-chat-language-model.test.ts.snap
+++ b/packages/amazon-bedrock/src/__snapshots__/amazon-bedrock-chat-language-model.test.ts.snap
@@ -44,6 +44,29 @@ There are 3 r's.",
       },
     },
   },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
+    },
+  },
   "response": {
     "headers": {
       "content-length": "865",
@@ -105,6 +128,29 @@ There are **3** "r"s in "strawberry."",
       "usage": {
         "cacheWriteInputTokens": 0,
       },
+    },
+  },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
     },
   },
   "response": {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -270,6 +270,17 @@ describe('doStream', () => {
         }
       `);
     });
+
+    it('should expose the request body', async () => {
+      const result = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(result.request?.body).toEqual(
+        await server.calls[0].requestBodyJson,
+      );
+    });
   });
 
   describe('reasoning', () => {
@@ -3288,6 +3299,16 @@ describe('doGenerate', () => {
           "test-header": "test-value",
         }
       `);
+    });
+
+    it('should expose the request body', async () => {
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.request?.body).toEqual(
+        await server.calls[0].requestBodyJson,
+      );
     });
   });
 

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -619,6 +619,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
         raw: response.stopReason ?? undefined,
       },
       usage: convertAmazonBedrockUsage(response.usage),
+      request: { body: args },
       response: {
         id: responseHeaders?.['x-amzn-requestid'] ?? undefined,
         timestamp:
@@ -1043,7 +1044,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           },
         }),
       ),
-      // TODO request?
+      request: { body: args },
       response: { headers: responseHeaders },
     };
   }


### PR DESCRIPTION
## Summary

Closes #13927.

This exposes the Bedrock Converse request body through the standard `request.body` metadata returned by both `doGenerate()` and `doStream()`.

The Bedrock provider already passes `args` as the request body to the Converse API, but it did not return that body in the provider result. This matches the existing `LanguageModelV4` request metadata contract and the behavior of other providers.

This does not add new logging; it only returns caller-visible request metadata already supported by the provider interface.

## Test Plan

- `pnpm vitest --config vitest.node.config.js --run src/amazon-bedrock-chat-language-model.test.ts`
- `pnpm --filter @ai-sdk/amazon-bedrock test:node`
- `pnpm --filter @ai-sdk/amazon-bedrock test:edge`
- `pnpm --filter @ai-sdk/amazon-bedrock type-check`
- `pnpm --filter @ai-sdk/amazon-bedrock build`
- `git diff --check`
