### PR TITLE
feat(openai): add namespaces for tool definitions

### DIFF
--- a/.changeset/odd-toys-fetch.md
+++ b/.changeset/odd-toys-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(openai): add namespaces for tool definitions

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1058,6 +1058,52 @@ In hosted mode, the model internally searches the deferred tools, loads the rele
 proceeds to call them — all within a single response. The `tool_search_call` and
 `tool_search_output` items appear in the response with `execution: 'server'` and `call_id: null`.
 
+##### Namespaces
+
+Use `providerOptions.openai.namespace` to group related function tools for OpenAI.
+The SDK keeps each tool executable as a normal AI SDK tool, but serializes grouped
+tools as OpenAI `namespace` entries in the request:
+
+```ts
+const crmNamespace = {
+  name: 'crm',
+  description: 'CRM tools for customer lookup and order management.',
+};
+
+const result = await generateText({
+  model: openai.responses('gpt-5.4'),
+  prompt: 'List open orders for customer cust_123.',
+  tools: {
+    toolSearch: openai.tools.toolSearch(),
+
+    get_customer_profile: tool({
+      description: 'Fetch a customer profile by customer ID.',
+      inputSchema: z.object({ customer_id: z.string() }),
+      execute: async ({ customer_id }) => ({ customer_id }),
+      providerOptions: {
+        openai: { namespace: crmNamespace },
+      },
+    }),
+
+    list_open_orders: tool({
+      description: 'List open orders for a customer ID.',
+      inputSchema: z.object({ customer_id: z.string() }),
+      execute: async ({ customer_id }) => ({ customer_id, orders: [] }),
+      providerOptions: {
+        openai: {
+          namespace: crmNamespace,
+          deferLoading: true,
+        },
+      },
+    }),
+  },
+});
+```
+
+Tools in the same namespace must use the same namespace `name` and `description`.
+For best results with tool search, keep namespace descriptions concise and put
+detailed usage guidance on the individual function tools.
+
 ##### Client-Executed Tool Search
 
 Use client-executed tool search when tool discovery depends on runtime state — for example,

--- a/examples/ai-functions/src/generate-text/openai/responses-tool-search-namespace.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-tool-search-namespace.ts
@@ -1,0 +1,70 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool, isStepCount } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const crmNamespace = {
+  name: 'crm',
+  description: 'CRM tools for customer lookup and order management.',
+};
+
+run(async () => {
+  const result = await generateText({
+    model: openai.responses('gpt-5.4'),
+    prompt:
+      'Look up customer cust_123 and list any open orders for that customer.',
+    stopWhen: isStepCount(10),
+    onStepFinish: step => {
+      console.log(`\n=== Step Content ===`);
+      console.dir(step.content, { depth: Infinity });
+      console.log(`\n=== Step Response ===`);
+      console.dir(step.response.body, { depth: Infinity });
+    },
+    tools: {
+      toolSearch: openai.tools.toolSearch(),
+
+      get_customer_profile: tool({
+        description: 'Fetch a customer profile by customer ID.',
+        inputSchema: z.object({
+          customer_id: z.string().describe('The customer ID to look up.'),
+        }),
+        execute: async ({ customer_id }) => ({
+          customer_id,
+          name: 'Jane Doe',
+          tier: 'enterprise',
+        }),
+        providerOptions: {
+          openai: {
+            namespace: crmNamespace,
+          },
+        },
+      }),
+
+      list_open_orders: tool({
+        description: 'List open orders for a customer ID.',
+        inputSchema: z.object({
+          customer_id: z.string().describe('The customer ID to look up.'),
+        }),
+        execute: async ({ customer_id }) => ({
+          customer_id,
+          orders: [
+            {
+              order_id: 'order_456',
+              status: 'processing',
+              total: '$129.99',
+            },
+          ],
+        }),
+        providerOptions: {
+          openai: {
+            namespace: crmNamespace,
+            deferLoading: true,
+          },
+        },
+      }),
+    },
+  });
+
+  console.log('\n=== Final Result ===');
+  console.log('Text:', result.text);
+});

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -286,14 +286,22 @@ export type OpenAIResponsesFileSearchToolCompoundFilter = {
   >;
 };
 
+export type OpenAIResponsesFunctionTool = {
+  type: 'function';
+  name: string;
+  description: string | undefined;
+  parameters: JSONSchema7;
+  strict?: boolean;
+  defer_loading?: boolean;
+};
+
 export type OpenAIResponsesTool =
+  | OpenAIResponsesFunctionTool
   | {
-      type: 'function';
+      type: 'namespace';
       name: string;
-      description: string | undefined;
-      parameters: JSONSchema7;
-      strict?: boolean;
-      defer_loading?: boolean;
+      description: string;
+      tools: Array<OpenAIResponsesFunctionTool>;
     }
   | {
       type: 'apply_patch';

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1734,6 +1734,185 @@ describe('prepareResponsesTools', () => {
         }
       `);
     });
+
+    it('should group function tools by OpenAI namespace provider option', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.tool_search',
+            name: 'toolSearch',
+            args: {},
+          },
+          {
+            type: 'function',
+            name: 'get_customer_profile',
+            description: 'Fetch a customer profile by customer ID.',
+            inputSchema: {
+              type: 'object',
+              properties: { customer_id: { type: 'string' } },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            providerOptions: {
+              openai: {
+                namespace: {
+                  name: 'crm',
+                  description:
+                    'CRM tools for customer lookup and order management.',
+                },
+              },
+            },
+          },
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the current weather',
+            inputSchema: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+              additionalProperties: false,
+            },
+          },
+          {
+            type: 'function',
+            name: 'list_open_orders',
+            description: 'List open orders for a customer ID.',
+            inputSchema: {
+              type: 'object',
+              properties: { customer_id: { type: 'string' } },
+              required: ['customer_id'],
+              additionalProperties: false,
+            },
+            strict: true,
+            providerOptions: {
+              openai: {
+                deferLoading: true,
+                namespace: {
+                  name: 'crm',
+                  description:
+                    'CRM tools for customer lookup and order management.',
+                },
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "type": "tool_search",
+            },
+            {
+              "description": "CRM tools for customer lookup and order management.",
+              "name": "crm",
+              "tools": [
+                {
+                  "description": "Fetch a customer profile by customer ID.",
+                  "name": "get_customer_profile",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "customer_id": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "customer_id",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "function",
+                },
+                {
+                  "defer_loading": true,
+                  "description": "List open orders for a customer ID.",
+                  "name": "list_open_orders",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "customer_id": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "customer_id",
+                    ],
+                    "type": "object",
+                  },
+                  "strict": true,
+                  "type": "function",
+                },
+              ],
+              "type": "namespace",
+            },
+            {
+              "description": "Get the current weather",
+              "name": "get_weather",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "location": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "location",
+                ],
+                "type": "object",
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should reject conflicting descriptions for the same OpenAI namespace', async () => {
+      await expect(
+        prepareResponsesTools({
+          tools: [
+            {
+              type: 'function',
+              name: 'get_customer_profile',
+              description: 'Fetch a customer profile by customer ID.',
+              inputSchema: { type: 'object', properties: {} },
+              providerOptions: {
+                openai: {
+                  namespace: {
+                    name: 'crm',
+                    description: 'CRM tools.',
+                  },
+                },
+              },
+            },
+            {
+              type: 'function',
+              name: 'list_open_orders',
+              description: 'List open orders for a customer ID.',
+              inputSchema: { type: 'object', properties: {} },
+              providerOptions: {
+                openai: {
+                  namespace: {
+                    name: 'crm',
+                    description: 'Different CRM tools.',
+                  },
+                },
+              },
+            },
+          ],
+          toolChoice: undefined,
+        }),
+      ).rejects.toThrow(
+        'conflicting descriptions for OpenAI tool namespace "crm"',
+      );
+    });
   });
 
   describe('allowedTools provider option', () => {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -1,6 +1,7 @@
 import {
   UnsupportedFunctionalityError,
   type LanguageModelV4CallOptions,
+  type LanguageModelV4FunctionTool,
   type SharedV4ProviderReference,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
@@ -18,7 +19,18 @@ import { shellArgsSchema } from '../tool/shell';
 import { toolSearchArgsSchema } from '../tool/tool-search';
 import { webSearchArgsSchema } from '../tool/web-search';
 import { webSearchPreviewArgsSchema } from '../tool/web-search-preview';
-import type { OpenAIResponsesTool } from './openai-responses-api';
+import type {
+  OpenAIResponsesFunctionTool,
+  OpenAIResponsesTool,
+} from './openai-responses-api';
+
+type OpenAIToolOptions = {
+  deferLoading?: boolean;
+  namespace?: {
+    name: string;
+    description: string;
+  };
+};
 
 export async function prepareResponsesTools({
   tools,
@@ -67,6 +79,10 @@ export async function prepareResponsesTools({
   }
 
   const openaiTools: Array<OpenAIResponsesTool> = [];
+  const namespaceTools = new Map<
+    string,
+    Extract<OpenAIResponsesTool, { type: 'namespace' }>
+  >();
   const resolvedCustomProviderToolNames =
     customProviderToolNames ?? new Set<string>();
 
@@ -74,18 +90,36 @@ export async function prepareResponsesTools({
     switch (tool.type) {
       case 'function': {
         const openaiOptions = tool.providerOptions?.openai as
-          | { deferLoading?: boolean }
+          | OpenAIToolOptions
           | undefined;
-        const deferLoading = openaiOptions?.deferLoading;
-
-        openaiTools.push({
-          type: 'function',
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.inputSchema,
-          ...(tool.strict != null ? { strict: tool.strict } : {}),
-          ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
+        const openaiFunctionTool = prepareFunctionTool({
+          tool,
+          options: openaiOptions,
         });
+        const namespace = openaiOptions?.namespace;
+
+        if (namespace == null) {
+          openaiTools.push(openaiFunctionTool);
+        } else {
+          let namespaceTool = namespaceTools.get(namespace.name);
+
+          if (namespaceTool == null) {
+            namespaceTool = {
+              type: 'namespace',
+              name: namespace.name,
+              description: namespace.description,
+              tools: [],
+            };
+            namespaceTools.set(namespace.name, namespaceTool);
+            openaiTools.push(namespaceTool);
+          } else if (namespaceTool.description !== namespace.description) {
+            throw new UnsupportedFunctionalityError({
+              functionality: `conflicting descriptions for OpenAI tool namespace "${namespace.name}"`,
+            });
+          }
+
+          namespaceTool.tools.push(openaiFunctionTool);
+        }
         break;
       }
       case 'provider': {
@@ -355,6 +389,25 @@ export async function prepareResponsesTools({
       });
     }
   }
+}
+
+function prepareFunctionTool({
+  tool,
+  options,
+}: {
+  tool: LanguageModelV4FunctionTool;
+  options: OpenAIToolOptions | undefined;
+}): OpenAIResponsesFunctionTool {
+  const deferLoading = options?.deferLoading;
+
+  return {
+    type: 'function',
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.inputSchema,
+    ...(tool.strict != null ? { strict: tool.strict } : {}),
+    ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
+  };
 }
 
 function mapShellEnvironment(environment: {


### PR DESCRIPTION
## Background

OpenAI for a while now has had the feature to group tools/functions in a `namespace` - https://developers.openai.com/api/docs/guides/function-calling#defining-namespaces

this PR adds support for it in the AI SDK 

## Summary

- changed the api structure to support namespace tools definition shape
- namespaces can be defined via `providerOptions.openai.namespace `

## Manual Verification

- verified by running the example `examples/ai-functions/src/generate-text/openai/responses-tool-search-namespace.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)