### PR TITLE
[codex] Add xAI text-to-speech support

### DIFF
--- a/.changeset/xai-speech-to-text.md
+++ b/.changeset/xai-speech-to-text.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Add xAI speech-to-text transcription support.

--- a/.changeset/xai-text-to-speech.md
+++ b/.changeset/xai-text-to-speech.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): add text-to-speech support

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -226,5 +226,6 @@ try {
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
+| [xAI](/providers/ai-sdk-providers/xai#transcription-models)               | `default`                |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -226,6 +226,6 @@ try {
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
-| [xAI](/providers/ai-sdk-providers/xai#transcription-models)               | `default`                |
+| [xAI](/providers/ai-sdk-providers/xai#transcription-models)                     | `default`                |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -172,5 +172,6 @@ try {
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-pro-tts`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-flash-lite-preview-tts` |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-3.1-flash-tts-preview`      |
+| [xAI](/providers/ai-sdk-providers/xai#speech-models)                     | `default`                           |
 
 Above are a small subset of the speech models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -638,6 +638,94 @@ const result = await generateSpeech({
 | --------- | ------------------- | ------------------- | -------------------------- |
 | `default` | <Check size={18} /> | <Check size={18} /> | mp3, wav, pcm, mulaw, alaw |
 
+## Transcription Models
+
+You can create models that call the [xAI Speech to Text API](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text)
+using the `.transcription()` factory method. xAI's batch transcription endpoint
+does not require a model identifier.
+
+```ts
+const model = xai.transcription();
+```
+
+Use xAI transcription models with the `transcribe` function:
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+
+const result = await transcribe({
+  model: xai.transcription(),
+  audio: await readFile('meeting.mp3'),
+});
+```
+
+### Provider Options
+
+You can pass xAI-specific controls using `providerOptions.xai`:
+
+```ts
+import { xai, type XaiTranscriptionModelOptions } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+
+const result = await transcribe({
+  model: xai.transcription(),
+  audio: await readFile('meeting.mp3'),
+  providerOptions: {
+    xai: {
+      language: 'en',
+      format: true,
+      keyterm: ['AI SDK', 'Grok'],
+      diarize: true,
+    } satisfies XaiTranscriptionModelOptions,
+  },
+});
+```
+
+- **audioFormat** _`pcm` | `mulaw` | `alaw`_
+
+  Audio encoding for raw, headerless input audio.
+
+- **sampleRate** _8000 | 16000 | 22050 | 24000 | 44100 | 48000_
+
+  Sample rate of the input audio in Hz.
+
+- **language** _string_
+
+  Language code used for inverse text normalization.
+
+- **format** _boolean_
+
+  Enables inverse text normalization. Requires `language`.
+
+- **multichannel** _boolean_
+
+  Enables per-channel transcription for interleaved multichannel audio.
+
+- **channels** _2 | 3 | 4 | 5 | 6 | 7 | 8_
+
+  Number of interleaved audio channels.
+
+- **diarize** _boolean_
+
+  Enables speaker diarization.
+
+- **keyterm** _string | string[]_
+
+  One or more terms to bias transcription toward.
+
+- **fillerWords** _boolean_
+
+  Includes filler words such as `uh` and `um` in the transcript.
+
+### Model Capabilities
+
+| Model     | Word Timestamps     | Diarization         | Multichannel        |
+| --------- | ------------------- | ------------------- | ------------------- |
+| `default` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
 ## Image Models
 
 You can create xAI image models using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -534,6 +534,110 @@ The following provider options are available:
   can also pass any available provider model ID as a string if needed.
 </Note>
 
+## Speech Models
+
+You can create models that call the [xAI Text to Speech API](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech)
+using the `.speech()` factory method. xAI's text-to-speech endpoint does not
+require a model identifier.
+
+```ts
+const model = xai.speech();
+```
+
+Use xAI speech models with the `generateSpeech` function:
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+
+const result = await generateSpeech({
+  model: xai.speech(),
+  text: 'Hello from the AI SDK!',
+  voice: 'ara',
+  language: 'en',
+  outputFormat: 'mp3',
+  speed: 1.1,
+});
+```
+
+### Supported Parameters
+
+- **text** _string_ (required)
+
+  Text to synthesize. You can include xAI speech tags such as `[pause]`,
+  `[laugh]`, or `<whisper>...</whisper>` directly in the text.
+
+- **voice** _string_
+
+  The xAI voice ID. Defaults to `'eve'`. Built-in voice IDs are `'eve'`,
+  `'ara'`, `'rex'`, `'sal'`, and `'leo'`; custom voice IDs are also accepted.
+
+- **language** _string_
+
+  A BCP-47 language code or `'auto'` for automatic detection. Defaults to
+  `'auto'` when omitted.
+
+- **speed** _number_
+
+  Speech rate multiplier from `0.7` to `1.5`.
+
+- **outputFormat** _string_
+
+  The audio codec to generate. Supported values are `'mp3'`, `'wav'`, `'pcm'`,
+  `'mulaw'`, and `'alaw'`. Defaults to `'mp3'`.
+
+<Note>
+  xAI does not expose a separate `instructions` field for text-to-speech. Use
+  speech tags in `text` to control expressive delivery.
+</Note>
+
+### Provider Options
+
+You can pass xAI-specific controls using `providerOptions.xai`:
+
+```ts
+import { xai, type XaiSpeechModelOptions } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+
+const result = await generateSpeech({
+  model: xai.speech(),
+  text: 'A high fidelity narration sample.',
+  outputFormat: 'mp3',
+  providerOptions: {
+    xai: {
+      sampleRate: 44100,
+      bitRate: 192000,
+      optimizeStreamingLatency: 1,
+      textNormalization: true,
+    } satisfies XaiSpeechModelOptions,
+  },
+});
+```
+
+- **sampleRate** _8000 | 16000 | 22050 | 24000 | 44100 | 48000_
+
+  Sample rate of the output audio in Hz.
+
+- **bitRate** _32000 | 64000 | 96000 | 128000 | 192000_
+
+  MP3 bit rate in bits per second. Only applies when `outputFormat` is
+  `'mp3'`.
+
+- **optimizeStreamingLatency** _0 | 1 | 2_
+
+  Latency optimization level. Higher values reduce time to first audio with a
+  quality tradeoff at chunk boundaries.
+
+- **textNormalization** _boolean_
+
+  Whether to normalize written-form input text before synthesizing speech.
+
+### Model Capabilities
+
+| Model     | Language            | Speed               | Output Formats             |
+| --------- | ------------------- | ------------------- | -------------------------- |
+| `default` | <Check size={18} /> | <Check size={18} /> | mp3, wav, pcm, mulaw, alaw |
+
 ## Image Models
 
 You can create xAI image models using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).

--- a/examples/ai-functions/src/generate-speech/xai/basic.ts
+++ b/examples/ai-functions/src/generate-speech/xai/basic.ts
@@ -1,0 +1,17 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: xai.speech(),
+    text: 'Hello from the AI SDK!',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/generate-speech/xai/output-format.ts
+++ b/examples/ai-functions/src/generate-speech/xai/output-format.ts
@@ -1,0 +1,27 @@
+import { xai, type XaiSpeechModelOptions } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: xai.speech(),
+    text: 'A high fidelity narration sample generated with xAI.',
+    voice: 'rex',
+    language: 'en',
+    outputFormat: 'mp3',
+    providerOptions: {
+      xai: {
+        sampleRate: 44100,
+        bitRate: 192000,
+        textNormalization: true,
+      } satisfies XaiSpeechModelOptions,
+    },
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/generate-speech/xai/speech-tags.ts
+++ b/examples/ai-functions/src/generate-speech/xai/speech-tags.ts
@@ -1,0 +1,19 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: xai.speech(),
+    text: 'Wait for it. [pause] <whisper>This is synthesized by xAI.</whisper> [laugh]',
+    voice: 'eve',
+    language: 'en',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/generate-speech/xai/voice.ts
+++ b/examples/ai-functions/src/generate-speech/xai/voice.ts
@@ -1,0 +1,19 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: xai.speech(),
+    text: 'Hello from the AI SDK!',
+    voice: 'ara',
+    language: 'en',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/transcribe/xai/basic.ts
+++ b/examples/ai-functions/src/transcribe/xai/basic.ts
@@ -1,0 +1,18 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: xai.transcription(),
+    audio: await readFile('data/galileo.mp3'),
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/ai-functions/src/transcribe/xai/string.ts
+++ b/examples/ai-functions/src/transcribe/xai/string.ts
@@ -1,0 +1,25 @@
+import { xai, type XaiTranscriptionModelOptions } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: xai.transcription(),
+    audio: Buffer.from(await readFile('./data/galileo.mp3')).toString('base64'),
+    providerOptions: {
+      xai: {
+        language: 'en',
+        format: true,
+        keyterm: ['Galileo', 'Jupiter'],
+      } satisfies XaiTranscriptionModelOptions,
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/ai-functions/src/transcribe/xai/url.ts
+++ b/examples/ai-functions/src/transcribe/xai/url.ts
@@ -1,0 +1,19 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: xai.transcription(),
+    audio: new URL(
+      'https://github.com/vercel/ai/raw/refs/heads/main/examples/ai-functions/data/galileo.mp3',
+    ),
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/xai-tts-demo/.env.example
+++ b/examples/xai-tts-demo/.env.example
@@ -1,0 +1,1 @@
+XAI_API_KEY=

--- a/examples/xai-tts-demo/package.json
+++ b/examples/xai-tts-demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Local browser demo for xAI text-to-speech via @ai-sdk/xai.",
+  "description": "Local browser demo for xAI text-to-speech and speech-to-text via @ai-sdk/xai.",
   "scripts": {
     "prestart": "pnpm --filter ai... --filter @ai-sdk/xai... build",
     "start": "node --env-file-if-exists=.env server.mjs"

--- a/examples/xai-tts-demo/package.json
+++ b/examples/xai-tts-demo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/xai-tts-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Local browser demo for xAI text-to-speech via @ai-sdk/xai.",
+  "scripts": {
+    "prestart": "pnpm --filter ai... --filter @ai-sdk/xai... build",
+    "start": "node --env-file-if-exists=.env server.mjs"
+  },
+  "dependencies": {
+    "@ai-sdk/xai": "workspace:*",
+    "ai": "workspace:*"
+  }
+}

--- a/examples/xai-tts-demo/server.mjs
+++ b/examples/xai-tts-demo/server.mjs
@@ -1,12 +1,17 @@
-// Minimal local app to test xAI TTS through @ai-sdk/xai.
-// The API key remains on this server and is never sent to the browser.
+// Minimal local app to test xAI text-to-speech and speech-to-text through
+// @ai-sdk/xai. The API key remains on this server and is never sent to the
+// browser.
 import { createServer } from 'node:http';
 import { xai } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import {
+  experimental_generateSpeech as generateSpeech,
+  experimental_transcribe as transcribe,
+} from 'ai';
 
 const PORT = Number(process.env.PORT) || 5051;
 const VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'];
 const LANGUAGES = ['auto', 'en', 'es-ES', 'fr', 'de', 'ja', 'pt-BR'];
+const TRANSCRIPTION_LANGUAGES = ['auto', 'en', 'es', 'fr', 'de', 'ja', 'pt', 'zh'];
 const CODECS = ['mp3', 'wav', 'pcm', 'mulaw', 'alaw'];
 const SAMPLE_RATES = [8000, 16000, 22050, 24000, 44100, 48000];
 
@@ -23,7 +28,7 @@ const page = `<!doctype html>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>xAI Text-to-Speech</title>
+  <title>xAI Voice Demo</title>
   <style>
     :root {
       --bg: #fafafa;
@@ -35,6 +40,7 @@ const page = `<!doctype html>
       --button-text: #fff;
       --error: #dc2626;
       --success: #15803d;
+      --surface: #f4f4f5;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -45,6 +51,7 @@ const page = `<!doctype html>
         --muted: #a1a1aa;
         --button: #f4f4f5;
         --button-text: #09090b;
+        --surface: #18181b;
       }
     }
     * { box-sizing: border-box; }
@@ -56,7 +63,7 @@ const page = `<!doctype html>
       font: 14px system-ui, sans-serif;
     }
     main {
-      max-width: 600px;
+      max-width: 640px;
       margin: 0 auto;
       padding: 28px;
       border: 1px solid var(--border);
@@ -64,6 +71,7 @@ const page = `<!doctype html>
       background: var(--card);
     }
     h1 { margin: 0 0 8px; font-size: 22px; }
+    h2 { margin: 0 0 8px; font-size: 15px; }
     p { margin: 0 0 24px; color: var(--muted); line-height: 1.5; }
     code { font-family: ui-monospace, monospace; }
     .field { margin-bottom: 16px; }
@@ -79,6 +87,7 @@ const page = `<!doctype html>
       font: inherit;
     }
     textarea { height: 108px; resize: vertical; line-height: 1.5; }
+    input[type='checkbox'] { width: auto; margin-right: 8px; }
     button {
       width: 100%;
       padding: 11px 16px;
@@ -90,65 +99,134 @@ const page = `<!doctype html>
       font-weight: 600;
       cursor: pointer;
     }
+    button.secondary {
+      color: var(--fg);
+      background: transparent;
+      border: 1px solid var(--border);
+    }
     button:disabled { opacity: .55; cursor: wait; }
-    #status { min-height: 20px; margin: 15px 0 0; color: var(--muted); }
-    #status.error { color: var(--error); }
-    #status.success { color: var(--success); }
+    #speechStatus, #transcriptionStatus {
+      min-height: 20px;
+      margin: 15px 0 0;
+      color: var(--muted);
+    }
+    #speechStatus.error, #transcriptionStatus.error { color: var(--error); }
+    #speechStatus.success, #transcriptionStatus.success { color: var(--success); }
     audio { width: 100%; margin-top: 16px; }
     audio:not([src]) { display: none; }
     .hint { font-size: 12px; color: var(--muted); font-weight: normal; }
+    .divider { border: 0; border-top: 1px solid var(--border); margin: 30px 0; }
+    .section-copy { margin-bottom: 18px; }
+    .recording { touch-action: none; }
+    .recording.active { background: var(--error); color: #fff; }
+    #transcriptionResult { margin-top: 18px; }
+    #transcriptionResult.hidden { display: none; }
+    .meta { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 14px; }
+    .meta div { padding: 10px 12px; border-radius: 9px; background: var(--surface); }
+    .meta strong { display: block; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+    .meta span { display: block; margin-top: 4px; font-size: 13px; }
+    .transcript { padding: 14px; border-radius: 10px; background: var(--surface); white-space: pre-wrap; line-height: 1.55; }
+    .segments { margin-top: 14px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 10px; background: var(--card); }
+    .segments summary { cursor: pointer; color: var(--muted); }
+    .segments pre { overflow: auto; margin: 12px 0 0; font-size: 12px; line-height: 1.5; }
+    #uploadInput { display: none; }
+    .or { margin: 12px 0; color: var(--muted); font-size: 12px; text-align: center; }
   </style>
 </head>
 <body>
   <main>
-    <h1>xAI Text-to-Speech</h1>
-    <p>Speech via <code>@ai-sdk/xai</code> <code>xai.speech()</code> and <code>generateSpeech</code>. Include tags such as <code>[pause]</code> or <code>&lt;whisper&gt;...&lt;/whisper&gt;</code> in the text.</p>
-    <div class="field">
-      <label for="text">Text</label>
-      <textarea id="text">Hello from the AI SDK. [pause] &lt;whisper&gt;This is xAI text to speech.&lt;/whisper&gt;</textarea>
-    </div>
-    <div class="field row">
-      <div>
-        <label for="voice">Voice</label>
-        <select id="voice">${options(VOICES, 'eve')}</select>
+    <h1>xAI Voice Demo</h1>
+    <p>Text-to-speech and speech-to-text via <code>@ai-sdk/xai</code>.</p>
+
+    <section>
+      <h2>Text-to-Speech</h2>
+      <p class="section-copy">Speech via <code>xai.speech()</code> and <code>generateSpeech</code>. Include tags such as <code>[pause]</code> or <code>&lt;whisper&gt;...&lt;/whisper&gt;</code> in the text.</p>
+      <div class="field">
+        <label for="text">Text</label>
+        <textarea id="text">Hello from the AI SDK. [pause] &lt;whisper&gt;This is xAI text to speech.&lt;/whisper&gt;</textarea>
       </div>
-      <div>
-        <label for="language">Language</label>
-        <select id="language">${options(LANGUAGES, 'auto')}</select>
+      <div class="field row">
+        <div>
+          <label for="voice">Voice</label>
+          <select id="voice">${options(VOICES, 'eve')}</select>
+        </div>
+        <div>
+          <label for="language">Language</label>
+          <select id="language">${options(LANGUAGES, 'auto')}</select>
+        </div>
       </div>
-    </div>
-    <div class="field row">
-      <div>
-        <label for="codec">Output format</label>
-        <select id="codec">${options(CODECS, 'mp3')}</select>
+      <div class="field row">
+        <div>
+          <label for="codec">Output format</label>
+          <select id="codec">${options(CODECS, 'mp3')}</select>
+        </div>
+        <div>
+          <label for="sampleRate">Sample rate</label>
+          <select id="sampleRate">${options(SAMPLE_RATES, 24000)}</select>
+        </div>
       </div>
-      <div>
-        <label for="sampleRate">Sample rate</label>
-        <select id="sampleRate">${options(SAMPLE_RATES, 24000)}</select>
+      <div class="field row">
+        <div>
+          <label for="speed">Speed <span class="hint">(0.7 - 1.5)</span></label>
+          <input id="speed" type="number" min="0.7" max="1.5" step="0.1" value="1" />
+        </div>
+        <div>
+          <label for="latency">Latency optimization</label>
+          <select id="latency">${options([0, 1, 2], 0)}</select>
+        </div>
       </div>
-    </div>
-    <div class="field row">
-      <div>
-        <label for="speed">Speed <span class="hint">(0.7 - 1.5)</span></label>
-        <input id="speed" type="number" min="0.7" max="1.5" step="0.1" value="1" />
+      <div class="field">
+        <label><input id="normalization" type="checkbox" />Normalize text for speech</label>
       </div>
-      <div>
-        <label for="latency">Latency optimization</label>
-        <select id="latency">${options([0, 1, 2], 0)}</select>
+      <button id="generate">Generate and play</button>
+      <div id="speechStatus"></div>
+      <audio id="audio" controls></audio>
+    </section>
+
+    <hr class="divider" />
+
+    <section>
+      <h2>Speech-to-Text</h2>
+      <p class="section-copy">Batch transcription via <code>xai.transcription()</code> and <code>transcribe</code>. Hold the button to record, then release to transcribe, or upload a file directly.</p>
+      <div class="field row">
+        <div>
+          <label for="transcriptionLanguage">Language <span class="hint">(for formatting)</span></label>
+          <select id="transcriptionLanguage">${options(TRANSCRIPTION_LANGUAGES, 'auto')}</select>
+        </div>
+        <div>
+          <label for="keyterm">Key terms <span class="hint">(comma separated)</span></label>
+          <input id="keyterm" type="text" placeholder="Galileo, Jupiter" />
+        </div>
       </div>
-    </div>
-    <div class="field">
-      <label><input id="normalization" type="checkbox" style="width:auto;margin-right:8px" />Normalize text for speech</label>
-    </div>
-    <button id="generate">Generate and play</button>
-    <div id="status"></div>
-    <audio id="audio" controls></audio>
+      <div class="field row">
+        <label><input id="format" type="checkbox" />Normalize formatted text</label>
+        <label><input id="diarize" type="checkbox" />Speaker diarization</label>
+      </div>
+      <button id="record" class="recording">Hold to talk</button>
+      <div class="or">or</div>
+      <button id="upload" class="secondary">Upload audio file</button>
+      <input id="uploadInput" type="file" accept="audio/*,.mp3,.wav,.m4a,.ogg,.webm,.flac" />
+      <div id="transcriptionStatus"></div>
+      <section id="transcriptionResult" class="hidden">
+        <div class="meta">
+          <div><strong>Language</strong><span id="resultLanguage"></span></div>
+          <div><strong>Duration</strong><span id="resultDuration"></span></div>
+          <div><strong>Segments</strong><span id="resultSegments"></span></div>
+        </div>
+        <div id="transcript" class="transcript"></div>
+        <details class="segments">
+          <summary>Word timestamps</summary>
+          <pre id="segments"></pre>
+        </details>
+      </section>
+    </section>
   </main>
   <script>
     var get = function (id) { return document.getElementById(id); };
+
     get('generate').onclick = async function () {
       var button = get('generate');
-      var status = get('status');
+      var status = get('speechStatus');
       button.disabled = true;
       button.textContent = 'Generating...';
       status.className = '';
@@ -185,6 +263,133 @@ const page = `<!doctype html>
         button.textContent = 'Generate and play';
       }
     };
+
+    var mediaTypeForFile = function (file) {
+      if (file.type) return file.type;
+      var name = file.name.toLowerCase();
+      if (name.endsWith('.mp3')) return 'audio/mpeg';
+      if (name.endsWith('.wav')) return 'audio/wav';
+      if (name.endsWith('.m4a')) return 'audio/mp4';
+      if (name.endsWith('.ogg')) return 'audio/ogg';
+      if (name.endsWith('.webm')) return 'audio/webm';
+      if (name.endsWith('.flac')) return 'audio/flac';
+      return 'application/octet-stream';
+    };
+
+    var showTranscription = function (result) {
+      get('resultLanguage').textContent = result.language || 'unknown';
+      get('resultDuration').textContent = result.durationInSeconds == null
+        ? 'unknown'
+        : result.durationInSeconds.toFixed(2) + ' s';
+      get('resultSegments').textContent = String(result.segments.length);
+      get('transcript').textContent = result.text;
+      get('segments').textContent = JSON.stringify(result.segments, null, 2);
+      get('transcriptionResult').className = '';
+    };
+
+    var transcribeFile = async function (file) {
+      var status = get('transcriptionStatus');
+      status.className = '';
+      status.textContent = 'Transcribing...';
+      get('transcriptionResult').className = 'hidden';
+      var reader = new FileReader();
+      var dataUrl = await new Promise(function (resolve, reject) {
+        reader.onload = function () { resolve(reader.result); };
+        reader.onerror = function () { reject(reader.error); };
+        reader.readAsDataURL(file);
+      });
+      var keyterm = get('keyterm').value
+        .split(',')
+        .map(function (value) { return value.trim(); })
+        .filter(Boolean);
+      var language = get('transcriptionLanguage').value;
+      var response = await fetch('/api/transcribe', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          audio: String(dataUrl).split(',')[1],
+          mediaType: mediaTypeForFile(file),
+          language: language === 'auto' ? undefined : language,
+          keyterm: keyterm.length ? keyterm : undefined,
+          format: get('format').checked,
+          diarize: get('diarize').checked,
+        }),
+      });
+      if (!response.ok) {
+        var error = await response.json().catch(function () { return {}; });
+        throw new Error(error.error || response.statusText);
+      }
+      var result = await response.json();
+      showTranscription(result);
+      status.className = 'success';
+      status.textContent = 'Transcription complete.';
+    };
+
+    get('upload').onclick = function () {
+      get('uploadInput').click();
+    };
+
+    get('uploadInput').onchange = async function () {
+      var file = get('uploadInput').files[0];
+      if (!file) return;
+      try {
+        await transcribeFile(file);
+      } catch (error) {
+        get('transcriptionStatus').className = 'error';
+        get('transcriptionStatus').textContent = 'Error: ' + error.message;
+      }
+    };
+
+    var recorder;
+    var stream;
+    var chunks = [];
+    var recording = false;
+
+    var stopRecording = function () {
+      if (!recording) return;
+      recording = false;
+      recorder.stop();
+      get('record').classList.remove('active');
+      get('record').textContent = 'Hold to talk';
+    };
+
+    get('record').onpointerdown = async function (event) {
+      event.preventDefault();
+      if (recording) return;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        chunks = [];
+        recorder = new MediaRecorder(stream);
+        recorder.ondataavailable = function (data) {
+          if (data.data.size) chunks.push(data.data);
+        };
+        recorder.onstop = async function () {
+          var file = new File(chunks, 'recording.webm', {
+            type: recorder.mimeType || 'audio/webm',
+          });
+          stream.getTracks().forEach(function (track) { track.stop(); });
+          try {
+            await transcribeFile(file);
+          } catch (error) {
+            get('transcriptionStatus').className = 'error';
+            get('transcriptionStatus').textContent = 'Error: ' + error.message;
+          }
+        };
+        recorder.start();
+        recording = true;
+        get('record').classList.add('active');
+        get('record').textContent = 'Release to transcribe';
+        get('transcriptionStatus').className = '';
+        get('transcriptionStatus').textContent = 'Recording...';
+      } catch (error) {
+        get('transcriptionStatus').className = 'error';
+        get('transcriptionStatus').textContent = 'Error: ' + error.message;
+      }
+    };
+
+    get('record').onpointerup = stopRecording;
+    get('record').onpointerleave = stopRecording;
+    get('record').onpointercancel = stopRecording;
   </script>
 </body>
 </html>`;
@@ -274,13 +479,66 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  if (req.method === 'POST' && req.url === '/api/transcribe') {
+    try {
+      if (!process.env.XAI_API_KEY) {
+        throw new Error('XAI_API_KEY is not set in the environment.');
+      }
+
+      const { audio, mediaType, language, keyterm, format, diarize } =
+        await readJson(req);
+
+      if (!audio) {
+        throw new Error('audio is required');
+      }
+
+      if (format && !language) {
+        throw new Error('language is required when formatting is enabled');
+      }
+
+      const result = await transcribe({
+        model: xai.transcription(),
+        audio,
+        mediaType: mediaType || 'audio/webm',
+        providerOptions: {
+          xai: {
+            language,
+            keyterm,
+            format: format || undefined,
+            diarize: diarize || undefined,
+          },
+        },
+      });
+
+      if (result.warnings.length) {
+        console.log('warnings:', JSON.stringify(result.warnings));
+      }
+
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          text: result.text,
+          language: result.language,
+          durationInSeconds: result.durationInSeconds,
+          segments: result.segments,
+        }),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('transcription error:', message);
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: message }));
+    }
+    return;
+  }
+
   res.writeHead(404, { 'content-type': 'text/plain' });
   res.end('not found');
 });
 
 server.listen(PORT, () => {
-  console.log(`xAI TTS demo: http://localhost:${PORT}`);
+  console.log(`xAI voice demo: http://localhost:${PORT}`);
   if (!process.env.XAI_API_KEY) {
-    console.log('XAI_API_KEY is not set; add it to .env before generating audio.');
+    console.log('XAI_API_KEY is not set; add it to .env before using the demo.');
   }
 });

--- a/examples/xai-tts-demo/server.mjs
+++ b/examples/xai-tts-demo/server.mjs
@@ -1,0 +1,286 @@
+// Minimal local app to test xAI TTS through @ai-sdk/xai.
+// The API key remains on this server and is never sent to the browser.
+import { createServer } from 'node:http';
+import { xai } from '@ai-sdk/xai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+
+const PORT = Number(process.env.PORT) || 5051;
+const VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'];
+const LANGUAGES = ['auto', 'en', 'es-ES', 'fr', 'de', 'ja', 'pt-BR'];
+const CODECS = ['mp3', 'wav', 'pcm', 'mulaw', 'alaw'];
+const SAMPLE_RATES = [8000, 16000, 22050, 24000, 44100, 48000];
+
+const options = (values, selected) =>
+  values
+    .map(
+      value =>
+        `<option value="${value}"${value === selected ? ' selected' : ''}>${value}</option>`,
+    )
+    .join('');
+
+const page = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>xAI Text-to-Speech</title>
+  <style>
+    :root {
+      --bg: #fafafa;
+      --card: #fff;
+      --border: #e5e7eb;
+      --fg: #18181b;
+      --muted: #71717a;
+      --button: #18181b;
+      --button-text: #fff;
+      --error: #dc2626;
+      --success: #15803d;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #09090b;
+        --card: #111113;
+        --border: #27272a;
+        --fg: #f4f4f5;
+        --muted: #a1a1aa;
+        --button: #f4f4f5;
+        --button-text: #09090b;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 52px 20px;
+      background: var(--bg);
+      color: var(--fg);
+      font: 14px system-ui, sans-serif;
+    }
+    main {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 28px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: var(--card);
+    }
+    h1 { margin: 0 0 8px; font-size: 22px; }
+    p { margin: 0 0 24px; color: var(--muted); line-height: 1.5; }
+    code { font-family: ui-monospace, monospace; }
+    .field { margin-bottom: 16px; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    label { display: block; margin-bottom: 6px; font-weight: 600; }
+    textarea, input, select {
+      width: 100%;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 9px;
+      background: var(--card);
+      color: var(--fg);
+      font: inherit;
+    }
+    textarea { height: 108px; resize: vertical; line-height: 1.5; }
+    button {
+      width: 100%;
+      padding: 11px 16px;
+      border: 0;
+      border-radius: 9px;
+      color: var(--button-text);
+      background: var(--button);
+      font: inherit;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:disabled { opacity: .55; cursor: wait; }
+    #status { min-height: 20px; margin: 15px 0 0; color: var(--muted); }
+    #status.error { color: var(--error); }
+    #status.success { color: var(--success); }
+    audio { width: 100%; margin-top: 16px; }
+    audio:not([src]) { display: none; }
+    .hint { font-size: 12px; color: var(--muted); font-weight: normal; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>xAI Text-to-Speech</h1>
+    <p>Speech via <code>@ai-sdk/xai</code> <code>xai.speech()</code> and <code>generateSpeech</code>. Include tags such as <code>[pause]</code> or <code>&lt;whisper&gt;...&lt;/whisper&gt;</code> in the text.</p>
+    <div class="field">
+      <label for="text">Text</label>
+      <textarea id="text">Hello from the AI SDK. [pause] &lt;whisper&gt;This is xAI text to speech.&lt;/whisper&gt;</textarea>
+    </div>
+    <div class="field row">
+      <div>
+        <label for="voice">Voice</label>
+        <select id="voice">${options(VOICES, 'eve')}</select>
+      </div>
+      <div>
+        <label for="language">Language</label>
+        <select id="language">${options(LANGUAGES, 'auto')}</select>
+      </div>
+    </div>
+    <div class="field row">
+      <div>
+        <label for="codec">Output format</label>
+        <select id="codec">${options(CODECS, 'mp3')}</select>
+      </div>
+      <div>
+        <label for="sampleRate">Sample rate</label>
+        <select id="sampleRate">${options(SAMPLE_RATES, 24000)}</select>
+      </div>
+    </div>
+    <div class="field row">
+      <div>
+        <label for="speed">Speed <span class="hint">(0.7 - 1.5)</span></label>
+        <input id="speed" type="number" min="0.7" max="1.5" step="0.1" value="1" />
+      </div>
+      <div>
+        <label for="latency">Latency optimization</label>
+        <select id="latency">${options([0, 1, 2], 0)}</select>
+      </div>
+    </div>
+    <div class="field">
+      <label><input id="normalization" type="checkbox" style="width:auto;margin-right:8px" />Normalize text for speech</label>
+    </div>
+    <button id="generate">Generate and play</button>
+    <div id="status"></div>
+    <audio id="audio" controls></audio>
+  </main>
+  <script>
+    var get = function (id) { return document.getElementById(id); };
+    get('generate').onclick = async function () {
+      var button = get('generate');
+      var status = get('status');
+      button.disabled = true;
+      button.textContent = 'Generating...';
+      status.className = '';
+      status.textContent = '';
+      try {
+        var response = await fetch('/api/speech', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            text: get('text').value,
+            voice: get('voice').value,
+            language: get('language').value,
+            outputFormat: get('codec').value,
+            sampleRate: Number(get('sampleRate').value),
+            speed: Number(get('speed').value),
+            optimizeStreamingLatency: Number(get('latency').value),
+            textNormalization: get('normalization').checked,
+          }),
+        });
+        if (!response.ok) {
+          var error = await response.json().catch(function () { return {}; });
+          throw new Error(error.error || response.statusText);
+        }
+        var audio = await response.blob();
+        get('audio').src = URL.createObjectURL(audio);
+        await get('audio').play().catch(function () {});
+        status.className = 'success';
+        status.textContent = 'Generated ' + (audio.size / 1024).toFixed(1) + ' KB (' + audio.type + ').';
+      } catch (error) {
+        status.className = 'error';
+        status.textContent = 'Error: ' + error.message;
+      } finally {
+        button.disabled = false;
+        button.textContent = 'Generate and play';
+      }
+    };
+  </script>
+</body>
+</html>`;
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk;
+    });
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+const MEDIA_TYPES = {
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  pcm: 'audio/pcm',
+  mulaw: 'audio/basic',
+  alaw: 'audio/alaw',
+};
+
+const server = createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(page);
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/speech') {
+    try {
+      if (!process.env.XAI_API_KEY) {
+        throw new Error('XAI_API_KEY is not set in the environment.');
+      }
+
+      const {
+        text,
+        voice,
+        language,
+        outputFormat,
+        sampleRate,
+        speed,
+        optimizeStreamingLatency,
+        textNormalization,
+      } = await readJson(req);
+
+      if (!text) {
+        throw new Error('text is required');
+      }
+
+      const codec = CODECS.includes(outputFormat) ? outputFormat : 'mp3';
+      const result = await generateSpeech({
+        model: xai.speech(),
+        text,
+        voice: voice || 'eve',
+        language: language || 'auto',
+        outputFormat: codec,
+        speed,
+        providerOptions: {
+          xai: {
+            sampleRate,
+            optimizeStreamingLatency,
+            textNormalization,
+          },
+        },
+      });
+
+      if (result.warnings.length) {
+        console.log('warnings:', JSON.stringify(result.warnings));
+      }
+
+      res.writeHead(200, { 'content-type': MEDIA_TYPES[codec] });
+      res.end(Buffer.from(result.audio.uint8Array));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('speech error:', message);
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: message }));
+    }
+    return;
+  }
+
+  res.writeHead(404, { 'content-type': 'text/plain' });
+  res.end('not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`xAI TTS demo: http://localhost:${PORT}`);
+  if (!process.env.XAI_API_KEY) {
+    console.log('XAI_API_KEY is not set; add it to .env before generating audio.');
+  }
+});

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -21,6 +21,7 @@ export type {
   XaiVideoModelOptions as XaiVideoProviderOptions,
 } from './xai-video-model-options';
 export type { XaiSpeechModelOptions } from './xai-speech-model-options';
+export type { XaiTranscriptionModelOptions } from './xai-transcription-model-options';
 export type { XaiFilesOptions } from './files/xai-files-options';
 export { createXai, xai } from './xai-provider';
 export type { XaiProvider, XaiProviderSettings } from './xai-provider';

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -20,6 +20,7 @@ export type {
   /** @deprecated Use `XaiVideoModelOptions` instead. */
   XaiVideoModelOptions as XaiVideoProviderOptions,
 } from './xai-video-model-options';
+export type { XaiSpeechModelOptions } from './xai-speech-model-options';
 export type { XaiFilesOptions } from './files/xai-files-options';
 export { createXai, xai } from './xai-provider';
 export type { XaiProvider, XaiProviderSettings } from './xai-provider';

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -5,12 +5,14 @@ import { XaiChatLanguageModel } from './xai-chat-language-model';
 import { XaiResponsesLanguageModel } from './responses/xai-responses-language-model';
 import { XaiImageModel } from './xai-image-model';
 import { XaiVideoModel } from './xai-video-model';
+import { XaiSpeechModel } from './xai-speech-model';
 
 const XaiChatLanguageModelMock = XaiChatLanguageModel as unknown as Mock;
 const XaiResponsesLanguageModelMock =
   XaiResponsesLanguageModel as unknown as Mock;
 const XaiImageModelMock = XaiImageModel as unknown as Mock;
 const XaiVideoModelMock = XaiVideoModel as unknown as Mock;
+const XaiSpeechModelMock = XaiSpeechModel as unknown as Mock;
 
 vi.mock('./xai-chat-language-model', () => ({
   XaiChatLanguageModel: vi.fn(),
@@ -26,6 +28,10 @@ vi.mock('./xai-image-model', () => ({
 
 vi.mock('./xai-video-model', () => ({
   XaiVideoModel: vi.fn(),
+}));
+
+vi.mock('./xai-speech-model', () => ({
+  XaiSpeechModel: vi.fn(),
 }));
 
 vi.mock('@ai-sdk/provider-utils', async () => {
@@ -220,6 +226,46 @@ describe('xAIProvider', () => {
       expect(XaiVideoModelMock).toHaveBeenCalledOnce();
       const constructorCall = XaiVideoModelMock.mock.calls[0];
       expect(constructorCall[0]).toBe(modelId);
+    });
+  });
+
+  describe('speechModel', () => {
+    it('should construct a speech model with correct configuration', () => {
+      const provider = createXai();
+
+      provider.speechModel();
+
+      expect(XaiSpeechModelMock).toHaveBeenCalledOnce();
+
+      const constructorCall = XaiSpeechModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('');
+      expect(constructorCall[1].provider).toBe('xai.speech');
+      expect(constructorCall[1].baseURL).toBe('https://api.x.ai/v1');
+    });
+
+    it('should use custom baseURL and headers for speech models', () => {
+      const provider = createXai({
+        baseURL: 'https://custom.xai.api',
+        headers: { 'Custom-Header': 'test-value' },
+      });
+
+      provider.speech();
+
+      const constructorCall = XaiSpeechModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://custom.xai.api');
+      expect(constructorCall[1].headers()).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'custom-header': 'test-value',
+        'user-agent': 'ai-sdk/xai/0.0.0-test',
+      });
+    });
+
+    it('should create a speech model via .speech() alias', () => {
+      const provider = createXai();
+
+      provider.speech();
+
+      expect(XaiSpeechModelMock).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -6,6 +6,7 @@ import { XaiResponsesLanguageModel } from './responses/xai-responses-language-mo
 import { XaiImageModel } from './xai-image-model';
 import { XaiVideoModel } from './xai-video-model';
 import { XaiSpeechModel } from './xai-speech-model';
+import { XaiTranscriptionModel } from './xai-transcription-model';
 
 const XaiChatLanguageModelMock = XaiChatLanguageModel as unknown as Mock;
 const XaiResponsesLanguageModelMock =
@@ -13,6 +14,7 @@ const XaiResponsesLanguageModelMock =
 const XaiImageModelMock = XaiImageModel as unknown as Mock;
 const XaiVideoModelMock = XaiVideoModel as unknown as Mock;
 const XaiSpeechModelMock = XaiSpeechModel as unknown as Mock;
+const XaiTranscriptionModelMock = XaiTranscriptionModel as unknown as Mock;
 
 vi.mock('./xai-chat-language-model', () => ({
   XaiChatLanguageModel: vi.fn(),
@@ -32,6 +34,10 @@ vi.mock('./xai-video-model', () => ({
 
 vi.mock('./xai-speech-model', () => ({
   XaiSpeechModel: vi.fn(),
+}));
+
+vi.mock('./xai-transcription-model', () => ({
+  XaiTranscriptionModel: vi.fn(),
 }));
 
 vi.mock('@ai-sdk/provider-utils', async () => {
@@ -266,6 +272,46 @@ describe('xAIProvider', () => {
       provider.speech();
 
       expect(XaiSpeechModelMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('transcriptionModel', () => {
+    it('should construct a transcription model with correct configuration', () => {
+      const provider = createXai();
+
+      provider.transcriptionModel();
+
+      expect(XaiTranscriptionModelMock).toHaveBeenCalledOnce();
+
+      const constructorCall = XaiTranscriptionModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('');
+      expect(constructorCall[1].provider).toBe('xai.transcription');
+      expect(constructorCall[1].baseURL).toBe('https://api.x.ai/v1');
+    });
+
+    it('should use custom baseURL and headers for transcription models', () => {
+      const provider = createXai({
+        baseURL: 'https://custom.xai.api',
+        headers: { 'Custom-Header': 'test-value' },
+      });
+
+      provider.transcription();
+
+      const constructorCall = XaiTranscriptionModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://custom.xai.api');
+      expect(constructorCall[1].headers()).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'custom-header': 'test-value',
+        'user-agent': 'ai-sdk/xai/0.0.0-test',
+      });
+    });
+
+    it('should create a transcription model via .transcription() alias', () => {
+      const provider = createXai();
+
+      provider.transcription();
+
+      expect(XaiTranscriptionModelMock).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -8,6 +8,7 @@ import {
   NoSuchModelError,
   type ProviderV4,
   type SpeechModelV4,
+  type TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -29,6 +30,7 @@ import { XaiFiles } from './files/xai-files';
 import { XaiVideoModel } from './xai-video-model';
 import type { XaiVideoModelId } from './xai-video-settings';
 import { XaiSpeechModel } from './xai-speech-model';
+import { XaiTranscriptionModel } from './xai-transcription-model';
 
 export interface XaiProvider extends ProviderV4 {
   (modelId: XaiResponsesModelId): LanguageModelV4;
@@ -79,6 +81,16 @@ export interface XaiProvider extends ProviderV4 {
    * Creates an xAI model for speech generation (text-to-speech).
    */
   speechModel(): SpeechModelV4;
+
+  /**
+   * Creates an xAI model for speech-to-text transcription.
+   */
+  transcription(): TranscriptionModelV4;
+
+  /**
+   * Creates an xAI model for speech-to-text transcription.
+   */
+  transcriptionModel(): TranscriptionModelV4;
 
   /**
    * Returns the xAI files interface for uploading files.
@@ -192,6 +204,15 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
     });
   };
 
+  const createTranscriptionModel = () => {
+    return new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
   const experimentalRealtimeFactory = Object.assign(
     (modelId: string) => createRealtimeModel(modelId),
     {
@@ -237,6 +258,8 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
   provider.experimental_realtime = experimentalRealtimeFactory;
   provider.speechModel = createSpeechModel;
   provider.speech = createSpeechModel;
+  provider.transcriptionModel = createTranscriptionModel;
+  provider.transcription = createTranscriptionModel;
   provider.files = createFiles;
   provider.tools = xaiTools;
 

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -7,6 +7,7 @@ import {
   type LanguageModelV4,
   NoSuchModelError,
   type ProviderV4,
+  type SpeechModelV4,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -27,6 +28,7 @@ import { VERSION } from './version';
 import { XaiFiles } from './files/xai-files';
 import { XaiVideoModel } from './xai-video-model';
 import type { XaiVideoModelId } from './xai-video-settings';
+import { XaiSpeechModel } from './xai-speech-model';
 
 export interface XaiProvider extends ProviderV4 {
   (modelId: XaiResponsesModelId): LanguageModelV4;
@@ -67,6 +69,16 @@ export interface XaiProvider extends ProviderV4 {
   videoModel(modelId: XaiVideoModelId): Experimental_VideoModelV4;
 
   experimental_realtime: RealtimeFactoryV4;
+
+  /**
+   * Creates an xAI model for speech generation (text-to-speech).
+   */
+  speech(): SpeechModelV4;
+
+  /**
+   * Creates an xAI model for speech generation (text-to-speech).
+   */
+  speechModel(): SpeechModelV4;
 
   /**
    * Returns the xAI files interface for uploading files.
@@ -171,6 +183,15 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
     });
   };
 
+  const createSpeechModel = () => {
+    return new XaiSpeechModel('', {
+      provider: 'xai.speech',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
   const experimentalRealtimeFactory = Object.assign(
     (modelId: string) => createRealtimeModel(modelId),
     {
@@ -214,6 +235,8 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
   provider.videoModel = createVideoModel;
   provider.video = createVideoModel;
   provider.experimental_realtime = experimentalRealtimeFactory;
+  provider.speechModel = createSpeechModel;
+  provider.speech = createSpeechModel;
   provider.files = createFiles;
   provider.tools = xaiTools;
 

--- a/packages/xai/src/xai-speech-model-options.ts
+++ b/packages/xai/src/xai-speech-model-options.ts
@@ -1,0 +1,55 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const xaiSpeechModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Sample rate of the generated audio in Hz.
+       */
+      sampleRate: z
+        .union([
+          z.literal(8000),
+          z.literal(16000),
+          z.literal(22050),
+          z.literal(24000),
+          z.literal(44100),
+          z.literal(48000),
+        ])
+        .nullish(),
+
+      /**
+       * MP3 bit rate in bits per second. Only applies when outputFormat is mp3.
+       */
+      bitRate: z
+        .union([
+          z.literal(32000),
+          z.literal(64000),
+          z.literal(96000),
+          z.literal(128000),
+          z.literal(192000),
+        ])
+        .nullish(),
+
+      /**
+       * Reduce time to first audio chunk, trading some quality for latency.
+       */
+      optimizeStreamingLatency: z
+        .union([z.literal(0), z.literal(1), z.literal(2)])
+        .nullish(),
+
+      /**
+       * Normalize written-form text into spoken-form text before synthesis.
+       */
+      textNormalization: z.boolean().nullish(),
+    }),
+  ),
+);
+
+export type XaiSpeechModelOptions = InferSchema<
+  typeof xaiSpeechModelOptionsSchema
+>;

--- a/packages/xai/src/xai-speech-model.test.ts
+++ b/packages/xai/src/xai-speech-model.test.ts
@@ -1,0 +1,267 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createXai } from './xai-provider';
+import { XaiSpeechModel } from './xai-speech-model';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createXai({ apiKey: 'test-api-key' });
+const model = provider.speech();
+const url = 'https://api.x.ai/v1/tts';
+
+const server = createTestServer({
+  [url]: {},
+});
+
+describe('XaiSpeechModel', () => {
+  it('should expose correct provider and model information', () => {
+    expect(model.provider).toBe('xai.speech');
+    expect(model.modelId).toBe('');
+    expect(model.specificationVersion).toBe('v4');
+  });
+});
+
+describe('doGenerate', () => {
+  function prepareAudioResponse({
+    headers,
+    contentType = 'audio/mpeg',
+  }: {
+    headers?: Record<string, string>;
+    contentType?: string;
+  } = {}) {
+    const audio = new Uint8Array([1, 2, 3, 4]);
+    server.urls[url].response = {
+      type: 'binary',
+      headers: {
+        'content-type': contentType,
+        ...headers,
+      },
+      body: Buffer.from(audio),
+    };
+    return audio;
+  }
+
+  it('should send text with xAI defaults', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({ text: 'Hello from the AI SDK!' });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      text: 'Hello from the AI SDK!',
+      voice_id: 'eve',
+      language: 'auto',
+      output_format: { codec: 'mp3' },
+    });
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestUrl).toBe(url);
+  });
+
+  it('should pass standard speech options', async () => {
+    prepareAudioResponse({ contentType: 'audio/wav' });
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'ara',
+      language: 'en',
+      outputFormat: 'wav',
+      speed: 1.2,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      text: 'Hello from the AI SDK!',
+      voice_id: 'ara',
+      language: 'en',
+      output_format: { codec: 'wav' },
+      speed: 1.2,
+    });
+  });
+
+  it.each(['mp3', 'wav', 'pcm', 'mulaw', 'alaw'])(
+    'should accept the %s output format',
+    async outputFormat => {
+      prepareAudioResponse();
+
+      await model.doGenerate({
+        text: 'Hello from the AI SDK!',
+        outputFormat,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        output_format: { codec: outputFormat },
+      });
+    },
+  );
+
+  it('should map provider options onto xAI request fields', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      providerOptions: {
+        xai: {
+          sampleRate: 44100,
+          bitRate: 192000,
+          optimizeStreamingLatency: 1,
+          textNormalization: true,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      output_format: {
+        codec: 'mp3',
+        sample_rate: 44100,
+        bit_rate: 192000,
+      },
+      optimize_streaming_latency: 1,
+      text_normalization: true,
+    });
+  });
+
+  it('should warn and use mp3 for unsupported output formats', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      outputFormat: 'flac',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      output_format: { codec: 'mp3' },
+    });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ type: 'unsupported', feature: 'outputFormat' }),
+    );
+  });
+
+  it('should warn and ignore bitRate for non-mp3 output', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      outputFormat: 'wav',
+      providerOptions: { xai: { bitRate: 192000 } },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody).toMatchObject({
+      output_format: { codec: 'wav' },
+    });
+    expect(requestBody).not.toMatchObject({
+      output_format: { bit_rate: expect.any(Number) },
+    });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'providerOptions',
+      }),
+    );
+  });
+
+  it('should warn when instructions are provided', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      instructions: 'Speak cheerfully',
+    });
+
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ type: 'unsupported', feature: 'instructions' }),
+    );
+  });
+
+  it('should pass headers and the xAI user agent', async () => {
+    prepareAudioResponse();
+
+    const customProvider = createXai({
+      apiKey: 'test-api-key',
+      headers: { 'Custom-Provider-Header': 'provider-header-value' },
+    });
+
+    await customProvider.speech().doGenerate({
+      text: 'Hello from the AI SDK!',
+      headers: { 'Custom-Request-Header': 'request-header-value' },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain('ai-sdk/xai/0.0.0-test');
+  });
+
+  it('should return binary audio data', async () => {
+    const audio = prepareAudioResponse();
+
+    const result = await model.doGenerate({ text: 'Hello from the AI SDK!' });
+
+    expect(result.audio).toStrictEqual(audio);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should include response timestamp, model id, and headers', async () => {
+    prepareAudioResponse({ headers: { 'x-request-id': 'test-request-id' } });
+    const testDate = new Date(0);
+    const customModel = new XaiSpeechModel('', {
+      provider: 'xai.speech',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId: '',
+      headers: expect.objectContaining({ 'x-request-id': 'test-request-id' }),
+    });
+  });
+
+  it('should handle API errors', async () => {
+    server.urls[url].response = {
+      type: 'error',
+      status: 400,
+      body: JSON.stringify({
+        error: {
+          message: 'Invalid text',
+          type: 'invalid_request_error',
+        },
+      }),
+    };
+
+    await expect(
+      model.doGenerate({
+        text: 'Hello from the AI SDK!',
+      }),
+    ).rejects.toMatchObject({
+      message: 'Invalid text',
+      statusCode: 400,
+    });
+  });
+
+  it('should use the real date when no custom date provider is specified', async () => {
+    prepareAudioResponse();
+
+    const beforeDate = new Date();
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+    const afterDate = new Date();
+
+    expect(result.response.timestamp.getTime()).toBeGreaterThanOrEqual(
+      beforeDate.getTime(),
+    );
+    expect(result.response.timestamp.getTime()).toBeLessThanOrEqual(
+      afterDate.getTime(),
+    );
+    expect(result.response.modelId).toBe('');
+  });
+});

--- a/packages/xai/src/xai-speech-model.ts
+++ b/packages/xai/src/xai-speech-model.ts
@@ -1,0 +1,167 @@
+import type { SharedV4Warning, SpeechModelV4 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createBinaryResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { xaiFailedResponseHandler } from './xai-error';
+import { xaiSpeechModelOptionsSchema } from './xai-speech-model-options';
+
+interface XaiSpeechModelConfig {
+  provider: string;
+  baseURL: string | undefined;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+type XaiSpeechCodec = 'mp3' | 'wav' | 'pcm' | 'mulaw' | 'alaw';
+
+export class XaiSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: XaiSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: '';
+    config: XaiSpeechModelConfig;
+  }) {
+    return new XaiSpeechModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: '',
+    private readonly config: XaiSpeechModelConfig,
+  ) {}
+
+  private async getArgs({
+    text,
+    voice = 'eve',
+    outputFormat = 'mp3',
+    instructions,
+    speed,
+    language = 'auto',
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+    const xaiOptions = await parseProviderOptions({
+      provider: 'xai',
+      providerOptions,
+      schema: xaiSpeechModelOptionsSchema,
+    });
+
+    let codec: XaiSpeechCodec = 'mp3';
+    if (['mp3', 'wav', 'pcm', 'mulaw', 'alaw'].includes(outputFormat)) {
+      codec = outputFormat as XaiSpeechCodec;
+    } else {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'outputFormat',
+        details: `Unsupported output format: ${outputFormat}. Using mp3 instead.`,
+      });
+    }
+
+    if (instructions != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'xAI speech models do not support the `instructions` option. ' +
+          'Use xAI speech tags in `text` to control delivery.',
+      });
+    }
+
+    const output_format: {
+      codec: XaiSpeechCodec;
+      sample_rate?: number;
+      bit_rate?: number;
+    } = {
+      codec,
+    };
+
+    if (xaiOptions?.sampleRate != null) {
+      output_format.sample_rate = xaiOptions.sampleRate;
+    }
+
+    if (xaiOptions?.bitRate != null) {
+      if (codec === 'mp3') {
+        output_format.bit_rate = xaiOptions.bitRate;
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'providerOptions',
+          details:
+            'xAI `bitRate` is supported only for mp3 output. It was ignored.',
+        });
+      }
+    }
+
+    const requestBody = {
+      text,
+      voice_id: voice,
+      language,
+      output_format,
+      speed,
+      optimize_streaming_latency: xaiOptions?.optimizeStreamingLatency,
+      text_normalization: xaiOptions?.textNormalization,
+    };
+
+    return { requestBody, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestBody, warnings } = await this.getArgs(options);
+
+    const {
+      value: audio,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/tts`,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createBinaryResponseHandler(),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      audio,
+      warnings,
+      request: {
+        body: JSON.stringify(requestBody),
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}

--- a/packages/xai/src/xai-transcription-model-options.ts
+++ b/packages/xai/src/xai-transcription-model-options.ts
@@ -1,0 +1,70 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const xaiTranscriptionModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Audio encoding for raw, headerless input audio.
+       */
+      audioFormat: z.enum(['pcm', 'mulaw', 'alaw']).nullish(),
+
+      /**
+       * Sample rate of the input audio in Hz.
+       */
+      sampleRate: z
+        .union([
+          z.literal(8000),
+          z.literal(16000),
+          z.literal(22050),
+          z.literal(24000),
+          z.literal(44100),
+          z.literal(48000),
+        ])
+        .nullish(),
+
+      /**
+       * Language code used for inverse text normalization.
+       */
+      language: z.string().nullish(),
+
+      /**
+       * Enable inverse text normalization. Requires `language`.
+       */
+      format: z.boolean().nullish(),
+
+      /**
+       * Enable per-channel transcription for multichannel audio.
+       */
+      multichannel: z.boolean().nullish(),
+
+      /**
+       * Number of interleaved audio channels.
+       */
+      channels: z.number().int().min(2).max(8).nullish(),
+
+      /**
+       * Enable speaker diarization.
+       */
+      diarize: z.boolean().nullish(),
+
+      /**
+       * Terms to bias transcription toward.
+       */
+      keyterm: z.union([z.string(), z.array(z.string())]).nullish(),
+
+      /**
+       * Include filler words such as "uh" and "um" in the transcript.
+       */
+      fillerWords: z.boolean().nullish(),
+    }),
+  ),
+);
+
+export type XaiTranscriptionModelOptions = InferSchema<
+  typeof xaiTranscriptionModelOptionsSchema
+>;

--- a/packages/xai/src/xai-transcription-model.test.ts
+++ b/packages/xai/src/xai-transcription-model.test.ts
@@ -1,0 +1,261 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createXai } from './xai-provider';
+import { XaiTranscriptionModel } from './xai-transcription-model';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const audioData = new Uint8Array([1, 2, 3, 4]);
+const provider = createXai({ apiKey: 'test-api-key' });
+const model = provider.transcription();
+const url = 'https://api.x.ai/v1/stt';
+
+const server = createTestServer({
+  [url]: {},
+});
+
+function prepareJsonResponse(headers?: Record<string, string>) {
+  server.urls[url].response = {
+    type: 'json-value',
+    headers,
+    body: {
+      text: 'Hello from the AI SDK!',
+      language: 'en',
+      duration: 2.5,
+      words: [
+        {
+          text: 'Hello',
+          start: 0,
+          end: 1,
+        },
+        {
+          text: 'from the AI SDK!',
+          start: 1,
+          end: 2.5,
+        },
+      ],
+    },
+  };
+}
+
+describe('XaiTranscriptionModel', () => {
+  it('should expose correct provider and model information', () => {
+    expect(model.provider).toBe('xai.transcription');
+    expect(model.modelId).toBe('');
+    expect(model.specificationVersion).toBe('v4');
+  });
+});
+
+describe('doGenerate', () => {
+  it('should send a multipart request with the audio file', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!.file).toBeInstanceOf(File);
+    expect((body!.file as File).name).toBe('audio.wav');
+    expect((body!.file as File).type).toBe('audio/wav');
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestUrl).toBe(url);
+  });
+
+  it('should map provider options onto xAI request fields', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/pcm',
+      providerOptions: {
+        xai: {
+          audioFormat: 'pcm',
+          sampleRate: 16000,
+          language: 'en',
+          format: true,
+          multichannel: true,
+          channels: 2,
+          diarize: true,
+          keyterm: ['AI SDK', 'Grok'],
+          fillerWords: true,
+        },
+      },
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body).toMatchObject({
+      audio_format: 'pcm',
+      sample_rate: '16000',
+      language: 'en',
+      format: 'true',
+      multichannel: 'true',
+      channels: '2',
+      diarize: 'true',
+      keyterm: 'Grok',
+      filler_words: 'true',
+    });
+  });
+
+  it('should append file after all other multipart fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          text: 'Hello from the AI SDK!',
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    const customModel = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await customModel.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/pcm',
+      providerOptions: {
+        xai: {
+          audioFormat: 'pcm',
+          sampleRate: 16000,
+          language: 'en',
+          format: true,
+          multichannel: true,
+          channels: 2,
+          diarize: true,
+          keyterm: ['AI SDK', 'Grok'],
+          fillerWords: true,
+        },
+      },
+    });
+
+    const request = fetchMock.mock.calls[0][1];
+    const body = request.body as FormData;
+    expect(Array.from(body.keys())).toEqual([
+      'audio_format',
+      'sample_rate',
+      'language',
+      'format',
+      'multichannel',
+      'channels',
+      'diarize',
+      'filler_words',
+      'keyterm',
+      'keyterm',
+      'file',
+    ]);
+  });
+
+  it('should pass headers and the xAI user agent', async () => {
+    prepareJsonResponse();
+
+    const customProvider = createXai({
+      apiKey: 'test-api-key',
+      headers: { 'Custom-Provider-Header': 'provider-header-value' },
+    });
+
+    await customProvider.transcription().doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      headers: { 'Custom-Request-Header': 'request-header-value' },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'content-type': expect.stringMatching(
+        /^multipart\/form-data; boundary=----formdata-undici-\d+$/,
+      ),
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain('ai-sdk/xai/0.0.0-test');
+  });
+
+  it('should extract text, segments, language, and duration', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result).toMatchObject({
+      text: 'Hello from the AI SDK!',
+      language: 'en',
+      durationInSeconds: 2.5,
+      segments: [
+        {
+          text: 'Hello',
+          startSecond: 0,
+          endSecond: 1,
+        },
+        {
+          text: 'from the AI SDK!',
+          startSecond: 1,
+          endSecond: 2.5,
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it('should include response timestamp, model id, and headers', async () => {
+    prepareJsonResponse({
+      'x-request-id': 'test-request-id',
+      'x-ratelimit-remaining': '123',
+    });
+    const testDate = new Date(0);
+    const customModel = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId: '',
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': 'test-request-id',
+        'x-ratelimit-remaining': '123',
+      },
+    });
+  });
+
+  it('should handle missing words, duration, and empty language', async () => {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        text: 'Hello from the AI SDK!',
+        language: '',
+      },
+    };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result).toMatchObject({
+      text: 'Hello from the AI SDK!',
+      language: undefined,
+      durationInSeconds: undefined,
+      segments: [],
+      warnings: [],
+    });
+  });
+});

--- a/packages/xai/src/xai-transcription-model.ts
+++ b/packages/xai/src/xai-transcription-model.ts
@@ -1,0 +1,166 @@
+import type { SharedV4Warning, TranscriptionModelV4 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  createJsonResponseHandler,
+  mediaTypeToExtension,
+  parseProviderOptions,
+  postFormDataToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { xaiFailedResponseHandler } from './xai-error';
+import { xaiTranscriptionModelOptionsSchema } from './xai-transcription-model-options';
+
+interface XaiTranscriptionModelConfig {
+  provider: string;
+  baseURL: string | undefined;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+export class XaiTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: XaiTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: '';
+    config: XaiTranscriptionModelConfig;
+  }) {
+    return new XaiTranscriptionModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: '',
+    private readonly config: XaiTranscriptionModelConfig,
+  ) {}
+
+  private async getArgs({
+    audio,
+    mediaType,
+    providerOptions,
+  }: Parameters<TranscriptionModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+    const xaiOptions = await parseProviderOptions({
+      provider: 'xai',
+      providerOptions,
+      schema: xaiTranscriptionModelOptionsSchema,
+    });
+
+    const formData = new FormData();
+    const transcriptionOptions = {
+      audio_format: xaiOptions?.audioFormat,
+      sample_rate: xaiOptions?.sampleRate,
+      language: xaiOptions?.language,
+      format: xaiOptions?.format,
+      multichannel: xaiOptions?.multichannel,
+      channels: xaiOptions?.channels,
+      diarize: xaiOptions?.diarize,
+      filler_words: xaiOptions?.fillerWords,
+    };
+
+    for (const [key, value] of Object.entries(transcriptionOptions)) {
+      if (value != null) {
+        formData.append(key, String(value));
+      }
+    }
+
+    if (xaiOptions?.keyterm != null) {
+      const keyterms = Array.isArray(xaiOptions.keyterm)
+        ? xaiOptions.keyterm
+        : [xaiOptions.keyterm];
+
+      for (const keyterm of keyterms) {
+        formData.append('keyterm', keyterm);
+      }
+    }
+
+    const blob =
+      audio instanceof Uint8Array
+        ? new Blob([audio])
+        : new Blob([convertBase64ToUint8Array(audio)]);
+    const fileExtension = mediaTypeToExtension(mediaType);
+
+    // xAI requires `file` to be the final multipart field.
+    formData.append(
+      'file',
+      new File([blob], 'audio', { type: mediaType }),
+      `audio.${fileExtension}`,
+    );
+
+    return { formData, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { formData, warnings } = await this.getArgs(options);
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postFormDataToApi({
+      url: `${this.config.baseURL ?? 'https://api.x.ai/v1'}/stt`,
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      formData,
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      text: response.text,
+      segments:
+        response.words?.map(word => ({
+          text: word.text,
+          startSecond: word.start,
+          endSecond: word.end,
+        })) ?? [],
+      language: response.language || undefined,
+      durationInSeconds: response.duration ?? undefined,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}
+
+const xaiTranscriptionResponseSchema = z.object({
+  text: z.string(),
+  language: z.string().nullish(),
+  duration: z.number().nullish(),
+  words: z
+    .array(
+      z.object({
+        text: z.string(),
+        start: z.number(),
+        end: z.number(),
+      }),
+    )
+    .nullish(),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,6 +1444,15 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  examples/xai-tts-demo:
+    dependencies:
+      '@ai-sdk/xai':
+        specifier: workspace:*
+        version: link:../../packages/xai
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+
   packages/ai:
     dependencies:
       '@ai-sdk/gateway':


### PR DESCRIPTION
## Summary

Adds batch xAI text-to-speech support through the `/v1/tts` endpoint.

- Adds `xai.speech()` and `xai.speechModel()`.
- Adds `XaiSpeechModel` with support for voices, language, speed, output formats, and xAI-specific speech options.
- Adds typed `XaiSpeechModelOptions` for sample rate, MP3 bit rate, latency optimization, and text normalization.
- Adds provider docs, speech docs listing, ai-functions examples, and a local `examples/xai-tts-demo` app.
- Includes the merged xAI speech-to-text support from #15909, including the shared voice demo and transcription docs/examples.
- Preserves the newly landed xAI realtime provider surface while adding batch voice support.

## Why

xAI exposes dedicated `/v1/tts` and `/v1/stt` APIs but did not yet have AI SDK `generateSpeech` or `transcribe` support. This brings it in line with the existing speech and transcription provider patterns used across the SDK.

## Validation

- `pnpm check`
- `pnpm --filter @ai-sdk/xai test`
  - Node: 16 files, 354 tests passed
  - Edge: 16 files, 354 tests passed
- `pnpm --filter @ai-sdk/xai type-check`
- `pnpm --filter @ai-sdk/xai build`
- `pnpm --filter @example/ai-functions type-check`
- `node --check examples/xai-tts-demo/server.mjs`
- `git diff --check`

The local xAI demo was also started and verified with real speech and transcription requests after loading the local CA bundle required by this machine.
