### PR TITLE
fix(gateway): add missing 'caching' property to GatewayProviderOptions type

### DIFF
--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -111,6 +111,15 @@ const gatewayProviderOptions = lazySchema(() =>
        * default.
        */
       serviceTier: z.enum(['flex', 'priority']).optional(),
+      /**
+       * Enable automatic caching for the request.
+       *
+       * When set to `'auto'`, the AI Gateway will automatically cache
+       * responses based on the request content and provider capabilities.
+       *
+       * Example: `{ gateway: { caching: 'auto' } }`
+       */
+      caching: z.literal('auto').optional(),
     }),
   ),
 );

--- a/packages/gateway/src/gateway-provider.test-d.ts
+++ b/packages/gateway/src/gateway-provider.test-d.ts
@@ -1,4 +1,5 @@
 import { createGateway } from './gateway-provider';
+import type { GatewayProviderOptions } from './gateway-provider-options';
 
 createGateway({ apiKey: 'vck_test-key' });
 createGateway({ apiKey: 'vca_test-token' });
@@ -8,3 +9,19 @@ createGateway({});
 
 // @ts-expect-error token is not a supported Gateway provider setting
 createGateway({ token: 'vca_test-token' });
+
+// Test GatewayProviderOptions type includes caching
+const _providerOptions = {
+  caching: 'auto',
+  only: ['openai', 'anthropic'],
+  order: ['bedrock', 'azure'],
+  sort: 'cost',
+  user: 'user-123',
+  tags: ['chat', 'v2'],
+  models: ['openai/gpt-4o', 'anthropic/claude-3'],
+  zeroDataRetention: true,
+  disallowPromptTraining: true,
+  hipaaCompliant: true,
+  quotaEntityId: 'entity-123',
+  serviceTier: 'flex',
+} satisfies GatewayProviderOptions;


### PR DESCRIPTION
Fixes #14595

The  type was missing the  property that is documented in the AI Gateway automatic caching documentation (https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching).

When users tried to use the documented  option with TypeScript, they got a type error:
```
Object literal may only specify known properties, and 'caching' does not exist in type '{ only?: string[] | undefined; order?: string[] | undefined; ... }'.
```

This PR adds  to the Zod schema in , along with a type test to ensure the property is accepted.

## Changes
- Added  field to  Zod schema with proper JSDoc documentation
- Added type test to verify the property works with `satisfies GatewayProviderOptions`

## Testing
- All existing tests pass (429 tests in gateway package)
- Type-check passes
- New type test validates the fix