### PR TITLE
fix(core): wrap invalid tool call input in object to prevent API rejection

### DIFF
--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -471,7 +471,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -510,7 +512,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -94,7 +94,9 @@ export async function parseToolCall<TOOLS extends ToolSet>({
   } catch (error) {
     // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
     const tool = tools?.[toolCall.toolName];
 
     // TODO AI SDK 6: special invalid tool call parts


### PR DESCRIPTION
Fixes #14442

When `parseToolCall` fails to parse a tool call's JSON input, it was storing the raw string as the input. This caused issues with providers like Amazon Bedrock that require `toolUse.input` to be a JSON object (the Bedrock provider does `input: part.input as JSONObject`).

The raw string flows through `to-response-messages.ts` and `convert-to-language-model-prompt.ts` into the assistant message for the next API step, causing the API to reject the request before the model ever sees the `tool-error` result.

## Changes
- In `parse-tool-call.ts`, wrap the fallback input in an object: `{ rawInvalidInput: toolCall.input }`
- Updated snapshot tests to reflect the new expected behavior

## Testing
- All existing tests pass (3079 tests in ai package)
- Type-check passes
- The fix ensures the model sees the `tool-error` and can retry

## Related
- Blocks tools like [Cline CLI Kanban](https://github.com/cline/cline) which use `@ai-sdk/amazon-bedrock` (related: cline/cline#10293)
