### PR TITLE
[codex] Add xAI speech-to-text support

### DIFF
--- a/.changeset/xai-speech-to-text.md
+++ b/.changeset/xai-speech-to-text.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Add xAI speech-to-text transcription support.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -226,5 +226,6 @@ try {
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
+| [xAI](/providers/ai-sdk-providers/xai#transcription-models)               | `default`                |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -638,6 +638,94 @@ const result = await generateSpeech({
 | --------- | ------------------- | ------------------- | -------------------------- |
 | `default` | <Check size={18} /> | <Check size={18} /> | mp3, wav, pcm, mulaw, alaw |
 
+## Transcription Models
+
+You can create models that call the [xAI Speech to Text API](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text)
+using the `.transcription()` factory method. xAI's batch transcription endpoint
+does not require a model identifier.
+
+```ts
+const model = xai.transcription();
+```
+
+Use xAI transcription models with the `transcribe` function:
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+
+const result = await transcribe({
+  model: xai.transcription(),
+  audio: await readFile('meeting.mp3'),
+});
+```
+
+### Provider Options
+
+You can pass xAI-specific controls using `providerOptions.xai`:
+
+```ts
+import { xai, type XaiTranscriptionModelOptions } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+
+const result = await transcribe({
+  model: xai.transcription(),
+  audio: await readFile('meeting.mp3'),
+  providerOptions: {
+    xai: {
+      language: 'en',
+      format: true,
+      keyterm: ['AI SDK', 'Grok'],
+      diarize: true,
+    } satisfies XaiTranscriptionModelOptions,
+  },
+});
+```
+
+- **audioFormat** _`pcm` | `mulaw` | `alaw`_
+
+  Audio encoding for raw, headerless input audio.
+
+- **sampleRate** _8000 | 16000 | 22050 | 24000 | 44100 | 48000_
+
+  Sample rate of the input audio in Hz.
+
+- **language** _string_
+
+  Language code used for inverse text normalization.
+
+- **format** _boolean_
+
+  Enables inverse text normalization. Requires `language`.
+
+- **multichannel** _boolean_
+
+  Enables per-channel transcription for interleaved multichannel audio.
+
+- **channels** _2 | 3 | 4 | 5 | 6 | 7 | 8_
+
+  Number of interleaved audio channels.
+
+- **diarize** _boolean_
+
+  Enables speaker diarization.
+
+- **keyterm** _string | string[]_
+
+  One or more terms to bias transcription toward.
+
+- **fillerWords** _boolean_
+
+  Includes filler words such as `uh` and `um` in the transcript.
+
+### Model Capabilities
+
+| Model     | Word Timestamps     | Diarization         | Multichannel        |
+| --------- | ------------------- | ------------------- | ------------------- |
+| `default` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
 ## Image Models
 
 You can create xAI image models using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).

--- a/examples/ai-functions/src/transcribe/xai/basic.ts
+++ b/examples/ai-functions/src/transcribe/xai/basic.ts
@@ -1,0 +1,18 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: xai.transcription(),
+    audio: await readFile('data/galileo.mp3'),
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/ai-functions/src/transcribe/xai/string.ts
+++ b/examples/ai-functions/src/transcribe/xai/string.ts
@@ -1,0 +1,25 @@
+import { xai, type XaiTranscriptionModelOptions } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: xai.transcription(),
+    audio: Buffer.from(await readFile('./data/galileo.mp3')).toString('base64'),
+    providerOptions: {
+      xai: {
+        language: 'en',
+        format: true,
+        keyterm: ['Galileo', 'Jupiter'],
+      } satisfies XaiTranscriptionModelOptions,
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/ai-functions/src/transcribe/xai/url.ts
+++ b/examples/ai-functions/src/transcribe/xai/url.ts
@@ -1,0 +1,19 @@
+import { xai } from '@ai-sdk/xai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: xai.transcription(),
+    audio: new URL(
+      'https://github.com/vercel/ai/raw/refs/heads/main/examples/ai-functions/data/galileo.mp3',
+    ),
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/examples/xai-tts-demo/package.json
+++ b/examples/xai-tts-demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Local browser demo for xAI text-to-speech via @ai-sdk/xai.",
+  "description": "Local browser demo for xAI text-to-speech and speech-to-text via @ai-sdk/xai.",
   "scripts": {
     "prestart": "pnpm --filter ai... --filter @ai-sdk/xai... build",
     "start": "node --env-file-if-exists=.env server.mjs"

--- a/examples/xai-tts-demo/server.mjs
+++ b/examples/xai-tts-demo/server.mjs
@@ -1,12 +1,17 @@
-// Minimal local app to test xAI TTS through @ai-sdk/xai.
-// The API key remains on this server and is never sent to the browser.
+// Minimal local app to test xAI text-to-speech and speech-to-text through
+// @ai-sdk/xai. The API key remains on this server and is never sent to the
+// browser.
 import { createServer } from 'node:http';
 import { xai } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import {
+  experimental_generateSpeech as generateSpeech,
+  experimental_transcribe as transcribe,
+} from 'ai';
 
 const PORT = Number(process.env.PORT) || 5051;
 const VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'];
 const LANGUAGES = ['auto', 'en', 'es-ES', 'fr', 'de', 'ja', 'pt-BR'];
+const TRANSCRIPTION_LANGUAGES = ['auto', 'en', 'es', 'fr', 'de', 'ja', 'pt', 'zh'];
 const CODECS = ['mp3', 'wav', 'pcm', 'mulaw', 'alaw'];
 const SAMPLE_RATES = [8000, 16000, 22050, 24000, 44100, 48000];
 
@@ -23,7 +28,7 @@ const page = `<!doctype html>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>xAI Text-to-Speech</title>
+  <title>xAI Voice Demo</title>
   <style>
     :root {
       --bg: #fafafa;
@@ -35,6 +40,7 @@ const page = `<!doctype html>
       --button-text: #fff;
       --error: #dc2626;
       --success: #15803d;
+      --surface: #f4f4f5;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -45,6 +51,7 @@ const page = `<!doctype html>
         --muted: #a1a1aa;
         --button: #f4f4f5;
         --button-text: #09090b;
+        --surface: #18181b;
       }
     }
     * { box-sizing: border-box; }
@@ -56,7 +63,7 @@ const page = `<!doctype html>
       font: 14px system-ui, sans-serif;
     }
     main {
-      max-width: 600px;
+      max-width: 640px;
       margin: 0 auto;
       padding: 28px;
       border: 1px solid var(--border);
@@ -64,6 +71,7 @@ const page = `<!doctype html>
       background: var(--card);
     }
     h1 { margin: 0 0 8px; font-size: 22px; }
+    h2 { margin: 0 0 8px; font-size: 15px; }
     p { margin: 0 0 24px; color: var(--muted); line-height: 1.5; }
     code { font-family: ui-monospace, monospace; }
     .field { margin-bottom: 16px; }
@@ -79,6 +87,7 @@ const page = `<!doctype html>
       font: inherit;
     }
     textarea { height: 108px; resize: vertical; line-height: 1.5; }
+    input[type='checkbox'] { width: auto; margin-right: 8px; }
     button {
       width: 100%;
       padding: 11px 16px;
@@ -90,65 +99,134 @@ const page = `<!doctype html>
       font-weight: 600;
       cursor: pointer;
     }
+    button.secondary {
+      color: var(--fg);
+      background: transparent;
+      border: 1px solid var(--border);
+    }
     button:disabled { opacity: .55; cursor: wait; }
-    #status { min-height: 20px; margin: 15px 0 0; color: var(--muted); }
-    #status.error { color: var(--error); }
-    #status.success { color: var(--success); }
+    #speechStatus, #transcriptionStatus {
+      min-height: 20px;
+      margin: 15px 0 0;
+      color: var(--muted);
+    }
+    #speechStatus.error, #transcriptionStatus.error { color: var(--error); }
+    #speechStatus.success, #transcriptionStatus.success { color: var(--success); }
     audio { width: 100%; margin-top: 16px; }
     audio:not([src]) { display: none; }
     .hint { font-size: 12px; color: var(--muted); font-weight: normal; }
+    .divider { border: 0; border-top: 1px solid var(--border); margin: 30px 0; }
+    .section-copy { margin-bottom: 18px; }
+    .recording { touch-action: none; }
+    .recording.active { background: var(--error); color: #fff; }
+    #transcriptionResult { margin-top: 18px; }
+    #transcriptionResult.hidden { display: none; }
+    .meta { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 14px; }
+    .meta div { padding: 10px 12px; border-radius: 9px; background: var(--surface); }
+    .meta strong { display: block; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+    .meta span { display: block; margin-top: 4px; font-size: 13px; }
+    .transcript { padding: 14px; border-radius: 10px; background: var(--surface); white-space: pre-wrap; line-height: 1.55; }
+    .segments { margin-top: 14px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 10px; background: var(--card); }
+    .segments summary { cursor: pointer; color: var(--muted); }
+    .segments pre { overflow: auto; margin: 12px 0 0; font-size: 12px; line-height: 1.5; }
+    #uploadInput { display: none; }
+    .or { margin: 12px 0; color: var(--muted); font-size: 12px; text-align: center; }
   </style>
 </head>
 <body>
   <main>
-    <h1>xAI Text-to-Speech</h1>
-    <p>Speech via <code>@ai-sdk/xai</code> <code>xai.speech()</code> and <code>generateSpeech</code>. Include tags such as <code>[pause]</code> or <code>&lt;whisper&gt;...&lt;/whisper&gt;</code> in the text.</p>
-    <div class="field">
-      <label for="text">Text</label>
-      <textarea id="text">Hello from the AI SDK. [pause] &lt;whisper&gt;This is xAI text to speech.&lt;/whisper&gt;</textarea>
-    </div>
-    <div class="field row">
-      <div>
-        <label for="voice">Voice</label>
-        <select id="voice">${options(VOICES, 'eve')}</select>
+    <h1>xAI Voice Demo</h1>
+    <p>Text-to-speech and speech-to-text via <code>@ai-sdk/xai</code>.</p>
+
+    <section>
+      <h2>Text-to-Speech</h2>
+      <p class="section-copy">Speech via <code>xai.speech()</code> and <code>generateSpeech</code>. Include tags such as <code>[pause]</code> or <code>&lt;whisper&gt;...&lt;/whisper&gt;</code> in the text.</p>
+      <div class="field">
+        <label for="text">Text</label>
+        <textarea id="text">Hello from the AI SDK. [pause] &lt;whisper&gt;This is xAI text to speech.&lt;/whisper&gt;</textarea>
       </div>
-      <div>
-        <label for="language">Language</label>
-        <select id="language">${options(LANGUAGES, 'auto')}</select>
+      <div class="field row">
+        <div>
+          <label for="voice">Voice</label>
+          <select id="voice">${options(VOICES, 'eve')}</select>
+        </div>
+        <div>
+          <label for="language">Language</label>
+          <select id="language">${options(LANGUAGES, 'auto')}</select>
+        </div>
       </div>
-    </div>
-    <div class="field row">
-      <div>
-        <label for="codec">Output format</label>
-        <select id="codec">${options(CODECS, 'mp3')}</select>
+      <div class="field row">
+        <div>
+          <label for="codec">Output format</label>
+          <select id="codec">${options(CODECS, 'mp3')}</select>
+        </div>
+        <div>
+          <label for="sampleRate">Sample rate</label>
+          <select id="sampleRate">${options(SAMPLE_RATES, 24000)}</select>
+        </div>
       </div>
-      <div>
-        <label for="sampleRate">Sample rate</label>
-        <select id="sampleRate">${options(SAMPLE_RATES, 24000)}</select>
+      <div class="field row">
+        <div>
+          <label for="speed">Speed <span class="hint">(0.7 - 1.5)</span></label>
+          <input id="speed" type="number" min="0.7" max="1.5" step="0.1" value="1" />
+        </div>
+        <div>
+          <label for="latency">Latency optimization</label>
+          <select id="latency">${options([0, 1, 2], 0)}</select>
+        </div>
       </div>
-    </div>
-    <div class="field row">
-      <div>
-        <label for="speed">Speed <span class="hint">(0.7 - 1.5)</span></label>
-        <input id="speed" type="number" min="0.7" max="1.5" step="0.1" value="1" />
+      <div class="field">
+        <label><input id="normalization" type="checkbox" />Normalize text for speech</label>
       </div>
-      <div>
-        <label for="latency">Latency optimization</label>
-        <select id="latency">${options([0, 1, 2], 0)}</select>
+      <button id="generate">Generate and play</button>
+      <div id="speechStatus"></div>
+      <audio id="audio" controls></audio>
+    </section>
+
+    <hr class="divider" />
+
+    <section>
+      <h2>Speech-to-Text</h2>
+      <p class="section-copy">Batch transcription via <code>xai.transcription()</code> and <code>transcribe</code>. Hold the button to record, then release to transcribe, or upload a file directly.</p>
+      <div class="field row">
+        <div>
+          <label for="transcriptionLanguage">Language <span class="hint">(for formatting)</span></label>
+          <select id="transcriptionLanguage">${options(TRANSCRIPTION_LANGUAGES, 'auto')}</select>
+        </div>
+        <div>
+          <label for="keyterm">Key terms <span class="hint">(comma separated)</span></label>
+          <input id="keyterm" type="text" placeholder="Galileo, Jupiter" />
+        </div>
       </div>
-    </div>
-    <div class="field">
-      <label><input id="normalization" type="checkbox" style="width:auto;margin-right:8px" />Normalize text for speech</label>
-    </div>
-    <button id="generate">Generate and play</button>
-    <div id="status"></div>
-    <audio id="audio" controls></audio>
+      <div class="field row">
+        <label><input id="format" type="checkbox" />Normalize formatted text</label>
+        <label><input id="diarize" type="checkbox" />Speaker diarization</label>
+      </div>
+      <button id="record" class="recording">Hold to talk</button>
+      <div class="or">or</div>
+      <button id="upload" class="secondary">Upload audio file</button>
+      <input id="uploadInput" type="file" accept="audio/*,.mp3,.wav,.m4a,.ogg,.webm,.flac" />
+      <div id="transcriptionStatus"></div>
+      <section id="transcriptionResult" class="hidden">
+        <div class="meta">
+          <div><strong>Language</strong><span id="resultLanguage"></span></div>
+          <div><strong>Duration</strong><span id="resultDuration"></span></div>
+          <div><strong>Segments</strong><span id="resultSegments"></span></div>
+        </div>
+        <div id="transcript" class="transcript"></div>
+        <details class="segments">
+          <summary>Word timestamps</summary>
+          <pre id="segments"></pre>
+        </details>
+      </section>
+    </section>
   </main>
   <script>
     var get = function (id) { return document.getElementById(id); };
+
     get('generate').onclick = async function () {
       var button = get('generate');
-      var status = get('status');
+      var status = get('speechStatus');
       button.disabled = true;
       button.textContent = 'Generating...';
       status.className = '';
@@ -185,6 +263,133 @@ const page = `<!doctype html>
         button.textContent = 'Generate and play';
       }
     };
+
+    var mediaTypeForFile = function (file) {
+      if (file.type) return file.type;
+      var name = file.name.toLowerCase();
+      if (name.endsWith('.mp3')) return 'audio/mpeg';
+      if (name.endsWith('.wav')) return 'audio/wav';
+      if (name.endsWith('.m4a')) return 'audio/mp4';
+      if (name.endsWith('.ogg')) return 'audio/ogg';
+      if (name.endsWith('.webm')) return 'audio/webm';
+      if (name.endsWith('.flac')) return 'audio/flac';
+      return 'application/octet-stream';
+    };
+
+    var showTranscription = function (result) {
+      get('resultLanguage').textContent = result.language || 'unknown';
+      get('resultDuration').textContent = result.durationInSeconds == null
+        ? 'unknown'
+        : result.durationInSeconds.toFixed(2) + ' s';
+      get('resultSegments').textContent = String(result.segments.length);
+      get('transcript').textContent = result.text;
+      get('segments').textContent = JSON.stringify(result.segments, null, 2);
+      get('transcriptionResult').className = '';
+    };
+
+    var transcribeFile = async function (file) {
+      var status = get('transcriptionStatus');
+      status.className = '';
+      status.textContent = 'Transcribing...';
+      get('transcriptionResult').className = 'hidden';
+      var reader = new FileReader();
+      var dataUrl = await new Promise(function (resolve, reject) {
+        reader.onload = function () { resolve(reader.result); };
+        reader.onerror = function () { reject(reader.error); };
+        reader.readAsDataURL(file);
+      });
+      var keyterm = get('keyterm').value
+        .split(',')
+        .map(function (value) { return value.trim(); })
+        .filter(Boolean);
+      var language = get('transcriptionLanguage').value;
+      var response = await fetch('/api/transcribe', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          audio: String(dataUrl).split(',')[1],
+          mediaType: mediaTypeForFile(file),
+          language: language === 'auto' ? undefined : language,
+          keyterm: keyterm.length ? keyterm : undefined,
+          format: get('format').checked,
+          diarize: get('diarize').checked,
+        }),
+      });
+      if (!response.ok) {
+        var error = await response.json().catch(function () { return {}; });
+        throw new Error(error.error || response.statusText);
+      }
+      var result = await response.json();
+      showTranscription(result);
+      status.className = 'success';
+      status.textContent = 'Transcription complete.';
+    };
+
+    get('upload').onclick = function () {
+      get('uploadInput').click();
+    };
+
+    get('uploadInput').onchange = async function () {
+      var file = get('uploadInput').files[0];
+      if (!file) return;
+      try {
+        await transcribeFile(file);
+      } catch (error) {
+        get('transcriptionStatus').className = 'error';
+        get('transcriptionStatus').textContent = 'Error: ' + error.message;
+      }
+    };
+
+    var recorder;
+    var stream;
+    var chunks = [];
+    var recording = false;
+
+    var stopRecording = function () {
+      if (!recording) return;
+      recording = false;
+      recorder.stop();
+      get('record').classList.remove('active');
+      get('record').textContent = 'Hold to talk';
+    };
+
+    get('record').onpointerdown = async function (event) {
+      event.preventDefault();
+      if (recording) return;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        chunks = [];
+        recorder = new MediaRecorder(stream);
+        recorder.ondataavailable = function (data) {
+          if (data.data.size) chunks.push(data.data);
+        };
+        recorder.onstop = async function () {
+          var file = new File(chunks, 'recording.webm', {
+            type: recorder.mimeType || 'audio/webm',
+          });
+          stream.getTracks().forEach(function (track) { track.stop(); });
+          try {
+            await transcribeFile(file);
+          } catch (error) {
+            get('transcriptionStatus').className = 'error';
+            get('transcriptionStatus').textContent = 'Error: ' + error.message;
+          }
+        };
+        recorder.start();
+        recording = true;
+        get('record').classList.add('active');
+        get('record').textContent = 'Release to transcribe';
+        get('transcriptionStatus').className = '';
+        get('transcriptionStatus').textContent = 'Recording...';
+      } catch (error) {
+        get('transcriptionStatus').className = 'error';
+        get('transcriptionStatus').textContent = 'Error: ' + error.message;
+      }
+    };
+
+    get('record').onpointerup = stopRecording;
+    get('record').onpointerleave = stopRecording;
+    get('record').onpointercancel = stopRecording;
   </script>
 </body>
 </html>`;
@@ -274,13 +479,66 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  if (req.method === 'POST' && req.url === '/api/transcribe') {
+    try {
+      if (!process.env.XAI_API_KEY) {
+        throw new Error('XAI_API_KEY is not set in the environment.');
+      }
+
+      const { audio, mediaType, language, keyterm, format, diarize } =
+        await readJson(req);
+
+      if (!audio) {
+        throw new Error('audio is required');
+      }
+
+      if (format && !language) {
+        throw new Error('language is required when formatting is enabled');
+      }
+
+      const result = await transcribe({
+        model: xai.transcription(),
+        audio,
+        mediaType: mediaType || 'audio/webm',
+        providerOptions: {
+          xai: {
+            language,
+            keyterm,
+            format: format || undefined,
+            diarize: diarize || undefined,
+          },
+        },
+      });
+
+      if (result.warnings.length) {
+        console.log('warnings:', JSON.stringify(result.warnings));
+      }
+
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          text: result.text,
+          language: result.language,
+          durationInSeconds: result.durationInSeconds,
+          segments: result.segments,
+        }),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('transcription error:', message);
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: message }));
+    }
+    return;
+  }
+
   res.writeHead(404, { 'content-type': 'text/plain' });
   res.end('not found');
 });
 
 server.listen(PORT, () => {
-  console.log(`xAI TTS demo: http://localhost:${PORT}`);
+  console.log(`xAI voice demo: http://localhost:${PORT}`);
   if (!process.env.XAI_API_KEY) {
-    console.log('XAI_API_KEY is not set; add it to .env before generating audio.');
+    console.log('XAI_API_KEY is not set; add it to .env before using the demo.');
   }
 });

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -21,6 +21,7 @@ export type {
   XaiVideoModelOptions as XaiVideoProviderOptions,
 } from './xai-video-model-options';
 export type { XaiSpeechModelOptions } from './xai-speech-model-options';
+export type { XaiTranscriptionModelOptions } from './xai-transcription-model-options';
 export type { XaiFilesOptions } from './files/xai-files-options';
 export { createXai, xai } from './xai-provider';
 export type { XaiProvider, XaiProviderSettings } from './xai-provider';

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -6,6 +6,7 @@ import { XaiResponsesLanguageModel } from './responses/xai-responses-language-mo
 import { XaiImageModel } from './xai-image-model';
 import { XaiVideoModel } from './xai-video-model';
 import { XaiSpeechModel } from './xai-speech-model';
+import { XaiTranscriptionModel } from './xai-transcription-model';
 
 const XaiChatLanguageModelMock = XaiChatLanguageModel as unknown as Mock;
 const XaiResponsesLanguageModelMock =
@@ -13,6 +14,7 @@ const XaiResponsesLanguageModelMock =
 const XaiImageModelMock = XaiImageModel as unknown as Mock;
 const XaiVideoModelMock = XaiVideoModel as unknown as Mock;
 const XaiSpeechModelMock = XaiSpeechModel as unknown as Mock;
+const XaiTranscriptionModelMock = XaiTranscriptionModel as unknown as Mock;
 
 vi.mock('./xai-chat-language-model', () => ({
   XaiChatLanguageModel: vi.fn(),
@@ -32,6 +34,10 @@ vi.mock('./xai-video-model', () => ({
 
 vi.mock('./xai-speech-model', () => ({
   XaiSpeechModel: vi.fn(),
+}));
+
+vi.mock('./xai-transcription-model', () => ({
+  XaiTranscriptionModel: vi.fn(),
 }));
 
 vi.mock('@ai-sdk/provider-utils', async () => {
@@ -266,6 +272,46 @@ describe('xAIProvider', () => {
       provider.speech();
 
       expect(XaiSpeechModelMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('transcriptionModel', () => {
+    it('should construct a transcription model with correct configuration', () => {
+      const provider = createXai();
+
+      provider.transcriptionModel();
+
+      expect(XaiTranscriptionModelMock).toHaveBeenCalledOnce();
+
+      const constructorCall = XaiTranscriptionModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('');
+      expect(constructorCall[1].provider).toBe('xai.transcription');
+      expect(constructorCall[1].baseURL).toBe('https://api.x.ai/v1');
+    });
+
+    it('should use custom baseURL and headers for transcription models', () => {
+      const provider = createXai({
+        baseURL: 'https://custom.xai.api',
+        headers: { 'Custom-Header': 'test-value' },
+      });
+
+      provider.transcription();
+
+      const constructorCall = XaiTranscriptionModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://custom.xai.api');
+      expect(constructorCall[1].headers()).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'custom-header': 'test-value',
+        'user-agent': 'ai-sdk/xai/0.0.0-test',
+      });
+    });
+
+    it('should create a transcription model via .transcription() alias', () => {
+      const provider = createXai();
+
+      provider.transcription();
+
+      expect(XaiTranscriptionModelMock).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -8,6 +8,7 @@ import {
   NoSuchModelError,
   type ProviderV4,
   type SpeechModelV4,
+  type TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -29,6 +30,7 @@ import { XaiFiles } from './files/xai-files';
 import { XaiVideoModel } from './xai-video-model';
 import type { XaiVideoModelId } from './xai-video-settings';
 import { XaiSpeechModel } from './xai-speech-model';
+import { XaiTranscriptionModel } from './xai-transcription-model';
 
 export interface XaiProvider extends ProviderV4 {
   (modelId: XaiResponsesModelId): LanguageModelV4;
@@ -79,6 +81,16 @@ export interface XaiProvider extends ProviderV4 {
    * Creates an xAI model for speech generation (text-to-speech).
    */
   speechModel(): SpeechModelV4;
+
+  /**
+   * Creates an xAI model for speech-to-text transcription.
+   */
+  transcription(): TranscriptionModelV4;
+
+  /**
+   * Creates an xAI model for speech-to-text transcription.
+   */
+  transcriptionModel(): TranscriptionModelV4;
 
   /**
    * Returns the xAI files interface for uploading files.
@@ -192,6 +204,15 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
     });
   };
 
+  const createTranscriptionModel = () => {
+    return new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
   const experimentalRealtimeFactory = Object.assign(
     (modelId: string) => createRealtimeModel(modelId),
     {
@@ -237,6 +258,8 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
   provider.experimental_realtime = experimentalRealtimeFactory;
   provider.speechModel = createSpeechModel;
   provider.speech = createSpeechModel;
+  provider.transcriptionModel = createTranscriptionModel;
+  provider.transcription = createTranscriptionModel;
   provider.files = createFiles;
   provider.tools = xaiTools;
 

--- a/packages/xai/src/xai-transcription-model-options.ts
+++ b/packages/xai/src/xai-transcription-model-options.ts
@@ -1,0 +1,70 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const xaiTranscriptionModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Audio encoding for raw, headerless input audio.
+       */
+      audioFormat: z.enum(['pcm', 'mulaw', 'alaw']).nullish(),
+
+      /**
+       * Sample rate of the input audio in Hz.
+       */
+      sampleRate: z
+        .union([
+          z.literal(8000),
+          z.literal(16000),
+          z.literal(22050),
+          z.literal(24000),
+          z.literal(44100),
+          z.literal(48000),
+        ])
+        .nullish(),
+
+      /**
+       * Language code used for inverse text normalization.
+       */
+      language: z.string().nullish(),
+
+      /**
+       * Enable inverse text normalization. Requires `language`.
+       */
+      format: z.boolean().nullish(),
+
+      /**
+       * Enable per-channel transcription for multichannel audio.
+       */
+      multichannel: z.boolean().nullish(),
+
+      /**
+       * Number of interleaved audio channels.
+       */
+      channels: z.number().int().min(2).max(8).nullish(),
+
+      /**
+       * Enable speaker diarization.
+       */
+      diarize: z.boolean().nullish(),
+
+      /**
+       * Terms to bias transcription toward.
+       */
+      keyterm: z.union([z.string(), z.array(z.string())]).nullish(),
+
+      /**
+       * Include filler words such as "uh" and "um" in the transcript.
+       */
+      fillerWords: z.boolean().nullish(),
+    }),
+  ),
+);
+
+export type XaiTranscriptionModelOptions = InferSchema<
+  typeof xaiTranscriptionModelOptionsSchema
+>;

--- a/packages/xai/src/xai-transcription-model.test.ts
+++ b/packages/xai/src/xai-transcription-model.test.ts
@@ -1,0 +1,261 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createXai } from './xai-provider';
+import { XaiTranscriptionModel } from './xai-transcription-model';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const audioData = new Uint8Array([1, 2, 3, 4]);
+const provider = createXai({ apiKey: 'test-api-key' });
+const model = provider.transcription();
+const url = 'https://api.x.ai/v1/stt';
+
+const server = createTestServer({
+  [url]: {},
+});
+
+function prepareJsonResponse(headers?: Record<string, string>) {
+  server.urls[url].response = {
+    type: 'json-value',
+    headers,
+    body: {
+      text: 'Hello from the AI SDK!',
+      language: 'en',
+      duration: 2.5,
+      words: [
+        {
+          text: 'Hello',
+          start: 0,
+          end: 1,
+        },
+        {
+          text: 'from the AI SDK!',
+          start: 1,
+          end: 2.5,
+        },
+      ],
+    },
+  };
+}
+
+describe('XaiTranscriptionModel', () => {
+  it('should expose correct provider and model information', () => {
+    expect(model.provider).toBe('xai.transcription');
+    expect(model.modelId).toBe('');
+    expect(model.specificationVersion).toBe('v4');
+  });
+});
+
+describe('doGenerate', () => {
+  it('should send a multipart request with the audio file', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!.file).toBeInstanceOf(File);
+    expect((body!.file as File).name).toBe('audio.wav');
+    expect((body!.file as File).type).toBe('audio/wav');
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestUrl).toBe(url);
+  });
+
+  it('should map provider options onto xAI request fields', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/pcm',
+      providerOptions: {
+        xai: {
+          audioFormat: 'pcm',
+          sampleRate: 16000,
+          language: 'en',
+          format: true,
+          multichannel: true,
+          channels: 2,
+          diarize: true,
+          keyterm: ['AI SDK', 'Grok'],
+          fillerWords: true,
+        },
+      },
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body).toMatchObject({
+      audio_format: 'pcm',
+      sample_rate: '16000',
+      language: 'en',
+      format: 'true',
+      multichannel: 'true',
+      channels: '2',
+      diarize: 'true',
+      keyterm: 'Grok',
+      filler_words: 'true',
+    });
+  });
+
+  it('should append file after all other multipart fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          text: 'Hello from the AI SDK!',
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    const customModel = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await customModel.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/pcm',
+      providerOptions: {
+        xai: {
+          audioFormat: 'pcm',
+          sampleRate: 16000,
+          language: 'en',
+          format: true,
+          multichannel: true,
+          channels: 2,
+          diarize: true,
+          keyterm: ['AI SDK', 'Grok'],
+          fillerWords: true,
+        },
+      },
+    });
+
+    const request = fetchMock.mock.calls[0][1];
+    const body = request.body as FormData;
+    expect(Array.from(body.keys())).toEqual([
+      'audio_format',
+      'sample_rate',
+      'language',
+      'format',
+      'multichannel',
+      'channels',
+      'diarize',
+      'filler_words',
+      'keyterm',
+      'keyterm',
+      'file',
+    ]);
+  });
+
+  it('should pass headers and the xAI user agent', async () => {
+    prepareJsonResponse();
+
+    const customProvider = createXai({
+      apiKey: 'test-api-key',
+      headers: { 'Custom-Provider-Header': 'provider-header-value' },
+    });
+
+    await customProvider.transcription().doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      headers: { 'Custom-Request-Header': 'request-header-value' },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'content-type': expect.stringMatching(
+        /^multipart\/form-data; boundary=----formdata-undici-\d+$/,
+      ),
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain('ai-sdk/xai/0.0.0-test');
+  });
+
+  it('should extract text, segments, language, and duration', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result).toMatchObject({
+      text: 'Hello from the AI SDK!',
+      language: 'en',
+      durationInSeconds: 2.5,
+      segments: [
+        {
+          text: 'Hello',
+          startSecond: 0,
+          endSecond: 1,
+        },
+        {
+          text: 'from the AI SDK!',
+          startSecond: 1,
+          endSecond: 2.5,
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it('should include response timestamp, model id, and headers', async () => {
+    prepareJsonResponse({
+      'x-request-id': 'test-request-id',
+      'x-ratelimit-remaining': '123',
+    });
+    const testDate = new Date(0);
+    const customModel = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId: '',
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': 'test-request-id',
+        'x-ratelimit-remaining': '123',
+      },
+    });
+  });
+
+  it('should handle missing words, duration, and empty language', async () => {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        text: 'Hello from the AI SDK!',
+        language: '',
+      },
+    };
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result).toMatchObject({
+      text: 'Hello from the AI SDK!',
+      language: undefined,
+      durationInSeconds: undefined,
+      segments: [],
+      warnings: [],
+    });
+  });
+});

--- a/packages/xai/src/xai-transcription-model.ts
+++ b/packages/xai/src/xai-transcription-model.ts
@@ -1,0 +1,166 @@
+import type { SharedV4Warning, TranscriptionModelV4 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  createJsonResponseHandler,
+  mediaTypeToExtension,
+  parseProviderOptions,
+  postFormDataToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { xaiFailedResponseHandler } from './xai-error';
+import { xaiTranscriptionModelOptionsSchema } from './xai-transcription-model-options';
+
+interface XaiTranscriptionModelConfig {
+  provider: string;
+  baseURL: string | undefined;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+export class XaiTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: XaiTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: '';
+    config: XaiTranscriptionModelConfig;
+  }) {
+    return new XaiTranscriptionModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: '',
+    private readonly config: XaiTranscriptionModelConfig,
+  ) {}
+
+  private async getArgs({
+    audio,
+    mediaType,
+    providerOptions,
+  }: Parameters<TranscriptionModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+    const xaiOptions = await parseProviderOptions({
+      provider: 'xai',
+      providerOptions,
+      schema: xaiTranscriptionModelOptionsSchema,
+    });
+
+    const formData = new FormData();
+    const transcriptionOptions = {
+      audio_format: xaiOptions?.audioFormat,
+      sample_rate: xaiOptions?.sampleRate,
+      language: xaiOptions?.language,
+      format: xaiOptions?.format,
+      multichannel: xaiOptions?.multichannel,
+      channels: xaiOptions?.channels,
+      diarize: xaiOptions?.diarize,
+      filler_words: xaiOptions?.fillerWords,
+    };
+
+    for (const [key, value] of Object.entries(transcriptionOptions)) {
+      if (value != null) {
+        formData.append(key, String(value));
+      }
+    }
+
+    if (xaiOptions?.keyterm != null) {
+      const keyterms = Array.isArray(xaiOptions.keyterm)
+        ? xaiOptions.keyterm
+        : [xaiOptions.keyterm];
+
+      for (const keyterm of keyterms) {
+        formData.append('keyterm', keyterm);
+      }
+    }
+
+    const blob =
+      audio instanceof Uint8Array
+        ? new Blob([audio])
+        : new Blob([convertBase64ToUint8Array(audio)]);
+    const fileExtension = mediaTypeToExtension(mediaType);
+
+    // xAI requires `file` to be the final multipart field.
+    formData.append(
+      'file',
+      new File([blob], 'audio', { type: mediaType }),
+      `audio.${fileExtension}`,
+    );
+
+    return { formData, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { formData, warnings } = await this.getArgs(options);
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postFormDataToApi({
+      url: `${this.config.baseURL ?? 'https://api.x.ai/v1'}/stt`,
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      formData,
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      text: response.text,
+      segments:
+        response.words?.map(word => ({
+          text: word.text,
+          startSecond: word.start,
+          endSecond: word.end,
+        })) ?? [],
+      language: response.language || undefined,
+      durationInSeconds: response.duration ?? undefined,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}
+
+const xaiTranscriptionResponseSchema = z.object({
+  text: z.string(),
+  language: z.string().nullish(),
+  duration: z.number().nullish(),
+  words: z
+    .array(
+      z.object({
+        text: z.string(),
+        start: z.number(),
+        end: z.number(),
+      }),
+    )
+    .nullish(),
+});


### PR DESCRIPTION
## Summary
- Add xAI transcription() and transcriptionModel() factories for the batch /v1/stt endpoint.
- Add typed xAI transcription provider options and response mapping for word timestamps, duration, and language.
- Add xAI transcription docs, examples, and a changeset.
- Add focused tests for multipart request shape, file-last ordering, headers, response metadata, and node/edge behavior.
- Extend the existing xAI TTS demo with a second speech-to-text panel instead of introducing a separate STT demo.

## Why

xAI now exposes a batch speech-to-text REST endpoint alongside its existing realtime voice support. The batch endpoint does not require a model identifier, so this follows the same no-argument provider pattern used by providers with a default transcription endpoint.

## Stacking

This PR is based on #15905 because the shared local demo extends the xAI TTS demo added there.

## Validation
- pnpm --filter @ai-sdk/xai test
- pnpm --filter @ai-sdk/xai type-check
- pnpm --filter @ai-sdk/xai build
- pnpm --filter @example/ai-functions type-check
- pnpm check
- node --check examples/xai-tts-demo/server.mjs
- git diff --check

The combined demo was also started locally and verified with both a real TTS request and a real STT request.
