### PR TITLE
fix(ai): add approval guard for denied tool outputs

### DIFF
--- a/.changeset/friendly-zoos-tease.md
+++ b/.changeset/friendly-zoos-tease.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): add approval guard for denied tool outputs

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -2229,6 +2229,75 @@ describe('convertToModelMessages', () => {
       `);
     });
 
+    it('should convert tool output denied without approval (static tool)', async () => {
+      const result = await convertToModelMessages([
+        {
+          parts: [
+            {
+              text: 'What is the weather in Tokyo?',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          role: 'assistant',
+          parts: [
+            {
+              input: {
+                city: 'Tokyo',
+              },
+              state: 'output-denied',
+              toolCallId: 'call-1',
+              type: 'tool-weather',
+            },
+          ],
+        },
+      ] as unknown as UIMessage[]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "What is the weather in Tokyo?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "city": "Tokyo",
+                },
+                "providerExecuted": undefined,
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Tool call execution denied.",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+    });
+
     it('should convert tool output denied (dynamic tool)', async () => {
       const result = await convertToModelMessages([
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -346,7 +346,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                         output: {
                           type: 'error-text' as const,
                           value:
-                            toolPart.approval.reason ??
+                            toolPart.approval?.reason ??
                             'Tool call execution denied.',
                         },
                         ...(toolPart.callProviderMetadata != null


### PR DESCRIPTION
## Background

reported in https://github.com/vercel/ai/issues/15787

there are sometimes cases when the denied tool history is persisted and rehydrated from storage and a tool part can legitimately be in `output-denied` without an `approval` field.

this in turn will throw the error
```
TypeError: Cannot read properties of undefined (reading 'reason')
```

## Summary

added a guard check to only attach reason when `approval` exists otherwise fallback to default

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15787 