### PR TITLE
[codex] add Google Vertex telephony transcription model

### DIFF
--- a/.changeset/google-vertex-chirp-transcription.md
+++ b/.changeset/google-vertex-chirp-transcription.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google-vertex': patch
 ---
 
-feat(provider/google-vertex): add Chirp speech-to-text (transcription) model support
+feat(provider/google-vertex): add Google Cloud Speech-to-Text transcription model support

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -225,5 +225,6 @@ try {
 | [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `wizper`                 |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1334,10 +1334,10 @@ rate is reported in `result.providerMetadata.google.sampleRate`.
 | `gemini-2.5-flash-lite-preview-tts` | <Check size={18} /> | <Check size={18} />    |
 | `gemini-3.1-flash-tts-preview`      | <Check size={18} /> | <Check size={18} />    |
 
-### Transcription Models (Chirp)
+### Transcription Models
 
-You can transcribe audio with Google Cloud [Chirp](https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3)
-speech-to-text models using the `.transcription()` factory method together with
+You can transcribe audio with Google Cloud Speech-to-Text models using the
+`.transcription()` factory method together with
 [`transcribe()`](/docs/reference/ai-sdk-core/transcribe).
 
 ```ts
@@ -1351,18 +1351,22 @@ const result = await transcribe({
 });
 ```
 
-Chirp uses standard Google Cloud credentials (OAuth, Application Default
+The provider supports [Chirp](https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3)
+models `chirp_2` and `chirp_3`, plus `telephony` for phone-call audio.
+Speech-to-Text uses standard Google Cloud credentials (OAuth, Application Default
 Credentials, or a service account) and calls the Cloud Speech-to-Text API.
 Express Mode API keys are not supported for transcription models. Set
 `GOOGLE_VERTEX_LOCATION` (or `providerOptions.googleVertex.region`) to a
-Speech-to-Text region: `chirp_2` is available in `us-central1`, `europe-west4`,
-and `asia-southeast1`; `chirp_3` in the `us` and `eu` multi-regions. Chirp is
-not available in the `global` Speech-to-Text location, and these regions differ
-from Vertex AI regions.
+Speech-to-Text region. For Chirp, `chirp_2` is available in `us-central1`,
+`europe-west4`, and `asia-southeast1`; `chirp_3` in the `us` and `eu`
+multi-regions. Chirp is not available in the `global` Speech-to-Text location,
+and these regions differ from Vertex AI regions. `telephony` availability
+depends on the selected Speech-to-Text region and language.
 
 The synchronous API transcribes audio up to one minute or 10 MB, whichever is
 reached first. The spoken language is auto-detected by default; pass
-`languageCodes` to restrict it.
+`languageCodes` to restrict it. For `telephony`, pass a supported language code
+such as `['en-US']`.
 
 ```ts
 const result = await transcribe({
@@ -1402,10 +1406,11 @@ The following provider options are available:
 
 #### Transcription Model Capabilities
 
-| Model     | Word timestamps                                           | Auto language detection |
-| --------- | --------------------------------------------------------- | ----------------------- |
-| `chirp_2` | Available with a potential quality and speed tradeoff     | <Check size={18} />     |
-| `chirp_3` | Available with a potential transcription quality tradeoff | <Check size={18} />     |
+| Model       | Word timestamps                                           | Language detection                                                             |
+| ----------- | --------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `chirp_2`   | Available with a potential quality and speed tradeoff     | Auto detection with `['auto']`                                                 |
+| `chirp_3`   | Available with a potential transcription quality tradeoff | Auto detection with `['auto']`                                                 |
+| `telephony` | Available                                                 | Explicit supported language codes, with alternative language detection support |
 
 ## Google Vertex Anthropic Provider Usage
 

--- a/examples/ai-functions/src/transcribe/google-vertex/telephony.ts
+++ b/examples/ai-functions/src/transcribe/google-vertex/telephony.ts
@@ -1,0 +1,26 @@
+import {
+  googleVertex,
+  type GoogleVertexTranscriptionModelOptions,
+} from '@ai-sdk/google-vertex';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: googleVertex.transcription('telephony'),
+    audio: await readFile('data/galileo.mp3'),
+    providerOptions: {
+      googleVertex: {
+        languageCodes: ['en-US'],
+      } satisfies GoogleVertexTranscriptionModelOptions,
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+});

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -103,14 +103,14 @@ export interface GoogleVertexProvider extends ProviderV4 {
   speechModel(modelId: GoogleVertexSpeechModelId): SpeechModelV4;
 
   /**
-   * Creates a model for transcription (speech-to-text) using Chirp.
+   * Creates a model for transcription (speech-to-text).
    */
   transcription(
     modelId: GoogleVertexTranscriptionModelId,
   ): TranscriptionModelV4;
 
   /**
-   * Creates a model for transcription (speech-to-text) using Chirp.
+   * Creates a model for transcription (speech-to-text).
    */
   transcriptionModel(
     modelId: GoogleVertexTranscriptionModelId,
@@ -262,8 +262,8 @@ export function createGoogleVertex(
   const createSpeechModel = (modelId: GoogleVertexSpeechModelId) =>
     new GoogleSpeechModel(modelId, createConfig('speech'));
 
-  // Chirp (Cloud Speech-to-Text) reuses the Vertex auth headers from
-  // createConfig, but targets the Speech-to-Text API.
+  // Cloud Speech-to-Text reuses the Vertex auth headers from createConfig, but
+  // targets the Speech-to-Text API.
   const createTranscriptionModel = (
     modelId: GoogleVertexTranscriptionModelId,
   ) => {

--- a/packages/google-vertex/src/google-vertex-transcription-model-options.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model-options.ts
@@ -1,16 +1,18 @@
 import { z } from 'zod/v4';
 
-// Google Cloud Speech-to-Text "Chirp" transcription models (Speech-to-Text v2).
-// https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3
+// Google Cloud Speech-to-Text transcription models (Speech-to-Text v2).
+// https://docs.cloud.google.com/speech-to-text/docs/transcription-model
 export type GoogleVertexTranscriptionModelId =
   | 'chirp_2'
   | 'chirp_3'
+  | 'telephony'
   | (string & {});
 
 export const googleVertexTranscriptionProviderOptionsSchema = z.object({
   /**
    * BCP-47 language codes to recognize (e.g. `['en-US']`), or `['auto']` to let
-   * Chirp auto-detect the spoken language. Defaults to `['auto']`.
+   * Chirp auto-detect the spoken language. Defaults to `['auto']`. For
+   * `telephony`, pass a supported explicit language code.
    */
   languageCodes: z.array(z.string()).optional(),
 

--- a/packages/google-vertex/src/google-vertex-transcription-model.ts
+++ b/packages/google-vertex/src/google-vertex-transcription-model.ts
@@ -119,7 +119,7 @@ export class GoogleVertexTranscriptionModel implements TranscriptionModelV4 {
       config: {
         model: this.modelId,
         languageCodes,
-        // Let Chirp auto-detect the audio encoding (wav/mp3/flac/…).
+        // Let Speech-to-Text auto-detect the audio encoding (wav/mp3/flac/…).
         autoDecodingConfig: {},
         features: {
           // Word timing populates `segments`.


### PR DESCRIPTION
## Summary

follow up to https://github.com/vercel/ai/pull/15750

- Adds telephony as a first-class Google Vertex transcription model id.
- Updates Google Vertex and core transcription docs to cover Cloud Speech-to-Text models beyond Chirp.
- Adds an AI Functions example for googleVertex transcription telephony with languageCodes en-US.

## Context

Stacked on PR 15806. Gregor asked for the third Speech-to-Text model, telephony, and the model needs an explicit supported language code such as en-US.

## Validation

- pnpm --filter @ai-sdk/google-vertex type-check
- pnpm --filter @ai-sdk/google-vertex test:node google-vertex-transcription-model.test.ts
- pnpm exec tsc noEmit strict target es2022 module esnext moduleResolution bundler for src/transcribe/google-vertex/telephony.ts
- Manual localhost demo check: Telephony appears in the transcription model dropdown on localhost:5050.
