### PR TITLE
Support toModelOutput in WorkflowAgent

### DIFF
--- a/.changeset/workflow-agent-to-model-output.md
+++ b/.changeset/workflow-agent-to-model-output.md
@@ -3,4 +3,8 @@
 '@ai-sdk/workflow': patch
 ---
 
-Support tool `toModelOutput` conversions in `WorkflowAgent`.
+Honor `tool.toModelOutput` in `WorkflowAgent`.
+
+`WorkflowAgent` now routes successful local, provider-executed, and approved tool results through each tool's optional `toModelOutput` hook, matching `generateText`, `streamText`, and `ToolLoopAgent`. Previously the hook was ignored and results were always serialized as `text` or `json`.
+
+Internally exports the shared tool-result model-output helpers from `ai/internal`, and uses the shared `getErrorMessage` behavior for workflow tool error results.

--- a/.changeset/workflow-agent-to-model-output.md
+++ b/.changeset/workflow-agent-to-model-output.md
@@ -1,0 +1,6 @@
+---
+'ai': patch
+'@ai-sdk/workflow': patch
+---
+
+Support tool `toModelOutput` conversions in `WorkflowAgent`.

--- a/examples/next-workflow/README.md
+++ b/examples/next-workflow/README.md
@@ -6,9 +6,30 @@ This example demonstrates using the AI SDK's `WorkflowAgent` with the Workflow D
 
 - **Durable Agent**: Uses `WorkflowAgent` from `@ai-sdk/workflow` for fault-tolerant AI agent execution
 - **Tool Calling**: Includes weather lookup and calculator tools implemented as durable steps
+- **`toModelOutput`**: The `getWeather` tool sends the model a compact one-line summary while the UI keeps the full structured result
 - **Streaming**: Real-time streaming responses via `getWritable()` and `createUIMessageStreamResponse`
 - **Resumable**: Workflow runs survive restarts and can be reconnected
 - **Telemetry E2E Harness**: Visit `/telemetry` to run deterministic WorkflowAgent telemetry scenarios for lifecycle events, tool execution, context filtering, approvals, errors, and reconnects
+
+## Testing `toModelOutput`
+
+`WorkflowAgent` honors a tool's optional `toModelOutput` hook, just like `generateText`, `streamText`, and `ToolLoopAgent`. The hook controls what the model sees for a tool result, independent of what the app/UI receives.
+
+The `getWeather` tool in `workflow/agent-chat.ts` demonstrates this:
+
+1. Run the app and ask: **"What's the weather in Boston?"**
+2. In the browser, the rendered tool result shows the full JSON object (`{ city, temperature, unit, condition }`) from the raw `execute` return.
+3. In the dev server terminal, the `onEnd` callback logs the model-facing tool result, for example:
+
+   ```json
+   {
+     "type": "tool-result",
+     "toolName": "getWeather",
+     "output": { "type": "text", "value": "Boston: 22°C, sunny." }
+   }
+   ```
+
+The `calculate` tool has no `toModelOutput`, so its model-facing output stays the default `json` serialization for comparison.
 
 ## Running
 

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -87,6 +87,20 @@ const tools = {
       defaultUnit: z.enum(['celsius', 'fahrenheit']),
     }),
     execute: getWeather,
+
+    // `toModelOutput` controls what the model sees for this tool result.
+    // The app/UI still receives the full structured object, but the model
+    // receives this compact one-line summary instead of raw JSON.
+    toModelOutput: ({
+      output,
+    }: {
+      output: Awaited<ReturnType<typeof getWeather>>;
+    }) => ({
+      type: 'text' as const,
+      value: `${output.city}: ${output.temperature}°${
+        output.unit === 'celsius' ? 'C' : 'F'
+      }, ${output.condition}.`,
+    }),
   },
   calculate: {
     description: 'Evaluate a math expression.',
@@ -169,6 +183,20 @@ export async function chat(messages: UIMessage[], request: ChatRequestContext) {
         return { temperature: 0.2 };
       }
       return {};
+    },
+
+    // Make `toModelOutput` observable end-to-end. The tool-role messages here
+    // carry the model-facing tool results, while the UI renders raw tool output.
+    onEnd: ({ messages }) => {
+      const modelFacingToolResults = messages
+        .filter(message => message.role === 'tool')
+        .flatMap(message =>
+          Array.isArray(message.content) ? message.content : [],
+        );
+      console.log(
+        '[WorkflowAgent] model-facing tool results (post toModelOutput):',
+        JSON.stringify(modelFacingToolResults, null, 2),
+      );
     },
   });
 

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -133,7 +133,11 @@ export interface ChatRequestContext {
 export async function chat(messages: UIMessage[], request: ChatRequestContext) {
   'use workflow';
 
-  const modelMessages = await convertToModelMessages(messages);
+  // Pass `tools` so prior tool results from the UI history are reconstructed
+  // through each tool's `toModelOutput` hook — the same conversion WorkflowAgent
+  // applies to fresh tool results. Without this, earlier-turn tool results would
+  // fall back to default `json`/`text` serialization, diverging across turns.
+  const modelMessages = await convertToModelMessages(messages, { tools });
 
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),

--- a/packages/ai/internal/index.ts
+++ b/packages/ai/internal/index.ts
@@ -7,6 +7,7 @@ export { convertAsyncIteratorToReadableStream } from '@ai-sdk/provider-utils';
 // internal
 export { createAsyncIterableStream } from '../src/util/async-iterable-stream';
 export { convertToLanguageModelPrompt } from '../src/prompt/convert-to-language-model-prompt';
+export { createToolModelOutput } from '../src/prompt/create-tool-model-output';
 export { prepareToolChoice } from '../src/prompt/prepare-tool-choice';
 export { prepareTools } from '../src/prompt/prepare-tools';
 export { standardizePrompt } from '../src/prompt/standardize-prompt';

--- a/packages/ai/internal/index.ts
+++ b/packages/ai/internal/index.ts
@@ -8,10 +8,14 @@ export { convertAsyncIteratorToReadableStream } from '@ai-sdk/provider-utils';
 export { createAsyncIterableStream } from '../src/util/async-iterable-stream';
 export {
   convertToLanguageModelPrompt,
-  createLanguageModelToolResultOutput,
+  downloadAssets,
   mapToolResultOutput,
 } from '../src/prompt/convert-to-language-model-prompt';
 export { createToolModelOutput } from '../src/prompt/create-tool-model-output';
+export {
+  createDefaultDownloadFunction,
+  type DownloadFunction,
+} from '../src/util/download/download-function';
 export { prepareToolChoice } from '../src/prompt/prepare-tool-choice';
 export { prepareTools } from '../src/prompt/prepare-tools';
 export { standardizePrompt } from '../src/prompt/standardize-prompt';

--- a/packages/ai/internal/index.ts
+++ b/packages/ai/internal/index.ts
@@ -6,7 +6,11 @@ export { convertAsyncIteratorToReadableStream } from '@ai-sdk/provider-utils';
 
 // internal
 export { createAsyncIterableStream } from '../src/util/async-iterable-stream';
-export { convertToLanguageModelPrompt } from '../src/prompt/convert-to-language-model-prompt';
+export {
+  convertToLanguageModelPrompt,
+  createLanguageModelToolResultOutput,
+  mapToolResultOutput,
+} from '../src/prompt/convert-to-language-model-prompt';
 export { createToolModelOutput } from '../src/prompt/create-tool-model-output';
 export { prepareToolChoice } from '../src/prompt/prepare-tool-choice';
 export { prepareTools } from '../src/prompt/prepare-tools';

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -17,7 +17,6 @@ import {
   type ReasoningFilePart,
   type ReasoningPart,
   type TextPart,
-  type Tool,
   type ToolCallPart,
   type ToolResultOutput,
   type ToolResultPart,
@@ -32,7 +31,6 @@ import type { Warning } from '../types/warning';
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import type { StandardizedPrompt } from './standardize-prompt';
 import { MissingToolResultsError } from '../error/missing-tool-result-error';
-import { createToolModelOutput } from './create-tool-model-output';
 
 export async function convertToLanguageModelPrompt({
   prompt,
@@ -428,7 +426,7 @@ function convertImagePartToFilePart(
 /**
  * Downloads files from URLs in the user messages.
  */
-async function downloadAssets(
+export async function downloadAssets(
   messages: ModelMessage[],
   download: DownloadFunction,
   supportedUrls: Record<string, RegExp[]>,
@@ -592,63 +590,6 @@ function convertPartToLanguageModelPart(
     data,
     providerOptions: part.providerOptions,
   };
-}
-
-export async function createLanguageModelToolResultOutput({
-  toolCallId,
-  toolName,
-  input,
-  output,
-  tool,
-  errorMode,
-  supportedUrls,
-  download = createDefaultDownloadFunction(),
-  provider,
-}: {
-  toolCallId: string;
-  toolName: string;
-  input: unknown;
-  output: unknown;
-  tool: Tool | undefined;
-  errorMode: 'none' | 'text' | 'json';
-  supportedUrls: Record<string, RegExp[]>;
-  download?: DownloadFunction;
-  provider?: string;
-}): Promise<LanguageModelV4ToolResultOutput> {
-  const modelOutput = await createToolModelOutput({
-    toolCallId,
-    input,
-    output,
-    tool,
-    errorMode,
-  });
-
-  const downloadedAssets =
-    modelOutput.type === 'content'
-      ? await downloadAssets(
-          [
-            {
-              role: 'tool',
-              content: [
-                {
-                  type: 'tool-result',
-                  toolCallId,
-                  toolName,
-                  output: modelOutput,
-                },
-              ],
-            },
-          ],
-          download,
-          supportedUrls,
-        )
-      : {};
-
-  return mapToolResultOutput({
-    output: modelOutput,
-    provider,
-    downloadedAssets,
-  });
 }
 
 export function mapToolResultOutput({

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -17,6 +17,7 @@ import {
   type ReasoningFilePart,
   type ReasoningPart,
   type TextPart,
+  type Tool,
   type ToolCallPart,
   type ToolResultOutput,
   type ToolResultPart,
@@ -31,6 +32,7 @@ import type { Warning } from '../types/warning';
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import type { StandardizedPrompt } from './standardize-prompt';
 import { MissingToolResultsError } from '../error/missing-tool-result-error';
+import { createToolModelOutput } from './create-tool-model-output';
 
 export async function convertToLanguageModelPrompt({
   prompt,
@@ -592,7 +594,64 @@ function convertPartToLanguageModelPart(
   };
 }
 
-function mapToolResultOutput({
+export async function createLanguageModelToolResultOutput({
+  toolCallId,
+  toolName,
+  input,
+  output,
+  tool,
+  errorMode,
+  supportedUrls,
+  download = createDefaultDownloadFunction(),
+  provider,
+}: {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  output: unknown;
+  tool: Tool | undefined;
+  errorMode: 'none' | 'text' | 'json';
+  supportedUrls: Record<string, RegExp[]>;
+  download?: DownloadFunction;
+  provider?: string;
+}): Promise<LanguageModelV4ToolResultOutput> {
+  const modelOutput = await createToolModelOutput({
+    toolCallId,
+    input,
+    output,
+    tool,
+    errorMode,
+  });
+
+  const downloadedAssets =
+    modelOutput.type === 'content'
+      ? await downloadAssets(
+          [
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId,
+                  toolName,
+                  output: modelOutput,
+                },
+              ],
+            },
+          ],
+          download,
+          supportedUrls,
+        )
+      : {};
+
+  return mapToolResultOutput({
+    output: modelOutput,
+    provider,
+    downloadedAssets,
+  });
+}
+
+export function mapToolResultOutput({
   output,
   // `provider` is only needed here to convert legacy "file-id" and "image-file-id" types to provider references, in case they are using string ID values.
   // TODO: remove in v8 when "file-id" and "image-file-id" types are removed

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -21,8 +21,7 @@ export async function createToolModelOutput({
   }
 
   if (tool?.toModelOutput) {
-    const { toModelOutput } = tool;
-    return await toModelOutput({ toolCallId, input, output });
+    return await tool.toModelOutput({ toolCallId, input, output });
   }
 
   return typeof output === 'string'

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -21,7 +21,8 @@ export async function createToolModelOutput({
   }
 
   if (tool?.toModelOutput) {
-    return await tool.toModelOutput({ toolCallId, input, output });
+    const { toModelOutput } = tool;
+    return await toModelOutput({ toolCallId, input, output });
   }
 
   return typeof output === 'string'

--- a/packages/workflow/src/create-language-model-tool-result-output.ts
+++ b/packages/workflow/src/create-language-model-tool-result-output.ts
@@ -1,0 +1,85 @@
+import type { LanguageModelV4ToolResultOutput } from '@ai-sdk/provider';
+import type { Tool } from '@ai-sdk/provider-utils';
+import type { ModelMessage } from 'ai';
+import {
+  createDefaultDownloadFunction,
+  createToolModelOutput,
+  downloadAssets,
+  mapToolResultOutput,
+  type DownloadFunction,
+} from 'ai/internal';
+
+/**
+ * Converts a single tool result into a provider-level
+ * `LanguageModelV4ToolResultOutput`, honoring the tool's optional
+ * `toModelOutput` hook.
+ *
+ * Unlike `generateText`/`streamText`, `WorkflowAgent` assembles the
+ * `LanguageModelV4` prompt incrementally — appending one tool result at a time
+ * — instead of building AI-level `ModelMessage`s and converting the whole
+ * prompt once via `convertToLanguageModelPrompt`. This helper performs the
+ * equivalent per-result conversion using the shared `ai/internal` primitives:
+ *
+ *   1. `createToolModelOutput` — applies `tool.toModelOutput` (or the
+ *      text/json/error fallback).
+ *   2. `downloadAssets` — for `content`-type outputs, downloads any file/image
+ *      assets so URLs become bytes the provider can consume.
+ *   3. `mapToolResultOutput` — maps the AI-level `ToolResultOutput` to the
+ *      provider-level output and converts legacy file types.
+ */
+export async function createLanguageModelToolResultOutput({
+  toolCallId,
+  toolName,
+  input,
+  output,
+  tool,
+  errorMode,
+  supportedUrls,
+  download = createDefaultDownloadFunction(),
+  provider,
+}: {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  output: unknown;
+  tool: Tool | undefined;
+  errorMode: 'none' | 'text' | 'json';
+  supportedUrls: Record<string, RegExp[]>;
+  download?: DownloadFunction;
+  provider?: string;
+}): Promise<LanguageModelV4ToolResultOutput> {
+  const modelOutput = await createToolModelOutput({
+    toolCallId,
+    input,
+    output,
+    tool,
+    errorMode,
+  });
+
+  const downloadedAssets =
+    modelOutput.type === 'content'
+      ? await downloadAssets(
+          [
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId,
+                  toolName,
+                  output: modelOutput,
+                },
+              ],
+            } satisfies ModelMessage,
+          ],
+          download,
+          supportedUrls,
+        )
+      : {};
+
+  return mapToolResultOutput({
+    output: modelOutput,
+    provider,
+    downloadedAssets,
+  });
+}

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -294,6 +294,97 @@ describe('WorkflowAgent', () => {
       });
     });
 
+    it('should use toModelOutput for local tool results while preserving raw output', async () => {
+      const rawToolResult = { public: 'visible to user', secret: 'hide me' };
+      const toolInput = { query: 'test query' };
+      const toModelOutput = vi.fn(({ output }: any) => ({
+        type: 'text' as const,
+        value: `model sees: ${output.public}`,
+      }));
+      const tools: ToolSet = {
+        testTool: {
+          description: 'A test tool',
+          inputSchema: z.object({ query: z.string() }),
+          execute: async () => rawToolResult,
+          toModelOutput,
+        },
+      };
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools,
+      });
+
+      const write = vi.fn();
+      const mockWritable = new WritableStream({
+        write,
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockMessages: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'test-call-id',
+                  toolName: 'testTool',
+                  input: toolInput,
+                } as unknown as LanguageModelV4ToolCall,
+              ],
+              messages: mockMessages,
+            },
+          })
+          .mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      expect(toModelOutput).toHaveBeenCalledWith({
+        toolCallId: 'test-call-id',
+        input: toolInput,
+        output: rawToolResult,
+      });
+
+      const continuationToolResults = mockIterator.next.mock.calls[1][0];
+      expect(continuationToolResults[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'test-call-id',
+        toolName: 'testTool',
+        output: {
+          type: 'text',
+          value: 'model sees: visible to user',
+        },
+      });
+      expect(result.toolResults[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'test-call-id',
+        toolName: 'testTool',
+        input: toolInput,
+        output: rawToolResult,
+      });
+      expect(write.mock.calls.map(([chunk]) => chunk)).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-result',
+          toolCallId: 'test-call-id',
+          output: rawToolResult,
+        }),
+      );
+    });
+
     it('should skip local execution for provider-executed tools', async () => {
       // This tool should NOT be called because the tool call is provider-executed
       const executeFn = vi.fn();
@@ -378,6 +469,98 @@ describe('WorkflowAgent', () => {
           type: 'text',
           value: 'Search results for: test query',
         },
+      });
+    });
+
+    it('should use toModelOutput for provider-executed tool results while preserving raw output', async () => {
+      const rawProviderResult = {
+        public: 'provider result',
+        secret: 'hide me',
+      };
+      const toolInput = { query: 'test query' };
+      const executeFn = vi.fn();
+      const toModelOutput = vi.fn(({ output }: any) => ({
+        type: 'text' as const,
+        value: `model sees: ${output.public}`,
+      }));
+      const tools: ToolSet = {
+        WebSearch: {
+          description: 'A provider-executed tool',
+          inputSchema: z.object({ query: z.string() }),
+          execute: executeFn,
+          toModelOutput,
+        },
+      };
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools,
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockMessages: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+      const providerExecutedToolResults = new Map();
+      providerExecutedToolResults.set('provider-call-id', {
+        toolCallId: 'provider-call-id',
+        toolName: 'WebSearch',
+        result: rawProviderResult,
+        isError: false,
+      });
+
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'provider-call-id',
+                  toolName: 'WebSearch',
+                  input: toolInput,
+                  providerExecuted: true,
+                } as unknown as LanguageModelV4ToolCall,
+              ],
+              messages: mockMessages,
+              providerExecutedToolResults,
+            },
+          })
+          .mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+      });
+
+      expect(executeFn).not.toHaveBeenCalled();
+      expect(toModelOutput).toHaveBeenCalledWith({
+        toolCallId: 'provider-call-id',
+        input: toolInput,
+        output: rawProviderResult,
+      });
+
+      const continuationToolResults = mockIterator.next.mock.calls[1][0];
+      expect(continuationToolResults[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'provider-call-id',
+        toolName: 'WebSearch',
+        output: {
+          type: 'text',
+          value: 'model sees: provider result',
+        },
+      });
+      expect(result.toolResults[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'provider-call-id',
+        toolName: 'WebSearch',
+        input: toolInput,
+        output: rawProviderResult,
       });
     });
 
@@ -3067,6 +3250,107 @@ describe('WorkflowAgent', () => {
 
       // The streamTextIterator should have been called (the agent continues after approval)
       expect(mockIterator.next).toHaveBeenCalled();
+    });
+
+    it('should use toModelOutput for approved tool results while preserving raw stream output', async () => {
+      const rawToolResult = { public: 'weather summary', secret: 'hide me' };
+      const executeFn = vi.fn().mockResolvedValue(rawToolResult);
+      const toModelOutput = vi.fn(({ output }: any) => ({
+        type: 'text' as const,
+        value: `model sees: ${output.public}`,
+      }));
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: executeFn,
+          needsApproval: true as const,
+          toModelOutput,
+        },
+      };
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools,
+      });
+
+      const write = vi.fn();
+      const mockWritable = new WritableStream({
+        write,
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: "What's the weather in London?" },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                input: { city: 'London' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      expect(toModelOutput).toHaveBeenCalledWith({
+        toolCallId: 'call-1',
+        input: { city: 'London' },
+        output: rawToolResult,
+      });
+
+      const iteratorArgs = vi
+        .mocked(streamTextIterator)
+        .mock.calls.at(-1)?.[0] as any;
+      const toolMessage = iteratorArgs.prompt.find(
+        (message: any) =>
+          message.role === 'tool' &&
+          message.content.some((part: any) => part.toolCallId === 'call-1'),
+      );
+      expect(toolMessage.content[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'getWeather',
+        output: {
+          type: 'text',
+          value: 'model sees: weather summary',
+        },
+      });
+      expect(write.mock.calls.map(([chunk]) => chunk)).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          output: rawToolResult,
+        }),
+      );
     });
 
     it('should create denial results for denied tools and continue', async () => {

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -145,7 +145,7 @@ describe('WorkflowAgent', () => {
         toolName: 'testTool',
         output: {
           type: 'error-text',
-          value: errorMessage,
+          value: `FatalError: ${errorMessage}`,
         },
       });
     });
@@ -219,7 +219,7 @@ describe('WorkflowAgent', () => {
         toolName: 'testTool',
         output: {
           type: 'error-text',
-          value: errorMessage,
+          value: `Error: ${errorMessage}`,
         },
       });
     });
@@ -297,10 +297,12 @@ describe('WorkflowAgent', () => {
     it('should use toModelOutput for local tool results while preserving raw output', async () => {
       const rawToolResult = { public: 'visible to user', secret: 'hide me' };
       const toolInput = { query: 'test query' };
-      const toModelOutput = vi.fn(({ output }: any) => ({
-        type: 'text' as const,
-        value: `model sees: ${output.public}`,
-      }));
+      const toModelOutput = vi.fn(
+        ({ output }: { output: typeof rawToolResult }) => ({
+          type: 'text' as const,
+          value: `model sees: ${output.public}`,
+        }),
+      );
       const tools: ToolSet = {
         testTool: {
           description: 'A test tool',
@@ -479,10 +481,12 @@ describe('WorkflowAgent', () => {
       };
       const toolInput = { query: 'test query' };
       const executeFn = vi.fn();
-      const toModelOutput = vi.fn(({ output }: any) => ({
-        type: 'text' as const,
-        value: `model sees: ${output.public}`,
-      }));
+      const toModelOutput = vi.fn(
+        ({ output }: { output: typeof rawProviderResult }) => ({
+          type: 'text' as const,
+          value: `model sees: ${output.public}`,
+        }),
+      );
       const tools: ToolSet = {
         WebSearch: {
           description: 'A provider-executed tool',
@@ -904,7 +908,7 @@ describe('WorkflowAgent', () => {
           {
             "output": {
               "type": "error-text",
-              "value": "Invalid input for tool testTool",
+              "value": "Error: Invalid input for tool testTool",
             },
             "toolCallId": "invalid-call-id",
             "toolName": "testTool",
@@ -2198,7 +2202,7 @@ describe('WorkflowAgent', () => {
         toolName: 'failingTool',
         output: {
           type: 'error-text',
-          value: errorMessage,
+          value: `Error: ${errorMessage}`,
         },
       });
     });
@@ -2457,7 +2461,7 @@ describe('WorkflowAgent', () => {
         expect.objectContaining({
           stepNumber: 0,
           success: false,
-          error: 'tool failed',
+          error: 'Error: tool failed',
           durationMs: expect.any(Number),
         }),
       );
@@ -3255,10 +3259,12 @@ describe('WorkflowAgent', () => {
     it('should use toModelOutput for approved tool results while preserving raw stream output', async () => {
       const rawToolResult = { public: 'weather summary', secret: 'hide me' };
       const executeFn = vi.fn().mockResolvedValue(rawToolResult);
-      const toModelOutput = vi.fn(({ output }: any) => ({
-        type: 'text' as const,
-        value: `model sees: ${output.public}`,
-      }));
+      const toModelOutput = vi.fn(
+        ({ output }: { output: typeof rawToolResult }) => ({
+          type: 'text' as const,
+          value: `model sees: ${output.public}`,
+        }),
+      );
       const tools: ToolSet = {
         getWeather: {
           description: 'Get weather',

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -34,13 +34,13 @@ import {
   type Instructions,
 } from 'ai';
 import {
-  createLanguageModelToolResultOutput,
   createRestrictedTelemetryDispatcher,
   convertToLanguageModelPrompt,
   mergeAbortSignals,
   mergeCallbacks,
   standardizePrompt,
 } from 'ai/internal';
+import { createLanguageModelToolResultOutput } from './create-language-model-tool-result-output.js';
 import { streamTextIterator } from './stream-text-iterator.js';
 
 // Re-export for consumers

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -2,16 +2,15 @@ import type {
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
   LanguageModelV4StreamPart,
-  LanguageModelV4ToolResultOutput,
   LanguageModelV4ToolResultPart,
   SharedV4ProviderOptions,
 } from '@ai-sdk/provider';
 import {
+  getErrorMessage,
   validateTypes,
   type Context,
   type HasRequiredKey,
   type InferToolSetContext,
-  type Tool,
 } from '@ai-sdk/provider-utils';
 import {
   Output,
@@ -35,8 +34,8 @@ import {
   type Instructions,
 } from 'ai';
 import {
+  createLanguageModelToolResultOutput,
   createRestrictedTelemetryDispatcher,
-  createToolModelOutput,
   convertToLanguageModelPrompt,
   mergeAbortSignals,
   mergeCallbacks,
@@ -1417,12 +1416,14 @@ export class WorkflowAgent<
               type: 'tool-result' as const,
               toolCallId: approval.toolCallId,
               toolName: approval.toolName,
-              output: await createWorkflowToolModelOutput({
-                toolCall: approval,
+              output: await createLanguageModelToolResultOutput({
+                toolCallId: approval.toolCallId,
+                toolName: approval.toolName,
                 input: approval.input,
                 output: toolResult,
                 tool,
                 errorMode: 'none',
+                supportedUrls: {},
                 download,
               }),
             });
@@ -1452,12 +1453,14 @@ export class WorkflowAgent<
               type: 'tool-result' as const,
               toolCallId: approval.toolCallId,
               toolName: approval.toolName,
-              output: await createWorkflowToolModelOutput({
-                toolCall: approval,
+              output: await createLanguageModelToolResultOutput({
+                toolCallId: approval.toolCallId,
+                toolName: approval.toolName,
                 input: approval.input,
                 output: errorMessage,
                 tool,
                 errorMode: 'text',
+                supportedUrls: {},
                 download,
               }),
             });
@@ -2525,96 +2528,6 @@ function aggregateUsage(steps: StepResult<any, any>[]): LanguageModelUsage {
   } as LanguageModelUsage;
 }
 
-// Matches AI SDK's getErrorMessage from @ai-sdk/provider-utils
-function getErrorMessage(error: unknown): string {
-  if (error == null) {
-    return 'unknown error';
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return JSON.stringify(error);
-}
-
-async function createWorkflowToolModelOutput({
-  toolCall,
-  input,
-  output,
-  tool,
-  errorMode,
-  download,
-}: {
-  toolCall: { toolCallId: string; toolName: string };
-  input: unknown;
-  output: unknown;
-  tool: Tool | undefined;
-  errorMode: 'none' | 'text' | 'json';
-  download?: DownloadFunction;
-}): Promise<LanguageModelV4ToolResultOutput> {
-  const modelOutput = await createToolModelOutput({
-    toolCallId: toolCall.toolCallId,
-    input,
-    output,
-    tool,
-    errorMode,
-  });
-
-  if (modelOutput.type !== 'content') {
-    return modelOutput;
-  }
-
-  const convertedPrompt = await convertToLanguageModelPrompt({
-    prompt: {
-      instructions: undefined,
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            {
-              type: 'tool-call',
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.toolName,
-              input,
-            },
-          ],
-        },
-        {
-          role: 'tool',
-          content: [
-            {
-              type: 'tool-result',
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.toolName,
-              output: modelOutput,
-            },
-          ],
-        },
-      ],
-    } satisfies Parameters<typeof convertToLanguageModelPrompt>[0]['prompt'],
-    supportedUrls: {},
-    download,
-  });
-  const toolMessage = convertedPrompt.find(message => message.role === 'tool');
-  const toolResult = toolMessage?.content.find(
-    (part): part is LanguageModelV4ToolResultPart =>
-      part.type === 'tool-result' && part.toolCallId === toolCall.toolCallId,
-  );
-
-  if (toolResult == null) {
-    throw new Error(
-      `Tool result "${toolCall.toolCallId}" was missing after prompt conversion.`,
-    );
-  }
-
-  return toolResult.output;
-}
-
 async function resolveProviderToolResult(
   toolCall: { toolCallId: string; toolName: string; input: unknown },
   providerExecutedToolResults?: Map<
@@ -2657,12 +2570,14 @@ async function resolveProviderToolResult(
       type: 'tool-result' as const,
       toolCallId: toolCall.toolCallId,
       toolName: toolCall.toolName,
-      output: await createWorkflowToolModelOutput({
-        toolCall,
+      output: await createLanguageModelToolResultOutput({
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
         input: toolCall.input,
         output: result,
         tool: tools?.[toolCall.toolName],
         errorMode,
+        supportedUrls: {},
         download,
       }),
     },
@@ -2738,12 +2653,14 @@ async function executeTool(
         type: 'tool-result',
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
-        output: await createWorkflowToolModelOutput({
-          toolCall,
+        output: await createLanguageModelToolResultOutput({
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
           input: parsedInput,
           output: errorMessage,
           tool,
           errorMode: 'text',
+          supportedUrls: {},
           download,
         }),
       },
@@ -2757,12 +2674,14 @@ async function executeTool(
       type: 'tool-result' as const,
       toolCallId: toolCall.toolCallId,
       toolName: toolCall.toolName,
-      output: await createWorkflowToolModelOutput({
-        toolCall,
+      output: await createLanguageModelToolResultOutput({
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
         input: parsedInput,
         output: toolResult,
         tool,
         errorMode: 'none',
+        supportedUrls: {},
         download,
       }),
     },

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1,8 +1,8 @@
 import type {
-  JSONValue,
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
   LanguageModelV4StreamPart,
+  LanguageModelV4ToolResultOutput,
   LanguageModelV4ToolResultPart,
   SharedV4ProviderOptions,
 } from '@ai-sdk/provider';
@@ -11,6 +11,7 @@ import {
   type Context,
   type HasRequiredKey,
   type InferToolSetContext,
+  type Tool,
 } from '@ai-sdk/provider-utils';
 import {
   Output,
@@ -35,6 +36,7 @@ import {
 } from 'ai';
 import {
   createRestrictedTelemetryDispatcher,
+  createToolModelOutput,
   convertToLanguageModelPrompt,
   mergeAbortSignals,
   mergeCallbacks,
@@ -1053,6 +1055,12 @@ export interface ToolResult {
   output: unknown;
 }
 
+type WorkflowToolExecutionResult = {
+  modelResult: LanguageModelV4ToolResultPart;
+  rawOutput: unknown;
+  isError: boolean;
+};
+
 /**
  * Result of the WorkflowAgent.stream method.
  */
@@ -1338,6 +1346,7 @@ export class WorkflowAgent<
         ? { prompt: effectivePrompt }
         : { messages: effectiveMessages! }),
     } as Prompt);
+    const download = options.experimental_download ?? this.experimentalDownload;
 
     // Process tool approval responses before starting the agent loop.
     // This mirrors how stream-text.ts handles tool-approval-response parts:
@@ -1348,14 +1357,12 @@ export class WorkflowAgent<
 
     if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
       const _toolResultMessages: ModelMessage[] = [];
-      const toolResultContent: Array<{
-        type: 'tool-result';
+      const toolResultContent: LanguageModelV4ToolResultPart[] = [];
+      const approvedRawResults: Array<{
         toolCallId: string;
         toolName: string;
-        output:
-          | { type: 'text'; value: string }
-          | { type: 'json'; value: JSONValue }
-          | { type: 'execution-denied'; reason: string | undefined };
+        input: unknown;
+        output: unknown;
       }> = [];
 
       // Execute approved tools
@@ -1410,12 +1417,23 @@ export class WorkflowAgent<
               type: 'tool-result' as const,
               toolCallId: approval.toolCallId,
               toolName: approval.toolName,
-              output:
-                typeof toolResult === 'string'
-                  ? { type: 'text' as const, value: toolResult }
-                  : { type: 'json' as const, value: toolResult },
+              output: await createWorkflowToolModelOutput({
+                toolCall: approval,
+                input: approval.input,
+                output: toolResult,
+                tool,
+                errorMode: 'none',
+                download,
+              }),
+            });
+            approvedRawResults.push({
+              toolCallId: approval.toolCallId,
+              toolName: approval.toolName,
+              input: approval.input,
+              output: toolResult,
             });
           } catch (error) {
+            const errorMessage = getErrorMessage(error);
             await telemetryDispatcher.onToolExecutionEnd?.({
               toolCall: {
                 type: 'tool-call',
@@ -1434,10 +1452,20 @@ export class WorkflowAgent<
               type: 'tool-result' as const,
               toolCallId: approval.toolCallId,
               toolName: approval.toolName,
-              output: {
-                type: 'text' as const,
-                value: getErrorMessage(error),
-              },
+              output: await createWorkflowToolModelOutput({
+                toolCall: approval,
+                input: approval.input,
+                output: errorMessage,
+                tool,
+                errorMode: 'text',
+                download,
+              }),
+            });
+            approvedRawResults.push({
+              toolCallId: approval.toolCallId,
+              toolName: approval.toolName,
+              input: approval.input,
+              output: errorMessage,
             });
           }
         }
@@ -1492,22 +1520,12 @@ export class WorkflowAgent<
       // can transition approved/denied tool parts to the correct state
       // and properly separate them from the subsequent model step.
       if (options.writable && toolResultContent.length > 0) {
-        const approvedResults = toolResultContent
-          .filter(r => r.output.type !== 'execution-denied')
-          .map(r => ({
-            toolCallId: r.toolCallId,
-            toolName: r.toolName,
-            input: approvedToolApprovals.find(
-              a => a.toolCallId === r.toolCallId,
-            )?.input,
-            output: 'value' in r.output ? r.output.value : undefined,
-          }));
         const deniedResults = toolResultContent
           .filter(r => r.output.type === 'execution-denied')
           .map(r => ({ toolCallId: r.toolCallId }));
         await writeApprovalToolResults(
           options.writable,
-          approvedResults,
+          approvedRawResults,
           deniedResults,
         );
       }
@@ -1516,7 +1534,7 @@ export class WorkflowAgent<
     const modelPrompt = await convertToLanguageModelPrompt({
       prompt,
       supportedUrls: {},
-      download: options.experimental_download ?? this.experimentalDownload,
+      download,
     });
 
     const effectiveAbortSignal = mergeAbortSignals(
@@ -1659,7 +1677,7 @@ export class WorkflowAgent<
       messages: LanguageModelV4Prompt,
       perToolContexts: Record<string, Context | undefined>,
       currentStepNumber: number = 0,
-    ): Promise<LanguageModelV4ToolResultPart> => {
+    ): Promise<WorkflowToolExecutionResult> => {
       const toolCallEvent: ToolCall = {
         type: 'tool-call',
         toolCallId: toolCall.toolCallId,
@@ -1697,10 +1715,10 @@ export class WorkflowAgent<
       });
 
       const startTime = Date.now();
-      let result: LanguageModelV4ToolResultPart;
+      let result: WorkflowToolExecutionResult;
       try {
         const execute = () =>
-          executeTool(toolCall, tools, messages, resolvedContext);
+          executeTool(toolCall, tools, messages, resolvedContext, download);
         result =
           telemetryDispatcher.executeTool != null
             ? await telemetryDispatcher.executeTool({
@@ -1740,12 +1758,7 @@ export class WorkflowAgent<
 
       const durationMs = Date.now() - startTime;
       if (mergedOnToolExecutionEnd) {
-        const isError =
-          result.output &&
-          'type' in result.output &&
-          (result.output.type === 'error-text' ||
-            result.output.type === 'error-json');
-        if (isError) {
+        if (result.isError) {
           await mergedOnToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
@@ -1755,7 +1768,7 @@ export class WorkflowAgent<
               | InferToolSetContext<TTools>[keyof InferToolSetContext<TTools>]
               | undefined,
             success: false,
-            error: 'value' in result.output ? result.output.value : undefined,
+            error: result.rawOutput,
           });
         } else {
           await mergedOnToolExecutionEnd({
@@ -1767,19 +1780,11 @@ export class WorkflowAgent<
               | InferToolSetContext<TTools>[keyof InferToolSetContext<TTools>]
               | undefined,
             success: true,
-            output:
-              result.output && 'value' in result.output
-                ? result.output.value
-                : undefined,
+            output: result.rawOutput,
           });
         }
       }
-      if (
-        result.output &&
-        'type' in result.output &&
-        (result.output.type === 'error-text' ||
-          result.output.type === 'error-json')
-      ) {
+      if (result.isError) {
         await telemetryDispatcher.onToolExecutionEnd?.({
           toolCall: toolCallEvent,
           stepNumber: currentStepNumber,
@@ -1789,7 +1794,7 @@ export class WorkflowAgent<
             | InferToolSetContext<TTools>[keyof InferToolSetContext<TTools>]
             | undefined,
           success: false,
-          error: 'value' in result.output ? result.output.value : undefined,
+          error: result.rawOutput,
         });
       } else {
         await telemetryDispatcher.onToolExecutionEnd?.({
@@ -1801,10 +1806,7 @@ export class WorkflowAgent<
             | InferToolSetContext<TTools>[keyof InferToolSetContext<TTools>]
             | undefined,
           success: true,
-          output:
-            result.output && 'value' in result.output
-              ? result.output.value
-              : undefined,
+          output: result.rawOutput,
         });
       }
       return result;
@@ -1812,7 +1814,7 @@ export class WorkflowAgent<
 
     const recordProviderExecutedToolTelemetry = async (
       toolCall: { toolCallId: string; toolName: string; input: unknown },
-      result: LanguageModelV4ToolResultPart,
+      result: WorkflowToolExecutionResult,
       messages: LanguageModelV4Prompt,
       currentStepNumber: number,
     ) => {
@@ -1831,32 +1833,20 @@ export class WorkflowAgent<
         toolContext: undefined,
       });
 
-      const isError =
-        result.output &&
-        'type' in result.output &&
-        (result.output.type === 'error-text' ||
-          result.output.type === 'error-json');
-
       await telemetryDispatcher.onToolExecutionEnd?.({
         toolCall: toolCallEvent,
         stepNumber: currentStepNumber,
         durationMs: 0,
         messages: modelMessages,
         toolContext: undefined,
-        ...(isError
+        ...(result.isError
           ? {
               success: false as const,
-              error:
-                result.output && 'value' in result.output
-                  ? result.output.value
-                  : undefined,
+              error: result.rawOutput,
             }
           : {
               success: true as const,
-              output:
-                result.output && 'value' in result.output
-                  ? result.output.value
-                  : undefined,
+              output: result.rawOutput,
             }),
       });
     };
@@ -2000,7 +1990,7 @@ export class WorkflowAgent<
             // Execute any executable tools that were also called in this step
             const executableResults = await Promise.all(
               executableToolCalls.map(
-                (toolCall): Promise<LanguageModelV4ToolResultPart> =>
+                (toolCall): Promise<WorkflowToolExecutionResult> =>
                   executeToolWithCallbacks(
                     toolCall,
                     effectiveTools as ToolSet,
@@ -2012,11 +2002,15 @@ export class WorkflowAgent<
             );
 
             // Collect provider tool results
-            const providerResults: LanguageModelV4ToolResultPart[] =
-              providerToolCalls.map(toolCall =>
-                resolveProviderToolResult(
-                  toolCall,
-                  providerExecutedToolResults,
+            const providerResults: WorkflowToolExecutionResult[] =
+              await Promise.all(
+                providerToolCalls.map(toolCall =>
+                  resolveProviderToolResult(
+                    toolCall,
+                    providerExecutedToolResults,
+                    effectiveTools as ToolSet,
+                    download,
+                  ),
                 ),
               );
             await Promise.all(
@@ -2033,9 +2027,9 @@ export class WorkflowAgent<
             const continuationInvalidResults = invalidToolCalls.map(
               createInvalidToolResult,
             );
-            const resolvedResults = [
-              ...executableResults,
-              ...providerResults,
+            const resolvedResults: LanguageModelV4ToolResultPart[] = [
+              ...executableResults.map(result => result.modelResult),
+              ...providerResults.map(result => result.modelResult),
               ...continuationInvalidResults,
             ];
             const executedResults = [...executableResults, ...providerResults];
@@ -2049,11 +2043,12 @@ export class WorkflowAgent<
 
             const allToolResults: ToolResult[] = executedResults.map(r => ({
               type: 'tool-result' as const,
-              toolCallId: r.toolCallId,
-              toolName: r.toolName,
-              input: toolCalls.find(tc => tc.toolCallId === r.toolCallId)
-                ?.input,
-              output: 'value' in r.output ? r.output.value : undefined,
+              toolCallId: r.modelResult.toolCallId,
+              toolName: r.modelResult.toolName,
+              input: toolCalls.find(
+                tc => tc.toolCallId === r.modelResult.toolCallId,
+              )?.input,
+              output: r.rawOutput,
             }));
 
             if (resolvedResults.length > 0) {
@@ -2134,7 +2129,7 @@ export class WorkflowAgent<
           // Execute client tools (all have execute functions at this point)
           const clientToolResults = await Promise.all(
             nonProviderToolCalls.map(
-              (toolCall): Promise<LanguageModelV4ToolResultPart> =>
+              (toolCall): Promise<WorkflowToolExecutionResult> =>
                 executeToolWithCallbacks(
                   toolCall,
                   effectiveTools as ToolSet,
@@ -2146,9 +2141,16 @@ export class WorkflowAgent<
           );
 
           // For provider-executed tools, use the results from the stream
-          const providerToolResults: LanguageModelV4ToolResultPart[] =
-            providerToolCalls.map(toolCall =>
-              resolveProviderToolResult(toolCall, providerExecutedToolResults),
+          const providerToolResults: WorkflowToolExecutionResult[] =
+            await Promise.all(
+              providerToolCalls.map(toolCall =>
+                resolveProviderToolResult(
+                  toolCall,
+                  providerExecutedToolResults,
+                  effectiveTools as ToolSet,
+                  download,
+                ),
+              ),
             );
           await Promise.all(
             providerToolCalls.map((toolCall, index) =>
@@ -2167,25 +2169,28 @@ export class WorkflowAgent<
           // Combine executable/provider results in the original order,
           // while preserving invalid tool calls as error results for the
           // next model step without emitting them as synthetic UI success.
+          const executedToolResults = toolCalls.flatMap(tc => {
+            const clientResult = clientToolResults.find(
+              r => r.modelResult.toolCallId === tc.toolCallId,
+            );
+            if (clientResult) return [clientResult];
+            const providerResult = providerToolResults.find(
+              r => r.modelResult.toolCallId === tc.toolCallId,
+            );
+            if (providerResult) return [providerResult];
+            return [];
+          });
           const continuationToolResults = toolCalls.flatMap(tc => {
             const invalidResult = continuationInvalidToolResults.find(
               r => r.toolCallId === tc.toolCallId,
             );
             if (invalidResult) return [invalidResult];
-            const clientResult = clientToolResults.find(
-              r => r.toolCallId === tc.toolCallId,
+            const executedResult = executedToolResults.find(
+              r => r.modelResult.toolCallId === tc.toolCallId,
             );
-            if (clientResult) return [clientResult];
-            const providerResult = providerToolResults.find(
-              r => r.toolCallId === tc.toolCallId,
-            );
-            if (providerResult) return [providerResult];
+            if (executedResult) return [executedResult.modelResult];
             return [];
           });
-          const executedToolResults = continuationToolResults.filter(
-            result =>
-              !invalidToolCalls.some(tc => tc.toolCallId === result.toolCallId),
-          );
 
           // Write tool results and step boundaries to the stream so the
           // UI can transition tool parts to output-available state and
@@ -2194,11 +2199,12 @@ export class WorkflowAgent<
             await writeToolResultsWithStepBoundary(
               options.writable,
               executedToolResults.map(r => ({
-                toolCallId: r.toolCallId,
-                toolName: r.toolName,
-                input: toolCalls.find(tc => tc.toolCallId === r.toolCallId)
-                  ?.input,
-                output: 'value' in r.output ? r.output.value : undefined,
+                toolCallId: r.modelResult.toolCallId,
+                toolName: r.modelResult.toolName,
+                input: toolCalls.find(
+                  tc => tc.toolCallId === r.modelResult.toolCallId,
+                )?.input,
+                output: r.rawOutput,
               })),
             );
           }
@@ -2212,10 +2218,12 @@ export class WorkflowAgent<
           }));
           lastStepToolResults = executedToolResults.map(r => ({
             type: 'tool-result' as const,
-            toolCallId: r.toolCallId,
-            toolName: r.toolName,
-            input: toolCalls.find(tc => tc.toolCallId === r.toolCallId)?.input,
-            output: 'value' in r.output ? r.output.value : undefined,
+            toolCallId: r.modelResult.toolCallId,
+            toolName: r.modelResult.toolName,
+            input: toolCalls.find(
+              tc => tc.toolCallId === r.modelResult.toolCallId,
+            )?.input,
+            output: r.rawOutput,
           }));
 
           result = await iterator.next(continuationToolResults);
@@ -2534,13 +2542,88 @@ function getErrorMessage(error: unknown): string {
   return JSON.stringify(error);
 }
 
-function resolveProviderToolResult(
-  toolCall: { toolCallId: string; toolName: string },
+async function createWorkflowToolModelOutput({
+  toolCall,
+  input,
+  output,
+  tool,
+  errorMode,
+  download,
+}: {
+  toolCall: { toolCallId: string; toolName: string };
+  input: unknown;
+  output: unknown;
+  tool: Tool | undefined;
+  errorMode: 'none' | 'text' | 'json';
+  download?: DownloadFunction;
+}): Promise<LanguageModelV4ToolResultOutput> {
+  const modelOutput = await createToolModelOutput({
+    toolCallId: toolCall.toolCallId,
+    input,
+    output,
+    tool,
+    errorMode,
+  });
+
+  if (modelOutput.type !== 'content') {
+    return modelOutput;
+  }
+
+  const convertedPrompt = await convertToLanguageModelPrompt({
+    prompt: {
+      instructions: undefined,
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              input,
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              output: modelOutput,
+            },
+          ],
+        },
+      ],
+    } satisfies Parameters<typeof convertToLanguageModelPrompt>[0]['prompt'],
+    supportedUrls: {},
+    download,
+  });
+  const toolMessage = convertedPrompt.find(message => message.role === 'tool');
+  const toolResult = toolMessage?.content.find(
+    (part): part is LanguageModelV4ToolResultPart =>
+      part.type === 'tool-result' && part.toolCallId === toolCall.toolCallId,
+  );
+
+  if (toolResult == null) {
+    throw new Error(
+      `Tool result "${toolCall.toolCallId}" was missing after prompt conversion.`,
+    );
+  }
+
+  return toolResult.output;
+}
+
+async function resolveProviderToolResult(
+  toolCall: { toolCallId: string; toolName: string; input: unknown },
   providerExecutedToolResults?: Map<
     string,
     { toolCallId: string; toolName: string; result: unknown; isError?: boolean }
   >,
-): LanguageModelV4ToolResultPart {
+  tools?: ToolSet,
+  download?: DownloadFunction,
+): Promise<WorkflowToolExecutionResult> {
   const streamResult = providerExecutedToolResults?.get(toolCall.toolCallId);
   if (!streamResult) {
     console.warn(
@@ -2548,36 +2631,43 @@ function resolveProviderToolResult(
         `did not receive a result from the stream. This may indicate a provider issue.`,
     );
     return {
-      type: 'tool-result' as const,
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      output: {
-        type: 'text' as const,
-        value: '',
+      modelResult: {
+        type: 'tool-result' as const,
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        output: {
+          type: 'text' as const,
+          value: '',
+        },
       },
+      rawOutput: '',
+      isError: false,
     };
   }
 
   const result = streamResult.result;
-  const isString = typeof result === 'string';
+  const errorMode = streamResult.isError
+    ? typeof result === 'string'
+      ? 'text'
+      : 'json'
+    : 'none';
 
   return {
-    type: 'tool-result' as const,
-    toolCallId: toolCall.toolCallId,
-    toolName: toolCall.toolName,
-    output: isString
-      ? streamResult.isError
-        ? { type: 'error-text' as const, value: result }
-        : { type: 'text' as const, value: result }
-      : streamResult.isError
-        ? {
-            type: 'error-json' as const,
-            value: result as JSONValue,
-          }
-        : {
-            type: 'json' as const,
-            value: result as JSONValue,
-          },
+    modelResult: {
+      type: 'tool-result' as const,
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+      output: await createWorkflowToolModelOutput({
+        toolCall,
+        input: toolCall.input,
+        output: result,
+        tool: tools?.[toolCall.toolName],
+        errorMode,
+        download,
+      }),
+    },
+    rawOutput: result,
+    isError: streamResult.isError === true,
   };
 }
 
@@ -2610,7 +2700,8 @@ async function executeTool(
   tools: ToolSet,
   messages: LanguageModelV4Prompt,
   context?: unknown,
-): Promise<LanguageModelV4ToolResultPart> {
+  download?: DownloadFunction,
+): Promise<WorkflowToolExecutionResult> {
   const tool = tools[toolCall.toolName];
   if (!tool) throw new Error(`Tool "${toolCall.toolName}" not found`);
   if (typeof tool.execute !== 'function') {
@@ -2621,6 +2712,7 @@ async function executeTool(
   }
   // Input is already parsed and validated by streamModelCall's parseToolCall
   const parsedInput = toolCall.input;
+  let toolResult: unknown;
 
   try {
     // Extract execute function to avoid binding `this` to the tool object.
@@ -2629,41 +2721,54 @@ async function executeTool(
     // When the execute function is a workflow step (marked with 'use step'),
     // the step system captures `this` for serialization, causing failures.
     const { execute } = tool;
-    const toolResult = await execute(parsedInput, {
+    toolResult = await execute(parsedInput, {
       toolCallId: toolCall.toolCallId,
       // Pass the conversation messages to the tool so it has context about the conversation
       messages,
       // Pass per-tool context to the tool (resolved from `toolsContext`)
       context,
     });
-
-    // Use the appropriate output type based on the result
-    // AI SDK supports 'text' for strings and 'json' for objects
-    const output =
-      typeof toolResult === 'string'
-        ? { type: 'text' as const, value: toolResult }
-        : { type: 'json' as const, value: toolResult };
-
-    return {
-      type: 'tool-result' as const,
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      output,
-    };
   } catch (error) {
     // Convert tool errors to error-text results sent back to the model,
     // allowing the agent to recover rather than killing the entire stream.
     // This aligns with AI SDK's streamText behavior for individual tool failures.
+    const errorMessage = getErrorMessage(error);
     return {
-      type: 'tool-result',
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      output: {
-        type: 'error-text',
-        value: getErrorMessage(error),
+      modelResult: {
+        type: 'tool-result',
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        output: await createWorkflowToolModelOutput({
+          toolCall,
+          input: parsedInput,
+          output: errorMessage,
+          tool,
+          errorMode: 'text',
+          download,
+        }),
       },
+      rawOutput: errorMessage,
+      isError: true,
     };
   }
+
+  return {
+    modelResult: {
+      type: 'tool-result' as const,
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+      output: await createWorkflowToolModelOutput({
+        toolCall,
+        input: parsedInput,
+        output: toolResult,
+        tool,
+        errorMode: 'none',
+        download,
+      }),
+    },
+    rawOutput: toolResult,
+    isError: false,
+  };
 }
 
 /**


### PR DESCRIPTION
## Background

`WorkflowAgent` did not honor tool `toModelOutput`, unlike core text generation.

## Summary

- route WorkflowAgent tool results through model-output conversion
- keep raw tool output for UI/results/callbacks
- add next-workflow example + docs

## Manual Verification

Tested examples/next-workflow end-to-end

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)