### PR TITLE
docs(provider): add Latitude observability provider (v7)

### DIFF
--- a/content/providers/05-observability/index.mdx
+++ b/content/providers/05-observability/index.mdx
@@ -15,6 +15,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [LangSmith](/providers/observability/langsmith)
 - [Laminar](/providers/observability/laminar)
 - [LangWatch](/providers/observability/langwatch)
+- [Latitude](/providers/observability/latitude)
 - [MLflow](/providers/observability/mlflow)
 - [Maxim](/providers/observability/maxim)
 - [PostHog](/providers/observability/posthog)

--- a/content/providers/05-observability/latitude.mdx
+++ b/content/providers/05-observability/latitude.mdx
@@ -1,0 +1,83 @@
+---
+title: Latitude
+description: Monitor and debug your AI SDK application with Latitude
+---
+
+# Latitude Observability
+
+[Latitude](https://latitude.so) ([GitHub](https://github.com/latitude-dev/latitude-llm)) is an open-source MIT-licensed platform for AI agent observability with semantic trace search and issue tracking. It integrates with the AI SDK to capture:
+
+- Traces of every `generateText`, `streamText`, and tool call
+- Token usage and latency per call
+- Errors and failure patterns grouped as recurring issues
+
+## Setup
+
+Latitude's SDK registers a global OpenTelemetry tracer. Once you register the AI SDK's telemetry integration, every AI SDK call emits spans automatically.
+
+Install both packages:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @latitude-data/telemetry @ai-sdk/otel" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @latitude-data/telemetry @ai-sdk/otel" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @latitude-data/telemetry @ai-sdk/otel" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @latitude-data/telemetry @ai-sdk/otel" dark />
+  </Tab>
+</Tabs>
+
+Sign in at [app.latitude.so](https://app.latitude.so) and grab your API key and project slug from the dashboard. Set them in your environment:
+
+```bash filename=".env"
+LATITUDE_API_KEY="..."
+LATITUDE_PROJECT_SLUG="..."
+```
+
+Initialize Latitude and register telemetry once at startup. After that, every AI SDK call emits traces automatically:
+
+```ts
+import { Latitude } from '@latitude-data/telemetry';
+import { registerTelemetry, generateText } from 'ai';
+import { OpenTelemetry } from '@ai-sdk/otel';
+import { openai } from '@ai-sdk/openai';
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
+});
+
+registerTelemetry(new OpenTelemetry());
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+});
+
+await latitude.shutdown();
+```
+
+For named traces and per-call metadata (tags, user IDs, session IDs), wrap calls in Latitude's `capture()` helper:
+
+```ts
+import { capture } from '@latitude-data/telemetry';
+
+await capture('generate-support-reply', async () => {
+  const { text } = await generateText({
+    model: openai('gpt-4o'),
+    prompt: 'Hello',
+  });
+  return text;
+});
+```
+
+## Resources
+
+- [Latitude Vercel AI SDK guide](https://docs.latitude.so/telemetry/frameworks/vercel-ai-sdk)
+- [Latitude documentation](https://docs.latitude.so)
+- [GitHub repository](https://github.com/latitude-dev/latitude-llm)


### PR DESCRIPTION
Adds Latitude as an observability provider for the AI SDK v7. Companion to #15816 (which targets `release-v6.0`).

Per the v7 telemetry docs, telemetry is enabled with a one-time `registerTelemetry(new OpenTelemetry())` call rather than the per-call `experimental_telemetry` flag. This PR uses that new pattern.

Two file changes:

- New `content/providers/05-observability/latitude.mdx` with install, env setup, and a minimal `generateText` example using `registerTelemetry`
- `content/providers/05-observability/index.mdx` updated to list Latitude alphabetically between LangWatch and MLflow

Verified locally with `ai@7.0.0-beta.116`, `@ai-sdk/otel@1.0.0-beta.62`, and `@latitude-data/telemetry`: `generateText` emits spans through Latitude's global tracer with no per-call flags.

Links:

- Site: https://latitude.so
- Vercel AI SDK guide on Latitude docs: https://docs.latitude.so/telemetry/frameworks/vercel-ai-sdk
- Repo: https://github.com/latitude-dev/latitude-llm