### PR TITLE
doc: fix broken video embed in MLflow observability docs

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -271,15 +271,15 @@ Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-m
 <Note>
   Implementing language model middleware is advanced functionality and requires
   a solid understanding of the [language model
-  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+  specification](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
 </Note>
 
 You can implement any of the following three function to modify the behavior of the language model:
 
 1. `transformParams`: Transforms the parameters before they are passed to the language model, for both `doGenerate` and `doStream`.
-2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
-3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
 
 Here are some examples of how to implement language model middleware:

--- a/content/providers/05-observability/mlflow.mdx
+++ b/content/providers/05-observability/mlflow.mdx
@@ -5,7 +5,7 @@ description: Track, visualize, and debug Vercel AI SDK traces with MLflow Tracin
 
 # MLflow Observability
 
-![MLflow Tracing Vercel AI SDK](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
+[MLflow Tracing Vercel AI SDK Demo Video](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
 
 [MLflow Tracing](https://mlflow.org/docs/latest/genai/tracing) provides automatic tracing for applications built with the [Vercel AI SDK](https://ai-sdk.dev/) (the `ai` package) via OpenTelemetry, unlocking observability for TypeScript and JavaScript apps.
 


### PR DESCRIPTION
The video embed in the MLflow observability documentation was rendering as a broken link on the website. The MP4 video file exists and is accessible, but markdown image syntax () creates an  tag which cannot play MP4 videos.

Changed the embed to a direct link so users can click to view the video.

Fixes #12472
