### PR TITLE
fix(gateway): add missing 'caching' property to GatewayProviderOptions type

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -271,15 +271,15 @@ Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-m
 <Note>
   Implementing language model middleware is advanced functionality and requires
   a solid understanding of the [language model
-  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+  specification](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
 </Note>
 
 You can implement any of the following three function to modify the behavior of the language model:
 
 1. `transformParams`: Transforms the parameters before they are passed to the language model, for both `doGenerate` and `doStream`.
-2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
-3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
 
 Here are some examples of how to implement language model middleware:

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -900,6 +900,28 @@ The following gateway provider options are available:
   });
   ```
 
+- **caching** _'auto'_
+  Enables automatic caching for the request. When set to `'auto'`, the AI Gateway
+  will automatically cache responses when the same request is made again, reducing
+  latency and cost for repeated queries. See the
+  [Automatic Caching documentation](https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching)
+  for details.
+
+  ```ts
+  import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+  import { generateText } from 'ai';
+
+  const { text } = await generateText({
+    model: 'openai/gpt-5-mini',
+    prompt: 'Hello',
+    providerOptions: {
+      gateway: {
+        caching: 'auto',
+      } satisfies GatewayProviderOptions,
+    },
+  });
+  ```
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts

--- a/content/providers/05-observability/mlflow.mdx
+++ b/content/providers/05-observability/mlflow.mdx
@@ -5,7 +5,7 @@ description: Track, visualize, and debug Vercel AI SDK traces with MLflow Tracin
 
 # MLflow Observability
 
-![MLflow Tracing Vercel AI SDK](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
+[MLflow Tracing Vercel AI SDK Demo Video](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
 
 [MLflow Tracing](https://mlflow.org/docs/latest/genai/tracing) provides automatic tracing for applications built with the [Vercel AI SDK](https://ai-sdk.dev/) (the `ai` package) via OpenTelemetry, unlocking observability for TypeScript and JavaScript apps.
 

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -111,6 +111,12 @@ const gatewayProviderOptions = lazySchema(() =>
        * default.
        */
       serviceTier: z.enum(['flex', 'priority']).optional(),
+      /**
+       * Caching behavior for automatic caching in AI Gateway.
+       *
+       * - `'auto'`: Automatically cache responses when possible.
+       */
+      caching: z.literal('auto').optional(),
     }),
   ),
 );


### PR DESCRIPTION
Closes #14595

## Summary
The documentation for automatic caching in AI Gateway suggests using  in provider options, but the TypeScript type  did not include this property, causing a type error.

## Changes
- Added  to the  Zod schema in 
- Updated documentation () with:
  - Description of the  option
  - Usage example showing  in providerOptions

## Testing
- All existing tests pass (429 tests in gateway package)
- TypeScript type-check passes
- The type now correctly accepts  in 