### PR TITLE
fix: handle undefined activeResponse in Chat.makeRequest finally block

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -755,17 +755,19 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       this.setStatus({ status: 'error', error: err as Error });
     } finally {
-      try {
-        this.onFinish?.({
-          message: this.activeResponse!.state.message,
-          messages: this.state.messages,
-          isAbort,
-          isDisconnect,
-          isError,
-          finishReason: this.activeResponse?.state.finishReason,
-        });
-      } catch (err) {
-        console.error(err);
+      if (this.activeResponse) {
+        try {
+          this.onFinish?.({
+            message: this.activeResponse.state.message,
+            messages: this.state.messages,
+            isAbort,
+            isDisconnect,
+            isError,
+            finishReason: this.activeResponse.state.finishReason,
+          });
+        } catch (err) {
+          console.error(err);
+        }
       }
 
       this.activeResponse = undefined;


### PR DESCRIPTION
## Summary

When overlapping resume-stream requests clear , the  block in  would throw `Cannot read properties of undefined (reading 'state')` due to the non-null assertion (`!`) on line 760.

## Changes

- Guard the  call with an  check
- Only call  when  exists
- This aligns with the existing optional chaining on 

## Testing

- All existing tests pass (26 tests in chat.test.ts)

Closes #15668