### PR TITLE
docs: link nextjs examples to correct github url

### DIFF
--- a/content/docs/04-ai-sdk-ui/01-overview.mdx
+++ b/content/docs/04-ai-sdk-ui/01-overview.mdx
@@ -34,7 +34,7 @@ Here is a comparison of the supported functions across these frameworks:
 
 Explore these example implementations for different frameworks:
 
-- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/next-openai)
+- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next)
 - [**Nuxt**](https://github.com/vercel/ai/tree/main/examples/nuxt-openai)
 - [**SvelteKit**](https://github.com/vercel/ai/tree/main/examples/sveltekit-openai)
 - [**Angular**](https://github.com/vercel/ai/tree/main/examples/angular)


### PR DESCRIPTION
## Background

the docs were pointing to an older version of the repo. clicking on it lead to a 404 error

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)