### PR TITLE
fix: add missing name to run-agent-tui returns table

### DIFF
--- a/content/docs/07-reference/06-ai-sdk-tui/01-run-agent-tui.mdx
+++ b/content/docs/07-reference/06-ai-sdk-tui/01-run-agent-tui.mdx
@@ -100,6 +100,7 @@ await runAgentTUI({
 <PropertiesTable
   content={[
     {
+      name: 'returns',
       type: 'Promise<void>',
       description: 'A promise that resolves when the terminal UI exits.',
     },


### PR DESCRIPTION
## Summary

The `### Returns` `<PropertiesTable>` in `content/docs/07-reference/06-ai-sdk-tui/01-run-agent-tui.mdx` (added in #15845) has an entry with no `name` field:

```jsx
content={[
  {
    type: 'Promise<void>',
    description: 'A promise that resolves when the terminal UI exits.',
  },
]}
```

Every other reference parameter object carries a `name`. The downstream docs renderer (ai-studio) maps each parameter through `camelToKebab(parameter.name)`, which calls `.replace()` on the value with no null guard — so a missing `name` throws `TypeError: Cannot read properties of undefined (reading 'replace')` during static prerender.

This has broken the **Sync Versioned Docs** build in `vercel/ai-studio` on every run since 2026-06-05 (the docs are synced live from this repo at build time), because the page fails to prerender.

## Fix

Add `name: 'returns'` to the Returns table entry.

## Note

The same file exists on `release-v6.0` and `release-v5.0` (synced as v6/v5), so this fix needs to be ported to those branches too for the docs build to fully recover. Happy to open those backports.