### PR TITLE
fix(middleware): preserve leading whitespace in streamed JSON suffix

### DIFF
--- a/.changeset/fix-extract-json-middleware-leading-space.md
+++ b/.changeset/fix-extract-json-middleware-leading-space.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(middleware): preserve leading whitespace in the trailing suffix of streamed text in `extractJsonMiddleware`. Previously, when no markdown code fence was stripped, the default transform's `trim()` was applied to the 12-character suffix buffer, removing a legitimate word-boundary space and fusing the last word with whatever came before it.

--- a/packages/ai/src/middleware/extract-json-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.test.ts
@@ -817,5 +817,44 @@ describe('extractJsonMiddleware', () => {
 
       expect(await result.text).toBe('{"value": "test"}');
     });
+
+    it('should preserve leading whitespace in the trailing suffix when no markdown prefix was stripped (#15921)', async () => {
+      // The middleware keeps a 12-character suffix buffer. When the prior delta
+      // ends mid-sentence and the final suffix begins with a legitimate
+      // word-boundary space, that space must survive into the merged output.
+      const mockModel = new MockLanguageModelV4({
+        async doStream() {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'there' },
+              { type: 'text-delta', id: '1', delta: ' altogether?' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      });
+
+      const result = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractJsonMiddleware(),
+        }),
+        prompt: 'Generate text',
+      });
+
+      expect(await result.text).toBe('there altogether?');
+    });
   });
 });

--- a/packages/ai/src/middleware/extract-json-middleware.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.ts
@@ -166,12 +166,15 @@ export function extractJsonMiddleware(options?: {
                   let remaining = block.buffer;
                   if (block.phase === 'buffering') {
                     remaining = transform(remaining);
-                  } else if (block.prefixStripped) {
-                    // strip suffix since prefix already handled
-                    remaining = remaining.replace(/\n?```\s*$/, '').trimEnd();
                   } else {
-                    // Apply full transform (handles both prefix and suffix)
-                    remaining = transform(remaining);
+                    // We're in the streaming phase: earlier deltas already
+                    // streamed text content as-is, and the buffer holds at most
+                    // the trailing SUFFIX_BUFFER_SIZE characters. Strip any
+                    // trailing markdown fence and `.trimEnd()` only — leading
+                    // whitespace here is a legitimate word boundary continuing
+                    // from the previously emitted delta, not a code-fence
+                    // artifact, so it must be preserved.
+                    remaining = remaining.replace(/\n?```\s*$/, '').trimEnd();
                   }
 
                   if (remaining.length > 0) {


### PR DESCRIPTION
## Why

Fixes #15921.

\`extractJsonMiddleware.wrapStream\` keeps a 12-character suffix buffer and, on \`text-end\`, applies the default markdown-fence transform to whatever remains when no prefix was stripped. The default transform ends in \`.trim()\`, which drops a legitimate word-boundary space at the start of the trailing suffix and fuses the final word with the previously emitted delta:

\`\`\`
'there' + ' altogether?'  →  'therealtogether?'   // expected: 'there altogether?'
\`\`\`

## Fix

In the streaming phase the buffer can only contain the *trailing* characters of the response — everything before it was already streamed out as-is. So leading whitespace in the buffer is part of the content, not a fence artifact, and the cleanup should only strip a trailing fence and trim the right side. Reuse the same \`replace(/\n?\\\`\\\`\\\`\\s*\$/, '').trimEnd()\` logic that was already applied when \`prefixStripped\` was true.

10-line diff in [\`extract-json-middleware.ts\`](https://github.com/vercel/ai/blob/main/packages/ai/src/middleware/extract-json-middleware.ts).

## Tests

Added a regression test \`should preserve leading whitespace in the trailing suffix when no markdown prefix was stripped (#15921)\` mirroring the reproduction in the issue. Verified by stashing the fix and re-running the suite — the new test fails on \`main\` (\`'therealtogether?'\` vs \`'there altogether?'\`) and passes with the fix. All 22 \`extractJsonMiddleware\` tests pass.

## Changeset

\`patch\` on the \`ai\` package — non-breaking bug fix.