### PR TITLE
test: verify `this` binding for class-based tool execute and toModelOutput

### DIFF
--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -13,7 +13,9 @@ import {
   tool,
   type ModelMessage,
   type Experimental_SandboxSession as SandboxSession,
+  type Tool,
   type ToolExecuteFunction,
+  type ToolResultOutput,
 } from '@ai-sdk/provider-utils';
 import { mockId } from '@ai-sdk/provider-utils/test';
 import {
@@ -1249,6 +1251,90 @@ describe('generateText', () => {
           },
         ]
       `);
+    });
+  });
+
+  describe('class-based tool `this` binding', () => {
+    // A class-based tool whose `execute` and `toModelOutput` both rely on `this`.
+    // This guards against re-introducing a "this-binding guard" that would
+    // destructure these methods off the tool before calling them and thereby
+    // break the binding.
+    // See https://github.com/vercel/ai/pull/15917#discussion_r3376474765
+    it('should preserve `this` for execute and toModelOutput', async () => {
+      class CalculatorTool implements Tool {
+        readonly inputSchema = z.object({ a: z.number(), b: z.number() });
+        private readonly prefix = 'calc';
+
+        async execute(input: { a: number; b: number }) {
+          // accesses `this.prefix`, requiring `this` to be bound to the
+          // tool instance when `execute` is invoked.
+          return { id: this.prefix, sum: input.a + input.b };
+        }
+
+        toModelOutput({ output }: { output: unknown }): ToolResultOutput {
+          // accesses `this.prefix`, requiring `this` to be bound to the
+          // tool instance when `toModelOutput` is invoked.
+          const { sum } = output as { sum: number };
+          return { type: 'text', value: `${this.prefix}:${sum}` };
+        }
+      }
+
+      let step1Prompt: LanguageModelV4Prompt | undefined;
+      let responseCount = 0;
+
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async ({ prompt }) => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  ...dummyResponseValues,
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: 'call-1',
+                      toolName: 'calculator',
+                      input: `{ "a": 1, "b": 2 }`,
+                    },
+                  ],
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                };
+              case 1:
+                step1Prompt = prompt;
+                return {
+                  ...dummyResponseValues,
+                  content: [{ type: 'text', text: 'Done.' }],
+                };
+              default:
+                throw new Error(`Unexpected response count: ${responseCount}`);
+            }
+          },
+        }),
+        tools: { calculator: new CalculatorTool() },
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      // `execute` ran with `this` bound to the tool instance:
+      expect(result.toolResults[0].output).toStrictEqual({
+        id: 'calc',
+        sum: 3,
+      });
+
+      // `toModelOutput` ran with `this` bound and its value was sent to the model:
+      expect(step1Prompt).toContainEqual({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'calculator',
+            output: { type: 'text', value: 'calc:3' },
+          },
+        ],
+        providerOptions: undefined,
+      });
     });
   });
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -13,7 +13,6 @@ import {
   tool,
   type ModelMessage,
   type Experimental_SandboxSession as SandboxSession,
-  type Tool,
   type ToolExecuteFunction,
   type ToolResultOutput,
 } from '@ai-sdk/provider-utils';
@@ -1261,7 +1260,7 @@ describe('generateText', () => {
     // break the binding.
     // See https://github.com/vercel/ai/pull/15917#discussion_r3376474765
     it('should preserve `this` for execute and toModelOutput', async () => {
-      class CalculatorTool implements Tool {
+      class CalculatorTool {
         readonly inputSchema = z.object({ a: z.number(), b: z.number() });
         private readonly prefix = 'calc';
 

--- a/packages/ai/src/prompt/create-tool-model-output.test.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.test.ts
@@ -170,7 +170,7 @@ describe('createToolModelOutput', () => {
     // class-based tools that rely on `this` in `toModelOutput`.
     // See https://github.com/vercel/ai/pull/15917#discussion_r3376474765
     it('should preserve `this` when calling a class-based tool.toModelOutput', async () => {
-      class WeatherTool implements Tool {
+      class WeatherTool {
         readonly inputSchema = z.object({});
         private readonly unit = '°C';
 

--- a/packages/ai/src/prompt/create-tool-model-output.test.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.test.ts
@@ -1,4 +1,4 @@
-import { tool, type Tool } from '@ai-sdk/provider-utils';
+import { tool, type Tool, type ToolResultOutput } from '@ai-sdk/provider-utils';
 import { createToolModelOutput } from './create-tool-model-output';
 import z from 'zod/v4';
 import { describe, it, expect } from 'vitest';
@@ -159,6 +159,40 @@ describe('createToolModelOutput', () => {
               "type": "text",
             },
           ],
+        }
+      `);
+    });
+  });
+
+  describe('this binding', () => {
+    // Guards against re-introducing a "this-binding guard" (e.g. destructuring
+    // `toModelOutput` off the tool before calling it), which would break
+    // class-based tools that rely on `this` in `toModelOutput`.
+    // See https://github.com/vercel/ai/pull/15917#discussion_r3376474765
+    it('should preserve `this` when calling a class-based tool.toModelOutput', async () => {
+      class WeatherTool implements Tool {
+        readonly inputSchema = z.object({});
+        private readonly unit = '°C';
+
+        toModelOutput({ output }: { output: unknown }): ToolResultOutput {
+          // accesses `this.unit`, which requires `this` to be bound to the
+          // tool instance when `toModelOutput` is invoked.
+          return { type: 'text', value: `${output}${this.unit}` };
+        }
+      }
+
+      const result = await createToolModelOutput({
+        toolCallId: '123',
+        input: {},
+        output: '21',
+        tool: new WeatherTool(),
+        errorMode: 'none',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "type": "text",
+          "value": "21°C",
         }
       `);
     });

--- a/packages/provider-utils/src/types/execute-tool.test.ts
+++ b/packages/provider-utils/src/types/execute-tool.test.ts
@@ -2,9 +2,49 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { executeTool } from './execute-tool';
 import type { ExecutableTool } from './executable-tool';
-import { tool } from './tool';
+import { tool, type Tool } from './tool';
 import type { ToolExecutionOptions } from './tool-execute-function';
 describe('executeTool', () => {
+  // Guards against re-introducing a "this-binding guard" (e.g. destructuring
+  // `execute` off the tool before calling it), which would break class-based
+  // tools that rely on `this` in `execute`.
+  // See https://github.com/vercel/ai/pull/15917#discussion_r3376474765
+  it('preserves `this` for a class-based tool.execute', async () => {
+    class CalculatorTool implements Tool {
+      readonly inputSchema = z.object({ a: z.number(), b: z.number() });
+      private readonly prefix = 'calc';
+
+      async execute(input: { a: number; b: number }) {
+        // accesses `this.prefix`, requiring `this` to be bound to the tool
+        // instance when `execute` is invoked.
+        return { id: this.prefix, sum: input.a + input.b };
+      }
+    }
+
+    const calculatorTool = new CalculatorTool();
+
+    const results: Array<{
+      type: 'preliminary' | 'final';
+      output: { id: string; sum: number };
+    }> = [];
+
+    for await (const result of executeTool({
+      tool: calculatorTool as ExecutableTool<typeof calculatorTool>,
+      input: { a: 1, b: 2 },
+      options: {
+        toolCallId: 'tool-call-1',
+        messages: [],
+        context: undefined,
+      },
+    })) {
+      results.push(result);
+    }
+
+    expect(results).toEqual([
+      { type: 'final', output: { id: 'calc', sum: 3 } },
+    ]);
+  });
+
   it('yields a single final output for non-streaming tools', async () => {
     const weatherTool = tool({
       inputSchema: z.object({

--- a/packages/provider-utils/src/types/execute-tool.test.ts
+++ b/packages/provider-utils/src/types/execute-tool.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { executeTool } from './execute-tool';
 import type { ExecutableTool } from './executable-tool';
-import { tool, type Tool } from './tool';
+import { tool } from './tool';
 import type { ToolExecutionOptions } from './tool-execute-function';
 describe('executeTool', () => {
   // Guards against re-introducing a "this-binding guard" (e.g. destructuring
@@ -10,7 +10,7 @@ describe('executeTool', () => {
   // tools that rely on `this` in `execute`.
   // See https://github.com/vercel/ai/pull/15917#discussion_r3376474765
   it('preserves `this` for a class-based tool.execute', async () => {
-    class CalculatorTool implements Tool {
+    class CalculatorTool {
       readonly inputSchema = z.object({ a: z.number(), b: z.number() });
       private readonly prefix = 'calc';
 
@@ -34,7 +34,7 @@ describe('executeTool', () => {
       options: {
         toolCallId: 'tool-call-1',
         messages: [],
-        context: undefined,
+        context: undefined as never,
       },
     })) {
       results.push(result);


### PR DESCRIPTION
## Background

Follow-up to the discussion at https://github.com/vercel/ai/pull/15917#discussion_r3376474765.

A "this-binding guard" was briefly considered for `toModelOutput` (and temporarily added to the workflow agent). After discussion, the decision was to **not** guard against `this` usage, but instead to **add regression tests** proving that class-based tools keep their `this` binding for both `execute` and `toModelOutput`.

## Summary

Adds tests with a tool implemented as a **class** whose methods rely on `this` (tests only — no production code changes):

- `packages/provider-utils/src/types/execute-tool.test.ts` — class-based `tool.execute` reads `this`
- `packages/ai/src/prompt/create-tool-model-output.test.ts` — class-based `tool.toModelOutput` reads `this`
- `packages/ai/src/generate-text/generate-text.test.ts` — end-to-end via `generateText`, exercising both bindings (execute output in `result.toolResults`, `toModelOutput` value in the prompt sent to the model)

## Manual Verification

Confirmed the new tests **fail** when a this-binding guard is (temporarily) introduced at either call site, e.g. destructuring the method off the tool before calling it:

```ts
// create-tool-model-output.ts
const { toModelOutput } = tool;
return await toModelOutput({ toolCallId, input, output }); // → TypeError: Cannot read properties of undefined (reading 'unit')

// provider-utils/.../execute-tool.ts
const { execute } = tool;
const result = execute(input, options); // → TypeError: Cannot read properties of undefined (reading 'prefix')
```

With the current (correct) implementation, all tests pass.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Follow-up to #15917