### PR TITLE
feat(elevenlabs): add scribe v2 transcription model

### DIFF
--- a/.changeset/elevenlabs-scribe-v2.md
+++ b/.changeset/elevenlabs-scribe-v2.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': patch
+---
+
+Add `scribe_v2` to the ElevenLabs transcription model ID list and update transcription examples.

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -182,10 +182,10 @@ const result = await generateSpeech({
 You can create models that call the [ElevenLabs transcription API](https://elevenlabs.io/speech-to-text)
 using the `.transcription()` factory method.
 
-The first argument is the model id e.g. `scribe_v1`.
+The first argument is the model id e.g. `scribe_v2`.
 
 ```ts
-const model = elevenLabs.transcription('scribe_v1');
+const model = elevenLabs.transcription('scribe_v2');
 ```
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format can sometimes improve transcription performance if known beforehand.
@@ -198,7 +198,7 @@ import {
 } from '@ai-sdk/elevenlabs';
 
 const result = await transcribe({
-  model: elevenLabs.transcription('scribe_v1'),
+  model: elevenLabs.transcription('scribe_v2'),
   audio: new Uint8Array([1, 2, 3, 4]),
   providerOptions: {
     elevenlabs: {

--- a/examples/ai-functions/src/transcribe/elevenlabs/basic.ts
+++ b/examples/ai-functions/src/transcribe/elevenlabs/basic.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await transcribe({
-    model: elevenLabs.transcription('scribe_v1'),
+    model: elevenLabs.transcription('scribe_v2'),
     audio: await readFile('data/galileo.mp3'),
   });
 

--- a/examples/ai-functions/src/transcribe/elevenlabs/string.ts
+++ b/examples/ai-functions/src/transcribe/elevenlabs/string.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await transcribe({
-    model: elevenLabs.transcription('scribe_v1'),
+    model: elevenLabs.transcription('scribe_v2'),
     audio: Buffer.from(await readFile('./data/galileo.mp3')).toString('base64'),
   });
 

--- a/examples/ai-functions/src/transcribe/elevenlabs/url.ts
+++ b/examples/ai-functions/src/transcribe/elevenlabs/url.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await transcribe({
-    model: elevenLabs.transcription('scribe_v1'),
+    model: elevenLabs.transcription('scribe_v2'),
     audio: new URL(
       'https://github.com/vercel/ai/raw/refs/heads/main/examples/ai-functions/data/galileo.mp3',
     ),

--- a/packages/elevenlabs/README.md
+++ b/packages/elevenlabs/README.md
@@ -36,7 +36,7 @@ import { elevenlabs } from '@ai-sdk/elevenlabs';
 import { experimental_transcribe as transcribe } from 'ai';
 
 const { text } = await transcribe({
-  model: elevenlabs.transcription('scribe_v1'),
+  model: elevenlabs.transcription('scribe_v2'),
   audio: new URL(
     'https://github.com/vercel/ai/raw/refs/heads/main/examples/ai-functions/data/galileo.mp3',
   ),

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -17,7 +17,7 @@ import { VERSION } from './version';
 
 export interface ElevenLabsProvider extends ProviderV4 {
   (
-    modelId: 'scribe_v1',
+    modelId: ElevenLabsTranscriptionModelId,
     settings?: {},
   ): {
     transcription: ElevenLabsTranscriptionModel;

--- a/packages/elevenlabs/src/elevenlabs-transcription-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-options.ts
@@ -1,4 +1,5 @@
 export type ElevenLabsTranscriptionModelId =
   | 'scribe_v1'
   | 'scribe_v1_experimental'
+  | 'scribe_v2'
   | (string & {});


### PR DESCRIPTION
## Background

ElevenLabs documents `scribe_v2` as an allowed Speech-to-Text `model_id`, but `@ai-sdk/elevenlabs` only typed `scribe_v1` and `scribe_v1_experimental`.

## Summary

- Add `scribe_v2` to `ElevenLabsTranscriptionModelId`.
- Allow the callable provider overload to accept all ElevenLabs transcription model IDs.
- Update ElevenLabs transcription docs, README, and examples to use `scribe_v2`.
- Add a patch changeset.

## Verification

- `pnpm --filter @ai-sdk/provider --filter @ai-sdk/provider-utils --filter @ai-sdk/test-server --filter @ai-sdk/elevenlabs build`
- `pnpm --filter @ai-sdk/elevenlabs test`
- `pnpm --filter @ai-sdk/elevenlabs type-check`
- `pnpm exec ultracite check .changeset/elevenlabs-scribe-v2.md packages/elevenlabs/src/elevenlabs-transcription-options.ts packages/elevenlabs/src/elevenlabs-provider.ts examples/ai-functions/src/transcribe/elevenlabs/basic.ts examples/ai-functions/src/transcribe/elevenlabs/string.ts examples/ai-functions/src/transcribe/elevenlabs/url.ts content/providers/01-ai-sdk-providers/90-elevenlabs.mdx packages/elevenlabs/README.md`
- `pnpm type-check:full`

Fixes #13556