### PR TITLE
docs(provider/deepseek): prefer DeepSeek V4 model IDs

### DIFF
--- a/.changeset/fresh-deepseek-v4.md
+++ b/.changeset/fresh-deepseek-v4.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepseek': patch
+---
+
+Add DeepSeek V4 model IDs to the provider model type and update DeepSeek docs to prefer V4 model names.

--- a/content/cookbook/00-guides/26-deepseek-v3-2.mdx
+++ b/content/cookbook/00-guides/26-deepseek-v3-2.mdx
@@ -1,52 +1,52 @@
 ---
-title: Get started with DeepSeek V3.2
-description: Get started with DeepSeek V3.2 using the AI SDK.
+title: Get started with DeepSeek V4
+description: Get started with DeepSeek V4 using the AI SDK.
 tags: ['getting-started', 'agents']
 ---
 
-# Get started with DeepSeek V3.2
+# Get started with DeepSeek V4
 
-With the [release of DeepSeek V3.2](https://api-docs.deepseek.com/news/news251201), there has never been a better time to start building AI applications that require advanced reasoning and agentic capabilities.
+With the [release of DeepSeek V4](https://api-docs.deepseek.com/news/news260424), DeepSeek's API now exposes `deepseek-v4-flash` and `deepseek-v4-pro` as the current model IDs for applications that need reasoning, long context, and agentic capabilities.
 
-The [AI SDK](/) is a powerful TypeScript toolkit for building AI applications with large language models (LLMs) like DeepSeek V3.2 alongside popular frameworks like React, Next.js, Vue, Svelte, Node.js, and more.
+The [AI SDK](/) is a powerful TypeScript toolkit for building AI applications with large language models (LLMs) like DeepSeek V4 alongside popular frameworks like React, Next.js, Vue, Svelte, Node.js, and more.
 
-## DeepSeek V3.2
+## DeepSeek V4
 
-DeepSeek V3.2 is a frontier model that harmonizes high computational efficiency with superior reasoning and agent performance. It introduces several key technical breakthroughs that enable it to perform comparably to GPT-5 while remaining open-source.
+DeepSeek V4 introduces two current API models with 1M context windows, high output limits, and support for both thinking and non-thinking modes.
 
 The series includes two primary variants:
 
-- **DeepSeek V3.2**: The official successor to V3.2-Exp. A balanced model optimized for both reasoning and inference efficiency, delivering GPT-5 level performance.
-- **DeepSeek V3.2-Speciale**: A high-compute variant with maxed-out reasoning capabilities that rivals Gemini-3.0-Pro. Achieves gold-medal performance in IMO 2025, CMO 2025, ICPC World Finals 2025, and IOI 2025. As of release, it does not support tool-use.
+- **DeepSeek V4 Flash**: A fast, efficient, cost-effective model for most production workloads.
+- **DeepSeek V4 Pro**: A larger model for stronger reasoning, coding, STEM, and agentic workloads.
 
-### Benchmarks
+### Capabilities
 
-DeepSeek V3.2 models excel in both reasoning and agentic tasks, delivering competitive performance across key benchmarks:
+DeepSeek V4 models support:
 
-**Reasoning Capabilities**
+- 1M context windows
+- Thinking and non-thinking modes
+- Tool calls
+- JSON output
+- Chat prefix completion
+- FIM completion in non-thinking mode
 
-- **AIME 2025 (Pass@1)**: 96.0% (Speciale)
-- **HMMT 2025 (Pass@1)**: 99.2% (Speciale)
-- **HLE (Pass@1)**: 30.6%
-- **Codeforces (Rating)**: 2701 (Speciale)
-
-**Agentic Capabilities**
-
-- **SWE Verified (Resolved)**: 73.1%
-- **Terminal Bench 2.0 (Acc)**: 46.4%
-- **τ2 Bench (Pass@1)**: 80.3%
-- **Tool Decathlon (Pass@1)**: 35.2%
-
-[Source](https://huggingface.co/deepseek-ai/DeepSeek-V3.2/resolve/main/assets/paper.pdf)
+[Source](https://api-docs.deepseek.com/quick_start/pricing)
 
 ### Model Options
 
-When using DeepSeek V3.2 with the AI SDK, you have two model options:
+When using DeepSeek V4 with the AI SDK, prefer the current V4 model IDs:
 
-| Model Alias         | Model Version                     | Description                                    |
-| ------------------- | --------------------------------- | ---------------------------------------------- |
-| `deepseek-chat`     | DeepSeek-V3.2 (Non-thinking Mode) | Standard chat model                            |
-| `deepseek-reasoner` | DeepSeek-V3.2 (Thinking Mode)     | Enhanced reasoning for complex problem-solving |
+| Model ID            | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `deepseek-v4-flash` | Fast, efficient model for general use           |
+| `deepseek-v4-pro`   | Stronger model for complex reasoning and agents |
+
+<Note>
+  DeepSeek's `deepseek-chat` and `deepseek-reasoner` compatibility aliases are
+  scheduled for deprecation on 2026-07-24 at 15:59 UTC. During the transition,
+  they route to the non-thinking and thinking modes of `deepseek-v4-flash`,
+  respectively.
+</Note>
 
 ## Getting Started with the AI SDK
 
@@ -54,14 +54,14 @@ The AI SDK is the TypeScript toolkit designed to help developers build AI-powere
 
 The AI SDK abstracts away the differences between model providers, eliminates boilerplate code for building agents, and allows you to go beyond text output to generate rich, interactive components.
 
-At the center of the AI SDK is [AI SDK Core](/docs/ai-sdk-core/overview), which provides a unified API to call any LLM. The code snippet below is all you need to call DeepSeek V3.2 with the AI SDK:
+At the center of the AI SDK is [AI SDK Core](/docs/ai-sdk-core/overview), which provides a unified API to call any LLM. The code snippet below is all you need to call DeepSeek V4 with the AI SDK:
 
 ```ts
 import { deepSeek } from '@ai-sdk/deepseek';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: deepSeek('deepseek-chat'),
+  model: deepSeek('deepseek-v4-flash'),
   prompt: 'Explain the concept of sparse attention in transformers.',
 });
 ```
@@ -74,7 +74,7 @@ AI SDK UI provides robust abstractions that simplify the complex tasks of managi
 
 With three main hooks — [`useChat`](/docs/reference/ai-sdk-ui/use-chat), [`useCompletion`](/docs/reference/ai-sdk-ui/use-completion), and [`useObject`](/docs/reference/ai-sdk-ui/use-object) — you can incorporate real-time chat capabilities, text completions, streamed JSON, and interactive assistant features into your app.
 
-Let's explore building an agent with [Next.js](https://nextjs.org), the AI SDK, and DeepSeek V3.2:
+Let's explore building an agent with [Next.js](https://nextjs.org), the AI SDK, and DeepSeek V4:
 
 In a new Next.js application, first install the AI SDK and the DeepSeek provider:
 
@@ -83,7 +83,10 @@ In a new Next.js application, first install the AI SDK and the DeepSeek provider
 Then, create a route handler for the chat endpoint:
 
 ```tsx filename="app/api/chat/route.ts"
-import { deepSeek } from '@ai-sdk/deepseek';
+import {
+  deepSeek,
+  type DeepSeekLanguageModelChatOptions,
+} from '@ai-sdk/deepseek';
 import {
   convertToModelMessages,
   createUIMessageStreamResponse,
@@ -96,8 +99,14 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: deepSeek('deepseek-reasoner'),
+    model: deepSeek('deepseek-v4-pro'),
     messages: await convertToModelMessages(messages),
+    providerOptions: {
+      deepseek: {
+        thinking: { type: 'enabled' },
+        reasoningEffort: 'high',
+      } satisfies DeepSeekLanguageModelChatOptions,
+    },
   });
 
   return createUIMessageStreamResponse({
@@ -156,14 +165,17 @@ The useChat hook on your root page (`app/page.tsx`) will make a request to your 
 
 ## Enhance Your Agent with Tools
 
-One of the key strengths of DeepSeek V3.2 is its agentic capabilities. You can extend your agent's functionality by adding tools that allow the model to perform specific actions or retrieve information.
+One of the key strengths of DeepSeek V4 is its agentic capabilities. You can extend your agent's functionality by adding tools that allow the model to perform specific actions or retrieve information.
 
 ### Update Your Route Handler
 
 Let's add a weather tool to your agent. Update your route handler at `app/api/chat/route.ts`:
 
 ```tsx filename="app/api/chat/route.ts"
-import { deepSeek } from '@ai-sdk/deepseek';
+import {
+  deepSeek,
+  type DeepSeekLanguageModelChatOptions,
+} from '@ai-sdk/deepseek';
 import {
   convertToModelMessages,
   createUIMessageStreamResponse,
@@ -179,8 +191,14 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: deepSeek('deepseek-reasoner'),
+    model: deepSeek('deepseek-v4-pro'),
     messages: await convertToModelMessages(messages),
+    providerOptions: {
+      deepseek: {
+        thinking: { type: 'enabled' },
+        reasoningEffort: 'high',
+      } satisfies DeepSeekLanguageModelChatOptions,
+    },
     tools: {
       weather: tool({
         description: 'Get the weather in a location',

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -150,8 +150,8 @@ Here are the capabilities of popular models:
 | [Mistral](/providers/ai-sdk-providers/mistral)     | `mistral-medium-3.5`                        | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Mistral](/providers/ai-sdk-providers/mistral)     | `mistral-small-latest`                      | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Mistral](/providers/ai-sdk-providers/mistral)     | `pixtral-12b-2409`                          | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-chat`                             | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-reasoner`                         | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-v4-flash`                         | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-v4-pro`                           | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)   | `llama3.1-8b`                               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)   | `llama3.1-70b`                              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)   | `llama3.3-70b`                              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -75,7 +75,7 @@ import { deepSeek } from '@ai-sdk/deepseek';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: deepSeek('deepseek-chat'),
+  model: deepSeek('deepseek-v4-flash'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -83,19 +83,26 @@ const { text } = await generateText({
 You can also use the `.chat()` or `.languageModel()` factory methods:
 
 ```ts
-const model = deepSeek.chat('deepseek-chat');
+const model = deepSeek.chat('deepseek-v4-flash');
 // or
-const model = deepSeek.languageModel('deepseek-chat');
+const model = deepSeek.languageModel('deepseek-v4-flash');
 ```
 
 DeepSeek language models can be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+<Note>
+  DeepSeek's `deepseek-chat` and `deepseek-reasoner` compatibility aliases are
+  scheduled for deprecation on 2026-07-24 at 15:59 UTC. During the transition,
+  they route to the non-thinking and thinking modes of `deepseek-v4-flash`,
+  respectively. Prefer `deepseek-v4-flash` or `deepseek-v4-pro` for new code.
+</Note>
+
 The following optional provider options are available for DeepSeek models:
 
 - `thinking` _object_
 
-  Optional. Controls thinking mode (chain-of-thought reasoning). You can enable thinking mode either by using the `deepseek-reasoner` model or by setting this option.
+  Optional. Controls thinking mode (chain-of-thought reasoning). DeepSeek V4 models support both thinking and non-thinking modes, and thinking mode defaults to `enabled`.
   - `type`: `'adaptive' | 'enabled' | 'disabled'` - Enable, disable, or let the model decide (`adaptive`) when to think. See [DeepSeek's thinking mode docs](https://api-docs.deepseek.com/guides/thinking_mode).
 
 - `reasoningEffort` _'low' | 'medium' | 'high' | 'xhigh' | 'max'_
@@ -115,7 +122,7 @@ import {
 import { generateText } from 'ai';
 
 const { text, reasoning } = await generateText({
-  model: deepSeek('deepseek-chat'),
+  model: deepSeek('deepseek-v4-pro'),
   prompt: 'How many "r"s are in the word "strawberry"?',
   providerOptions: {
     deepseek: {
@@ -128,15 +135,20 @@ const { text, reasoning } = await generateText({
 
 ### Reasoning
 
-DeepSeek has reasoning support for the `deepseek-reasoner` model. The reasoning is exposed through streaming:
+DeepSeek V4 models support reasoning when thinking mode is enabled. The reasoning is exposed through streaming:
 
 ```ts
 import { deepSeek } from '@ai-sdk/deepseek';
 import { streamText } from 'ai';
 
 const result = streamText({
-  model: deepSeek('deepseek-reasoner'),
+  model: deepSeek('deepseek-v4-pro'),
   prompt: 'How many "r"s are in the word "strawberry"?',
+  providerOptions: {
+    deepseek: {
+      thinking: { type: 'enabled' },
+    },
+  },
 });
 
 for await (const part of result.stream) {
@@ -162,7 +174,7 @@ import { deepSeek } from '@ai-sdk/deepseek';
 import { generateText } from 'ai';
 
 const result = await generateText({
-  model: deepSeek('deepseek-chat'),
+  model: deepSeek('deepseek-v4-flash'),
   prompt: 'Your prompt here',
 });
 
@@ -184,8 +196,8 @@ The metrics include:
 
 | Model               | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
 | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `deepseek-chat`     | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `deepseek-reasoner` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `deepseek-v4-flash` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `deepseek-v4-pro`   | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   Please see the [DeepSeek

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -65,8 +65,8 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [Cohere](/providers/ai-sdk-providers/cohere)               | `command-a-reasoning-08-2025`                       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cohere](/providers/ai-sdk-providers/cohere)               | `command-r-plus`                                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cohere](/providers/ai-sdk-providers/cohere)               | `command-r`                                         | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-chat`                                     | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-reasoner`                                 | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-v4-flash`                                 | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-v4-pro`                                   | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Moonshot AI](/providers/ai-sdk-providers/moonshotai)      | `kimi-k2.5`                                         | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Moonshot AI](/providers/ai-sdk-providers/moonshotai)      | `kimi-k2-thinking`                                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                   | `meta-llama/llama-4-scout-17b-16e-instruct`         | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/packages/deepseek/README.md
+++ b/packages/deepseek/README.md
@@ -22,20 +22,20 @@ npx skills add vercel/ai
 
 ## Provider Instance
 
-You can import the default provider instance `deepseek` from `@ai-sdk/deepseek`:
+You can import the default provider instance `deepSeek` from `@ai-sdk/deepseek`:
 
 ```ts
-import { deepseek } from '@ai-sdk/deepseek';
+import { deepSeek } from '@ai-sdk/deepseek';
 ```
 
 ## Example
 
 ```ts
-import { deepseek } from '@ai-sdk/deepseek';
+import { deepSeek } from '@ai-sdk/deepseek';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: deepseek('deepseek-chat'),
+  model: deepSeek('deepseek-v4-flash'),
   prompt: 'Write a JavaScript function that sorts a list:',
 });
 ```

--- a/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
@@ -2,6 +2,8 @@ import { z } from 'zod/v4';
 
 // https://api-docs.deepseek.com/quick_start/pricing
 export type DeepSeekChatModelId =
+  | 'deepseek-v4-flash'
+  | 'deepseek-v4-pro'
   | 'deepseek-chat'
   | 'deepseek-reasoner'
   | (string & {});


### PR DESCRIPTION
## Summary

Related to #15894.

- add `deepseek-v4-flash` and `deepseek-v4-pro` to the explicit DeepSeek provider model ID union
- update DeepSeek provider docs, README, cookbook guide, and model support tables to prefer the current V4 model IDs
- document the `deepseek-chat` and `deepseek-reasoner` compatibility alias deprecation date and routing behavior

## Notes

The reported AI Gateway `/v1/models` pricing/catalog mismatch is service-side: `packages/gateway/src/gateway-*-model-settings.ts` is generated from the live Gateway model feed, and the live endpoint still returns the V3.2 entries/pricing. This PR fixes the SDK/docs surface so new DeepSeek usage is steered toward the current V4 IDs while that catalog issue is handled upstream.

## Tests

- `pnpm exec ultracite fix .changeset/fresh-deepseek-v4.md packages/deepseek/src/chat/deepseek-chat-language-model-options.ts packages/deepseek/README.md content/providers/01-ai-sdk-providers/index.mdx content/docs/02-foundations/02-providers-and-models.mdx content/providers/01-ai-sdk-providers/30-deepseek.mdx content/cookbook/00-guides/26-deepseek-v3-2.mdx`
- `pnpm --filter @ai-sdk/deepseek test:node`
- `pnpm --filter @ai-sdk/deepseek type-check`
- `pnpm type-check:full`
- `pnpm validate:docs`
