### PR TITLE
fix(ai): Harden UI message stream processing against prototype pollution from chunk IDs

### DIFF
--- a/.changeset/ui-stream-id-map-hardening.md
+++ b/.changeset/ui-stream-id-map-hardening.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Harden UI message stream processing against prototype pollution from chunk IDs.

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -14,6 +14,21 @@ function createUIMessageStream(parts: UIMessageChunk[]) {
   return convertArrayToReadableStream(parts);
 }
 
+type ObjectPrototypeState = {
+  input?: unknown;
+  providerMetadata?: unknown;
+  state?: unknown;
+  text?: unknown;
+};
+
+function clearObjectPrototypeState() {
+  const objectPrototype = Object.prototype as ObjectPrototypeState;
+  delete objectPrototype.input;
+  delete objectPrototype.providerMetadata;
+  delete objectPrototype.state;
+  delete objectPrototype.text;
+}
+
 describe('processUIMessageStream', () => {
   let writeCalls: Array<{ message: UIMessage }> = [];
   let state: StreamingUIMessageState<UIMessage> | undefined;
@@ -321,6 +336,130 @@ describe('processUIMessageStream', () => {
         'Received tool-input-delta for missing tool call with ID "tool-1". ' +
           'Ensure a "tool-input-start" chunk is sent before any "tool-input-delta" chunks.',
       );
+    });
+
+    it('should not read Object.prototype for missing text part ids', async () => {
+      clearObjectPrototypeState();
+
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        { type: 'text-delta', id: '__proto__', delta: 'Hello' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      try {
+        await expect(
+          consumeStream({
+            stream: processUIMessageStream({
+              stream,
+              runUpdateMessageJob,
+              onError: error => {
+                throw error;
+              },
+            }),
+            onError: error => {
+              throw error;
+            },
+          }),
+        ).rejects.toThrow(
+          'Received text-delta for missing text part with ID "__proto__". ' +
+            'Ensure a "text-start" chunk is sent before any "text-delta" chunks.',
+        );
+
+        expect(Object.hasOwn(Object.prototype, 'providerMetadata')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
+    });
+
+    it('should not read Object.prototype for missing reasoning part ids', async () => {
+      clearObjectPrototypeState();
+
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        { type: 'reasoning-delta', id: '__proto__', delta: 'Thinking...' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      try {
+        await expect(
+          consumeStream({
+            stream: processUIMessageStream({
+              stream,
+              runUpdateMessageJob,
+              onError: error => {
+                throw error;
+              },
+            }),
+            onError: error => {
+              throw error;
+            },
+          }),
+        ).rejects.toThrow(
+          'Received reasoning-delta for missing reasoning part with ID "__proto__". ' +
+            'Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.',
+        );
+
+        expect(Object.hasOwn(Object.prototype, 'providerMetadata')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
+    });
+
+    it('should not read Object.prototype for missing partial tool call ids', async () => {
+      clearObjectPrototypeState();
+
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-delta',
+          toolCallId: '__proto__',
+          inputTextDelta: '{"key":',
+        },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      try {
+        await expect(
+          consumeStream({
+            stream: processUIMessageStream({
+              stream,
+              runUpdateMessageJob,
+              onError: error => {
+                throw error;
+              },
+            }),
+            onError: error => {
+              throw error;
+            },
+          }),
+        ).rejects.toThrow(
+          'Received tool-input-delta for missing tool call with ID "__proto__". ' +
+            'Ensure a "tool-input-start" chunk is sent before any "tool-input-delta" chunks.',
+        );
+
+        expect(Object.hasOwn(Object.prototype, 'input')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
     });
 
     it('should throw descriptive error when text-end is received without text-start', async () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -9,6 +9,7 @@ import {
   type InferUIMessageChunk,
   type UIMessageChunk,
 } from '../ui-message-stream/ui-message-chunks';
+import { createIdMap } from '../util/create-id-map';
 import type { ErrorHandler } from '../util/error-handler';
 import { mergeObjects } from '../util/merge-objects';
 import { parsePartialJson } from '../util/parse-partial-json';
@@ -68,9 +69,9 @@ export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
               InferUIMessageTools<UI_MESSAGE>
             >[],
           } as UI_MESSAGE),
-    activeTextParts: {},
-    activeReasoningParts: {},
-    partialToolCalls: {},
+    activeTextParts: createIdMap(),
+    activeReasoningParts: createIdMap(),
+    partialToolCalls: createIdMap(),
   };
 }
 
@@ -822,8 +823,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'finish-step': {
               // reset the current text and reasoning parts
-              state.activeTextParts = {};
-              state.activeReasoningParts = {};
+              state.activeTextParts = createIdMap();
+              state.activeReasoningParts = createIdMap();
               break;
             }
 

--- a/packages/ai/src/util/create-id-map.test.ts
+++ b/packages/ai/src/util/create-id-map.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { createIdMap } from './create-id-map';
+
+type TextPart = {
+  text: string;
+};
+
+type ObjectPrototypeState = {
+  text?: unknown;
+};
+
+function clearObjectPrototypeState() {
+  delete (Object.prototype as ObjectPrototypeState).text;
+}
+
+describe('createIdMap', () => {
+  it('should create a null-prototype map', () => {
+    const map = createIdMap<string>();
+
+    expect(Object.getPrototypeOf(map)).toBeNull();
+  });
+
+  it('should store object prototype property names as own keys', () => {
+    const map = createIdMap<string>();
+    const protoKey: string = '__proto__';
+    const constructorKey: string = 'constructor';
+    const prototypeKey: string = 'prototype';
+
+    map[protoKey] = 'proto value';
+    map[constructorKey] = 'constructor value';
+    map[prototypeKey] = 'prototype value';
+
+    expect(map[protoKey]).toBe('proto value');
+    expect(map[constructorKey]).toBe('constructor value');
+    expect(map[prototypeKey]).toBe('prototype value');
+    expect(Object.keys(map)).toEqual(['__proto__', 'constructor', 'prototype']);
+  });
+
+  it('should prevent prototype pollution from missing __proto__ lookups', () => {
+    clearObjectPrototypeState();
+    // Use an indirect key to avoid the deprecated literal __proto__ access diagnostic.
+    const protoKey: string = '__proto__';
+
+    try {
+      const plainObjectMap: Record<string, TextPart> = {};
+      const unsafeTextPart = plainObjectMap[protoKey];
+
+      expect(unsafeTextPart).toBe(Object.prototype);
+
+      unsafeTextPart.text = 'polluted';
+
+      expect(({} as ObjectPrototypeState).text).toBe('polluted');
+    } finally {
+      clearObjectPrototypeState();
+    }
+
+    const idMap = createIdMap<TextPart>();
+    const missingTextPart = idMap[protoKey];
+
+    expect(missingTextPart).toBeUndefined();
+    expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+  });
+});

--- a/packages/ai/src/util/create-id-map.ts
+++ b/packages/ai/src/util/create-id-map.ts
@@ -1,0 +1,11 @@
+/**
+ * Creates a string-keyed map without an object prototype.
+ *
+ * Use this for lookup tables keyed by IDs or names that may come from outside
+ * the SDK, such as streamed chunk IDs or tool call IDs. Unlike `{}`, these maps
+ * do not inherit `__proto__`, `constructor`, or other Object prototype members,
+ * so a missing untrusted key cannot resolve to a shared prototype object.
+ */
+export function createIdMap<T>(): Record<string, T> {
+  return Object.create(null);
+}


### PR DESCRIPTION
## Background

UI message stream processing keeps in-flight text parts, reasoning parts, and
partial tool calls in ID-keyed lookup tables. Those IDs can come from streamed
chunks, so special object property names like `__proto__` should not resolve to
or mutate `Object.prototype`.

## Summary

- Added a `createIdMap` helper that creates null-prototype string-keyed maps for
  untrusted IDs.
- Updated UI message stream state to use null-prototype maps for active text
  parts, active reasoning parts, and partial tool calls, including step resets.
- Added regression coverage for prototype-pollution edge cases in UI message
  stream processing and direct tests for `createIdMap`.
- Added a patch changeset for the `ai` package.

## Manual Verification

Not manually verified. This change is covered by targeted automated tests for
the ID map helper and UI message stream processing.