### PR TITLE
fix(ai): return schema-transformed elements in array output mode

### DIFF
--- a/.changeset/fix-array-output-transforms.md
+++ b/.changeset/fix-array-output-transforms.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): return schema-transformed elements in array output mode
+
+Previously final array output validation checked each element against the schema but returned the raw model output. Array output now returns the validated values so Zod transforms, coercions, defaults, and pipes are applied consistently with object output.

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -906,6 +906,36 @@ describe('generateObject', () => {
       }
     `);
     });
+
+    it('should return transformed array elements', async () => {
+      const model = new MockLanguageModelV4({
+        doGenerate: {
+          ...dummyResponseValues,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                elements: [{ content: 'element 1' }, { content: 'element 2' }],
+              }),
+            },
+          ],
+        },
+      });
+
+      const result = await generateObject({
+        model,
+        schema: z.object({
+          content: z
+            .string()
+            .transform(value => value.length)
+            .pipe(z.number()),
+        }),
+        output: 'array',
+        prompt: 'prompt',
+      });
+
+      expect(result.object).toStrictEqual([{ content: 9 }, { content: 9 }]);
+    });
   });
 
   describe('output = "enum"', () => {

--- a/packages/ai/src/generate-object/output-strategy.ts
+++ b/packages/ai/src/generate-object/output-strategy.ts
@@ -239,6 +239,7 @@ const arrayOutputStrategy = <ELEMENT>(
       }
 
       const inputArray = value.elements as Array<JSONObject>;
+      const resultArray: Array<ELEMENT> = [];
 
       // check that each element in the array is of the correct type:
       for (const element of inputArray) {
@@ -246,9 +247,10 @@ const arrayOutputStrategy = <ELEMENT>(
         if (!result.success) {
           return result;
         }
+        resultArray.push(result.value);
       }
 
-      return { success: true, value: inputArray as Array<ELEMENT> };
+      return { success: true, value: resultArray };
     },
 
     createElementStream(


### PR DESCRIPTION
## Background

Array output mode validated each final element against the schema but returned the raw model output array. That meant schema transforms, coercions, defaults, and pipes could be silently discarded while the result was typed as the transformed value, unlike object output mode.

## Summary

- Return the collected `safeValidateTypes` values from final array output validation.
- Add a regression test that verifies Zod-transformed array elements are returned from `generateObject`.
- Add a patch changeset for the `ai` package.

## Manual Verification

Not performed. This change is covered by a focused regression test and package type checking.

## Automated verification

- `pnpm test:node src/generate-object/generate-object.test.ts`
- `pnpm --filter ai type-check`

Note: `pnpm type-check:full` currently fails on pre-existing generated `.next/types` references in `examples/ai-e2e-next`.