### PR TITLE
docs(openai-compatible-providers): add LLMBase

### DIFF
--- a/content/providers/02-openai-compatible-providers/47-llmbase.mdx
+++ b/content/providers/02-openai-compatible-providers/47-llmbase.mdx
@@ -1,0 +1,126 @@
+---
+title: LLMBase
+description: Use the LLMBase OpenAI compatible API with the AI SDK.
+---
+
+# LLMBase Provider
+
+[LLMBase](https://llmbase.ai) is a privacy-focused, sovereign AI platform for
+hosted open-source models. Its direct inference API is OpenAI-compatible, so you
+can use it with the AI SDK through the `@ai-sdk/openai-compatible` module.
+
+## Setup
+
+The LLMBase provider is available via the `@ai-sdk/openai-compatible` module as
+it is compatible with the OpenAI API. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+To use LLMBase, create a custom provider instance with the
+`createOpenAICompatible` function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const llmbase = createOpenAICompatible({
+  name: 'llmbase',
+  baseURL: 'https://api.llmbase.ai/v1',
+  apiKey: process.env.LLMBASE_API_KEY,
+  includeUsage: true,
+  supportsStructuredOutputs: true,
+});
+```
+
+<Note>
+  Create an inference API key in the LLMBase dashboard and set it as the
+  `LLMBASE_API_KEY` environment variable. Direct AI SDK integrations should use
+  the `https://api.llmbase.ai/v1` inference endpoint with a `llmbase_...` key.
+  LLMBase chat-agent keys (`llmbase_chat_...`) are for subscription-backed agent
+  tools such as OpenClaw and Hermes.
+</Note>
+
+## Language Models
+
+You can create LLMBase models using a provider instance. The first argument is
+the model ID from the LLMBase model list, for example
+`deepseek/deepseek-v4-flash`.
+
+```ts
+const model = llmbase('deepseek/deepseek-v4-flash');
+```
+
+### Example
+
+You can use LLMBase language models to generate text with the `generateText`
+function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const llmbase = createOpenAICompatible({
+  name: 'llmbase',
+  baseURL: 'https://api.llmbase.ai/v1',
+  apiKey: process.env.LLMBASE_API_KEY,
+  includeUsage: true,
+  supportsStructuredOutputs: true,
+});
+
+const { text } = await generateText({
+  model: llmbase('deepseek/deepseek-v4-flash'),
+  prompt: 'Write a short deployment checklist.',
+});
+
+console.log(text);
+```
+
+LLMBase language models can also generate text in a streaming fashion with the
+`streamText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+
+const llmbase = createOpenAICompatible({
+  name: 'llmbase',
+  baseURL: 'https://api.llmbase.ai/v1',
+  apiKey: process.env.LLMBASE_API_KEY,
+  includeUsage: true,
+  supportsStructuredOutputs: true,
+});
+
+const result = streamText({
+  model: llmbase('deepseek/deepseek-v4-flash'),
+  prompt: 'Write a short haiku about private inference.',
+});
+
+for await (const message of result.textStream) {
+  console.log(message);
+}
+```
+
+You can list available models from the OpenAI-compatible models endpoint:
+
+```bash
+curl https://api.llmbase.ai/v1/models \
+  -H "Authorization: Bearer $LLMBASE_API_KEY"
+```
+
+Use `https://api.llmbase.ai/v1/models?metadata=true` when you need detailed
+model metadata such as context length, modalities, pricing, and supported
+features.

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -15,6 +15,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [NIM](/providers/openai-compatible-providers/nim)
 - [Heroku](/providers/openai-compatible-providers/heroku)
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
+- [LLMBase](/providers/openai-compatible-providers/llmbase)
 - [NEAR AI Cloud](/providers/openai-compatible-providers/nearai)
 
 The general setup and provider instance creation is the same for all of these providers.


### PR DESCRIPTION
## Background

LLMBase provides a privacy-focused, sovereign AI platform for hosted open-source models. Its direct inference endpoint is OpenAI-compatible, so AI SDK users can connect to it through `@ai-sdk/openai-compatible` without a dedicated provider package.

## Summary

- Added an LLMBase page under OpenAI-compatible providers.
- Linked LLMBase from the OpenAI-compatible providers index.
- Documented the `createOpenAICompatible` setup with `https://api.llmbase.ai/v1`, `LLMBASE_API_KEY`, text generation, streaming, and model listing.
- Clarified that direct AI SDK integrations use inference API keys, while `llmbase_chat_...` keys are for subscription-backed chat-agent tools.

## Manual Verification

- `corepack pnpm exec ultracite check content/providers/02-openai-compatible-providers/index.mdx content/providers/02-openai-compatible-providers/47-llmbase.mdx`
- `corepack pnpm validate:docs`
- `git diff --check`

No live API call was run because this is a docs-only change and requires a user API key.

## Checklist

- [ ] I have added tests, or they are not required.
- [x] I have added documentation if applicable.
- [ ] I have added a changeset if needed.
- [x] I have read the Contributing Guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have signed my commits.

## Future Work

None.

## Related Issues

None.