### PR TITLE
fix(mcp): add optional hook to validate authorization servers

### DIFF
--- a/.changeset/dull-camels-battle.md
+++ b/.changeset/dull-camels-battle.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): add optional hook to validate authorization servers

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -124,6 +124,38 @@ transports by providing an `authProvider`.
 
 </Note>
 
+### OAuth Authorization Server Validation
+
+When using MCP OAuth in server-side applications, the MCP server can advertise
+the OAuth authorization server to use. If you connect to MCP servers outside
+your control, implement `validateAuthorizationServerURL` on your
+`authProvider` to allow only the authorization server origins you trust:
+
+```typescript
+const allowedAuthorizationServerOrigins = new Set([
+  'https://accounts.example.com',
+  'https://tenant.auth0.com',
+]);
+
+const myOAuthClientProvider = {
+  // ...other OAuthClientProvider methods
+
+  validateAuthorizationServerURL(serverUrl, authorizationServerUrl) {
+    const origin = new URL(authorizationServerUrl).origin;
+
+    if (!allowedAuthorizationServerOrigins.has(origin)) {
+      throw new Error(
+        `Unexpected OAuth authorization server for ${serverUrl}: ${origin}`,
+      );
+    }
+  },
+};
+```
+
+This hook is called before the SDK fetches authorization server metadata, so a
+rejected URL is not requested. It is optional and does not change existing OAuth
+flows unless you implement it.
+
 ### Closing the MCP Client
 
 After initialization, you should close the MCP client based on your usage pattern:

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -106,7 +106,7 @@ It currently does not support accepting notifications from an MCP server, and cu
                       type: 'OAuthClientProvider',
                       isOptional: true,
                       description:
-                        'Optional OAuth provider for authorization to access protected remote MCP servers.',
+                        'Optional OAuth provider for authorization to access protected remote MCP servers. Implement `validateAuthorizationServerURL` on the provider to allowlist discovered OAuth authorization server URLs before metadata is fetched.',
                     },
                     {
                       name: 'redirect',

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1929,6 +1929,72 @@ describe('auth function', () => {
     expect(evilTokenRequests).toHaveLength(0);
   });
 
+  it('allows providers to reject discovered authorization server URLs before metadata discovery', async () => {
+    const validateAuthorizationServerURL = vi.fn(() => {
+      throw new Error('Unexpected authorization server');
+    });
+
+    mockFetch.mockImplementation(url => {
+      const urlString = url.toString();
+
+      if (urlString.includes('/.well-known/oauth-protected-resource')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            resource: 'https://api.example.com/mcp-server',
+            authorization_servers: ['https://evil.example'],
+          }),
+        });
+      } else if (
+        urlString ===
+        'https://evil.example/.well-known/oauth-authorization-server'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://evil.example',
+            authorization_endpoint: 'https://evil.example/authorize',
+            token_endpoint: 'https://evil.example/token',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      }
+
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    (mockProvider.clientInformation as Mock).mockResolvedValue({
+      client_id: 'real-client',
+      client_secret: 'real-secret',
+    });
+    (mockProvider.tokens as Mock).mockResolvedValue(undefined);
+    const providerWithValidation = {
+      ...mockProvider,
+      validateAuthorizationServerURL,
+    };
+
+    await expect(
+      auth(providerWithValidation, {
+        serverUrl: 'https://api.example.com/mcp-server',
+      }),
+    ).rejects.toThrow('Unexpected authorization server');
+
+    expect(validateAuthorizationServerURL).toHaveBeenCalledWith(
+      'https://api.example.com/mcp-server',
+      'https://evil.example',
+    );
+    expect(
+      mockFetch.mock.calls.some(
+        call =>
+          call[0].toString() ===
+          'https://evil.example/.well-known/oauth-authorization-server',
+      ),
+    ).toBe(false);
+  });
+
   it('skips default PRM resource validation when custom validateResourceURL is provided', async () => {
     const mockValidateResourceURL = vi.fn().mockResolvedValue(undefined);
     const providerWithCustomValidation = {

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -94,6 +94,14 @@ export interface OAuthClientProvider {
   saveAuthorizationServerInformation?(
     authorizationServerInformation: OAuthAuthorizationServerInformation,
   ): void | Promise<void>;
+  /**
+   * Validates an authorization server URL discovered from MCP protected resource
+   * metadata before the client fetches its OAuth metadata.
+   */
+  validateAuthorizationServerURL?(
+    serverUrl: string | URL,
+    authorizationServerUrl: string | URL,
+  ): void | Promise<void>;
   state?(): string | Promise<string>;
   saveState?(state: string): void | Promise<void>;
   storedState?(): string | undefined | Promise<string | undefined>;
@@ -1112,6 +1120,12 @@ async function authInternal(
     serverUrl,
     provider,
     resourceMetadata,
+  );
+
+  /** Let applications constrain discovered AS URLs before metadata fetches. */
+  await provider.validateAuthorizationServerURL?.(
+    serverUrl,
+    authorizationServerUrl,
   );
 
   /** Discover AS metadata and derive the credential pin for this flow */


### PR DESCRIPTION
## Background

currently, a remote mcp server could make a server fetch oauth urls that the mcp server chose. for example: 

1. your app runs server-side and connects to `https://evil-mcp.example.com`
2. that MCP server returns OAuth metadata saying:
```
{
  "authorization_servers": ["http://169.254.169.254/latest/meta-data"]
}
```
3. the AI SDK follows that url during oauth discovery.
4. your server, not the attacker’s machine, makes a request to `169.254.169.254`

## Summary

added `validateAuthorizationServerURL`, an optional hook that runs before the SDK fetches authorization server metadata

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)