### PR TITLE
fix(provider/amazon-bedrock): extract Cohere embedding token usage from response header

### DIFF
--- a/.changeset/spotty-pandas-shop.md
+++ b/.changeset/spotty-pandas-shop.md
@@ -2,4 +2,4 @@
 '@ai-sdk/amazon-bedrock': patch
 ---
 
-fix (provider/amazon-bedrock): extract embedding token usage from the x-amzn-bedrock-input-token-count response header for Cohere models
+fix(provider/amazon-bedrock): extract Cohere embedding token usage from response header

--- a/.changeset/spotty-pandas-shop.md
+++ b/.changeset/spotty-pandas-shop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix (provider/amazon-bedrock): extract embedding token usage from the x-amzn-bedrock-input-token-count response header for Cohere models

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
@@ -50,6 +50,7 @@ describe('doEmbed', () => {
         type: 'binary',
         headers: {
           'content-type': 'application/json',
+          'x-amzn-bedrock-input-token-count': '6',
         },
         body: Buffer.from(
           JSON.stringify({
@@ -63,6 +64,7 @@ describe('doEmbed', () => {
         type: 'binary',
         headers: {
           'content-type': 'application/json',
+          'x-amzn-bedrock-input-token-count': '6',
         },
         body: Buffer.from(
           JSON.stringify({
@@ -156,7 +158,7 @@ describe('doEmbed', () => {
         0.04,
       ]
     `);
-    expect(Number.isNaN(usage?.tokens)).toBe(true);
+    expect(usage?.tokens).toBe(6);
 
     const body = await server.calls[0].requestBodyJson;
     expect(body).toEqual({
@@ -188,7 +190,7 @@ describe('doEmbed', () => {
         0.04,
       ]
     `);
-    expect(Number.isNaN(usage?.tokens)).toBe(true);
+    expect(usage?.tokens).toBe(6);
 
     const body = await server.calls[0].requestBodyJson;
     expect(body).toEqual({
@@ -197,6 +199,32 @@ describe('doEmbed', () => {
       truncate: undefined,
       output_dimension: undefined,
     });
+  });
+
+  it('should return NaN usage for Cohere models when the token count header is absent', async () => {
+    server.urls[cohereV4EmbedUrl].response = {
+      type: 'binary',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: Buffer.from(
+        JSON.stringify({
+          embeddings: { float: [mockEmbeddings[0]] },
+        }),
+      ),
+    };
+
+    const cohereV4Model = new AmazonBedrockEmbeddingModel('cohere.embed-v4:0', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: mockConfigHeaders,
+      fetch: fakeFetchWithAuth,
+    });
+
+    const { usage } = await cohereV4Model.doEmbed({
+      values: [testValues[0]],
+    });
+
+    expect(Number.isNaN(usage?.tokens)).toBe(true);
   });
 
   it('should pass outputDimension for Cohere v4 embedding models', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -171,9 +171,7 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
       embedding = response.embeddings.float[0];
     }
 
-    // Extract token count based on response format. Cohere responses don't
-    // include a token count in the body, so fall back to the InvokeModel
-    // response header (NaN when the header is absent).
+    // Extract token count based on response format
     const headerTokenCount = Number(
       responseHeaders?.['x-amzn-bedrock-input-token-count'],
     );

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -128,7 +128,7 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
           };
 
     const url = this.getUrl(this.modelId);
-    const { value: response } = await postJsonToApi({
+    const { value: response, responseHeaders } = await postJsonToApi({
       url,
       headers: await resolve(
         combineHeaders(
@@ -171,13 +171,18 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
       embedding = response.embeddings.float[0];
     }
 
-    // Extract token count based on response format
+    // Extract token count based on response format. Cohere responses don't
+    // include a token count in the body, so fall back to the InvokeModel
+    // response header (NaN when the header is absent).
+    const headerTokenCount = Number(
+      responseHeaders?.['x-amzn-bedrock-input-token-count'],
+    );
     const tokens =
       'inputTextTokenCount' in response
         ? response.inputTextTokenCount // Titan response
         : 'inputTokenCount' in response
           ? (response.inputTokenCount ?? 0) // Nova response
-          : NaN; // Cohere doesn't return token count
+          : headerTokenCount;
 
     return {
       embeddings: [embedding],


### PR DESCRIPTION
## Background

Cohere embedding responses on Bedrock (`cohere.embed-english-v3`, `cohere.embed-v4:0`, etc.) carry no token count in the response body — only the Titan (`inputTextTokenCount`) and Nova (`inputTokenCount`) shapes do. The embedding model currently returns `usage: { tokens: NaN }` for Cohere models, so callers get no usage data (`NaN` also serializes to `null` in JSON, which breaks downstream consumers that validate usage as a number).

## Summary

Bedrock reports the input token count on every InvokeModel response via the `x-amzn-bedrock-input-token-count` header. This PR reads that header as a fallback when the response body has no token count, so Cohere embedding models now report real usage. Behavior for Titan and Nova is unchanged, and the result is still `NaN` if the header is absent.

## Verification

- Updated the Cohere v3/v4 unit tests to serve the header and assert the extracted usage, plus a new test covering the header-absent → `NaN` case
- Verified end-to-end against live Bedrock with `cohere.embed-v4:0` (via Vercel AI Gateway), which surfaced the bug: embeddings succeeded but usage came back as `tokens: null`

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Documentation has been updated (for features)
- [x] Formatting issues have been fixed (run `pnpm fix` in the project root)

## Future Work

Backport to the v6 release line (will be handled separately).