### PR TITLE
fix(mcp): support official sdk protocol version negotiation

### DIFF
--- a/.changeset/olive-bottles-reply.md
+++ b/.changeset/olive-bottles-reply.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): support official sdk protocol version negotiation

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -1,4 +1,5 @@
 import type * as McpTransportModule from './mcp-transport';
+import type { MCPTransport } from './mcp-transport';
 import { z } from 'zod/v4';
 import { MCPClientError } from '../error/mcp-client-error';
 import { createMCPClient } from './mcp-client';
@@ -14,7 +15,7 @@ import {
   type GetPromptResult,
   type Configuration,
 } from './types';
-import type { JSONRPCRequest } from './json-rpc-message';
+import type { JSONRPCMessage, JSONRPCRequest } from './json-rpc-message';
 import {
   beforeEach,
   afterEach,
@@ -26,6 +27,48 @@ import {
 } from 'vitest';
 
 const createMockTransport = vi.fn(config => new MockMCPTransport(config));
+
+class GetterOnlyProtocolVersionTransport implements MCPTransport {
+  private readonly transport: MockMCPTransport;
+  private negotiatedProtocolVersion?: string;
+
+  onmessage?: (message: JSONRPCMessage) => void;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+
+  constructor(protocolVersion: string) {
+    this.transport = new MockMCPTransport({
+      initializeResult: {
+        protocolVersion,
+        serverInfo: { name: 'mock-mcp-server', version: '1.0.0' },
+        capabilities: { tools: {} },
+      },
+    });
+  }
+
+  get protocolVersion(): string | undefined {
+    return this.negotiatedProtocolVersion;
+  }
+
+  setProtocolVersion(version: string): void {
+    this.negotiatedProtocolVersion = version;
+  }
+
+  async start(): Promise<void> {
+    await this.transport.start();
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    this.transport.onmessage = this.onmessage;
+    this.transport.onclose = this.onclose;
+    this.transport.onerror = this.onerror;
+    await this.transport.send(message);
+  }
+
+  async close(): Promise<void> {
+    await this.transport.close();
+  }
+}
 
 vi.mock('./mcp-transport.ts', async importOriginal => {
   const actual = await importOriginal<typeof McpTransportModule>();
@@ -2201,6 +2244,16 @@ describe('MCPClient', () => {
       });
 
       expect(mockTransport.protocolVersion).toBe('2025-06-18');
+    });
+
+    it('should support transports with getter-only protocolVersion and setProtocolVersion', async () => {
+      const transport = new GetterOnlyProtocolVersionTransport('2025-06-18');
+
+      client = await createMCPClient({
+        transport,
+      });
+
+      expect(transport.protocolVersion).toBe('2025-06-18');
     });
   });
 });

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -322,7 +322,11 @@ class DefaultMCPClient implements MCPClient {
 
       this.serverCapabilities = result.capabilities;
       this._serverInfo = result.serverInfo;
-      this.transport.protocolVersion = result.protocolVersion;
+      if (this.transport.setProtocolVersion) {
+        this.transport.setProtocolVersion(result.protocolVersion);
+      } else {
+        this.transport.protocolVersion = result.protocolVersion;
+      }
       this._serverInstructions = result.instructions;
 
       // Complete initialization handshake:

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -75,6 +75,10 @@ export class HttpMCPTransport implements MCPTransport {
     this.fetchFn = fetchFn ?? globalThis.fetch;
   }
 
+  setProtocolVersion(version: string): void {
+    this.protocolVersion = version;
+  }
+
   private async commonHeaders(
     base: Record<string, string>,
   ): Promise<Record<string, string>> {

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -55,6 +55,10 @@ export class SseMCPTransport implements MCPTransport {
     this.fetchFn = fetchFn ?? globalThis.fetch;
   }
 
+  setProtocolVersion(version: string): void {
+    this.protocolVersion = version;
+  }
+
   private async commonHeaders(
     base: Record<string, string>,
   ): Promise<Record<string, string>> {

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -45,6 +45,11 @@ export interface MCPTransport {
    * The protocol version negotiated during initialization.
    */
   protocolVersion?: string;
+
+  /**
+   * Set the protocol version negotiated during initialization.
+   */
+  setProtocolVersion?(version: string): void;
 }
 
 export type MCPTransportConfig = {


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15952

currently the MCP client connected to the server, got the negotiated protocol version, then crashed while trying to save it onto the transport. this is because the official MCP SDK transports don’t allow direct writes to `protocolVersion`

## Summary

now, the client uses the official transport method to save the negotiated version when it exists, and still supports the old writable property for existing AI SDK transports

## Manual Verification

verified by running the repro example here:
<details>
<summary>repro example:</summary>

```ts
import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
import { createMCPClient } from '@ai-sdk/mcp';
import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';

const NEGOTIATED_PROTOCOL_VERSION = '2025-06-18';

type JsonRpcMessage = {
  id?: string | number | null;
  method?: string;
};

type RequestRecord = {
  method?: string;
  protocolVersionHeader?: string;
};

const requests: RequestRecord[] = [];

function getProtocolVersionHeader(
  request: IncomingMessage,
): string | undefined {
  const value = request.headers['mcp-protocol-version'];
  return Array.isArray(value) ? value.join(', ') : value;
}

async function readRequestBody(request: IncomingMessage): Promise<string> {
  const chunks: Buffer[] = [];

  for await (const chunk of request) {
    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
  }

  return Buffer.concat(chunks).toString('utf8');
}

function sendJson(
  response: ServerResponse,
  statusCode: number,
  body: unknown,
): void {
  response.writeHead(statusCode, { 'content-type': 'application/json' });
  response.end(JSON.stringify(body));
}

async function handleMcpRequest(
  request: IncomingMessage,
  response: ServerResponse,
): Promise<void> {
  if (request.method !== 'POST') {
    response.writeHead(405).end();
    return;
  }

  const body = await readRequestBody(request);
  const message = JSON.parse(body) as JsonRpcMessage;

  requests.push({
    method: message.method,
    protocolVersionHeader: getProtocolVersionHeader(request),
  });

  if (!('id' in message)) {
    response.writeHead(202).end();
    return;
  }

  if (message.method === 'initialize') {
    sendJson(response, 200, {
      jsonrpc: '2.0',
      id: message.id,
      result: {
        protocolVersion: NEGOTIATED_PROTOCOL_VERSION,
        capabilities: { tools: {} },
        serverInfo: { name: 'official-transport-repro', version: '1.0.0' },
      },
    });
    return;
  }

  if (message.method === 'tools/list') {
    sendJson(response, 200, {
      jsonrpc: '2.0',
      id: message.id,
      result: {
        tools: [],
      },
    });
    return;
  }

  sendJson(response, 200, {
    jsonrpc: '2.0',
    id: message.id,
    error: {
      code: -32601,
      message: `Unsupported method: ${message.method}`,
    },
  });
}

async function listen(server: ReturnType<typeof createServer>): Promise<URL> {
  return new Promise((resolve, reject) => {
    server.once('error', reject);
    server.listen(0, '127.0.0.1', () => {
      server.off('error', reject);

      const address = server.address();
      if (address === null || typeof address === 'string') {
        reject(new Error('Unable to determine server port'));
        return;
      }

      resolve(new URL(`http://127.0.0.1:${address.port}/mcp`));
    });
  });
}

async function closeServer(
  server: ReturnType<typeof createServer>,
): Promise<void> {
  if (!server.listening) {
    return;
  }

  await new Promise<void>((resolve, reject) => {
    server.close(error => {
      if (error) {
        reject(error);
        return;
      }

      resolve();
    });
  });
}

async function main(): Promise<void> {
  const server = createServer((request, response) => {
    handleMcpRequest(request, response).catch(error => {
      console.error('Mock MCP server failed:', error);
      if (!response.headersSent) {
        sendJson(response, 500, {
          jsonrpc: '2.0',
          id: null,
          error: { code: -32603, message: 'Internal server error' },
        });
      }
    });
  });

  let client: Awaited<ReturnType<typeof createMCPClient>> | undefined;

  try {
    const url = await listen(server);
    const transport = new StreamableHTTPClientTransport(url);

    client = await createMCPClient({ transport });

    const tools = await client.tools();
    const toolsListRequest = requests.find(
      request => request.method === 'tools/list',
    );

    if (
      toolsListRequest?.protocolVersionHeader !== NEGOTIATED_PROTOCOL_VERSION
    ) {
      throw new Error(
        `Expected tools/list to use negotiated protocol version ${NEGOTIATED_PROTOCOL_VERSION}, got ${toolsListRequest?.protocolVersionHeader}`,
      );
    }

    console.log('Connected with official StreamableHTTPClientTransport.');
    console.log(
      `tools/list used mcp-protocol-version: ${toolsListRequest.protocolVersionHeader}`,
    );
    console.log(`Loaded ${Object.keys(tools).length} tool(s).`);
    console.log(
      'Repro passed. On affected versions this fails during createMCPClient with a getter-only protocolVersion TypeError.',
    );
  } finally {
    await client?.close();
    await closeServer(server);
  }
}

main().catch(error => {
  console.error('Repro failed:');
  console.error(error);
  process.exit(1);
});
```

</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15952