### PR TITLE
fix(provider/amazon-bedrock): detect Cohere embedding models behind cross-region inference profile ids

### DIFF
--- a/.changeset/lucky-poems-march.md
+++ b/.changeset/lucky-poems-march.md
@@ -2,4 +2,4 @@
 '@ai-sdk/amazon-bedrock': patch
 ---
 
-fix(provider/amazon-bedrock): detect embedding model families behind cross-region inference profile ids
+fix(provider/amazon-bedrock): detect Cohere embedding models behind cross-region inference profile ids

--- a/.changeset/lucky-poems-march.md
+++ b/.changeset/lucky-poems-march.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): detect embedding model families behind cross-region inference profile ids

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
@@ -24,6 +24,10 @@ const cohereV4EmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/
   'cohere.embed-v4:0',
 )}/invoke`;
 
+const cohereV4UsProfileEmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
+  'us.cohere.embed-v4:0',
+)}/invoke`;
+
 describe('doEmbed', () => {
   const mockConfigHeaders = {
     'config-header': 'config-value',
@@ -60,6 +64,20 @@ describe('doEmbed', () => {
       },
     },
     [cohereV4EmbedUrl]: {
+      response: {
+        type: 'binary',
+        headers: {
+          'content-type': 'application/json',
+          'x-amzn-bedrock-input-token-count': '6',
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            embeddings: { float: [mockEmbeddings[0]] },
+          }),
+        ),
+      },
+    },
+    [cohereV4UsProfileEmbedUrl]: {
       response: {
         type: 'binary',
         headers: {
@@ -225,6 +243,32 @@ describe('doEmbed', () => {
     });
 
     expect(Number.isNaN(usage?.tokens)).toBe(true);
+  });
+
+  it('should support Cohere models behind cross-region inference profile ids', async () => {
+    const cohereV4UsProfileModel = new AmazonBedrockEmbeddingModel(
+      'us.cohere.embed-v4:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+      },
+    );
+
+    const { embeddings, usage } = await cohereV4UsProfileModel.doEmbed({
+      values: [testValues[0]],
+    });
+
+    expect(embeddings.length).toBe(1);
+    expect(usage?.tokens).toBe(6);
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body).toEqual({
+      input_type: 'search_query',
+      texts: [testValues[0]],
+      truncate: undefined,
+      output_dimension: undefined,
+    });
   });
 
   it('should pass outputDimension for Cohere v4 embedding models', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -95,10 +95,10 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
     // Note: Different embedding model families expect different request/response
     // payloads (e.g. Titan vs Cohere vs Nova). We keep the public interface stable and
     // adapt here based on the modelId.
+    const isNovaModel =
+      this.modelId.startsWith('amazon.nova-') && this.modelId.includes('embed');
     // Use `includes` so cross-region inference profile ids (e.g.
     // `us.cohere.embed-v4:0`, `global.cohere.embed-v4:0`) are detected too.
-    const isNovaModel =
-      this.modelId.includes('amazon.nova-') && this.modelId.includes('embed');
     const isCohereModel = this.modelId.includes('cohere.embed-');
 
     const args = isNovaModel

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -95,9 +95,11 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
     // Note: Different embedding model families expect different request/response
     // payloads (e.g. Titan vs Cohere vs Nova). We keep the public interface stable and
     // adapt here based on the modelId.
+    // Use `includes` so cross-region inference profile ids (e.g.
+    // `us.cohere.embed-v4:0`, `global.cohere.embed-v4:0`) are detected too.
     const isNovaModel =
-      this.modelId.startsWith('amazon.nova-') && this.modelId.includes('embed');
-    const isCohereModel = this.modelId.startsWith('cohere.embed-');
+      this.modelId.includes('amazon.nova-') && this.modelId.includes('embed');
+    const isCohereModel = this.modelId.includes('cohere.embed-');
 
     const args = isNovaModel
       ? {


### PR DESCRIPTION
## Background

The embedding model adapts its request body per model family using `modelId.startsWith(...)` checks. Bedrock cross-region inference profile ids carry a geo/global prefix (`us.cohere.embed-v4:0`, `eu.cohere.embed-v4:0`, `global.cohere.embed-v4:0`), so `startsWith('cohere.embed-')` misses them and the request falls through to the Titan body shape (`{ inputText }`). Bedrock then rejects with "Malformed request. Please check your parameter/values and try again."

Reproduced live: `bedrock.embedding('us.cohere.embed-v4:0')` sends `{ inputText: ... }` and fails, while `cohere.embed-v4:0` works.

## Summary

Use `includes` instead of `startsWith` for the Cohere embedding family check, so inference-profile-prefixed ids select the correct request body. The Nova check is intentionally left unchanged — regional support for Nova embeddings can be added separately if needed.

## Verification

- New unit test: `us.cohere.embed-v4:0` produces a Cohere-shaped request body and extracts usage from the response header
- All existing embedding model tests pass (11 total)
- Live-verified against Bedrock with `us.cohere.embed-v4:0` (see PR comments)

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Documentation has been updated (for features)
- [x] Formatting issues have been fixed (run `pnpm fix` in the project root)

## Future Work

Backport to the v6 release line (handled separately, same as #15973).