### PR TITLE
Backport: fix(provider/amazon-bedrock): detect Cohere embedding models behind cross-region inference profile ids

### DIFF
--- a/.changeset/lucky-poems-march.md
+++ b/.changeset/lucky-poems-march.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): detect Cohere embedding models behind cross-region inference profile ids

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
@@ -24,6 +24,10 @@ const cohereV4EmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/
   'cohere.embed-v4:0',
 )}/invoke`;
 
+const cohereV4UsProfileEmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
+  'us.cohere.embed-v4:0',
+)}/invoke`;
+
 describe('doEmbed', () => {
   const mockConfigHeaders = {
     'config-header': 'config-value',
@@ -60,6 +64,20 @@ describe('doEmbed', () => {
       },
     },
     [cohereV4EmbedUrl]: {
+      response: {
+        type: 'binary',
+        headers: {
+          'content-type': 'application/json',
+          'x-amzn-bedrock-input-token-count': '6',
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            embeddings: { float: [mockEmbeddings[0]] },
+          }),
+        ),
+      },
+    },
+    [cohereV4UsProfileEmbedUrl]: {
       response: {
         type: 'binary',
         headers: {
@@ -219,6 +237,32 @@ describe('doEmbed', () => {
     });
 
     expect(Number.isNaN(usage?.tokens)).toBe(true);
+  });
+
+  it('should support Cohere models behind cross-region inference profile ids', async () => {
+    const cohereV4UsProfileModel = new BedrockEmbeddingModel(
+      'us.cohere.embed-v4:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+      },
+    );
+
+    const { embeddings, usage } = await cohereV4UsProfileModel.doEmbed({
+      values: [testValues[0]],
+    });
+
+    expect(embeddings.length).toBe(1);
+    expect(usage?.tokens).toBe(6);
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body).toEqual({
+      input_type: 'search_query',
+      texts: [testValues[0]],
+      truncate: undefined,
+      output_dimension: undefined,
+    });
   });
 
   it('should pass outputDimension for Cohere v4 embedding models', async () => {

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -73,7 +73,9 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
     // adapt here based on the modelId.
     const isNovaModel =
       this.modelId.startsWith('amazon.nova-') && this.modelId.includes('embed');
-    const isCohereModel = this.modelId.startsWith('cohere.embed-');
+    // Use `includes` so cross-region inference profile ids (e.g.
+    // `us.cohere.embed-v4:0`, `global.cohere.embed-v4:0`) are detected too.
+    const isCohereModel = this.modelId.includes('cohere.embed-');
 
     const args = isNovaModel
       ? {


### PR DESCRIPTION
Manual backport of #15979 to `release-v6.0` (the backport action didn't run).

Cherry-picked cleanly apart from one adjustment: the new test uses the v6 class name `BedrockEmbeddingModel` instead of v7's `AmazonBedrockEmbeddingModel` (same adjustment as #15977).

All 11 embedding model tests pass on this branch.