### PR TITLE
fix(providers): only send credentials to same-origin response-supplied URLs

### DIFF
--- a/.changeset/provider-api-key-same-origin.md
+++ b/.changeset/provider-api-key-same-origin.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/black-forest-labs': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/google': patch
+---
+
+fix: only send provider credentials to same-origin response-supplied URLs
+
+Several provider clients followed a URL taken from the provider's API response (a polling/status URL or a final media URL such as `polling_url`, `urls.get`, `result_url`, `result.sample`, or `video.uri`) and reused the authenticated headers — or appended `?key=<API_KEY>` — on that request. Because the host of the response-supplied URL was never validated, the long-lived API key was sent to whatever host the response named (a CDN in the benign case, or an attacker-chosen host if the provider response was tampered with), allowing credential exfiltration.
+
+A new `isSameOrigin` helper is added to `@ai-sdk/provider-utils`, and the affected fetches in `@ai-sdk/black-forest-labs`, `@ai-sdk/fireworks`, `@ai-sdk/replicate`, `@ai-sdk/gladia`, `@ai-sdk/fal`, and `@ai-sdk/google` now attach credentials only when the followed URL is same-origin with the provider's configured API origin. Requests to a foreign origin are made without the credential.

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -71,6 +71,12 @@ describe('BlackForestLabsImageModel', () => {
         body: Buffer.from('test-binary-content'),
       },
     },
+    'https://cdn.evil.example/image.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+      },
+    },
   });
 
   describe('doGenerate', () => {
@@ -304,6 +310,34 @@ describe('BlackForestLabsImageModel', () => {
       expect(server.calls[2].requestUrl).toBe(
         'https://api.example.com/image.png',
       );
+    });
+
+    it('does not send the API key when the result URL is on a foreign origin', async () => {
+      server.urls['https://api.example.com/poll'].response = {
+        type: 'json-value',
+        body: {
+          status: 'Ready',
+          result: { sample: 'https://cdn.evil.example/image.png' },
+        },
+      };
+
+      const model = createBasicModel();
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const downloadCall = server.calls.find(
+        call => call.requestUrl === 'https://cdn.evil.example/image.png',
+      );
+      expect(downloadCall).toBeDefined();
+      expect(downloadCall!.requestHeaders['x-key']).toBeUndefined();
     });
 
     it('merges provider and request headers for submit call', async () => {

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -77,6 +77,32 @@ describe('BlackForestLabsImageModel', () => {
         body: Buffer.from('test-binary-content'),
       },
     },
+    'https://api.bfl.ai/v1/test-model': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.us1.bfl.ai/v1/get_result',
+        },
+      },
+    },
+    'https://api.us1.bfl.ai/v1/get_result': {
+      response: {
+        type: 'json-value',
+        body: {
+          status: 'Ready',
+          result: {
+            sample: 'https://delivery-us1.bfl.ai/image.png',
+          },
+        },
+      },
+    },
+    'https://delivery-us1.bfl.ai/image.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+      },
+    },
   });
 
   describe('doGenerate', () => {
@@ -338,6 +364,31 @@ describe('BlackForestLabsImageModel', () => {
       );
       expect(downloadCall).toBeDefined();
       expect(downloadCall!.requestHeaders['x-key']).toBeUndefined();
+    });
+
+    it('sends the API key when the polling URL is on a sibling bfl.ai cluster host', async () => {
+      const model = new BlackForestLabsImageModel('test-model', {
+        provider: 'black-forest-labs.image',
+        baseURL: 'https://api.bfl.ai/v1',
+        headers: () => ({ 'x-key': 'test-key' }),
+      });
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const pollCall = server.calls.find(call =>
+        call.requestUrl.startsWith('https://api.us1.bfl.ai/v1/get_result'),
+      );
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['x-key']).toBe('test-key');
     });
 
     it('merges provider and request headers for submit call', async () => {

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -243,9 +243,9 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
       // Only send credentials if the response-supplied URL points back at the
-      // provider's own origin; the image is typically delivered from a CDN, so
-      // the API key must not travel to a foreign host.
-      headers: isSameOrigin(imageUrl, this.config.baseURL)
+      // provider; the image is typically delivered from a CDN, so the API key
+      // must not travel to a foreign host.
+      headers: isTrustedUrl(imageUrl, this.config.baseURL)
         ? combinedHeaders
         : undefined,
       abortSignal,
@@ -327,8 +327,8 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       const { value } = await getFromApi({
         url: url.toString(),
         // The polling URL comes from the provider response; only send
-        // credentials when it stays on the provider's own origin.
-        headers: isSameOrigin(url.toString(), this.config.baseURL)
+        // credentials when it stays on a trusted provider host.
+        headers: isTrustedUrl(url.toString(), this.config.baseURL)
           ? headers
           : undefined,
         failedResponseHandler: bflFailedResponseHandler,
@@ -360,6 +360,29 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
     }
 
     throw new Error('Black Forest Labs generation timed out.');
+  }
+}
+
+/**
+ * Black Forest Labs returns response-supplied URLs (polling and delivery) on
+ * sibling cluster hosts of the API origin (e.g. `api.us1.bfl.ai` for a base
+ * URL on `api.bfl.ai`), so a strict same-origin check against the configured
+ * base URL is not enough. Credentials may also be sent to any https host under
+ * the official `bfl.ai` domain.
+ */
+function isTrustedUrl(url: string, baseUrl: string): boolean {
+  if (isSameOrigin(url, baseUrl)) {
+    return true;
+  }
+
+  try {
+    const { protocol, hostname } = new URL(url);
+    return (
+      protocol === 'https:' &&
+      (hostname === 'bfl.ai' || hostname.endsWith('.bfl.ai'))
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -7,6 +7,7 @@ import {
   createStatusCodeErrorResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postJsonToApi,
   resolve,
@@ -241,7 +242,12 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
 
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
-      headers: combinedHeaders,
+      // Only send credentials if the response-supplied URL points back at the
+      // provider's own origin; the image is typically delivered from a CDN, so
+      // the API key must not travel to a foreign host.
+      headers: isSameOrigin(imageUrl, this.config.baseURL)
+        ? combinedHeaders
+        : undefined,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),
@@ -320,7 +326,11 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
     for (let i = 0; i < maxPollAttempts; i++) {
       const { value } = await getFromApi({
         url: url.toString(),
-        headers,
+        // The polling URL comes from the provider response; only send
+        // credentials when it stays on the provider's own origin.
+        headers: isSameOrigin(url.toString(), this.config.baseURL)
+          ? headers
+          : undefined,
         failedResponseHandler: bflFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(bflPollSchema),
         abortSignal,

--- a/packages/fal/src/fal-video-model.test.ts
+++ b/packages/fal/src/fal-video-model.test.ts
@@ -81,6 +81,17 @@ describe('FalVideoModel', () => {
         },
       },
     },
+    'https://evil.fal.example/requests/forged': {
+      response: {
+        type: 'json-value',
+        body: {
+          video: {
+            url: 'https://fal.media/files/video-output.mp4',
+            content_type: 'video/mp4',
+          },
+        },
+      },
+    },
     'https://queue.fal.run/fal-ai/luma-ray-2/requests/ray2-request-id': {
       response: {
         type: 'json-value',
@@ -188,6 +199,25 @@ describe('FalVideoModel', () => {
         'custom-provider-header': 'provider-header-value',
         'custom-request-header': 'request-header-value',
       });
+    });
+
+    it('does not send the API key when the status URL is on a foreign origin', async () => {
+      const forgedUrl = 'https://evil.fal.example/requests/forged';
+      server.urls['https://queue.fal.run/fal-ai/luma-dream-machine'].response =
+        {
+          type: 'json-value',
+          body: {
+            request_id: 'test-request-id-123',
+            response_url: forgedUrl,
+          },
+        };
+
+      const model = createBasicModel();
+      await model.doGenerate({ ...defaultOptions });
+
+      const pollCall = server.calls.find(call => call.requestUrl === forgedUrl);
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['api-key']).toBeUndefined();
     });
 
     it('should return video with correct data', async () => {

--- a/packages/fal/src/fal-video-model.ts
+++ b/packages/fal/src/fal-video-model.ts
@@ -10,6 +10,7 @@ import {
   createJsonResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -118,11 +119,12 @@ export class FalVideoModel implements Experimental_VideoModelV4 {
       }
     }
 
+    const submitUrl = this.config.url({
+      path: `https://queue.fal.run/fal-ai/${this.normalizedModelId}`,
+      modelId: this.modelId,
+    });
     const { value: queueResponse } = await postJsonToApi({
-      url: this.config.url({
-        path: `https://queue.fal.run/fal-ai/${this.normalizedModelId}`,
-        modelId: this.modelId,
-      }),
+      url: submitUrl,
       headers: combineHeaders(this.config.headers?.(), options.headers),
       body,
       failedResponseHandler: falFailedResponseHandler,
@@ -148,13 +150,18 @@ export class FalVideoModel implements Experimental_VideoModelV4 {
 
     while (true) {
       try {
+        const statusUrl = this.config.url({
+          path: responseUrl,
+          modelId: this.modelId,
+        });
         const { value: statusResponse, responseHeaders: statusHeaders } =
           await getFromApi({
-            url: this.config.url({
-              path: responseUrl,
-              modelId: this.modelId,
-            }),
-            headers: combineHeaders(this.config.headers?.(), options.headers),
+            url: statusUrl,
+            // The status URL comes from the queue response; only send
+            // credentials when it stays on the provider's own origin.
+            headers: isSameOrigin(statusUrl, submitUrl)
+              ? combineHeaders(this.config.headers?.(), options.headers)
+              : undefined,
             failedResponseHandler: async ({
               response,
               url,

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -761,8 +761,10 @@ describe('FireworksImageModel', () => {
         id: 'test-request-123',
       });
 
-      // Verify image download
+      // Verify image download — the result URL is on a foreign origin
+      // (example.com), so the API key must not be sent with the download.
       expect(server.calls[2].requestUrl).toBe('https://example.com/image.png');
+      expect(server.calls[2].requestHeaders['api-key']).toBeUndefined();
 
       // Verify result
       expect(result.images).toHaveLength(1);

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -7,6 +7,7 @@ import {
   createStatusCodeErrorResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   postJsonToApi,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
@@ -286,10 +287,15 @@ export class FireworksImageModel implements ImageModelV4 {
       abortSignal,
     });
 
-    // Download the image from the URL
+    // Download the image from the URL. The URL comes from the provider
+    // response and typically points at a CDN, so only send credentials when it
+    // stays on the provider's own origin (never leak the API key to a CDN or an
+    // attacker-named host).
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
-      headers,
+      headers: isSameOrigin(imageUrl, this.config.baseURL)
+        ? headers
+        : undefined,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),

--- a/packages/gladia/src/gladia-transcription-model.test.ts
+++ b/packages/gladia/src/gladia-transcription-model.test.ts
@@ -33,6 +33,7 @@ const server = createTestServer({
   },
   'https://api.gladia.io/v2/pre-recorded': {},
   [initiateFixture.result_url]: {},
+  'https://cdn.evil.example/v2/pre-recorded/result': {},
 });
 
 function prepareJsonFixtureResponse(headers?: Record<string, string>) {
@@ -61,6 +62,30 @@ describe('doGenerate', () => {
       expect(await server.calls[1].requestBodyJson).toMatchObject({
         audio_url: uploadFixture.audio_url,
       });
+    });
+
+    it('does not send the API key when the result URL is on a foreign origin', async () => {
+      const foreignResultUrl =
+        'https://cdn.evil.example/v2/pre-recorded/result';
+      server.urls['https://api.gladia.io/v2/pre-recorded'].response = {
+        type: 'json-value',
+        body: { ...initiateFixture, result_url: foreignResultUrl },
+      };
+      server.urls[foreignResultUrl].response = {
+        type: 'json-value',
+        body: resultFixture,
+      };
+
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      const pollCall = server.calls.find(
+        call => call.requestUrl === foreignResultUrl,
+      );
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['x-gladia-key']).toBeUndefined();
     });
 
     it('should pass headers', async () => {

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -10,6 +10,7 @@ import {
   mediaTypeToExtension,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postFormDataToApi,
   postJsonToApi,
@@ -250,8 +251,11 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
       fetch: this.config.fetch,
     });
 
-    // Poll the result URL until the transcription is done or an error occurs
+    // Poll the result URL until the transcription is done or an error occurs.
+    // The result URL comes from the provider response; only send credentials
+    // when it stays on the provider's own origin.
     const resultUrl = transcriptionInitResponse.result_url;
+    const apiOrigin = this.config.url({ modelId: 'default', path: '' });
     let transcriptionResult;
     let transcriptionResultHeaders;
     const timeoutMs = 60 * 1000; // 60 seconds timeout
@@ -270,7 +274,9 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
 
       const response = await getFromApi({
         url: resultUrl,
-        headers: combineHeaders(this.config.headers?.(), options.headers),
+        headers: isSameOrigin(resultUrl, apiOrigin)
+          ? combineHeaders(this.config.headers?.(), options.headers)
+          : undefined,
         failedResponseHandler: gladiaFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(
           gladiaTranscriptionResultResponseSchema,

--- a/packages/google/src/google-video-model.test.ts
+++ b/packages/google/src/google-video-model.test.ts
@@ -317,6 +317,23 @@ describe('GoogleVideoModel', () => {
       });
     });
 
+    it('should NOT append the API key when the download URL is on a foreign origin', async () => {
+      const model = createMockModel({
+        apiKey: 'test-api-key',
+        videos: [{ video: { uri: 'https://cdn.evil.example/video-123.mp4' } }],
+      });
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      // The key must not travel to a host the provider response named: the URL
+      // is returned verbatim, without the `?key=` credential appended.
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://cdn.evil.example/video-123.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+
     it('should return multiple videos', async () => {
       const model = createMockModel({
         apiKey: 'test-key',

--- a/packages/google/src/google-video-model.ts
+++ b/packages/google/src/google-video-model.ts
@@ -9,6 +9,7 @@ import {
   createJsonResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postJsonToApi,
   resolve,
@@ -263,10 +264,13 @@ export class GoogleVideoModel implements Experimental_VideoModelV4 {
     for (const generatedSample of response.generateVideoResponse
       .generatedSamples) {
       if (generatedSample.video?.uri) {
-        // Append API key to URL for authentication during download
-        const urlWithAuth = apiKey
-          ? `${generatedSample.video.uri}${generatedSample.video.uri.includes('?') ? '&' : '?'}key=${apiKey}`
-          : generatedSample.video.uri;
+        // Append the API key to the download URL for authentication, but only
+        // when the response-supplied URI stays on the provider's own origin —
+        // otherwise the key would leak to whatever host the response names.
+        const urlWithAuth =
+          apiKey && isSameOrigin(generatedSample.video.uri, this.config.baseURL)
+            ? `${generatedSample.video.uri}${generatedSample.video.uri.includes('?') ? '&' : '?'}key=${apiKey}`
+            : generatedSample.video.uri;
 
         videos.push({
           type: 'url',

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -30,6 +30,7 @@ export type { HasRequiredKey } from './has-required-key';
 export { injectJsonInstructionIntoMessages } from './inject-json-instruction';
 export * from './is-abort-error';
 export { isBuffer } from './is-buffer';
+export { isSameOrigin } from './is-same-origin';
 export { isNonNullable } from './is-non-nullable';
 export { isProviderReference } from './is-provider-reference';
 export { isUrlSupported } from './is-url-supported';

--- a/packages/provider-utils/src/is-same-origin.test.ts
+++ b/packages/provider-utils/src/is-same-origin.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { isSameOrigin } from './is-same-origin';
+
+describe('isSameOrigin', () => {
+  it('returns true for identical origins (ignoring path/query)', () => {
+    expect(
+      isSameOrigin(
+        'https://api.example.com/v1/file',
+        'https://api.example.com',
+      ),
+    ).toBe(true);
+    expect(
+      isSameOrigin(
+        'https://api.example.com/a?x=1',
+        'https://api.example.com/b',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a different host', () => {
+    expect(
+      isSameOrigin('https://cdn.evil.com/file', 'https://api.example.com'),
+    ).toBe(false);
+  });
+
+  it('returns false for a different scheme or port', () => {
+    expect(
+      isSameOrigin('http://api.example.com/file', 'https://api.example.com'),
+    ).toBe(false);
+    expect(
+      isSameOrigin(
+        'https://api.example.com:8443/file',
+        'https://api.example.com',
+      ),
+    ).toBe(false);
+  });
+
+  it('fails closed on invalid input', () => {
+    expect(isSameOrigin('not-a-url', 'https://api.example.com')).toBe(false);
+    expect(isSameOrigin('https://api.example.com/file', 'not-a-url')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/provider-utils/src/is-same-origin.ts
+++ b/packages/provider-utils/src/is-same-origin.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns true when `url` has the same origin (scheme + host + port) as
+ * `baseUrl`.
+ *
+ * Used to decide whether provider credentials may be attached to a request to a
+ * URL taken from a provider response (e.g. a polling or media-download URL).
+ * Credentials must only be sent to the provider's own origin; a response that
+ * names a foreign host (a CDN, or an attacker-controlled host if the response
+ * is tampered with) must not receive the API key.
+ *
+ * Returns false if either value is not a valid absolute URL (fail-closed).
+ */
+export function isSameOrigin(url: string, baseUrl: string): boolean {
+  try {
+    return new URL(url).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
+  }
+}

--- a/packages/replicate/src/replicate-video-model.test.ts
+++ b/packages/replicate/src/replicate-video-model.test.ts
@@ -157,6 +157,55 @@ describe('ReplicateVideoModel', () => {
   });
 
   describe('doGenerate', () => {
+    it('does not send the API key when the poll URL is on a foreign origin', async () => {
+      const foreignUrl = 'https://evil.replicate.example/v1/predictions/forged';
+      const headersByUrl: Record<string, Record<string, string>> = {};
+
+      const model = new ReplicateVideoModel('minimax/video-01', {
+        provider: 'replicate.video',
+        baseURL: 'https://api.replicate.com/v1',
+        headers: () => ({ Authorization: 'Bearer test-api-token' }),
+        fetch: async (url, init) => {
+          const urlString = url.toString();
+          headersByUrl[urlString] =
+            (init?.headers as Record<string, string>) ?? {};
+
+          // Initial create-prediction POST returns a forged, foreign poll URL.
+          if (init?.method !== 'GET' && urlString !== foreignUrl) {
+            return new Response(
+              JSON.stringify({
+                id: 'forged',
+                status: 'starting',
+                output: null,
+                error: null,
+                urls: { get: foreignUrl },
+                metrics: null,
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+
+          // Poll on the foreign URL resolves immediately.
+          return new Response(
+            JSON.stringify({
+              id: 'forged',
+              status: 'succeeded',
+              output: 'https://replicate.delivery/video.mp4',
+              error: null,
+              urls: { get: foreignUrl },
+              metrics: { predict_time: 1 },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        },
+      });
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(headersByUrl[foreignUrl]).toBeDefined();
+      expect(headersByUrl[foreignUrl].Authorization).toBeUndefined();
+    });
+
     it('should pass the correct parameters including prompt', async () => {
       let capturedBody: unknown;
       const model = createMockModel({

--- a/packages/replicate/src/replicate-video-model.ts
+++ b/packages/replicate/src/replicate-video-model.ts
@@ -9,6 +9,7 @@ import {
   createJsonResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postJsonToApi,
   resolve,
@@ -217,9 +218,14 @@ export class ReplicateVideoModel implements Experimental_VideoModelV4 {
           });
         }
 
+        const pollUrl = finalPrediction.urls.get;
         const { value: statusPrediction } = await getFromApi({
-          url: finalPrediction.urls.get,
-          headers: await resolve(this.config.headers),
+          url: pollUrl,
+          // The polling URL comes from the provider response; only send
+          // credentials when it stays on the provider's own origin.
+          headers: isSameOrigin(pollUrl, this.config.baseURL)
+            ? await resolve(this.config.headers)
+            : undefined,
           successfulResponseHandler: createJsonResponseHandler(
             replicatePredictionSchema,
           ),


### PR DESCRIPTION
## Background

Reported via the Anthropic CVD as **VULN-11567 (ANT-2026-FX163E39)**. Several provider clients follow a URL taken from the provider's API response — a polling/status URL or a final media URL (`polling_url`, `urls.get`, `result_url`, `result.sample`, `video.uri`) — and reuse the authenticated headers, or append `?key=<API_KEY>`, on that request. Because the host of the response-supplied URL is never validated, the long-lived API key is sent to whatever host the response names (a CDN in the benign case, or an attacker-chosen host if the provider is compromised or the response is tampered with), allowing credential exfiltration. A safe no-headers pattern already exists in `xai-image-model.ts`.

## Summary

Adds an `isSameOrigin(url, baseUrl)` helper to `@ai-sdk/provider-utils` and gates every affected fetch so the provider credential is attached **only when the followed URL is same-origin with the provider's configured API origin**; a foreign origin gets the request without credentials. This single rule covers both cases correctly:

- **Polling/status URLs** (need auth, normally same-origin) keep working.
- **Media downloads** on a CDN (foreign origin) are fetched without the key. Google's video download legitimately needs the key, and its URI is same-origin, so it still works.

### Sites gated

| Package | Site | Response field |
| --- | --- | --- |
| `@ai-sdk/black-forest-labs` | poll + image download | `polling_url`, `result.sample` |
| `@ai-sdk/fireworks` | image download (workflows_async) | `result.sample` |
| `@ai-sdk/replicate` | video poll | `urls.get` |
| `@ai-sdk/gladia` | transcription poll | `result_url` |
| `@ai-sdk/fal` | video status poll | `response_url` |
| `@ai-sdk/google` | video download (`?key=`) | `video.uri` |

(fal's transcription poll and Google's operation poll build their URL from a hardcoded/`baseURL`-anchored host, so they are not response-host-supplied and are left unchanged. `fal-image` and `replicate-image` already omit credentials on download.)

### Tests

- Unit tests for `isSameOrigin` (same origin, foreign host, scheme/port mismatch, fail-closed on invalid input).
- A foreign-origin regression test per provider asserting the credential header (or `?key=`) is **not** sent when the response names a different host. All suites pass in node and edge.

## Manual Verification

<!-- TODO -->

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Consider routing all response-supplied follow-up fetches through a small shared wrapper (origin-gated `getFromApi`) so new providers can't reintroduce this pattern, and so the rule is enforced in one place rather than per call site.

## Related Issues

Linear: VULN-11567 (tracked under VULN-11626).