### PR TITLE
fix(prodia): validate user-supplied image URLs before fetching (SSRF)

### DIFF
--- a/.changeset/prodia-video-image-url-ssrf.md
+++ b/.changeset/prodia-video-image-url-ssrf.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/prodia': patch
+---
+
+fix(prodia): validate user-supplied image URLs before fetching (SSRF)
+
+The Prodia video model's `resolveVideoFileData` fetched a user-supplied `image` URL directly with `fetch()`, bypassing the SDK's SSRF guard. An attacker who could supply the image URL could make the server request internal endpoints (e.g. cloud metadata) and have the response uploaded to Prodia's API. The URL is now downloaded via `downloadBlob`, which routes through `validateDownloadUrl` and rejects private/internal addresses, matching the pattern used by other providers.

--- a/packages/prodia/src/prodia-video-model.test.ts
+++ b/packages/prodia/src/prodia-video-model.test.ts
@@ -84,6 +84,13 @@ describe('ProdiaVideoModel', () => {
         },
       },
     },
+    'https://cdn.example.com/input.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('input-image-bytes'),
+        headers: { 'content-type': 'image/png' },
+      },
+    },
   });
 
   describe('constructor', () => {
@@ -399,6 +406,72 @@ describe('ProdiaVideoModel', () => {
       expect(server.calls[0].requestHeaders['content-type']).toContain(
         'multipart/form-data',
       );
+    });
+
+    it('downloads a public image URL and sends it as multipart form-data', async () => {
+      const model = createBasicModel({
+        modelId: 'inference.wan2-2.lightning.img2vid.v0',
+      });
+
+      await model.doGenerate({
+        prompt,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: {
+          type: 'url',
+          url: 'https://cdn.example.com/input.png',
+        },
+        providerOptions: {},
+      });
+
+      // The image is downloaded, then the job is POSTed as multipart form-data.
+      expect(
+        server.calls.some(
+          call => call.requestUrl === 'https://cdn.example.com/input.png',
+        ),
+      ).toBe(true);
+      const jobCall = server.calls.find(
+        call => call.requestUrl === 'https://api.example.com/v2/job?price=true',
+      );
+      expect(jobCall?.requestMethod).toBe('POST');
+      expect(jobCall?.requestHeaders['content-type']).toContain(
+        'multipart/form-data',
+      );
+    });
+
+    it('blocks an image URL pointing at a private address (SSRF guard)', async () => {
+      const model = createBasicModel({
+        modelId: 'inference.wan2-2.lightning.img2vid.v0',
+      });
+
+      await expect(
+        model.doGenerate({
+          prompt,
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          image: {
+            type: 'url',
+            url: 'http://169.254.169.254/latest/meta-data/',
+          },
+          providerOptions: {},
+        }),
+      ).rejects.toThrow();
+
+      // The internal URL must never be requested, and no job is submitted.
+      expect(
+        server.calls.some(call => call.requestUrl.includes('169.254.169.254')),
+      ).toBe(false);
+      expect(
+        server.calls.some(call => call.requestUrl.includes('/v2/job')),
+      ).toBe(false);
     });
   });
 });

--- a/packages/prodia/src/prodia-video-model.ts
+++ b/packages/prodia/src/prodia-video-model.ts
@@ -5,13 +5,13 @@ import type {
 import {
   combineHeaders,
   convertBase64ToUint8Array,
+  downloadBlob,
   parseJSON,
   parseProviderOptions,
   postFormDataToApi,
   postToApi,
   resolve,
   zodSchema,
-  type FetchFunction,
 } from '@ai-sdk/provider-utils';
 import {
   buildProdiaProviderMetadata,
@@ -82,7 +82,7 @@ export class ProdiaVideoModel implements Experimental_VideoModelV4 {
       // img2vid: multipart form-data request
       const imageData = await resolveVideoFileData(
         options.image,
-        this.config.fetch,
+        options.abortSignal,
       );
       const formData = new FormData();
       formData.append(
@@ -236,7 +236,7 @@ async function resolveVideoFileData(
   file: NonNullable<
     Parameters<Experimental_VideoModelV4['doGenerate']>[0]['image']
   >,
-  fetchFunction?: FetchFunction,
+  abortSignal?: AbortSignal,
 ): Promise<{ bytes: Uint8Array; mediaType: string }> {
   if (file.type === 'file') {
     const data =
@@ -245,11 +245,12 @@ async function resolveVideoFileData(
         : file.data;
     return { bytes: data, mediaType: file.mediaType };
   }
-  // URL type - fetch the data
-  const response = await (fetchFunction ?? globalThis.fetch)(file.url);
-  const arrayBuffer = await response.arrayBuffer();
-  const mediaType =
-    response.headers.get('content-type') ?? 'application/octet-stream';
+  // URL type - download via downloadBlob so the user-supplied URL is routed
+  // through the SSRF guard (validateDownloadUrl) instead of being fetched
+  // directly, preventing requests to private/internal addresses.
+  const blob = await downloadBlob(file.url, { abortSignal });
+  const arrayBuffer = await blob.arrayBuffer();
+  const mediaType = blob.type || 'application/octet-stream';
   return { bytes: new Uint8Array(arrayBuffer), mediaType };
 }
 


### PR DESCRIPTION
## Background

Reported via the Anthropic CVD as **VULN-11535 (ANT-2026-MX75JS88)**. The Prodia video model's `resolveVideoFileData()` fetched a user-supplied `image` URL directly with `fetch(file.url)`, skipping the SDK's `validateDownloadUrl()` SSRF guard that other providers use via `downloadBlob()`. There was no scheme check, private-IP/link-local filtering, or redirect validation. The fetched bytes are uploaded as the multipart `input` to `inference.prodia.com`, so an attacker who controls the image URL could make the server fetch internal endpoints (e.g. AWS IMDS) and exfiltrate the response.

## Summary

`resolveVideoFileData()` now downloads URL-type images via **`downloadBlob()`** (which routes through `validateDownloadUrl()` and rejects private/internal addresses) instead of calling `fetch()` directly. This matches the pattern already used by `deepinfra`, `fal`, and `replicate` image models. The `file`-type (base64/bytes) path is unchanged.

Note: like the other providers' download paths, the URL download now uses the standard fetch (the provider's custom `config.fetch` was only relevant for Prodia's own API calls, not for downloading an arbitrary user URL).

### Tests

- Blocks an image URL pointing at a private address (`169.254.169.254`) — `doGenerate` rejects, the internal URL is never requested, and no job is submitted.
- Happy path: a public image URL is downloaded and sent as multipart form-data.

All prodia tests pass in node and edge; type-check clean.

## Manual Verification

<!-- TODO -->

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Linear: VULN-11535 (tracked under VULN-11626).