### PR TITLE
fix(ai): redact server error details from UI message streams by default

### DIFF
--- a/.changeset/ui-message-stream-default-onerror-redacts.md
+++ b/.changeset/ui-message-stream-default-onerror-redacts.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+fix: redact server error details from UI message streams by default
+
+`toUIMessageStream`, `createUIMessageStream`, and `toUIMessageChunk` defaulted their `onError` callback to `getErrorMessage`, which serializes the raw error (`error.toString()` / `JSON.stringify(error)`) into the client-facing `{ type: 'error', errorText }` chunk — and also into `tool-output-error` parts. The documented default was `() => 'An error occurred.'`, so applications relying on the documented behavior were unknowingly streaming server exception details (internal hostnames, paths, provider request data, validation inputs) to end users.
+
+The default `onError` now returns the documented generic `'An error occurred.'`. Raw error details are only emitted when the developer explicitly supplies an `onError` handler. This also redacts `tool-output-error` and invalid-tool-input error text by default; pass an `onError` to surface richer messages.

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -221,7 +221,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error m
   "data: {"type":"start-step"}
 
 ",
-  "data: {"type":"error","errorText":"error"}
+  "data: {"type":"error","errorText":"An error occurred."}
 
 ",
   "data: {"type":"finish-step"}
@@ -646,7 +646,7 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
     "type": "start-step",
   },
   {
-    "errorText": "error",
+    "errorText": "An error occurred.",
     "type": "error",
   },
   {
@@ -735,7 +735,7 @@ exports[`streamText > result.toUIMessageStreamResponse > should mask error messa
   "data: {"type":"start-step"}
 
 ",
-  "data: {"type":"error","errorText":"error"}
+  "data: {"type":"error","errorText":"An error occurred."}
 
 ",
   "data: {"type":"finish-step"}

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -17802,7 +17802,7 @@ describe('streamText', () => {
               "type": "tool-input-available",
             },
             {
-              "errorText": "Error: test error",
+              "errorText": "An error occurred.",
               "toolCallId": "call-1",
               "type": "tool-output-error",
             },
@@ -23005,17 +23005,7 @@ describe('streamText', () => {
                 "type": "tool-input-delta",
               },
               {
-                "errorText": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
-            Error message: [
-              {
-                "expected": "string",
-                "code": "invalid_type",
-                "path": [
-                  "city"
-                ],
-                "message": "Invalid input: expected string, received undefined"
-              }
-            ]",
+                "errorText": "An error occurred.",
                 "input": {
                   "cities": "San Francisco",
                 },
@@ -23024,17 +23014,7 @@ describe('streamText', () => {
                 "type": "tool-input-error",
               },
               {
-                "errorText": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
-            Error message: [
-              {
-                "expected": "string",
-                "code": "invalid_type",
-                "path": [
-                  "city"
-                ],
-                "message": "Invalid input: expected string, received undefined"
-              }
-            ]",
+                "errorText": "An error occurred.",
                 "toolCallId": "call-1",
                 "type": "tool-output-error",
               },

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -1,6 +1,5 @@
 import {
   generateId as generateIdFunc,
-  getErrorMessage,
   type IdGenerator,
 } from '@ai-sdk/provider-utils';
 import type { UIMessage } from '../ui/ui-messages';
@@ -15,7 +14,7 @@ import type { UIMessageStreamWriter } from './ui-message-stream-writer';
  * Creates a UI message stream that can be used to send messages to the client.
  *
  * @param options.execute - A function that is called with a writer to write UI message chunks to the stream.
- * @param options.onError - A function that extracts an error message from an error. Defaults to `getErrorMessage`.
+ * @param options.onError - A function that extracts an error message from an error. Defaults to `() => 'An error occurred.'` so server-side error details are not leaked to the client; supply your own to surface richer messages.
  * @param options.originalMessages - The original messages. If provided, persistence mode is assumed
  *   and a message ID is provided for the response message.
  * @param options.onStepEnd - A callback that is called when each step ends. Useful for persisting intermediate messages.
@@ -27,7 +26,7 @@ import type { UIMessageStreamWriter } from './ui-message-stream-writer';
  */
 export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   execute,
-  onError = getErrorMessage,
+  onError = () => 'An error occurred.', // prevent leaking server error details to the client by default
   originalMessages,
   onStepEnd,
   onStepFinish,

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -1,4 +1,4 @@
-import { getErrorMessage, type ToolSet } from '@ai-sdk/provider-utils';
+import type { ToolSet } from '@ai-sdk/provider-utils';
 import type { TextStreamPart } from '../generate-text/stream-text-result';
 import type {
   InferUIMessageData,
@@ -38,7 +38,7 @@ export function toUIMessageChunk<
     sendSources = false,
     sendStart = true,
     sendFinish = true,
-    onError = getErrorMessage,
+    onError = () => 'An error occurred.', // prevent leaking server error details to the client by default
     messageMetadata,
     responseMessageId,
   }: ToUIMessageChunkOptions<TOOLS, UI_MESSAGE> = {},

--- a/packages/ai/src/ui-message-stream/to-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-stream.ts
@@ -1,4 +1,4 @@
-import { getErrorMessage, type ToolSet } from '@ai-sdk/provider-utils';
+import type { ToolSet } from '@ai-sdk/provider-utils';
 import type {
   TextStreamPart,
   UIMessageStreamOptions,
@@ -25,7 +25,7 @@ export function toUIMessageStream<
   sendSources = false,
   sendStart = true,
   sendFinish = true,
-  onError = getErrorMessage,
+  onError = () => 'An error occurred.', // prevent leaking server error details to the client by default
   messageMetadata,
   originalMessages,
   generateMessageId,


### PR DESCRIPTION
## Background

`toUIMessageStream`, `createUIMessageStream`, and `toUIMessageChunk` defaulted their `onError` callback to `getErrorMessage`, which serializes the raw error (`error.toString()` / `JSON.stringify(error)`) into the client-facing `{ type: 'error', errorText }` chunk. The public `UIMessageStreamOptions` type documents the default as `() => 'An error occurred.'`, but the implementation fell through to `getErrorMessage`, so `streamText().toUIMessageStream()` / `toUIMessageStreamResponse()` streamed raw server exception details (internal hostnames, ports, file paths, provider request data) to end users.

## Summary

The default `onError` for all three entry points now returns the documented generic **`'An error occurred.'`**. Raw error details are emitted only when the developer explicitly supplies an `onError` handler (opt-in).

Because `onError` also serializes **`tool-output-error`** parts and invalid-tool-input errors, those are now redacted by default too (they previously leaked e.g. the rejected tool input). This matches the documented contract; supply `onError` to surface richer messages.

### Tests

The existing `streamText` tests named **"should mask error messages by default"** had snapshots that captured the *buggy* raw `"error"` text — those snapshots are updated to `"An error occurred."`, along with the tool-error/invalid-tool-call snapshots. The full `ai` suite passes (3120 tests), type-check and lint clean.

## Manual Verification

<!-- TODO -->

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- If surfacing benign tool errors (e.g. validation messages) to clients is desired out of the box, consider a separate handler for `tool-output-error` parts distinct from the stream-level `error` chunk, so tool errors can be shown while server exceptions stay redacted. Left as a follow-up since the current single-`onError` knob matches the documented contract.

## Related Issues

Linear: VULN-11578 (tracked under VULN-11626).