### PR TITLE
fix(examples): require host origin for MCP sandbox-proxy resource-ready

### DIFF
--- a/examples/ai-e2e-next/app/chat/mcp-apps/sandbox/route.ts
+++ b/examples/ai-e2e-next/app/chat/mcp-apps/sandbox/route.ts
@@ -44,9 +44,14 @@ const sandboxProxyHtml = `<!doctype html>
       window.addEventListener('message', event => {
         const data = event.data;
 
+        // Only the trusted host window may (re)configure the inner iframe's
+        // sandbox and content. Without this source check the untrusted inner
+        // frame could forge a resource-ready message to grant itself
+        // 'allow-same-origin' and escape to the host origin.
         if (
           isJsonRpc(data) &&
-          data.method === 'ui/notifications/sandbox-resource-ready'
+          data.method === 'ui/notifications/sandbox-resource-ready' &&
+          event.source === window.parent
         ) {
           createAppFrame(data.params || {});
           return;


### PR DESCRIPTION
## Background

The MCP sandbox-proxy reference page in `examples/ai-e2e-next` handled the `ui/notifications/sandbox-resource-ready` postMessage **without** checking `event.source === window.parent` — unlike the sibling relay branches. That message calls `createAppFrame(data.params)`, which sets the inner iframe's `sandbox` and `srcdoc` directly from `params`. The untrusted inner MCP app (opaque-origin `srcdoc`, `allow-scripts` only) could therefore forge a resource-ready message granting itself `sandbox: 'allow-scripts allow-same-origin'` with arbitrary HTML, and — because the outer proxy iframe is served same-origin — escape to the host origin (XSS).

## Summary

Gate the `sandbox-resource-ready` branch on `event.source === window.parent`, so only the trusted host window can (re)configure the inner iframe's sandbox and content. A forged message from the inner frame no longer reaches `createAppFrame`. This is the fix the CVD recommends ("never let the untrusted content influence its own sandbox policy"), and it matches the source checks the relay branches already perform.

This is a reference/example proxy, not core SDK runtime; `examples/*` is not a published package, so **no changeset** is included.

## Manual Verification

<!-- TODO -->

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Linear: VULN-11565 (tracked under VULN-11626). Example-only change (no published package), so no changeset.