### PR TITLE
fix(react): deny MCP App tool calls by default when allowedTools is omitted

### DIFF
--- a/.changeset/mcp-app-allowed-tools-deny-by-default.md
+++ b/.changeset/mcp-app-allowed-tools-deny-by-default.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix(react): deny MCP App tool calls by default when allowedTools is omitted
+
+`experimental_MCPAppRenderer`'s bridge only enforced the `allowedTools` allowlist when it was non-null, so omitting `allowedTools` skipped the check and forwarded every `tools/call` from the (untrusted) MCP App iframe to the host's `callTool`. A malicious or compromised MCP server could therefore invoke any tool the host wired up.
+
+Tool invocation from MCP App content is now deny-by-default: if `allowedTools` is not explicitly provided, all `tools/call` requests are rejected. To expose tools to an app, list them in `handlers.allowedTools`.

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -131,4 +131,66 @@ describe('MCPAppBridge', () => {
       ]
     `);
   });
+
+  it('denies tool calls by default when allowedTools is omitted', async () => {
+    const targetWindow = createTargetWindow();
+    const callTool = vi.fn(async () => ({ content: [] }));
+    const bridge = new MCPAppBridge({
+      targetWindow,
+      handlers: {
+        // no allowedTools => deny-by-default
+        callTool,
+      },
+    });
+
+    bridge.handleMessage(
+      messageEvent(targetWindow, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'filesystem/write', arguments: { path: '~/.ssh' } },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(targetWindow.postMessage).toHaveBeenCalled();
+    });
+
+    // The host handler must not be invoked, and an error is returned.
+    expect(callTool).not.toHaveBeenCalled();
+    const [response] = targetWindow.postMessage.mock.calls[0];
+    expect(response.id).toBe(3);
+    expect(response.result).toBeUndefined();
+    expect(response.error).toBeDefined();
+    expect(response.error.message).toContain('not app-visible');
+  });
+
+  it('denies tool calls not in allowedTools', async () => {
+    const targetWindow = createTargetWindow();
+    const callTool = vi.fn(async () => ({ content: [] }));
+    const bridge = new MCPAppBridge({
+      targetWindow,
+      handlers: {
+        allowedTools: ['refreshDashboardData'],
+        callTool,
+      },
+    });
+
+    bridge.handleMessage(
+      messageEvent(targetWindow, {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'filesystem/write', arguments: {} },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(targetWindow.postMessage).toHaveBeenCalled();
+    });
+
+    expect(callTool).not.toHaveBeenCalled();
+    const [response] = targetWindow.postMessage.mock.calls[0];
+    expect(response.error?.message).toContain('not app-visible');
+  });
 });

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -291,8 +291,11 @@ export class MCPAppBridge {
           throw new Error('No tools/call handler configured');
         }
         const params = assertToolCallParams(request.params);
+        // Deny-by-default: the (untrusted) MCP App may only invoke tools the
+        // host has explicitly allow-listed. Omitting `allowedTools` exposes no
+        // tools, rather than forwarding every requested tool to `callTool`.
         if (
-          this.handlers.allowedTools != null &&
+          this.handlers.allowedTools == null ||
           !this.handlers.allowedTools.includes(params.name)
         ) {
           throw new Error(`Tool is not app-visible: ${params.name}`);

--- a/packages/react/src/mcp-apps/types.ts
+++ b/packages/react/src/mcp-apps/types.ts
@@ -25,6 +25,11 @@ export type MCPAppToolCallParams = {
 };
 
 export type MCPAppBridgeHandlers = {
+  /**
+   * Tools the MCP App is allowed to invoke via `tools/call`. Deny-by-default:
+   * if omitted, the (untrusted) app cannot call any tool. List only the tools
+   * the app is meant to see.
+   */
   allowedTools?: string[];
   callTool?: (params: MCPAppToolCallParams) => Promise<unknown> | unknown;
   readResource?: (params: { uri: string }) => Promise<unknown> | unknown;


### PR DESCRIPTION
## Background

`experimental_MCPAppRenderer` renders MCP-server-supplied HTML in a sandboxed iframe and bridges `tools/call` messages to the host's `callTool`. The allowlist guard only ran when `handlers.allowedTools` was non-null:

```ts
if (this.handlers.allowedTools != null && !this.handlers.allowedTools.includes(params.name)) throw ...
```

Since `allowedTools` is optional with no default, omitting it short-circuited the check and forwarded **every** tool name from the (untrusted) iframe to `callTool` — allow-any instead of deny-by-default. A malicious/compromised MCP server could invoke any tool the host wired up (e.g. `filesystem/write`).

## Summary

Tool invocation from MCP App content is now **deny-by-default**: the call is rejected unless `allowedTools` is explicitly provided **and** includes the requested tool. To expose tools to an app, list them in `handlers.allowedTools`. Updated the `allowedTools` doc comment to state the deny-by-default behavior.

### Tests

Added regression tests: a `tools/call` with `allowedTools` omitted, and one with a tool not in the list — both must not invoke `callTool` and must return a "not app-visible" error. mcp-apps suite passes; type-check + lint clean.

## Manual Verification

<!-- TODO -->

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Linear: VULN-11582 (tracked under VULN-11626).