### PR TITLE
Backport: fix(ai): return schema-transformed elements in array output mode

### DIFF
--- a/.changeset/fix-array-output-transforms.md
+++ b/.changeset/fix-array-output-transforms.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): return schema-transformed elements in array output mode
+
+Previously final array output validation checked each element against the schema but returned the raw model output. Array output now returns the validated values so Zod transforms, coercions, defaults, and pipes are applied consistently with object output.

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -885,6 +885,36 @@ describe('generateObject', () => {
       }
     `);
     });
+
+    it('should return transformed array elements', async () => {
+      const model = new MockLanguageModelV3({
+        doGenerate: {
+          ...dummyResponseValues,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                elements: [{ content: 'element 1' }, { content: 'element 2' }],
+              }),
+            },
+          ],
+        },
+      });
+
+      const result = await generateObject({
+        model,
+        schema: z.object({
+          content: z
+            .string()
+            .transform(value => value.length)
+            .pipe(z.number()),
+        }),
+        output: 'array',
+        prompt: 'prompt',
+      });
+
+      expect(result.object).toStrictEqual([{ content: 9 }, { content: 9 }]);
+    });
   });
 
   describe('output = "enum"', () => {

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -887,7 +887,7 @@ describe('generateObject', () => {
     });
 
     it('should return transformed array elements', async () => {
-      const model = new MockLanguageModelV3({
+      const model = new MockLanguageModelV2({
         doGenerate: {
           ...dummyResponseValues,
           content: [

--- a/packages/ai/src/generate-object/output-strategy.ts
+++ b/packages/ai/src/generate-object/output-strategy.ts
@@ -236,6 +236,7 @@ const arrayOutputStrategy = <ELEMENT>(
       }
 
       const inputArray = value.elements as Array<JSONObject>;
+      const resultArray: Array<ELEMENT> = [];
 
       // check that each element in the array is of the correct type:
       for (const element of inputArray) {
@@ -243,9 +244,10 @@ const arrayOutputStrategy = <ELEMENT>(
         if (!result.success) {
           return result;
         }
+        resultArray.push(result.value);
       }
 
-      return { success: true, value: inputArray as Array<ELEMENT> };
+      return { success: true, value: resultArray };
     },
 
     createElementStream(


### PR DESCRIPTION
This is a backport of https://github.com/vercel/ai/pull/15954 to the release-v5.0 branch.