### PR TITLE
fix(provider/open-responses): Harden streamed tool call argument handling against prototype pollution

### DIFF
--- a/.changeset/open-responses-tool-call-map-hardening.md
+++ b/.changeset/open-responses-tool-call-map-hardening.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/open-responses': patch
+---
+
+Harden streamed tool call argument handling against prototype pollution.

--- a/packages/open-responses/src/responses/open-responses-language-model.test.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.test.ts
@@ -687,6 +687,64 @@ describe('OpenResponsesLanguageModel', () => {
       });
     });
 
+    it('should not pollute Object.prototype from tool call item ids', async () => {
+      const originalArgumentsDescriptor = Object.getOwnPropertyDescriptor(
+        Object.prototype,
+        'arguments',
+      );
+
+      try {
+        server.urls[URL].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data: ${JSON.stringify({
+              type: 'response.function_call_arguments.done',
+              item_id: '__proto__',
+              output_index: 0,
+              arguments: 'polluted',
+              sequence_number: 0,
+            })}\n\n`,
+            `data: ${JSON.stringify({
+              type: 'response.completed',
+              response: {
+                incomplete_details: null,
+                status: 'completed',
+                usage: {
+                  input_tokens: 0,
+                  input_tokens_details: { cached_tokens: 0 },
+                  output_tokens: 0,
+                  output_tokens_details: { reasoning_tokens: 0 },
+                  total_tokens: 0,
+                },
+              },
+              sequence_number: 1,
+            })}\n\n`,
+            'data: [DONE]\n\n',
+          ],
+        };
+
+        const result = await createModel().doStream({
+          prompt: TEST_PROMPT,
+        });
+
+        await convertReadableStreamToArray(result.stream);
+
+        expect(
+          Object.getOwnPropertyDescriptor(Object.prototype, 'arguments'),
+        ).toStrictEqual(originalArgumentsDescriptor);
+      } finally {
+        if (originalArgumentsDescriptor == null) {
+          delete (Object.prototype as { arguments?: unknown }).arguments;
+        } else {
+          Reflect.defineProperty(
+            Object.prototype,
+            'arguments',
+            originalArgumentsDescriptor,
+          );
+        }
+      }
+    });
+
     describe('pdf input file', () => {
       it('should stream content from pdf input', async () => {
         prepareChunksFixtureResponse('openai-pdf-input-file.1');

--- a/packages/open-responses/src/responses/open-responses-language-model.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.ts
@@ -326,7 +326,6 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
         errorSchema: openResponsesErrorSchema,
         errorToMessage: error => error.error.message,
       }),
-      // TODO consider validation
       successfulResponseHandler: createEventSourceResponseHandler(z.any()),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
@@ -380,10 +379,10 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
       unified: 'other',
       raw: undefined,
     };
-    const toolCallsByItemId: Record<
+    const toolCallsByItemId = new Map<
       string,
       { toolName?: string; toolCallId?: string; arguments?: string }
-    > = {};
+    >();
 
     return {
       stream: response.pipeThrough(
@@ -415,41 +414,43 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
               chunk.type === 'response.output_item.added' &&
               chunk.item.type === 'function_call'
             ) {
-              toolCallsByItemId[chunk.item.id] = {
+              toolCallsByItemId.set(chunk.item.id, {
                 toolName: chunk.item.name,
                 toolCallId: chunk.item.call_id,
                 arguments: chunk.item.arguments,
-              };
+              });
             } else if (
-              (chunk as { type: string }).type ===
-              'response.function_call_arguments.delta'
+              chunk.type === 'response.function_call_arguments.delta'
             ) {
-              const functionCallChunk = chunk as {
-                item_id: string;
-                delta: string;
-              };
-              const toolCall =
-                toolCallsByItemId[functionCallChunk.item_id] ??
-                (toolCallsByItemId[functionCallChunk.item_id] = {});
+              const functionCallChunk = chunk;
+              const toolCall = toolCallsByItemId.get(functionCallChunk.item_id);
+
+              if (toolCall == null) {
+                toolCallsByItemId.set(functionCallChunk.item_id, {
+                  arguments: functionCallChunk.delta,
+                });
+                return;
+              }
+
               toolCall.arguments =
                 (toolCall.arguments ?? '') + functionCallChunk.delta;
-            } else if (
-              (chunk as { type: string }).type ===
-              'response.function_call_arguments.done'
-            ) {
-              const functionCallChunk = chunk as {
-                item_id: string;
-                arguments: string;
-              };
-              const toolCall =
-                toolCallsByItemId[functionCallChunk.item_id] ??
-                (toolCallsByItemId[functionCallChunk.item_id] = {});
+            } else if (chunk.type === 'response.function_call_arguments.done') {
+              const functionCallChunk = chunk;
+              const toolCall = toolCallsByItemId.get(functionCallChunk.item_id);
+
+              if (toolCall == null) {
+                toolCallsByItemId.set(functionCallChunk.item_id, {
+                  arguments: functionCallChunk.arguments,
+                });
+                return;
+              }
+
               toolCall.arguments = functionCallChunk.arguments;
             } else if (
               chunk.type === 'response.output_item.done' &&
               chunk.item.type === 'function_call'
             ) {
-              const toolCall = toolCallsByItemId[chunk.item.id];
+              const toolCall = toolCallsByItemId.get(chunk.item.id);
               const toolName = toolCall?.toolName ?? chunk.item.name;
               const toolCallId = toolCall?.toolCallId ?? chunk.item.call_id;
               const input = toolCall?.arguments ?? chunk.item.arguments ?? '';
@@ -462,7 +463,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
               });
               hasToolCalls = true;
 
-              delete toolCallsByItemId[chunk.item.id];
+              toolCallsByItemId.delete(chunk.item.id);
             }
 
             // Reasoning events (note: response.reasoning_text.delta is an LM Studio extension, not in official spec)


### PR DESCRIPTION
## Background

Streaming Open Responses tool-call argument events used the provider-controlled `item_id` as a key in a plain object. A malicious or compromised Open Responses-compatible endpoint could emit an `item_id` such as `__proto__`, causing the lookup to resolve through `Object.prototype` and allowing the stream handler to write to `Object.prototype.arguments`.

## Summary

This PR hardens streamed tool-call argument handling in `@ai-sdk/open-responses` by storing in-progress tool calls in a `Map` instead of a plain object. This preserves support for arbitrary provider item IDs while avoiding prototype lookup semantics.

It also adds a regression test that streams a malicious `__proto__` tool-call item ID and verifies `Object.prototype.arguments` remains unchanged, plus a patch changeset for `@ai-sdk/open-responses`.