### PR TITLE
fix: Harden stream text processing and middleware against prototype pollution from stream part IDs

### DIFF
--- a/.changeset/stream-part-id-map-hardening.md
+++ b/.changeset/stream-part-id-map-hardening.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Harden stream text processing and middleware against prototype pollution from stream part IDs.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -77,6 +77,17 @@ const defaultSettings = () =>
     onError: () => {},
   }) as const;
 
+type ObjectPrototypeState = {
+  providerMetadata?: unknown;
+  text?: unknown;
+};
+
+function clearObjectPrototypeState() {
+  const objectPrototype = Object.prototype as ObjectPrototypeState;
+  delete objectPrototype.providerMetadata;
+  delete objectPrototype.text;
+}
+
 const testUsage: LanguageModelV4Usage = {
   inputTokens: {
     total: 3,
@@ -2372,6 +2383,86 @@ describe('streamText', () => {
           error: new Error('test error'),
         },
       ]);
+    });
+
+    it('should not read Object.prototype for missing text part ids', async () => {
+      clearObjectPrototypeState();
+      const protoKey: string = '__proto__';
+
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-delta', id: protoKey, delta: 'Hello' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      try {
+        expect(await convertAsyncIterableToArray(result.stream)).toContainEqual(
+          {
+            type: 'error',
+            error: `text part ${protoKey} not found`,
+          },
+        );
+
+        expect(Object.hasOwn(Object.prototype, 'providerMetadata')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
+    });
+
+    it('should not read Object.prototype for missing reasoning part ids', async () => {
+      clearObjectPrototypeState();
+      const protoKey: string = '__proto__';
+
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'reasoning-delta', id: protoKey, delta: 'Thinking...' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      try {
+        expect(await convertAsyncIterableToArray(result.stream)).toContainEqual(
+          {
+            type: 'error',
+            error: `reasoning part ${protoKey} not found`,
+          },
+        );
+
+        expect(Object.hasOwn(Object.prototype, 'providerMetadata')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
     });
 
     it('should invoke onError callback when error is thrown', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -70,6 +70,7 @@ import {
 } from '../util/async-iterable-stream';
 import type { Callback } from '../util/callback';
 import { consumeStream } from '../util/consume-stream';
+import { createIdMap } from '../util/create-id-map';
 import { createStitchableStream } from '../util/create-stitchable-stream';
 import type { DownloadFunction } from '../util/download/download-function';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
@@ -1038,7 +1039,7 @@ class DefaultStreamTextResult<
         text: string;
         providerMetadata: ProviderMetadata | undefined;
       }
-    > = {};
+    > = createIdMap();
 
     let activeReasoningContent: Record<
       string,
@@ -1047,7 +1048,7 @@ class DefaultStreamTextResult<
         text: string;
         providerMetadata: ProviderMetadata | undefined;
       }
-    > = {};
+    > = createIdMap();
     let recordedNoOutputError: NoOutputGeneratedError | undefined;
 
     const eventProcessor = new TransformStream<
@@ -1197,8 +1198,8 @@ class DefaultStreamTextResult<
         if (part.type === 'start-step') {
           // reset the recorded data when a new step starts:
           recordedContent = [];
-          activeReasoningContent = {};
-          activeTextContent = {};
+          activeReasoningContent = createIdMap();
+          activeTextContent = createIdMap();
 
           recordedRequest = part.request;
           recordedWarnings = part.warnings;

--- a/packages/ai/src/middleware/extract-json-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.test.ts
@@ -23,6 +23,19 @@ const testUsage: LanguageModelV4Usage = {
   },
 };
 
+type ObjectPrototypeState = {
+  buffer?: unknown;
+  providerMetadata?: unknown;
+  text?: unknown;
+};
+
+function clearObjectPrototypeState() {
+  const objectPrototype = Object.prototype as ObjectPrototypeState;
+  delete objectPrototype.buffer;
+  delete objectPrototype.providerMetadata;
+  delete objectPrototype.text;
+}
+
 describe('extractJsonMiddleware', () => {
   describe('wrapGenerate', () => {
     it('should strip markdown json fence from text content', async () => {
@@ -180,6 +193,51 @@ describe('extractJsonMiddleware', () => {
   });
 
   describe('wrapStream', () => {
+    it('should not read Object.prototype for missing text part ids', async () => {
+      clearObjectPrototypeState();
+      const protoKey: string = '__proto__';
+
+      const mockModel = new MockLanguageModelV4({
+        async doStream() {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-delta', id: protoKey, delta: '{"value": "test"}' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      });
+
+      const result = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractJsonMiddleware(),
+        }),
+        prompt: 'Generate JSON',
+        onError: () => {},
+      });
+
+      try {
+        await convertAsyncIterableToArray(result.stream);
+
+        expect(Object.hasOwn(Object.prototype, 'buffer')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'providerMetadata')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
+    });
+
     it('should strip markdown json fence from streamed text', async () => {
       const mockModel = new MockLanguageModelV4({
         async doStream() {

--- a/packages/ai/src/middleware/extract-json-middleware.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.ts
@@ -3,6 +3,7 @@ import type {
   LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 import type { LanguageModelMiddleware } from '../types/language-model-middleware';
+import { createIdMap } from '../util/create-id-map';
 
 /**
  * Default transform function that strips markdown code fences from text.
@@ -68,7 +69,7 @@ export function extractJsonMiddleware(options?: {
           buffer: string;
           prefixStripped: boolean;
         }
-      > = {};
+      > = createIdMap();
 
       const SUFFIX_BUFFER_SIZE = 12;
 

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -24,6 +24,23 @@ const testUsage: LanguageModelV4Usage = {
   },
 };
 
+type ObjectPrototypeState = {
+  afterSwitch?: unknown;
+  buffer?: unknown;
+  isFirstText?: unknown;
+  providerMetadata?: unknown;
+  text?: unknown;
+};
+
+function clearObjectPrototypeState() {
+  const objectPrototype = Object.prototype as ObjectPrototypeState;
+  delete objectPrototype.afterSwitch;
+  delete objectPrototype.buffer;
+  delete objectPrototype.isFirstText;
+  delete objectPrototype.providerMetadata;
+  delete objectPrototype.text;
+}
+
 function normalizeStreamPerformance(parts: Array<TextStreamPart<any>>) {
   return parts.map(part =>
     part.type === 'finish-step'
@@ -269,6 +286,53 @@ describe('extractReasoningMiddleware', () => {
   });
 
   describe('wrapStream', () => {
+    it('should not read Object.prototype for missing text part ids', async () => {
+      clearObjectPrototypeState();
+      const protoKey: string = '__proto__';
+
+      const mockModel = new MockLanguageModelV4({
+        async doStream() {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-delta', id: protoKey, delta: 'Hello' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      });
+
+      const result = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        }),
+        prompt: 'Hello, how can I help?',
+        onError: () => {},
+      });
+
+      try {
+        await convertAsyncIterableToArray(result.stream);
+
+        expect(Object.hasOwn(Object.prototype, 'afterSwitch')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'buffer')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'isFirstText')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'providerMetadata')).toBe(false);
+        expect(Object.hasOwn(Object.prototype, 'text')).toBe(false);
+      } finally {
+        clearObjectPrototypeState();
+      }
+    });
+
     it('should extract reasoning from split <think> tags', async () => {
       const mockModel = new MockLanguageModelV4({
         async doStream() {

--- a/packages/ai/src/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.ts
@@ -3,6 +3,7 @@ import type {
   LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 import type { LanguageModelMiddleware } from '../types/language-model-middleware';
+import { createIdMap } from '../util/create-id-map';
 import { getPotentialStartIndex } from '../util/get-potential-start-index';
 
 /**
@@ -92,7 +93,7 @@ export function extractReasoningMiddleware({
           idCounter: number;
           textId: string;
         }
-      > = {};
+      > = createIdMap();
 
       let delayedTextStart: LanguageModelV4StreamPart | undefined;
 


### PR DESCRIPTION
## Background

Provider stream part IDs come from upstream model responses and should not be trusted as plain object keys. `streamText` and the JSON/reasoning extraction middleware kept per-part state in `{}` objects, so a missing stream delta with an ID such as `__proto__` could resolve to `Object.prototype` and mutate shared prototype state while handling the chunk.

## Summary

This PR hardens stream-part state tracking by using the existing null-prototype `createIdMap()` helper for provider-controlled IDs in:

- `streamText` active text and reasoning content maps, including step resets
- `extractJsonMiddleware` text block state
- `extractReasoningMiddleware` reasoning extraction state

It also adds regression tests for missing `__proto__` stream part IDs to verify that `Object.prototype` is not read or polluted, and includes a patch changeset for `ai`.
