### PR TITLE
fix: Promote `transcribe` and `TranscriptionResult` to stable

### DIFF
--- a/.changeset/stable-transcribe.md
+++ b/.changeset/stable-transcribe.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Promote `transcribe` and `TranscriptionResult` to stable exports, with deprecated experimental aliases for backwards compatibility.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -5,13 +5,11 @@ description: Learn how to transcribe audio with the AI SDK.
 
 # Transcription
 
-<Note type="warning">Transcription is an experimental feature.</Note>
-
 The AI SDK provides the [`transcribe`](/docs/reference/ai-sdk-core/transcribe)
 function to transcribe audio using a transcription model.
 
 ```ts
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { readFile } from 'fs/promises';
 
@@ -39,7 +37,7 @@ const durationInSeconds = transcript.durationInSeconds; // duration of the trans
 Transcription models often have provider or model-specific settings which you can set using the `providerOptions` parameter.
 
 ```ts highlight="8-12"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { readFile } from 'fs/promises';
 
@@ -60,7 +58,7 @@ When `audio` is a URL, the SDK downloads the file with a default **2 GiB** size 
 You can customize this using `createDownload`:
 
 ```ts highlight="1,8"
-import { experimental_transcribe as transcribe, createDownload } from 'ai';
+import { transcribe, createDownload } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const transcript = await transcribe({
@@ -73,7 +71,7 @@ const transcript = await transcribe({
 You can also provide a fully custom download function:
 
 ```ts highlight="6-12"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const transcript = await transcribe({
@@ -92,7 +90,7 @@ const transcript = await transcribe({
 If a download exceeds the size limit, a `DownloadError` is thrown:
 
 ```ts
-import { experimental_transcribe as transcribe, DownloadError } from 'ai';
+import { transcribe, DownloadError } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 try {
@@ -117,7 +115,7 @@ This is particularly useful when combined with URL downloads to prevent long-run
 
 ```ts highlight="8"
 import { openai } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const transcript = await transcribe({
   model: openai.transcription('whisper-1'),
@@ -133,7 +131,7 @@ that you can use to add custom headers to the transcription request.
 
 ```ts highlight="8"
 import { openai } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 
 const transcript = await transcribe({
@@ -149,7 +147,7 @@ Warnings (e.g. unsupported parameters) are available on the `warnings` property.
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 
 const transcript = await transcribe({
@@ -176,7 +174,7 @@ The error preserves the following information to help you log the issue:
 
 ```ts
 import {
-  experimental_transcribe as transcribe,
+  transcribe,
   NoTranscriptGeneratedError,
 } from 'ai';
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -173,10 +173,7 @@ The error preserves the following information to help you log the issue:
 - `cause`: The cause of the error. You can use this for more detailed error handling.
 
 ```ts
-import {
-  transcribe,
-  NoTranscriptGeneratedError,
-} from 'ai';
+import { transcribe, NoTranscriptGeneratedError } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { readFile } from 'fs/promises';
 

--- a/content/docs/07-reference/01-ai-sdk-core/11-transcribe.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/11-transcribe.mdx
@@ -5,12 +5,10 @@ description: API Reference for transcribe.
 
 # `transcribe()`
 
-<Note type="warning">`transcribe` is an experimental feature.</Note>
-
 Generates a transcript from an audio file.
 
 ```ts
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { readFile } from 'fs/promises';
 
@@ -25,7 +23,7 @@ console.log(transcript);
 ## Import
 
 <Snippet
-  text={`import { experimental_transcribe as transcribe } from "ai"`}
+  text={`import { transcribe } from "ai"`}
   prompt={false}
 />
 

--- a/content/docs/07-reference/01-ai-sdk-core/11-transcribe.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/11-transcribe.mdx
@@ -22,10 +22,7 @@ console.log(transcript);
 
 ## Import
 
-<Snippet
-  text={`import { transcribe } from "ai"`}
-  prompt={false}
-/>
+<Snippet text={`import { transcribe } from "ai"`} prompt={false} />
 
 ## API Signature
 

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -54,7 +54,7 @@ AI SDK Core contains the following main functions:
       href: '/docs/reference/ai-sdk-core/generate-video',
     },
     {
-      title: 'experimental_transcribe()',
+      title: 'transcribe()',
       description: 'Generate a transcript from an audio file.',
       href: '/docs/reference/ai-sdk-core/transcribe',
     },

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -84,6 +84,36 @@ export const myProvider = customProvider({
 This is only an import and symbol rename. The `customProvider` options and
 behavior are unchanged.
 
+### Transcription: `experimental_transcribe` Renamed to `transcribe`
+
+The transcription API has graduated out of experimental status and has been
+renamed to `transcribe`. The `Experimental_TranscriptionResult` type has also
+been renamed to `TranscriptionResult`.
+
+```tsx filename="AI SDK 6"
+import {
+  experimental_transcribe as transcribe,
+  type Experimental_TranscriptionResult,
+} from 'ai';
+
+const result: Experimental_TranscriptionResult = await transcribe({
+  model: yourTranscriptionModel,
+  audio,
+});
+```
+
+```tsx filename="AI SDK 7"
+import { transcribe, type TranscriptionResult } from 'ai';
+
+const result: TranscriptionResult = await transcribe({
+  model: yourTranscriptionModel,
+  audio,
+});
+```
+
+The old names continue to work as deprecated aliases in AI SDK 7 and will be
+removed in a future major release.
+
 ### Prompt Instructions: `system` Renamed to `instructions`
 
 The top-level prompt option for system instructions has been renamed from

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -652,7 +652,7 @@ Use xAI transcription models with the `transcribe` function:
 
 ```ts
 import { xai } from '@ai-sdk/xai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 
 const result = await transcribe({
@@ -667,7 +667,7 @@ You can pass xAI-specific controls using `providerOptions.xai`:
 
 ```ts
 import { xai, type XaiTranscriptionModelOptions } from '@ai-sdk/xai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 
 const result = await transcribe({

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -2646,7 +2646,7 @@ const model = openai.transcription('whisper-1');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format will improve accuracy and latency.
 
 ```ts highlight="6"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { openai, type OpenAITranscriptionModelOptions } from '@ai-sdk/openai';
 
 const result = await transcribe({
@@ -2661,7 +2661,7 @@ const result = await transcribe({
 To get word-level timestamps, specify the granularity:
 
 ```ts highlight="8-9"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { openai, type OpenAITranscriptionModelOptions } from '@ai-sdk/openai';
 
 const result = await transcribe({

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -1056,7 +1056,7 @@ When using useDeploymentBasedUrls, the default api-version is not valid. You mus
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format will improve accuracy and latency.
 
 ```ts highlight="6"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { azure, type OpenAITranscriptionModelOptions } from '@ai-sdk/azure';
 import { readFile } from 'fs/promises';
 

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -437,7 +437,7 @@ const model = groq.transcription('whisper-large-v3');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format will improve accuracy and latency.
 
 ```ts highlight="6"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { groq, type GroqTranscriptionModelOptions } from '@ai-sdk/groq';
 import { readFile } from 'fs/promises';
 

--- a/content/providers/01-ai-sdk-providers/10-fal.mdx
+++ b/content/providers/01-ai-sdk-providers/10-fal.mdx
@@ -219,7 +219,7 @@ const model = fal.transcription('wizper');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `batchSize` option will increase the number of audio chunks processed in parallel.
 
 ```ts highlight="6"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { fal, type FalTranscriptionModelOptions } from '@ai-sdk/fal';
 import { readFile } from 'fs/promises';
 

--- a/content/providers/01-ai-sdk-providers/100-assemblyai.mdx
+++ b/content/providers/01-ai-sdk-providers/100-assemblyai.mdx
@@ -78,7 +78,7 @@ const model = assemblyai.transcription('best');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `contentSafety` option will enable content safety filtering.
 
 ```ts highlight="7"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { assemblyai } from '@ai-sdk/assemblyai';
 import { type AssemblyAITranscriptionModelOptions } from '@ai-sdk/assemblyai';
 import { readFile } from 'fs/promises';

--- a/content/providers/01-ai-sdk-providers/110-deepgram.mdx
+++ b/content/providers/01-ai-sdk-providers/110-deepgram.mdx
@@ -182,7 +182,7 @@ const model = deepgram.transcription('nova-3');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `summarize` option will enable summaries for sections of content.
 
 ```ts highlight="6"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import {
   deepgram,
   type DeepgramTranscriptionModelOptions,

--- a/content/providers/01-ai-sdk-providers/120-gladia.mdx
+++ b/content/providers/01-ai-sdk-providers/120-gladia.mdx
@@ -76,7 +76,7 @@ const model = gladia.transcription();
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `summarize` option will enable summaries for sections of content.
 
 ```ts highlight="7"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { gladia } from '@ai-sdk/gladia';
 import { type GladiaTranscriptionModelOptions } from '@ai-sdk/gladia';
 import { readFile } from 'fs/promises';

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1342,7 +1342,7 @@ You can transcribe audio with Google Cloud Speech-to-Text models using the
 
 ```ts
 import { googleVertex } from '@ai-sdk/google-vertex';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 
 const result = await transcribe({

--- a/content/providers/01-ai-sdk-providers/160-revai.mdx
+++ b/content/providers/01-ai-sdk-providers/160-revai.mdx
@@ -78,7 +78,7 @@ const model = revai.transcription('machine');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format can sometimes improve transcription performance if known beforehand.
 
 ```ts highlight="7"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { revai } from '@ai-sdk/revai';
 import { type RevaiTranscriptionModelOptions } from '@ai-sdk/revai';
 import { readFile } from 'fs/promises';

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -191,7 +191,7 @@ const model = elevenLabs.transcription('scribe_v1');
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format can sometimes improve transcription performance if known beforehand.
 
 ```ts highlight="6"
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import {
   elevenLabs,
   type ElevenLabsTranscriptionModelOptions,

--- a/content/providers/03-community-providers/04-aihubmix.mdx
+++ b/content/providers/03-community-providers/04-aihubmix.mdx
@@ -120,7 +120,7 @@ const { embedding } = await embed({
 
 ```ts
 import { aihubmix } from '@aihubmix/ai-sdk-provider';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: aihubmix.transcription('whisper-1'),

--- a/content/providers/03-community-providers/35-react-native-apple.mdx
+++ b/content/providers/03-community-providers/35-react-native-apple.mdx
@@ -184,9 +184,9 @@ Apple provides speech-to-text transcription using `SpeechAnalyzer` and `SpeechTr
 
 ```ts
 import { apple } from '@react-native-ai/apple';
-import { experimental_transcribe } from 'ai';
+import { transcribe } from 'ai';
 
-const response = await experimental_transcribe({
+const response = await transcribe({
   model: apple.transcriptionModel(),
   audio: audioBuffer,
 });

--- a/content/providers/03-community-providers/40-sarvam.mdx
+++ b/content/providers/03-community-providers/40-sarvam.mdx
@@ -50,7 +50,7 @@ const sarvam = createSarvam({
 - Transcribe speech to text
 
 ```ts
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 
 await transcribe({

--- a/content/providers/03-community-providers/41-soniox.mdx
+++ b/content/providers/03-community-providers/41-soniox.mdx
@@ -34,7 +34,7 @@ Get your API key from the [Soniox Console](https://console.soniox.com).
 
 ```ts
 import { soniox } from '@soniox/vercel-ai-sdk-provider';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: soniox.transcription('stt-async-v3'),

--- a/examples/ai-functions/src/registry/transcribe-openai.ts
+++ b/examples/ai-functions/src/registry/transcribe-openai.ts
@@ -1,4 +1,4 @@
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { registry } from './setup-registry';
 import { run } from '../lib/run';

--- a/examples/ai-functions/src/transcribe/assemblyai/basic.ts
+++ b/examples/ai-functions/src/transcribe/assemblyai/basic.ts
@@ -1,5 +1,5 @@
 import { assemblyai } from '@ai-sdk/assemblyai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/assemblyai/string.ts
+++ b/examples/ai-functions/src/transcribe/assemblyai/string.ts
@@ -1,5 +1,5 @@
 import { assemblyai } from '@ai-sdk/assemblyai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/assemblyai/url.ts
+++ b/examples/ai-functions/src/transcribe/assemblyai/url.ts
@@ -1,5 +1,5 @@
 import { assemblyai } from '@ai-sdk/assemblyai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/azure/basic.ts
+++ b/examples/ai-functions/src/transcribe/azure/basic.ts
@@ -1,5 +1,5 @@
 import { azure } from '@ai-sdk/azure';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/azure/deployment-based.ts
+++ b/examples/ai-functions/src/transcribe/azure/deployment-based.ts
@@ -1,5 +1,5 @@
 import { createAzure } from '@ai-sdk/azure';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/azure/string.ts
+++ b/examples/ai-functions/src/transcribe/azure/string.ts
@@ -1,5 +1,5 @@
 import { createAzure } from '@ai-sdk/azure';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/azure/url.ts
+++ b/examples/ai-functions/src/transcribe/azure/url.ts
@@ -1,5 +1,5 @@
 import { createAzure } from '@ai-sdk/azure';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/deepgram/basic.ts
+++ b/examples/ai-functions/src/transcribe/deepgram/basic.ts
@@ -1,5 +1,5 @@
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/deepgram/string.ts
+++ b/examples/ai-functions/src/transcribe/deepgram/string.ts
@@ -1,5 +1,5 @@
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/deepgram/url.ts
+++ b/examples/ai-functions/src/transcribe/deepgram/url.ts
@@ -1,5 +1,5 @@
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/elevenlabs/basic.ts
+++ b/examples/ai-functions/src/transcribe/elevenlabs/basic.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/elevenlabs/string.ts
+++ b/examples/ai-functions/src/transcribe/elevenlabs/string.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/elevenlabs/url.ts
+++ b/examples/ai-functions/src/transcribe/elevenlabs/url.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/fal/basic.ts
+++ b/examples/ai-functions/src/transcribe/fal/basic.ts
@@ -1,5 +1,5 @@
 import { fal } from '@ai-sdk/fal';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/fal/string.ts
+++ b/examples/ai-functions/src/transcribe/fal/string.ts
@@ -1,5 +1,5 @@
 import { fal } from '@ai-sdk/fal';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/fal/url.ts
+++ b/examples/ai-functions/src/transcribe/fal/url.ts
@@ -1,5 +1,5 @@
 import { fal } from '@ai-sdk/fal';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/gladia/basic.ts
+++ b/examples/ai-functions/src/transcribe/gladia/basic.ts
@@ -1,5 +1,5 @@
 import { gladia } from '@ai-sdk/gladia';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/gladia/string.ts
+++ b/examples/ai-functions/src/transcribe/gladia/string.ts
@@ -1,5 +1,5 @@
 import { gladia } from '@ai-sdk/gladia';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/gladia/url.ts
+++ b/examples/ai-functions/src/transcribe/gladia/url.ts
@@ -1,5 +1,5 @@
 import { gladia } from '@ai-sdk/gladia';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/google-vertex/basic.ts
+++ b/examples/ai-functions/src/transcribe/google-vertex/basic.ts
@@ -1,5 +1,5 @@
 import { googleVertex } from '@ai-sdk/google-vertex';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/google-vertex/telephony.ts
+++ b/examples/ai-functions/src/transcribe/google-vertex/telephony.ts
@@ -2,7 +2,7 @@ import {
   googleVertex,
   type GoogleVertexTranscriptionModelOptions,
 } from '@ai-sdk/google-vertex';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/groq/basic.ts
+++ b/examples/ai-functions/src/transcribe/groq/basic.ts
@@ -1,5 +1,5 @@
 import { groq } from '@ai-sdk/groq';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/groq/string.ts
+++ b/examples/ai-functions/src/transcribe/groq/string.ts
@@ -1,5 +1,5 @@
 import { groq, type GroqTranscriptionModelOptions } from '@ai-sdk/groq';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/groq/timestamp.ts
+++ b/examples/ai-functions/src/transcribe/groq/timestamp.ts
@@ -1,5 +1,5 @@
 import { groq, type GroqTranscriptionModelOptions } from '@ai-sdk/groq';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import 'dotenv/config';
 import { readFile } from 'fs/promises';
 import path from 'path';

--- a/examples/ai-functions/src/transcribe/groq/url.ts
+++ b/examples/ai-functions/src/transcribe/groq/url.ts
@@ -1,5 +1,5 @@
 import { groq } from '@ai-sdk/groq';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/openai/basic.ts
+++ b/examples/ai-functions/src/transcribe/openai/basic.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/openai/string.ts
+++ b/examples/ai-functions/src/transcribe/openai/string.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/openai/url.ts
+++ b/examples/ai-functions/src/transcribe/openai/url.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/openai/verbose.ts
+++ b/examples/ai-functions/src/transcribe/openai/verbose.ts
@@ -1,5 +1,5 @@
 import { openai, type OpenAITranscriptionModelOptions } from '@ai-sdk/openai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/revai/basic.ts
+++ b/examples/ai-functions/src/transcribe/revai/basic.ts
@@ -1,5 +1,5 @@
 import { revai } from '@ai-sdk/revai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/revai/string.ts
+++ b/examples/ai-functions/src/transcribe/revai/string.ts
@@ -1,5 +1,5 @@
 import { revai } from '@ai-sdk/revai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/revai/url.ts
+++ b/examples/ai-functions/src/transcribe/revai/url.ts
@@ -1,5 +1,5 @@
 import { revai } from '@ai-sdk/revai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/transcribe/xai/basic.ts
+++ b/examples/ai-functions/src/transcribe/xai/basic.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/xai/string.ts
+++ b/examples/ai-functions/src/transcribe/xai/string.ts
@@ -1,5 +1,5 @@
 import { xai, type XaiTranscriptionModelOptions } from '@ai-sdk/xai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { readFile } from 'fs/promises';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/transcribe/xai/url.ts
+++ b/examples/ai-functions/src/transcribe/xai/url.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/xai-tts-demo/server.mjs
+++ b/examples/xai-tts-demo/server.mjs
@@ -5,7 +5,7 @@ import { createServer } from 'node:http';
 import { xai } from '@ai-sdk/xai';
 import {
   experimental_generateSpeech as generateSpeech,
-  experimental_transcribe as transcribe,
+  transcribe,
 } from 'ai';
 
 const PORT = Number(process.env.PORT) || 5051;

--- a/packages/ai/src/transcribe/index.ts
+++ b/packages/ai/src/transcribe/index.ts
@@ -1,2 +1,19 @@
-export { transcribe as experimental_transcribe } from './transcribe';
-export type { TranscriptionResult as Experimental_TranscriptionResult } from './transcribe-result';
+import type { TranscriptionResult } from './transcribe-result';
+import { transcribe } from './transcribe';
+
+export { transcribe } from './transcribe';
+export type { TranscriptionResult } from './transcribe-result';
+
+// deprecated exports
+
+/**
+ * @deprecated Use `transcribe` instead.
+ */
+const experimental_transcribe = transcribe;
+export { experimental_transcribe };
+
+/**
+ * @deprecated Use `TranscriptionResult` instead.
+ */
+type Experimental_TranscriptionResult = TranscriptionResult;
+export type { Experimental_TranscriptionResult };

--- a/packages/assemblyai/README.md
+++ b/packages/assemblyai/README.md
@@ -33,7 +33,7 @@ import { assemblyai } from '@ai-sdk/assemblyai';
 
 ```ts
 import { assemblyai } from '@ai-sdk/assemblyai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: assemblyai.transcription('best'),

--- a/packages/deepgram/README.md
+++ b/packages/deepgram/README.md
@@ -35,7 +35,7 @@ import { deepgram } from '@ai-sdk/deepgram';
 
 ```ts
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: deepgram.transcription('nova-3'),
@@ -49,7 +49,7 @@ const { text } = await transcribe({
 
 ```ts
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text, language } = await transcribe({
   model: deepgram.transcription('nova-3'),

--- a/packages/elevenlabs/README.md
+++ b/packages/elevenlabs/README.md
@@ -33,7 +33,7 @@ import { elevenlabs } from '@ai-sdk/elevenlabs';
 
 ```ts
 import { elevenlabs } from '@ai-sdk/elevenlabs';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: elevenlabs.transcription('scribe_v1'),

--- a/packages/gladia/README.md
+++ b/packages/gladia/README.md
@@ -33,7 +33,7 @@ import { gladia } from '@ai-sdk/gladia';
 
 ```ts
 import { gladia } from '@ai-sdk/gladia';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: gladia.transcription(),

--- a/packages/revai/README.md
+++ b/packages/revai/README.md
@@ -33,7 +33,7 @@ import { revai } from '@ai-sdk/revai';
 
 ```ts
 import { revai } from '@ai-sdk/revai';
-import { experimental_transcribe as transcribe } from 'ai';
+import { transcribe } from 'ai';
 
 const { text } = await transcribe({
   model: revai.transcription('machine'),


### PR DESCRIPTION
## Background

`transcribe` has graduated from experimental status for AI SDK 7. Users should be able to import the stable `transcribe` function and `TranscriptionResult` type directly while existing `experimental_` imports continue to work during the deprecation window.

## Summary

- Promote `transcribe` and `TranscriptionResult` to stable exports from `ai`.
- Keep `experimental_transcribe` and `Experimental_TranscriptionResult` as deprecated aliases for backwards compatibility.
- Update transcription docs, provider snippets, examples, and package READMEs to use the stable import.
- Add an AI SDK 7 migration-guide entry and patch changeset.

## Automated Verification

- `pnpm --filter ai type-check`
- `node tools/validate-properties-tables.mjs`
- `git diff --check`

Note: `pnpm type-check:full` currently fails on unrelated generated artifact issues in `packages/deepseek/dist` and `examples/ai-e2e-next/.next/types`.
