### PR TITLE
fix: Promote `generateSpeech` and `SpeechResult` to stable

### DIFF
--- a/.changeset/stable-generate-speech.md
+++ b/.changeset/stable-generate-speech.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Promote `generateSpeech` and `SpeechResult` to stable exports.

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -5,13 +5,11 @@ description: Learn how to generate speech from text with the AI SDK.
 
 # Speech
 
-<Note type="warning">Speech is an experimental feature.</Note>
-
 The AI SDK provides the [`generateSpeech`](/docs/reference/ai-sdk-core/generate-speech)
 function to generate speech from text using a speech model.
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const audio = await generateSpeech({
@@ -26,7 +24,7 @@ const audio = await generateSpeech({
 You can specify the language for speech generation (provider support varies):
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { lmnt } from '@ai-sdk/lmnt';
 
 const audio = await generateSpeech({
@@ -51,7 +49,7 @@ const audioBase64 = result.audio.base64; // audio data as base64 string
 You can set model-specific settings with the `providerOptions` parameter.
 
 ```ts highlight="7-11"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const audio = await generateSpeech({
@@ -73,7 +71,7 @@ that you can use to abort the speech generation process or set a timeout.
 
 ```ts highlight="7"
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const audio = await generateSpeech({
   model: openai.speech('tts-1'),
@@ -89,7 +87,7 @@ that you can use to add custom headers to the speech generation request.
 
 ```ts highlight="7"
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const audio = await generateSpeech({
   model: openai.speech('tts-1'),
@@ -104,7 +102,7 @@ Warnings (e.g. unsupported parameters) are available on the `warnings` property.
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const audio = await generateSpeech({
   model: openai.speech('tts-1'),
@@ -129,10 +127,7 @@ The error preserves the following information to help you log the issue:
 - `cause`: The cause of the error. You can use this for more detailed error handling.
 
 ```ts
-import {
-  experimental_generateSpeech as generateSpeech,
-  NoSpeechGeneratedError,
-} from 'ai';
+import { generateSpeech, NoSpeechGeneratedError } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 try {

--- a/content/docs/07-reference/01-ai-sdk-core/12-generate-speech.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/12-generate-speech.mdx
@@ -5,12 +5,10 @@ description: API Reference for generateSpeech.
 
 # `generateSpeech()`
 
-<Note type="warning">`generateSpeech` is an experimental feature.</Note>
-
 Generates speech audio from text.
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { audio } = await generateSpeech({
@@ -27,7 +25,7 @@ console.log(audio);
 ### OpenAI
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { audio } = await generateSpeech({
@@ -40,7 +38,7 @@ const { audio } = await generateSpeech({
 ### ElevenLabs
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { elevenLabs } from '@ai-sdk/elevenlabs';
 
 const { audio } = await generateSpeech({
@@ -52,10 +50,7 @@ const { audio } = await generateSpeech({
 
 ## Import
 
-<Snippet
-  text={`import { experimental_generateSpeech as generateSpeech } from "ai"`}
-  prompt={false}
-/>
+<Snippet text={`import { generateSpeech } from "ai"`} prompt={false} />
 
 ## API Signature
 

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -59,7 +59,7 @@ AI SDK Core contains the following main functions:
       href: '/docs/reference/ai-sdk-core/transcribe',
     },
     {
-      title: 'experimental_generateSpeech()',
+      title: 'generateSpeech()',
       description: 'Generate speech audio from text.',
       href: '/docs/reference/ai-sdk-core/generate-speech',
     },

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -84,6 +84,30 @@ export const myProvider = customProvider({
 This is only an import and symbol rename. The `customProvider` options and
 behavior are unchanged.
 
+### Speech: `experimental_generateSpeech` Renamed to `generateSpeech`
+
+The speech generation function has graduated out of experimental status and has been renamed to `generateSpeech`. The `Experimental_SpeechResult` type has also been renamed to `SpeechResult`.
+
+```tsx filename="AI SDK 6"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+
+const result = await generateSpeech({
+  model: yourSpeechModel,
+  text: 'Hello',
+});
+```
+
+```tsx filename="AI SDK 7"
+import { generateSpeech } from 'ai';
+
+const result = await generateSpeech({
+  model: yourSpeechModel,
+  text: 'Hello',
+});
+```
+
+The old `experimental_generateSpeech` and `Experimental_SpeechResult` exports continue to work as deprecated aliases in AI SDK 7 and will be removed in a future major release.
+
 ### Prompt Instructions: `system` Renamed to `instructions`
 
 The top-level prompt option for system instructions has been renamed from

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -548,7 +548,7 @@ Use xAI speech models with the `generateSpeech` function:
 
 ```ts
 import { xai } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: xai.speech(),
@@ -597,7 +597,7 @@ You can pass xAI-specific controls using `providerOptions.xai`:
 
 ```ts
 import { xai, type XaiSpeechModelOptions } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: xai.speech(),

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -2725,7 +2725,7 @@ const model = openai.speech('tts-1');
 The `voice` argument can be set to one of OpenAI's available voices: `alloy`, `ash`, `coral`, `echo`, `fable`, `onyx`, `nova`, `sage`, or `shimmer`.
 
 ```ts highlight="6"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const result = await generateSpeech({
@@ -2738,7 +2738,7 @@ const result = await generateSpeech({
 You can also pass additional provider-specific options using the `providerOptions` argument:
 
 ```ts highlight="7-9"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { openai, type OpenAISpeechModelOptions } from '@ai-sdk/openai';
 
 const result = await generateSpeech({

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -1117,7 +1117,7 @@ const model = azure.speech('your-tts-deployment-name');
 
 ```ts
 import { azure } from '@ai-sdk/azure';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: azure.speech('your-tts-deployment-name'),
@@ -1130,7 +1130,7 @@ You can also pass additional provider-specific options using the `providerOption
 
 ```ts
 import { azure, type OpenAISpeechModelOptions } from '@ai-sdk/azure';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: azure.speech('your-tts-deployment-name'),

--- a/content/providers/01-ai-sdk-providers/10-fal.mdx
+++ b/content/providers/01-ai-sdk-providers/10-fal.mdx
@@ -277,7 +277,7 @@ You can create models that call Fal text-to-speech endpoints using the `.speech(
 ### Basic Usage
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { fal } from '@ai-sdk/fal';
 
 const result = await generateSpeech({

--- a/content/providers/01-ai-sdk-providers/110-deepgram.mdx
+++ b/content/providers/01-ai-sdk-providers/110-deepgram.mdx
@@ -78,7 +78,7 @@ const model = deepgram.speech('aura-2-helena-en');
 You can use the model with the `generateSpeech` function:
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { deepgram } from '@ai-sdk/deepgram';
 
 const result = await generateSpeech({
@@ -90,7 +90,7 @@ const result = await generateSpeech({
 You can also pass additional provider-specific options using the `providerOptions` argument:
 
 ```ts highlight="7-11"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { deepgram, type DeepgramSpeechModelOptions } from '@ai-sdk/deepgram';
 
 const result = await generateSpeech({

--- a/content/providers/01-ai-sdk-providers/140-lmnt.mdx
+++ b/content/providers/01-ai-sdk-providers/140-lmnt.mdx
@@ -78,7 +78,7 @@ const model = lmnt.speech('aurora');
 The `voice` parameter can be set to a voice ID from LMNT. You can find available voices in the [LMNT documentation](https://docs.lmnt.com/api-reference/voices/list-voices).
 
 ```ts highlight="7"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { lmnt } from '@ai-sdk/lmnt';
 
 const result = await generateSpeech({
@@ -92,7 +92,7 @@ const result = await generateSpeech({
 You can also pass additional provider-specific options using the `providerOptions` argument:
 
 ```ts highlight="10-14"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { lmnt } from '@ai-sdk/lmnt';
 import { type LMNTSpeechModelOptions } from '@ai-sdk/lmnt';
 

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1977,7 +1977,7 @@ The `voice` argument can be set to one of Gemini's [30 prebuilt voices](https://
 e.g. `Kore`, `Puck`, `Zephyr`, or `Charon`. Voice names are case-sensitive. It defaults to `Kore`.
 
 ```ts highlight="6"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { google } from '@ai-sdk/google';
 
 const result = await generateSpeech({
@@ -2000,7 +2000,7 @@ For multi-speaker dialogue, pass a `multiSpeakerVoiceConfig` through `providerOp
 name must match a name used in the input text. When set, it overrides the top-level `voice`.
 
 ```ts highlight="8-23"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { google, type GoogleSpeechModelOptions } from '@ai-sdk/google';
 
 const result = await generateSpeech({

--- a/content/providers/01-ai-sdk-providers/150-hume.mdx
+++ b/content/providers/01-ai-sdk-providers/150-hume.mdx
@@ -76,7 +76,7 @@ const model = hume.speech();
 You can pass standard speech generation options like `voice`, `speed`, `instructions`, and `outputFormat`:
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { hume } from '@ai-sdk/hume';
 
 const result = await generateSpeech({
@@ -123,7 +123,7 @@ const result = await generateSpeech({
 You can pass additional provider-specific options using the `providerOptions` argument:
 
 ```ts
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { hume } from '@ai-sdk/hume';
 import { type HumeSpeechModelOptions } from '@ai-sdk/hume';
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1308,7 +1308,7 @@ generation with the AI SDK see [generateSpeech()](/docs/reference/ai-sdk-core/ge
 
 ```ts
 import { googleVertex } from '@ai-sdk/google-vertex';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: googleVertex.speech('gemini-2.5-flash-tts'),

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -79,7 +79,7 @@ The `voice` argument can be set to a voice ID from the [ElevenLabs Voice Library
 You can find voice IDs by selecting a voice in the library and copying its ID.
 
 ```ts highlight="6"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { elevenLabs } from '@ai-sdk/elevenlabs';
 
 const result = await generateSpeech({
@@ -92,7 +92,7 @@ const result = await generateSpeech({
 You can also pass additional provider-specific options using the `providerOptions` argument:
 
 ```ts highlight="7-9"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import {
   elevenLabs,
   type ElevenLabsSpeechModelOptions,

--- a/content/providers/03-community-providers/04-aihubmix.mdx
+++ b/content/providers/03-community-providers/04-aihubmix.mdx
@@ -240,7 +240,7 @@ console.log('Usage:', usage);
 
 ```ts
 import { aihubmix } from '@aihubmix/ai-sdk-provider';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const { audio } = await generateSpeech({
   model: aihubmix.speech('tts-1'),

--- a/content/providers/03-community-providers/35-react-native-apple.mdx
+++ b/content/providers/03-community-providers/35-react-native-apple.mdx
@@ -204,9 +204,9 @@ Convert text to speech:
 
 ```ts
 import { apple } from '@react-native-ai/apple';
-import { experimental_generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
-const response = await experimental_generateSpeech({
+const response = await generateSpeech({
   model: apple.speechModel(),
   text: 'Hello from Apple on-device speech!',
   language: 'en-US',
@@ -218,7 +218,7 @@ const response = await experimental_generateSpeech({
 You can configure the voice to use for speech synthesis by passing its identifier to the `voice` option.
 
 ```ts
-const response = await experimental_generateSpeech({
+const response = await generateSpeech({
   model: apple.speechModel(),
   text: 'Custom voice example',
   voice: 'com.apple.ttsbundle.Samantha-compact',

--- a/examples/ai-functions/src/generate-speech/azure/basic.ts
+++ b/examples/ai-functions/src/generate-speech/azure/basic.ts
@@ -1,5 +1,5 @@
 import { azure } from '@ai-sdk/azure';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/deepgram/basic.ts
+++ b/examples/ai-functions/src/generate-speech/deepgram/basic.ts
@@ -1,5 +1,5 @@
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/basic.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/basic.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/context.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/context.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/flash.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/flash.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/language.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/language.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/output-format.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/output-format.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/turbo.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/turbo.ts
@@ -1,5 +1,5 @@
 import { elevenLabs } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/elevenlabs/voice-settings.ts
+++ b/examples/ai-functions/src/generate-speech/elevenlabs/voice-settings.ts
@@ -2,7 +2,7 @@ import {
   elevenLabs,
   type ElevenLabsSpeechModelOptions,
 } from '@ai-sdk/elevenlabs';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/fal/basic.ts
+++ b/examples/ai-functions/src/generate-speech/fal/basic.ts
@@ -1,5 +1,5 @@
 import { fal } from '@ai-sdk/fal';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/fal/chatterbox.ts
+++ b/examples/ai-functions/src/generate-speech/fal/chatterbox.ts
@@ -1,5 +1,5 @@
 import { fal, type FalSpeechModelOptions } from '@ai-sdk/fal';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/fal/dia-voice-clone.ts
+++ b/examples/ai-functions/src/generate-speech/fal/dia-voice-clone.ts
@@ -1,5 +1,5 @@
 import { fal, type FalSpeechModelOptions } from '@ai-sdk/fal';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/fal/dia.ts
+++ b/examples/ai-functions/src/generate-speech/fal/dia.ts
@@ -1,5 +1,5 @@
 import { fal } from '@ai-sdk/fal';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/fal/voice.ts
+++ b/examples/ai-functions/src/generate-speech/fal/voice.ts
@@ -1,5 +1,5 @@
 import { fal, type FalSpeechModelOptions } from '@ai-sdk/fal';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google-vertex/basic.ts
+++ b/examples/ai-functions/src/generate-speech/google-vertex/basic.ts
@@ -1,5 +1,5 @@
 import { googleVertex } from '@ai-sdk/google-vertex';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google-vertex/instructions.ts
+++ b/examples/ai-functions/src/generate-speech/google-vertex/instructions.ts
@@ -1,5 +1,5 @@
 import { googleVertex } from '@ai-sdk/google-vertex';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google-vertex/voice.ts
+++ b/examples/ai-functions/src/generate-speech/google-vertex/voice.ts
@@ -1,5 +1,5 @@
 import { googleVertex } from '@ai-sdk/google-vertex';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google/basic.ts
+++ b/examples/ai-functions/src/generate-speech/google/basic.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google/instructions.ts
+++ b/examples/ai-functions/src/generate-speech/google/instructions.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google/multi-speaker.ts
+++ b/examples/ai-functions/src/generate-speech/google/multi-speaker.ts
@@ -1,5 +1,5 @@
 import { google, type GoogleSpeechModelOptions } from '@ai-sdk/google';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/google/voice.ts
+++ b/examples/ai-functions/src/generate-speech/google/voice.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/hume/basic.ts
+++ b/examples/ai-functions/src/generate-speech/hume/basic.ts
@@ -1,5 +1,5 @@
 import { hume } from '@ai-sdk/hume';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/hume/instructions.ts
+++ b/examples/ai-functions/src/generate-speech/hume/instructions.ts
@@ -1,5 +1,5 @@
 import { hume } from '@ai-sdk/hume';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/hume/language.ts
+++ b/examples/ai-functions/src/generate-speech/hume/language.ts
@@ -1,5 +1,5 @@
 import { hume } from '@ai-sdk/hume';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/hume/speed.ts
+++ b/examples/ai-functions/src/generate-speech/hume/speed.ts
@@ -1,5 +1,5 @@
 import { hume } from '@ai-sdk/hume';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/hume/voice.ts
+++ b/examples/ai-functions/src/generate-speech/hume/voice.ts
@@ -1,5 +1,5 @@
 import { hume } from '@ai-sdk/hume';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/lmnt/basic.ts
+++ b/examples/ai-functions/src/generate-speech/lmnt/basic.ts
@@ -1,5 +1,5 @@
 import { lmnt } from '@ai-sdk/lmnt';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/lmnt/language.ts
+++ b/examples/ai-functions/src/generate-speech/lmnt/language.ts
@@ -1,5 +1,5 @@
 import { lmnt } from '@ai-sdk/lmnt';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/lmnt/speed.ts
+++ b/examples/ai-functions/src/generate-speech/lmnt/speed.ts
@@ -1,5 +1,5 @@
 import { lmnt } from '@ai-sdk/lmnt';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/lmnt/voice.ts
+++ b/examples/ai-functions/src/generate-speech/lmnt/voice.ts
@@ -1,5 +1,5 @@
 import { lmnt } from '@ai-sdk/lmnt';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/openai/basic.ts
+++ b/examples/ai-functions/src/generate-speech/openai/basic.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/openai/instructions.ts
+++ b/examples/ai-functions/src/generate-speech/openai/instructions.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/openai/language.ts
+++ b/examples/ai-functions/src/generate-speech/openai/language.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/openai/speed.ts
+++ b/examples/ai-functions/src/generate-speech/openai/speed.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/openai/voice.ts
+++ b/examples/ai-functions/src/generate-speech/openai/voice.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/xai/basic.ts
+++ b/examples/ai-functions/src/generate-speech/xai/basic.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/xai/output-format.ts
+++ b/examples/ai-functions/src/generate-speech/xai/output-format.ts
@@ -1,5 +1,5 @@
 import { xai, type XaiSpeechModelOptions } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/xai/speech-tags.ts
+++ b/examples/ai-functions/src/generate-speech/xai/speech-tags.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/generate-speech/xai/voice.ts
+++ b/examples/ai-functions/src/generate-speech/xai/voice.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { saveAudioFile } from '../../lib/save-audio';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/registry/generate-speech-elevenlabs.ts
+++ b/examples/ai-functions/src/registry/generate-speech-elevenlabs.ts
@@ -1,4 +1,4 @@
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { registry } from './setup-registry';
 import { run } from '../lib/run';
 

--- a/examples/ai-functions/src/registry/generate-speech-openai.ts
+++ b/examples/ai-functions/src/registry/generate-speech-openai.ts
@@ -1,4 +1,4 @@
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 import { registry } from './setup-registry';
 import { run } from '../lib/run';
 

--- a/examples/xai-tts-demo/server.mjs
+++ b/examples/xai-tts-demo/server.mjs
@@ -4,7 +4,7 @@
 import { createServer } from 'node:http';
 import { xai } from '@ai-sdk/xai';
 import {
-  experimental_generateSpeech as generateSpeech,
+  generateSpeech,
   experimental_transcribe as transcribe,
 } from 'ai';
 

--- a/packages/ai/src/generate-speech/index.ts
+++ b/packages/ai/src/generate-speech/index.ts
@@ -1,3 +1,20 @@
-export { generateSpeech as experimental_generateSpeech } from './generate-speech';
-export type { SpeechResult as Experimental_SpeechResult } from './generate-speech-result';
+import type { SpeechResult } from './generate-speech-result';
+import { generateSpeech } from './generate-speech';
+
+export { generateSpeech } from './generate-speech';
+export type { SpeechResult } from './generate-speech-result';
 export type { GeneratedAudioFile } from './generated-audio-file';
+
+// deprecated exports
+
+/**
+ * @deprecated Use `generateSpeech` instead.
+ */
+const experimental_generateSpeech = generateSpeech;
+export { experimental_generateSpeech };
+
+/**
+ * @deprecated Use `SpeechResult` instead.
+ */
+type Experimental_SpeechResult = SpeechResult;
+export type { Experimental_SpeechResult };

--- a/packages/deepgram/README.md
+++ b/packages/deepgram/README.md
@@ -68,7 +68,7 @@ const { text, language } = await transcribe({
 
 ```ts
 import { deepgram } from '@ai-sdk/deepgram';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const { audio } = await generateSpeech({
   model: deepgram.speech('aura-2-helena-en'),

--- a/packages/hume/README.md
+++ b/packages/hume/README.md
@@ -33,7 +33,7 @@ import { hume } from '@ai-sdk/hume';
 
 ```ts
 import { hume } from '@ai-sdk/hume';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: hume.speech('aurora'),

--- a/packages/lmnt/README.md
+++ b/packages/lmnt/README.md
@@ -33,7 +33,7 @@ import { lmnt } from '@ai-sdk/lmnt';
 
 ```ts
 import { lmnt } from '@ai-sdk/lmnt';
-import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { generateSpeech } from 'ai';
 
 const result = await generateSpeech({
   model: lmnt.speech('aurora'),


### PR DESCRIPTION
## Background

`generateSpeech` has graduated from experimental status for AI SDK 7. Users should be able to import the stable `generateSpeech` function and `SpeechResult` type directly while existing experimental imports continue to work during the deprecation window.

## Summary

- Promote `generateSpeech` and `SpeechResult` to stable exports from `ai`.
- Keep `experimental_generateSpeech` and `Experimental_SpeechResult` as deprecated aliases.
- Update speech docs, provider docs, README snippets, examples, and the AI SDK 7 migration guide to use the stable `generateSpeech` import.
- Add a patch changeset for the `ai` package.

## Automated Verification

- `pnpm --filter ai type-check`
- `pnpm --filter ai test:node src/generate-speech/generate-speech.test.ts`
- `pnpm check`

`pnpm type-check:full` was also run and still fails on unrelated workspace issues involving missing package/module references in `packages/azure`, `packages/harness`, and `packages/harness-claude-code`.

## Future Work

Remove the deprecated `experimental_generateSpeech` and `Experimental_SpeechResult` aliases in a future major release.