### PR TITLE
fix(generate-text): wrap unparseable tool-call input in an object

### DIFF
--- a/.changeset/fix-invalid-tool-input-object.md
+++ b/.changeset/fix-invalid-tool-input-object.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+fix(generate-text): wrap unparseable tool-call input in an object so it doesn't break the next provider step
+
+`parseToolCall` previously stored the raw tool-call string as `input` when neither parsing nor repair succeeded. That string flowed through `to-response-messages.ts` and `convert-to-language-model-prompt.ts` into the next assistant message, and providers like Amazon Bedrock reject the request because `toolUse.input` must be a JSON object. The model never saw the `tool-error` and never had a chance to retry.
+
+The unparseable input is now wrapped as `{ rawInvalidInput: toolCall.input }` so the conversation history stays valid for the next API call while the raw text is preserved for debugging.

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -471,7 +471,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -510,7 +512,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -94,7 +94,14 @@ export async function parseToolCall<TOOLS extends ToolSet>({
   } catch (error) {
     // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    // Wrap an unparseable input in an object so downstream serializers don't
+    // emit a raw string for `toolUse.input`. Providers like Amazon Bedrock
+    // reject the next request with "Provide a json object for the field" if a
+    // bare string flows through the assistant message into the next step. The
+    // raw text is preserved under `rawInvalidInput` for debugging.
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
     const tool = tools?.[toolCall.toolName];
 
     // TODO AI SDK 6: special invalid tool call parts


### PR DESCRIPTION
Closes #14442.

## Summary

`parseToolCall` previously stored the raw tool-call string as `input` when neither parsing nor repair succeeded. That string flowed through `to-response-messages.ts` and `convert-to-language-model-prompt.ts` into the next assistant message, and providers like Amazon Bedrock reject the request with:

> The format of the value at messages.X.content.Y.toolUse.input is invalid. Provide a json object for the field and try again.

so the model never saw the `tool-error` and never had a chance to retry.

## Fix

```diff
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
```

The unparseable input is now wrapped as `{ rawInvalidInput: toolCall.input }` so the conversation history stays valid for the next API call while the raw text is preserved for debugging.

## Tests

The two existing snapshots in `parse-tool-call.test.ts` that covered the unparseable+unrepaired paths (repair-returns-null and repair-throws) are updated to reflect the new object shape — both implicitly assert the regression. All 21 tests in the file pass.

Open to a different key name (`_rawInvalidInput`, `raw`, etc.) if maintainers prefer; happy to swap.