### PR TITLE
chore: fix long outdated `@vercel/sandbox` version in `ai-e2e-next` example

### DIFF
--- a/examples/ai-e2e-next/agent/openai/local-shell-agent.ts
+++ b/examples/ai-e2e-next/agent/openai/local-shell-agent.ts
@@ -2,13 +2,13 @@ import { openai } from '@ai-sdk/openai';
 import { Sandbox } from '@vercel/sandbox';
 import { ToolLoopAgent, type InferAgentUIMessage } from 'ai';
 // warning: this is a demo sandbox that is shared across chats on localhost
-let globalSandboxId: string | null = null;
+let globalSandboxName: string | null = null;
 async function getSandbox(): Promise<Sandbox> {
-  if (globalSandboxId) {
-    return await Sandbox.get({ sandboxId: globalSandboxId });
+  if (globalSandboxName) {
+    return await Sandbox.get({ name: globalSandboxName });
   }
   const sandbox = await Sandbox.create();
-  globalSandboxId = sandbox.sandboxId;
+  globalSandboxName = sandbox.name;
   return sandbox;
 }
 

--- a/examples/ai-e2e-next/agent/openai/sandbox-agent.ts
+++ b/examples/ai-e2e-next/agent/openai/sandbox-agent.ts
@@ -19,5 +19,5 @@ export const sandboxAgent = new ToolLoopAgent({
 
 export type SandboxAgentUIMessage = InferAgentUIMessage<
   typeof sandboxAgent,
-  { sandboxId?: string }
+  { sandboxName?: string }
 >;

--- a/examples/ai-e2e-next/agent/openai/shell-agent.ts
+++ b/examples/ai-e2e-next/agent/openai/shell-agent.ts
@@ -2,13 +2,13 @@ import { openai } from '@ai-sdk/openai';
 import { Sandbox } from '@vercel/sandbox';
 import { ToolLoopAgent, type InferAgentUIMessage } from 'ai';
 // warning: this is a demo sandbox that is shared across chats on localhost
-let globalSandboxId: string | null = null;
+let globalSandboxName: string | null = null;
 async function getSandbox(): Promise<Sandbox> {
-  if (globalSandboxId) {
-    return await Sandbox.get({ sandboxId: globalSandboxId });
+  if (globalSandboxName) {
+    return await Sandbox.get({ name: globalSandboxName });
   }
   const sandbox = await Sandbox.create();
-  globalSandboxId = sandbox.sandboxId;
+  globalSandboxName = sandbox.name;
   return sandbox;
 }
 

--- a/examples/ai-e2e-next/agent/openai/shell-skills-agent.ts
+++ b/examples/ai-e2e-next/agent/openai/shell-skills-agent.ts
@@ -9,13 +9,13 @@ const skillMd = readFileSync(
   join(process.cwd(), 'data', 'island-rescue', 'SKILL.md'),
 );
 
-let globalSandboxId: string | null = null;
+let globalSandboxName: string | null = null;
 async function getSandbox(): Promise<Sandbox> {
-  if (globalSandboxId) {
-    return await Sandbox.get({ sandboxId: globalSandboxId });
+  if (globalSandboxName) {
+    return await Sandbox.get({ name: globalSandboxName });
   }
   const sandbox = await Sandbox.create();
-  globalSandboxId = sandbox.sandboxId;
+  globalSandboxName = sandbox.name;
 
   await sandbox.runCommand({ cmd: 'mkdir', args: ['-p', skillPath] });
   await sandbox.writeFiles([

--- a/examples/ai-e2e-next/app/api/chat/sandbox/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/sandbox/route.ts
@@ -6,10 +6,10 @@ import { createAgentUIStreamResponse } from 'ai';
 import { Sandbox } from '@vercel/sandbox';
 import { VercelSandboxSession } from '@/sandbox/vercel-sandbox';
 
-async function getSandbox(sandboxId?: string) {
-  if (sandboxId != null) {
+async function getSandbox(sandboxName?: string) {
+  if (sandboxName != null) {
     try {
-      const sandbox = await Sandbox.get({ sandboxId });
+      const sandbox = await Sandbox.get({ name: sandboxName });
       if (sandbox.status !== 'stopped' && sandbox.status !== 'failed') {
         return sandbox;
       }
@@ -21,15 +21,15 @@ async function getSandbox(sandboxId?: string) {
   return Sandbox.create({ timeout: 60_000 * 3 });
 }
 
-function getLatestSandboxId(messages: SandboxAgentUIMessage[]) {
-  return messages.findLast(message => message.metadata?.sandboxId)?.metadata
-    ?.sandboxId;
+function getLatestSandboxName(messages: SandboxAgentUIMessage[]) {
+  return messages.findLast(message => message.metadata?.sandboxName)?.metadata
+    ?.sandboxName;
 }
 
 export async function POST(req: Request) {
   const { messages }: { messages: SandboxAgentUIMessage[] } = await req.json();
 
-  const vercelSandbox = await getSandbox(getLatestSandboxId(messages));
+  const vercelSandbox = await getSandbox(getLatestSandboxName(messages));
 
   const sandbox = new VercelSandboxSession(vercelSandbox);
 
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
     experimental_sandbox: sandbox,
     messageMetadata: ({ part }) => {
       if (part.type === 'start') {
-        return { sandboxId: vercelSandbox.sandboxId };
+        return { sandboxName: vercelSandbox.name };
       }
     },
   });

--- a/examples/ai-e2e-next/package.json
+++ b/examples/ai-e2e-next/package.json
@@ -37,7 +37,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@valibot/to-json-schema": "^1.7.0",
     "@vercel/blob": "^0.26.0",
-    "@vercel/sandbox": "^0.0.21",
+    "@vercel/sandbox": "^2.0.1",
     "ai": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
+++ b/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
@@ -28,11 +28,7 @@ const rootDirectory = '/vercel/sandbox';
 // Without OIDC, @vercel/sandbox reports a missing `x-vercel-oidc-token`
 // header when creating or retrieving sandboxes.
 export class VercelSandboxSession implements SandboxSession {
-  constructor(
-    public readonly sandbox: Awaited<
-      ReturnType<typeof VercelSandboxSDK.create>
-    >,
-  ) {}
+  constructor(public readonly sandbox: VercelSandboxSDK) {}
 
   private resolvePath(path: string): string {
     return isAbsolute(path) ? path : join(rootDirectory, path);
@@ -194,7 +190,7 @@ export class VercelSandboxSession implements SandboxSession {
   }
 
   get description() {
-    return `Vercel Sandbox: ${this.sandbox.sandboxId}\nRoot directory: ${rootDirectory}`;
+    return `Vercel Sandbox: ${this.sandbox.name}\nRoot directory: ${rootDirectory}`;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^0.26.0
         version: 0.26.0
       '@vercel/sandbox':
-        specifier: ^0.0.21
-        version: 0.0.21
+        specifier: ^2.0.1
+        version: 2.1.1
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -11614,9 +11614,6 @@ packages:
   '@vercel/queue@0.1.4':
     resolution: {integrity: sha512-wo+jCycmCX078vQSbkX+RcLvySONDCK0f9aQp5UMKQD1+B+xKt3YVbIYbZukvoHQpbm5nnk6If+ADSeK/PmCgQ==}
     engines: {node: '>=20.0.0'}
-
-  '@vercel/sandbox@0.0.21':
-    resolution: {integrity: sha512-j6nAUQyuw6znVaZGd7yI0nab1EWhEtIZPnTXvpDatJ2SObodYZOz5hGoLjCopAuhQBC7vOngbZ1bwP6HxtB5+g==}
 
   '@vercel/sandbox@2.1.1':
     resolution: {integrity: sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==}
@@ -30250,19 +30247,6 @@ snapshots:
       minimatch: 10.2.5
       mixpart: 0.0.5
       picocolors: 1.1.1
-
-  '@vercel/sandbox@0.0.21':
-    dependencies:
-      '@vercel/oidc': 2.0.2
-      async-retry: 1.3.3
-      jsonlines: 0.1.1
-      ms: 2.1.3
-      tar-stream: 3.1.7
-      undici: 7.25.0
-      zod: 3.24.4
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   '@vercel/sandbox@2.1.1':
     dependencies:


### PR DESCRIPTION
## Summary

`examples/ai-e2e-next` was using the long outdated `0.0.21` version of `@vercel/sandbox`. This PR updates it to use the latest `2.x` version. It also updates some code based on public API changes.

The rest of the repo was already using the same `2.x` version.

## Manual Verification

N/A

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
