### PR TITLE
fix(gateway): accept deprecated warnings in image, speech, transcription, and video responses

### DIFF
--- a/.changeset/quick-eagles-explain.md
+++ b/.changeset/quick-eagles-explain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): accept deprecated warnings in image, speech, transcription, and video responses

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -73,6 +73,7 @@ describe('GatewayImageModel', () => {
       warnings?: Array<
         | { type: 'unsupported'; feature: string; details?: string }
         | { type: 'compatibility'; feature: string; details?: string }
+        | { type: 'deprecated'; setting: string; message: string }
         | { type: 'other'; message: string }
       >;
       providerMetadata?: Record<string, unknown>;
@@ -286,6 +287,34 @@ describe('GatewayImageModel', () => {
     it('should return warnings when provided', async () => {
       const mockWarnings = [
         { type: 'other' as const, message: 'Setting not supported' },
+      ];
+
+      prepareJsonResponse({
+        images: ['base64-1'],
+        warnings: mockWarnings,
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toEqual(mockWarnings);
+    });
+
+    it('should return deprecated warnings correctly', async () => {
+      const mockWarnings = [
+        {
+          type: 'deprecated' as const,
+          setting: 'size',
+          message: 'Use `aspectRatio` instead.',
+        },
       ];
 
       prepareJsonResponse({

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -168,6 +168,11 @@ const gatewayImageWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/gateway-speech-model.ts
+++ b/packages/gateway/src/gateway-speech-model.ts
@@ -126,6 +126,11 @@ const gatewaySpeechWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -125,6 +125,11 @@ const gatewayTranscriptionWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -240,6 +240,11 @@ const gatewayVideoWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),


### PR DESCRIPTION
## Summary

The v4 spec's `SharedV4Warning` has four variants, including `{ type: 'deprecated', setting, message }`. The gateway client's response warning schemas for **image, speech, transcription, and video** were discriminated unions of only `unsupported | compatibility | other` — so if the gateway server (or an upstream provider passing through it) ever emits a `deprecated` warning on those routes, the entire response zod parse fails and the whole `generateImage`/`generateSpeech`/`transcribe`/`generateVideo` call **throws**, instead of surfacing a warning.

Language-model responses are unaffected (they use a lenient `z.any()` handler), and the embedding client ignores `warnings`.

Today no pinned provider emits `deprecated` on these paths, so this is a latent break rather than a live one — but it's a one-warning-away failure mode going into v7 GA.

## Change

Add the `deprecated` variant (`{ type, setting, message }`, matching `shared-v4-warning.ts`) to the warning schema in:

- `gateway-image-model.ts`
- `gateway-speech-model.ts`
- `gateway-transcription-model.ts`
- `gateway-video-model.ts`

## Tests

Added a `deprecated` warnings round-trip test to `gateway-image-model.test.ts` (the four schemas are identical; image is the representative). Full `@ai-sdk/gateway` node suite passes (459 tests / 19 files), typecheck / oxlint / oxfmt clean. Changeset included.

## Context

Found in an AI Gateway v7 GA-readiness sweep. Companion server-side fix (v4 unified tool-result file URL downloads) is vercel/ai-gateway#2237.