### PR TITLE
fix(gateway): surface provider warnings in embedding and reranking responses

### DIFF
--- a/.changeset/eighty-cars-dream.md
+++ b/.changeset/eighty-cars-dream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): surface provider warnings in embedding and reranking responses

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -38,10 +38,17 @@ describe('GatewayEmbeddingModel', () => {
   function prepareJsonResponse({
     embeddings = dummyEmbeddings,
     usage = { tokens: 8 },
+    warnings,
     headers,
   }: {
     embeddings?: number[][];
     usage?: { tokens: number };
+    warnings?: Array<
+      | { type: 'unsupported'; feature: string; details?: string }
+      | { type: 'compatibility'; feature: string; details?: string }
+      | { type: 'deprecated'; setting: string; message: string }
+      | { type: 'other'; message: string }
+    >;
     headers?: Record<string, string>;
   } = {}) {
     server.urls['https://api.test.com/embedding-model'].response = {
@@ -50,6 +57,7 @@ describe('GatewayEmbeddingModel', () => {
       body: {
         embeddings,
         usage,
+        ...(warnings && { warnings }),
       },
     };
   }
@@ -99,6 +107,34 @@ describe('GatewayEmbeddingModel', () => {
 
       expect(embeddings).toStrictEqual(dummyEmbeddings);
       expect(usage).toStrictEqual({ tokens: 42 });
+    });
+
+    it('should extract warnings', async () => {
+      const mockWarnings = [
+        {
+          type: 'deprecated' as const,
+          setting: 'dimensions',
+          message: 'Use outputDimensions instead.',
+        },
+      ];
+
+      prepareJsonResponse({ warnings: mockWarnings });
+
+      const { warnings } = await createTestModel().doEmbed({
+        values: testValues,
+      });
+
+      expect(warnings).toStrictEqual(mockWarnings);
+    });
+
+    it('should default warnings to an empty array when absent', async () => {
+      prepareJsonResponse();
+
+      const { warnings } = await createTestModel().doEmbed({
+        values: testValues,
+      });
+
+      expect(warnings).toStrictEqual([]);
     });
 
     it('should send value as array', async () => {

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -98,7 +98,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV4 {
         providerMetadata:
           responseBody.providerMetadata as unknown as SharedV4ProviderMetadata,
         response: { headers: responseHeaders, body: rawValue },
-        warnings: [],
+        warnings: responseBody.warnings ?? [],
       };
     } catch (error) {
       throw await asGatewayError(
@@ -120,11 +120,34 @@ export class GatewayEmbeddingModel implements EmbeddingModelV4 {
   }
 }
 
+const gatewayEmbeddingWarningSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('unsupported'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('compatibility'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
+    type: z.literal('other'),
+    message: z.string(),
+  }),
+]);
+
 const gatewayEmbeddingResponseSchema = lazySchema(() =>
   zodSchema(
     z.object({
       embeddings: z.array(z.array(z.number())),
       usage: z.object({ tokens: z.number() }).nullish(),
+      warnings: z.array(gatewayEmbeddingWarningSchema).optional(),
       providerMetadata: z
         .record(z.string(), z.record(z.string(), z.unknown()))
         .optional(),

--- a/packages/gateway/src/gateway-reranking-model.test.ts
+++ b/packages/gateway/src/gateway-reranking-model.test.ts
@@ -48,15 +48,22 @@ const createTestModel = (
 describe('GatewayRerankingModel', () => {
   function prepareJsonResponse({
     ranking = dummyRanking,
+    warnings,
     headers,
   }: {
     ranking?: Array<{ index: number; relevanceScore: number }>;
+    warnings?: Array<
+      | { type: 'unsupported'; feature: string; details?: string }
+      | { type: 'compatibility'; feature: string; details?: string }
+      | { type: 'deprecated'; setting: string; message: string }
+      | { type: 'other'; message: string }
+    >;
     headers?: Record<string, string>;
   } = {}) {
     server.urls['https://api.test.com/reranking-model'].response = {
       type: 'json-value',
       headers,
-      body: { ranking },
+      body: { ranking, ...(warnings && { warnings }) },
     };
   }
 
@@ -106,6 +113,36 @@ describe('GatewayRerankingModel', () => {
       });
 
       expect(ranking).toStrictEqual(dummyRanking);
+    });
+
+    it('should extract warnings', async () => {
+      const mockWarnings = [
+        {
+          type: 'unsupported' as const,
+          feature: 'topN',
+          details: 'This model ignores topN.',
+        },
+      ];
+
+      prepareJsonResponse({ warnings: mockWarnings });
+
+      const { warnings } = await createTestModel().doRerank({
+        documents: testDocuments,
+        query: testQuery,
+      });
+
+      expect(warnings).toStrictEqual(mockWarnings);
+    });
+
+    it('should default warnings to an empty array when absent', async () => {
+      prepareJsonResponse();
+
+      const { warnings } = await createTestModel().doRerank({
+        documents: testDocuments,
+        query: testQuery,
+      });
+
+      expect(warnings).toStrictEqual([]);
     });
 
     it('should send documents and query in request body', async () => {

--- a/packages/gateway/src/gateway-reranking-model.ts
+++ b/packages/gateway/src/gateway-reranking-model.ts
@@ -80,7 +80,7 @@ export class GatewayRerankingModel implements RerankingModelV4 {
         providerMetadata:
           responseBody.providerMetadata as unknown as SharedV4ProviderMetadata,
         response: { headers: responseHeaders, body: rawValue },
-        warnings: [],
+        warnings: responseBody.warnings ?? [],
       };
     } catch (error) {
       throw await asGatewayError(
@@ -102,6 +102,28 @@ export class GatewayRerankingModel implements RerankingModelV4 {
   }
 }
 
+const gatewayRerankingWarningSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('unsupported'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('compatibility'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
+    type: z.literal('other'),
+    message: z.string(),
+  }),
+]);
+
 const gatewayRerankingResponseSchema = lazySchema(() =>
   zodSchema(
     z.object({
@@ -111,6 +133,7 @@ const gatewayRerankingResponseSchema = lazySchema(() =>
           relevanceScore: z.number(),
         }),
       ),
+      warnings: z.array(gatewayRerankingWarningSchema).optional(),
       providerMetadata: z
         .record(z.string(), z.record(z.string(), z.unknown()))
         .optional(),


### PR DESCRIPTION
## Summary

The gateway client's **embedding** and **reranking** response schemas did not model `warnings` at all. zod's strip mode discarded the field from the response body, and both `doEmbed`/`doRerank` returned a hardcoded `warnings: []` — so any warning the gateway returned (e.g. "this setting is unsupported and was ignored") was **silently invisible** to users on those two modalities.

This is the third warning-handling category found in the v7 GA-readiness sweep: image/speech/transcription/video had strict-but-incomplete schemas that **crashed** on the `deprecated` variant (#16030), language is fully lenient, and embedding/reranking **silently discarded** all warnings — fixed here.

## Change

- Add a warning schema (all four `SharedV4Warning` variants, including `deprecated`) and an optional `warnings` field to the embedding and reranking response schemas.
- Return `responseBody.warnings ?? []` instead of the hardcoded `[]`.

The spec's embedding result requires `warnings`; reranking's is optional — defaulting to `[]` satisfies both.

## Server counterpart

The gateway server also wasn't forwarding these warnings — companion fix: vercel/ai-gateway#2239. The two are safe to land in either order: this client defaults to `[]` when the field is absent, and old clients strip the new server field harmlessly.

## Tests

Embedding + reranking: warnings round-trip test and absent-defaults-to-`[]` test each. Full `@ai-sdk/gateway` node suite passes (462 tests / 19 files), typecheck / oxlint / oxfmt clean. Changeset included.