### PR TITLE
Backport: fix(provider-utils,ai): harden download SSRF guard against hostname and redirect bypasses

### DIFF
--- a/.changeset/ssrf-download-guard-hardening.md
+++ b/.changeset/ssrf-download-guard-hardening.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+fix: harden download URL SSRF guard against hostname and redirect bypasses
+
+`validateDownloadUrl` and the file download helpers (`downloadBlob`, `download`) could be bypassed in several ways when handling untrusted URLs:
+
+- A fully-qualified hostname with a trailing dot (e.g. `localhost.`, `myhost.local.`) skipped the localhost/`.local` blocklist.
+- IPv6 addresses that embed an IPv4 address in their last 32 bits — IPv4-compatible (`::127.0.0.1`), IPv4-translated (`::ffff:0:127.0.0.1`), and NAT64 (`64:ff9b::127.0.0.1`, including the `64:ff9b:1::/48` local-use prefix) — were not decoded and checked against the private IPv4 ranges.
+- Redirects were validated only *after* `fetch` had already followed them, so the request to a redirect target (e.g. an internal/metadata address) had already been issued before the check ran.
+- Several reserved/internal address ranges were not blocked: CGNAT (`100.64.0.0/10`, used by some cloud providers for internal traffic), benchmarking (`198.18.0.0/15`), IETF protocol assignments (`192.0.0.0/24`), the reserved `240.0.0.0/4` block (including the `255.255.255.255` broadcast address), and IPv6 site-local (`fec0::/10`) and multicast (`ff00::/8`).
+
+The validator now strips trailing dots before the hostname checks and fully expands IPv6 addresses to detect embedded private IPv4 targets. The download helpers now follow redirects manually (`redirect: 'manual'`), re-validating each hop before requesting it, so an unsafe redirect target is never fetched. When a redirect cannot be inspected because the runtime returns an opaque response, the helpers fail closed (reject the redirect) on the server; only in a real browser — where SSRF is not reachable (fetch is constrained by CORS and cannot reach a server's internal network or cloud-metadata endpoints) — is the redirect followed natively so legitimate redirected downloads keep working.

--- a/packages/ai/src/util/download/download.test.ts
+++ b/packages/ai/src/util/download/download.test.ts
@@ -1,26 +1,24 @@
-import { DownloadError } from './download-error';
+import { DownloadError } from '@ai-sdk/provider-utils';
 import { download } from './download';
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 
 describe('download SSRF protection', () => {
   it('should reject private IPv4 addresses', async () => {
-    for (const ip of ['127.0.0.1', '10.0.0.1', '169.254.169.254']) {
-      try {
-        await download({ url: new URL(`http://${ip}/file`) });
-        expect.fail(`Expected download to throw for ${ip}`);
-      } catch (error) {
-        expect(DownloadError.isInstance(error)).toBe(true);
-      }
-    }
+    await expect(
+      download({ url: new URL('http://127.0.0.1/file') }),
+    ).rejects.toThrow(DownloadError);
+    await expect(
+      download({ url: new URL('http://10.0.0.1/file') }),
+    ).rejects.toThrow(DownloadError);
+    await expect(
+      download({ url: new URL('http://169.254.169.254/latest/meta-data/') }),
+    ).rejects.toThrow(DownloadError);
   });
 
   it('should reject localhost', async () => {
-    try {
-      await download({ url: new URL('http://localhost/file') });
-      expect.fail('Expected download to throw for localhost');
-    } catch (error) {
-      expect(DownloadError.isInstance(error)).toBe(true);
-    }
+    await expect(
+      download({ url: new URL('http://localhost/file') }),
+    ).rejects.toThrow(DownloadError);
   });
 });
 
@@ -31,73 +29,139 @@ describe('download SSRF redirect protection', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('should reject redirects to private IP addresses', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      redirected: true,
-      url: 'http://169.254.169.254/latest/meta-data/',
-      headers: new Headers({ 'content-type': 'text/plain' }),
-      body: new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('secret'));
-          controller.close();
-        },
+  it('should reject a redirect to a private IP without requesting it', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 302,
+      headers: new Headers({
+        location: 'http://169.254.169.254/latest/meta-data/',
       }),
+      body: null,
     } as unknown as Response);
+    globalThis.fetch = fetchMock;
 
-    try {
-      await download({ url: new URL('https://evil.com/redirect') });
-      expect.fail('Expected download to throw');
-    } catch (error) {
-      expect(DownloadError.isInstance(error)).toBe(true);
-    }
+    await expect(
+      download({ url: new URL('https://evil.com/redirect') }),
+    ).rejects.toThrow(DownloadError);
+    // The redirect target must never be requested.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should reject redirects to localhost', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      redirected: true,
-      url: 'http://localhost:8080/admin',
-      headers: new Headers({ 'content-type': 'text/plain' }),
-      body: new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('secret'));
-          controller.close();
-        },
-      }),
+  it('should reject a redirect to localhost without requesting it', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 307,
+      headers: new Headers({ location: 'http://localhost:8080/admin' }),
+      body: null,
     } as unknown as Response);
+    globalThis.fetch = fetchMock;
 
-    try {
-      await download({ url: new URL('https://evil.com/redirect') });
-      expect.fail('Expected download to throw');
-    } catch (error) {
-      expect(DownloadError.isInstance(error)).toBe(true);
-    }
+    await expect(
+      download({ url: new URL('https://evil.com/redirect') }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should allow redirects to safe URLs', async () => {
+  it('should let the browser follow redirects natively on an opaque redirect', async () => {
+    const globalThisAny = globalThis as { window?: unknown };
+    globalThisAny.window = {};
     const content = new Uint8Array([1, 2, 3]);
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      redirected: true,
-      url: 'https://cdn.example.com/image.png',
-      headers: new Headers({ 'content-type': 'image/png' }),
-      body: new ReadableStream({
-        start(controller) {
-          controller.enqueue(content);
-          controller.close();
-        },
-      }),
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        type: 'opaqueredirect',
+        status: 0,
+        ok: false,
+        headers: new Headers(),
+        body: null,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'image/png' }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(content);
+            controller.close();
+          },
+        }),
+      } as unknown as Response);
+    globalThis.fetch = fetchMock;
+
+    try {
+      const result = await download({
+        url: new URL('https://example.com/image.png'),
+      });
+      expect(result.data).toEqual(content);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        'https://example.com/image.png',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/image.png',
+        expect.objectContaining({ redirect: 'follow' }),
+      );
+    } finally {
+      delete globalThisAny.window;
+    }
+  });
+
+  it('should fail closed on an opaque redirect outside the browser', async () => {
+    // A spec-compliant server runtime may return an opaque redirect for
+    // `redirect: 'manual'`. Since the hop cannot be validated and SSRF is
+    // reachable on the server, we must reject rather than follow it natively.
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      type: 'opaqueredirect',
+      status: 0,
+      ok: false,
+      headers: new Headers(),
+      body: null,
     } as unknown as Response);
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      download({ url: new URL('https://example.com/redirect') }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should follow redirects to safe URLs', async () => {
+    const content = new Uint8Array([1, 2, 3]);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: 'https://cdn.example.com/image.png' }),
+        body: null,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'image/png' }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(content);
+            controller.close();
+          },
+        }),
+      } as unknown as Response);
+    globalThis.fetch = fetchMock;
 
     const result = await download({
       url: new URL('https://example.com/image.png'),
     });
     expect(result.data).toEqual(content);
     expect(result.mediaType).toBe('image/png');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://cdn.example.com/image.png',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
   });
 });
 

--- a/packages/ai/src/util/download/download.ts
+++ b/packages/ai/src/util/download/download.ts
@@ -1,8 +1,8 @@
-import { DownloadError } from './download-error';
 import {
+  DownloadError,
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,
-  validateDownloadUrl,
+  fetchWithValidatedRedirects,
   withUserAgentSuffix,
   getRuntimeEnvironmentUserAgent,
 } from '@ai-sdk/provider-utils';
@@ -28,21 +28,18 @@ export const download = async ({
   abortSignal?: AbortSignal;
 }) => {
   const urlText = url.toString();
-  validateDownloadUrl(urlText);
   try {
-    const response = await fetch(urlText, {
-      headers: withUserAgentSuffix(
-        {},
-        `ai-sdk/${VERSION}`,
-        getRuntimeEnvironmentUserAgent(),
-      ),
-      signal: abortSignal,
-    });
+    const headers = withUserAgentSuffix(
+      {},
+      `ai-sdk/${VERSION}`,
+      getRuntimeEnvironmentUserAgent(),
+    );
 
-    // Validate final URL after redirects to prevent SSRF via open redirect
-    if (response.redirected) {
-      validateDownloadUrl(response.url);
-    }
+    const response = await fetchWithValidatedRedirects({
+      url: urlText,
+      headers,
+      abortSignal,
+    });
 
     if (!response.ok) {
       throw new DownloadError({

--- a/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DownloadError } from './download-error';
+import { fetchWithValidatedRedirects } from './fetch-with-validated-redirects';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete (globalThis as { window?: unknown }).window;
+});
+
+function redirectResponse(location: string, status = 302): Response {
+  return {
+    ok: false,
+    status,
+    headers: new Headers({ location }),
+    body: null,
+  } as unknown as Response;
+}
+
+function okResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'image/png' }),
+    body: null,
+  } as unknown as Response;
+}
+
+describe('fetchWithValidatedRedirects', () => {
+  it('validates the initial URL before requesting it', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchWithValidatedRedirects({ url: 'http://localhost/file' }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('uses redirect: manual and omits headers when none are provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(okResponse());
+    globalThis.fetch = fetchMock;
+
+    await fetchWithValidatedRedirects({ url: 'https://example.com/file' });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/file', {
+      signal: undefined,
+      redirect: 'manual',
+    });
+  });
+
+  it('follows a redirect to a safe URL, validating the hop', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('https://cdn.example.com/file'))
+      .mockResolvedValueOnce(okResponse());
+    globalThis.fetch = fetchMock;
+
+    const response = await fetchWithValidatedRedirects({
+      url: 'https://example.com/file',
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://cdn.example.com/file',
+      {
+        signal: undefined,
+        redirect: 'manual',
+      },
+    );
+  });
+
+  it('rejects a redirect to a private address without requesting it', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('http://169.254.169.254/'));
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchWithValidatedRedirects({ url: 'https://evil.com/redirect' }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves relative redirect targets against the current URL', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('/internal'))
+      .mockResolvedValueOnce(okResponse());
+    globalThis.fetch = fetchMock;
+
+    await fetchWithValidatedRedirects({ url: 'https://example.com/start' });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://example.com/internal',
+      { signal: undefined, redirect: 'manual' },
+    );
+  });
+
+  it('rejects once the redirect limit is exceeded', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(redirectResponse('https://example.com/next'));
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchWithValidatedRedirects({
+        url: 'https://example.com/start',
+        maxRedirects: 2,
+      }),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('fails closed on an opaque redirect outside the browser', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      type: 'opaqueredirect',
+      status: 0,
+      ok: false,
+      headers: new Headers(),
+      body: null,
+    } as unknown as Response);
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchWithValidatedRedirects({ url: 'https://example.com/redirect' }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows redirects natively on an opaque redirect in the browser', async () => {
+    (globalThis as { window?: unknown }).window = {};
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        type: 'opaqueredirect',
+        status: 0,
+        ok: false,
+        headers: new Headers(),
+        body: null,
+      } as unknown as Response)
+      .mockResolvedValueOnce(okResponse());
+    globalThis.fetch = fetchMock;
+
+    const response = await fetchWithValidatedRedirects({
+      url: 'https://example.com/file',
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://example.com/file', {
+      signal: undefined,
+      redirect: 'follow',
+    });
+  });
+});

--- a/packages/provider-utils/src/fetch-with-validated-redirects.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.ts
@@ -1,0 +1,82 @@
+import { DownloadError } from './download-error';
+import { isBrowserRuntime } from './is-browser-runtime';
+import { validateDownloadUrl } from './validate-download-url';
+
+const MAX_DOWNLOAD_REDIRECTS = 10;
+
+/**
+ * Fetches a URL while enforcing the SSRF download guard on every hop.
+ *
+ * Redirects are followed manually (`redirect: 'manual'`) so each hop is
+ * validated with {@link validateDownloadUrl} *before* it is requested. Relying
+ * on the default `redirect: 'follow'` would issue the request to a redirect
+ * target (e.g. an internal address) before we ever see its URL, defeating the
+ * SSRF guard.
+ *
+ * A `redirect: 'manual'` request yields an unreadable opaque response in the
+ * browser (and in other spec-compliant fetch implementations), so the redirect
+ * target cannot be validated here. In a real browser this is safe to follow
+ * natively because SSRF is not reachable (fetch is constrained by CORS and
+ * cannot reach a server's internal network or cloud-metadata). On any other
+ * runtime we cannot validate the hop, so we fail closed rather than follow it
+ * blindly and bypass the SSRF guard.
+ *
+ * The returned response is the final (non-redirect) response. The caller is
+ * responsible for checking `response.ok` and reading the body.
+ *
+ * @throws DownloadError if a hop is unsafe, the redirect limit is exceeded, or
+ * a redirect cannot be validated on a non-browser runtime.
+ */
+export async function fetchWithValidatedRedirects({
+  url,
+  headers,
+  abortSignal,
+  maxRedirects = MAX_DOWNLOAD_REDIRECTS,
+}: {
+  url: string;
+  headers?: HeadersInit;
+  abortSignal?: AbortSignal;
+  maxRedirects?: number;
+}): Promise<Response> {
+  // Per-hop request options. Only the `redirect` mode varies between hops, so
+  // the rest is assembled once. `headers` is omitted entirely when not provided
+  // so callers that send none issue a bare request.
+  const baseInit: RequestInit = { signal: abortSignal };
+  if (headers !== undefined) {
+    baseInit.headers = headers;
+  }
+
+  let currentUrl = url;
+  // The bound also acts as a backstop against an unterminated redirect chain.
+  for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
+    validateDownloadUrl(currentUrl);
+
+    const response = await fetch(currentUrl, {
+      ...baseInit,
+      redirect: 'manual',
+    });
+
+    if (response.type === 'opaqueredirect') {
+      if (!isBrowserRuntime()) {
+        throw new DownloadError({
+          url,
+          message: `Redirect from ${currentUrl} could not be validated and was blocked`,
+        });
+      }
+      return await fetch(currentUrl, { ...baseInit, redirect: 'follow' });
+    }
+
+    const location = response.headers.get('location');
+    if (response.status >= 300 && response.status < 400 && location) {
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+
+    return response;
+  }
+
+  throw new DownloadError({
+    url,
+    message: `Too many redirects (max ${maxRedirects})`,
+  });
+}

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -4,6 +4,8 @@ export * from './delay';
 export { DelayedPromise } from './delayed-promise';
 export * from './extract-response-headers';
 export { DownloadError } from './download-error';
+export { fetchWithValidatedRedirects } from './fetch-with-validated-redirects';
+export { isBrowserRuntime } from './is-browser-runtime';
 export {
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,

--- a/packages/provider-utils/src/is-browser-runtime.test.ts
+++ b/packages/provider-utils/src/is-browser-runtime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isBrowserRuntime } from './is-browser-runtime';
+
+describe('isBrowserRuntime', () => {
+  it('returns true when a global window is present', () => {
+    expect(isBrowserRuntime({ window: {} })).toBe(true);
+  });
+
+  it('returns false when there is no window (server runtimes)', () => {
+    expect(isBrowserRuntime({})).toBe(false);
+    expect(isBrowserRuntime({ window: undefined })).toBe(false);
+    expect(isBrowserRuntime({ process: { versions: { node: '22' } } })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/provider-utils/src/is-browser-runtime.ts
+++ b/packages/provider-utils/src/is-browser-runtime.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns `true` when running in a browser.
+ *
+ * Detection keys on the presence of a global `window`, matching the browser
+ * check used elsewhere in this package (see `getRuntimeEnvironmentUserAgent`)
+ * so the SDK has a single, consistent definition of "browser". Server runtimes
+ * (Node.js, Deno, Bun, edge/workers) do not define `window`.
+ */
+export function isBrowserRuntime(
+  globalThisAny: any = globalThis as any,
+): boolean {
+  return globalThisAny.window != null;
+}

--- a/packages/provider-utils/src/validate-download-url.test.ts
+++ b/packages/provider-utils/src/validate-download-url.test.ts
@@ -193,4 +193,158 @@ describe('validateDownloadUrl', () => {
       ).not.toThrow();
     });
   });
+
+  // Regression: a fully-qualified name with a trailing dot resolves the same as
+  // the bare name, so it must not bypass the hostname blocklist.
+  describe('trailing-dot hostnames', () => {
+    it('should block localhost. (trailing dot)', () => {
+      expect(() => validateDownloadUrl('http://localhost./file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block .local. (trailing dot)', () => {
+      expect(() => validateDownloadUrl('http://myhost.local./file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block .localhost. (trailing dot)', () => {
+      expect(() => validateDownloadUrl('http://app.localhost./file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should still allow public hosts with a trailing dot', () => {
+      expect(() =>
+        validateDownloadUrl('https://example.com./image.png'),
+      ).not.toThrow();
+    });
+  });
+
+  // Regression: numeric IPv4 in non-dotted notation is normalized to dotted
+  // form by the URL parser, so the IPv4 private checks must still apply.
+  describe('non-dotted IPv4 notations', () => {
+    it('should block decimal 2130706433 (127.0.0.1)', () => {
+      expect(() => validateDownloadUrl('http://2130706433/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block hex 0x7f000001 (127.0.0.1)', () => {
+      expect(() => validateDownloadUrl('http://0x7f000001/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block octal 0177.0.0.1 (127.0.0.1)', () => {
+      expect(() => validateDownloadUrl('http://0177.0.0.1/file')).toThrow(
+        DownloadError,
+      );
+    });
+  });
+
+  // Regression: IPv6 forms that embed an IPv4 address in their last 32 bits
+  // must be decoded and checked against the IPv4 private ranges.
+  describe('IPv6 with embedded IPv4', () => {
+    it('should block IPv4-compatible ::127.0.0.1', () => {
+      expect(() => validateDownloadUrl('http://[::127.0.0.1]/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block IPv4-translated ::ffff:0:127.0.0.1', () => {
+      expect(() =>
+        validateDownloadUrl('http://[::ffff:0:127.0.0.1]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should block NAT64 64:ff9b::127.0.0.1', () => {
+      expect(() =>
+        validateDownloadUrl('http://[64:ff9b::127.0.0.1]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should block NAT64 64:ff9b::169.254.169.254 (metadata)', () => {
+      expect(() =>
+        validateDownloadUrl('http://[64:ff9b::169.254.169.254]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should block NAT64 local-use 64:ff9b:1::169.254.169.254', () => {
+      expect(() =>
+        validateDownloadUrl('http://[64:ff9b:1::169.254.169.254]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should allow NAT64 with a public embedded IPv4', () => {
+      expect(() =>
+        validateDownloadUrl('http://[64:ff9b::203.0.113.1]/file'),
+      ).not.toThrow();
+    });
+
+    it('should allow a regular public IPv6 address', () => {
+      expect(() =>
+        validateDownloadUrl('http://[2001:db8::1]/file'),
+      ).not.toThrow();
+    });
+  });
+
+  // Additional reserved/internal IPv4 ranges that must not be reachable.
+  describe('additional reserved IPv4 ranges', () => {
+    it('should block 100.64.0.0/10 (CGNAT)', () => {
+      expect(() => validateDownloadUrl('http://100.64.0.1/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://100.127.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should allow 100.63.x.x and 100.128.x.x (public)', () => {
+      expect(() => validateDownloadUrl('http://100.63.0.1/file')).not.toThrow();
+      expect(() =>
+        validateDownloadUrl('http://100.128.0.1/file'),
+      ).not.toThrow();
+    });
+
+    it('should block 198.18.0.0/15 (benchmarking)', () => {
+      expect(() => validateDownloadUrl('http://198.18.0.1/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://198.19.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 192.0.0.0/24 (IETF protocol assignments)', () => {
+      expect(() => validateDownloadUrl('http://192.0.0.1/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 240.0.0.0/4 (reserved) and the broadcast address', () => {
+      expect(() => validateDownloadUrl('http://240.0.0.1/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://255.255.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
+  });
+
+  // Additional internal IPv6 ranges.
+  describe('additional reserved IPv6 ranges', () => {
+    it('should block fec0::/10 (site-local)', () => {
+      expect(() => validateDownloadUrl('http://[fec0::1]/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block ff00::/8 (multicast)', () => {
+      expect(() => validateDownloadUrl('http://[ff02::1]/file')).toThrow(
+        DownloadError,
+      );
+    });
+  });
 });

--- a/packages/provider-utils/src/validate-download-url.ts
+++ b/packages/provider-utils/src/validate-download-url.ts
@@ -4,6 +4,10 @@ import { DownloadError } from './download-error';
  * Validates that a URL is safe to download from, blocking private/internal addresses
  * to prevent SSRF attacks.
  *
+ * Note: this performs string/literal-IP checks only. It does not resolve DNS, so a
+ * hostname that resolves to a private address is not blocked here (see callers, which
+ * should additionally constrain egress at the network layer when handling untrusted URLs).
+ *
  * @param url - The URL string to validate.
  * @throws DownloadError if the URL is unsafe.
  */
@@ -31,7 +35,9 @@ export function validateDownloadUrl(url: string): void {
     });
   }
 
-  const hostname = parsed.hostname;
+  // Strip a trailing dot so a fully-qualified name like `localhost.` (which resolves
+  // identically to `localhost`) cannot bypass the hostname blocklist below.
+  const hostname = parsed.hostname.toLowerCase().replace(/\.+$/, '');
 
   // Block empty hostname
   if (!hostname) {
@@ -90,59 +96,135 @@ function isIPv4(hostname: string): boolean {
 
 function isPrivateIPv4(ip: string): boolean {
   const parts = ip.split('.').map(Number);
-  const [a, b] = parts;
+  const [a, b, c] = parts;
 
   // 0.0.0.0/8
   if (a === 0) return true;
   // 10.0.0.0/8
   if (a === 10) return true;
+  // 100.64.0.0/10 (CGNAT, used by some cloud providers for internal traffic)
+  if (a === 100 && b >= 64 && b <= 127) return true;
   // 127.0.0.0/8
   if (a === 127) return true;
   // 169.254.0.0/16
   if (a === 169 && b === 254) return true;
   // 172.16.0.0/12
   if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.0.0.0/24 (IETF protocol assignments)
+  if (a === 192 && b === 0 && c === 0) return true;
   // 192.168.0.0/16
   if (a === 192 && b === 168) return true;
+  // 198.18.0.0/15 (benchmarking)
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // 240.0.0.0/4 (reserved, includes 255.255.255.255 broadcast)
+  if (a >= 240) return true;
 
   return false;
 }
 
-function isPrivateIPv6(ip: string): boolean {
-  const normalized = ip.toLowerCase();
-
-  // ::1 (loopback)
-  if (normalized === '::1') return true;
-  // :: (unspecified)
-  if (normalized === '::') return true;
-
-  // Check for IPv4-mapped addresses (::ffff:x.x.x.x or ::ffff:HHHH:HHHH)
-  if (normalized.startsWith('::ffff:')) {
-    const mappedPart = normalized.slice(7);
-    // Dotted-decimal form: ::ffff:127.0.0.1
-    if (isIPv4(mappedPart)) {
-      return isPrivateIPv4(mappedPart);
-    }
-    // Hex form: ::ffff:7f00:1 (URL parser normalizes to this)
-    const hexParts = mappedPart.split(':');
-    if (hexParts.length === 2) {
-      const high = parseInt(hexParts[0], 16);
-      const low = parseInt(hexParts[1], 16);
-      if (!isNaN(high) && !isNaN(low)) {
-        const a = (high >> 8) & 0xff;
-        const b = high & 0xff;
-        const c = (low >> 8) & 0xff;
-        const d = low & 0xff;
-        return isPrivateIPv4(`${a}.${b}.${c}.${d}`);
-      }
-    }
+/**
+ * Expands an IPv6 address string into its 8 16-bit groups, handling `::`
+ * compression and an optional dotted-decimal IPv4 tail (e.g. `::ffff:127.0.0.1`).
+ *
+ * @returns the 8 groups, or null if the input is not a parseable IPv6 address.
+ */
+function parseIPv6(ip: string): number[] | null {
+  // Strip an optional zone id (e.g. `fe80::1%eth0`).
+  let address = ip.toLowerCase();
+  const zoneIndex = address.indexOf('%');
+  if (zoneIndex !== -1) {
+    address = address.slice(0, zoneIndex);
   }
 
-  // fc00::/7 (unique local addresses - fc00:: and fd00::)
-  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+  // At most one `::` compression marker is allowed.
+  const halves = address.split('::');
+  if (halves.length > 2) return null;
+
+  const toGroups = (segment: string): number[] | null => {
+    if (segment === '') return [];
+    const groups: number[] = [];
+    const parts = segment.split(':');
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      // A dotted-decimal IPv4 tail is only valid as the final part.
+      if (part.includes('.')) {
+        if (i !== parts.length - 1 || !isIPv4(part)) return null;
+        const [a, b, c, d] = part.split('.').map(Number);
+        groups.push((a << 8) | b, (c << 8) | d);
+        continue;
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(part)) return null;
+      groups.push(parseInt(part, 16));
+    }
+    return groups;
+  };
+
+  const head = toGroups(halves[0]);
+  if (head === null) return null;
+
+  if (halves.length === 2) {
+    const tail = toGroups(halves[1]);
+    if (tail === null) return null;
+    const fill = 8 - head.length - tail.length;
+    if (fill < 0) return null;
+    return [...head, ...new Array<number>(fill).fill(0), ...tail];
+  }
+
+  // No `::` compression: the address must contain exactly 8 groups.
+  return head.length === 8 ? head : null;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const groups = parseIPv6(ip);
+
+  // Fail closed: if the address cannot be parsed, treat it as unsafe.
+  if (groups === null) return true;
+
+  const topZero = (count: number) =>
+    groups.slice(0, count).every(group => group === 0);
+
+  // ::1 (loopback) and :: (unspecified)
+  if (topZero(7) && (groups[7] === 0 || groups[7] === 1)) return true;
+
+  // fc00::/7 (unique local addresses)
+  if ((groups[0] & 0xfe00) === 0xfc00) return true;
 
   // fe80::/10 (link-local)
-  if (normalized.startsWith('fe80')) return true;
+  if ((groups[0] & 0xffc0) === 0xfe80) return true;
+
+  // fec0::/10 (site-local, deprecated but still routable internally)
+  if ((groups[0] & 0xffc0) === 0xfec0) return true;
+
+  // ff00::/8 (multicast)
+  if ((groups[0] & 0xff00) === 0xff00) return true;
+
+  // Addresses that embed an IPv4 address in their last 32 bits. For these we
+  // extract the embedded IPv4 and reuse the IPv4 private-range checks, so that
+  // e.g. ::ffff:127.0.0.1 or 64:ff9b::169.254.169.254 are blocked.
+  const embedsIPv4 =
+    // ::/96 — IPv4-compatible (deprecated)
+    topZero(6) ||
+    // ::ffff:0:0/96 — IPv4-mapped (ffff in group 5)
+    (topZero(5) && groups[5] === 0xffff) ||
+    // ::ffff:0:0/96 — IPv4-translated form (ffff in group 4, group 5 zero)
+    (topZero(4) && groups[4] === 0xffff && groups[5] === 0) ||
+    // 64:ff9b::/96 — NAT64 well-known prefix
+    (groups[0] === 0x0064 &&
+      groups[1] === 0xff9b &&
+      groups[2] === 0 &&
+      groups[3] === 0 &&
+      groups[4] === 0 &&
+      groups[5] === 0) ||
+    // 64:ff9b:1::/48 — NAT64 local-use prefix
+    (groups[0] === 0x0064 && groups[1] === 0xff9b && groups[2] === 0x0001);
+
+  if (embedsIPv4) {
+    const a = (groups[6] >> 8) & 0xff;
+    const b = groups[6] & 0xff;
+    const c = (groups[7] >> 8) & 0xff;
+    const d = groups[7] & 0xff;
+    return isPrivateIPv4(`${a}.${b}.${c}.${d}`);
+  }
 
   return false;
 }


### PR DESCRIPTION
Backport of #15980 to **release-v5.0** (VULN-11554 / VULN-11552 / VULN-11560).

## Applicable scope on v5.0

`validate-download-url.ts` is identical on v5/v6 and `download.ts` (in `ai`) exists on v5.0, so the hardening applies. `downloadBlob` does **not** exist on release-v5.0, so the `download-blob.ts` portion of #15980 is omitted as not-applicable.

## Changes
- `validate-download-url.ts`: strip trailing-dot hostnames; fully expand IPv6 and decode embedded-IPv4 (IPv4-compatible / IPv4-translated / NAT64) so internal targets are blocked.
- New `fetch-with-validated-redirects.ts` (+ `is-browser-runtime.ts`): follow redirects manually with per-hop re-validation on the server; fall back to native follow only in a real browser (where SSRF isn't reachable).
- `download.ts` (`ai`) now routes through `fetchWithValidatedRedirects`; aligned its `DownloadError` import to `@ai-sdk/provider-utils` so the download path uses a single error class (identical to main's `download.ts`).
- Exported `fetchWithValidatedRedirects` + `isBrowserRuntime` from `@ai-sdk/provider-utils`.

## Validation
Resolved cherry-pick conflicts (dropped the v5-N/A `download-blob` files, kept v5's `index.ts` + added the two new exports, took main's `download.test.ts`). Verified locally on the v5 branch: `@ai-sdk/provider-utils` download/redirect/runtime tests (60) and `ai` `download.test.ts` (13) pass in **node and edge**; type-check clean.

Related: #15980 (main), #16023 (release-v6.0 backport). Linear: VULN-11554, VULN-11552, VULN-11560.