### PR TITLE
fix(mcp): prevent prototype-named tools from bypassing the schemas allowlist

### DIFF
--- a/.changeset/mcp-schemas-allowlist-own-property.md
+++ b/.changeset/mcp-schemas-allowlist-own-property.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): prevent prototype-named tools from bypassing the `schemas` allowlist
+
+When using `client.tools({ schemas })` to expose only an explicitly allowed
+subset of an MCP server's tools, the allowlist check used the `in` operator,
+which also matches inherited `Object.prototype` properties. A server-advertised
+tool named `constructor`, `toString`, `__proto__`, etc. would pass the check
+even though the developer never defined it in `schemas`, and was then exposed to
+the model and executable. The check now uses `Object.hasOwn`, so only
+explicitly defined tools are returned.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -926,9 +926,13 @@ describe('MCPClient', () => {
     });
 
     expect(Object.keys(tools)).toEqual(['allowed-tool']);
-    expect(Object.hasOwn(tools, 'constructor')).toBe(false);
-    expect(Object.hasOwn(tools, 'toString')).toBe(false);
-    expect(Object.hasOwn(tools, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(tools, 'constructor')).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(tools, 'toString')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(tools, '__proto__')).toBe(
+      false,
+    );
   });
 
   it('should error when calling tool with misconfigured parameters', async () => {

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -884,6 +884,53 @@ describe('MCPClient', () => {
     expect(tools).not.toHaveProperty('nonexistent-tool');
   });
 
+  it('should not return server tools named after Object.prototype properties unless explicitly allowed', async () => {
+    const mockTransport = new MockMCPTransport({
+      overrideTools: [
+        {
+          name: 'allowed-tool',
+          description: 'An explicitly allowed tool',
+          inputSchema: {
+            type: 'object',
+            properties: { foo: { type: 'string' } },
+          },
+        },
+        {
+          name: 'constructor',
+          description: 'Tool named after an inherited prototype property',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: 'toString',
+          description: 'Tool named after an inherited prototype property',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: '__proto__',
+          description: 'Tool named after an inherited prototype property',
+          inputSchema: { type: 'object' },
+        },
+      ],
+    });
+
+    client = await createMCPClient({
+      transport: mockTransport,
+    });
+
+    const tools = await client.tools({
+      schemas: {
+        'allowed-tool': {
+          inputSchema: z.object({ foo: z.string() }),
+        },
+      },
+    });
+
+    expect(Object.keys(tools)).toEqual(['allowed-tool']);
+    expect(Object.hasOwn(tools, 'constructor')).toBe(false);
+    expect(Object.hasOwn(tools, 'toString')).toBe(false);
+    expect(Object.hasOwn(tools, '__proto__')).toBe(false);
+  });
+
   it('should error when calling tool with misconfigured parameters', async () => {
     createMockTransport.mockImplementation(
       () =>

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -618,7 +618,7 @@ class DefaultMCPClient implements MCPClient {
       _meta,
     } of definitions.tools) {
       const resolvedTitle = title ?? annotations?.title;
-      if (schemas !== 'automatic' && !(name in schemas)) {
+      if (schemas !== 'automatic' && !Object.hasOwn(schemas, name)) {
         continue;
       }
 

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -618,7 +618,10 @@ class DefaultMCPClient implements MCPClient {
       _meta,
     } of definitions.tools) {
       const resolvedTitle = title ?? annotations?.title;
-      if (schemas !== 'automatic' && !Object.hasOwn(schemas, name)) {
+      if (
+        schemas !== 'automatic' &&
+        !Object.prototype.hasOwnProperty.call(schemas, name)
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

Fixes a bypass of the MCP `client.tools({ schemas })` allowlist. The allowlist check used the `in` operator (`name in schemas`), which also matches inherited `Object.prototype` properties. Because tool names come from the (potentially untrusted) MCP server's `tools/list` response, a server could advertise a tool named `constructor`, `toString`, `__proto__`, `valueOf`, etc. and have it pass the allowlist even though the developer never defined it in `schemas`. The tool was then exposed to the model and executable via `tools/call`.

The fix switches the check to `Object.hasOwn(schemas, name)`, so only explicitly defined tools pass.

```diff
-      if (schemas !== 'automatic' && !(name in schemas)) {
+      if (schemas !== 'automatic' && !Object.hasOwn(schemas, name)) {
         continue;
       }
```

## Test

Adds a regression test that advertises tools named `constructor`, `toString`, and `__proto__` alongside an explicitly allowed tool and asserts only the allowed tool is returned. The test fails on the previous `in`-based check and passes with `Object.hasOwn`.

Internal ref: VULN-11352