### PR TITLE
Backport: fix(mcp): prevent prototype-named tools from bypassing the schemas allowlist

### DIFF
--- a/.changeset/mcp-schemas-allowlist-own-property.md
+++ b/.changeset/mcp-schemas-allowlist-own-property.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): prevent prototype-named tools from bypassing the `schemas` allowlist
+
+When using `client.tools({ schemas })` to expose only an explicitly allowed
+subset of an MCP server's tools, the allowlist check used the `in` operator,
+which also matches inherited `Object.prototype` properties. A server-advertised
+tool named `constructor`, `toString`, `__proto__`, etc. would pass the check
+even though the developer never defined it in `schemas`, and was then exposed to
+the model and executable. The check now uses `Object.hasOwn`, so only
+explicitly defined tools are returned.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -335,9 +335,13 @@ describe('MCPClient', () => {
     });
 
     expect(Object.keys(tools)).toEqual(['allowed-tool']);
-    expect(Object.hasOwn(tools, 'constructor')).toBe(false);
-    expect(Object.hasOwn(tools, 'toString')).toBe(false);
-    expect(Object.hasOwn(tools, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(tools, 'constructor')).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(tools, 'toString')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(tools, '__proto__')).toBe(
+      false,
+    );
   });
 
   it('should error when calling tool with misconfigured parameters', async () => {

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -293,6 +293,53 @@ describe('MCPClient', () => {
     expect(tools).not.toHaveProperty('nonexistent-tool');
   });
 
+  it('should not return server tools named after Object.prototype properties unless explicitly allowed', async () => {
+    const mockTransport = new MockMCPTransport({
+      overrideTools: [
+        {
+          name: 'allowed-tool',
+          description: 'An explicitly allowed tool',
+          inputSchema: {
+            type: 'object',
+            properties: { foo: { type: 'string' } },
+          },
+        },
+        {
+          name: 'constructor',
+          description: 'Tool named after an inherited prototype property',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: 'toString',
+          description: 'Tool named after an inherited prototype property',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: '__proto__',
+          description: 'Tool named after an inherited prototype property',
+          inputSchema: { type: 'object' },
+        },
+      ],
+    });
+
+    client = await createMCPClient({
+      transport: mockTransport,
+    });
+
+    const tools = await client.tools({
+      schemas: {
+        'allowed-tool': {
+          inputSchema: z.object({ foo: z.string() }),
+        },
+      },
+    });
+
+    expect(Object.keys(tools)).toEqual(['allowed-tool']);
+    expect(Object.hasOwn(tools, 'constructor')).toBe(false);
+    expect(Object.hasOwn(tools, 'toString')).toBe(false);
+    expect(Object.hasOwn(tools, '__proto__')).toBe(false);
+  });
+
   it('should error when calling tool with misconfigured parameters', async () => {
     createMockTransport.mockImplementation(
       () =>

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -498,7 +498,10 @@ class DefaultMCPClient implements MCPClient {
       const listToolsResult = await this.listTools();
 
       for (const { name, description, inputSchema } of listToolsResult.tools) {
-        if (schemas !== 'automatic' && !Object.hasOwn(schemas, name)) {
+        if (
+          schemas !== 'automatic' &&
+          !Object.prototype.hasOwnProperty.call(schemas, name)
+        ) {
           continue;
         }
 

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -498,7 +498,7 @@ class DefaultMCPClient implements MCPClient {
       const listToolsResult = await this.listTools();
 
       for (const { name, description, inputSchema } of listToolsResult.tools) {
-        if (schemas !== 'automatic' && !(name in schemas)) {
+        if (schemas !== 'automatic' && !Object.hasOwn(schemas, name)) {
           continue;
         }
 


### PR DESCRIPTION
Backport of #16035 to `release-v5.0`.

## Summary

Fixes a bypass of the MCP `client.tools({ schemas })` allowlist. The allowlist check used `name in schemas`, which also matches inherited `Object.prototype` properties. An untrusted MCP server could advertise a tool named `constructor`, `toString`, `__proto__`, etc. to pass the allowlist even when the developer never defined it in `schemas`; the tool was then exposed to the model and executable. The check now uses `Object.hasOwn`.

Includes a regression test. Internal ref: VULN-11352