### PR TITLE
Backport: fix(providers): only send credentials to same-origin response-supplied URLs

### DIFF
--- a/.changeset/provider-api-key-same-origin.md
+++ b/.changeset/provider-api-key-same-origin.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/black-forest-labs': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/google': patch
+---
+
+fix: only send provider credentials to same-origin response-supplied URLs
+
+Several provider clients followed a URL taken from the provider's API response (a polling/status URL or a final media URL such as `polling_url`, `urls.get`, `result_url`, `result.sample`, or `video.uri`) and reused the authenticated headers — or appended `?key=<API_KEY>` — on that request. Because the host of the response-supplied URL was never validated, the long-lived API key was sent to whatever host the response named (a CDN in the benign case, or an attacker-chosen host if the provider response was tampered with), allowing credential exfiltration.
+
+A new `isSameOrigin` helper is added to `@ai-sdk/provider-utils`, and the affected fetches in `@ai-sdk/black-forest-labs`, `@ai-sdk/fireworks`, `@ai-sdk/replicate`, `@ai-sdk/gladia`, `@ai-sdk/fal`, and `@ai-sdk/google` now attach credentials only when the followed URL is same-origin with the provider's configured API origin. Requests to a foreign origin are made without the credential.

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -71,6 +71,38 @@ describe('BlackForestLabsImageModel', () => {
         body: Buffer.from('test-binary-content'),
       },
     },
+    'https://cdn.evil.example/image.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+      },
+    },
+    'https://api.bfl.ai/v1/test-model': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.us1.bfl.ai/v1/get_result',
+        },
+      },
+    },
+    'https://api.us1.bfl.ai/v1/get_result': {
+      response: {
+        type: 'json-value',
+        body: {
+          status: 'Ready',
+          result: {
+            sample: 'https://delivery-us1.bfl.ai/image.png',
+          },
+        },
+      },
+    },
+    'https://delivery-us1.bfl.ai/image.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+      },
+    },
   });
 
   describe('doGenerate', () => {
@@ -304,6 +336,59 @@ describe('BlackForestLabsImageModel', () => {
       expect(server.calls[2].requestUrl).toBe(
         'https://api.example.com/image.png',
       );
+    });
+
+    it('does not send the API key when the result URL is on a foreign origin', async () => {
+      server.urls['https://api.example.com/poll'].response = {
+        type: 'json-value',
+        body: {
+          status: 'Ready',
+          result: { sample: 'https://cdn.evil.example/image.png' },
+        },
+      };
+
+      const model = createBasicModel();
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const downloadCall = server.calls.find(
+        call => call.requestUrl === 'https://cdn.evil.example/image.png',
+      );
+      expect(downloadCall).toBeDefined();
+      expect(downloadCall!.requestHeaders['x-key']).toBeUndefined();
+    });
+
+    it('sends the API key when the polling URL is on a sibling bfl.ai cluster host', async () => {
+      const model = new BlackForestLabsImageModel('test-model', {
+        provider: 'black-forest-labs.image',
+        baseURL: 'https://api.bfl.ai/v1',
+        headers: () => ({ 'x-key': 'test-key' }),
+      });
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const pollCall = server.calls.find(call =>
+        call.requestUrl.startsWith('https://api.us1.bfl.ai/v1/get_result'),
+      );
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['x-key']).toBe('test-key');
     });
 
     it('merges provider and request headers for submit call', async () => {

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -7,6 +7,7 @@ import {
   createStatusCodeErrorResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   lazySchema,
   parseProviderOptions,
   postJsonToApi,
@@ -226,7 +227,12 @@ export class BlackForestLabsImageModel implements ImageModelV3 {
 
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
-      headers: combinedHeaders,
+      // Only send credentials if the response-supplied URL points back at the
+      // provider; the image is typically delivered from a CDN, so the API key
+      // must not travel to a foreign host.
+      headers: isTrustedUrl(imageUrl, this.config.baseURL)
+        ? combinedHeaders
+        : undefined,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),
@@ -305,7 +311,11 @@ export class BlackForestLabsImageModel implements ImageModelV3 {
     for (let i = 0; i < maxPollAttempts; i++) {
       const { value } = await getFromApi({
         url: url.toString(),
-        headers,
+        // The polling URL comes from the provider response; only send
+        // credentials when it stays on a trusted provider host.
+        headers: isTrustedUrl(url.toString(), this.config.baseURL)
+          ? headers
+          : undefined,
         failedResponseHandler: bflFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(bflPollSchema),
         abortSignal,
@@ -335,6 +345,29 @@ export class BlackForestLabsImageModel implements ImageModelV3 {
     }
 
     throw new Error('Black Forest Labs generation timed out.');
+  }
+}
+
+/**
+ * Black Forest Labs returns response-supplied URLs (polling and delivery) on
+ * sibling cluster hosts of the API origin (e.g. `api.us1.bfl.ai` for a base
+ * URL on `api.bfl.ai`), so a strict same-origin check against the configured
+ * base URL is not enough. Credentials may also be sent to any https host under
+ * the official `bfl.ai` domain.
+ */
+function isTrustedUrl(url: string, baseUrl: string): boolean {
+  if (isSameOrigin(url, baseUrl)) {
+    return true;
+  }
+
+  try {
+    const { protocol, hostname } = new URL(url);
+    return (
+      protocol === 'https:' &&
+      (hostname === 'bfl.ai' || hostname.endsWith('.bfl.ai'))
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/packages/fal/src/fal-video-model.test.ts
+++ b/packages/fal/src/fal-video-model.test.ts
@@ -81,6 +81,17 @@ describe('FalVideoModel', () => {
         },
       },
     },
+    'https://evil.fal.example/requests/forged': {
+      response: {
+        type: 'json-value',
+        body: {
+          video: {
+            url: 'https://fal.media/files/video-output.mp4',
+            content_type: 'video/mp4',
+          },
+        },
+      },
+    },
     'https://queue.fal.run/fal-ai/luma-ray-2/requests/ray2-request-id': {
       response: {
         type: 'json-value',
@@ -188,6 +199,25 @@ describe('FalVideoModel', () => {
         'custom-provider-header': 'provider-header-value',
         'custom-request-header': 'request-header-value',
       });
+    });
+
+    it('does not send the API key when the status URL is on a foreign origin', async () => {
+      const forgedUrl = 'https://evil.fal.example/requests/forged';
+      server.urls['https://queue.fal.run/fal-ai/luma-dream-machine'].response =
+        {
+          type: 'json-value',
+          body: {
+            request_id: 'test-request-id-123',
+            response_url: forgedUrl,
+          },
+        };
+
+      const model = createBasicModel();
+      await model.doGenerate({ ...defaultOptions });
+
+      const pollCall = server.calls.find(call => call.requestUrl === forgedUrl);
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['api-key']).toBeUndefined();
     });
 
     it('should return video with correct data', async () => {

--- a/packages/fal/src/fal-video-model.ts
+++ b/packages/fal/src/fal-video-model.ts
@@ -10,6 +10,7 @@ import {
   createJsonResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   lazySchema,
   parseProviderOptions,
   postJsonToApi,
@@ -153,11 +154,12 @@ export class FalVideoModel implements Experimental_VideoModelV3 {
       }
     }
 
+    const submitUrl = this.config.url({
+      path: `https://queue.fal.run/fal-ai/${this.normalizedModelId}`,
+      modelId: this.modelId,
+    });
     const { value: queueResponse } = await postJsonToApi({
-      url: this.config.url({
-        path: `https://queue.fal.run/fal-ai/${this.normalizedModelId}`,
-        modelId: this.modelId,
-      }),
+      url: submitUrl,
       headers: combineHeaders(this.config.headers(), options.headers),
       body,
       failedResponseHandler: falFailedResponseHandler,
@@ -183,13 +185,18 @@ export class FalVideoModel implements Experimental_VideoModelV3 {
 
     while (true) {
       try {
+        const statusUrl = this.config.url({
+          path: responseUrl,
+          modelId: this.modelId,
+        });
         const { value: statusResponse, responseHeaders: statusHeaders } =
           await getFromApi({
-            url: this.config.url({
-              path: responseUrl,
-              modelId: this.modelId,
-            }),
-            headers: combineHeaders(this.config.headers(), options.headers),
+            url: statusUrl,
+            // The status URL comes from the queue response; only send
+            // credentials when it stays on the provider's own origin.
+            headers: isSameOrigin(statusUrl, submitUrl)
+              ? combineHeaders(this.config.headers(), options.headers)
+              : undefined,
             failedResponseHandler: async ({
               response,
               url,

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -761,8 +761,10 @@ describe('FireworksImageModel', () => {
         id: 'test-request-123',
       });
 
-      // Verify image download
+      // Verify image download — the result URL is on a foreign origin
+      // (example.com), so the API key must not be sent with the download.
       expect(server.calls[2].requestUrl).toBe('https://example.com/image.png');
+      expect(server.calls[2].requestHeaders['api-key']).toBeUndefined();
 
       // Verify result
       expect(result.images).toHaveLength(1);

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -7,6 +7,7 @@ import {
   createStatusCodeErrorResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   postJsonToApi,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
@@ -269,10 +270,15 @@ export class FireworksImageModel implements ImageModelV3 {
       abortSignal,
     });
 
-    // Download the image from the URL
+    // Download the image from the URL. The URL comes from the provider
+    // response and typically points at a CDN, so only send credentials when it
+    // stays on the provider's own origin (never leak the API key to a CDN or an
+    // attacker-named host).
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
-      headers,
+      headers: isSameOrigin(imageUrl, this.config.baseURL)
+        ? headers
+        : undefined,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),

--- a/packages/gladia/src/gladia-transcription-model.test.ts
+++ b/packages/gladia/src/gladia-transcription-model.test.ts
@@ -33,6 +33,7 @@ const server = createTestServer({
   },
   'https://api.gladia.io/v2/pre-recorded': {},
   [initiateFixture.result_url]: {},
+  'https://cdn.evil.example/v2/pre-recorded/result': {},
 });
 
 function prepareJsonFixtureResponse(headers?: Record<string, string>) {
@@ -61,6 +62,30 @@ describe('doGenerate', () => {
       expect(await server.calls[1].requestBodyJson).toMatchObject({
         audio_url: uploadFixture.audio_url,
       });
+    });
+
+    it('does not send the API key when the result URL is on a foreign origin', async () => {
+      const foreignResultUrl =
+        'https://cdn.evil.example/v2/pre-recorded/result';
+      server.urls['https://api.gladia.io/v2/pre-recorded'].response = {
+        type: 'json-value',
+        body: { ...initiateFixture, result_url: foreignResultUrl },
+      };
+      server.urls[foreignResultUrl].response = {
+        type: 'json-value',
+        body: resultFixture,
+      };
+
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      const pollCall = server.calls.find(
+        call => call.requestUrl === foreignResultUrl,
+      );
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['x-gladia-key']).toBeUndefined();
     });
 
     it('should pass headers', async () => {

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -10,6 +10,7 @@ import {
   mediaTypeToExtension,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postFormDataToApi,
   postJsonToApi,
@@ -540,8 +541,11 @@ export class GladiaTranscriptionModel implements TranscriptionModelV3 {
       fetch: this.config.fetch,
     });
 
-    // Poll the result URL until the transcription is done or an error occurs
+    // Poll the result URL until the transcription is done or an error occurs.
+    // The result URL comes from the provider response; only send credentials
+    // when it stays on the provider's own origin.
     const resultUrl = transcriptionInitResponse.result_url;
+    const apiOrigin = this.config.url({ modelId: 'default', path: '' });
     let transcriptionResult;
     let transcriptionResultHeaders;
     const timeoutMs = 60 * 1000; // 60 seconds timeout
@@ -560,7 +564,9 @@ export class GladiaTranscriptionModel implements TranscriptionModelV3 {
 
       const response = await getFromApi({
         url: resultUrl,
-        headers: combineHeaders(this.config.headers(), options.headers),
+        headers: isSameOrigin(resultUrl, apiOrigin)
+          ? combineHeaders(this.config.headers(), options.headers)
+          : undefined,
         failedResponseHandler: gladiaFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(
           gladiaTranscriptionResultResponseSchema,

--- a/packages/google/src/google-generative-ai-video-model.test.ts
+++ b/packages/google/src/google-generative-ai-video-model.test.ts
@@ -317,6 +317,23 @@ describe('GoogleGenerativeAIVideoModel', () => {
       });
     });
 
+    it('should NOT append the API key when the download URL is on a foreign origin', async () => {
+      const model = createMockModel({
+        apiKey: 'test-api-key',
+        videos: [{ video: { uri: 'https://cdn.evil.example/video-123.mp4' } }],
+      });
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      // The key must not travel to a host the provider response named: the URL
+      // is returned verbatim, without the `?key=` credential appended.
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://cdn.evil.example/video-123.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+
     it('should return multiple videos', async () => {
       const model = createMockModel({
         apiKey: 'test-key',

--- a/packages/google/src/google-generative-ai-video-model.ts
+++ b/packages/google/src/google-generative-ai-video-model.ts
@@ -10,6 +10,7 @@ import {
   delay,
   type FetchFunction,
   getFromApi,
+  isSameOrigin,
   lazySchema,
   parseProviderOptions,
   postJsonToApi,
@@ -279,10 +280,13 @@ export class GoogleGenerativeAIVideoModel implements Experimental_VideoModelV3 {
     for (const generatedSample of response.generateVideoResponse
       .generatedSamples) {
       if (generatedSample.video?.uri) {
-        // Append API key to URL for authentication during download
-        const urlWithAuth = apiKey
-          ? `${generatedSample.video.uri}${generatedSample.video.uri.includes('?') ? '&' : '?'}key=${apiKey}`
-          : generatedSample.video.uri;
+        // Append the API key to the download URL for authentication, but only
+        // when the response-supplied URI stays on the provider's own origin —
+        // otherwise the key would leak to whatever host the response names.
+        const urlWithAuth =
+          apiKey && isSameOrigin(generatedSample.video.uri, this.config.baseURL)
+            ? `${generatedSample.video.uri}${generatedSample.video.uri.includes('?') ? '&' : '?'}key=${apiKey}`
+            : generatedSample.video.uri;
 
         videos.push({
           type: 'url',

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -23,6 +23,7 @@ export { getRuntimeEnvironmentUserAgent } from './get-runtime-environment-user-a
 export { injectJsonInstructionIntoMessages } from './inject-json-instruction';
 export * from './is-abort-error';
 export { isNonNullable } from './is-non-nullable';
+export { isSameOrigin } from './is-same-origin';
 export { isUrlSupported } from './is-url-supported';
 export * from './load-api-key';
 export { loadOptionalSetting } from './load-optional-setting';

--- a/packages/provider-utils/src/is-same-origin.test.ts
+++ b/packages/provider-utils/src/is-same-origin.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { isSameOrigin } from './is-same-origin';
+
+describe('isSameOrigin', () => {
+  it('returns true for identical origins (ignoring path/query)', () => {
+    expect(
+      isSameOrigin(
+        'https://api.example.com/v1/file',
+        'https://api.example.com',
+      ),
+    ).toBe(true);
+    expect(
+      isSameOrigin(
+        'https://api.example.com/a?x=1',
+        'https://api.example.com/b',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a different host', () => {
+    expect(
+      isSameOrigin('https://cdn.evil.com/file', 'https://api.example.com'),
+    ).toBe(false);
+  });
+
+  it('returns false for a different scheme or port', () => {
+    expect(
+      isSameOrigin('http://api.example.com/file', 'https://api.example.com'),
+    ).toBe(false);
+    expect(
+      isSameOrigin(
+        'https://api.example.com:8443/file',
+        'https://api.example.com',
+      ),
+    ).toBe(false);
+  });
+
+  it('fails closed on invalid input', () => {
+    expect(isSameOrigin('not-a-url', 'https://api.example.com')).toBe(false);
+    expect(isSameOrigin('https://api.example.com/file', 'not-a-url')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/provider-utils/src/is-same-origin.ts
+++ b/packages/provider-utils/src/is-same-origin.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns true when `url` has the same origin (scheme + host + port) as
+ * `baseUrl`.
+ *
+ * Used to decide whether provider credentials may be attached to a request to a
+ * URL taken from a provider response (e.g. a polling or media-download URL).
+ * Credentials must only be sent to the provider's own origin; a response that
+ * names a foreign host (a CDN, or an attacker-controlled host if the response
+ * is tampered with) must not receive the API key.
+ *
+ * Returns false if either value is not a valid absolute URL (fail-closed).
+ */
+export function isSameOrigin(url: string, baseUrl: string): boolean {
+  try {
+    return new URL(url).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
+  }
+}

--- a/packages/replicate/src/replicate-video-model.test.ts
+++ b/packages/replicate/src/replicate-video-model.test.ts
@@ -157,6 +157,55 @@ describe('ReplicateVideoModel', () => {
   });
 
   describe('doGenerate', () => {
+    it('does not send the API key when the poll URL is on a foreign origin', async () => {
+      const foreignUrl = 'https://evil.replicate.example/v1/predictions/forged';
+      const headersByUrl: Record<string, Record<string, string>> = {};
+
+      const model = new ReplicateVideoModel('minimax/video-01', {
+        provider: 'replicate.video',
+        baseURL: 'https://api.replicate.com/v1',
+        headers: () => ({ Authorization: 'Bearer test-api-token' }),
+        fetch: async (url, init) => {
+          const urlString = url.toString();
+          headersByUrl[urlString] =
+            (init?.headers as Record<string, string>) ?? {};
+
+          // Initial create-prediction POST returns a forged, foreign poll URL.
+          if (init?.method !== 'GET' && urlString !== foreignUrl) {
+            return new Response(
+              JSON.stringify({
+                id: 'forged',
+                status: 'starting',
+                output: null,
+                error: null,
+                urls: { get: foreignUrl },
+                metrics: null,
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+
+          // Poll on the foreign URL resolves immediately.
+          return new Response(
+            JSON.stringify({
+              id: 'forged',
+              status: 'succeeded',
+              output: 'https://replicate.delivery/video.mp4',
+              error: null,
+              urls: { get: foreignUrl },
+              metrics: { predict_time: 1 },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        },
+      });
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(headersByUrl[foreignUrl]).toBeDefined();
+      expect(headersByUrl[foreignUrl].Authorization).toBeUndefined();
+    });
+
     it('should pass the correct parameters including prompt', async () => {
       let capturedBody: unknown;
       const model = createMockModel({

--- a/packages/replicate/src/replicate-video-model.ts
+++ b/packages/replicate/src/replicate-video-model.ts
@@ -10,6 +10,7 @@ import {
   delay,
   type FetchFunction,
   getFromApi,
+  isSameOrigin,
   lazySchema,
   parseProviderOptions,
   postJsonToApi,
@@ -239,9 +240,14 @@ export class ReplicateVideoModel implements Experimental_VideoModelV3 {
           });
         }
 
+        const pollUrl = finalPrediction.urls.get;
         const { value: statusPrediction } = await getFromApi({
-          url: finalPrediction.urls.get,
-          headers: await resolve(this.config.headers),
+          url: pollUrl,
+          // The polling URL comes from the provider response; only send
+          // credentials when it stays on the provider's own origin.
+          headers: isSameOrigin(pollUrl, this.config.baseURL)
+            ? await resolve(this.config.headers)
+            : undefined,
           successfulResponseHandler: createJsonResponseHandler(
             replicatePredictionSchema,
           ),


### PR DESCRIPTION
Backport of #15989 to **release-v6.0** (VULN-11567 / ANT-2026-FX163E39).

Adds `isSameOrigin` to `@ai-sdk/provider-utils` and gates response-supplied follow-up fetches so the provider credential is attached **only when the followed URL is same-origin** with the provider's configured API origin.

## Providers gated (all present on v6)
- `black-forest-labs` — poll (`polling_url`) + image download (`result.sample`); uses `isTrustedUrl` to additionally allow sibling `*.bfl.ai` hosts.
- `fireworks` — image download (`result.sample`).
- `replicate` — video poll (`urls.get`).
- `gladia` — transcription poll (`result_url`).
- `fal` — video status poll (`response_url`).
- `google` — video download `?key=` on `google-generative-ai-video-model.ts` (`video.uri`).

## Resolution notes
Cherry-pick conflicted because v6's providers diverge from main (`this.config.headers()` vs `headers?.()`, `lazySchema` options, and the Google model is named `google-generative-ai-video-model.ts`). I re-applied the gate to each v6 source file by hand; the `is-same-origin` helper + per-provider foreign-origin regression tests came from the cherry-pick unchanged.

## Validation
All affected suites pass locally on the v6 branch (node): provider-utils `is-same-origin` (4), black-forest-labs (22), fal (31), fireworks (28), gladia (7), replicate (35), google (27). Type-check clean for all seven packages.

Related: #15989 (main). A release-v5.0 backport (3 applicable providers) will follow. Linear: VULN-11567.