### PR TITLE
Backport: fix(providers): only send credentials to same-origin response-supplied URLs

### DIFF
--- a/.changeset/provider-api-key-same-origin.md
+++ b/.changeset/provider-api-key-same-origin.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/black-forest-labs': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/google': patch
+---
+
+fix: only send provider credentials to same-origin response-supplied URLs
+
+Several provider clients followed a URL taken from the provider's API response (a polling/status URL or a final media URL such as `polling_url`, `urls.get`, `result_url`, `result.sample`, or `video.uri`) and reused the authenticated headers — or appended `?key=<API_KEY>` — on that request. Because the host of the response-supplied URL was never validated, the long-lived API key was sent to whatever host the response named (a CDN in the benign case, or an attacker-chosen host if the provider response was tampered with), allowing credential exfiltration.
+
+A new `isSameOrigin` helper is added to `@ai-sdk/provider-utils`, and the affected fetches in `@ai-sdk/black-forest-labs`, `@ai-sdk/fireworks`, `@ai-sdk/replicate`, `@ai-sdk/gladia`, `@ai-sdk/fal`, and `@ai-sdk/google` now attach credentials only when the followed URL is same-origin with the provider's configured API origin. Requests to a foreign origin are made without the credential.

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -59,6 +59,38 @@ describe('BlackForestLabsImageModel', () => {
         body: Buffer.from('test-binary-content'),
       },
     },
+    'https://cdn.evil.example/image.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+      },
+    },
+    'https://api.bfl.ai/v1/test-model': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.us1.bfl.ai/v1/get_result',
+        },
+      },
+    },
+    'https://api.us1.bfl.ai/v1/get_result': {
+      response: {
+        type: 'json-value',
+        body: {
+          status: 'Ready',
+          result: {
+            sample: 'https://delivery-us1.bfl.ai/image.png',
+          },
+        },
+      },
+    },
+    'https://delivery-us1.bfl.ai/image.png': {
+      response: {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+      },
+    },
   });
 
   describe('doGenerate', () => {
@@ -221,6 +253,55 @@ describe('BlackForestLabsImageModel', () => {
       expect(server.calls[2].requestUrl).toBe(
         'https://api.example.com/image.png',
       );
+    });
+
+    it('does not send the API key when the result URL is on a foreign origin', async () => {
+      server.urls['https://api.example.com/poll'].response = {
+        type: 'json-value',
+        body: {
+          status: 'Ready',
+          result: { sample: 'https://cdn.evil.example/image.png' },
+        },
+      };
+
+      const model = createBasicModel();
+      await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const downloadCall = server.calls.find(
+        call => call.requestUrl === 'https://cdn.evil.example/image.png',
+      );
+      expect(downloadCall).toBeDefined();
+      expect(downloadCall!.requestHeaders['x-key']).toBeUndefined();
+    });
+
+    it('sends the API key when the polling URL is on a sibling bfl.ai cluster host', async () => {
+      const model = new BlackForestLabsImageModel('test-model', {
+        provider: 'black-forest-labs.image',
+        baseURL: 'https://api.bfl.ai/v1',
+        headers: () => ({ 'x-key': 'test-key' }),
+      });
+
+      await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const pollCall = server.calls.find(call =>
+        call.requestUrl.startsWith('https://api.us1.bfl.ai/v1/get_result'),
+      );
+      expect(pollCall).toBeDefined();
+      expect(pollCall!.requestHeaders['x-key']).toBe('test-key');
     });
 
     it('merges provider and request headers for submit call', async () => {

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -10,6 +10,7 @@ import {
   createStatusCodeErrorResponseHandler,
   delay,
   getFromApi,
+  isSameOrigin,
   lazySchema,
   parseProviderOptions,
   postJsonToApi,
@@ -189,7 +190,12 @@ export class BlackForestLabsImageModel implements ImageModelV2 {
 
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
-      headers: combinedHeaders,
+      // Only send credentials if the response-supplied URL points back at the
+      // provider; the image is typically delivered from a CDN, so the API key
+      // must not travel to a foreign host.
+      headers: isTrustedUrl(imageUrl, this.config.baseURL)
+        ? combinedHeaders
+        : undefined,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),
@@ -268,7 +274,11 @@ export class BlackForestLabsImageModel implements ImageModelV2 {
     for (let i = 0; i < maxPollAttempts; i++) {
       const { value } = await getFromApi({
         url: url.toString(),
-        headers,
+        // The polling URL comes from the provider response; only send
+        // credentials when it stays on a trusted provider host.
+        headers: isTrustedUrl(url.toString(), this.config.baseURL)
+          ? headers
+          : undefined,
         failedResponseHandler: bflFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(bflPollSchema),
         abortSignal,
@@ -298,6 +308,29 @@ export class BlackForestLabsImageModel implements ImageModelV2 {
     }
 
     throw new Error('Black Forest Labs generation timed out.');
+  }
+}
+
+/**
+ * Black Forest Labs returns response-supplied URLs (polling and delivery) on
+ * sibling cluster hosts of the API origin (e.g. `api.us1.bfl.ai` for a base
+ * URL on `api.bfl.ai`), so a strict same-origin check against the configured
+ * base URL is not enough. Credentials may also be sent to any https host under
+ * the official `bfl.ai` domain.
+ */
+function isTrustedUrl(url: string, baseUrl: string): boolean {
+  if (isSameOrigin(url, baseUrl)) {
+    return true;
+  }
+
+  try {
+    const { protocol, hostname } = new URL(url);
+    return (
+      protocol === 'https:' &&
+      (hostname === 'bfl.ai' || hostname.endsWith('.bfl.ai'))
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -10,6 +10,7 @@ import {
   mediaTypeToExtension,
   delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postFormDataToApi,
   postJsonToApi,
@@ -540,8 +541,11 @@ export class GladiaTranscriptionModel implements TranscriptionModelV2 {
       fetch: this.config.fetch,
     });
 
-    // Poll the result URL until the transcription is done or an error occurs
+    // Poll the result URL until the transcription is done or an error occurs.
+    // The result URL comes from the provider response; only send credentials
+    // when it stays on the provider's own origin.
     const resultUrl = transcriptionInitResponse.result_url;
+    const apiOrigin = this.config.url({ modelId: 'default', path: '' });
     let transcriptionResult;
     let transcriptionResultHeaders;
     const timeoutMs = 60 * 1000; // 60 seconds timeout
@@ -560,7 +564,9 @@ export class GladiaTranscriptionModel implements TranscriptionModelV2 {
 
       const response = await getFromApi({
         url: resultUrl,
-        headers: combineHeaders(this.config.headers(), options.headers),
+        headers: isSameOrigin(resultUrl, apiOrigin)
+          ? combineHeaders(this.config.headers(), options.headers)
+          : undefined,
         failedResponseHandler: gladiaFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(
           gladiaTranscriptionResultResponseSchema,

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -15,6 +15,7 @@ export * from './get-from-api';
 export { getRuntimeEnvironmentUserAgent } from './get-runtime-environment-user-agent';
 export { injectJsonInstructionIntoMessages } from './inject-json-instruction';
 export * from './is-abort-error';
+export { isSameOrigin } from './is-same-origin';
 export { isUrlSupported } from './is-url-supported';
 export * from './load-api-key';
 export { loadOptionalSetting } from './load-optional-setting';

--- a/packages/provider-utils/src/is-same-origin.test.ts
+++ b/packages/provider-utils/src/is-same-origin.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { isSameOrigin } from './is-same-origin';
+
+describe('isSameOrigin', () => {
+  it('returns true for identical origins (ignoring path/query)', () => {
+    expect(
+      isSameOrigin(
+        'https://api.example.com/v1/file',
+        'https://api.example.com',
+      ),
+    ).toBe(true);
+    expect(
+      isSameOrigin(
+        'https://api.example.com/a?x=1',
+        'https://api.example.com/b',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a different host', () => {
+    expect(
+      isSameOrigin('https://cdn.evil.com/file', 'https://api.example.com'),
+    ).toBe(false);
+  });
+
+  it('returns false for a different scheme or port', () => {
+    expect(
+      isSameOrigin('http://api.example.com/file', 'https://api.example.com'),
+    ).toBe(false);
+    expect(
+      isSameOrigin(
+        'https://api.example.com:8443/file',
+        'https://api.example.com',
+      ),
+    ).toBe(false);
+  });
+
+  it('fails closed on invalid input', () => {
+    expect(isSameOrigin('not-a-url', 'https://api.example.com')).toBe(false);
+    expect(isSameOrigin('https://api.example.com/file', 'not-a-url')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/provider-utils/src/is-same-origin.ts
+++ b/packages/provider-utils/src/is-same-origin.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns true when `url` has the same origin (scheme + host + port) as
+ * `baseUrl`.
+ *
+ * Used to decide whether provider credentials may be attached to a request to a
+ * URL taken from a provider response (e.g. a polling or media-download URL).
+ * Credentials must only be sent to the provider's own origin; a response that
+ * names a foreign host (a CDN, or an attacker-controlled host if the response
+ * is tampered with) must not receive the API key.
+ *
+ * Returns false if either value is not a valid absolute URL (fail-closed).
+ */
+export function isSameOrigin(url: string, baseUrl: string): boolean {
+  try {
+    return new URL(url).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Backport of #15989 to **release-v5.0** (VULN-11567 / ANT-2026-FX163E39).

Adds `isSameOrigin` to `@ai-sdk/provider-utils` and gates response-supplied follow-up fetches so the provider credential is attached **only when the followed URL is same-origin** with the provider's configured API origin.

## Applicable scope on v5.0
Only the providers that exist on release-v5.0 are gated:
- `black-forest-labs` — poll (`polling_url`) + image download (`result.sample`); uses `isTrustedUrl` to also allow sibling `*.bfl.ai` hosts.
- `gladia` — transcription poll (`result_url`).

**Not applicable on v5.0** (omitted): `@ai-sdk/fal` video, `@ai-sdk/replicate` video, and `@ai-sdk/google` video models don't exist on this branch; and `@ai-sdk/fireworks` on v5 has no async `result.sample` download path (no `getFromApi` follow-up fetch), so there's nothing to gate there.

## Resolution notes
Hand-resolved the cherry-pick: dropped the absent provider files, re-applied the BFL/gladia gates to v5's source (which uses `this.config.headers()`), added the `isSameOrigin` export, and adjusted the BFL foreign-origin regression test to v5's `ImageModelV2CallOptions` (no `files`/`mask`). The gladia/fireworks per-provider regression tests were left as v5's existing suites (the gate is covered by the BFL regression test + the `isSameOrigin` unit tests).

## Validation
Passes on the v5 branch in **node and edge**: provider-utils `is-same-origin` (4), black-forest-labs (20), gladia (5); fireworks unchanged (14). Type-check clean for all four packages.

Related: #15989 (main), #16038 (release-v6.0 backport). Linear: VULN-11567.