### PR TITLE
fix(google): prevent prototype pollution when streaming tool args

### DIFF
--- a/.changeset/green-laws-grab.md
+++ b/.changeset/green-laws-grab.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): prevent prototype pollution when streaming tool args

--- a/packages/google/src/google-json-accumulator.test.ts
+++ b/packages/google/src/google-json-accumulator.test.ts
@@ -219,6 +219,69 @@ describe('GoogleJSONAccumulator', () => {
     });
   });
 
+  describe('prototype pollution protection', () => {
+    it('should not pollute Object.prototype through __proto__ path segments', () => {
+      const pollutedKey = 'pollutedByGoogleAccumulatorTest';
+      const objectPrototype = Object.prototype as Record<string, unknown>;
+      delete objectPrototype[pollutedKey];
+
+      try {
+        const accumulator = new GoogleJSONAccumulator();
+        const result = accumulator.processPartialArgs([
+          {
+            jsonPath: `$.__proto__.${pollutedKey}`,
+            stringValue: 'true',
+          },
+        ]);
+
+        expect(objectPrototype[pollutedKey]).toBeUndefined();
+        const protoDescriptor = Object.getOwnPropertyDescriptor(
+          result.currentJSON,
+          '__proto__',
+        );
+        expect(protoDescriptor?.value[pollutedKey]).toBe('true');
+        expect(result.currentJSON).toMatchInlineSnapshot(`
+          {
+            "__proto__": {
+              "pollutedByGoogleAccumulatorTest": "true",
+            },
+          }
+        `);
+      } finally {
+        delete objectPrototype[pollutedKey];
+      }
+    });
+
+    it('should not pollute Object.prototype through constructor.prototype path segments', () => {
+      const pollutedKey = 'pollutedByGoogleConstructorTest';
+      const objectPrototype = Object.prototype as Record<string, unknown>;
+      delete objectPrototype[pollutedKey];
+
+      try {
+        const accumulator = new GoogleJSONAccumulator();
+        const result = accumulator.processPartialArgs([
+          {
+            jsonPath: `$.constructor.prototype.${pollutedKey}`,
+            stringValue: 'true',
+          },
+        ]);
+
+        expect(objectPrototype[pollutedKey]).toBeUndefined();
+        expect(result.currentJSON).toMatchInlineSnapshot(`
+          {
+            "constructor": {
+              "prototype": {
+                "pollutedByGoogleConstructorTest": "true",
+              },
+            },
+          }
+        `);
+      } finally {
+        delete objectPrototype[pollutedKey];
+      }
+    });
+  });
+
   describe('nested paths', () => {
     it('should build nested object from dotted jsonPath', () => {
       const accumulator = new GoogleJSONAccumulator();

--- a/packages/google/src/google-json-accumulator.ts
+++ b/packages/google/src/google-json-accumulator.ts
@@ -276,6 +276,35 @@ function parsePath(rawPath: string): Array<string | number> {
   return segments;
 }
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
+/**
+ * Checks only direct properties so path traversal never follows the prototype chain.
+ */
+function hasOwnProperty(
+  obj: Record<string | number, unknown>,
+  key: string | number,
+): boolean {
+  return hasOwn.call(obj, key);
+}
+
+/**
+ * Defines path values as own data properties so special keys like `__proto__`
+ * cannot invoke prototype setters while accumulating streamed arguments.
+ */
+function defineOwnProperty(
+  obj: Record<string | number, unknown>,
+  key: string | number,
+  value: unknown,
+): void {
+  Object.defineProperty(obj, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
 /**
  * Traverses a nested object along the given path segments and returns the leaf value.
  *
@@ -289,7 +318,9 @@ function getNestedValue(
   let current: unknown = obj;
   for (const pathSegment of segments) {
     if (current == null || typeof current !== 'object') return undefined;
-    current = (current as Record<string | number, unknown>)[pathSegment];
+    const currentRecord = current as Record<string | number, unknown>;
+    if (!hasOwnProperty(currentRecord, pathSegment)) return undefined;
+    current = currentRecord[pathSegment];
   }
   return current;
 }
@@ -309,12 +340,16 @@ function setNestedValue(
   for (let i = 0; i < segments.length - 1; i++) {
     const pathSegment = segments[i];
     const nextSeg = segments[i + 1];
-    if (current[pathSegment] == null) {
-      current[pathSegment] = typeof nextSeg === 'number' ? [] : {};
+    if (!hasOwnProperty(current, pathSegment) || current[pathSegment] == null) {
+      defineOwnProperty(
+        current,
+        pathSegment,
+        typeof nextSeg === 'number' ? [] : {},
+      );
     }
     current = current[pathSegment] as Record<string | number, unknown>;
   }
-  current[segments[segments.length - 1]] = value;
+  defineOwnProperty(current, segments[segments.length - 1], value);
 }
 
 /**


### PR DESCRIPTION
## Background

before the change, `jsonPath` segments were used directly with bracket access:
```
current[pathSegment] = value;
```
so if a malicious path was streamed like the following:
```
$.__proto__.isAdmin
```
the code effectively did:
```
current = current['__proto__']; // Object.prototype
current['isAdmin'] = 'true';    // pollutes every object
```
after that, unrelated objects could unexpectedly have the value:
```
({}).isAdmin // "true"
```

PS: the attack vector is only possible if the provider streaming the chunks (in this case, Google) sends malicious chunks - the chances of which are negligible. nevertheless, this is a good guard to have

## Summary

we now only follow own properties, not inherited prototype properties. and when we write a key, we use `Object.defineProperty`, so `__proto__` is stored as a normal json key instead of triggering the prototype setter. the global prototype stays clean

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)