### PR TITLE
fix(devtools): secure devtools viewer api access

### DIFF
--- a/.changeset/nasty-cups-wait.md
+++ b/.changeset/nasty-cups-wait.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/devtools": patch
+---
+
+fix(devtools): secure devtools viewer api access

--- a/packages/devtools/src/viewer/server.test.ts
+++ b/packages/devtools/src/viewer/server.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { app, startViewer } from './server.js';
+
+const { mockOn, mockServe } = vi.hoisted(() => {
+  const mockOn = vi.fn();
+  return {
+    mockOn,
+    mockServe: vi.fn(() => ({ on: mockOn })),
+  };
+});
+
+vi.mock('@hono/node-server', () => ({
+  serve: mockServe,
+}));
+
+vi.mock('../db.js', () => ({
+  getRuns: vi.fn(async () => []),
+  getRunWithSteps: vi.fn(),
+  getStepsForRun: vi.fn(async () => []),
+  clearDatabase: vi.fn(),
+  reloadDb: vi.fn(),
+}));
+
+describe('viewer server security', () => {
+  it('serves API requests from the local viewer without wildcard CORS', async () => {
+    const response = await app.request('http://localhost:4983/api/runs', {
+      headers: {
+        host: 'localhost:4983',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    await expect(response.json()).resolves.toEqual([]);
+  });
+
+  it('rejects cross-origin API requests from other sites', async () => {
+    const response = await app.request('http://localhost:4983/api/runs', {
+      headers: {
+        host: 'localhost:4983',
+        origin: 'https://example.com',
+      },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects API requests for non-local hosts', async () => {
+    const response = await app.request('http://192.0.2.10:4983/api/runs', {
+      headers: {
+        host: '192.0.2.10:4983',
+      },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('binds the viewer to localhost', () => {
+    startViewer();
+
+    expect(mockServe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 4983,
+        hostname: 'localhost',
+      }),
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/devtools/src/viewer/server.ts
+++ b/packages/devtools/src/viewer/server.ts
@@ -1,7 +1,6 @@
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { Hono } from 'hono';
-import { cors } from 'hono/cors';
 import { streamSSE } from 'hono/streaming';
 import path from 'path';
 import fs from 'fs';
@@ -56,11 +55,40 @@ const clientDir = path.join(projectRoot, 'dist/client');
 // Track the DB path from the most recent notify call so all reads
 // use the correct file, even when the viewer runs in a different CWD.
 let remoteDbPath: string | undefined;
+let viewerPort = 4983;
 
-const app = new Hono();
+export const app = new Hono();
 
-// Enable CORS for development
-app.use('/*', cors());
+const getAllowedHosts = () =>
+  new Set([
+    `localhost:${viewerPort}`,
+    `127.0.0.1:${viewerPort}`,
+    `[::1]:${viewerPort}`,
+  ]);
+
+const getAllowedOrigins = () =>
+  new Set([
+    `http://localhost:${viewerPort}`,
+    `http://127.0.0.1:${viewerPort}`,
+    `http://[::1]:${viewerPort}`,
+    'http://localhost:5173',
+    'http://127.0.0.1:5173',
+    'http://[::1]:5173',
+  ]);
+
+app.use('/api/*', async (c, next) => {
+  const host = c.req.header('host');
+  if (!host || !getAllowedHosts().has(host)) {
+    return c.text('Forbidden', 403);
+  }
+
+  const origin = c.req.header('origin');
+  if (origin && !getAllowedOrigins().has(origin)) {
+    return c.text('Forbidden', 403);
+  }
+
+  await next();
+});
 
 // API Routes
 app.get('/api/runs', async c => {
@@ -288,10 +316,13 @@ app.get('*', async c => {
 });
 
 export const startViewer = (port = 4983) => {
+  viewerPort = port;
+
   const server = serve(
     {
       fetch: app.fetch,
       port,
+      hostname: 'localhost',
     },
     () => {
       if (isDevMode) {


### PR DESCRIPTION
## Background

`@ai-sdk/devtools` served its API with wildcard CORS and listened without an explicit hostname. any website could fetch against the api route, and LAN peers could potentially hit the viewer directly if reachable.

## Summary

malicious cross-origin pages and non-local host requests now get 403

## Manual Verification

verified that there was no regression by running the viewer and the example `examples/ai-functions/src/generate-text/anthropic/nested-subagent-with-telemetry.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)