### PR TITLE
Backport: fix(ai): redact server error details from UI message streams by default

### DIFF
--- a/.changeset/ui-message-stream-default-onerror-redacts.md
+++ b/.changeset/ui-message-stream-default-onerror-redacts.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+fix: redact server error details from UI message streams by default
+
+`streamText(...).toUIMessageStream()` and `createUIMessageStream` defaulted their `onError` callback to `getErrorMessage`, which serializes the raw error (`error.toString()` / `JSON.stringify(error)`) into the client-facing `{ type: 'error', errorText }` chunk — and also into `tool-output-error` parts. The documented default was `() => 'An error occurred.'`, so applications relying on the documented behavior were unknowingly streaming server exception details (internal hostnames, paths, provider request data, validation inputs) to end users.
+
+The default `onError` now returns the documented generic `'An error occurred.'`. Raw error details are only emitted when the developer explicitly supplies an `onError` handler. This also redacts `tool-output-error` and invalid-tool-input error text by default; pass an `onError` to surface richer messages.

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -427,7 +427,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error m
   "data: {"type":"start-step"}
 
 ",
-  "data: {"type":"error","errorText":"error"}
+  "data: {"type":"error","errorText":"An error occurred."}
 
 ",
   "data: {"type":"finish-step"}
@@ -572,7 +572,7 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
     "type": "start-step",
   },
   {
-    "errorText": "error",
+    "errorText": "An error occurred.",
     "type": "error",
   },
   {
@@ -661,7 +661,7 @@ exports[`streamText > result.toUIMessageStreamResponse > should mask error messa
   "data: {"type":"start-step"}
 
 ",
-  "data: {"type":"error","errorText":"error"}
+  "data: {"type":"error","errorText":"An error occurred."}
 
 ",
   "data: {"type":"finish-step"}

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -9073,7 +9073,7 @@ describe('streamText', () => {
                 "type": "tool-input-available",
               },
               {
-                "errorText": "ERROR",
+                "errorText": "An error occurred.",
                 "providerExecuted": true,
                 "toolCallId": "call-2",
                 "type": "tool-output-error",
@@ -10196,7 +10196,7 @@ describe('streamText', () => {
               "type": "tool-input-available",
             },
             {
-              "errorText": "test error",
+              "errorText": "An error occurred.",
               "toolCallId": "call-1",
               "type": "tool-output-error",
             },
@@ -13422,17 +13422,7 @@ describe('streamText', () => {
                 "type": "tool-input-delta",
               },
               {
-                "errorText": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
-            Error message: [
-              {
-                "expected": "string",
-                "code": "invalid_type",
-                "path": [
-                  "city"
-                ],
-                "message": "Invalid input: expected string, received undefined"
-              }
-            ]",
+                "errorText": "An error occurred.",
                 "input": {
                   "cities": "San Francisco",
                 },
@@ -13441,17 +13431,7 @@ describe('streamText', () => {
                 "type": "tool-input-error",
               },
               {
-                "errorText": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
-            Error message: [
-              {
-                "expected": "string",
-                "code": "invalid_type",
-                "path": [
-                  "city"
-                ],
-                "message": "Invalid input: expected string, received undefined"
-              }
-            ]",
+                "errorText": "An error occurred.",
                 "toolCallId": "call-1",
                 "type": "tool-output-error",
               },

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1752,7 +1752,7 @@ However, the LLM results are expected to be small enough to not cause issues.
     sendSources = false,
     sendStart = true,
     sendFinish = true,
-    onError = getErrorMessage,
+    onError = () => 'An error occurred.', // prevent leaking server error details to the client by default
   }: UIMessageStreamOptions<UI_MESSAGE> = {}): AsyncIterableStream<
     InferUIMessageChunk<UI_MESSAGE>
   > {

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -1,7 +1,6 @@
 import {
   type IdGenerator,
   generateId as generateIdFunc,
-  getErrorMessage,
 } from '@ai-sdk/provider-utils';
 import type { UIMessage } from '../ui/ui-messages';
 import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
@@ -9,9 +8,22 @@ import type { InferUIMessageChunk } from './ui-message-chunks';
 import type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
 import type { UIMessageStreamWriter } from './ui-message-stream-writer';
 
+/**
+ * Creates a UI message stream that can be used to send messages to the client.
+ *
+ * @param options.execute - A function that is called with a writer to write UI message chunks to the stream.
+ * @param options.onError - A function that extracts an error message from an error. Defaults to `() => 'An error occurred.'` so server-side error details are not leaked to the client; supply your own to surface richer messages.
+ * @param options.originalMessages - The original messages. If provided, persistence mode is assumed
+ *   and a message ID is provided for the response message.
+ * @param options.onStepFinish - A callback that is called when each step finishes. Useful for persisting intermediate messages.
+ * @param options.onFinish - A callback that is called when the stream finishes.
+ * @param options.generateId - A function that generates a unique ID. Defaults to the built-in ID generator.
+ *
+ * @returns A `ReadableStream` of UI message chunks.
+ */
 export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   execute,
-  onError = getErrorMessage,
+  onError = () => 'An error occurred.', // prevent leaking server error details to the client by default
   originalMessages,
   onFinish,
   generateId = generateIdFunc,


### PR DESCRIPTION
Manual backport of #15994 (via the v6.0 backport #16041) to **release-v5.0** — VULN-11578 / ANT-2026-S913191P.

The default `onError` for `streamText(...).toUIMessageStream()` and `createUIMessageStream` was `getErrorMessage`, which serialized raw server exception details into the client-facing `{ type: 'error', errorText }` chunk (and `tool-output-error` parts). The documented default was `() => 'An error occurred.'`. This restores that documented, redacting default; raw details are emitted only when the developer supplies their own `onError`.

### Why manual
The auto-backport workflow runs on `push` to `release-v6.0` and resolves the source PR via `GET /commits/{sha}/pulls`. For the squash-merge commit of #16041 that lookup returned *"No pull request found"* (GitHub had not yet associated the squash commit with the PR when the push webhook fired), so the workflow short-circuited and never created the v5 PR. ([failed run](https://github.com/vercel/ai/actions/runs/27375598141/job/80898886745))

### Scope on v5.0
v5 carries the same vulnerable default in the same two locations (`generate-text/stream-text.ts`, `ui-message-stream/create-ui-message-stream.ts`); the standalone `to-ui-message-chunk.ts` / `to-ui-message-stream.ts` files do not exist on v5 (same as v6). Resolved the cherry-pick conflict in `create-ui-message-stream.ts` (dropped the now-unused `getErrorMessage` import, kept the doc comment) and updated the v5 `tool-output-error` snapshot to the redacted text.

### Validation
Type-check clean; **232 tests pass (node + edge)** across `stream-text` + `ui-message-stream`.

Related: #15994 (main), #16041 (release-v6.0). Linear: VULN-11578.