### PR TITLE
fix(devtools): validate viewer database paths

### DIFF
--- a/.changeset/old-singers-add.md
+++ b/.changeset/old-singers-add.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/devtools": patch
+---
+
+fix(devtools): validate viewer database paths

--- a/packages/devtools/src/db.test.ts
+++ b/packages/devtools/src/db.test.ts
@@ -101,4 +101,20 @@ describe('devtools db path validation', () => {
 
     await expect(db.getRuns()).resolves.toEqual([]);
   });
+
+  it('rejects devtools databases larger than the size cap', async () => {
+    const { db, tempDir } = await loadDbModule();
+    const dbPath = path.join(tempDir, 'app', '.devtools', 'generations.json');
+
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    // Sparse file just over the 100 MB cap — reports a large size without
+    // consuming disk, standing in for a huge / OOM-inducing database.
+    fs.writeFileSync(dbPath, '');
+    fs.truncateSync(dbPath, 100 * 1024 * 1024 + 1);
+
+    expect(db.validateRemoteDbPath(dbPath)).toBeUndefined();
+    await db.reloadDb(dbPath);
+
+    await expect(db.getRuns()).resolves.toEqual([]);
+  });
 });

--- a/packages/devtools/src/db.test.ts
+++ b/packages/devtools/src/db.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalCwd = process.cwd();
+let tempDirs: string[] = [];
+
+const loadDbModule = async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-sdk-devtools-'));
+  tempDirs.push(tempDir);
+  process.chdir(tempDir);
+  vi.resetModules();
+
+  return {
+    db: await import('./db.js'),
+    tempDir,
+  };
+};
+
+const writeDb = (dbPath: string, runs: Array<Record<string, unknown>>) => {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  fs.writeFileSync(dbPath, JSON.stringify({ runs, steps: [] }));
+};
+
+describe('devtools db path validation', () => {
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.resetModules();
+
+    for (const tempDir of tempDirs) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it('accepts real .devtools/generations.json files', async () => {
+    const { db, tempDir } = await loadDbModule();
+    const dbPath = path.join(tempDir, 'app', '.devtools', 'generations.json');
+
+    writeDb(dbPath, []);
+
+    expect(db.validateRemoteDbPath(dbPath)).toBe(fs.realpathSync(dbPath));
+  });
+
+  it('rejects paths outside .devtools/generations.json', async () => {
+    const { db, tempDir } = await loadDbModule();
+    const dbPath = path.join(tempDir, 'app', 'generations.json');
+
+    writeDb(dbPath, []);
+
+    expect(db.validateRemoteDbPath(dbPath)).toBeUndefined();
+    expect(db.validateRemoteDbPath(null)).toBeUndefined();
+  });
+
+  it('reloads a validated remote devtools database', async () => {
+    const { db, tempDir } = await loadDbModule();
+    const run = {
+      id: 'run-1',
+      started_at: '2026-06-11T00:00:00.000Z',
+      parent_run_id: null,
+      parent_step_id: null,
+      function_id: null,
+    };
+    const dbPath = path.join(tempDir, 'app', '.devtools', 'generations.json');
+
+    writeDb(dbPath, [run]);
+    await db.reloadDb(dbPath);
+
+    await expect(db.getRuns()).resolves.toEqual([run]);
+  });
+
+  it('does not reload arbitrary JSON files', async () => {
+    const { db, tempDir } = await loadDbModule();
+    const run = {
+      id: 'run-1',
+      started_at: '2026-06-11T00:00:00.000Z',
+      parent_run_id: null,
+      parent_step_id: null,
+      function_id: null,
+    };
+    const dbPath = path.join(tempDir, 'app', 'generations.json');
+
+    writeDb(dbPath, [run]);
+    await db.reloadDb(dbPath);
+
+    await expect(db.getRuns()).resolves.toEqual([]);
+  });
+
+  it('rejects symlinked devtools databases that resolve outside devtools', async () => {
+    const { db, tempDir } = await loadDbModule();
+    const dbPath = path.join(tempDir, 'app', '.devtools', 'generations.json');
+    const targetPath = path.join(tempDir, 'target.json');
+
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    writeDb(targetPath, []);
+    fs.symlinkSync(targetPath, dbPath);
+
+    expect(db.validateRemoteDbPath(dbPath)).toBeUndefined();
+    await db.reloadDb(dbPath);
+
+    await expect(db.getRuns()).resolves.toEqual([]);
+  });
+});

--- a/packages/devtools/src/db.ts
+++ b/packages/devtools/src/db.ts
@@ -1,8 +1,10 @@
 import path from 'node:path';
 import fs from 'node:fs';
 
-const DB_DIR = path.join(process.cwd(), '.devtools');
-const DB_PATH = path.join(DB_DIR, 'generations.json');
+const DEVTOOLS_DB_DIR = '.devtools';
+const DEVTOOLS_DB_FILE = 'generations.json';
+const DB_DIR = path.join(process.cwd(), DEVTOOLS_DB_DIR);
+const DB_PATH = path.join(DB_DIR, DEVTOOLS_DB_FILE);
 const DEVTOOLS_PORT = process.env.AI_SDK_DEVTOOLS_PORT
   ? parseInt(process.env.AI_SDK_DEVTOOLS_PORT)
   : 4983;
@@ -140,21 +142,57 @@ const saveDb = (db: Database): void => {
   writeDb(db);
 };
 
+const normalizeDevtoolsDbPath = (dbPath: string): string | undefined => {
+  const resolvedPath = path.resolve(dbPath);
+  const dbDir = path.dirname(resolvedPath);
+
+  if (
+    path.basename(resolvedPath) !== DEVTOOLS_DB_FILE ||
+    path.basename(dbDir) !== DEVTOOLS_DB_DIR
+  ) {
+    return undefined;
+  }
+
+  return resolvedPath;
+};
+
+export const validateRemoteDbPath = (dbPath: unknown): string | undefined => {
+  if (typeof dbPath !== 'string') {
+    return undefined;
+  }
+
+  const normalizedPath = normalizeDevtoolsDbPath(dbPath);
+  if (!normalizedPath) {
+    return undefined;
+  }
+
+  try {
+    const stats = fs.statSync(normalizedPath);
+    if (!stats.isFile()) {
+      return undefined;
+    }
+
+    const realPath = fs.realpathSync(normalizedPath);
+    return normalizeDevtoolsDbPath(realPath);
+  } catch {
+    return undefined;
+  }
+};
+
 /**
  * Reload the database from disk.
  * Used by the viewer server to pick up changes made by the middleware/integration.
- * When a remote dbPath is provided (from a notify POST), reads from that path
- * instead of the local CWD-based path, so the viewer works regardless of where
- * it was started.
+ * When a valid remote dbPath is provided (from a notify POST), reads from that
+ * path instead of the local CWD-based path, so the viewer works regardless of
+ * where it was started.
  */
 export const reloadDb = async (remoteDbPath?: string): Promise<void> => {
-  if (remoteDbPath) {
+  const validatedRemoteDbPath = validateRemoteDbPath(remoteDbPath);
+  if (validatedRemoteDbPath) {
     try {
-      if (fs.existsSync(remoteDbPath)) {
-        const content = fs.readFileSync(remoteDbPath, 'utf-8');
-        dbCache = JSON.parse(content);
-        return;
-      }
+      const content = fs.readFileSync(validatedRemoteDbPath, 'utf-8');
+      dbCache = JSON.parse(content);
+      return;
     } catch {
       // Fall through to default
     }

--- a/packages/devtools/src/db.ts
+++ b/packages/devtools/src/db.ts
@@ -3,6 +3,9 @@ import fs from 'node:fs';
 
 const DEVTOOLS_DB_DIR = '.devtools';
 const DEVTOOLS_DB_FILE = 'generations.json';
+// Cap how many bytes we read from a remote database file. Guards against a
+// synchronous hang / OOM if the file is enormous.
+const MAX_DB_BYTES = 100 * 1024 * 1024; // 100 MB
 const DB_DIR = path.join(process.cwd(), DEVTOOLS_DB_DIR);
 const DB_PATH = path.join(DB_DIR, DEVTOOLS_DB_FILE);
 const DEVTOOLS_PORT = process.env.AI_SDK_DEVTOOLS_PORT
@@ -168,7 +171,7 @@ export const validateRemoteDbPath = (dbPath: unknown): string | undefined => {
 
   try {
     const stats = fs.statSync(normalizedPath);
-    if (!stats.isFile()) {
+    if (!stats.isFile() || stats.size > MAX_DB_BYTES) {
       return undefined;
     }
 

--- a/packages/devtools/src/viewer/server.ts
+++ b/packages/devtools/src/viewer/server.ts
@@ -12,6 +12,7 @@ import {
   getStepsForRun,
   clearDatabase,
   reloadDb,
+  validateRemoteDbPath,
 } from '../db.js';
 
 // SSE client management
@@ -230,9 +231,13 @@ app.get('/api/events', c => {
 
 // Notification endpoint (called by middleware/integration)
 app.post('/api/notify', async c => {
-  const body = await c.req.json();
-  if (body.dbPath) {
-    remoteDbPath = body.dbPath;
+  const body = (await c.req.json()) as Record<string, unknown>;
+  if (body.dbPath !== undefined) {
+    const validatedDbPath = validateRemoteDbPath(body.dbPath);
+    if (!validatedDbPath) {
+      return c.text('Invalid dbPath', 400);
+    }
+    remoteDbPath = validatedDbPath;
   }
   // Reload database from disk, using the remote dbPath if provided so the
   // viewer works even when started from a different directory than the app.


### PR DESCRIPTION
## Background

currently `/api/notify` trusted whatever `dbPath` came in the request body. the viewer would store `/etc/passwd` as `remoteDbPath`, and the next `/api/runs` call would pass it into `reloadDb()`, which attempted to `readFileSync()` and parse that file. If the file happened to be JSON shaped like the devtools DB, it could be exposed through the viewer APIs

## Summary

`dbPath` is only accepted if it resolves to a real regular file named:

`<some-project>/.devtools/generations.json`

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)