### PR TITLE
fix(mcp): lock first sse endpoint received via event

### DIFF
--- a/.changeset/giant-squids-sip.md
+++ b/.changeset/giant-squids-sip.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): lock first sse endpoint received via event

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -21,6 +21,14 @@ describe('SseMCPTransport', () => {
       },
     },
     'http://localhost:3333/sse': {},
+    'http://localhost:3333/messages': {
+      response: {
+        type: 'json-value',
+        body: {
+          ok: true,
+        },
+      },
+    },
   });
 
   let transport: SseMCPTransport;
@@ -201,6 +209,79 @@ describe('SseMCPTransport', () => {
     expect(server.calls[1].requestMethod).toBe('POST');
     expect(server.calls[1].requestUrl).toBe('http://localhost:3000/messages');
     expect(await server.calls[1].requestBodyJson).toEqual(message);
+
+    await transport.close();
+  });
+
+  it('should reject cross-origin endpoints before connecting', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const errorPromise = new Promise<unknown>(resolve => {
+      transport.onerror = err => resolve(err);
+    });
+
+    const connectPromise = transport.start();
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3333/messages\n\n',
+    );
+
+    await expect(connectPromise).rejects.toThrow(
+      'Endpoint origin does not match connection origin: http://localhost:3333',
+    );
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(MCPClientError);
+    expect(transport['connected']).toBe(false);
+    expect(transport['endpoint']).toBeUndefined();
+
+    await expect(
+      transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'test',
+        params: {},
+        id: '1',
+      }),
+    ).rejects.toThrow('Not connected');
+
+    await transport.close();
+  });
+
+  it('should ignore endpoint events after connecting', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const connectPromise = transport.start();
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+    await connectPromise;
+
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3333/messages\n\n',
+    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const message = {
+      jsonrpc: '2.0' as const,
+      method: 'test',
+      params: { foo: 'bar' },
+      id: '1',
+    };
+
+    await transport.send(message);
+
+    const postCalls = server.calls.filter(c => c.requestMethod === 'POST');
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].requestUrl).toBe('http://localhost:3000/messages');
 
     await transport.close();
   });

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -161,14 +161,23 @@ export class SseMCPTransport implements MCPTransport {
                 const { event, data } = value;
 
                 if (event === 'endpoint') {
-                  this.endpoint = new URL(data, this.url);
+                  if (this.endpoint) {
+                    continue;
+                  }
 
-                  if (this.endpoint.origin !== this.url.origin) {
+                  const endpoint = new URL(data, this.url);
+
+                  if (endpoint.origin !== this.url.origin) {
+                    this.connected = false;
+                    this.endpoint = undefined;
+                    this.sseConnection?.close();
+                    this.abortController?.abort();
                     throw new MCPClientError({
-                      message: `MCP SSE Transport Error: Endpoint origin does not match connection origin: ${this.endpoint.origin}`,
+                      message: `MCP SSE Transport Error: Endpoint origin does not match connection origin: ${endpoint.origin}`,
                     });
                   }
 
+                  this.endpoint = endpoint;
                   this.connected = true;
                   resolve();
                 } else if (event === 'message') {
@@ -217,6 +226,7 @@ export class SseMCPTransport implements MCPTransport {
 
   async close(): Promise<void> {
     this.connected = false;
+    this.endpoint = undefined;
     this.sseConnection?.close();
     this.abortController?.abort();
     this.onclose?.();


### PR DESCRIPTION
## Background

currently if a client connects to an endpoint `https://mcp.example/sse`, the client will POST tool calls to `https://mcp.example/messages`

but  if a later SSE event said:
```
event: endpoint
data: https://evil.example/collect
```
the client accidentally stored that bad URL before rejecting it. and the next tool call could POST to `evil.example`

## Summary

the first valid endpoint stays locked in and later endpoint events are ignored now

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)