### PR TITLE
fix(harness): fix various bugs with harness skills not being correctly processed by the harness adapters

### DIFF
--- a/.changeset/spotty-lamps-prove.md
+++ b/.changeset/spotty-lamps-prove.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-pi": patch
+"@ai-sdk/harness": patch
+---
+
+fix(harness): fix various bugs with harness skills not being correctly processed by the harness adapters

--- a/content/docs/03-ai-sdk-harnesses/04-skills.mdx
+++ b/content/docs/03-ai-sdk-harnesses/04-skills.mdx
@@ -27,7 +27,14 @@ const agent = new HarnessAgent({
       name: 'careful-refactors',
       description: 'Make small, low-risk code changes.',
       content:
-        'Prefer minimal diffs. Preserve public APIs. Run the narrowest relevant tests before broad checks.',
+        'Prefer minimal diffs. Preserve public APIs. Before editing, read references/checklist.md and follow it.',
+      files: [
+        {
+          path: 'references/checklist.md',
+          content:
+            '# Refactor checklist\n\n- Identify the smallest useful change.\n- Preserve public APIs.\n- Run the narrowest relevant test.',
+        },
+      ],
     },
   ],
 });
@@ -38,6 +45,11 @@ Each skill has:
 - `name`: stable identifier for the skill.
 - `description`: short model-facing summary.
 - `content`: full instruction content.
+- `files`: optional additional text files bundled with the skill.
+
+Additional files use skill-relative POSIX paths, for example
+`reference.md`, `references/codes.md`, or `templates/config.json`. Reference
+those paths from `content` when the agent should read them.
 
 ## When to Use Skills
 

--- a/examples/ai-functions/src/harness-agent/claude-code/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-skills.ts
@@ -14,7 +14,7 @@ import { run } from '../../lib/run';
  * This example: a skill teaching the agent a fictional, project-specific
  * release-notes format. The prompt is a request to draft release notes —
  * the kind of task the description points at — so the agent pulls the skill
- * in to know the format.
+ * in and reads the attached format reference file.
  */
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -33,6 +33,12 @@ run(async () => {
           'Use when the user asks to write, draft, or update release notes. Provides our team-specific format that you will not know otherwise.',
         content: `# Release notes format
 
+Before drafting release notes, read \`release-notes-format.md\`. It is the source of truth for the section order, tone, PR reference style, and version-tag rule.`,
+        files: [
+          {
+            path: 'release-notes-format.md',
+            content: `# Release notes format reference
+
 Structure release notes as exactly three top-level sections in this order:
 
 ## Highlights
@@ -48,6 +54,8 @@ Each item: a one-line summary followed by a "**Migration:**" sub-bullet.
 Omit this section entirely if there are no breaking changes.
 
 End the document with the version tag on a line by itself, prefixed with \`v\`.`,
+          },
+        ],
       },
     ],
   });

--- a/examples/ai-functions/src/harness-agent/codex/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-skills.ts
@@ -14,7 +14,7 @@ import { run } from '../../lib/run';
  * This example: a skill teaching the agent a fictional, project-specific
  * release-notes format. The prompt is a request to draft release notes —
  * the kind of task the description points at — so the agent pulls the skill
- * in to know the format.
+ * in and reads the attached format reference file.
  */
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -33,6 +33,12 @@ run(async () => {
           'Use when the user asks to write, draft, or update release notes. Provides our team-specific format that you will not know otherwise.',
         content: `# Release notes format
 
+Before drafting release notes, read \`release-notes-format.md\`. It is the source of truth for the section order, tone, PR reference style, and version-tag rule.`,
+        files: [
+          {
+            path: 'release-notes-format.md',
+            content: `# Release notes format reference
+
 Structure release notes as exactly three top-level sections in this order:
 
 ## Highlights
@@ -48,6 +54,8 @@ Each item: a one-line summary followed by a "**Migration:**" sub-bullet.
 Omit this section entirely if there are no breaking changes.
 
 End the document with the version tag on a line by itself, prefixed with \`v\`.`,
+          },
+        ],
       },
     ],
   });

--- a/examples/ai-functions/src/harness-agent/pi/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-skills.ts
@@ -30,6 +30,12 @@ run(async () => {
           'Use when the user asks to write, draft, or update release notes. Provides our team-specific format that you will not know otherwise.',
         content: `# Release notes format
 
+Before drafting release notes, read \`release-notes-format.md\`. It is the source of truth for the section order, tone, PR reference style, and version-tag rule.`,
+        files: [
+          {
+            path: 'release-notes-format.md',
+            content: `# Release notes format reference
+
 Structure release notes as exactly three top-level sections in this order:
 
 ## Highlights
@@ -45,6 +51,8 @@ Each item: a one-line summary followed by a "**Migration:**" sub-bullet.
 Omit this section entirely if there are no breaking changes.
 
 End the document with the version tag on a line by itself, prefixed with \`v\`.`,
+          },
+        ],
       },
     ],
   });

--- a/examples/harness-e2e-next/lib/weather-utils.ts
+++ b/examples/harness-e2e-next/lib/weather-utils.ts
@@ -15,7 +15,7 @@ export const weatherCodesSkill: HarnessAgentSkill = {
   name: 'weather-codes',
   description: 'Look up the meaning of a numeric weather code.',
   content:
-    'To map a numeric weather code to a human-readable description, read the `./weather-codes.md` file in the working directory.',
+    "To map a numeric weather code to a human-readable description, read the `weather-codes.md` file in the working directory - NOT in this skill's directory, but the primary work dir.",
 };
 
 export const WEATHER_CODES_REFERENCE = `# Weather code reference

--- a/examples/harness-e2e-tui/lib/weather-utils.ts
+++ b/examples/harness-e2e-tui/lib/weather-utils.ts
@@ -15,7 +15,7 @@ export const weatherCodesSkill: HarnessAgentSkill = {
   name: 'weather-codes',
   description: 'Look up the meaning of a numeric weather code.',
   content:
-    'To map a numeric weather code to a human-readable description, read the `./weather-codes.md` file in the working directory.',
+    "To map a numeric weather code to a human-readable description, read the `./weather-codes.md` file in the working directory - NOT in this skill's directory, but the primary work dir.",
 };
 
 export const WEATHER_CODES_REFERENCE = `# Weather code reference

--- a/packages/harness-claude-code/src/bridge/claude-skills-option.test.ts
+++ b/packages/harness-claude-code/src/bridge/claude-skills-option.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { toClaudeSkillsOption } from './claude-skills-option';
+
+describe('toClaudeSkillsOption', () => {
+  it('omits the SDK skills option when no harness skills are configured', () => {
+    expect(toClaudeSkillsOption(undefined)).toBeUndefined();
+    expect(toClaudeSkillsOption([])).toBeUndefined();
+  });
+
+  it('enables all discovered skills when harness skills are configured', () => {
+    expect(toClaudeSkillsOption(['weather-forecast'])).toBe('all');
+  });
+});

--- a/packages/harness-claude-code/src/bridge/claude-skills-option.ts
+++ b/packages/harness-claude-code/src/bridge/claude-skills-option.ts
@@ -1,0 +1,11 @@
+export function toClaudeSkillsOption(
+  skills: ReadonlyArray<string> | undefined,
+): 'all' | undefined {
+  /*
+   * The Claude Agent SDK treats `skills: string[]` as an allowlist, which hides
+   * built-in/default skills. When the harness writes project skills, ask Claude
+   * to enable every discovered skill so bundled defaults and project skills are
+   * both visible.
+   */
+  return skills && skills.length > 0 ? 'all' : undefined;
+}

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -35,6 +35,7 @@ import { argv, stdout } from 'node:process';
 import * as claudeAgentSdk from '@anthropic-ai/claude-agent-sdk';
 import * as mcpServerModule from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { toClaudeSkillsOption } from './claude-skills-option';
 
 /*
  * Native Claude Code tool name → cross-harness common name. Tools outside this
@@ -328,6 +329,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     pendingUserMessages: turn.pendingUserMessages,
     abortSignal: abortCtl.signal,
   });
+  const skillsOption = toClaudeSkillsOption(start.skills);
   const permissionOptions = createPermissionOptions({
     start,
     turn,
@@ -341,6 +343,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     options: {
       ...(start.model ? { model: start.model } : {}),
       ...(start.maxTurns !== undefined ? { maxTurns: start.maxTurns } : {}),
+      ...(skillsOption ? { skills: skillsOption } : {}),
       ...(toThinkingConfig(start.thinking)
         ? { thinking: toThinkingConfig(start.thinking) }
         : {}),

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -69,6 +69,7 @@ describe('inboundMessageSchema', () => {
         model: 'claude-sonnet-4-5',
         maxTurns: 5,
         thinking: 'adaptive',
+        skills: ['weather-forecast', 'weather-codes'],
         permissionMode: 'allow-edits',
       }),
     ).not.toThrow();

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
@@ -19,6 +19,7 @@ export type OutboundMessage = z.infer<typeof outboundMessageSchema>;
 export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   thinking: z.enum(['off', 'on', 'adaptive']).optional(),
   maxTurns: z.number().optional(),
+  skills: z.array(z.string()).optional(),
   // Resume signal. When true, the bridge passes `{ continue: true }` to the
   // Claude SDK so the in-workdir thread state is rehydrated. The host sets this
   // on the first prompt after a cross-process resume.

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -79,6 +79,9 @@ function fakeNetworkSandboxSessionForStartupSuccess({
   const session = {
     run: async ({ command }: { command: string }) => {
       runs.push(command);
+      if (command === 'printf "%s" "$HOME"') {
+        return { exitCode: 0, stdout: '/home/vercel-sandbox', stderr: '' };
+      }
       return { exitCode: 0, stdout: '', stderr: '' };
     },
     readTextFile: async () => null,
@@ -247,13 +250,11 @@ describe('createClaudeCode adapter', () => {
         skills: ['weather-forecast', 'weather-codes'],
       });
 
-      expect(runs).toContain(
-        'mkdir -p /vercel/sandbox/claude-code-s1/.claude/skills',
-      );
+      expect(runs).toContain("mkdir -p '/home/vercel-sandbox'/.claude/skills");
       expect(writes.map(write => write.path)).toEqual([
-        '/vercel/sandbox/claude-code-s1/.claude/skills/weather-forecast/SKILL.md',
-        '/vercel/sandbox/claude-code-s1/.claude/skills/weather-forecast/reference.md',
-        '/vercel/sandbox/claude-code-s1/.claude/skills/weather-codes/SKILL.md',
+        '/home/vercel-sandbox/.claude/skills/weather-forecast/SKILL.md',
+        '/home/vercel-sandbox/.claude/skills/weather-forecast/reference.md',
+        '/home/vercel-sandbox/.claude/skills/weather-codes/SKILL.md',
       ]);
       expect(writes[0].content).toContain('name: weather-forecast');
       expect(writes[1].content).toBe('# Forecast reference');
@@ -314,7 +315,7 @@ describe('createClaudeCode adapter', () => {
     ).rejects.toThrow('Invalid Claude Code skill file path');
     expect(writes).toEqual([]);
     expect(runs).not.toContain(
-      'mkdir -p /vercel/sandbox/claude-code-s1/.claude/skills',
+      "mkdir -p '/home/vercel-sandbox'/.claude/skills",
     );
   });
 

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -3,6 +3,7 @@ import {
   type HarnessV1NetworkSandboxSession,
 } from '@ai-sdk/harness';
 import type * as NodeFsPromises from 'node:fs/promises';
+import { WebSocketServer } from 'ws';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createClaudeCode } from './claude-code-harness';
 
@@ -60,6 +61,50 @@ function fakeNetworkSandboxSessionForStartupFailure({
     ports: [port],
     async getPortUrl() {
       return `ws://127.0.0.1:${port}`;
+    },
+    async stop() {},
+    ...session,
+  } as unknown as HarnessV1NetworkSandboxSession;
+}
+
+function fakeNetworkSandboxSessionForStartupSuccess({
+  bridgePortUrl,
+  writes,
+  runs,
+}: {
+  bridgePortUrl: string;
+  writes: Array<{ path: string; content: string }>;
+  runs: string[];
+}): HarnessV1NetworkSandboxSession {
+  const session = {
+    run: async ({ command }: { command: string }) => {
+      runs.push(command);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    readTextFile: async () => null,
+    writeTextFile: async ({
+      path,
+      content,
+    }: {
+      path: string;
+      content: string;
+    }) => {
+      writes.push({ path, content });
+    },
+    spawn: async () => ({
+      stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
+      stderr: textStream(''),
+      kill: async () => {},
+      wait: async () => ({ exitCode: 0 }),
+    }),
+  };
+  return {
+    id: 'test-sandbox',
+    defaultWorkingDirectory: '/vercel/sandbox',
+    restricted: () => session,
+    ports: [4319],
+    async getPortUrl() {
+      return bridgePortUrl;
     },
     async stop() {},
     ...session,
@@ -132,6 +177,145 @@ describe('createClaudeCode adapter', () => {
         sessionWorkDir: '/vercel/sandbox/claude-code-s1',
       }),
     ).rejects.toBeInstanceOf(HarnessCapabilityUnsupportedError);
+  });
+
+  it('writes standard Claude skill files and enables their names on start', async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const port = await new Promise<number>(resolve => {
+      wss.on('listening', () => {
+        const address = wss.address();
+        if (typeof address === 'object' && address !== null) {
+          resolve(address.port);
+        }
+      });
+    });
+    try {
+      const startMessage = new Promise<Record<string, unknown>>(resolve => {
+        wss.on('connection', ws => {
+          setTimeout(() => {
+            ws.send(JSON.stringify({ type: 'bridge-hello' }));
+          }, 0);
+          ws.on('message', raw => {
+            const message = JSON.parse(raw.toString('utf8')) as Record<
+              string,
+              unknown
+            >;
+            if (message.type === 'start') {
+              resolve(message);
+              ws.send(JSON.stringify({ type: 'finish' }));
+            }
+          });
+        });
+      });
+
+      const writes: Array<{ path: string; content: string }> = [];
+      const runs: string[] = [];
+      const harness = createClaudeCode({ startupTimeoutMs: 1000 });
+      const session = await harness.doStart({
+        sessionId: 's1',
+        sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+          bridgePortUrl: `ws://127.0.0.1:${port}`,
+          writes,
+          runs,
+        }),
+        sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+        skills: [
+          {
+            name: 'weather-forecast',
+            description: 'Use the weather forecast tool.',
+            content: 'Call `get_weather` before answering forecasts.',
+            files: [
+              {
+                path: 'reference.md',
+                content: '# Forecast reference',
+              },
+            ],
+          },
+          {
+            name: 'weather-codes',
+            description: 'Read weather code reference.',
+            content: 'Read `weather-codes.md` for code descriptions.',
+          },
+        ],
+      });
+      const control = await session.doPromptTurn({
+        prompt: 'which skills do you have available?',
+        emit: () => {},
+      });
+      void Promise.resolve(control.done).catch(() => {});
+      await expect(startMessage).resolves.toMatchObject({
+        skills: ['weather-forecast', 'weather-codes'],
+      });
+
+      expect(runs).toContain(
+        'mkdir -p /vercel/sandbox/claude-code-s1/.claude/skills',
+      );
+      expect(writes.map(write => write.path)).toEqual([
+        '/vercel/sandbox/claude-code-s1/.claude/skills/weather-forecast/SKILL.md',
+        '/vercel/sandbox/claude-code-s1/.claude/skills/weather-forecast/reference.md',
+        '/vercel/sandbox/claude-code-s1/.claude/skills/weather-codes/SKILL.md',
+      ]);
+      expect(writes[0].content).toContain('name: weather-forecast');
+      expect(writes[1].content).toBe('# Forecast reference');
+      await session.doDestroy();
+    } finally {
+      await new Promise<void>(resolve => wss.close(() => resolve()));
+    }
+  });
+
+  it('rejects unsafe skill names before writing skill files', async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const harness = createClaudeCode();
+
+    await expect(
+      harness.doStart({
+        sessionId: 's1',
+        sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+          bridgePortUrl: 'ws://127.0.0.1:1',
+          writes,
+          runs: [],
+        }),
+        sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+        skills: [
+          {
+            name: '../weather',
+            description: 'unsafe',
+            content: 'unsafe',
+          },
+        ],
+      }),
+    ).rejects.toThrow('Invalid Claude Code skill name');
+    expect(writes).toEqual([]);
+  });
+
+  it('rejects unsafe skill file paths before writing skill files', async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const runs: string[] = [];
+    const harness = createClaudeCode();
+
+    await expect(
+      harness.doStart({
+        sessionId: 's1',
+        sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+          bridgePortUrl: 'ws://127.0.0.1:1',
+          writes,
+          runs,
+        }),
+        sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+        skills: [
+          {
+            name: 'weather',
+            description: 'unsafe',
+            content: 'unsafe',
+            files: [{ path: '../weather-codes.md', content: 'unsafe' }],
+          },
+        ],
+      }),
+    ).rejects.toThrow('Invalid Claude Code skill file path');
+    expect(writes).toEqual([]);
+    expect(runs).not.toContain(
+      'mkdir -p /vercel/sandbox/claude-code-s1/.claude/skills',
+    );
   });
 
   it('includes bridge startup stdout, stderr, and exit code when ready never arrives', async () => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -538,12 +538,20 @@ export function createClaudeCode(
         }
       }
 
+      const sandboxHomeDir =
+        startOpts.skills && startOpts.skills.length > 0
+          ? await resolveSandboxHomeDir({
+              sandbox: session,
+              abortSignal: startOpts.abortSignal,
+            })
+          : undefined;
       const port = resolveBridgePort(sandboxSession, settings.port);
       const token = randomBytes(32).toString('hex');
       const env = {
         ...resolveClaudeCodeEnv(settings.auth),
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
+        ...(sandboxHomeDir ? { HOME: sandboxHomeDir } : {}),
         ...(respawnStrategy === 'replay'
           ? { BRIDGE_REPLAY_FROM_DISK: '1' }
           : {}),
@@ -562,9 +570,12 @@ export function createClaudeCode(
         });
 
         if (startOpts.skills && startOpts.skills.length > 0) {
+          if (!sandboxHomeDir) {
+            throw new Error('Unable to resolve sandbox HOME directory.');
+          }
           await writeSkills({
             sandbox: session,
-            workdir: workDir,
+            homeDir: sandboxHomeDir,
             skills: startOpts.skills,
             abortSignal: startOpts.abortSignal,
           });
@@ -656,19 +667,19 @@ function resolveBridgePort(
 
 /**
  * Materialise skill files into
- * `${workdir}/.claude/skills/<name>/SKILL.md`. The `claude` CLI
+ * `$HOME/.claude/skills/<name>/SKILL.md`. The `claude` CLI
  * auto-discovers skills from that directory on startup, so the files have to
- * be in place before the bridge is spawned. Each file uses the
- * YAML-frontmatter shape the CLI expects.
+ * be in place before the bridge is spawned without mutating the session
+ * workdir. Each file uses the YAML-frontmatter shape the CLI expects.
  */
 async function writeSkills({
   sandbox,
-  workdir,
+  homeDir,
   skills,
   abortSignal,
 }: {
   sandbox: Experimental_SandboxSession;
-  workdir: string;
+  homeDir: string;
   skills: ReadonlyArray<HarnessV1Skill>;
   abortSignal?: AbortSignal;
 }): Promise<void> {
@@ -683,12 +694,12 @@ async function writeSkills({
   }
 
   await sandbox.run({
-    command: `mkdir -p ${workdir}/.claude/skills`,
+    command: `mkdir -p ${shellQuote(homeDir)}/.claude/skills`,
     abortSignal,
   });
   for (const skill of skills) {
     const name = safeClaudeSkillName(skill.name);
-    const skillDir = `${workdir}/.claude/skills/${name}`;
+    const skillDir = `${homeDir}/.claude/skills/${name}`;
     const path = `${skillDir}/SKILL.md`;
     const content = `---\nname: ${skill.name}\ndescription: ${skill.description}\n---\n\n${skill.content}\n`;
     await sandbox.writeTextFile({ path, content, abortSignal });
@@ -704,6 +715,26 @@ async function writeSkills({
       });
     }
   }
+}
+
+async function resolveSandboxHomeDir({
+  sandbox,
+  abortSignal,
+}: {
+  sandbox: Experimental_SandboxSession;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = await sandbox.run({
+    command: 'printf "%s" "$HOME"',
+    abortSignal,
+  });
+  const homeDir = result.stdout.trim();
+  if (result.exitCode !== 0 || !homeDir || !path.posix.isAbsolute(homeDir)) {
+    throw new Error(
+      `Unable to resolve sandbox HOME directory: ${result.stderr || result.stdout}`,
+    );
+  }
+  return homeDir;
 }
 
 function safeClaudeSkillName(name: string): string {
@@ -731,6 +762,10 @@ function safeClaudeSkillFilePath({
     );
   }
   return normalized;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 async function readBridgeAsset(name: string): Promise<string> {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   commonTool,
@@ -506,6 +507,7 @@ export function createClaudeCode(
             sandboxId,
             debug: startOpts.observability?.debug,
             permissionMode: startOpts.permissionMode,
+            skills: startOpts.skills ?? [],
           });
         } catch {
           // Bridge no longer reachable — recover by respawning below.
@@ -632,6 +634,7 @@ export function createClaudeCode(
         sandboxId,
         debug: startOpts.observability?.debug,
         permissionMode: startOpts.permissionMode,
+        skills: startOpts.skills ?? [],
       });
     },
   };
@@ -652,10 +655,11 @@ function resolveBridgePort(
 }
 
 /**
- * Materialise skill files into `${workdir}/.claude/skills/<name>.md`. The
- * `claude` CLI auto-discovers skills from that directory on startup, so the
- * files have to be in place before the bridge is spawned. Each file uses
- * the YAML-frontmatter shape the CLI expects.
+ * Materialise skill files into
+ * `${workdir}/.claude/skills/<name>/SKILL.md`. The `claude` CLI
+ * auto-discovers skills from that directory on startup, so the files have to
+ * be in place before the bridge is spawned. Each file uses the
+ * YAML-frontmatter shape the CLI expects.
  */
 async function writeSkills({
   sandbox,
@@ -668,15 +672,65 @@ async function writeSkills({
   skills: ReadonlyArray<HarnessV1Skill>;
   abortSignal?: AbortSignal;
 }): Promise<void> {
+  for (const skill of skills) {
+    safeClaudeSkillName(skill.name);
+    for (const file of skill.files ?? []) {
+      safeClaudeSkillFilePath({
+        skillName: skill.name,
+        filePath: file.path,
+      });
+    }
+  }
+
   await sandbox.run({
     command: `mkdir -p ${workdir}/.claude/skills`,
     abortSignal,
   });
   for (const skill of skills) {
-    const path = `${workdir}/.claude/skills/${skill.name}.md`;
+    const name = safeClaudeSkillName(skill.name);
+    const skillDir = `${workdir}/.claude/skills/${name}`;
+    const path = `${skillDir}/SKILL.md`;
     const content = `---\nname: ${skill.name}\ndescription: ${skill.description}\n---\n\n${skill.content}\n`;
     await sandbox.writeTextFile({ path, content, abortSignal });
+    for (const file of skill.files ?? []) {
+      const filePath = safeClaudeSkillFilePath({
+        skillName: skill.name,
+        filePath: file.path,
+      });
+      await sandbox.writeTextFile({
+        path: `${skillDir}/${filePath}`,
+        content: file.content,
+        abortSignal,
+      });
+    }
   }
+}
+
+function safeClaudeSkillName(name: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(name) || name === '.' || name === '..') {
+    throw new Error(`Invalid Claude Code skill name: ${name}`);
+  }
+  return name;
+}
+
+function safeClaudeSkillFilePath({
+  skillName,
+  filePath,
+}: {
+  skillName: string;
+  filePath: string;
+}): string {
+  const normalized = path.posix.normalize(filePath);
+  if (
+    normalized === '.' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(
+      `Invalid Claude Code skill file path for ${skillName}: ${filePath}`,
+    );
+  }
+  return normalized;
 }
 
 async function readBridgeAsset(name: string): Promise<string> {
@@ -1063,6 +1117,7 @@ function createSession({
   sandboxId,
   debug,
   permissionMode,
+  skills,
 }: {
   sessionId: string;
   channel: ClaudeCodeChannel;
@@ -1079,6 +1134,7 @@ function createSession({
   sandboxId: string;
   debug: HarnessV1DebugConfig | undefined;
   permissionMode: HarnessV1PermissionMode | undefined;
+  skills: ReadonlyArray<HarnessV1Skill>;
 }): HarnessV1Session {
   let stopped = false;
   let stopPromise: Promise<void> | undefined;
@@ -1259,6 +1315,9 @@ function createSession({
         model,
         maxTurns,
         thinking,
+        ...(skills.length > 0
+          ? { skills: skills.map(skill => skill.name) }
+          : {}),
         ...(permissionMode ? { permissionMode } : {}),
         ...(debug ? { debug } : {}),
         ...(pendingResumeFlag ? { continue: true } : {}),
@@ -1307,6 +1366,9 @@ function createSession({
           model,
           maxTurns,
           thinking,
+          ...(skills.length > 0
+            ? { skills: skills.map(skill => skill.name) }
+            : {}),
           ...(permissionMode ? { permissionMode } : {}),
           ...(debug ? { debug } : {}),
           continue: true,

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -210,7 +210,6 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   const userMessage = composeUserMessage({
     text: start.prompt,
     instructions: start.instructions,
-    skills: start.skills,
     // Temporary workaround for upstream codex MCP-tool bug — see ./cli-relay.ts
     toolUsageBlock:
       cliShimPath && start.tools && start.tools.length > 0
@@ -522,19 +521,10 @@ function defaultUsage(): Record<string, unknown> {
 function composeUserMessage({
   text,
   instructions,
-  skills,
   toolUsageBlock,
 }: {
   text: string;
   instructions: string | undefined;
-  skills:
-    | ReadonlyArray<{
-        name: string;
-        description: string;
-        content: string;
-        files?: ReadonlyArray<{ path: string; content: string }>;
-      }>
-    | undefined;
   toolUsageBlock: string | undefined;
 }): string {
   const blocks: string[] = [];
@@ -552,19 +542,6 @@ function composeUserMessage({
         `${instructions}\n` +
         '</session-instructions>',
     );
-  }
-  if (skills && skills.length > 0) {
-    const lines: string[] = ['## Available skills'];
-    for (const skill of skills) {
-      lines.push('', `### ${skill.name}`, skill.description, '', skill.content);
-      if (skill.files && skill.files.length > 0) {
-        lines.push('', 'Skill files:');
-        for (const file of skill.files) {
-          lines.push('', `#### ${file.path}`, file.content);
-        }
-      }
-    }
-    blocks.push(lines.join('\n'));
   }
   if (toolUsageBlock) blocks.push(toolUsageBlock);
   blocks.push(instructions ? `<user-message>\n${text}\n</user-message>` : text);

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -528,7 +528,12 @@ function composeUserMessage({
   text: string;
   instructions: string | undefined;
   skills:
-    | ReadonlyArray<{ name: string; description: string; content: string }>
+    | ReadonlyArray<{
+        name: string;
+        description: string;
+        content: string;
+        files?: ReadonlyArray<{ path: string; content: string }>;
+      }>
     | undefined;
   toolUsageBlock: string | undefined;
 }): string {
@@ -552,6 +557,12 @@ function composeUserMessage({
     const lines: string[] = ['## Available skills'];
     for (const skill of skills) {
       lines.push('', `### ${skill.name}`, skill.description, '', skill.content);
+      if (skill.files && skill.files.length > 0) {
+        lines.push('', 'Skill files:');
+        for (const file of skill.files) {
+          lines.push('', `#### ${file.path}`, file.content);
+        }
+      }
     }
     blocks.push(lines.join('\n'));
   }

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -72,14 +72,6 @@ describe('inboundMessageSchema', () => {
         model: 'gpt-5.1',
         reasoningEffort: 'high',
         webSearch: true,
-        skills: [
-          {
-            name: 'demo',
-            description: 'Demo skill.',
-            content: 'Use the demo reference.',
-            files: [{ path: 'reference.md', content: '# Reference' }],
-          },
-        ],
       }),
     ).not.toThrow();
   });

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -72,6 +72,14 @@ describe('inboundMessageSchema', () => {
         model: 'gpt-5.1',
         reasoningEffort: 'high',
         webSearch: true,
+        skills: [
+          {
+            name: 'demo',
+            description: 'Demo skill.',
+            content: 'Use the demo reference.',
+            files: [{ path: 'reference.md', content: '# Reference' }],
+          },
+        ],
       }),
     ).not.toThrow();
   });

--- a/packages/harness-codex/src/codex-bridge-protocol.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.ts
@@ -20,18 +20,6 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   instructions: z.string().optional(),
   reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
   webSearch: z.boolean().optional(),
-  skills: z
-    .array(
-      z.object({
-        name: z.string(),
-        description: z.string(),
-        content: z.string(),
-        files: z
-          .array(z.object({ path: z.string(), content: z.string() }))
-          .optional(),
-      }),
-    )
-    .optional(),
   // Resume signal. When supplied, the bridge calls
   // `codex.resumeThread(resumeThreadId, …)` instead of starting a fresh thread.
   // The host sources the id from lifecycle state `data` cached from a prior

--- a/packages/harness-codex/src/codex-bridge-protocol.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.ts
@@ -26,6 +26,9 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
         name: z.string(),
         description: z.string(),
         content: z.string(),
+        files: z
+          .array(z.object({ path: z.string(), content: z.string() }))
+          .optional(),
       }),
     )
     .optional(),

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -764,6 +764,14 @@ function createSession({
                 name: s.name,
                 description: s.description,
                 content: s.content,
+                ...(s.files
+                  ? {
+                      files: s.files.map(file => ({
+                        path: file.path,
+                        content: file.content,
+                      })),
+                    }
+                  : {}),
               })),
             }
           : {}),

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   commonTool,
@@ -23,6 +24,7 @@ import { classifyDiskLog, SandboxChannel } from '@ai-sdk/harness/utils';
 import {
   safeParseJSON,
   type Experimental_SandboxProcess,
+  type Experimental_SandboxSession,
 } from '@ai-sdk/provider-utils';
 import { WebSocket } from 'ws';
 import { z } from 'zod';
@@ -36,6 +38,11 @@ import {
 
 type CodexChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 type CodexRespawnStrategy = 'replay' | 'rerun';
+
+type WriteSkillsResult = {
+  readonly homeDir: string;
+  readonly codexHomeDir: string;
+};
 
 /*
  * The model the adapter pins when the consumer configures none. The Codex SDK
@@ -258,7 +265,6 @@ export function createCodex(
             channel: attachChannel,
             // The live bridge was spawned by another process; no process handle.
             proc: undefined,
-            skills: startOpts.skills,
             model: settings.model ?? DEFAULT_CODEX_MODEL,
             reasoningEffort: settings.reasoningEffort,
             webSearch: settings.webSearch,
@@ -302,10 +308,24 @@ export function createCodex(
 
       const port = resolveBridgePort(sandboxSession, settings.port);
       const token = randomBytes(32).toString('hex');
+      const codexSkillSetup =
+        startOpts.skills && startOpts.skills.length > 0
+          ? await writeSkills({
+              sandbox: session,
+              skills: startOpts.skills,
+              abortSignal: startOpts.abortSignal,
+            })
+          : undefined;
       const env = {
         ...resolveCodexEnv(settings.auth),
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
+        ...(codexSkillSetup
+          ? {
+              HOME: codexSkillSetup.homeDir,
+              CODEX_HOME: codexSkillSetup.codexHomeDir,
+            }
+          : {}),
         ...(respawnStrategy === 'replay'
           ? { BRIDGE_REPLAY_FROM_DISK: '1' }
           : {}),
@@ -355,7 +375,6 @@ export function createCodex(
         sessionId: startOpts.sessionId,
         channel,
         proc,
-        skills: startOpts.skills,
         model: settings.model ?? DEFAULT_CODEX_MODEL,
         reasoningEffort: settings.reasoningEffort,
         webSearch: settings.webSearch,
@@ -403,6 +422,119 @@ async function readBridgeAsset(name: string): Promise<string> {
     }
   }
   throw lastErr ?? new Error(`bridge asset not found: ${name}`);
+}
+
+async function writeSkills({
+  sandbox,
+  skills,
+  abortSignal,
+}: {
+  sandbox: Experimental_SandboxSession;
+  skills: ReadonlyArray<HarnessV1Skill>;
+  abortSignal?: AbortSignal;
+}): Promise<WriteSkillsResult> {
+  for (const skill of skills) {
+    safeCodexSkillName(skill.name);
+    for (const file of skill.files ?? []) {
+      safeCodexSkillFilePath({
+        skillName: skill.name,
+        filePath: file.path,
+      });
+    }
+  }
+
+  const homeDir = await resolveSandboxHomeDir({ sandbox, abortSignal });
+  const codexHomeDir = path.posix.join(homeDir, '.codex');
+  await sandbox.run({
+    command: `mkdir -p ${shellQuote(codexHomeDir)}`,
+    abortSignal,
+  });
+
+  const rootDir = path.posix.join(homeDir, '.agents', 'skills');
+  await sandbox.run({
+    command: `mkdir -p ${shellQuote(rootDir)}`,
+    abortSignal,
+  });
+
+  for (const skill of skills) {
+    const name = safeCodexSkillName(skill.name);
+    const skillDir = path.posix.join(rootDir, name);
+    const content = `---\nname: ${skill.name}\ndescription: ${skill.description}\n---\n\n${skill.content}`;
+
+    await sandbox.writeTextFile({
+      path: path.posix.join(skillDir, 'SKILL.md'),
+      content,
+      abortSignal,
+    });
+
+    for (const file of skill.files ?? []) {
+      const filePath = safeCodexSkillFilePath({
+        skillName: skill.name,
+        filePath: file.path,
+      });
+      await sandbox.writeTextFile({
+        path: path.posix.join(skillDir, filePath),
+        content: file.content,
+        abortSignal,
+      });
+    }
+  }
+
+  return {
+    homeDir,
+    codexHomeDir,
+  };
+}
+
+async function resolveSandboxHomeDir({
+  sandbox,
+  abortSignal,
+}: {
+  sandbox: Experimental_SandboxSession;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = await sandbox.run({
+    command: 'printf "%s" "$HOME"',
+    abortSignal,
+  });
+  const homeDir = result.stdout.trim();
+  if (result.exitCode !== 0 || !homeDir || !path.posix.isAbsolute(homeDir)) {
+    throw new Error(
+      `Unable to resolve sandbox HOME directory: ${result.stderr || result.stdout}`,
+    );
+  }
+  return homeDir;
+}
+
+function safeCodexSkillName(name: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(name) || name === '.' || name === '..') {
+    throw new Error(`Invalid Codex skill name: ${name}`);
+  }
+  return name;
+}
+
+function safeCodexSkillFilePath({
+  skillName,
+  filePath,
+}: {
+  skillName: string;
+  filePath: string;
+}): string {
+  const normalized = path.posix.normalize(filePath);
+  if (
+    normalized === '.' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(
+      `Invalid Codex skill file path for ${skillName}: ${filePath}`,
+    );
+  }
+  return normalized;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 async function waitForBridgeReady({
@@ -536,7 +668,6 @@ function createSession({
   sessionId,
   channel,
   proc,
-  skills,
   model,
   reasoningEffort,
   webSearch,
@@ -554,7 +685,6 @@ function createSession({
   channel: CodexChannel;
   /** Undefined on `attach` — the live bridge was spawned by another process. */
   proc: Experimental_SandboxProcess | undefined;
-  skills: ReadonlyArray<HarnessV1Skill> | undefined;
   model: string | undefined;
   reasoningEffort: 'low' | 'medium' | 'high' | undefined;
   webSearch: boolean | undefined;
@@ -758,23 +888,6 @@ function createSession({
         reasoningEffort,
         webSearch,
         ...(permissionMode ? { permissionMode } : {}),
-        ...(skills && skills.length > 0
-          ? {
-              skills: skills.map(s => ({
-                name: s.name,
-                description: s.description,
-                content: s.content,
-                ...(s.files
-                  ? {
-                      files: s.files.map(file => ({
-                        path: file.path,
-                        content: file.content,
-                      })),
-                    }
-                  : {}),
-              })),
-            }
-          : {}),
         ...(pendingResumeThreadId
           ? { resumeThreadId: pendingResumeThreadId }
           : {}),

--- a/packages/harness-codex/src/codex-instructions.test.ts
+++ b/packages/harness-codex/src/codex-instructions.test.ts
@@ -3,6 +3,7 @@ import type {
   HarnessV1NetworkSandboxSession,
   HarnessV1ResumeSessionState,
   HarnessV1Session,
+  HarnessV1Skill,
 } from '@ai-sdk/harness';
 import type * as HarnessUtils from '@ai-sdk/harness/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,6 +17,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 const sentMessages: Array<Record<string, unknown>> = [];
 const openCalls: Array<{ resume?: boolean } | undefined> = [];
+const runCommands: Array<string> = [];
+const spawnEnvs: Array<Record<string, string | undefined>> = [];
+const writes: Array<{ path: string; content: string }> = [];
 
 vi.mock('@ai-sdk/harness/utils', async importOriginal => {
   const actual = await importOriginal<typeof HarnessUtils>();
@@ -70,14 +74,26 @@ function emptyStream(): ReadableStream<Uint8Array> {
 function fakeNetworkSandboxSession(): HarnessV1NetworkSandboxSession {
   const port = 4317;
   const session = {
-    run: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    run: async (input: { command: string }) => {
+      runCommands.push(input.command);
+      if (input.command === 'printf "%s" "$HOME"') {
+        return { exitCode: 0, stdout: '/home/vercel-sandbox', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
     readTextFile: async () => null,
-    spawn: async () => ({
-      stdout: readyStream(port),
-      stderr: emptyStream(),
-      kill: async () => {},
-      wait: async () => ({ exitCode: 0 }),
-    }),
+    writeTextFile: async (input: { path: string; content: string }) => {
+      writes.push({ path: input.path, content: input.content });
+    },
+    spawn: async (input: { env?: Record<string, string | undefined> }) => {
+      spawnEnvs.push(input.env ?? {});
+      return {
+        stdout: readyStream(port),
+        stderr: emptyStream(),
+        kill: async () => {},
+        wait: async () => ({ exitCode: 0 }),
+      };
+    },
   };
   return {
     id: 'sbx',
@@ -93,6 +109,7 @@ function fakeNetworkSandboxSession(): HarnessV1NetworkSandboxSession {
 async function startSession(options?: {
   resumeFrom?: HarnessV1ResumeSessionState;
   continueFrom?: HarnessV1ContinueTurnState;
+  skills?: ReadonlyArray<HarnessV1Skill>;
 }): Promise<HarnessV1Session> {
   const harness = createCodex();
   return harness.doStart({
@@ -101,6 +118,7 @@ async function startSession(options?: {
     sessionWorkDir: '/wd/codex-s1',
     ...(options?.resumeFrom ? { resumeFrom: options.resumeFrom } : {}),
     ...(options?.continueFrom ? { continueFrom: options.continueFrom } : {}),
+    ...(options?.skills ? { skills: options.skills } : {}),
   });
 }
 
@@ -114,6 +132,9 @@ describe('codex adapter — instructions gating', () => {
   beforeEach(() => {
     sentMessages.length = 0;
     openCalls.length = 0;
+    runCommands.length = 0;
+    spawnEnvs.length = 0;
+    writes.length = 0;
   });
 
   it('prepends instructions on the first user message only', async () => {
@@ -157,6 +178,9 @@ describe('codex adapter — attach replay mode', () => {
   beforeEach(() => {
     sentMessages.length = 0;
     openCalls.length = 0;
+    runCommands.length = 0;
+    spawnEnvs.length = 0;
+    writes.length = 0;
   });
 
   it('attaches a parked session without replaying old turn events', async () => {
@@ -233,5 +257,71 @@ describe('codex adapter — attach replay mode', () => {
         }
       ).bridge,
     ).toMatchObject({ lastSeenEventId: 7 });
+  });
+});
+
+describe('codex adapter — skills', () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+    openCalls.length = 0;
+    runCommands.length = 0;
+    spawnEnvs.length = 0;
+    writes.length = 0;
+  });
+
+  it('writes skills to sandbox HOME without sending skill metadata', async () => {
+    const session = await startSession({
+      skills: [
+        {
+          name: 'demo',
+          description: 'Demo skill.',
+          content: 'Use reference.md.',
+          files: [{ path: 'reference.md', content: '# Reference' }],
+        },
+      ],
+    });
+
+    await session.doPromptTurn({
+      prompt: 'use demo',
+      emit: () => {},
+    });
+
+    expect(runCommands).toContain("mkdir -p '/home/vercel-sandbox/.codex'");
+    expect(runCommands).toContain(
+      "mkdir -p '/home/vercel-sandbox/.agents/skills'",
+    );
+    expect(writes).toEqual([
+      {
+        path: '/home/vercel-sandbox/.agents/skills/demo/SKILL.md',
+        content:
+          '---\nname: demo\ndescription: Demo skill.\n---\n\nUse reference.md.',
+      },
+      {
+        path: '/home/vercel-sandbox/.agents/skills/demo/reference.md',
+        content: '# Reference',
+      },
+    ]);
+    expect(spawnEnvs.at(-1)?.HOME).toBe('/home/vercel-sandbox');
+    expect(spawnEnvs.at(-1)?.CODEX_HOME).toBe('/home/vercel-sandbox/.codex');
+    expect(lastStart().skills).toBeUndefined();
+    expect(JSON.stringify(lastStart())).not.toContain('Demo skill.');
+    expect(JSON.stringify(lastStart())).not.toContain('Use reference.md.');
+    expect(JSON.stringify(lastStart())).not.toContain('# Reference');
+  });
+
+  it('rejects unsafe skill file paths before writing files', async () => {
+    await expect(
+      startSession({
+        skills: [
+          {
+            name: 'demo',
+            description: 'Demo skill.',
+            content: 'Use reference.md.',
+            files: [{ path: '../reference.md', content: '# Reference' }],
+          },
+        ],
+      }),
+    ).rejects.toThrow('Invalid Codex skill file path');
+    expect(writes).toEqual([]);
   });
 });

--- a/packages/harness-pi/src/pi-paths.test.ts
+++ b/packages/harness-pi/src/pi-paths.test.ts
@@ -17,38 +17,56 @@ afterEach(() => {
 
 describe('createPiPathMapper', () => {
   it('translates relative paths to sandbox POSIX paths', () => {
-    const mapper = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+    const mapper = createPiPathMapper({ hostWorkDir, sandboxWorkDir });
     expect(mapper.toSandboxPath('src/foo.ts')).toBe(
       `${sandboxWorkDir}/src/foo.ts`,
     );
   });
 
   it('handles the workspace root itself', () => {
-    const mapper = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+    const mapper = createPiPathMapper({ hostWorkDir, sandboxWorkDir });
     expect(mapper.toSandboxPath('.')).toBe(sandboxWorkDir);
   });
 
   it('returns already-sandbox absolute paths inside the sandbox root unchanged', () => {
-    const mapper = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+    const mapper = createPiPathMapper({ hostWorkDir, sandboxWorkDir });
     expect(mapper.toSandboxPath(`${sandboxWorkDir}/already/here.ts`)).toBe(
       `${sandboxWorkDir}/already/here.ts`,
     );
   });
 
   it('throws when a path escapes the workspace', () => {
-    const mapper = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+    const mapper = createPiPathMapper({ hostWorkDir, sandboxWorkDir });
     expect(() => mapper.toSandboxPath('../escape.ts')).toThrow(
       /escapes the workspace/,
     );
   });
 
+  it('allows configured read-only sandbox roots for readable paths', () => {
+    const mapper = createPiPathMapper({
+      hostWorkDir,
+      sandboxWorkDir,
+      readableRoots: [{ sandboxDir: '/home/vercel-sandbox/.agents/skills' }],
+    });
+    expect(
+      mapper.toReadableSandboxPath(
+        '/home/vercel-sandbox/.agents/skills/weather-codes/SKILL.md',
+      ),
+    ).toBe('/home/vercel-sandbox/.agents/skills/weather-codes/SKILL.md');
+    expect(() =>
+      mapper.toSandboxPath(
+        '/home/vercel-sandbox/.agents/skills/weather-codes/SKILL.md',
+      ),
+    ).toThrow(/escapes the workspace/);
+  });
+
   it('toRelativePath returns "." for the sandbox root', () => {
-    const mapper = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+    const mapper = createPiPathMapper({ hostWorkDir, sandboxWorkDir });
     expect(mapper.toRelativePath(sandboxWorkDir)).toBe('.');
   });
 
   it('toRelativePath returns POSIX-relative form for nested paths', () => {
-    const mapper = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+    const mapper = createPiPathMapper({ hostWorkDir, sandboxWorkDir });
     expect(mapper.toRelativePath(`${sandboxWorkDir}/a/b/c.ts`)).toBe(
       'a/b/c.ts',
     );

--- a/packages/harness-pi/src/pi-paths.ts
+++ b/packages/harness-pi/src/pi-paths.ts
@@ -12,8 +12,23 @@ export interface PiPathMapper {
    * if the path would escape the workspace.
    */
   toSandboxPath(inputPath: string): string;
+  /**
+   * Translate a path for read-only tools. In addition to the workspace, this
+   * allows explicitly configured sandbox roots such as `$HOME/.agents/skills`.
+   */
+  toReadableSandboxPath(inputPath: string): string;
   /** Translate any path to its POSIX-relative form under `sandboxWorkDir`. */
   toRelativePath(inputPath: string): string;
+}
+
+export interface PiReadablePathRoot {
+  readonly sandboxDir: string;
+}
+
+export interface CreatePiPathMapperOptions {
+  readonly hostWorkDir: string;
+  readonly sandboxWorkDir: string;
+  readonly readableRoots?: ReadonlyArray<PiReadablePathRoot>;
 }
 
 function isInsidePath(parent: string, candidate: string): boolean {
@@ -48,42 +63,64 @@ function canonicalizeForContainment(inputPath: string): string {
 }
 
 export function createPiPathMapper(
-  hostWorkDir: string,
-  sandboxWorkDir: string,
+  options: CreatePiPathMapperOptions,
 ): PiPathMapper {
-  const normalizedHost = path.resolve(hostWorkDir);
-  const normalizedSandbox = path.posix.normalize(sandboxWorkDir);
+  const normalizedHost = path.resolve(options.hostWorkDir);
+  const normalizedSandbox = path.posix.normalize(options.sandboxWorkDir);
   const canonicalHost = canonicalizeForContainment(normalizedHost);
+  const readableRoots =
+    options.readableRoots?.map(root => ({
+      sandboxDir: path.posix.normalize(root.sandboxDir),
+    })) ?? [];
+
+  const toWorkspaceSandboxPath = (inputPath: string): string => {
+    if (path.posix.isAbsolute(inputPath)) {
+      const normalizedInput = path.posix.normalize(inputPath);
+      if (isInsidePosixPath(normalizedSandbox, normalizedInput)) {
+        return normalizedInput;
+      }
+    }
+
+    const resolvedHost = path.isAbsolute(inputPath)
+      ? path.resolve(inputPath)
+      : path.resolve(normalizedHost, inputPath);
+    const canonicalResolvedHost = canonicalizeForContainment(resolvedHost);
+    if (
+      !isInsidePath(normalizedHost, resolvedHost) ||
+      !isInsidePath(canonicalHost, canonicalResolvedHost)
+    ) {
+      throw new Error(`Pi path escapes the workspace: ${inputPath}`);
+    }
+
+    const relative = path
+      .relative(normalizedHost, resolvedHost)
+      .split(path.sep)
+      .join('/');
+    return relative
+      ? path.posix.join(normalizedSandbox, relative)
+      : normalizedSandbox;
+  };
 
   return {
     hostWorkDir: normalizedHost,
     sandboxWorkDir: normalizedSandbox,
     toSandboxPath(inputPath: string) {
+      return toWorkspaceSandboxPath(inputPath);
+    },
+    toReadableSandboxPath(inputPath: string) {
       if (path.posix.isAbsolute(inputPath)) {
         const normalizedInput = path.posix.normalize(inputPath);
-        if (isInsidePosixPath(normalizedSandbox, normalizedInput)) {
+        if (
+          isInsidePosixPath(normalizedSandbox, normalizedInput) ||
+          readableRoots.some(root =>
+            isInsidePosixPath(root.sandboxDir, normalizedInput),
+          )
+        ) {
           return normalizedInput;
         }
       }
 
-      const resolvedHost = path.isAbsolute(inputPath)
-        ? path.resolve(inputPath)
-        : path.resolve(normalizedHost, inputPath);
-      const canonicalResolvedHost = canonicalizeForContainment(resolvedHost);
-      if (
-        !isInsidePath(normalizedHost, resolvedHost) ||
-        !isInsidePath(canonicalHost, canonicalResolvedHost)
-      ) {
-        throw new Error(`Pi path escapes the workspace: ${inputPath}`);
-      }
-
-      const relative = path
-        .relative(normalizedHost, resolvedHost)
-        .split(path.sep)
-        .join('/');
-      return relative
-        ? path.posix.join(normalizedSandbox, relative)
-        : normalizedSandbox;
+      return toWorkspaceSandboxPath(inputPath);
     },
     toRelativePath(inputPath: string) {
       const sandboxPath = path.posix.isAbsolute(inputPath)

--- a/packages/harness-pi/src/pi-remote-ops.test.ts
+++ b/packages/harness-pi/src/pi-remote-ops.test.ts
@@ -70,7 +70,11 @@ const sandboxWorkDir = '/sandbox/workspace';
 
 function makeOps(behaviors: Parameters<typeof makeMockSandbox>[0]) {
   const env = makeMockSandbox(behaviors);
-  const paths = createPiPathMapper(hostWorkDir, sandboxWorkDir);
+  const paths = createPiPathMapper({
+    hostWorkDir,
+    sandboxWorkDir,
+    readableRoots: [{ sandboxDir: '/home/vercel-sandbox/.agents/skills' }],
+  });
   const ops = createPiRemoteOps({ sandbox: env.sandbox, paths });
   return { ...env, paths, ops };
 }
@@ -93,6 +97,17 @@ describe('createPiRemoteOps.readBuffer', () => {
       /Path not found/,
     );
   });
+
+  it('reads configured sandbox skill roots', async () => {
+    const skillPath =
+      '/home/vercel-sandbox/.agents/skills/weather-codes/SKILL.md';
+    const env = makeOps({
+      readBinary: p =>
+        p === skillPath ? new TextEncoder().encode('skill') : null,
+    });
+    const buf = await env.ops.readBuffer(skillPath);
+    expect(buf.toString('utf8')).toBe('skill');
+  });
 });
 
 describe('createPiRemoteOps.writeFile', () => {
@@ -111,7 +126,7 @@ describe('createPiRemoteOps.writeFile', () => {
     const sandboxEnv = makeMockSandbox({ readBinary: () => null });
     const ops = createPiRemoteOps({
       sandbox: sandboxEnv.sandbox,
-      paths: createPiPathMapper(hostWorkDir, sandboxWorkDir),
+      paths: createPiPathMapper({ hostWorkDir, sandboxWorkDir }),
       onFileChange,
     });
     await ops.writeFile('a.txt', 'x');
@@ -129,7 +144,7 @@ describe('createPiRemoteOps.writeFile', () => {
     });
     const ops = createPiRemoteOps({
       sandbox: sandboxEnv.sandbox,
-      paths: createPiPathMapper(hostWorkDir, sandboxWorkDir),
+      paths: createPiPathMapper({ hostWorkDir, sandboxWorkDir }),
       onFileChange,
     });
     await ops.writeFile('a.txt', 'x');
@@ -149,7 +164,7 @@ describe('createPiRemoteOps.editFile', () => {
     });
     const ops = createPiRemoteOps({
       sandbox: sandboxEnv.sandbox,
-      paths: createPiPathMapper(hostWorkDir, sandboxWorkDir),
+      paths: createPiPathMapper({ hostWorkDir, sandboxWorkDir }),
     });
     const result = await ops.editFile('a.txt', 'old text', 'new text');
     expect(result).toBe('new text here, and old text again');
@@ -161,7 +176,7 @@ describe('createPiRemoteOps.editFile', () => {
     });
     const ops = createPiRemoteOps({
       sandbox: sandboxEnv.sandbox,
-      paths: createPiPathMapper(hostWorkDir, sandboxWorkDir),
+      paths: createPiPathMapper({ hostWorkDir, sandboxWorkDir }),
     });
     await expect(ops.editFile('a.txt', 'missing', 'x')).rejects.toThrow(
       /not found/,

--- a/packages/harness-pi/src/pi-remote-ops.ts
+++ b/packages/harness-pi/src/pi-remote-ops.ts
@@ -96,7 +96,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
 
   const readBuffer = async (inputPath: string): Promise<Buffer> => {
     const bytes = await options.sandbox.readBinaryFile({
-      path: options.paths.toSandboxPath(inputPath),
+      path: options.paths.toReadableSandboxPath(inputPath),
     });
     if (!bytes) {
       throw new Error(`Path not found: ${inputPath}`);
@@ -140,7 +140,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     inputPath: string = '.',
     limit: number = 500,
   ): Promise<string[]> => {
-    const remotePath = options.paths.toSandboxPath(inputPath);
+    const remotePath = options.paths.toReadableSandboxPath(inputPath);
     const result = await runShell(
       [
         `if [ ! -e ${shellQuote(remotePath)} ]; then echo "__PI_LS_NOT_FOUND__"; exit 2; fi`,
@@ -173,7 +173,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     inputPath: string = '.',
     limit: number = 1_000,
   ): Promise<string[]> => {
-    const remotePath = options.paths.toSandboxPath(inputPath);
+    const remotePath = options.paths.toReadableSandboxPath(inputPath);
     const result = await runShell(
       [
         `if [ ! -e ${shellQuote(remotePath)} ]; then echo "__PI_FIND_NOT_FOUND__"; exit 2; fi`,
@@ -217,8 +217,12 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
       limit?: number;
     },
   ): Promise<string> => {
-    const remotePath = options.paths.toSandboxPath(input.path ?? '.');
+    const remotePath = options.paths.toReadableSandboxPath(input.path ?? '.');
     const relativeTarget = options.paths.toRelativePath(remotePath);
+    const targetPath =
+      relativeTarget.startsWith('../') || path.posix.isAbsolute(relativeTarget)
+        ? remotePath
+        : relativeTarget;
     const flags = [
       '-R',
       '-n',
@@ -235,7 +239,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
       [
         `if [ ! -e ${shellQuote(remotePath)} ]; then echo "__PI_GREP_NOT_FOUND__"; exit 2; fi`,
         `cd ${shellQuote(options.paths.sandboxWorkDir)}`,
-        `grep ${flags.map(shellQuote).join(' ')} -- ${shellQuote(pattern)} ${shellQuote(relativeTarget)} 2>/dev/null | head -n ${limit}`,
+        `grep ${flags.map(shellQuote).join(' ')} -- ${shellQuote(pattern)} ${shellQuote(targetPath)} 2>/dev/null | head -n ${limit}`,
       ].join('; '),
     );
 

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -8,6 +8,7 @@ import {
   SettingsManager,
   type AgentSession,
   type AgentToolResult,
+  type Skill,
   type ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
 import { mkdir, rm } from 'node:fs/promises';
@@ -27,6 +28,7 @@ import type {
   HarnessV1StreamPart,
   HarnessV1ToolSpec,
 } from '@ai-sdk/harness';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { resolvePiAuth, type PiAuthOptions } from './pi-auth';
 import { getPiTerminalError, parseNativeEvent } from './pi-events';
 import { createPiModelResolver } from './pi-model-resolver';
@@ -46,6 +48,7 @@ import { toolSpecToTypeBoxParameters } from './pi-typebox-adapter';
 import {
   extractUserText,
   frameInstructions,
+  safePiMetadataSegment,
   serializeToolOutput,
 } from './pi-utils';
 import { PiWorkspaceVfs } from './pi-workspace-vfs';
@@ -63,23 +66,75 @@ const HARNESS_ID = 'pi';
 const parkedPiSessions = new Map<string, HarnessV1Session>();
 
 /**
+ * Whether a discovered resource path belongs to a specific directory.
+ */
+function isWithinDirectory(parent: string, child: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
  * Whether a discovered resource path belongs to the session workspace — either
  * the sandbox-side working directory the model sees (`sessionWorkDir`) or its
- * host-side mirror (`hostWorkDir`). Pi runs in the host process and would
- * otherwise surface the host developer's personal skills (`~/.agents/skills`,
- * `~/.pi/agent/skills`) to the model; those resolve to host paths the
- * sandbox-backed tools cannot reach, so they are filtered out.
+ * host-side mirror (`hostWorkDir`).
  */
 function isWithinWorkspace(
   candidate: string,
   sessionWorkDir: string,
   hostWorkDir: string,
 ): boolean {
-  const inside = (parent: string, child: string): boolean => {
-    const rel = path.relative(parent, child);
-    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
-  };
-  return inside(sessionWorkDir, candidate) || inside(hostWorkDir, candidate);
+  return (
+    isWithinDirectory(sessionWorkDir, candidate) ||
+    isWithinDirectory(hostWorkDir, candidate)
+  );
+}
+
+function createHarnessPiSkills({
+  skills,
+  sandboxSkillRootDir,
+}: {
+  skills: ReadonlyArray<HarnessV1Skill>;
+  sandboxSkillRootDir: string;
+}): Skill[] {
+  return skills.map(skill => {
+    const name = safePiMetadataSegment(skill.name, 'skill');
+    const baseDir = path.posix.join(sandboxSkillRootDir, name);
+    const filePath = path.posix.join(baseDir, 'SKILL.md');
+    return {
+      name: skill.name,
+      description: skill.description,
+      filePath,
+      baseDir,
+      sourceInfo: {
+        path: filePath,
+        source: 'harness',
+        scope: 'temporary',
+        origin: 'top-level',
+        baseDir,
+      },
+      disableModelInvocation: false,
+    };
+  });
+}
+
+async function resolveSandboxHomeDir({
+  sandbox,
+  abortSignal,
+}: {
+  sandbox: Experimental_SandboxSession;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = await sandbox.run({
+    command: 'printf "%s" "$HOME"',
+    ...(abortSignal ? { abortSignal } : {}),
+  });
+  const homeDir = result.stdout.trim();
+  if (result.exitCode !== 0 || !homeDir || !path.posix.isAbsolute(homeDir)) {
+    throw new Error(
+      `Unable to resolve sandbox HOME directory: ${result.stderr || result.stdout}`,
+    );
+  }
+  return homeDir;
 }
 
 const PI_NATIVE_BUILTIN_NAMES = [
@@ -187,13 +242,23 @@ export async function createPiSession(
 
   const sandbox = input.sandboxSession.restricted();
   const permissionMode = input.permissionMode ?? 'allow-all';
+  let sandboxSkillRootDir: string | undefined;
+  let harnessSkills: Skill[] = [];
 
-  // Materialise skills into the sandbox workspace once. The host's VFS will
-  // make them visible to Pi's `DefaultResourceLoader` after mount + sync.
+  // Materialise harness-provided skills into sandbox HOME, not the workspace.
   if (input.skills.length > 0) {
+    const sandboxHomeDir = await resolveSandboxHomeDir({
+      sandbox,
+      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+    });
+    sandboxSkillRootDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
+    harnessSkills = createHarnessPiSkills({
+      skills: input.skills,
+      sandboxSkillRootDir,
+    });
     await writePiSkills({
       sandbox,
-      sessionWorkDir: input.sessionWorkDir,
+      sandboxHomeDir,
       skills: input.skills,
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });
@@ -228,7 +293,13 @@ export async function createPiSession(
   const workspaceVfs = new PiWorkspaceVfs();
   workspaceVfs.mount(hostWorkDir, sessionWorkDir);
 
-  const paths = createPiPathMapper(hostWorkDir, sessionWorkDir);
+  const paths = createPiPathMapper({
+    hostWorkDir,
+    sandboxWorkDir: sessionWorkDir,
+    readableRoots: sandboxSkillRootDir
+      ? [{ sandboxDir: sandboxSkillRootDir }]
+      : [],
+  });
 
   // Pi auth + model registry are global to this Pi session. These live on the
   // real host filesystem (`hostAgentDir`), never in the sandbox/workspace.
@@ -260,16 +331,19 @@ export async function createPiSession(
     // The harness does not expose extensions, themes, or prompt templates, so
     // disable those entirely — this also avoids loading and executing a host
     // developer's personal Pi extensions inside the server process. Skills are
-    // kept (the harness writes project skills into `.pi/skills`) but filtered
-    // to the workspace so host-home skills never reach the model.
+    // kept but filtered to workspace project skills plus harness-provided
+    // skills whose files live in sandbox HOME.
     noExtensions: true,
     noThemes: true,
     noPromptTemplates: true,
     skillsOverride: base => ({
       ...base,
-      skills: base.skills.filter(skill =>
-        isWithinWorkspace(skill.filePath, sessionWorkDir, hostWorkDir),
-      ),
+      skills: [
+        ...base.skills.filter(skill =>
+          isWithinWorkspace(skill.filePath, sessionWorkDir, hostWorkDir),
+        ),
+        ...harnessSkills,
+      ],
     }),
   });
   await resourceLoader.reload();

--- a/packages/harness-pi/src/pi-skills.test.ts
+++ b/packages/harness-pi/src/pi-skills.test.ts
@@ -16,7 +16,7 @@ describe('writePiSkills', () => {
 
     await writePiSkills({
       sandbox: makeSandbox(writes),
-      sessionWorkDir: '/workspace',
+      sandboxHomeDir: '/home/vercel-sandbox',
       skills: [
         {
           name: 'demo',
@@ -29,12 +29,12 @@ describe('writePiSkills', () => {
 
     expect(writes).toEqual([
       {
-        path: '/workspace/.pi/skills/demo/SKILL.md',
+        path: '/home/vercel-sandbox/.agents/skills/demo/SKILL.md',
         content:
           '---\nname: demo\ndescription: Demo skill.\n---\n\nUse reference.md.',
       },
       {
-        path: '/workspace/.pi/skills/demo/reference.md',
+        path: '/home/vercel-sandbox/.agents/skills/demo/reference.md',
         content: '# Reference',
       },
     ]);
@@ -46,7 +46,7 @@ describe('writePiSkills', () => {
     await expect(
       writePiSkills({
         sandbox: makeSandbox(writes),
-        sessionWorkDir: '/workspace',
+        sandboxHomeDir: '/home/vercel-sandbox',
         skills: [
           {
             name: 'demo',

--- a/packages/harness-pi/src/pi-skills.test.ts
+++ b/packages/harness-pi/src/pi-skills.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { writePiSkills } from './pi-skills';
+
+function makeSandbox(writes: Array<{ path: string; content: string }>) {
+  return {
+    async writeTextFile(input: { path: string; content: string }) {
+      writes.push({ path: input.path, content: input.content });
+    },
+  } as unknown as Experimental_SandboxSession;
+}
+
+describe('writePiSkills', () => {
+  it('writes SKILL.md and additional skill files', async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+
+    await writePiSkills({
+      sandbox: makeSandbox(writes),
+      sessionWorkDir: '/workspace',
+      skills: [
+        {
+          name: 'demo',
+          description: 'Demo skill.',
+          content: 'Use reference.md.',
+          files: [{ path: 'reference.md', content: '# Reference' }],
+        },
+      ],
+    });
+
+    expect(writes).toEqual([
+      {
+        path: '/workspace/.pi/skills/demo/SKILL.md',
+        content:
+          '---\nname: demo\ndescription: Demo skill.\n---\n\nUse reference.md.',
+      },
+      {
+        path: '/workspace/.pi/skills/demo/reference.md',
+        content: '# Reference',
+      },
+    ]);
+  });
+
+  it('rejects unsafe skill file paths before writing files', async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+
+    await expect(
+      writePiSkills({
+        sandbox: makeSandbox(writes),
+        sessionWorkDir: '/workspace',
+        skills: [
+          {
+            name: 'demo',
+            description: 'Demo skill.',
+            content: 'Use reference.md.',
+            files: [{ path: '../reference.md', content: '# Reference' }],
+          },
+        ],
+      }),
+    ).rejects.toThrow('Invalid Pi skill file path');
+    expect(writes).toEqual([]);
+  });
+});

--- a/packages/harness-pi/src/pi-skills.ts
+++ b/packages/harness-pi/src/pi-skills.ts
@@ -15,6 +15,13 @@ export async function writePiSkills(args: {
   readonly abortSignal?: AbortSignal;
 }): Promise<void> {
   for (const skill of args.skills) {
+    safePiMetadataSegment(skill.name, 'skill');
+    for (const file of skill.files ?? []) {
+      safePiSkillFilePath({ skillName: skill.name, filePath: file.path });
+    }
+  }
+
+  for (const skill of args.skills) {
     const name = safePiMetadataSegment(skill.name, 'skill');
     const remotePath = path.posix.join(
       args.sessionWorkDir,
@@ -28,5 +35,40 @@ export async function writePiSkills(args: {
       content: renderPiSkillFile(skill),
       ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
     });
+    for (const file of skill.files ?? []) {
+      const filePath = safePiSkillFilePath({
+        skillName: skill.name,
+        filePath: file.path,
+      });
+      await args.sandbox.writeTextFile({
+        path: path.posix.join(
+          args.sessionWorkDir,
+          '.pi',
+          'skills',
+          name,
+          filePath,
+        ),
+        content: file.content,
+        ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+      });
+    }
   }
+}
+
+function safePiSkillFilePath({
+  skillName,
+  filePath,
+}: {
+  skillName: string;
+  filePath: string;
+}): string {
+  const normalized = path.posix.normalize(filePath);
+  if (
+    normalized === '.' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(`Invalid Pi skill file path for ${skillName}: ${filePath}`);
+  }
+  return normalized;
 }

--- a/packages/harness-pi/src/pi-skills.ts
+++ b/packages/harness-pi/src/pi-skills.ts
@@ -4,13 +4,12 @@ import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { renderPiSkillFile, safePiMetadataSegment } from './pi-utils';
 
 /**
- * Materialize Pi skills as files under `${sessionWorkDir}/.pi/skills/<name>/SKILL.md`
- * inside the sandbox. Pi's `DefaultResourceLoader` auto-discovers them when
- * the resource loader is reloaded.
+ * Materialize Pi skills as files under
+ * `$HOME/.agents/skills/<name>/SKILL.md` inside the sandbox.
  */
 export async function writePiSkills(args: {
   readonly sandbox: Experimental_SandboxSession;
-  readonly sessionWorkDir: string;
+  readonly sandboxHomeDir: string;
   readonly skills: ReadonlyArray<HarnessV1Skill>;
   readonly abortSignal?: AbortSignal;
 }): Promise<void> {
@@ -23,31 +22,27 @@ export async function writePiSkills(args: {
 
   for (const skill of args.skills) {
     const name = safePiMetadataSegment(skill.name, 'skill');
-    const remotePath = path.posix.join(
-      args.sessionWorkDir,
-      '.pi',
+    const sandboxSkillDir = path.posix.join(
+      args.sandboxHomeDir,
+      '.agents',
       'skills',
       name,
-      'SKILL.md',
     );
+    const content = renderPiSkillFile(skill);
+
     await args.sandbox.writeTextFile({
-      path: remotePath,
-      content: renderPiSkillFile(skill),
+      path: path.posix.join(sandboxSkillDir, 'SKILL.md'),
+      content,
       ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
     });
+
     for (const file of skill.files ?? []) {
       const filePath = safePiSkillFilePath({
         skillName: skill.name,
         filePath: file.path,
       });
       await args.sandbox.writeTextFile({
-        path: path.posix.join(
-          args.sessionWorkDir,
-          '.pi',
-          'skills',
-          name,
-          filePath,
-        ),
+        path: path.posix.join(sandboxSkillDir, filePath),
         content: file.content,
         ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
       });

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -28,9 +28,7 @@ export type HarnessV1StartOptions = {
 
   /**
    * Skills made available to the underlying runtime for the lifetime of
-   * the session. Adapters decide how to surface them — the `claude` CLI
-   * picks them up from `.claude/skills/*.md`, while the `codex` adapter
-   * inlines them into every user message.
+   * the session. Adapters decide how to surface them.
    */
   readonly skills?: ReadonlyArray<HarnessV1Skill>;
 

--- a/packages/harness/src/v1/harness-v1-skill.ts
+++ b/packages/harness/src/v1/harness-v1-skill.ts
@@ -1,22 +1,36 @@
 /**
  * A self-contained instruction bundle the underlying runtime can load into
- * its context. Adapters decide how to surface skills to the runtime — the
- * `claude` CLI auto-discovers skills materialised as Markdown files in
- * `.claude/skills`, while the `codex` CLI has no skill mechanism and the
- * adapter inlines them into every user message.
+ * its context. Adapters decide how to surface skills to the runtime.
  */
 export type HarnessV1Skill = {
   /** Stable identifier for the skill (kebab-case slug). */
   readonly name: string;
 
   /**
-   * Short, model-facing description. For runtimes that auto-select skills
-   * (Claude Code), this is what the runtime sees to decide whether the
-   * skill is relevant; for runtimes that load every skill on every turn
-   * (Codex), it appears alongside the content.
+   * Short, model-facing description. This is what the runtime sees to
+   * decide whether the skill is relevant.
    */
   readonly description: string;
 
   /** Full skill content the model loads when the skill is active. */
+  readonly content: string;
+
+  /**
+   * Additional files that belong to this skill. Adapters with native skill
+   * directories materialize these next to `SKILL.md`; adapters without native
+   * skill files include them with the skill content.
+   */
+  readonly files?: ReadonlyArray<HarnessV1SkillFile>;
+};
+
+export type HarnessV1SkillFile = {
+  /**
+   * Skill-relative POSIX path, for example `reference.md` or
+   * `references/codes.md`. Absolute paths and `..` segments are rejected by
+   * adapters before writing.
+   */
+  readonly path: string;
+
+  /** UTF-8 text content for the file. */
   readonly content: string;
 };


### PR DESCRIPTION
## Summary

This fixes various skill related bugs in the harness adapters:

- Claude Code was not properly receiving custom skills at all, it didn't see them.
- Codex was using a horrible workaround where full skill contents were inlined in its instructions (defeating the purpose).
- Custom skills generally did not support additional files (i.e. only the `SKILL.md` file).
- Writing the custom skills as files into the workspace could be detrimental if that workspace was meant for other files (e.g. a git repo checkout, in which case they would have shown up as an unintended diff).

This PR addresses all those problems, in a single consistent way:
- All 3 harnesses now write custom skills as files into `$HOME/(.agents|.claude)/skills` inside the sandbox. This works consistently and prevents interferences with the sandbox workspace dir contents.
- The Claude Code and Codex primitives are fully relied on, instead of inventing custom solutions that weren't necessary.
- The `HarnessV1Skill` type now supports an optional `files` property, and those files are now being written into the sandbox too so the harness adapters can read them as needed.

## Manual Verification

Run the `examples/ai-functions/src/harness/*/with-skills.ts` examples or use the interactive `weather` examples in `examples/harness-e2e-next` / `examples/harness-e2e-tui`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
