### PR TITLE
chore(docs): fix harness docs label

### DIFF
--- a/content/docs/03-ai-sdk-harnesses/index.mdx
+++ b/content/docs/03-ai-sdk-harnesses/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: Harnesses
+title: AI SDK Harnesses
 description: Use established agent harnesses through the AI SDK.
 ---
 
-# Harnesses
+# AI SDK Harnesses
 
 The harness section covers the AI SDK harness abstraction: a uniform API for
 running established agent harnesses such as Claude Code, Codex, and Pi.


### PR DESCRIPTION
## Summary

I missed this in #16048: The harness docs index should be labelled "AI SDK Harnesses", in alignment with the other surrounding entrypoints.

## Manual Verification

N/A - we have to verify after this is deployed to the docs.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
