### PR TITLE
fix(devtools): read viewer database from server config only (VULN-11550)

### DIFF
--- a/.changeset/devtools-dbpath-server-config-only.md
+++ b/.changeset/devtools-dbpath-server-config-only.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+fix(devtools): determine the viewer database path from server-side config only
+
+The DevTools viewer previously stored a `dbPath` taken from the `/api/notify`
+request body and read that file on every API call, letting any page a developer
+visited point the viewer at an arbitrary file (arbitrary file read / existence
+oracle, plus a synchronous hang/OOM via `/dev/zero` or a huge file). The viewer
+now ignores any network-supplied path and reads only from a server-configured
+location — the default `<cwd>/.devtools/generations.json`, or the path in the
+new `AI_SDK_DEVTOOLS_DB_PATH` env var when the viewer runs in a different
+directory than the app. Reads are also bounded to regular files under a size
+cap.

--- a/packages/devtools/src/db.test.ts
+++ b/packages/devtools/src/db.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getRuns, reloadDb, type Run } from './db.js';
+
+const ENV_KEY = 'AI_SDK_DEVTOOLS_DB_PATH';
+
+const makeRun = (id: string): Run => ({
+  id,
+  started_at: new Date().toISOString(),
+  parent_run_id: null,
+  parent_step_id: null,
+  function_id: null,
+});
+
+describe('reloadDb (VULN-11550: database path is server-configured only)', () => {
+  let tmpDir: string;
+  const originalEnv = process.env[ENV_KEY];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'devtools-db-'));
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalEnv;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeDbFile = (name: string, db: unknown): string => {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, JSON.stringify(db));
+    return filePath;
+  };
+
+  it('reads runs from the configured database path', async () => {
+    process.env[ENV_KEY] = writeDbFile('generations.json', {
+      runs: [makeRun('run-1')],
+      steps: [],
+    });
+
+    await reloadDb();
+
+    expect((await getRuns()).map(r => r.id)).toEqual(['run-1']);
+  });
+
+  it('never reads a file other than the configured path', async () => {
+    // A path supplied over the network previously redirected reads here.
+    // `reloadDb()` now takes no path argument, so there is no way to point it
+    // at this file.
+    const attackerTarget = writeDbFile('attacker.json', {
+      runs: [makeRun('stolen')],
+      steps: [],
+    });
+    process.env[ENV_KEY] = writeDbFile('generations.json', {
+      runs: [],
+      steps: [],
+    });
+
+    await reloadDb();
+
+    expect(await getRuns()).toEqual([]);
+    // The attacker-controlled file is left entirely untouched.
+    expect(fs.existsSync(attackerTarget)).toBe(true);
+  });
+
+  it('yields no runs (and does not throw) when the configured path is not a regular file', async () => {
+    // A directory stands in for any non-regular file, e.g. a device file like
+    // /dev/zero that would otherwise hang or OOM a synchronous read.
+    process.env[ENV_KEY] = tmpDir;
+
+    await expect(reloadDb()).resolves.toBeUndefined();
+    expect(await getRuns()).toEqual([]);
+  });
+});

--- a/packages/devtools/src/db.ts
+++ b/packages/devtools/src/db.ts
@@ -3,6 +3,23 @@ import fs from 'node:fs';
 
 const DB_DIR = path.join(process.cwd(), '.devtools');
 const DB_PATH = path.join(DB_DIR, 'generations.json');
+
+// Cap how many bytes we read from a database file. Guards against a synchronous
+// hang / OOM if the configured file is enormous or a special device file.
+const MAX_DB_BYTES = 100 * 1024 * 1024; // 100 MB
+
+/**
+ * The database location is determined solely by server-side configuration —
+ * never by a path supplied over the network (see VULN-11550). A custom location
+ * can be set with the `AI_SDK_DEVTOOLS_DB_PATH` env var when the viewer runs in
+ * a different working directory than the app; otherwise the default
+ * `<cwd>/.devtools/generations.json` is used. Resolved lazily so the env var can
+ * be set before the viewer starts.
+ */
+const getConfiguredDbPath = (): string =>
+  process.env.AI_SDK_DEVTOOLS_DB_PATH
+    ? path.resolve(process.env.AI_SDK_DEVTOOLS_DB_PATH)
+    : DB_PATH;
 const DEVTOOLS_PORT = process.env.AI_SDK_DEVTOOLS_PORT
   ? parseInt(process.env.AI_SDK_DEVTOOLS_PORT)
   : 4983;
@@ -102,16 +119,26 @@ const ensureGitignore = (): void => {
   }
 };
 
-const readDb = (): Database => {
+/**
+ * Reads and parses a database file, returning null if it does not exist, is not
+ * a regular file (e.g. a device file like /dev/zero), exceeds the size cap, or
+ * fails to parse. Never throws.
+ */
+const readDbFile = (filePath: string): Database | null => {
   try {
-    if (fs.existsSync(DB_PATH)) {
-      const content = fs.readFileSync(DB_PATH, 'utf-8');
-      return JSON.parse(content);
+    const stat = fs.statSync(filePath, { throwIfNoEntry: false });
+    if (!stat || !stat.isFile() || stat.size > MAX_DB_BYTES) {
+      return null;
     }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   } catch {
-    // If file is corrupted, start fresh
+    // Missing/corrupted/oversized file: start fresh.
+    return null;
   }
-  return { runs: [], steps: [] };
+};
+
+const readDb = (): Database => {
+  return readDbFile(DB_PATH) ?? { runs: [], steps: [] };
 };
 
 const writeDb = (db: Database): void => {
@@ -143,23 +170,16 @@ const saveDb = (db: Database): void => {
 /**
  * Reload the database from disk.
  * Used by the viewer server to pick up changes made by the middleware/integration.
- * When a remote dbPath is provided (from a notify POST), reads from that path
- * instead of the local CWD-based path, so the viewer works regardless of where
- * it was started.
+ *
+ * The location is always taken from server-side configuration
+ * (`getConfiguredDbPath()`); it is never derived from a network request. A prior
+ * version accepted a `dbPath` from the `/api/notify` POST body and read it
+ * directly, allowing any web page the developer visited to point the viewer at
+ * an arbitrary file (VULN-11550). To run the viewer against a database in a
+ * different directory, set the `AI_SDK_DEVTOOLS_DB_PATH` env var.
  */
-export const reloadDb = async (remoteDbPath?: string): Promise<void> => {
-  if (remoteDbPath) {
-    try {
-      if (fs.existsSync(remoteDbPath)) {
-        const content = fs.readFileSync(remoteDbPath, 'utf-8');
-        dbCache = JSON.parse(content);
-        return;
-      }
-    } catch {
-      // Fall through to default
-    }
-  }
-  dbCache = readDb();
+export const reloadDb = async (): Promise<void> => {
+  dbCache = readDbFile(getConfiguredDbPath()) ?? { runs: [], steps: [] };
 };
 
 export const createRun = async (

--- a/packages/devtools/src/viewer/server.ts
+++ b/packages/devtools/src/viewer/server.ts
@@ -52,9 +52,6 @@ const projectRoot = path.resolve(__dirname, '../..');
 // Client directory: dist/client in both cases
 const clientDir = path.join(projectRoot, 'dist/client');
 
-// Track the DB path from the most recent notify call so all reads
-// use the correct file, even when the viewer runs in a different CWD.
-let remoteDbPath: string | undefined;
 let viewerPort = 4983;
 
 export const app = new Hono();
@@ -92,7 +89,7 @@ app.use('/api/*', async (c, next) => {
 
 // API Routes
 app.get('/api/runs', async c => {
-  await reloadDb(remoteDbPath);
+  await reloadDb();
   const runs = await getRuns();
   // Only return root-level runs (no parent) in the sidebar list
   const rootRuns = runs.filter(r => !r.parent_run_id);
@@ -143,7 +140,7 @@ app.get('/api/runs', async c => {
 });
 
 app.get('/api/runs/:id', async c => {
-  await reloadDb(remoteDbPath);
+  await reloadDb();
   const data = await getRunWithSteps(c.req.param('id'));
   if (!data) {
     return c.json({ error: 'Run not found' }, 404);
@@ -259,12 +256,11 @@ app.get('/api/events', c => {
 // Notification endpoint (called by middleware/integration)
 app.post('/api/notify', async c => {
   const body = await c.req.json();
-  if (body.dbPath) {
-    remoteDbPath = body.dbPath;
-  }
-  // Reload database from disk, using the remote dbPath if provided so the
-  // viewer works even when started from a different directory than the app.
-  await reloadDb(remoteDbPath);
+  // The database location is taken only from server-side configuration; any
+  // `dbPath` in the request body is ignored to prevent the viewer from being
+  // pointed at an arbitrary file (VULN-11550). Set `AI_SDK_DEVTOOLS_DB_PATH` to
+  // run the viewer against a database in a different directory.
+  await reloadDb();
   broadcastToClients('update', body);
   return c.json({ success: true });
 });


### PR DESCRIPTION
## Background

The DevTools viewer's `/api/notify` endpoint stored a `dbPath` taken from the (unauthenticated) POST body into a module-level `remoteDbPath`, and every API read called `reloadDb(remoteDbPath)`, which passed it straight to `fs.existsSync` / `fs.readFileSync` with no validation. Any web page a developer visited while the viewer was running could therefore point the viewer at an arbitrary file:

- **Arbitrary file read** — JSON files containing a `runs` array are returned verbatim via `/api/runs` (e.g. another project's `.devtools/generations.json`); other targets act as a JSON-validity / file-existence **oracle**.
- **DoS** — a `dbPath` of `/dev/zero` or a multi-GB file hangs / OOMs the synchronous `readFileSync`.
- The poisoned path is **module-level**, so a single POST persists until the viewer restarts.

This is VULN-11550 (ANT-2026-R88SY5T6). It is distinct from VULN-11530 (fixed in #16042), which only addressed *reachability* (wildcard CORS, `0.0.0.0` bind, Host/Origin allowlisting) and left this sink in place.

## Summary

Determine the viewer database location from server-side configuration only — never from a network request:

- `reloadDb()` no longer accepts a path argument. It reads only the configured location: the default `<cwd>/.devtools/generations.json`, or the new **`AI_SDK_DEVTOOLS_DB_PATH`** env var when the viewer runs in a different directory than the app.
- `/api/notify` ignores any `dbPath` in the request body (it remains a pure "data changed → reload" signal); the module-level `remoteDbPath` is removed.
- Database reads go through a shared helper that requires a **regular file** (`statSync`) under a **100 MB cap**, closing the `/dev/zero` / huge-file DoS vector.

Common usage (viewer launched from the project root) is unchanged — `<cwd>/.devtools/generations.json` already resolves to the file the SDK writes.

## Manual Verification

- Grepped every call site: there is no remaining `reloadDb(<network value>)` and no remaining reference to `remoteDbPath`; the only inputs to the read are `process.cwd()` and the `AI_SDK_DEVTOOLS_DB_PATH` env var.
- Confirmed the default configured path (`<cwd>/.devtools/generations.json`) is byte-identical to the `DB_PATH` the SDK writes to, so a viewer started in the project root behaves exactly as before.
- Confirmed the `statSync` + size-cap helper rejects a non-regular path (directory/device) without throwing, so a hostile or missing path degrades to an empty DB rather than hanging.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Document the new `AI_SDK_DEVTOOLS_DB_PATH` env var alongside `AI_SDK_DEVTOOLS_PORT` in the devtools docs.
- Assess whether `@ai-sdk/devtools` exists on the `release-v6.0` / `release-v5.0` branches and backport if applicable.

## Related Issues

- Fixes VULN-11550 (Linear / ANT-2026-R88SY5T6).
- Follow-up to #16042 (VULN-11530), which fixed the reachability side of the same endpoint.