### PR TITLE
test(harness-claude-code): fix flaky skill-files startup test under CI load

### DIFF
--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -213,7 +213,11 @@ describe('createClaudeCode adapter', () => {
 
       const writes: Array<{ path: string; content: string }> = [];
       const runs: string[] = [];
-      const harness = createClaudeCode({ startupTimeoutMs: 1000 });
+      // Generous startup budget: this exercises the happy path (skill files +
+      // bridge handshake), not the timeout path. A tight value flakes under
+      // parallel CI load because the budget also covers the WebSocket
+      // open + `bridge-hello` round trip.
+      const harness = createClaudeCode({ startupTimeoutMs: 10_000 });
       const session = await harness.doStart({
         sessionId: 's1',
         sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
@@ -262,7 +266,7 @@ describe('createClaudeCode adapter', () => {
     } finally {
       await new Promise<void>(resolve => wss.close(() => resolve()));
     }
-  });
+  }, 15_000);
 
   it('rejects unsafe skill names before writing skill files', async () => {
     const writes: Array<{ path: string; content: string }> = [];


### PR DESCRIPTION
## Background

CI intermittently fails `packages/harness-claude-code/src/claude-code-harness.test.ts` → *“writes standard Claude skill files and enables their names on start”* with:

```
Error: claude-code bridge did not complete WebSocket handshake within 1000ms after 1 attempt(s).
Last error: claude-code bridge did not send bridge-hello within 764ms
  ❯ openBridgeWebSocket src/claude-code-harness.ts:1088
  ❯ Object.doStart src/claude-code-harness.ts:629
```

(e.g. https://github.com/vercel/ai/actions/runs/27394295911/job/80958569655)

**Root cause — a too-tight test budget, not a product bug.** The test pinned `startupTimeoutMs: 1000`. In the harness, that single value is the deadline for the *whole* bridge handshake — the WebSocket `open` **and** the `bridge-hello` round trip (`openBridgeWebSocket`). On a loaded CI shard the `open` consumed ~236ms and `bridge-hello` didn't arrive within the remaining ~764ms, so the handshake's own timer fired and failed an otherwise-passing happy-path test. The production default (`startupTimeoutMs ?? 120_000`) is unaffected, and every other happy-path test in the file already uses that generous default.

## Summary

- Raise this test's `startupTimeoutMs` from `1000` → `10_000`, with a comment explaining it exercises the happy path (skill files + handshake), not the timeout path.
- Give the test a matching `15_000`ms wall-clock (`it(..., 15_000)`) so the larger handshake budget is actually usable (vitest's default `testTimeout` is 5s).

Test-only change — no product code touched; the default startup timeout stays 120s.

## Manual Verification

- Ran the previously-failing test in isolation **3×** — passes every time (was flaky at `startupTimeoutMs: 1000`).
- Ran the full file: **10/10 pass**.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

<!-- No changeset: this is a test-only change with no effect on published package output. -->

## Related Issues

Fixes flaky CI on `claude-code-harness.test.ts` introduced with the harness adapters (#15969).