### PR TITLE
fix(docs): fix model message file part reference docs

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -134,12 +134,10 @@ export interface FilePart {
   type: 'file';
 
   /**
-   * File data. Can either be:
-   * - data: a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer
-   * - URL: a URL that points to the file
-   * - ProviderReference: a provider reference from `uploadFile`
+   * File data. Use the tagged `FileData` shape.
+   * Bare `DataContent`, `URL`, and `ProviderReference` shorthands are also supported.
    */
-  data: DataContent | URL | ProviderReference;
+  data: FileData | DataContent | URL | ProviderReference;
 
   /**
    * Optional filename of the file.
@@ -147,10 +145,21 @@ export interface FilePart {
   filename?: string;
 
   /**
-   * IANA media type of the file.
+   * Either a full IANA media type (`type/subtype`, e.g. `image/png`) or just
+   * the top-level IANA segment (e.g. `image`, `audio`, `video`, `text`).
    */
   mediaType: string;
 }
+
+export type FileData =
+  // Raw bytes as a base64 string, Uint8Array, ArrayBuffer, or Buffer.
+  | { type: 'data'; data: DataContent }
+  // A URL that points to the file.
+  | { type: 'url'; url: URL }
+  // A provider reference from `uploadFile`.
+  | { type: 'reference'; reference: ProviderReference }
+  // Inline text content.
+  | { type: 'text'; text: string };
 ```
 
 ### `CustomPart`


### PR DESCRIPTION
## Summary

The file part docs under https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/model-message#filepart are currently out of sync with the actual file part shape which now supports a tagged union shape as primary surface, with the previous shorthands still supported to avoid unnecessary breakage.

This PR fixes those docs to be up to date again.

## Manual Verification

N/A - double check the docs after this has been deployed

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
