### PR TITLE
fix(example): prevent shell injection in mcp auth example

### DIFF
--- a/examples/mcp/src/mcp-with-auth/client.ts
+++ b/examples/mcp/src/mcp-with-auth/client.ts
@@ -23,7 +23,7 @@ import {
 } from '@ai-sdk/mcp';
 import 'dotenv/config';
 import { createServer } from 'node:http';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 
 class InMemoryOAuthClientProvider implements OAuthClientProvider {
   private _tokens?: OAuthTokens;
@@ -39,18 +39,21 @@ class InMemoryOAuthClientProvider implements OAuthClientProvider {
     this._tokens = tokens;
   }
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
-    const cmd =
+    const url = authorizationUrl.toString();
+    const command =
       process.platform === 'win32'
-        ? `start ${authorizationUrl.toString()}`
+        ? 'rundll32'
         : process.platform === 'darwin'
-          ? `open "${authorizationUrl.toString()}"`
-          : `xdg-open "${authorizationUrl.toString()}"`;
-    exec(cmd, error => {
+          ? 'open'
+          : 'xdg-open';
+    const args =
+      process.platform === 'win32'
+        ? ['url.dll,FileProtocolHandler', url]
+        : [url];
+
+    execFile(command, args, error => {
       if (error) {
-        console.error(
-          'Open this URL to continue:',
-          authorizationUrl.toString(),
-        );
+        console.error('Open this URL to continue:', url);
       }
     });
   }


### PR DESCRIPTION
## Background

we were using the `exec()` command of the node api which runs shell commands, and URL characters like `$()`, `&`, `|`, or backticks could be interpreted as commands instead of just URL text

## Summary

fixed it by replacing `exec()` with `execFile()` and passing the URL as a separate argument. that launches the browser opener directly, without shell parsing

## Manual Verification

verified that the example `examples/mcp/src/mcp-with-auth/client.ts` still runs and connects

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)