### PR TITLE
fix(mcp): validate oauth metadata issuer during discovery

### DIFF
--- a/.changeset/two-pugs-lie.md
+++ b/.changeset/two-pugs-lie.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): validate oauth metadata issuer during discovery

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -557,6 +557,25 @@ describe('discoverAuthorizationServerMetadata', () => {
     code_challenge_methods_supported: ['S256'],
   };
 
+  it('returns OAuth metadata when issuer matches path-aware discovery issuer', async () => {
+    const tenantMetadata = {
+      ...validOAuthMetadata,
+      issuer: 'https://auth.example.com/tenant1',
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => tenantMetadata,
+    });
+
+    const metadata = await discoverAuthorizationServerMetadata(
+      'https://auth.example.com/tenant1',
+    );
+
+    expect(metadata).toEqual(tenantMetadata);
+  });
+
   it('tries URLs in order and returns first successful metadata', async () => {
     // First OAuth URL fails with 404
     mockFetch.mockResolvedValueOnce({
@@ -586,6 +605,41 @@ describe('discoverAuthorizationServerMetadata', () => {
     expect(calls[1][0].toString()).toBe(
       'https://auth.example.com/.well-known/oauth-authorization-server',
     );
+  });
+
+  it('rejects OAuth metadata when issuer does not match discovery issuer', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...validOAuthMetadata,
+        issuer: 'https://login.real-idp.com',
+      }),
+    });
+
+    await expect(
+      discoverAuthorizationServerMetadata('https://attacker.example/tenantA'),
+    ).rejects.toThrow(/does not match expected issuer/);
+  });
+
+  it('rejects OIDC metadata when issuer does not match discovery issuer', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...validOpenIdMetadata,
+        issuer: 'https://login.real-idp.com',
+      }),
+    });
+
+    await expect(
+      discoverAuthorizationServerMetadata('https://auth.example.com'),
+    ).rejects.toThrow(/does not match expected issuer/);
   });
 
   it('throws error when OIDC provider does not support S256 PKCE', async () => {
@@ -627,7 +681,7 @@ describe('discoverAuthorizationServerMetadata', () => {
     });
 
     const metadata = await discoverAuthorizationServerMetadata(
-      'https://mcp.example.com',
+      'https://auth.example.com',
     );
 
     expect(metadata).toEqual(validOpenIdMetadata);
@@ -1520,7 +1574,7 @@ describe('auth function', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://resource.example.com',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             registration_endpoint: 'https://auth.example.com/register',
@@ -2147,7 +2201,7 @@ describe('auth function', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://api.example.com/mcp-server',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             response_types_supported: ['code'],
@@ -2206,7 +2260,7 @@ describe('auth function', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://api.example.com/mcp-server',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             response_types_supported: ['code'],
@@ -2276,7 +2330,7 @@ describe('auth function', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://api.example.com/mcp-server',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             response_types_supported: ['code'],
@@ -2358,7 +2412,7 @@ describe('auth function', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://resource.example.com',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             response_types_supported: ['code'],
@@ -2519,7 +2573,7 @@ describe('OAuth state validation', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://resource.example.com',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             response_types_supported: ['code'],
@@ -2549,7 +2603,7 @@ describe('OAuth state validation', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            issuer: 'https://auth.example.com',
+            issuer: 'https://resource.example.com',
             authorization_endpoint: 'https://auth.example.com/authorize',
             token_endpoint: 'https://auth.example.com/token',
             registration_endpoint: 'https://auth.example.com/register',

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -442,23 +442,30 @@ export async function discoverOAuthProtectedResourceMetadata(
  */
 export function buildDiscoveryUrls(
   authorizationServerUrl: string | URL,
-): { url: URL; type: 'oauth' | 'oidc' }[] {
+): { url: URL; type: 'oauth' | 'oidc'; expectedIssuer: string }[] {
   const url =
     typeof authorizationServerUrl === 'string'
       ? new URL(authorizationServerUrl)
       : authorizationServerUrl;
   const hasPath = url.pathname !== '/';
-  const urlsToTry: { url: URL; type: 'oauth' | 'oidc' }[] = [];
+  const rootIssuer = url.origin;
+  const urlsToTry: {
+    url: URL;
+    type: 'oauth' | 'oidc';
+    expectedIssuer: string;
+  }[] = [];
 
   if (!hasPath) {
     urlsToTry.push({
       url: new URL('/.well-known/oauth-authorization-server', url.origin),
       type: 'oauth',
+      expectedIssuer: rootIssuer,
     });
 
     urlsToTry.push({
       url: new URL('/.well-known/openid-configuration', url.origin),
       type: 'oidc',
+      expectedIssuer: rootIssuer,
     });
 
     return urlsToTry;
@@ -468,6 +475,7 @@ export function buildDiscoveryUrls(
   if (pathname.endsWith('/')) {
     pathname = pathname.slice(0, -1);
   }
+  const pathIssuer = `${url.origin}${pathname}`;
 
   urlsToTry.push({
     url: new URL(
@@ -475,24 +483,39 @@ export function buildDiscoveryUrls(
       url.origin,
     ),
     type: 'oauth',
+    expectedIssuer: pathIssuer,
   });
 
   urlsToTry.push({
     url: new URL('/.well-known/oauth-authorization-server', url.origin),
     type: 'oauth',
+    expectedIssuer: rootIssuer,
   });
 
   urlsToTry.push({
     url: new URL(`/.well-known/openid-configuration${pathname}`, url.origin),
     type: 'oidc',
+    expectedIssuer: pathIssuer,
   });
 
   urlsToTry.push({
     url: new URL(`${pathname}/.well-known/openid-configuration`, url.origin),
     type: 'oidc',
+    expectedIssuer: pathIssuer,
   });
 
   return urlsToTry;
+}
+
+function assertMetadataIssuerMatches(
+  metadata: AuthorizationServerMetadata,
+  expectedIssuer: string,
+): void {
+  if (metadata.issuer !== expectedIssuer) {
+    throw new MCPClientOAuthError({
+      message: `OAuth authorization server metadata issuer ${metadata.issuer} does not match expected issuer ${expectedIssuer}`,
+    });
+  }
 }
 
 export async function discoverAuthorizationServerMetadata(
@@ -509,7 +532,7 @@ export async function discoverAuthorizationServerMetadata(
 
   const urlsToTry = buildDiscoveryUrls(authorizationServerUrl);
 
-  for (const { url: endpointUrl, type } of urlsToTry) {
+  for (const { url: endpointUrl, type, expectedIssuer } of urlsToTry) {
     const response = await fetchWithCorsRetry(endpointUrl, headers, fetchFn);
 
     if (!response) {
@@ -531,11 +554,14 @@ export async function discoverAuthorizationServerMetadata(
     }
 
     if (type === 'oauth') {
-      return OAuthMetadataSchema.parse(await response.json());
+      const metadata = OAuthMetadataSchema.parse(await response.json());
+      assertMetadataIssuerMatches(metadata, expectedIssuer);
+      return metadata;
     } else {
       const metadata = OpenIdProviderDiscoveryMetadataSchema.parse(
         await response.json(),
       );
+      assertMetadataIssuerMatches(metadata, expectedIssuer);
 
       // MCP spec requires OIDC providers to support S256 PKCE
       if (!metadata.code_challenge_methods_supported?.includes('S256')) {


### PR DESCRIPTION
## Background

the oauth flow was fetching OAuth/OIDC well-known metadata and trusted its endpoints after schema parsing, but did not verify that `metadata.issuer` matched the issuer implied by the discovery url. 

this is a requirement mentioned in the spec and there was a gap: https://www.rfc-editor.org/rfc/rfc8414.html#section-3.3

## Summary

now each discovery candidate carries its expected issuer, and parsed metadata is rejected if `metadata.issuer` does not exactly match

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)