### PR TITLE
docs(human-in-the-loop): document tool-approval trust model + experimental_toolApprovalSecret

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -373,9 +373,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return createUIMessageStreamResponse({
-    stream: toUIMessageStream({ stream: result.stream }),
-  });
+  return result.toUIMessageStreamResponse();
 }
 ```
 

--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -10,6 +10,16 @@ When building agentic systems, it's important to add human-in-the-loop (HITL) fu
 
 This recipe shows how to add a human approval step to a Next.js chatbot using the AI SDK's native tool execution approval feature.
 
+<Note type="warning">
+  By default, the approval step is a human-in-the-loop UX affordance, **not** a
+  server-side security boundary. In the standard `useChat` pattern the approval
+  is replayed through client-controlled message history, so a malicious client
+  can forge an approval and run a `needsApproval` tool with schema-valid
+  arguments — no human in the loop. If a tool performs a sensitive action, set
+  `experimental_toolApprovalSecret` so approvals are cryptographically bound to
+  the server that issued them. See [Securing Approvals](#securing-approvals).
+</Note>
+
 ## Background
 
 To understand how to implement this functionality, let's look at how tool calling works in a Next.js chatbot application with the AI SDK.
@@ -324,6 +334,72 @@ const result = streamText({
   },
 });
 ```
+
+## Securing Approvals
+
+### Trust model
+
+In the standard `useChat` pattern, the server rebuilds the conversation from the messages the client sends each request — it does not persist conversation state between requests. **This means the message history is client-controlled input.**
+
+An approval reconstructed from that history is re-validated against the tool's input schema before execution, but the schema check only constrains _what_ can run; it does not prove that a human actually approved it. A client can submit a tool part in the `approval-responded` state with `approved: true`, and the SDK will run the approved `needsApproval` tool with any schema-conforming arguments, with no human in the loop.
+
+So by default the approval step is a UX affordance, **not** a security boundary. For tools that perform sensitive operations (modifying data, spending money, calling external APIs, accessing private resources), either enforce authorization inside the tool's `execute` or — preferably — enable signed approvals.
+
+### Signing approvals with `experimental_toolApprovalSecret`
+
+When you provide a secret, the server HMAC-signs each approval request when it is issued and verifies the signature when the approval is replayed. A forged or tampered approval is rejected before the tool executes.
+
+```ts filename="app/api/chat/route.ts" highlight="7-8"
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages,
+    // Bind approvals to the server that issued them so a client cannot forge them.
+    experimental_toolApprovalSecret: process.env.TOOL_APPROVAL_SECRET,
+    tools: {
+      getWeatherInformation: tool({
+        description: 'show the weather in a given city to the user',
+        inputSchema: z.object({ city: z.string() }),
+        needsApproval: true,
+        execute: async ({ city }) => {
+          const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy'];
+          return weatherOptions[
+            Math.floor(Math.random() * weatherOptions.length)
+          ];
+        },
+      }),
+    },
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
+}
+```
+
+The signature binds the approval to the exact tool name, tool call ID, and input arguments, so changing any of them after signing invalidates the approval.
+
+**Setting up the secret:**
+
+1. Generate a high-entropy random string (at least 32 bytes):
+   ```bash
+   openssl rand -base64 32
+   ```
+2. Store it as an environment variable available to all server instances:
+   ```
+   TOOL_APPROVAL_SECRET=your-generated-secret-here
+   ```
+3. Pass it to `streamText` (or `generateText`) via `experimental_toolApprovalSecret`.
+
+Every serverless instance that might handle a request needs the same secret, since one instance signs the approval and a different instance may verify it on the next turn. The secret is never sent to the client or included in the stream.
+
+<Note type="warning">
+  Without a secret, approval requests are not signed and client-supplied
+  approvals are trusted as-is — the human-in-the-loop step can be bypassed and
+  is not a security boundary.
+</Note>
 
 ## Full Example
 


### PR DESCRIPTION
## Background

`release-v6.0` (current stable) supports `experimental_toolApprovalSecret`, but it has **no documentation of the tool-approval trust model**. The dedicated Tool Approvals page (with the "Security Considerations / Trust model" section) only exists on `main` (v7). So stable users are not told that, by default, a tool approval is replayed through client-controlled `useChat` message history — a malicious client can submit an `approval-responded` part with `approved: true` and run a `needsApproval` tool with schema-valid arguments, with no human in the loop (VULN-6698 / ANT-2026-N56BQX9Z).

The signature-binding fix cannot be backported as a breaking default to v5/v6, so for v6 the mitigation is documentation: make the limitation explicit and show how to opt into signed approvals.

## Summary

Adds the trust-model guidance to `content/cookbook/01-next/75-human-in-the-loop.mdx` — the de-facto approval guide on v6 (the v7 `ToolLoopAgent`/`toolApproval` page doesn't exist here, so this is adapted to v6's `needsApproval` + `streamText` flow):

- A prominent `warning` callout up front: the approval step is a UX affordance, not a server-side security boundary; client-supplied approvals can be forged; set `experimental_toolApprovalSecret` for sensitive tools.
- A new **Securing Approvals** section: the trust model (message history is client-controlled; schema re-validation does not prove a human approved), then **Signing approvals with `experimental_toolApprovalSecret`** — a `streamText` snippet, the input-binding behavior, secret setup steps (`openssl rand`, shared across instances, never sent to the client), and a closing note that without a secret approvals are trusted as-is.

Docs-only; no code or published-package changes.

## Manual Verification

- Confirmed `experimental_toolApprovalSecret` is supported on this branch (`generate-text.ts`, `stream-text.ts`), so the guidance is accurate for v6.
- Confirmed the in-page anchor `#securing-approvals` resolves to the new `## Securing Approvals` heading, and the up-front callout links to it.
- Verified line numbers in the `highlight` directive point at the `experimental_toolApprovalSecret` line.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

<!-- Docs-only change: no automated tests and no changeset (content/ is not a published package). The "Documentation" item is the change itself. -->

## Future Work

- The equivalent clarification for `main`/v7 lives on a separate branch (`docs-tool-approval-trust-model`) where it sharpens the existing Tool Approvals page and the cookbook.
- v5 has no server-side tool-approval feature, so no docs change is needed there.

## Related Issues

Documentation mitigation for VULN-6698 / ANT-2026-N56BQX9Z on the stable v6 line.