### PR TITLE
fix(google): emit inlineData for non-image base64 tool-result file parts

### DIFF
--- a/.changeset/google-legacy-file-data-inline.md
+++ b/.changeset/google-legacy-file-data-inline.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): emit base64-data file parts as `inlineData` on the pre-Gemini-3 legacy tool-result path, regardless of media type. Previously only images were sent as `inlineData` and everything else (PDF, audio, video, …) fell through to `JSON.stringify`, which Gemini tokenized as raw text — a single 5-page PDF was ~4M tokens vs. ~2,800 with `inlineData`, instantly tripping the 1,048,576 input-token limit.

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -944,7 +944,69 @@ describe('tool messages', () => {
         text: 'Tool executed successfully and returned this image as a response',
       },
       {
-        text: `{"type":"file","data":{"type":"data","data":"base64pdfdata"},"mediaType":"application/pdf","filename":"report.pdf"}`,
+        inlineData: {
+          mimeType: 'application/pdf',
+          data: 'base64pdfdata',
+        },
+      },
+      {
+        text: 'Tool executed successfully and returned this file as a response',
+      },
+    ]);
+  });
+
+  it('should emit inlineData for non-image base64 tool-result file parts on the legacy path', async () => {
+    // Regression for #16072. The pre-Gemini-3 legacy path previously only
+    // emitted `inlineData` for images and stringified everything else, which
+    // turned a 5-page PDF into 4M+ text tokens and tripped the input-token
+    // limit. The fix routes every base64-data file part through `inlineData`,
+    // regardless of media type.
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'documentReader',
+              toolCallId: 'pdfCallId',
+              output: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'metadata' },
+                  {
+                    type: 'file',
+                    data: { type: 'data', data: 'base64pdfdata' },
+                    mediaType: 'application/pdf',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      { supportsFunctionResponseParts: false },
+    );
+
+    expect(result.contents[0].parts).toEqual([
+      {
+        functionResponse: {
+          id: 'pdfCallId',
+          name: 'documentReader',
+          response: {
+            name: 'documentReader',
+            content: 'metadata',
+          },
+        },
+      },
+      {
+        inlineData: {
+          mimeType: 'application/pdf',
+          data: 'base64pdfdata',
+        },
+      },
+      {
+        text: 'Tool executed successfully and returned this file as a response',
       },
     ]);
   });

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -162,10 +162,16 @@ function appendLegacyToolResultParts(
         });
         break;
       case 'file': {
-        if (
-          contentPart.data.type === 'data' &&
-          getTopLevelMediaType(contentPart.mediaType) === 'image'
-        ) {
+        if (contentPart.data.type === 'data') {
+          // Emit base64-data file parts as top-level `inlineData`, regardless
+          // of media type. The previous behavior only emitted `inlineData` for
+          // images and fell through to `JSON.stringify(contentPart)` for
+          // everything else (PDF, audio, video, etc.), which the Gemini API
+          // then tokenized as raw text. For a single 5-page PDF that's the
+          // difference between ~2,800 document tokens and >4,000,000 text
+          // tokens — instantly tripping the 1,048,576 input-token limit on
+          // pre-Gemini-3 models. See #16072.
+          const topLevelMediaType = getTopLevelMediaType(contentPart.mediaType);
           parts.push(
             {
               inlineData: {
@@ -174,7 +180,10 @@ function appendLegacyToolResultParts(
               },
             },
             {
-              text: 'Tool executed successfully and returned this image as a response',
+              text:
+                topLevelMediaType === 'image'
+                  ? 'Tool executed successfully and returned this image as a response'
+                  : 'Tool executed successfully and returned this file as a response',
             },
           );
         } else {


### PR DESCRIPTION
## Summary

Closes #16072.

\`appendLegacyToolResultParts\` in \`packages/google/src/convert-to-google-messages.ts\` only emitted top-level \`inlineData\` for images and fell through to \`JSON.stringify(contentPart)\` for every other media type. For a tool that returned a PDF (or audio, video, etc.) via \`toModelOutput\`, Gemini then tokenized the base64 payload as raw text instead of as a document.

The reporter measured the blow-up with Gemini \`countTokens\` on a 5-page PDF:

| Format | Total | Text | Document |
|---|---|---|---|
| user inlineData PDF | 2,807 | 7 | 2,800 |
| tool functionResponse inlineData PDF | 2,856 | 56 | 2,800 |
| **base64 as plain text** (current bug) | **4,065,979** | **4,065,979** | **0** |

A single 5-page PDF tool result instantly trips the 1,048,576 input-token limit on pre-Gemini-3 models with:

\`\`\`
AI_APICallError: The input token count exceeds the maximum number of tokens allowed 1048576.
\`\`\`

## Root cause

\`appendLegacyToolResultParts\` was structured around the image-only legacy contract:

\`\`\`ts
case 'file': {
  if (
    contentPart.data.type === 'data' &&
    getTopLevelMediaType(contentPart.mediaType) === 'image'   // ← here
  ) {
    parts.push({ inlineData: ... }, { text: '...returned this image...' });
  } else {
    parts.push({ text: JSON.stringify(contentPart) });        // ← PDF/audio/etc land here
  }
}
\`\`\`

But the modern (Gemini 3+) path at \`appendToolResultParts\` already routes every \`file.data.type === 'data'\` part through \`inlineData\` regardless of media type. Gemini's pre-3 API actually supports inline non-image data via top-level \`inlineData\` just fine — the legacy path's restriction was incidental, not contractual.

## Fix

Drop the image-only restriction. Keep the existing "image" caption when the media type is an image (back-compat for any consumer asserting against that exact string), use a generic "file" caption otherwise:

\`\`\`diff
 case 'file': {
-  if (
-    contentPart.data.type === 'data' &&
-    getTopLevelMediaType(contentPart.mediaType) === 'image'
-  ) {
+  if (contentPart.data.type === 'data') {
+    const topLevelMediaType = getTopLevelMediaType(contentPart.mediaType);
     parts.push(
       {
         inlineData: {
           mimeType: resolveFullMediaType({ part: contentPart }),
           data: convertToBase64(contentPart.data.data),
         },
       },
       {
-        text: 'Tool executed successfully and returned this image as a response',
+        text:
+          topLevelMediaType === 'image'
+            ? 'Tool executed successfully and returned this image as a response'
+            : 'Tool executed successfully and returned this file as a response',
       },
     );
   } else {
     parts.push({ text: JSON.stringify(contentPart) });
   }
\`\`\`

URL-typed file parts on the legacy path are unchanged — they're a separate stringification issue covered by the existing \`should keep URL tool result parts on the legacy path\` test, and outside this PR's scope.

## Tests

- **New** \`should emit inlineData for non-image base64 tool-result file parts on the legacy path\` — direct PDF regression for #16072. Mirrors the reporter's repro shape exactly (\`text\` metadata + \`file-data\` PDF), asserts the wire shape becomes \`functionResponse\` + \`inlineData\` + caption.
- **Updated** the existing \`should use legacy tool-result conversion when functionResponse parts are unsupported\` test. Its pdf assertion previously documented the bug (\`JSON.stringify\` of the contentPart) — now asserts \`inlineData\` instead. Image assertion in the same test is unchanged.

Both fail on \`main\`, both pass on this branch.

## Test plan

- [x] \`pnpm -F @ai-sdk/google test:node convert-to-google-messages.test\` — **54/54 pass** on this branch (53 existing + 1 new)
- [x] Verified the same test file fails on \`main\` with **2 failed | 52 passed** when only the production change is reverted — confirms the tests catch the actual code path
- [x] \`pnpm fix\` (ultracite format + lint) — clean
- [x] Changeset added (\`@ai-sdk/google\` patch)

## Why a fork branch with \`-v2\` suffix

My fork's \`main\` is several commits behind upstream and the gap includes a new \`.github/workflows/backport.yml\` that my Personal Access Token doesn't have \`workflow\` scope to push. I cherry-picked the fix commit onto \`origin/main\` (my fork's stale main) so the push contains only the actual fix files. Diff vs \`vercel/ai\` \`main\` is identical to the original branch.

## Notes for review

- The reporter cites \`gemini-flash-lite-latest\` specifically but the bug surface is every non-Gemini-3 model that goes through the legacy path. The fix is universal — no model-id gating.
- Considered also threading \`fileData\` for URL-typed file parts on the legacy path so a tool returning a hosted PDF URL doesn't hit the same stringify issue. Held back because Gemini's pre-3 \`functionResponse\` shape isn't documented to accept \`fileData\`, and the modern path uses \`convertUrlToolResultPart\` which only returns \`inlineData\` for base64 data URLs anyway. Worth a follow-up if reported, but skipping it here keeps this PR scoped to the directly-reported regression.