### PR TITLE
fix(langchain): prevent polluting global object.prototype

### DIFF
--- a/.changeset/four-keys-crash.md
+++ b/.changeset/four-keys-crash.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/langchain": patch
+---
+
+fix(langchain): prevent polluting global object.prototype

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -431,20 +431,14 @@ export function toUIMessageStream<TState = unknown>(
    * State for LangGraph stream handling
    */
   const langGraphState: LangGraphEventState = {
-    messageSeen: {} as Record<
-      string,
-      { text?: boolean; reasoning?: boolean; tool?: Record<string, boolean> }
-    >,
-    messageConcat: {} as Record<string, AIMessageChunk>,
+    messageSeen: new Map(),
+    messageConcat: new Map(),
     emittedToolCalls: new Set<string>(),
     emittedToolInputs: new Set<string>(),
     emittedImages: new Set<string>(),
     emittedReasoningIds: new Set<string>(),
-    messageReasoningIds: {} as Record<string, string>,
-    toolCallInfoByIndex: {} as Record<
-      string,
-      Record<number, { id: string; name: string }>
-    >,
+    messageReasoningIds: new Map(),
+    toolCallInfoByIndex: new Map(),
     currentStep: null as number | null,
     emittedToolCallsByKey: new Map<string, string>(),
     emittedSourceIds: new Set<string>(),
@@ -589,7 +583,7 @@ export function toUIMessageStream<TState = unknown>(
            * This handles streams without values events (e.g. streamMode: 'messages')
            * where the values handler never ran to emit *-end events.
            */
-          for (const [id, seen] of Object.entries(langGraphState.messageSeen)) {
+          for (const [id, seen] of langGraphState.messageSeen) {
             if (seen.text) {
               controller.enqueue({ type: 'text-end', id });
             }

--- a/packages/langchain/src/types.ts
+++ b/packages/langchain/src/types.ts
@@ -1,16 +1,19 @@
 import type { AIMessageChunk } from '@langchain/core/messages';
 
+export interface LangGraphMessageSeen {
+  text?: boolean;
+  reasoning?: boolean;
+  tool?: Set<string>;
+}
+
 /**
  * State for LangGraph event processing
  */
 export interface LangGraphEventState {
   /** Tracks which message IDs have been seen */
-  messageSeen: Record<
-    string,
-    { text?: boolean; reasoning?: boolean; tool?: Record<string, boolean> }
-  >;
+  messageSeen: Map<string, LangGraphMessageSeen>;
   /** Accumulates message chunks for later reference */
-  messageConcat: Record<string, AIMessageChunk>;
+  messageConcat: Map<string, AIMessageChunk>;
   /** Tracks which tool call IDs have emitted tool-input-start */
   emittedToolCalls: Set<string>;
   /** Tracks which tool call IDs have emitted complete tool inputs */
@@ -20,12 +23,9 @@ export interface LangGraphEventState {
   /** Maps reasoning block IDs to their message IDs (for chunks that don't include the ID) */
   emittedReasoningIds: Set<string>;
   /** Maps message IDs to their reasoning block IDs (for chunks that don't include the ID) */
-  messageReasoningIds: Record<string, string>;
+  messageReasoningIds: Map<string, string>;
   /** Maps message ID + tool call index to tool call info (for streaming chunks without ID) */
-  toolCallInfoByIndex: Record<
-    string,
-    Record<number, { id: string; name: string }>
-  >;
+  toolCallInfoByIndex: Map<string, Map<number, { id: string; name: string }>>;
   /** Tracks the current LangGraph step for start-step/finish-step events */
   currentStep: number | null;
   /** Maps tool call key (name:argsJson) to tool call ID for HITL interrupt handling */

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -28,7 +28,7 @@ import {
   extractCitationsFromContentBlocks,
   emitSourceChunks,
 } from './utils';
-import type { NormalizedCitation } from './types';
+import type { LangGraphEventState, NormalizedCitation } from './types';
 
 /**
  * Creates a mock ReadableStreamDefaultController for testing
@@ -44,6 +44,21 @@ function createMockController(
     error: () => {},
     desiredSize: 1,
   } as ReadableStreamDefaultController<UIMessageChunk>;
+}
+
+const objectPrototypeProperties = ['text', 'reasoning', 'tool', '0'] as const;
+
+function clearObjectPrototypeProperties() {
+  for (const property of objectPrototypeProperties) {
+    delete (Object.prototype as Record<string, unknown>)[property];
+  }
+}
+
+function expectObjectPrototypeNotPolluted() {
+  const object = {} as Record<string, unknown>;
+  for (const property of objectPrototypeProperties) {
+    expect(object[property]).toBeUndefined();
+  }
 }
 
 describe('convertToolResultPart', () => {
@@ -935,21 +950,15 @@ describe('extractImageOutputs', () => {
 });
 
 describe('processLangGraphEvent', () => {
-  const createMockState = () => ({
-    messageSeen: {} as Record<
-      string,
-      { text?: boolean; reasoning?: boolean; tool?: Record<string, boolean> }
-    >,
-    messageConcat: {} as Record<string, AIMessageChunk>,
+  const createMockState = (): LangGraphEventState => ({
+    messageSeen: new Map(),
+    messageConcat: new Map(),
     emittedToolCalls: new Set<string>(),
     emittedToolInputs: new Set<string>(),
     emittedImages: new Set<string>(),
     emittedReasoningIds: new Set<string>(),
-    messageReasoningIds: {} as Record<string, string>,
-    toolCallInfoByIndex: {} as Record<
-      string,
-      Record<number, { id: string; name: string }>
-    >,
+    messageReasoningIds: new Map(),
+    toolCallInfoByIndex: new Map(),
     currentStep: null as number | null,
     emittedToolCallsByKey: new Map<string, string>(),
     emittedSourceIds: new Set<string>(),
@@ -1508,6 +1517,101 @@ describe('processLangGraphEvent', () => {
     });
   });
 
+  it('should not pollute Object.prototype from remote text message ids', () => {
+    clearObjectPrototypeProperties();
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    try {
+      const plainMsg = { type: 'ai', content: 'Hello', id: '__proto__' };
+      processLangGraphEvent(['messages', [plainMsg]], state, controller);
+
+      expect(chunks).toContainEqual({ type: 'text-start', id: '__proto__' });
+      expect(chunks).toContainEqual({
+        type: 'text-delta',
+        delta: 'Hello',
+        id: '__proto__',
+      });
+      expect(state.messageSeen.get('__proto__')).toEqual({ text: true });
+      expectObjectPrototypeNotPolluted();
+    } finally {
+      clearObjectPrototypeProperties();
+    }
+  });
+
+  it('should not pollute Object.prototype from remote reasoning message ids', () => {
+    clearObjectPrototypeProperties();
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    try {
+      const plainMsg = {
+        type: 'ai',
+        content: '',
+        contentBlocks: [{ type: 'reasoning', reasoning: 'Thinking...' }],
+        id: '__proto__',
+      };
+      processLangGraphEvent(['messages', [plainMsg]], state, controller);
+
+      expect(chunks).toContainEqual({
+        type: 'reasoning-start',
+        id: '__proto__',
+      });
+      expect(chunks).toContainEqual({
+        type: 'reasoning-delta',
+        delta: 'Thinking...',
+        id: '__proto__',
+      });
+      expect(state.messageSeen.get('__proto__')).toEqual({ reasoning: true });
+      expectObjectPrototypeNotPolluted();
+    } finally {
+      clearObjectPrototypeProperties();
+    }
+  });
+
+  it('should not pollute Object.prototype from remote tool call message ids', () => {
+    clearObjectPrototypeProperties();
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    try {
+      const plainMsg = {
+        type: 'ai',
+        content: '',
+        id: '__proto__',
+        tool_call_chunks: [
+          { id: 'call-1', name: 'test_tool', args: '{"value":', index: 0 },
+        ],
+      };
+      processLangGraphEvent(['messages', [plainMsg]], state, controller);
+
+      expect(chunks).toContainEqual({
+        type: 'tool-input-start',
+        toolCallId: 'call-1',
+        toolName: 'test_tool',
+        dynamic: true,
+      });
+      expect(chunks).toContainEqual({
+        type: 'tool-input-delta',
+        toolCallId: 'call-1',
+        inputTextDelta: '{"value":',
+      });
+      expect(state.messageSeen.get('__proto__')?.tool?.has('call-1')).toBe(
+        true,
+      );
+      expect(state.toolCallInfoByIndex.get('__proto__')?.get(0)).toEqual({
+        id: 'call-1',
+        name: 'test_tool',
+      });
+      expectObjectPrototypeNotPolluted();
+    } finally {
+      clearObjectPrototypeProperties();
+    }
+  });
+
   it('should handle plain tool message objects from RemoteGraph', () => {
     const state = createMockState();
     const chunks: unknown[] = [];
@@ -1530,14 +1634,14 @@ describe('processLangGraphEvent', () => {
 
   it('should handle values event and finalize pending messages', () => {
     const state = createMockState();
-    state.messageSeen['msg-1'] = { text: true };
+    state.messageSeen.set('msg-1', { text: true });
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
 
     processLangGraphEvent(['values', {}], state, controller);
 
     expect(chunks).toContainEqual({ type: 'text-end', id: 'msg-1' });
-    expect(state.messageSeen['msg-1']).toBeUndefined();
+    expect(state.messageSeen.has('msg-1')).toBe(false);
   });
 
   it('should handle tool calls in values event', () => {
@@ -1686,7 +1790,7 @@ describe('processLangGraphEvent', () => {
     const state = createMockState();
     // Mark reasoning ID as already emitted (simulates streaming having already emitted this reasoning)
     state.emittedReasoningIds.add('rs_123');
-    state.messageSeen['msg-1'] = { reasoning: true };
+    state.messageSeen.set('msg-1', { reasoning: true });
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
 
@@ -2645,21 +2749,15 @@ describe('processModelChunk - sources', () => {
 });
 
 describe('processLangGraphEvent - sources', () => {
-  const createMockState = () => ({
-    messageSeen: {} as Record<
-      string,
-      { text?: boolean; reasoning?: boolean; tool?: Record<string, boolean> }
-    >,
-    messageConcat: {} as Record<string, AIMessageChunk>,
+  const createMockState = (): LangGraphEventState => ({
+    messageSeen: new Map(),
+    messageConcat: new Map(),
     emittedToolCalls: new Set<string>(),
     emittedToolInputs: new Set<string>(),
     emittedImages: new Set<string>(),
     emittedReasoningIds: new Set<string>(),
-    messageReasoningIds: {} as Record<string, string>,
-    toolCallInfoByIndex: {} as Record<
-      string,
-      Record<number, { id: string; name: string }>
-    >,
+    messageReasoningIds: new Map(),
+    toolCallInfoByIndex: new Map(),
     currentStep: null as number | null,
     emittedToolCallsByKey: new Map<string, string>(),
     emittedSourceIds: new Set<string>(),

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -20,6 +20,7 @@ import type {
 
 import type {
   LangGraphEventState,
+  LangGraphMessageSeen,
   ReasoningContentBlock,
   ThinkingContentBlock,
   GPT5ReasoningOutput,
@@ -1175,6 +1176,38 @@ function formatToolError(error: unknown): string {
 }
 
 /**
+ * Returns per-message bookkeeping, creating it on first use.
+ * Map keys keep remote-controlled message IDs like "__proto__" from touching Object.prototype.
+ */
+function getOrCreateMessageSeen(
+  messageSeen: LangGraphEventState['messageSeen'],
+  msgId: string,
+): LangGraphMessageSeen {
+  let seen = messageSeen.get(msgId);
+  if (!seen) {
+    seen = {};
+    messageSeen.set(msgId, seen);
+  }
+  return seen;
+}
+
+/**
+ * Returns the per-index tool call metadata for a message, creating it on first use.
+ * Later streamed chunks use this to recover tool call IDs/names from earlier chunks.
+ */
+function getOrCreateToolCallInfoByIndex(
+  toolCallInfoByIndex: LangGraphEventState['toolCallInfoByIndex'],
+  msgId: string,
+): Map<number, { id: string; name: string }> {
+  let toolCallInfo = toolCallInfoByIndex.get(msgId);
+  if (!toolCallInfo) {
+    toolCallInfo = new Map();
+    toolCallInfoByIndex.set(msgId, toolCallInfo);
+  }
+  return toolCallInfo;
+}
+
+/**
  * Processes a LangGraph event and emits UI message chunks.
  *
  * @param event - The event to process.
@@ -1257,16 +1290,16 @@ export function processLangGraphEvent(
           : null;
       if (langgraphStep !== null && langgraphStep !== state.currentStep) {
         if (state.currentStep !== null) {
-          for (const [id, seen] of Object.entries(messageSeen)) {
+          for (const [id, seen] of messageSeen) {
             if (seen.text) {
               controller.enqueue({ type: 'text-end', id });
             }
             if (seen.reasoning) {
               controller.enqueue({ type: 'reasoning-end', id });
             }
-            delete messageSeen[id];
-            delete messageConcat[id];
-            delete messageReasoningIds[id];
+            messageSeen.delete(id);
+            messageConcat.delete(id);
+            messageReasoningIds.delete(id);
           }
           controller.enqueue({ type: 'finish-step' });
         }
@@ -1279,17 +1312,19 @@ export function processLangGraphEvent(
        * Note: Only works for actual class instances, not serialized messages
        */
       if (AIMessageChunk.isInstance(msg)) {
-        if (messageConcat[msgId]) {
-          messageConcat[msgId] = messageConcat[msgId].concat(
-            msg,
-          ) as AIMessageChunk;
+        const existingMessage = messageConcat.get(msgId);
+        if (existingMessage) {
+          messageConcat.set(
+            msgId,
+            existingMessage.concat(msg) as AIMessageChunk,
+          );
         } else {
-          messageConcat[msgId] = msg;
+          messageConcat.set(msgId, msg);
         }
       }
 
       if (isAIMessageChunk(msg)) {
-        const concatChunk = messageConcat[msgId];
+        const concatChunk = messageConcat.get(msgId);
 
         /**
          * Handle image generation outputs from additional_kwargs.tool_outputs
@@ -1348,22 +1383,27 @@ export function processLangGraphEvent(
              * If this chunk has an id, store it for future lookups by index
              */
             if (toolCallChunk.id) {
-              toolCallInfoByIndex[msgId] ??= {};
-              toolCallInfoByIndex[msgId][toolCallIndex] = {
-                id: toolCallChunk.id,
-                name:
-                  toolCallChunk.name ||
-                  concatChunk?.tool_call_chunks?.[toolCallIndex]?.name ||
-                  'unknown',
-              };
+              getOrCreateToolCallInfoByIndex(toolCallInfoByIndex, msgId).set(
+                toolCallIndex,
+                {
+                  id: toolCallChunk.id,
+                  name:
+                    toolCallChunk.name ||
+                    concatChunk?.tool_call_chunks?.[toolCallIndex]?.name ||
+                    'unknown',
+                },
+              );
             }
 
             /**
              * Get the tool call ID from the chunk, stored info, or accumulated chunks
              */
+            const storedToolCallInfo = toolCallInfoByIndex
+              .get(msgId)
+              ?.get(toolCallIndex);
             const toolCallId =
               toolCallChunk.id ||
-              toolCallInfoByIndex[msgId]?.[toolCallIndex]?.id ||
+              storedToolCallInfo?.id ||
               concatChunk?.tool_call_chunks?.[toolCallIndex]?.id;
 
             /**
@@ -1375,7 +1415,7 @@ export function processLangGraphEvent(
 
             const toolName =
               toolCallChunk.name ||
-              toolCallInfoByIndex[msgId]?.[toolCallIndex]?.name ||
+              storedToolCallInfo?.name ||
               concatChunk?.tool_call_chunks?.[toolCallIndex]?.name ||
               'unknown';
 
@@ -1384,10 +1424,11 @@ export function processLangGraphEvent(
              * (even if args is empty - the first chunk often has empty args)
              * Set dynamic: true to enable HITL approval requests
              */
-            if (!messageSeen[msgId]?.tool?.[toolCallId]) {
-              messageSeen[msgId] ??= {};
-              messageSeen[msgId].tool ??= {};
-              messageSeen[msgId].tool![toolCallId] = true;
+            const seen = messageSeen.get(msgId);
+            if (!seen?.tool?.has(toolCallId)) {
+              const updatedSeen = getOrCreateMessageSeen(messageSeen, msgId);
+              updatedSeen.tool ??= new Set();
+              updatedSeen.tool.add(toolCallId);
 
               if (!emittedToolCalls.has(toolCallId)) {
                 emittedToolCalls.add(toolCallId);
@@ -1428,8 +1469,8 @@ export function processLangGraphEvent(
         // Capture reasoning ID when we first see it (even if no content yet)
         const chunkReasoningId = extractReasoningId(msg);
         if (chunkReasoningId) {
-          if (!messageReasoningIds[msgId]) {
-            messageReasoningIds[msgId] = chunkReasoningId;
+          if (!messageReasoningIds.has(msgId)) {
+            messageReasoningIds.set(msgId, chunkReasoningId);
           }
           // Immediately mark as emitted to prevent values from duplicating
           // This must happen as soon as we see the ID, before content arrives
@@ -1440,12 +1481,12 @@ export function processLangGraphEvent(
         if (reasoning) {
           // Use stored reasoning ID, or current chunk's ID, or fall back to message ID
           const reasoningId =
-            messageReasoningIds[msgId] ?? chunkReasoningId ?? msgId;
+            messageReasoningIds.get(msgId) ?? chunkReasoningId ?? msgId;
 
-          if (!messageSeen[msgId]?.reasoning) {
+          const seen = messageSeen.get(msgId);
+          if (!seen?.reasoning) {
             controller.enqueue({ type: 'reasoning-start', id: msgId });
-            messageSeen[msgId] ??= {};
-            messageSeen[msgId].reasoning = true;
+            getOrCreateMessageSeen(messageSeen, msgId).reasoning = true;
           }
 
           // Streaming chunks have delta text, emit directly without slicing
@@ -1463,10 +1504,10 @@ export function processLangGraphEvent(
          */
         const text = getMessageText(msg);
         if (text) {
-          if (!messageSeen[msgId]?.text) {
+          const seen = messageSeen.get(msgId);
+          if (!seen?.text) {
             controller.enqueue({ type: 'text-start', id: msgId });
-            messageSeen[msgId] ??= {};
-            messageSeen[msgId].text = true;
+            getOrCreateMessageSeen(messageSeen, msgId).text = true;
           }
 
           controller.enqueue({
@@ -1615,16 +1656,16 @@ export function processLangGraphEvent(
       /**
        * Finalize all pending message chunks
        */
-      for (const [id, seen] of Object.entries(messageSeen)) {
+      for (const [id, seen] of messageSeen) {
         if (seen.text) controller.enqueue({ type: 'text-end', id });
         if (seen.tool) {
-          for (const [toolCallId, toolCallSeen] of Object.entries(seen.tool)) {
-            const concatMsg = messageConcat[id];
+          for (const toolCallId of seen.tool) {
+            const concatMsg = messageConcat.get(id);
             const toolCall = concatMsg?.tool_calls?.find(
               call => call.id === toolCallId,
             );
 
-            if (toolCallSeen && toolCall) {
+            if (toolCall) {
               emittedToolCalls.add(toolCallId);
               // Store mapping for HITL interrupt lookup
               const toolCallKey = `${toolCall.name}:${JSON.stringify(toolCall.args)}`;
@@ -1647,9 +1688,9 @@ export function processLangGraphEvent(
           controller.enqueue({ type: 'reasoning-end', id });
         }
 
-        delete messageSeen[id];
-        delete messageConcat[id];
-        delete messageReasoningIds[id];
+        messageSeen.delete(id);
+        messageConcat.delete(id);
+        messageReasoningIds.delete(id);
       }
 
       /**
@@ -1828,7 +1869,7 @@ export function processLangGraphEvent(
              *    AND tool_calls. We skip those to avoid duplicate reasoning entries.)
              */
             const reasoningId = extractReasoningId(msg);
-            const wasStreamedThisRequest = !!messageSeen[msgId];
+            const wasStreamedThisRequest = messageSeen.has(msgId);
             const hasToolCalls = toolCalls && toolCalls.length > 0;
 
             /**


### PR DESCRIPTION
## Background

currently in the langchain provider, message IDs from the remote stream were used as keys in plain objects like `messageSeen[msgId]`

if the remote stream sent id: `"__proto__"`, `messageSeen["__proto__"]` resolves to `Object.prototype` not a normal own entry, which could pollute value of object globally
 
## Summary

the state now uses `Map`, and tool tracking uses `Set`

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)