### PR TITLE
Enable `includeUsage` for Fireworks so streaming responses report token usage

### DIFF
--- a/.changeset/fireworks-include-usage.md
+++ b/.changeset/fireworks-include-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Enable `includeUsage` for Fireworks so streaming responses report token usage

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -114,6 +114,14 @@ describe('FireworksProvider', () => {
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
 
+    it('should set includeUsage so streaming responses report token usage', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+      expect(config.includeUsage).toBe(true);
+    });
+
     it('should pass transformRequestBody that converts thinking options', () => {
       const provider = createFireworks();
       provider.chatModel('test-model');
@@ -255,6 +263,16 @@ describe('FireworksProvider', () => {
       const model = provider.completionModel(modelId);
 
       expect(model).toBeInstanceOf(OpenAICompatibleCompletionLanguageModel);
+    });
+
+    it('should set includeUsage so streaming responses report token usage', () => {
+      const provider = createFireworks();
+      provider.completionModel('test-model');
+
+      const config = (
+        OpenAICompatibleCompletionLanguageModel as unknown as Mock
+      ).mock.calls[0][1];
+      expect(config.includeUsage).toBe(true);
     });
   });
 

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -134,6 +134,7 @@ export function createFireworks(
   const createChatModel = (modelId: FireworksChatModelId) => {
     return new OpenAICompatibleChatLanguageModel(modelId, {
       ...getCommonModelConfig('chat'),
+      includeUsage: true,
       errorStructure: fireworksErrorStructure,
       transformRequestBody: args => {
         const thinking = args.thinking as
@@ -178,6 +179,7 @@ export function createFireworks(
   const createCompletionModel = (modelId: FireworksCompletionModelId) =>
     new OpenAICompatibleCompletionLanguageModel(modelId, {
       ...getCommonModelConfig('completion'),
+      includeUsage: true,
       errorStructure: fireworksErrorStructure,
     });
 


### PR DESCRIPTION
## Summary

The Fireworks provider never set `includeUsage`, so it never sent `stream_options: { include_usage: true }` on streaming requests. For models that don't return usage by default (e.g. `minimax-m3`), this means **streaming responses come back with `usage` entirely `undefined`** — no input/output/total tokens. Downstream consumers (incl. AI Gateway cost accounting) then compute a cost of `0`.

Other models served by Fireworks (e.g. `deepseek-v4-flash`, `kimi-k2.6`) include usage in the final chunk regardless, which masked the gap.

## Root cause

`OpenAICompatibleChatLanguageModel` only emits `stream_options.include_usage` when its config has `includeUsage` truthy:

```ts
stream_options: this.config.includeUsage ? { include_usage: true } : undefined
```

`createFireworks` built the chat/completion models without `includeUsage`, and — unlike `createOpenAICompatible` — the Fireworks settings type never exposed it, so the flag could not reach the model config.

## Fix

Set `includeUsage: true` on the Fireworks chat and completion model configs, mirroring how the closest sibling provider (`@ai-sdk/moonshotai`) already does it. This makes Fireworks request the usage chunk on streams so token usage is reported for all models.

## Verification

Reproduced through AI Gateway (`only: fireworks`, streaming) before/after:

| Model | Before | After |
|---|---|---|
| `minimax/minimax-m3` | usage `undefined`, cost `0` | input 132 / output 23, cost computed |
| `deepseek/deepseek-v4-flash` | usage present | usage present (unchanged) |
| `moonshotai/kimi-k2.6` | usage present | usage present (unchanged) |

`pnpm test:node` passes (45 tests, incl. new assertions that chat & completion configs set `includeUsage: true`).