### PR TITLE
Backport: Enable `includeUsage` for Fireworks so streaming responses report token usage

### DIFF
--- a/.changeset/fireworks-include-usage.md
+++ b/.changeset/fireworks-include-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Enable `includeUsage` for Fireworks so streaming responses report token usage

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -126,6 +126,14 @@ describe('FireworksProvider', () => {
 
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
+
+    it('should set includeUsage so streaming responses report token usage', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+      expect(config.includeUsage).toBe(true);
+    });
   });
 
   describe('completionModel', () => {
@@ -136,6 +144,16 @@ describe('FireworksProvider', () => {
       const model = provider.completionModel(modelId);
 
       expect(model).toBeInstanceOf(OpenAICompatibleCompletionLanguageModel);
+    });
+
+    it('should set includeUsage so streaming responses report token usage', () => {
+      const provider = createFireworks();
+      provider.completionModel('test-model');
+
+      const config = (
+        OpenAICompatibleCompletionLanguageModel as unknown as Mock
+      ).mock.calls[0][1];
+      expect(config.includeUsage).toBe(true);
     });
   });
 

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -131,6 +131,7 @@ export function createFireworks(
   const createChatModel = (modelId: FireworksChatModelId) => {
     return new OpenAICompatibleChatLanguageModel(modelId, {
       ...getCommonModelConfig('chat'),
+      includeUsage: true,
       errorStructure: fireworksErrorStructure,
     });
   };
@@ -138,6 +139,7 @@ export function createFireworks(
   const createCompletionModel = (modelId: FireworksCompletionModelId) =>
     new OpenAICompatibleCompletionLanguageModel(modelId, {
       ...getCommonModelConfig('completion'),
+      includeUsage: true,
       errorStructure: fireworksErrorStructure,
     });
 


### PR DESCRIPTION
Backport of #16087 to `release-v5.0` (AI SDK v5).

The Fireworks provider never set `includeUsage`, so it never sent `stream_options: { include_usage: true }` on streaming requests. For models that don't return usage by default (e.g. `minimax-m3`), streaming responses come back with `usage` entirely `undefined`. This is the path the AI Gateway **v2 spec** route (`/v1/ai`) uses via `@ai-sdk/fireworks@1.x`.

`OpenAICompatibleChatLanguageModel`/`OpenAICompatibleCompletionLanguageModel` on this branch only emit `stream_options.include_usage` when their config has `includeUsage` truthy — verified the gating is present in the v5 `@ai-sdk/openai-compatible` (chat + completion). This sets `includeUsage: true` on both Fireworks model configs so usage is reported.

Same one-line fix as #16087 / the v6 backport #16089. `pnpm test:node` passes (25 tests, incl. new assertions that chat & completion configs set `includeUsage: true`); `pnpm build` clean.