### PR TITLE
fix (mcp): handle SSE messages without explicit event fields

### DIFF
--- a/.changeset/thick-cherries-deliver.md
+++ b/.changeset/thick-cherries-deliver.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix (mcp): handle SSE messages without explicit event fields

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -107,6 +107,58 @@ describe('HttpMCPTransport', () => {
     });
   });
 
+  it('should initialize MCP client from SSE response without explicit event field', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:4000/stream'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return {
+            type: 'controlled-stream',
+            controller,
+            headers: { 'content-type': 'text/event-stream' },
+          };
+        case 2:
+          return { type: 'empty', status: 202 };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    const clientPromise = createMCPClient({
+      transport: {
+        type: 'http',
+        url: 'http://localhost:4000/stream',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(server.calls[1]?.requestMethod).toBe('POST');
+    });
+
+    controller.write(
+      `data: ${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 0,
+        result: {
+          protocolVersion: LATEST_PROTOCOL_VERSION,
+          capabilities: {},
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+        },
+      })}\n\n`,
+    );
+
+    const client = await clientPromise;
+    expect(client.serverInfo).toEqual({
+      name: 'test-server',
+      version: '1.0.0',
+    });
+
+    await client.close();
+  });
+
   it('should (re)open inbound SSE after 202 Accepted', async () => {
     const controller = new TestResponseController();
 
@@ -293,6 +345,29 @@ describe('HttpMCPTransport', () => {
     expect(error.statusCode).toBe(503);
     expect(error.url).toBe('http://localhost:4000/mcp');
     expect(error.message).toContain('GET SSE failed');
+  });
+
+  it('should handle inbound SSE messages without explicit event field', async () => {
+    const controller = new TestResponseController();
+    server.urls['http://localhost:4000/mcp'].response = {
+      type: 'controlled-stream',
+      controller,
+      headers: { 'content-type': 'text/event-stream' },
+    };
+
+    const message = { jsonrpc: '2.0' as const, id: 1, result: { ok: true } };
+    const messagePromise = new Promise(resolve => {
+      transport.onmessage = msg => resolve(msg);
+    });
+
+    await transport.start();
+    await vi.waitFor(() => {
+      expect(server.calls[0]?.requestMethod).toBe('GET');
+    });
+
+    controller.write(`data: ${JSON.stringify(message)}\n\n`);
+
+    expect(await messagePromise).toEqual(message);
   });
 
   it('should handle invalid JSON-RPC messages from inbound SSE', async () => {

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -21,6 +21,10 @@ import {
 } from './oauth';
 import { LATEST_PROTOCOL_VERSION } from './types';
 
+function isMessageEvent(event: string | undefined): boolean {
+  return event === undefined || event === 'message';
+}
+
 /**
  * HTTP MCP transport implementing the Streamable HTTP style.
  *
@@ -273,7 +277,7 @@ export class HttpMCPTransport implements MCPTransport {
                 const { done, value } = await reader.read();
                 if (done) return;
                 const { event, data } = value;
-                if (event === 'message') {
+                if (isMessageEvent(event)) {
                   try {
                     const jsonRpcMessage = await parseJSONRPCMessage(data);
                     this.onmessage?.(jsonRpcMessage);
@@ -421,7 +425,7 @@ export class HttpMCPTransport implements MCPTransport {
               this.lastInboundEventId = id;
             }
 
-            if (event === 'message') {
+            if (isMessageEvent(event)) {
               try {
                 const jsonRpcMessage = await parseJSONRPCMessage(data);
                 this.onmessage?.(jsonRpcMessage);

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -111,6 +111,40 @@ describe('SseMCPTransport', () => {
     await transport.close();
   });
 
+  it('should handle JSON-RPC messages without explicit event field', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const messagePromise = new Promise(resolve => {
+      transport.onmessage = msg => resolve(msg);
+    });
+
+    const connectPromise = transport.start();
+
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+
+    await connectPromise;
+
+    const testMessage = {
+      jsonrpc: '2.0' as const,
+      method: 'test',
+      params: { foo: 'bar' },
+      id: '1',
+    };
+
+    controller.write(`data: ${JSON.stringify(testMessage)}\n\n`);
+
+    expect(await messagePromise).toEqual(testMessage);
+
+    await transport.close();
+  });
+
   it('should handle invalid JSON-RPC messages', async () => {
     const controller = new TestResponseController();
 

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -16,6 +16,10 @@ import {
 } from './oauth';
 import { LATEST_PROTOCOL_VERSION } from './types';
 
+function isMessageEvent(event: string | undefined): boolean {
+  return event === undefined || event === 'message';
+}
+
 export class SseMCPTransport implements MCPTransport {
   private endpoint?: URL;
   private abortController?: AbortController;
@@ -180,7 +184,7 @@ export class SseMCPTransport implements MCPTransport {
                   this.endpoint = endpoint;
                   this.connected = true;
                   resolve();
-                } else if (event === 'message') {
+                } else if (isMessageEvent(event)) {
                   try {
                     const message = await parseJSONRPCMessage(data);
                     this.onmessage?.(message);


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/16002

the mcp `HTTP/SSE` transports only processed sse frames when `event === 'message'` 

bare sse frames were dropped, so JSON-RPC responses never reached `DefaultMCPClient.request()`, causing `createMCPClient()` to hang instead of resolving

## Summary

missing SSE event: fields are treated as the default message event, matching the SSE spec

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #16002