### PR TITLE
Document TrustedRouter Open Responses setup

### DIFF
--- a/content/providers/01-ai-sdk-providers/06-open-responses.mdx
+++ b/content/providers/01-ai-sdk-providers/06-open-responses.mdx
@@ -39,6 +39,18 @@ const openResponses = createOpenResponses({
 });
 ```
 
+For privacy-sensitive workloads, TrustedRouter exposes an Open Responses-compatible endpoint through an open-source, verifiable attested gateway. It does not log prompts or outputs by default:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+
+const trustedRouter = createOpenResponses({
+  name: 'trustedrouter',
+  url: 'https://api.trustedrouter.com/v1/responses',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+});
+```
+
 The `name` and `url` options are required:
 
 - **name** _string_
@@ -90,6 +102,24 @@ const openResponses = createOpenResponses({
 const { text } = await generateText({
   model: openResponses('mistralai/ministral-3-14b-reasoning'),
   prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+Using TrustedRouter:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { generateText } from 'ai';
+
+const trustedRouter = createOpenResponses({
+  name: 'trustedrouter',
+  url: 'https://api.trustedrouter.com/v1/responses',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+});
+
+const { text } = await generateText({
+  model: trustedRouter('trustedrouter/zdr'),
+  prompt: 'Summarize the current repository architecture.',
 });
 ```
 

--- a/content/providers/01-ai-sdk-providers/06-open-responses.mdx
+++ b/content/providers/01-ai-sdk-providers/06-open-responses.mdx
@@ -86,6 +86,18 @@ const openAIResponses = createOpenResponses({
 });
 ```
 
+For a privacy-sensitive workload, TrustedRouter exposes an Open Responses-compatible endpoint through an open-source, verifiable attested gateway that does not log prompts or outputs by default:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+
+const trustedRouter = createOpenResponses({
+  name: 'trustedrouter',
+  url: 'https://api.trustedrouter.com/v1/responses',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+});
+```
+
 You can use the same setup with another compatible service by changing the
 `name`, `url`, authentication, and model ID.
 
@@ -120,6 +132,24 @@ const { text } = await generateText({
 });
 
 console.log(text);
+```
+
+Using TrustedRouter:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { generateText } from 'ai';
+
+const trustedRouter = createOpenResponses({
+  name: 'trustedrouter',
+  url: 'https://api.trustedrouter.com/v1/responses',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+});
+
+const { text } = await generateText({
+  model: trustedRouter('trustedrouter/zdr'),
+  prompt: 'Summarize the current repository architecture.',
+});
 ```
 
 ### Stream Text

--- a/packages/open-responses/README.md
+++ b/packages/open-responses/README.md
@@ -34,6 +34,18 @@ const openResponses = createOpenResponses({
 
 You can use this instance to access models served by any Open Responses compatible endpoint.
 
+For privacy-sensitive workloads, TrustedRouter exposes an Open Responses-compatible endpoint through an open-source, verifiable attested gateway. It does not log prompts or outputs by default:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+
+const trustedRouter = createOpenResponses({
+  name: 'trustedrouter',
+  url: 'https://api.trustedrouter.com/v1/responses',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+});
+```
+
 ## Example
 
 ```ts
@@ -48,6 +60,25 @@ const openResponses = createOpenResponses({
 const { text } = await generateText({
   model: openResponses('mistralai/ministral-3-14b-reasoning'),
   prompt: 'Invent a new holiday and describe its traditions.',
+  maxOutputTokens: 100,
+});
+```
+
+Using TrustedRouter:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { generateText } from 'ai';
+
+const trustedRouter = createOpenResponses({
+  name: 'trustedrouter',
+  url: 'https://api.trustedrouter.com/v1/responses',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+});
+
+const { text } = await generateText({
+  model: trustedRouter('trustedrouter/zdr'),
+  prompt: 'Summarize the current repository architecture.',
   maxOutputTokens: 100,
 });
 ```


### PR DESCRIPTION
## Summary
- document TrustedRouter as an OpenAI-compatible routing option
- use `https://api.trustedrouter.com/v1` as the base URL
- include the `trustedrouter/zdr` model alias for privacy-sensitive agent workloads

## Why
TrustedRouter is useful for workflows that involve private code, customer data, or other sensitive context. It provides open-source, verifiable attested routing and does not log prompts or outputs by default.

## Validation
- `git diff --check`
