### PR TITLE
feat(harness-pi): add `providers` option to register custom providers per session

### DIFF
--- a/.changeset/harness-pi-custom-providers.md
+++ b/.changeset/harness-pi-custom-providers.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+feat(harness-pi): add `providers` option to register custom providers (incl. OAuth/subscription) per session
+
+`createPi({ providers })` registers caller-supplied providers into each session's `ModelRegistry`/`AuthStorage` before model resolution. A `credential` seeds `AuthStorage` (OAuth or API key) and a `config` is passed to `ModelRegistry.registerProvider`, so a host can use OAuth/subscription credentials (e.g. an `openai-codex` ChatGPT-subscription token) or fully custom providers for a catalog model without the `auth.customEnv` API-key path. Registered provider names are preferred during model resolution when a model id is published under multiple providers, and an optional `onCredentialRefresh` callback lets a long-running host persist credentials renewed by Pi's automatic OAuth refresh.

--- a/packages/harness-pi/src/index.ts
+++ b/packages/harness-pi/src/index.ts
@@ -9,3 +9,4 @@ export const pi = createPi();
 export { createPi } from './pi-harness';
 export type { PiHarnessSettings } from './pi-harness';
 export type { PiAuthOptions } from './pi-auth';
+export type { PiProvider } from './pi-session';

--- a/packages/harness-pi/src/pi-harness.ts
+++ b/packages/harness-pi/src/pi-harness.ts
@@ -7,7 +7,11 @@ import { tool } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import type { PiAuthOptions } from './pi-auth';
 import { piResumeStateSchema } from './pi-resume-state';
-import { createPiSession, type PiThinkingLevel } from './pi-session';
+import {
+  createPiSession,
+  type PiProvider,
+  type PiThinkingLevel,
+} from './pi-session';
 
 /**
  * Configuration knobs for `createPi`. Pi runs as an in-process Node library
@@ -16,6 +20,15 @@ import { createPiSession, type PiThinkingLevel } from './pi-session';
 export type PiHarnessSettings = {
   /** Where Pi sources API keys / gateway credentials from. */
   readonly auth?: PiAuthOptions;
+  /**
+   * Custom providers to register into each session's `ModelRegistry` /
+   * `AuthStorage` before model resolution. Enables OAuth / subscription
+   * credentials (e.g. an `openai-codex` ChatGPT-subscription token) and fully
+   * custom providers for catalog models without the `auth.customEnv` API-key
+   * path. Provider names are preferred during model resolution when a model id
+   * is published under multiple providers. See {@link PiProvider}.
+   */
+  readonly providers?: ReadonlyArray<PiProvider>;
   /**
    * Pi model id (or name). Leaving this unset falls back to the AI Gateway
    * default when `AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN` is set, and to
@@ -126,6 +139,7 @@ export function createPi(
         skills: startOpts.skills ?? [],
         settings: {
           ...(settings.auth ? { auth: settings.auth } : {}),
+          ...(settings.providers ? { providers: settings.providers } : {}),
           ...(settings.model ? { model: settings.model } : {}),
           ...(settings.thinkingLevel
             ? { thinkingLevel: settings.thinkingLevel }

--- a/packages/harness-pi/src/pi-model-resolver.test.ts
+++ b/packages/harness-pi/src/pi-model-resolver.test.ts
@@ -78,4 +78,62 @@ describe('createPiModelResolver', () => {
     });
     expect(resolve(undefined)).toBeUndefined();
   });
+
+  describe('preferred providers (multi-provider disambiguation)', () => {
+    // The same model id published under several providers.
+    const codexModel: PiModel = {
+      ...sampleModel,
+      id: 'gpt-5.5',
+      name: 'GPT-5.5',
+      provider: 'openai-codex',
+    };
+    const openaiModel: PiModel = {
+      ...sampleModel,
+      id: 'gpt-5.5',
+      name: 'GPT-5.5',
+      provider: 'openai',
+    };
+    const gatewayModel: PiModel = {
+      ...sampleModel,
+      id: 'gpt-5.5',
+      name: 'GPT-5.5',
+      provider: 'vercel-ai-gateway',
+    };
+
+    it('prefers a registered custom provider over other providers for the same id', () => {
+      const resolve = createPiModelResolver(
+        makeRegistry([openaiModel, gatewayModel, codexModel]),
+        {},
+        ['openai-codex'],
+      );
+      expect(resolve('gpt-5.5')).toEqual(codexModel);
+    });
+
+    it('prefers the custom provider even when gateway creds are present', () => {
+      const resolve = createPiModelResolver(
+        makeRegistry([gatewayModel, codexModel]),
+        { AI_GATEWAY_API_KEY: 'sk-test' },
+        ['openai-codex'],
+      );
+      expect(resolve('gpt-5.5')).toEqual(codexModel);
+    });
+
+    it('honours the order of preferred providers', () => {
+      const resolve = createPiModelResolver(
+        makeRegistry([openaiModel, codexModel]),
+        {},
+        ['openai', 'openai-codex'],
+      );
+      expect(resolve('gpt-5.5')).toEqual(openaiModel);
+    });
+
+    it('falls back to the default behaviour when no preferred provider matches', () => {
+      const resolve = createPiModelResolver(
+        makeRegistry([openaiModel, gatewayModel]),
+        { AI_GATEWAY_API_KEY: 'sk-test' },
+        ['openai-codex'],
+      );
+      expect(resolve('gpt-5.5')).toEqual(gatewayModel);
+    });
+  });
 });

--- a/packages/harness-pi/src/pi-model-resolver.ts
+++ b/packages/harness-pi/src/pi-model-resolver.ts
@@ -13,6 +13,12 @@ export const DEFAULT_PI_GATEWAY_MODEL_ID = 'anthropic/claude-sonnet-4.6';
 export function createPiModelResolver(
   modelRegistry: ModelRegistry,
   env: NodeJS.ProcessEnv = process.env,
+  /**
+   * Provider ids to prefer when a model id is published under more than one
+   * provider. Populated from any custom `providers` registered for the session,
+   * so dispatch uses the provider whose credential the caller actually seeded.
+   */
+  preferredProviders: ReadonlyArray<string> = [],
 ) {
   let cachedModels: PiModel[] | undefined;
 
@@ -38,11 +44,21 @@ export function createPiModelResolver(
     const matches = (m: PiModel) =>
       m.id === effectiveId || m.name === effectiveId;
 
-    // When gateway creds are present, prefer the gateway-routed entry for the
-    // given id. Pi's catalog lists the same model id under multiple providers
-    // (e.g. `anthropic/claude-sonnet-4.6` exists under both `openrouter` and
-    // `vercel-ai-gateway`); without this preference Pi would dispatch through
-    // a provider we didn't register, which fails with "No API key found".
+    // Pi's catalog lists the same model id under multiple providers (e.g.
+    // `gpt-5.5` is published under `openai-codex`, `openai`, `openrouter`,
+    // `vercel-ai-gateway`, ...). Without disambiguation Pi may dispatch through
+    // a provider the caller never registered, which fails with "No API key
+    // found".
+    //
+    // Preference order:
+    //  1. An explicitly registered custom provider (see `providers`), so a
+    //     caller-seeded credential is the one actually used.
+    //  2. The gateway-routed entry when gateway creds are present.
+    //  3. The first matching entry.
+    for (const provider of preferredProviders) {
+      const preferred = models.find(m => m.provider === provider && matches(m));
+      if (preferred) return preferred;
+    }
     return (
       (useGateway &&
         models.find(m => m.provider === 'vercel-ai-gateway' && matches(m))) ||

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -131,7 +131,9 @@ async function resolveSandboxHomeDir({
   const homeDir = result.stdout.trim();
   if (result.exitCode !== 0 || !homeDir || !path.posix.isAbsolute(homeDir)) {
     throw new Error(
-      `Unable to resolve sandbox HOME directory: ${result.stderr || result.stdout}`,
+      `Unable to resolve sandbox HOME directory: ${
+        result.stderr || result.stdout
+      }`,
     );
   }
   return homeDir;
@@ -171,10 +173,56 @@ export type PiThinkingLevel =
   | 'high'
   | 'xhigh';
 
+/**
+ * Credential accepted by Pi's per-session `AuthStorage` (OAuth or API key),
+ * derived from the SDK so it tracks upstream changes.
+ */
+type PiAuthCredential = Parameters<AuthStorage['set']>[1];
+
+/** Provider config accepted by `ModelRegistry.registerProvider`. */
+type PiProviderConfig = Parameters<ModelRegistry['registerProvider']>[1];
+
+/**
+ * A custom provider to register into the per-session `ModelRegistry` /
+ * `AuthStorage` before model resolution. Lets a host bring its own credentials
+ * — including OAuth / subscription credentials (e.g. an `openai-codex`
+ * ChatGPT-subscription token) — or fully custom providers for a catalog model,
+ * without going through the `auth.customEnv` API-key path.
+ */
+export interface PiProvider {
+  /** Provider id, e.g. `openai-codex` (built-in) or a custom provider name. */
+  readonly name: string;
+  /**
+   * Credential seeded into the per-session `AuthStorage` for `name`. For a
+   * built-in catalog provider (e.g. `openai-codex`) this is usually all that's
+   * needed: Pi's built-in OAuth refresh path renews it as required.
+   */
+  readonly credential?: PiAuthCredential;
+  /**
+   * Provider definition registered into the per-session `ModelRegistry` via
+   * `registerProvider` (base URL, headers, OAuth provider, custom models, ...).
+   * Use this for providers not in Pi's built-in catalog.
+   */
+  readonly config?: PiProviderConfig;
+  /**
+   * Called whenever Pi writes a refreshed credential for this provider into the
+   * per-session `AuthStorage` — i.e. after an automatic OAuth token refresh.
+   * Lets a long-running host persist the renewed credential to a durable store
+   * so it survives access-token expiry across sessions. Best-effort: throwing
+   * here never fails the turn.
+   */
+  readonly onCredentialRefresh?: (credential: PiAuthCredential) => void;
+}
+
 export interface PiSessionSettings {
   readonly auth?: PiAuthOptions;
   readonly model?: string;
   readonly thinkingLevel?: PiThinkingLevel;
+  /**
+   * Custom providers to register into the per-session `ModelRegistry` /
+   * `AuthStorage` before model resolution. See {@link PiProvider}.
+   */
+  readonly providers?: ReadonlyArray<PiProvider>;
 }
 
 export interface CreatePiSessionInput {
@@ -315,7 +363,68 @@ export async function createPiSession(
     authStorage,
     modelRegistry,
   });
-  const resolveModel = createPiModelResolver(modelRegistry, resolverEnv);
+
+  // Custom-provider passthrough. Register caller-supplied providers into THIS
+  // session's per-session AuthStorage + ModelRegistry before model resolution,
+  // so a host can bring OAuth / subscription credentials (e.g. an
+  // `openai-codex` ChatGPT-subscription token) or fully custom providers for a
+  // catalog model without the `customEnv` API-key path. A `credential` is
+  // seeded into AuthStorage (the built-in OAuth refresh path can then renew
+  // it); a `config` is registered into the ModelRegistry. The provider names
+  // are also handed to the resolver so a model id published under several
+  // providers resolves to the one we just seeded.
+  const customProviders = input.settings.providers ?? [];
+  const preferredProviders: string[] = [];
+  for (const provider of customProviders) {
+    if (!provider?.name) continue;
+    if (provider.credential) {
+      authStorage.set(provider.name, provider.credential);
+    }
+    if (provider.config) {
+      modelRegistry.registerProvider(provider.name, provider.config);
+    }
+    preferredProviders.push(provider.name);
+  }
+
+  // Refresh persistence. Pi auto-refreshes an expired OAuth credential inside
+  // `AuthStorage.getApiKey` (when `Date.now() >= cred.expires`) and writes the
+  // renewed credential into THIS session's ephemeral auth store via its locked
+  // storage backend — not via the public `set`. To let a long-running host
+  // persist that refresh, wrap `getApiKey` for our seeded providers: snapshot
+  // the stored credential before/after each call and, when it changed (a
+  // refresh happened), forward the renewed credential to `onCredentialRefresh`.
+  const refreshHandlers = new Map(
+    customProviders
+      .filter(p => p?.name && typeof p.onCredentialRefresh === 'function')
+      .map(p => [p.name, p.onCredentialRefresh!] as const),
+  );
+  if (refreshHandlers.size > 0) {
+    const originalGetApiKey = authStorage.getApiKey.bind(authStorage);
+    authStorage.getApiKey = async (providerName, options) => {
+      const handler = refreshHandlers.get(providerName);
+      const before = handler
+        ? JSON.stringify(authStorage.get(providerName) ?? null)
+        : undefined;
+      const apiKey = await originalGetApiKey(providerName, options);
+      if (handler) {
+        const current = authStorage.get(providerName);
+        if (current && JSON.stringify(current) !== before) {
+          try {
+            handler(current);
+          } catch {
+            // Persistence is best-effort; never break the turn.
+          }
+        }
+      }
+      return apiKey;
+    };
+  }
+
+  const resolveModel = createPiModelResolver(
+    modelRegistry,
+    resolverEnv,
+    preferredProviders,
+  );
   // Resolve once: deterministic given the configured model. This is the Pi
   // `Model` object handed to `createAgentSession`.
   const resolvedModel = resolveModel(input.settings.model);


### PR DESCRIPTION
## Summary

Adds a `providers` option to `createPi` / `PiHarnessSettings` that registers caller-supplied providers into each session's `ModelRegistry` / `AuthStorage` **before** model resolution.

## Motivation

Today a host can only reach providers through `auth.customEnv` (the `<PREFIX>_API_KEY` / `<PREFIX>_BASE_URL` pattern). That leaves out two real use-cases:

1. **OAuth / subscription credentials.** Running a built-in catalog model such as `gpt-5.5` through the `openai-codex` provider using a ChatGPT-subscription token (an OAuth credential, not an API key) is impossible via `customEnv`.
2. **Custom providers** that need a full `ModelRegistry.registerProvider` config (base URL, headers, OAuth provider, custom models).

This lets a host pass those directly through the harness.

## API

```ts
createPi({
  model: "gpt-5.5",
  providers: [
    {
      name: "openai-codex",
      // OAuth credential seeded into the per-session AuthStorage; Pi's built-in
      // OAuth refresh renews it as needed.
      credential: { type: "oauth", access, refresh, expires, accountId },
      // optional: persist the renewed credential after an automatic refresh
      onCredentialRefresh: (cred) => saveSomewhere(cred),
    },
  ],
});
```

Each `PiProvider`:
- `credential` — seeded into the per-session `AuthStorage` (OAuth or API key).
- `config` — passed verbatim to `ModelRegistry.registerProvider`.
- `onCredentialRefresh` — optional callback fired when Pi writes a refreshed credential for the provider into `AuthStorage` (after an automatic OAuth refresh), so a long-running host can persist the renewed credential durably and survive access-token expiry across sessions.

## Resolver disambiguation

Pi's catalog publishes the same model id under several providers (e.g. `gpt-5.5` under `openai-codex`, `openai`, `openrouter`, `vercel-ai-gateway`, ...). `createPiModelResolver` now receives the registered provider names and prefers a matching entry under one of them, so dispatch uses the provider whose credential the caller actually seeded — instead of an unauthenticated one, which would otherwise fail with `No API key found`. When no preferred provider matches, behaviour is unchanged (gateway-routed entry when gateway creds are present, else first match).

## Implementation notes

- Types are derived from the pi SDK (`Parameters<AuthStorage['set']>[1]`, `Parameters<ModelRegistry['registerProvider']>[1]`) so they track upstream, matching the existing `ProviderConfigInput` pattern in `pi-auth.ts`.
- The `onCredentialRefresh` hook works by wrapping the per-session `AuthStorage.getApiKey`: Pi refreshes an expired OAuth credential inside `getApiKey` and writes it back via its locked storage backend (not the public `set`), so the wrapper snapshots the stored credential before/after each call and fires the callback when it changes.
- Fully backward compatible: `providers` is optional; omitting it leaves all existing behaviour unchanged.

## Tests

- Added unit tests for the resolver preference (`pi-model-resolver.test.ts`): prefers a registered custom provider over other providers for the same id, prefers it even when gateway creds are present, honours preferred-provider order, and falls back to the default behaviour when no preferred provider matches.
- `pnpm --filter @ai-sdk/harness-pi type-check` and `build` pass; the resolver test file passes (11/11). A changeset is included.