### PR TITLE
fix(provider/fireworks): do not forward api key to server-supplied image download url

### DIFF
--- a/.changeset/nervous-knives-raise.md
+++ b/.changeset/nervous-knives-raise.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/fireworks": patch
+---
+
+fireworks: do not forward request headers when downloading async result images

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -771,6 +771,26 @@ describe('FireworksImageModel', () => {
       );
     });
 
+    it('should not forward provider credentials to the result image download', async () => {
+      const model = createAsyncModel();
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      // calls[2] is the download of the server-supplied result image url, which
+      // is an off-origin host. provider credentials must not be sent there.
+      expect(server.calls[2].requestUrl).toBe('https://example.com/image.png');
+      expect(server.calls[2].requestHeaders['api-key']).toBeUndefined();
+    });
+
     it('should poll multiple times until Ready', async () => {
       let pollCount = 0;
 

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -286,10 +286,10 @@ export class FireworksImageModel implements ImageModelV4 {
       abortSignal,
     });
 
-    // Download the image from the URL
+    // Download the image from the server-supplied URL without provider headers:
+    // the URL is an off-origin host, so forwarding the API key would leak it.
     const { value: imageBytes, responseHeaders } = await getFromApi({
       url: imageUrl,
-      headers,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),


### PR DESCRIPTION
## background

the fireworks async image path reused the request headers (including `authorization`) when downloading the server-supplied `result.sample` image url. this strips those headers for that fetch
