### PR TITLE
fix(provider/gateway): map forbidden error responses to GatewayForbiddenError

### DIFF
--- a/.changeset/gateway-forbidden-error.md
+++ b/.changeset/gateway-forbidden-error.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(provider/gateway): map `forbidden` error responses to GatewayForbiddenError instead of GatewayInternalServerError

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -7,6 +7,7 @@ import {
   GatewayModelNotFoundError,
   GatewayInternalServerError,
   GatewayFailedDependencyError,
+  GatewayForbiddenError,
   GatewayResponseError,
   type GatewayErrorResponse,
 } from './index';
@@ -46,6 +47,25 @@ describe('Valid error responses', () => {
     expect(error).toBeInstanceOf(GatewayInvalidRequestError);
     expect(error.message).toBe('Missing required parameter');
     expect(error.statusCode).toBe(400);
+  });
+
+  it('should create GatewayForbiddenError for forbidden type', async () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Request denied by a routing rule.',
+        type: 'forbidden',
+      },
+    };
+
+    const error = await createGatewayErrorFromResponse({
+      response,
+      statusCode: 403,
+    });
+
+    expect(error).toBeInstanceOf(GatewayForbiddenError);
+    expect(error.message).toBe('Request denied by a routing rule.');
+    expect(error.statusCode).toBe(403);
+    expect(error.type).toBe('forbidden');
   });
 
   it('should create GatewayRateLimitError for rate_limit_exceeded type', async () => {

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -9,6 +9,7 @@ import {
 } from './gateway-model-not-found-error';
 import { GatewayInternalServerError } from './gateway-internal-server-error';
 import { GatewayFailedDependencyError } from './gateway-failed-dependency-error';
+import { GatewayForbiddenError } from './gateway-forbidden-error';
 import { GatewayResponseError } from './gateway-response-error';
 import {
   lazySchema,
@@ -104,6 +105,13 @@ export async function createGatewayErrorFromResponse({
       });
     case 'failed_dependency':
       return new GatewayFailedDependencyError({
+        message,
+        statusCode,
+        cause,
+        generationId,
+      });
+    case 'forbidden':
+      return new GatewayForbiddenError({
         message,
         statusCode,
         cause,

--- a/packages/gateway/src/errors/gateway-forbidden-error.ts
+++ b/packages/gateway/src/errors/gateway-forbidden-error.ts
@@ -1,0 +1,34 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayForbiddenError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Forbidden - the request was rejected by policy (e.g. a routing rule),
+ * not an authentication failure.
+ */
+export class GatewayForbiddenError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'forbidden';
+
+  constructor({
+    message = 'Forbidden',
+    statusCode = 403,
+    cause,
+    generationId,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+    generationId?: string;
+  } = {}) {
+    super({ message, statusCode, cause, generationId });
+  }
+
+  static isInstance(error: unknown): error is GatewayForbiddenError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -7,6 +7,7 @@ export { extractApiCallResponse } from './extract-api-call-response';
 export { GatewayError } from './gateway-error';
 export { GatewayAuthenticationError } from './gateway-authentication-error';
 export { GatewayFailedDependencyError } from './gateway-failed-dependency-error';
+export { GatewayForbiddenError } from './gateway-forbidden-error';
 export { GatewayInternalServerError } from './gateway-internal-server-error';
 export { GatewayInvalidRequestError } from './gateway-invalid-request-error';
 export {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -46,6 +46,7 @@ export {
   GatewayError,
   GatewayAuthenticationError,
   GatewayFailedDependencyError,
+  GatewayForbiddenError,
   GatewayInvalidRequestError,
   GatewayRateLimitError,
   GatewayModelNotFoundError,


### PR DESCRIPTION
## Why

When the AI Gateway denies a request via a routing rule, it returns `403` with `{"error":{"type":"forbidden","message":"…"}}`. `createGatewayErrorFromResponse` has no `case 'forbidden'`, so it hits `default:` and surfaces as **`GatewayInternalServerError`** — a misleading 500-class error for what is a deliberate 403 policy denial.

This adds a `GatewayForbiddenError` (type `forbidden`, status 403) and a `case 'forbidden'` in the error switch, so denials map to a dedicated, correctly-classed error. The original `message` is preserved (e.g. `Request denied by a routing rule.` or a rule's custom reason), and the `403` status was already preserved.

## What

- New `GatewayForbiddenError` (mirrors the other `Gateway*Error` classes).
- `case 'forbidden'` in `createGatewayErrorFromResponse`.
- Exported from `errors/index.ts` and the package root.
- Test for the `forbidden` → `GatewayForbiddenError` mapping.

The gateway already emits `type: "forbidden"` for routing-rule denials, so no server-side change is needed — consumers get the proper error once they pick up this version.

## Validation

- Added a unit test in `create-gateway-error.test.ts` asserting `forbidden` maps to `GatewayForbiddenError` with status 403 and the original message.

> Note: I couldn't run the package test suite locally — `@ai-sdk/provider-utils` fails to build in my checkout on a missing `@workflow/serde` module (unrelated to this change). CI should exercise the new test.
