### PR TITLE
Backport: fix(provider/gateway): map forbidden error responses to GatewayForbiddenError

### DIFF
--- a/.changeset/gateway-forbidden-error.md
+++ b/.changeset/gateway-forbidden-error.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(provider/gateway): map `forbidden` error responses to GatewayForbiddenError instead of GatewayInternalServerError

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createGatewayErrorFromResponse,
   GatewayAuthenticationError,
+  GatewayForbiddenError,
   GatewayInvalidRequestError,
   GatewayRateLimitError,
   GatewayModelNotFoundError,
@@ -46,6 +47,25 @@ describe('Valid error responses', () => {
     expect(error).toBeInstanceOf(GatewayInvalidRequestError);
     expect(error.message).toBe('Missing required parameter');
     expect(error.statusCode).toBe(400);
+  });
+
+  it('should create GatewayForbiddenError for forbidden type', async () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Request denied by a routing rule.',
+        type: 'forbidden',
+      },
+    };
+
+    const error = await createGatewayErrorFromResponse({
+      response,
+      statusCode: 403,
+    });
+
+    expect(error).toBeInstanceOf(GatewayForbiddenError);
+    expect(error.message).toBe('Request denied by a routing rule.');
+    expect(error.statusCode).toBe(403);
+    expect(error.type).toBe('forbidden');
   });
 
   it('should create GatewayRateLimitError for rate_limit_exceeded type', async () => {

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 import type { GatewayError } from './gateway-error';
 import { GatewayAuthenticationError } from './gateway-authentication-error';
+import { GatewayForbiddenError } from './gateway-forbidden-error';
 import { GatewayInvalidRequestError } from './gateway-invalid-request-error';
 import { GatewayRateLimitError } from './gateway-rate-limit-error';
 import {
@@ -76,6 +77,8 @@ export async function createGatewayErrorFromResponse({
     }
     case 'internal_server_error':
       return new GatewayInternalServerError({ message, statusCode, cause });
+    case 'forbidden':
+      return new GatewayForbiddenError({ message, statusCode, cause });
     default:
       return new GatewayInternalServerError({ message, statusCode, cause });
   }

--- a/packages/gateway/src/errors/gateway-forbidden-error.ts
+++ b/packages/gateway/src/errors/gateway-forbidden-error.ts
@@ -1,0 +1,32 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayForbiddenError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Forbidden - the request was rejected by policy (e.g. a routing rule),
+ * not an authentication failure.
+ */
+export class GatewayForbiddenError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'forbidden';
+
+  constructor({
+    message = 'Forbidden',
+    statusCode = 403,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+  }
+
+  static isInstance(error: unknown): error is GatewayForbiddenError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -6,6 +6,7 @@ export {
 export { extractApiCallResponse } from './extract-api-call-response';
 export { GatewayError } from './gateway-error';
 export { GatewayAuthenticationError } from './gateway-authentication-error';
+export { GatewayForbiddenError } from './gateway-forbidden-error';
 export { GatewayInternalServerError } from './gateway-internal-server-error';
 export { GatewayInvalidRequestError } from './gateway-invalid-request-error';
 export {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -27,6 +27,7 @@ export type { GatewayProviderOptions } from './gateway-provider-options';
 export {
   GatewayError,
   GatewayAuthenticationError,
+  GatewayForbiddenError,
   GatewayInvalidRequestError,
   GatewayRateLimitError,
   GatewayModelNotFoundError,


### PR DESCRIPTION
Backport of #16105 (main) / #16106 (release-v6.0) to `release-v5.0` (AI SDK v5 / gateway v2).

Maps gateway `forbidden` error responses (HTTP 403, e.g. a request denied by a routing rule) to a dedicated `GatewayForbiddenError` instead of collapsing them into `GatewayInternalServerError`.

## Changes
- New `GatewayForbiddenError` (`type: 'forbidden'`, `statusCode: 403`) mirroring the v5 error-class pattern
- `createGatewayErrorFromResponse`: handle `case 'forbidden'`
- Exported from `errors/index.ts` and the package root
- Unit test for the `forbidden` mapping
- Changeset (`@ai-sdk/gateway`: patch) — identical text to #16105/#16106

## Notes
Adapted to the v5 gateway error shape: constructors take `{ message, statusCode, cause }` (no `generationId`), and there is no `GatewayFailedDependencyError` on this line, so neither is referenced.