### PR TITLE
fix: handle partial unicode escapes in fixJson (closes #15865)

### DIFF
--- a/packages/ai/src/util/fix-json.test.ts
+++ b/packages/ai/src/util/fix-json.test.ts
@@ -93,6 +93,10 @@ describe('string', () => {
     const fixedEmptyUnicodeEscape = fixJson('{"a":"\\u');
     assert.strictEqual(fixedEmptyUnicodeEscape, '{"a":""}');
     assert.doesNotThrow(() => JSON.parse(fixedEmptyUnicodeEscape));
+
+    const fixedEscapedBackslashBeforeU = fixJson('{"a":"\\\\u12');
+    assert.strictEqual(fixedEscapedBackslashBeforeU, '{"a":"\\\\u12"}');
+    assert.doesNotThrow(() => JSON.parse(fixedEscapedBackslashBeforeU));
   });
 });
 

--- a/packages/ai/src/util/fix-json.test.ts
+++ b/packages/ai/src/util/fix-json.test.ts
@@ -80,6 +80,20 @@ describe('string', () => {
       '"value with unicode \u003C"',
     );
   });
+
+  test('should handle incomplete unicode escape sequences', () => {
+    const fixedRootString = fixJson('"value with \\u12');
+    assert.strictEqual(fixedRootString, '"value with "');
+    assert.doesNotThrow(() => JSON.parse(fixedRootString));
+
+    const fixedObjectValue = fixJson('{"a":"text \\u00');
+    assert.strictEqual(fixedObjectValue, '{"a":"text "}');
+    assert.doesNotThrow(() => JSON.parse(fixedObjectValue));
+
+    const fixedEmptyUnicodeEscape = fixJson('{"a":"\\u');
+    assert.strictEqual(fixedEmptyUnicodeEscape, '{"a":""}');
+    assert.doesNotThrow(() => JSON.parse(fixedEmptyUnicodeEscape));
+  });
 });
 
 describe('array', () => {

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -24,6 +24,10 @@ type State =
 // Please note that invalid JSON is not considered/covered, because it
 // is assumed that the resulting JSON will be processed by a standard
 // JSON parser that will detect any invalid JSON.
+function removeIncompleteTrailingUnicodeEscape(input: string): string {
+  return input.replace(/\\u[0-9a-fA-F]{0,3}$/, '');
+}
+
 export function fixJson(input: string): string {
   const stack: State[] = ['ROOT'];
   let lastValidIndex = -1;
@@ -362,6 +366,7 @@ export function fixJson(input: string): string {
 
     switch (state) {
       case 'INSIDE_STRING': {
+        result = removeIncompleteTrailingUnicodeEscape(result);
         result += '"';
         break;
       }

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -25,7 +25,18 @@ type State =
 // is assumed that the resulting JSON will be processed by a standard
 // JSON parser that will detect any invalid JSON.
 function removeIncompleteTrailingUnicodeEscape(input: string): string {
-  return input.replace(/\\u[0-9a-fA-F]{0,3}$/, '');
+  const match = /\\u[0-9a-fA-F]{0,3}$/.exec(input);
+
+  if (match == null) {
+    return input;
+  }
+
+  let backslashCount = 0;
+  for (let i = match.index; i >= 0 && input[i] === '\\'; i--) {
+    backslashCount++;
+  }
+
+  return backslashCount % 2 === 1 ? input.slice(0, match.index) : input;
 }
 
 export function fixJson(input: string): string {


### PR DESCRIPTION
## Description

Closes #15865.

`fixJson` currently repairs strings truncated after a lone backslash, but it can still emit invalid JSON when the partial input ends inside a unicode escape sequence like `\u`, `\u12`, or `\u00`.

This PR drops an incomplete trailing unicode escape before closing an incomplete string, keeping the repaired partial JSON parseable while preserving all already-valid prefix content.

## Changes

- Add `removeIncompleteTrailingUnicodeEscape` for trailing `\u[0-9a-fA-F]{0,3}` fragments.
- Apply it before closing `INSIDE_STRING` repair output.
- Add regression tests for root string and object value cases.

## Notes

Complete unicode escapes (four hex digits) are untouched. This is scoped only to partial JSON repair for truncated streams.