### PR TITLE
feat(mcp): export JSON-RPC schemas (closes #15999)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,10 @@
+export {
+  JSONRPCErrorSchema,
+  JSONRPCMessageSchema,
+  JSONRPCNotificationSchema,
+  JSONRPCRequestSchema,
+  JSONRPCResponseSchema,
+} from './tool/json-rpc-message';
 export type {
   JSONRPCError,
   JSONRPCMessage,

--- a/packages/mcp/src/tool/json-rpc-message.test.ts
+++ b/packages/mcp/src/tool/json-rpc-message.test.ts
@@ -18,7 +18,6 @@ describe('JSON-RPC schema exports', () => {
     const notification = {
       jsonrpc: '2.0',
       method: 'notifications/progress',
-      params: { progressToken: 'token', progress: 1 },
     };
     const response = { jsonrpc: '2.0', id: '1', result: {} };
     const error = {

--- a/packages/mcp/src/tool/json-rpc-message.test.ts
+++ b/packages/mcp/src/tool/json-rpc-message.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  JSONRPCErrorSchema,
+  JSONRPCMessageSchema,
+  JSONRPCNotificationSchema,
+  JSONRPCRequestSchema,
+  JSONRPCResponseSchema,
+} from '../index';
+
+describe('JSON-RPC schema exports', () => {
+  it('exports schemas for validating JSON-RPC messages', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: '1',
+      method: 'tools/list',
+      params: {},
+    };
+    const notification = {
+      jsonrpc: '2.0',
+      method: 'notifications/progress',
+      params: { progressToken: 'token', progress: 1 },
+    };
+    const response = { jsonrpc: '2.0', id: '1', result: {} };
+    const error = {
+      jsonrpc: '2.0',
+      id: '1',
+      error: { code: -32600, message: 'Invalid Request' },
+    };
+
+    expect(JSONRPCRequestSchema.parse(request)).toEqual(request);
+    expect(JSONRPCNotificationSchema.parse(notification)).toEqual(notification);
+    expect(JSONRPCResponseSchema.parse(response)).toEqual(response);
+    expect(JSONRPCErrorSchema.parse(error)).toEqual(error);
+
+    expect(JSONRPCMessageSchema.parse(request)).toEqual(request);
+    expect(JSONRPCMessageSchema.parse(notification)).toEqual(notification);
+    expect(JSONRPCMessageSchema.parse(response)).toEqual(response);
+    expect(JSONRPCMessageSchema.parse(error)).toEqual(error);
+  });
+});

--- a/packages/mcp/src/tool/json-rpc-message.ts
+++ b/packages/mcp/src/tool/json-rpc-message.ts
@@ -4,7 +4,7 @@ import { BaseParamsSchema, RequestSchema, ResultSchema } from './types';
 
 const JSONRPC_VERSION = '2.0';
 
-const JSONRPCRequestSchema = z
+export const JSONRPCRequestSchema = z
   .object({
     jsonrpc: z.literal(JSONRPC_VERSION),
     id: z.union([z.string(), z.number().int()]),
@@ -14,7 +14,7 @@ const JSONRPCRequestSchema = z
 
 export type JSONRPCRequest = z.infer<typeof JSONRPCRequestSchema>;
 
-const JSONRPCResponseSchema = z
+export const JSONRPCResponseSchema = z
   .object({
     jsonrpc: z.literal(JSONRPC_VERSION),
     id: z.union([z.string(), z.number().int()]),
@@ -24,7 +24,7 @@ const JSONRPCResponseSchema = z
 
 export type JSONRPCResponse = z.infer<typeof JSONRPCResponseSchema>;
 
-const JSONRPCErrorSchema = z
+export const JSONRPCErrorSchema = z
   .object({
     jsonrpc: z.literal(JSONRPC_VERSION),
     id: z.union([z.string(), z.number().int()]),
@@ -38,7 +38,7 @@ const JSONRPCErrorSchema = z
 
 export type JSONRPCError = z.infer<typeof JSONRPCErrorSchema>;
 
-const JSONRPCNotificationSchema = z
+export const JSONRPCNotificationSchema = z
   .object({
     jsonrpc: z.literal(JSONRPC_VERSION),
   })


### PR DESCRIPTION
## Description

Closes #15999.

Exports the existing JSON-RPC Zod schemas from `@ai-sdk/mcp` alongside their inferred TypeScript types.

## Changes

- Export `JSONRPCRequestSchema`, `JSONRPCResponseSchema`, `JSONRPCErrorSchema`, and `JSONRPCNotificationSchema` from `json-rpc-message.ts`.
- Re-export all JSON-RPC schemas from the package entrypoint, including the already-public `JSONRPCMessageSchema`.
- Add a public API test that imports the schemas from `../index` and validates request, notification, response, error, and union message parsing.

## Why

Consumers already get the inferred JSON-RPC types, but cannot reuse the runtime schemas for validation. This exposes the schemas without duplicating validation logic outside the package.