### PR TITLE
fix(provider): stringify object APICallError messages (closes #15872)

### DIFF
--- a/packages/provider/src/errors/api-call-error.test.ts
+++ b/packages/provider/src/errors/api-call-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { APICallError } from './api-call-error';
+
+describe('APICallError', () => {
+  it('serializes object-like runtime messages instead of [object Object]', () => {
+    const error = new APICallError({
+      message: {
+        error: {
+          code: 503,
+          message: 'Service temporarily unavailable',
+        },
+      },
+      url: 'https://gateway.example.test/v1/responses',
+      requestBodyValues: {},
+      statusCode: 503,
+    });
+
+    expect(error.message).toBe(
+      JSON.stringify({
+        error: {
+          code: 503,
+          message: 'Service temporarily unavailable',
+        },
+      }),
+    );
+    expect(error.message).not.toBe('[object Object]');
+  });
+});

--- a/packages/provider/src/errors/api-call-error.ts
+++ b/packages/provider/src/errors/api-call-error.ts
@@ -1,5 +1,17 @@
 import { AISDKError } from './ai-sdk-error';
 
+function stringifyMessage(message: unknown): string {
+  if (typeof message === 'string') {
+    return message;
+  }
+
+  try {
+    return JSON.stringify(message);
+  } catch {
+    return String(message);
+  }
+}
+
 const name = 'AI_APICallError';
 const marker = `vercel.ai.error.${name}`;
 const symbol = Symbol.for(marker);
@@ -32,7 +44,7 @@ export class APICallError extends AISDKError {
         statusCode >= 500), // server error
     data,
   }: {
-    message: string;
+    message: unknown;
     url: string;
     requestBodyValues: unknown;
     statusCode?: number;
@@ -42,7 +54,7 @@ export class APICallError extends AISDKError {
     isRetryable?: boolean;
     data?: unknown;
   }) {
-    super({ name, message, cause });
+    super({ name, message: stringifyMessage(message), cause });
 
     this.url = url;
     this.requestBodyValues = requestBodyValues;

--- a/packages/provider/src/errors/api-call-error.ts
+++ b/packages/provider/src/errors/api-call-error.ts
@@ -6,7 +6,7 @@ function stringifyMessage(message: unknown): string {
   }
 
   try {
-    return JSON.stringify(message);
+    return JSON.stringify(message) ?? String(message);
   } catch {
     return String(message);
   }


### PR DESCRIPTION
## Description

Closes #15872.

Hardens `APICallError` so object-like runtime messages are serialized instead of becoming `[object Object]` in error cause chains.

## Changes

- Add `stringifyMessage` in `APICallError`.
- Accept `message: unknown` in the constructor input and pass a serialized string to `AISDKError`.
- Add a regression test for structured error payloads.

## Why

Some provider/gateway error paths can pass a structured payload as the message at runtime. Serializing it preserves useful diagnostics in logs instead of collapsing to `[object Object]`.