### PR TITLE
feat(anthropic): support cache diagnostics (closes #15986)

### DIFF
--- a/.changeset/anthropic-cache-diagnostics.md
+++ b/.changeset/anthropic-cache-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+Add Anthropic cache diagnostics provider option.

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -128,6 +128,20 @@ export const anthropicLanguageModelOptions = z.object({
     .optional(),
 
   /**
+   * Cache diagnostics configuration for diagnosing prompt cache misses.
+   *
+   * See https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics.
+   */
+  diagnostics: z
+    .object({
+      /**
+       * Previous Anthropic message id used to diagnose cache behavior across requests.
+       */
+      previousMessageId: z.string().optional(),
+    })
+    .optional(),
+
+  /**
    * Metadata to include with the request.
    *
    * See https://platform.claude.com/docs/en/api/messages/create for details.

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -63,6 +63,30 @@ describe('AnthropicLanguageModel', () => {
   }
 
   describe('doGenerate', () => {
+    it('should send cache diagnostics previous message id and beta header', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            diagnostics: {
+              previousMessageId: 'msg_previous_123',
+            },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        diagnostics: {
+          previous_message_id: 'msg_previous_123',
+        },
+      });
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        'anthropic-beta': 'cache-diagnosis-2026-04-07',
+      });
+    });
+
     describe('reasoning (thinking enabled)', () => {
       it('should pass thinking config; add budget tokens; clear out temperature, top_p, top_k; and return warnings', async () => {
         prepareJsonFixtureResponse('anthropic-text');

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -730,6 +730,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       betas.add('server-side-fallback-2026-06-01');
     }
 
+    if (anthropicOptions?.diagnostics?.previousMessageId != null) {
+      betas.add('cache-diagnosis-2026-04-07');
+    }
+
     const defaultEagerInputStreaming =
       stream && (anthropicOptions?.toolStreaming ?? true);
 

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -495,6 +495,11 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       ...(anthropicOptions?.metadata?.userId != null && {
         metadata: { user_id: anthropicOptions.metadata.userId },
       }),
+      ...(anthropicOptions?.diagnostics?.previousMessageId != null && {
+        diagnostics: {
+          previous_message_id: anthropicOptions.diagnostics.previousMessageId,
+        },
+      }),
 
       // mcp servers:
       ...(anthropicOptions?.mcpServers &&


### PR DESCRIPTION
## Description

Closes #15986.

Adds Anthropic cache diagnostics support through provider options.

## Changes

- Adds `diagnostics.previousMessageId` to `AnthropicLanguageModelOptions`.
- Sends `diagnostics.previous_message_id` in the Anthropic request body.
- Automatically adds the required `cache-diagnosis-2026-04-07` beta header when diagnostics are used.
- Adds a request-body/header regression test.

## Notes

This keeps the AI SDK option camelCase while mapping to Anthropic's snake_case request field.