### PR TITLE
chore(ai): bump main bundle size limit to 630 KB

### DIFF
--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 620 * 1024;
+const LIMIT = 630 * 1024;
 
 interface BundleResult {
   size: number;


### PR DESCRIPTION
fixes https://github.com/vercel/ai/actions/runs/27489849252/job/81252963229