### PR TITLE
fix(harness): reject websocket bind errors

### DIFF
--- a/.changeset/fresh-bridges-reject.md
+++ b/.changeset/fresh-bridges-reject.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+fix(harness): reject bridge startup when the WebSocket port cannot be bound

--- a/packages/harness/src/bridge/index.test.ts
+++ b/packages/harness/src/bridge/index.test.ts
@@ -78,6 +78,21 @@ function connect(port: number): Promise<Client> {
 }
 
 describe('runBridge', () => {
+  it('rejects when the requested port is already in use', async () => {
+    const handle = await startBridge(async () => {});
+
+    await expect(
+      runBridge<{ type: 'start' }>({
+        bridgeType: 'test',
+        bridgeStateDir: `${process.env.TMPDIR ?? '/tmp'}/harness-bridge-port-conflict`,
+        port: handle.port,
+        token: TOKEN,
+        onStart: async () => {},
+        onExit: () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'EADDRINUSE' });
+  });
+
   it('greets with bridge-hello and stamps a monotonic seq on emitted events', async () => {
     const handle = await startBridge(async (_start, turn) => {
       turn.emit({ type: 'text-delta', delta: 'a' });

--- a/packages/harness/src/bridge/index.ts
+++ b/packages/harness/src/bridge/index.ts
@@ -675,12 +675,14 @@ export async function runBridge<TStart extends { type: 'start' }>(
     emit({ type: 'error', error: serialiseError(err) });
   });
 
-  await new Promise<void>(resolve => {
+  await new Promise<void>((resolve, reject) => {
     if (wss.address() != null) {
       resolve();
       return;
     }
-    wss.on('listening', () => resolve());
+
+    wss.once('listening', resolve);
+    wss.once('error', reject);
   });
 
   return {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

`runBridge()` waits for the WebSocket server to start listening. If the port is already occupied, for example by another run in the same sandbox, the server emits `EADDRINUSE`. Because the startup promise did not handle that error, it remained pending and Node eventually exited with an unsettled top-level-await error.

## Summary

<!-- What did you change? -->

Added a listener for websocket error events that rejects the promise, also moved listeners to once instead of on.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Started a plain Node TCP server to occupy a port, called `runBridge()` requesting the same port and confirmed it properly rejects the promise and exists correctly.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
