### PR TITLE
docs: correct "finish reasoning" to "finish reason" in agent loop stop conditions

### DIFF
--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -224,7 +224,7 @@ const agent = new ToolLoopAgent({
 
 Each step represents one generation (which results in either text or a tool call). The loop continues until:
 
-- A finish reasoning other than tool-calls is returned, or
+- A finish reason other than tool-calls is returned, or
 - A tool that is invoked does not have an execute function, or
 - A tool call needs approval, or
 - A stop condition is met


### PR DESCRIPTION
## Background

The "Loop Control" section of the Building Agents docs lists the conditions under which the agent loop stops. The first item read "A finish reasoning other than tool-calls is returned" — "finish reasoning" is incorrect wording. The SDK concept is the finish reason (`finishReason`).

## Summary

Corrects "finish reasoning" to "finish reason" in the agent loop stop-condition list on the Building Agents page (`content/docs/03-agents/02-building-agents.mdx`).

## Checklist

- [x] All commits are signed
- [x] Documentation has been added / updated
- [x] I have reviewed this pull request (self-review)
