### PR TITLE
feat(ai): make the experimental lifecycle callbacks stable

### DIFF
--- a/.changeset/large-bottles-marry.md
+++ b/.changeset/large-bottles-marry.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): make the experimental lifecycle callbacks stable

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -471,11 +471,11 @@ These are useful for logging, observability, debugging, and custom telemetry.
 const result = await myAgent.generate({
   prompt: 'Research and summarize the latest AI trends',
 
-  experimental_onStart({ modelId }) {
+  onStart({ modelId }) {
     console.log('Agent started', { modelId });
   },
 
-  experimental_onStepStart({ stepNumber, modelId }) {
+  onStepStart({ stepNumber, modelId }) {
     console.log(`Step ${stepNumber} starting`, { modelId });
   },
 
@@ -514,8 +514,8 @@ const result = await myAgent.generate({
 
 The available lifecycle callbacks are:
 
-- **`experimental_onStart`**: Called once when the agent operation begins, before any LLM calls. Receives model info, messages, settings, and `runtimeContext`.
-- **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
+- **`onStart`**: Called once when the agent operation begins, before any LLM calls. Receives model info, messages, settings, and `runtimeContext`.
+- **`onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
 - **`onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and `toolContext`.
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
 - **`onStepEnd`**: Called after each step finishes. Receives step results including usage, performance, finish reason, and tool calls.

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -134,22 +134,22 @@ const result = await generateText({
     // ... your tools
   },
 
-  experimental_onStart({ modelId }) {
+  onStart({ modelId }) {
     console.log('Generation started', { modelId });
   },
 
-  experimental_onStepStart({ stepNumber, modelId, messages }) {
+  onStepStart({ stepNumber, modelId, messages }) {
     console.log(`Step ${stepNumber} starting`, { modelId });
   },
 
-  experimental_onLanguageModelCallStart({ modelId, messages }) {
+  onLanguageModelCallStart({ modelId, messages }) {
     console.log('Model call starting', {
       modelId,
       messageCount: messages.length,
     });
   },
 
-  experimental_onLanguageModelCallEnd({ modelId, finishReason, content }) {
+  onLanguageModelCallEnd({ modelId, finishReason, content }) {
     console.log('Model call finished', {
       modelId,
       finishReason,
@@ -184,10 +184,10 @@ const result = await generateText({
 
 The available lifecycle callbacks are:
 
-- **`experimental_onStart`**: Called once when the `generateText` operation begins, before any LLM calls. Receives model info, messages, settings, and `runtimeContext`.
-- **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
-- **`experimental_onLanguageModelCallStart`**: Called immediately before the provider model call begins. Useful when you want to observe the model invocation separately from later tool execution.
-- **`experimental_onLanguageModelCallEnd`**: Called after the model response has been normalized and parsed, but before any client-side tool execution begins. Receives the model-call content parts, usage, and finish reason.
+- **`onStart`**: Called once when the `generateText` operation begins, before any LLM calls. Receives model info, messages, settings, and `runtimeContext`.
+- **`onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
+- **`onLanguageModelCallStart`**: Called immediately before the provider model call begins. Useful when you want to observe the model invocation separately from later tool execution.
+- **`onLanguageModelCallEnd`**: Called after the model response has been normalized and parsed, but before any client-side tool execution begins. Receives the model-call content parts, usage, and finish reason.
 - **`onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and `toolContext`.
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
 - **`onStepEnd`**: Called after each step finishes. Includes `stepNumber` (zero-based index of the completed step).
@@ -368,22 +368,22 @@ const result = streamText({
     // ... your tools
   },
 
-  experimental_onStart({ modelId, instructions, messages }) {
+  onStart({ modelId, instructions, messages }) {
     console.log('Streaming started', { modelId });
   },
 
-  experimental_onStepStart({ stepNumber, modelId, messages }) {
+  onStepStart({ stepNumber, modelId, messages }) {
     console.log(`Step ${stepNumber} starting`, { modelId });
   },
 
-  experimental_onLanguageModelCallStart({ modelId, messages }) {
+  onLanguageModelCallStart({ modelId, messages }) {
     console.log('Model call starting', {
       modelId,
       messageCount: messages.length,
     });
   },
 
-  experimental_onLanguageModelCallEnd({ modelId, finishReason, content }) {
+  onLanguageModelCallEnd({ modelId, finishReason, content }) {
     console.log('Model call finished', {
       modelId,
       finishReason,
@@ -414,10 +414,10 @@ const result = streamText({
 
 The available lifecycle callbacks are:
 
-- **`experimental_onStart`**: Called once when the `streamText` operation begins, before any LLM calls. Receives model info, messages, settings, and `runtimeContext`.
-- **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
-- **`experimental_onLanguageModelCallStart`**: Called immediately before the provider model call begins. Useful when you want to observe the model invocation separately from later tool execution.
-- **`experimental_onLanguageModelCallEnd`**: Called after the model response has been normalized and parsed, but before any client-side tool execution begins. Receives the model-call content parts, usage, and finish reason.
+- **`onStart`**: Called once when the `streamText` operation begins, before any LLM calls. Receives model info, messages, settings, and `runtimeContext`.
+- **`onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
+- **`onLanguageModelCallStart`**: Called immediately before the provider model call begins. Useful when you want to observe the model invocation separately from later tool execution.
+- **`onLanguageModelCallEnd`**: Called after the model response has been normalized and parsed, but before any client-side tool execution begins. Receives the model-call content parts, usage, and finish reason.
 - **`onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and `toolContext`.
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
 - **`onStepEnd`**: Called after each step finishes. Receives the finish reason, usage, and other step details.

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -17,7 +17,7 @@ import { generateText } from 'ai';
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What is the weather in San Francisco?',
-  experimental_onStart: event => {
+  onStart: event => {
     console.log('Generation started:', event.modelId);
   },
   onEnd: event => {
@@ -33,24 +33,24 @@ const result = await generateText({
 <PropertiesTable
   content={[
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: GenerateTextStartEvent) => void | Promise<void>',
       description: 'Called when generation begins, before any LLM calls.',
     },
     {
-      name: 'experimental_onStepStart',
+      name: 'onStepStart',
       type: '(event: GenerateTextStepStartEvent) => void | Promise<void>',
       description:
         'Called when a step (LLM call) begins, before the provider is called.',
     },
     {
-      name: 'experimental_onLanguageModelCallStart',
+      name: 'onLanguageModelCallStart',
       type: '(event: LanguageModelCallStartEvent) => void | Promise<void>',
       description:
-        'Called immediately before the provider model call begins. Unlike `experimental_onStepStart`, this is scoped to model work only.',
+        'Called immediately before the provider model call begins. Unlike `onStepStart`, this is scoped to model work only.',
     },
     {
-      name: 'experimental_onLanguageModelCallEnd',
+      name: 'onLanguageModelCallEnd',
       type: '(event: LanguageModelCallEndEvent) => void | Promise<void>',
       description:
         'Called after the model response has been normalized and parsed, but before any client-side tool execution begins.',
@@ -80,21 +80,21 @@ const result = await generateText({
 />
 
 For multi-step text generations that use tools, the callback order is typically
-`experimental_onStepStart` -> `experimental_onLanguageModelCallStart` ->
-`experimental_onLanguageModelCallEnd` -> tool execution callbacks -> `onStepEnd`.
+`onStepStart` -> `onLanguageModelCallStart` ->
+`onLanguageModelCallEnd` -> tool execution callbacks -> `onStepEnd`.
 
 ### `embed` / `embedMany`
 
 <PropertiesTable
   content={[
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: EmbedStartEvent) => void | Promise<void>',
       description:
         'Called when the embedding operation begins, before the embedding model is called.',
     },
     {
-      name: 'experimental_onEnd',
+      name: 'onEnd',
       type: '(event: EmbedEndEvent) => void | Promise<void>',
       description:
         'Called when the embedding operation completes, after the embedding model returns.',
@@ -107,13 +107,13 @@ For multi-step text generations that use tools, the callback order is typically
 <PropertiesTable
   content={[
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: RerankStartEvent) => void | Promise<void>',
       description:
         'Called when the reranking operation begins, before the reranking model is called.',
     },
     {
-      name: 'experimental_onEnd',
+      name: 'onEnd',
       type: '(event: RerankEndEvent) => void | Promise<void>',
       description:
         'Called when the reranking operation completes, after the reranking model returns.',
@@ -125,7 +125,7 @@ For multi-step text generations that use tools, the callback order is typically
 
 ### `generateText` / `streamText`
 
-#### `experimental_onStart`
+#### `onStart`
 
 Called when the generation operation begins, before any LLM calls are made.
 
@@ -133,7 +133,7 @@ Called when the generation operation begins, before any LLM calls are made.
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
-  experimental_onStart: event => {
+  onStart: event => {
     console.log('Model:', event.modelId);
     console.log('Messages:', event.messages.length);
   },
@@ -268,7 +268,7 @@ const result = await generateText({
   ]}
 />
 
-#### `experimental_onStepStart`
+#### `onStepStart`
 
 Called before each step (LLM call) begins. Useful for tracking multi-step generations.
 
@@ -276,7 +276,7 @@ Called before each step (LLM call) begins. Useful for tracking multi-step genera
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
-  experimental_onStepStart: event => {
+  onStepStart: event => {
     console.log('Step:', event.stepNumber);
     console.log('Messages:', event.messages.length);
   },
@@ -382,17 +382,17 @@ const result = await generateText({
   ]}
 />
 
-#### `experimental_onLanguageModelCallStart`
+#### `onLanguageModelCallStart`
 
 Called immediately before the provider model call begins. Unlike
-`experimental_onStepStart`, this callback is scoped to model work only and
+`onStepStart`, this callback is scoped to model work only and
 excludes any later client-side tool execution.
 
 ```ts
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
-  experimental_onLanguageModelCallStart: event => {
+  onLanguageModelCallStart: event => {
     console.log('Model call:', event.modelId);
     console.log('Messages:', event.messages.length);
   },
@@ -434,7 +434,7 @@ const result = await generateText({
   ]}
 />
 
-#### `experimental_onLanguageModelCallEnd`
+#### `onLanguageModelCallEnd`
 
 Called after the model response has been normalized and parsed, but before any
 client-side tool execution begins.
@@ -443,7 +443,7 @@ client-side tool execution begins.
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What is the weather?',
-  experimental_onLanguageModelCallEnd: event => {
+  onLanguageModelCallEnd: event => {
     console.log('Finish reason:', event.finishReason);
     console.log('Content parts:', event.content.length);
   },
@@ -1060,7 +1060,7 @@ const result = await generateText({
 
 ### `embed` / `embedMany`
 
-#### `experimental_onStart`
+#### `onStart`
 
 Called when the embedding operation begins, before the embedding model is called. Both `embed` and `embedMany` share the same event interface; the `operationId` field distinguishes them (`'ai.embed'` vs `'ai.embedMany'`), and the `value` field is a single string for `embed` or an array of strings for `embedMany`.
 
@@ -1070,7 +1070,7 @@ import { embed } from 'ai';
 const result = await embed({
   model: openai.embedding('text-embedding-3-small'),
   value: 'sunny day at the beach',
-  experimental_onStart: event => {
+  onStart: event => {
     console.log('Operation:', event.operationId);
     console.log('Model:', event.model.modelId);
   },
@@ -1124,7 +1124,7 @@ const result = await embed({
   ]}
 />
 
-#### `experimental_onEnd`
+#### `onEnd`
 
 Called when the embedding operation completes. For `embed`, `embedding` is a single vector and `response` is a single response object. For `embedMany`, `embedding` is an array of vectors and `response` is an array of response objects (one per chunk).
 
@@ -1134,7 +1134,7 @@ import { embedMany } from 'ai';
 const result = await embedMany({
   model: openai.embedding('text-embedding-3-small'),
   values: ['sunny day at the beach', 'rainy afternoon in the city'],
-  experimental_onEnd: event => {
+  onEnd: event => {
     console.log('Operation:', event.operationId);
     console.log('Usage:', event.usage);
   },
@@ -1196,7 +1196,7 @@ const result = await embedMany({
 
 ### `rerank`
 
-#### `experimental_onStart`
+#### `onStart`
 
 Called when the reranking operation begins, before the reranking model is called.
 
@@ -1207,7 +1207,7 @@ const result = await rerank({
   model: cohere.reranking('rerank-v3.5'),
   documents: ['sunny day at the beach', 'rainy afternoon in the city'],
   query: 'talk about rain',
-  experimental_onStart: event => {
+  onStart: event => {
     console.log('Operation:', event.operationId);
     console.log('Model:', event.model.modelId);
   },
@@ -1269,7 +1269,7 @@ const result = await rerank({
   ]}
 />
 
-#### `experimental_onEnd`
+#### `onEnd`
 
 Called when the reranking operation completes, after the reranking model returns.
 
@@ -1280,7 +1280,7 @@ const result = await rerank({
   model: cohere.reranking('rerank-v3.5'),
   documents: ['sunny day at the beach', 'rainy afternoon in the city'],
   query: 'talk about rain',
-  experimental_onEnd: event => {
+  onEnd: event => {
     console.log('Operation:', event.operationId);
     console.log('Rankings:', event.ranking.length);
   },
@@ -1348,7 +1348,7 @@ import { generateText } from 'ai';
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
-  experimental_onStart: event => {
+  onStart: event => {
     console.log(`[${new Date().toISOString()}] Generation started`, {
       model: event.modelId,
       provider: event.provider,
@@ -1407,13 +1407,13 @@ import { embedMany } from 'ai';
 const result = await embedMany({
   model: openai.embedding('text-embedding-3-small'),
   values: ['sunny day at the beach', 'rainy afternoon in the city'],
-  experimental_onStart: event => {
+  onStart: event => {
     console.log(`Embedding started (${event.operationId})`, {
       model: event.model.modelId,
       valueCount: Array.isArray(event.value) ? event.value.length : 1,
     });
   },
-  experimental_onEnd: event => {
+  onEnd: event => {
     console.log(`Embedding complete (${event.operationId})`, {
       tokens: event.usage.tokens,
     });
@@ -1429,7 +1429,7 @@ Errors thrown inside callbacks are caught and do not break the generation, embed
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
-  experimental_onStart: () => {
+  onStart: () => {
     throw new Error('This error is caught internally');
     // Generation continues normally
   },

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1008,11 +1008,11 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: GenerateTextStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when the generateText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called when the generateText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'GenerateTextStartEvent',
@@ -1155,11 +1155,11 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onStepStart',
+      name: 'onStepStart',
       type: '(event: GenerateTextStepStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'GenerateTextStepStartEvent',
@@ -1276,11 +1276,11 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onLanguageModelCallStart',
+      name: 'onLanguageModelCallStart',
       type: '(event: LanguageModelCallStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called immediately before the provider model call begins. Unlike `experimental_onStepStart`, this callback is scoped to model work only and excludes any later client-side tool execution. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called immediately before the provider model call begins. Unlike `onStepStart`, this callback is scoped to model work only and excludes any later client-side tool execution. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'LanguageModelCallStartEvent',
@@ -1321,11 +1321,11 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onLanguageModelCallEnd',
+      name: 'onLanguageModelCallEnd',
       type: '(event: LanguageModelCallEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called after the model response has been normalized and parsed, but before any client-side tool execution begins. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called after the model response has been normalized and parsed, but before any client-side tool execution begins. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'LanguageModelCallEndEvent',
@@ -1430,7 +1430,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: '(event: ToolExecutionStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
+        "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow.",
       properties: [
         {
           type: 'ToolExecutionStartEvent',
@@ -1468,7 +1468,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: '(event: ToolExecutionEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        "Callback that is called right after a tool's execute function completes (or errors). The `toolOutput` field is a discriminated union: when `toolOutput.type` is `'tool-result'`, the `output` field contains the tool result; when `toolOutput.type` is `'tool-error'`, the `error` field contains the error. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
+        "Callback that is called right after a tool's execute function completes (or errors). The `toolOutput` field is a discriminated union: when `toolOutput.type` is `'tool-result'`, the `output` field contains the tool result; when `toolOutput.type` is `'tool-error'`, the `error` field contains the error. Errors thrown in this callback are silently caught and do not break the generation flow.",
       properties: [
         {
           type: 'ToolExecutionEndEvent',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1994,11 +1994,11 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: GenerateTextStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when the streamText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called when the streamText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'GenerateTextStartEvent',
@@ -2141,11 +2141,11 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onStepStart',
+      name: 'onStepStart',
       type: '(event: GenerateTextStepStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'GenerateTextStepStartEvent',
@@ -2260,11 +2260,11 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onLanguageModelCallStart',
+      name: 'onLanguageModelCallStart',
       type: '(event: LanguageModelCallStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called immediately before the provider model call begins. Unlike `experimental_onStepStart`, this callback is scoped to model work only and excludes any later client-side tool execution. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called immediately before the provider model call begins. Unlike `onStepStart`, this callback is scoped to model work only and excludes any later client-side tool execution. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'LanguageModelCallStartEvent',
@@ -2305,11 +2305,11 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onLanguageModelCallEnd',
+      name: 'onLanguageModelCallEnd',
       type: '(event: LanguageModelCallEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called after the model response has been normalized and parsed, but before any client-side tool execution begins. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+        'Callback that is called after the model response has been normalized and parsed, but before any client-side tool execution begins. Errors thrown in this callback are silently caught and do not break the generation flow.',
       properties: [
         {
           type: 'LanguageModelCallEndEvent',
@@ -2414,7 +2414,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '(event: ToolExecutionStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
+        "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow.",
       properties: [
         {
           type: 'ToolExecutionStartEvent',
@@ -2452,7 +2452,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '(event: ToolExecutionEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        "Callback that is called right after a tool's execute function completes (or errors). The `toolOutput` field is a discriminated union: when `toolOutput.type` is `'tool-result'`, the `output` field contains the tool result; when `toolOutput.type` is `'tool-error'`, the `error` field contains the error. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
+        "Callback that is called right after a tool's execute function completes (or errors). The `toolOutput` field is a discriminated union: when `toolOutput.type` is `'tool-result'`, the `output` field contains the tool result; when `toolOutput.type` is `'tool-error'`, the `error` field contains the error. Errors thrown in this callback are silently caught and do not break the generation flow.",
       properties: [
         {
           type: 'ToolExecutionEndEvent',

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -116,11 +116,11 @@ const { embedding } = await embed({
       ],
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: EmbedStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when the embed operation begins, before the embedding model is called. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
+        'Callback that is called when the embed operation begins, before the embedding model is called. Errors thrown in this callback are silently caught and do not break the embedding flow.',
       properties: [
         {
           type: 'EmbedStartEvent',
@@ -170,11 +170,11 @@ const { embedding } = await embed({
       ],
     },
     {
-      name: 'experimental_onEnd',
+      name: 'onEnd',
       type: '(event: EmbedEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when the embed operation completes, after the embedding model returns. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
+        'Callback that is called when the embed operation completes, after the embedding model returns. Errors thrown in this callback are silently caught and do not break the embedding flow.',
       properties: [
         {
           type: 'EmbedEndEvent',

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -128,11 +128,11 @@ const { embeddings } = await embedMany({
       ],
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: EmbedStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when the embedMany operation begins, before the embedding model is called. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
+        'Callback that is called when the embedMany operation begins, before the embedding model is called. Errors thrown in this callback are silently caught and do not break the embedding flow.',
       properties: [
         {
           type: 'EmbedStartEvent',
@@ -183,11 +183,11 @@ const { embeddings } = await embedMany({
       ],
     },
     {
-      name: 'experimental_onEnd',
+      name: 'onEnd',
       type: '(event: EmbedEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
-        'Callback that is called when the embedMany operation completes, after all embedding model calls return. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
+        'Callback that is called when the embedMany operation completes, after all embedding model calls return. Errors thrown in this callback are silently caught and do not break the embedding flow.',
       properties: [
         {
           type: 'EmbedEndEvent',

--- a/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
@@ -130,14 +130,14 @@ const { ranking } = await rerank({
       ],
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: '(event: RerankStartEvent) => void | Promise<void>',
       isOptional: true,
       description:
         'Called when the rerank operation begins, before the reranking model is called.',
     },
     {
-      name: 'experimental_onEnd',
+      name: 'onEnd',
       type: '(event: RerankEndEvent) => void | Promise<void>',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -75,11 +75,11 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
      */
-    experimental_onStart?: GenerateTextOnStartCallback<TOOLS>;
+    onStart?: GenerateTextOnStartCallback<TOOLS>;
     /**
      * Callback that is called when a step (LLM call) begins, before the provider is called.
      */
-    experimental_onStepStart?: GenerateTextOnStepStartCallback<TOOLS>;
+    onStepStart?: GenerateTextOnStepStartCallback<TOOLS>;
     /**
      * Callback that is called before each tool execution begins.
      */
@@ -182,8 +182,8 @@ Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS, TO
 - `abortSignal` (optional): An `AbortSignal` to cancel the operation
 - `timeout` (optional): A timeout in milliseconds. Can be specified as a number or as an object with a `totalMs` property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside `abortSignal`.
 - `experimental_sandbox` (optional): An experimental sandbox environment forwarded to tool execution.
-- `experimental_onStart` (optional): Callback invoked when the agent operation begins, before any LLM calls. Experimental.
-- `experimental_onStepStart` (optional): Callback invoked when a step (LLM call) begins, before the provider is called. Experimental.
+- `onStart` (optional): Callback invoked when the agent operation begins, before any LLM calls.
+- `onStepStart` (optional): Callback invoked when a step (LLM call) begins, before the provider is called.
 - `onToolExecutionStart` (optional): Callback invoked right before a tool's execute function runs.
 - `onToolExecutionEnd` (optional): Callback invoked right after a tool's execute function completes or errors.
 - `onStepEnd` (optional): A callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage, per-step performance, or logging.

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -147,11 +147,11 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Optional mapping of tool names to functions that refine parsed tool inputs. Each function receives the typed input for its tool and must return the same input type shape. The refined input is used for tool execution, output parts, lifecycle callbacks, and telemetry in both `generate()` and `stream()`.',
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: 'GenerateTextOnStartCallback',
       isOptional: true,
       description:
-        'Callback that is called when the agent operation begins, before any LLM calls are made. Useful for logging, analytics, or initializing state. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).',
+        'Callback that is called when the agent operation begins, before any LLM calls are made. Useful for logging, analytics, or initializing state. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).',
       properties: [
         {
           type: 'GenerateTextStartEvent',
@@ -293,11 +293,11 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onStepStart',
+      name: 'onStepStart',
       type: 'GenerateTextOnStepStartCallback',
       isOptional: true,
       description:
-        'Callback that is called when a step (LLM call) begins, before the provider is called. Each step represents a single LLM invocation. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).',
+        'Callback that is called when a step (LLM call) begins, before the provider is called. Each step represents a single LLM invocation. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).',
       properties: [
         {
           type: 'GenerateTextStepStartEvent',
@@ -411,7 +411,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       type: 'OnToolExecutionStartCallback',
       isOptional: true,
       description:
-        "Callback that is called right before a tool's execute function runs. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).",
+        "Callback that is called right before a tool's execute function runs. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).",
       properties: [
         {
           type: 'ToolExecutionStartEvent',
@@ -449,7 +449,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       type: 'OnToolExecutionEndCallback',
       isOptional: true,
       description:
-        "Callback that is called right after a tool's execute function completes (or errors). The `toolOutput` field is a discriminated union: when `toolOutput.type` is `'tool-result'`, the `output` field contains the tool result; when `toolOutput.type` is `'tool-error'`, the `error` field contains the error. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).",
+        "Callback that is called right after a tool's execute function completes (or errors). The `toolOutput` field is a discriminated union: when `toolOutput.type` is `'tool-result'`, the `output` field contains the tool result; when `toolOutput.type` is `'tool-error'`, the `error` field contains the error. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).",
       properties: [
         {
           type: 'ToolExecutionEndEvent',
@@ -732,32 +732,32 @@ const result = await agent.generate({
         'Custom call options when the agent is configured with a callOptionsSchema.',
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: 'GenerateTextOnStartCallback',
       isOptional: true,
       description:
-        'Callback that is called when the agent operation begins, before any LLM calls are made. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
+        'Callback that is called when the agent operation begins, before any LLM calls are made. If also specified in the constructor, both callbacks are called (constructor first).',
     },
     {
-      name: 'experimental_onStepStart',
+      name: 'onStepStart',
       type: 'GenerateTextOnStepStartCallback',
       isOptional: true,
       description:
-        'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
+        'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first).',
     },
     {
       name: 'onToolExecutionStart',
       type: 'OnToolExecutionStartCallback',
       isOptional: true,
       description:
-        "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
+        "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first).",
     },
     {
       name: 'onToolExecutionEnd',
       type: 'OnToolExecutionEndCallback',
       isOptional: true,
       description:
-        "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
+        "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first).",
     },
     {
       name: 'onStepEnd',
@@ -855,32 +855,32 @@ for await (const chunk of stream.textStream) {
         'Optional stream transformation(s). They are applied in the order provided and must maintain the stream structure. See `streamText` docs for details.',
     },
     {
-      name: 'experimental_onStart',
+      name: 'onStart',
       type: 'GenerateTextOnStartCallback',
       isOptional: true,
       description:
-        'Callback that is called when the agent operation begins, before any LLM calls are made. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
+        'Callback that is called when the agent operation begins, before any LLM calls are made. If also specified in the constructor, both callbacks are called (constructor first).',
     },
     {
-      name: 'experimental_onStepStart',
+      name: 'onStepStart',
       type: 'GenerateTextOnStepStartCallback',
       isOptional: true,
       description:
-        'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
+        'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first).',
     },
     {
       name: 'onToolExecutionStart',
       type: 'OnToolExecutionStartCallback',
       isOptional: true,
       description:
-        "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
+        "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first).",
     },
     {
       name: 'onToolExecutionEnd',
       type: 'OnToolExecutionEndCallback',
       isOptional: true,
       description:
-        "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
+        "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first).",
     },
     {
       name: 'onStepEnd',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -293,8 +293,58 @@ const result = await generateText({
 const result = await generateText({
   model: yourModel,
   prompt: 'Hello!',
-  experimental_onStart: ({ instructions }) => {
+  onStart: ({ instructions }) => {
     console.log(instructions);
+  },
+});
+```
+
+#### `experimental_onStart` Renamed to `onStart`
+
+The generation start callback for `generateText`, `streamText`, and agents has
+been renamed from `experimental_onStart` to `onStart`.
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+  experimental_onStart: () => {
+    console.log('Generation started');
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+  onStart: () => {
+    console.log('Generation started');
+  },
+});
+```
+
+#### `experimental_onStepStart` Renamed to `onStepStart`
+
+The per-step start callback for `generateText`, `streamText`, and agents has
+been renamed from `experimental_onStepStart` to `onStepStart`.
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+  experimental_onStepStart: ({ stepNumber }) => {
+    console.log(`Step ${stepNumber} started`);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+  onStepStart: ({ stepNumber }) => {
+    console.log(`Step ${stepNumber} started`);
   },
 });
 ```

--- a/examples/ai-e2e-next/agent/xai/web-search-agent.ts
+++ b/examples/ai-e2e-next/agent/xai/web-search-agent.ts
@@ -10,7 +10,7 @@ export const xaiWebSearchAgent = new ToolLoopAgent({
       enableImageUnderstanding: true,
     }),
   },
-  experimental_onStepStart: ({ messages }) => {
+  onStepStart: ({ messages }) => {
     console.log('Messages:', JSON.stringify(messages, null, 2));
   },
   onStepFinish: ({ response }) => {

--- a/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
+++ b/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
@@ -20,13 +20,13 @@ async function main() {
       }),
     },
     stopWhen: isStepCount(3),
-    experimental_onStart: event => {
+    onStart: event => {
       console.log('\n--- onStart ---');
       console.log('Provider:', event.provider);
       console.log('Model:', event.modelId);
       console.log('Temperature:', event.temperature);
     },
-    experimental_onStepStart: event => {
+    onStepStart: event => {
       console.log('\n--- onStepStart ---');
       console.log('Step:', event.steps.length);
       console.log('Message count:', event.messages.length);

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -77,10 +77,24 @@ export type AgentCallParameters<
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
      */
+    onStart?: GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT>;
+
+    /**
+     * Callback that is called when the agent operation begins, before any LLM calls.
+     *
+     * @deprecated Use `onStart` instead.
+     */
     experimental_onStart?: GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT>;
 
     /**
      * Callback that is called when a step (LLM call) begins, before the provider is called.
+     */
+    onStepStart?: GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT>;
+
+    /**
+     * Callback that is called when a step (LLM call) begins, before the provider is called.
+     *
+     * @deprecated Use `onStepStart` instead.
      */
     experimental_onStepStart?: GenerateTextOnStepStartCallback<
       TOOLS,

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -155,6 +155,17 @@ export type ToolLoopAgentSettings<
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
      */
+    onStart?: GenerateTextOnStartCallback<
+      NoInfer<TOOLS>,
+      RUNTIME_CONTEXT,
+      NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called when the agent operation begins, before any LLM calls.
+     *
+     * @deprecated Use `onStart` instead.
+     */
     experimental_onStart?: GenerateTextOnStartCallback<
       NoInfer<TOOLS>,
       RUNTIME_CONTEXT,
@@ -163,6 +174,17 @@ export type ToolLoopAgentSettings<
 
     /**
      * Callback that is called when a step (LLM call) begins, before the provider is called.
+     */
+    onStepStart?: GenerateTextOnStepStartCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>,
+      NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called when a step (LLM call) begins, before the provider is called.
+     *
+     * @deprecated Use `onStepStart` instead.
      */
     experimental_onStepStart?: GenerateTextOnStepStartCallback<
       NoInfer<TOOLS>,

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -139,6 +139,28 @@ describe('ToolLoopAgent', () => {
         },
       });
     });
+
+    it('should support stable start callbacks', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        onStart: event => {
+          expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+        onStepStart: event => {
+          expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        onStart: event => {
+          expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+        onStepStart: event => {
+          expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -191,6 +213,22 @@ describe('ToolLoopAgent', () => {
       expectTypeOf<typeof partialOutputStream>().toEqualTypeOf<
         AsyncIterableStream<DeepPartial<{ value: string }>>
       >();
+    });
+
+    it('should support stable start callbacks', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      await agent.stream({
+        prompt: 'Hello, world!',
+        onStart: event => {
+          expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+        onStepStart: event => {
+          expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+      });
     });
   });
 

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1198,6 +1198,54 @@ describe('ToolLoopAgent', () => {
     });
   });
 
+  describe('stable callback aliases', () => {
+    it('should prefer stable callbacks over deprecated experimental aliases', async () => {
+      const onStartCalls: string[] = [];
+
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'reply' }],
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              cachedInputTokens: undefined,
+              inputTokens: {
+                total: 3,
+                noCache: 3,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 10,
+                text: 10,
+                reasoning: undefined,
+              },
+            },
+            warnings: [],
+          }),
+        }),
+        onStart: async () => {
+          onStartCalls.push('constructor-onStart');
+        },
+        experimental_onStart: async () => {
+          onStartCalls.push('constructor-experimental_onStart');
+        },
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        onStart: async () => {
+          onStartCalls.push('method-onStart');
+        },
+        experimental_onStart: async () => {
+          onStartCalls.push('method-experimental_onStart');
+        },
+      });
+
+      expect(onStartCalls).toEqual(['constructor-onStart', 'method-onStart']);
+    });
+  });
+
   describe('experimental_onStart', () => {
     describe('generate', () => {
       let doGenerateOptions: LanguageModelV4CallOptions | undefined;

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1198,55 +1198,7 @@ describe('ToolLoopAgent', () => {
     });
   });
 
-  describe('stable callback aliases', () => {
-    it('should prefer stable callbacks over deprecated experimental aliases', async () => {
-      const onStartCalls: string[] = [];
-
-      const agent = new ToolLoopAgent({
-        model: new MockLanguageModelV4({
-          doGenerate: async () => ({
-            content: [{ type: 'text', text: 'reply' }],
-            finishReason: { unified: 'stop', raw: 'stop' },
-            usage: {
-              cachedInputTokens: undefined,
-              inputTokens: {
-                total: 3,
-                noCache: 3,
-                cacheRead: undefined,
-                cacheWrite: undefined,
-              },
-              outputTokens: {
-                total: 10,
-                text: 10,
-                reasoning: undefined,
-              },
-            },
-            warnings: [],
-          }),
-        }),
-        onStart: async () => {
-          onStartCalls.push('constructor-onStart');
-        },
-        experimental_onStart: async () => {
-          onStartCalls.push('constructor-experimental_onStart');
-        },
-      });
-
-      await agent.generate({
-        prompt: 'Hello, world!',
-        onStart: async () => {
-          onStartCalls.push('method-onStart');
-        },
-        experimental_onStart: async () => {
-          onStartCalls.push('method-experimental_onStart');
-        },
-      });
-
-      expect(onStartCalls).toEqual(['constructor-onStart', 'method-onStart']);
-    });
-  });
-
-  describe('experimental_onStart', () => {
+  describe('onStart', () => {
     describe('generate', () => {
       let doGenerateOptions: LanguageModelV4CallOptions | undefined;
       let mockModel: MockLanguageModelV4;
@@ -1279,12 +1231,12 @@ describe('ToolLoopAgent', () => {
         });
       });
 
-      it('should call experimental_onStart from constructor', async () => {
+      it('should call onStart from constructor', async () => {
         const onStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('constructor');
           },
         });
@@ -1300,7 +1252,7 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onStart from generate method', async () => {
+      it('should call onStart from generate method', async () => {
         const onStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -1309,7 +1261,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('method');
           },
         });
@@ -1321,19 +1273,19 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call both constructor and method experimental_onStart in correct order', async () => {
+      it('should call both constructor and method onStart in correct order', async () => {
         const onStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('constructor');
           },
         });
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('method');
           },
         });
@@ -1378,7 +1330,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStart: async () => {
+          onStart: async () => {
             callOrder.push('onStart');
           },
         });
@@ -1398,7 +1350,7 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStart: async () => {
+          onStart: async () => {
             throw new Error('callback error');
           },
         });
@@ -1421,7 +1373,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStart: async event => {
+          onStart: async event => {
             startEvent = event;
           },
         });
@@ -1463,7 +1415,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           messages: [{ role: 'user', content: 'test-message' }],
-          experimental_onStart: async event => {
+          onStart: async event => {
             startEvent = event;
           },
         });
@@ -1523,12 +1475,12 @@ describe('ToolLoopAgent', () => {
         });
       });
 
-      it('should call experimental_onStart from constructor', async () => {
+      it('should call onStart from constructor', async () => {
         const onStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('constructor');
           },
         });
@@ -1543,14 +1495,14 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onStart from stream method', async () => {
+      it('should call onStart from stream method', async () => {
         const onStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({ model: mockModel });
 
         const result = await agent.stream({
           prompt: 'Hello, world!',
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('method');
           },
         });
@@ -1564,19 +1516,19 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call both constructor and method experimental_onStart in correct order', async () => {
+      it('should call both constructor and method onStart in correct order', async () => {
         const onStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('constructor');
           },
         });
 
         const result = await agent.stream({
           prompt: 'Hello, world!',
-          experimental_onStart: async () => {
+          onStart: async () => {
             onStartCalls.push('method');
           },
         });
@@ -1606,7 +1558,7 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.stream({
           prompt: 'Hello, world!',
-          experimental_onStart: async event => {
+          onStart: async event => {
             startEvent = event;
           },
         });
@@ -1643,7 +1595,7 @@ describe('ToolLoopAgent', () => {
     });
   });
 
-  describe('experimental_onStepStart', () => {
+  describe('onStepStart', () => {
     describe('generate', () => {
       let mockModel: MockLanguageModelV4;
 
@@ -1673,12 +1625,12 @@ describe('ToolLoopAgent', () => {
         });
       });
 
-      it('should call experimental_onStepStart from constructor', async () => {
+      it('should call onStepStart from constructor', async () => {
         const onStepStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('constructor');
           },
         });
@@ -1694,7 +1646,7 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onStepStart from generate method', async () => {
+      it('should call onStepStart from generate method', async () => {
         const onStepStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -1703,7 +1655,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('method');
           },
         });
@@ -1715,19 +1667,19 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call both constructor and method experimental_onStepStart in correct order', async () => {
+      it('should call both constructor and method onStepStart in correct order', async () => {
         const onStepStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('constructor');
           },
         });
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('method');
           },
         });
@@ -1772,7 +1724,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             callOrder.push('onStepStart');
           },
         });
@@ -1792,7 +1744,7 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             throw new Error('callback error');
           },
         });
@@ -1813,7 +1765,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async event => {
+          onStepStart: async event => {
             stepStartEvent = event;
           },
         });
@@ -1886,12 +1838,12 @@ describe('ToolLoopAgent', () => {
         });
       });
 
-      it('should call experimental_onStepStart from constructor', async () => {
+      it('should call onStepStart from constructor', async () => {
         const onStepStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('constructor');
           },
         });
@@ -1906,14 +1858,14 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onStepStart from stream method', async () => {
+      it('should call onStepStart from stream method', async () => {
         const onStepStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({ model: mockModel });
 
         const result = await agent.stream({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('method');
           },
         });
@@ -1927,19 +1879,19 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call both constructor and method experimental_onStepStart in correct order', async () => {
+      it('should call both constructor and method onStepStart in correct order', async () => {
         const onStepStartCalls: string[] = [];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('constructor');
           },
         });
 
         const result = await agent.stream({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async () => {
+          onStepStart: async () => {
             onStepStartCalls.push('method');
           },
         });
@@ -1967,7 +1919,7 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.stream({
           prompt: 'Hello, world!',
-          experimental_onStepStart: async event => {
+          onStepStart: async event => {
             stepStartEvent = event;
           },
         });
@@ -3620,7 +3572,7 @@ describe('ToolLoopAgent', () => {
             userId: 'user-123',
             requestId: 'request-123',
           },
-          experimental_onStart: async ({ runtimeContext }) => {
+          onStart: async ({ runtimeContext }) => {
             callbackContexts.push(runtimeContext);
           },
           onStepFinish: async ({ runtimeContext }) => {
@@ -3676,7 +3628,7 @@ describe('ToolLoopAgent', () => {
               finishReason: { unified: 'stop' as const, raw: 'stop' },
             }),
           }),
-          experimental_onStart: async () => {
+          onStart: async () => {
             events.push('agent-onStart');
           },
           onStepFinish: async () => {
@@ -3935,7 +3887,7 @@ describe('ToolLoopAgent', () => {
             userId: 'user-123',
             requestId: 'request-123',
           },
-          experimental_onStart: async ({ runtimeContext }) => {
+          onStart: async ({ runtimeContext }) => {
             callbackContexts.push(runtimeContext);
           },
           onStepFinish: async ({ runtimeContext }) => {
@@ -4002,7 +3954,7 @@ describe('ToolLoopAgent', () => {
               ]),
             }),
           }),
-          experimental_onStart: async () => {
+          onStart: async () => {
             events.push('agent-onStart');
           },
           onStepFinish: async () => {

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -87,7 +87,9 @@ export class ToolLoopAgent<
       | 'prepareCall'
       | 'instructions'
       | 'allowSystemInMessages'
+      | 'onStart'
       | 'experimental_onStart'
+      | 'onStepStart'
       | 'experimental_onStepStart'
       | 'onToolExecutionStart'
       | 'onToolExecutionEnd'
@@ -111,8 +113,10 @@ export class ToolLoopAgent<
     }
 
     const {
-      experimental_onStart: _settingsOnStart,
-      experimental_onStepStart: _settingsOnStepStart,
+      onStart: _settingsStableOnStart,
+      experimental_onStart: _settingsExperimentalOnStart,
+      onStepStart: _settingsStableOnStepStart,
+      experimental_onStepStart: _settingsExperimentalOnStepStart,
       onToolExecutionStart: _settingsOnToolExecutionStart,
       onToolExecutionEnd: _settingsOnToolExecutionEnd,
       onStepEnd: _settingsOnStepEnd,
@@ -179,7 +183,9 @@ export class ToolLoopAgent<
     abortSignal,
     timeout,
     experimental_sandbox: sandbox,
+    onStart,
     experimental_onStart,
+    onStepStart,
     experimental_onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -200,15 +206,15 @@ export class ToolLoopAgent<
       abortSignal,
       timeout,
       experimental_sandbox: sandbox,
-      experimental_onStart: mergeCallbacks(
-        this.settings.experimental_onStart,
-        experimental_onStart as
+      onStart: mergeCallbacks(
+        this.settings.onStart ?? this.settings.experimental_onStart,
+        (onStart ?? experimental_onStart) as
           | GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
-      experimental_onStepStart: mergeCallbacks(
-        this.settings.experimental_onStepStart,
-        experimental_onStepStart as
+      onStepStart: mergeCallbacks(
+        this.settings.onStepStart ?? this.settings.experimental_onStepStart,
+        (onStepStart ?? experimental_onStepStart) as
           | GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
@@ -241,7 +247,9 @@ export class ToolLoopAgent<
     timeout,
     experimental_sandbox: sandbox,
     experimental_transform,
+    onStart,
     experimental_onStart,
+    onStepStart,
     experimental_onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -263,15 +271,15 @@ export class ToolLoopAgent<
       timeout,
       experimental_sandbox: sandbox,
       experimental_transform,
-      experimental_onStart: mergeCallbacks(
-        this.settings.experimental_onStart,
-        experimental_onStart as
+      onStart: mergeCallbacks(
+        this.settings.onStart ?? this.settings.experimental_onStart,
+        (onStart ?? experimental_onStart) as
           | GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
-      experimental_onStepStart: mergeCallbacks(
-        this.settings.experimental_onStepStart,
-        experimental_onStepStart as
+      onStepStart: mergeCallbacks(
+        this.settings.onStepStart ?? this.settings.experimental_onStepStart,
+        (onStepStart ?? experimental_onStepStart) as
           | GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),

--- a/packages/ai/src/embed/__snapshots__/embed-many.test.ts.snap
+++ b/packages/ai/src/embed/__snapshots__/embed-many.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.experimental_onEnd > should send correct event information (single call path) 1`] = `
+exports[`options.onEnd > should send correct event information (single call path) 1`] = `
 {
   "callId": "test-call-id",
   "embedding": [
@@ -42,7 +42,7 @@ exports[`options.experimental_onEnd > should send correct event information (sin
 }
 `;
 
-exports[`options.experimental_onStart > should send correct event information 1`] = `
+exports[`options.onStart > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "headers": {

--- a/packages/ai/src/embed/__snapshots__/embed.test.ts.snap
+++ b/packages/ai/src/embed/__snapshots__/embed.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.experimental_onEnd > should send correct event information 1`] = `
+exports[`options.onEnd > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "embedding": [
@@ -24,7 +24,7 @@ exports[`options.experimental_onEnd > should send correct event information 1`] 
 }
 `;
 
-exports[`options.experimental_onStart > should send correct event information 1`] = `
+exports[`options.onStart > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "headers": {

--- a/packages/ai/src/embed/embed-events.ts
+++ b/packages/ai/src/embed/embed-events.ts
@@ -35,7 +35,7 @@ export type EmbedStartEvent = {
 };
 
 /**
- * Event passed to the `experimental_onEnd` callback for embed and embedMany operations.
+ * Event passed to the `onEnd` callback for embed and embedMany operations.
  *
  * Called when the operation completes, after the embedding model returns.
  */

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -589,7 +589,7 @@ describe('logWarnings', () => {
   });
 });
 
-describe('options.experimental_onStart', () => {
+describe('options.onStart', () => {
   it('should send correct event information', async () => {
     let startEvent!: EmbedStartEvent;
 
@@ -605,7 +605,7 @@ describe('options.experimental_onStart', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -628,7 +628,7 @@ describe('options.experimental_onStart', () => {
         recordOutputs: true,
         functionId: 'embed-many-fn',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -654,7 +654,7 @@ describe('options.experimental_onStart', () => {
         recordOutputs: true,
         functionId: 'embed-many-fn-deprecated',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -674,7 +674,7 @@ describe('options.experimental_onStart', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -696,7 +696,7 @@ describe('options.experimental_onStart', () => {
         },
       }),
       values: testValues,
-      experimental_onStart: async () => {
+      onStart: async () => {
         callOrder.push('onStart');
       },
     });
@@ -711,7 +711,7 @@ describe('options.experimental_onStart', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onStart: async () => {
+      onStart: async () => {
         throw new Error('callback error');
       },
     });
@@ -730,7 +730,7 @@ describe('options.experimental_onStart', () => {
       values: testValues,
       headers: { 'x-custom': 'header-value' },
       providerOptions: { myProvider: { key: 'value' } },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -745,7 +745,7 @@ describe('options.experimental_onStart', () => {
   });
 });
 
-describe('options.experimental_onEnd', () => {
+describe('options.onEnd', () => {
   it('should send correct event information (single call path)', async () => {
     let endEvent!: EmbedEndEvent;
 
@@ -761,7 +761,7 @@ describe('options.experimental_onEnd', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -801,7 +801,7 @@ describe('options.experimental_onEnd', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -823,7 +823,7 @@ describe('options.experimental_onEnd', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings, { tokens: 15 }),
       }),
       values: testValues,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -842,7 +842,7 @@ describe('options.experimental_onEnd', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -864,7 +864,7 @@ describe('options.experimental_onEnd', () => {
         }),
       }),
       values: testValues,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -889,7 +889,7 @@ describe('options.experimental_onEnd', () => {
         },
       }),
       values: testValues,
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         callOrder.push('onEnd');
       },
     });
@@ -904,7 +904,7 @@ describe('options.experimental_onEnd', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         throw new Error('callback error');
       },
     });
@@ -913,7 +913,7 @@ describe('options.experimental_onEnd', () => {
   });
 });
 
-describe('options.experimental_onStart and experimental_onEnd together', () => {
+describe('options.onStart and onEnd together', () => {
   it('should have consistent callId across both events', async () => {
     let startEvent!: EmbedStartEvent;
     let endEvent!: EmbedEndEvent;
@@ -927,10 +927,10 @@ describe('options.experimental_onStart and experimental_onEnd together', () => {
       _internal: {
         generateCallId: () => 'consistent-call-id',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -952,10 +952,10 @@ describe('options.experimental_onStart and experimental_onEnd together', () => {
         },
       }),
       values: testValues,
-      experimental_onStart: async () => {
+      onStart: async () => {
         callOrder.push('onStart');
       },
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         callOrder.push('onEnd');
       },
     });
@@ -972,10 +972,10 @@ describe('options.experimental_onStart and experimental_onEnd together', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
-      experimental_onStart: async () => {
+      onStart: async () => {
         throw new Error('start error');
       },
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         endCalled = true;
       },
     });

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -56,8 +56,10 @@ export async function embedMany({
   providerOptions,
   experimental_telemetry,
   telemetry = experimental_telemetry,
-  experimental_onStart: onStart,
-  experimental_onEnd: onEnd,
+  onStart,
+  experimental_onStart,
+  onEnd,
+  experimental_onEnd,
   _internal: { generateCallId = originalGenerateCallId } = {},
 }: {
   /**
@@ -118,11 +120,27 @@ export async function embedMany({
    * Callback that is called when the embedMany operation begins,
    * before the embedding model is called.
    */
+  onStart?: Callback<EmbedStartEvent>;
+
+  /**
+   * Callback that is called when the embedMany operation begins,
+   * before the embedding model is called.
+   *
+   * @deprecated Use `onStart` instead.
+   */
   experimental_onStart?: Callback<EmbedStartEvent>;
 
   /**
    * Callback that is called when the embedMany operation completes,
    * after all embedding model calls return.
+   */
+  onEnd?: Callback<EmbedEndEvent>;
+
+  /**
+   * Callback that is called when the embedMany operation completes,
+   * after all embedding model calls return.
+   *
+   * @deprecated Use `onEnd` instead.
    */
   experimental_onEnd?: Callback<EmbedEndEvent>;
 
@@ -139,6 +157,8 @@ export async function embedMany({
     maxRetries: maxRetriesArg,
     abortSignal,
   });
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnEnd = onEnd ?? experimental_onEnd;
 
   const headersWithUserAgent = withUserAgentSuffix(
     headers ?? {},
@@ -162,7 +182,7 @@ export async function embedMany({
       headers: headersWithUserAgent,
       providerOptions,
     },
-    callbacks: [onStart, telemetryDispatcher.onStart],
+    callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
   });
 
   try {
@@ -240,7 +260,7 @@ export async function embedMany({
           providerMetadata,
           response: [response],
         },
-        callbacks: [onEnd, telemetryDispatcher.onEnd],
+        callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
       });
 
       return new DefaultEmbedManyResult({
@@ -366,7 +386,7 @@ export async function embedMany({
         providerMetadata,
         response: responses,
       },
-      callbacks: [onEnd, telemetryDispatcher.onEnd],
+      callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultEmbedManyResult({

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -237,6 +237,33 @@ describe('logWarnings', () => {
   });
 });
 
+describe('stable callback aliases', () => {
+  it('should prefer stable callbacks over deprecated experimental aliases', async () => {
+    const calls: string[] = [];
+
+    await embed({
+      model: new MockEmbeddingModelV4({
+        doEmbed: mockEmbed([testValue], [dummyEmbedding]),
+      }),
+      value: testValue,
+      onStart: async () => {
+        calls.push('onStart');
+      },
+      experimental_onStart: async () => {
+        calls.push('experimental_onStart');
+      },
+      onEnd: async () => {
+        calls.push('onEnd');
+      },
+      experimental_onEnd: async () => {
+        calls.push('experimental_onEnd');
+      },
+    });
+
+    expect(calls).toEqual(['onStart', 'onEnd']);
+  });
+});
+
 describe('options.experimental_onStart', () => {
   it('should send correct event information', async () => {
     let startEvent!: EmbedStartEvent;

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -237,34 +237,7 @@ describe('logWarnings', () => {
   });
 });
 
-describe('stable callback aliases', () => {
-  it('should prefer stable callbacks over deprecated experimental aliases', async () => {
-    const calls: string[] = [];
-
-    await embed({
-      model: new MockEmbeddingModelV4({
-        doEmbed: mockEmbed([testValue], [dummyEmbedding]),
-      }),
-      value: testValue,
-      onStart: async () => {
-        calls.push('onStart');
-      },
-      experimental_onStart: async () => {
-        calls.push('experimental_onStart');
-      },
-      onEnd: async () => {
-        calls.push('onEnd');
-      },
-      experimental_onEnd: async () => {
-        calls.push('experimental_onEnd');
-      },
-    });
-
-    expect(calls).toEqual(['onStart', 'onEnd']);
-  });
-});
-
-describe('options.experimental_onStart', () => {
+describe('options.onStart', () => {
   it('should send correct event information', async () => {
     let startEvent!: EmbedStartEvent;
 
@@ -279,7 +252,7 @@ describe('options.experimental_onStart', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -301,7 +274,7 @@ describe('options.experimental_onStart', () => {
         recordOutputs: true,
         functionId: 'embed-fn',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -326,7 +299,7 @@ describe('options.experimental_onStart', () => {
         recordOutputs: true,
         functionId: 'embed-fn-deprecated',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -345,7 +318,7 @@ describe('options.experimental_onStart', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -366,7 +339,7 @@ describe('options.experimental_onStart', () => {
         },
       }),
       value: testValue,
-      experimental_onStart: async () => {
+      onStart: async () => {
         callOrder.push('onStart');
       },
     });
@@ -380,7 +353,7 @@ describe('options.experimental_onStart', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onStart: async () => {
+      onStart: async () => {
         throw new Error('callback error');
       },
     });
@@ -398,7 +371,7 @@ describe('options.experimental_onStart', () => {
       value: testValue,
       headers: { 'x-custom': 'header-value' },
       providerOptions: { myProvider: { key: 'value' } },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
     });
@@ -413,7 +386,7 @@ describe('options.experimental_onStart', () => {
   });
 });
 
-describe('options.experimental_onEnd', () => {
+describe('options.onEnd', () => {
   it('should send correct event information', async () => {
     let endEvent!: EmbedEndEvent;
 
@@ -428,7 +401,7 @@ describe('options.experimental_onEnd', () => {
       _internal: {
         generateCallId: () => 'test-call-id',
       },
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -444,7 +417,7 @@ describe('options.experimental_onEnd', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding], { tokens: 15 }),
       }),
       value: testValue,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -462,7 +435,7 @@ describe('options.experimental_onEnd', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -493,7 +466,7 @@ describe('options.experimental_onEnd', () => {
         ),
       }),
       value: testValue,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -513,7 +486,7 @@ describe('options.experimental_onEnd', () => {
         }),
       }),
       value: testValue,
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -535,7 +508,7 @@ describe('options.experimental_onEnd', () => {
         },
       }),
       value: testValue,
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         callOrder.push('onEnd');
       },
     });
@@ -549,7 +522,7 @@ describe('options.experimental_onEnd', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         throw new Error('callback error');
       },
     });
@@ -558,7 +531,7 @@ describe('options.experimental_onEnd', () => {
   });
 });
 
-describe('options.experimental_onStart and experimental_onEnd together', () => {
+describe('options.onStart and onEnd together', () => {
   it('should have consistent callId across both events', async () => {
     let startEvent!: EmbedStartEvent;
     let endEvent!: EmbedEndEvent;
@@ -571,10 +544,10 @@ describe('options.experimental_onStart and experimental_onEnd together', () => {
       _internal: {
         generateCallId: () => 'consistent-call-id',
       },
-      experimental_onStart: async event => {
+      onStart: async event => {
         startEvent = event;
       },
-      experimental_onEnd: async event => {
+      onEnd: async event => {
         endEvent = event;
       },
     });
@@ -595,10 +568,10 @@ describe('options.experimental_onStart and experimental_onEnd together', () => {
         },
       }),
       value: testValue,
-      experimental_onStart: async () => {
+      onStart: async () => {
         callOrder.push('onStart');
       },
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         callOrder.push('onEnd');
       },
     });
@@ -614,10 +587,10 @@ describe('options.experimental_onStart and experimental_onEnd together', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_onStart: async () => {
+      onStart: async () => {
         throw new Error('start error');
       },
-      experimental_onEnd: async () => {
+      onEnd: async () => {
         endCalled = true;
       },
     });

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -47,8 +47,10 @@ export async function embed({
   headers,
   experimental_telemetry,
   telemetry = experimental_telemetry,
-  experimental_onStart: onStart,
-  experimental_onEnd: onEnd,
+  onStart,
+  experimental_onStart,
+  onEnd,
+  experimental_onEnd,
   _internal: { generateCallId = originalGenerateCallId } = {},
 }: {
   /**
@@ -102,11 +104,27 @@ export async function embed({
    * Callback that is called when the embed operation begins,
    * before the embedding model is called.
    */
+  onStart?: Callback<EmbedStartEvent>;
+
+  /**
+   * Callback that is called when the embed operation begins,
+   * before the embedding model is called.
+   *
+   * @deprecated Use `onStart` instead.
+   */
   experimental_onStart?: Callback<EmbedStartEvent>;
 
   /**
    * Callback that is called when the embed operation completes,
    * after the embedding model returns.
+   */
+  onEnd?: Callback<EmbedEndEvent>;
+
+  /**
+   * Callback that is called when the embed operation completes,
+   * after the embedding model returns.
+   *
+   * @deprecated Use `onEnd` instead.
    */
   experimental_onEnd?: Callback<EmbedEndEvent>;
 
@@ -123,6 +141,8 @@ export async function embed({
     maxRetries: maxRetriesArg,
     abortSignal,
   });
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnEnd = onEnd ?? experimental_onEnd;
 
   const headersWithUserAgent = withUserAgentSuffix(
     headers ?? {},
@@ -146,7 +166,7 @@ export async function embed({
       headers: headersWithUserAgent,
       providerOptions,
     },
-    callbacks: [onStart, telemetryDispatcher.onStart],
+    callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
   });
 
   try {
@@ -214,7 +234,7 @@ export async function embed({
         providerMetadata,
         response,
       },
-      callbacks: [onEnd, telemetryDispatcher.onEnd],
+      callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultEmbedResult({

--- a/packages/ai/src/generate-object/__snapshots__/stream-object.test.ts.snap
+++ b/packages/ai/src/generate-object/__snapshots__/stream-object.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`streamObject > callbacks > experimental_onStart > should send correct information with text prompt 1`] = `
+exports[`streamObject > callbacks > onStart > should send correct information with text prompt 1`] = `
 {
   "callId": "test-call-id",
   "frequencyPenalty": undefined,

--- a/packages/ai/src/generate-object/generate-object.test-d.ts
+++ b/packages/ai/src/generate-object/generate-object.test-d.ts
@@ -55,4 +55,18 @@ describe('generateObject', () => {
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<number[]>();
   });
+
+  it('should support stable start callbacks', async () => {
+    generateObject({
+      schema: z.object({ number: z.number() }),
+      model: undefined!,
+      messages: [],
+      onStart: event => {
+        expectTypeOf(event.operationId).toEqualTypeOf<string>();
+      },
+      onStepStart: event => {
+        expectTypeOf(event.stepNumber).toEqualTypeOf<0>();
+      },
+    });
+  });
 });

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -1124,7 +1124,7 @@ describe('generateObject', () => {
   });
 
   describe('callbacks', () => {
-    describe('experimental_onStart', () => {
+    describe('onStart', () => {
       it('should call onStart before the model call', async () => {
         const events: string[] = [];
 
@@ -1144,7 +1144,7 @@ describe('generateObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: () => {
+          onStart: () => {
             events.push('onStart');
           },
         });
@@ -1175,7 +1175,7 @@ describe('generateObject', () => {
           telemetry: {
             functionId: 'test-function',
           },
-          experimental_onStart: event => {
+          onStart: event => {
             startEvent = event;
           },
           _internal: {
@@ -1242,7 +1242,7 @@ describe('generateObject', () => {
             isEnabled: true,
             functionId: 'deprecated-fn',
           },
-          experimental_onStart: event => {
+          onStart: event => {
             startEvent = event;
           },
         });
@@ -1252,7 +1252,7 @@ describe('generateObject', () => {
       });
     });
 
-    describe('experimental_onStepStart', () => {
+    describe('onStepStart', () => {
       it('should call onStepStart before the model call', async () => {
         const events: string[] = [];
 
@@ -1272,7 +1272,7 @@ describe('generateObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStepStart: () => {
+          onStepStart: () => {
             events.push('onStepStart');
           },
         });
@@ -1296,7 +1296,7 @@ describe('generateObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStepStart: event => {
+          onStepStart: event => {
             stepStartEvent = event;
           },
         });
@@ -1504,10 +1504,10 @@ describe('generateObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: () => {
+          onStart: () => {
             events.push('onStart');
           },
-          experimental_onStepStart: () => {
+          onStepStart: () => {
             events.push('onStepStart');
           },
           onStepFinish: () => {
@@ -1541,10 +1541,10 @@ describe('generateObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: event => {
+          onStart: event => {
             callIds.push(event.callId);
           },
-          experimental_onStepStart: event => {
+          onStepStart: event => {
             callIds.push(event.callId);
           },
           onStepFinish: event => {
@@ -1573,10 +1573,10 @@ describe('generateObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: () => {
+          onStart: () => {
             throw new Error('onStart error');
           },
-          experimental_onStepStart: () => {
+          onStepStart: () => {
             throw new Error('onStepStart error');
           },
           onStepFinish: () => {

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -105,8 +105,10 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  * to the provider from the AI SDK and enable provider-specific
  * functionality that can be fully encapsulated in the provider.
  *
- * @param experimental_onStart - Callback invoked when generation begins, before the LLM call.
- * @param experimental_onStepStart - Callback invoked when the model call begins.
+ * @param onStart - Callback invoked when generation begins, before the LLM call.
+ * @param experimental_onStart - Deprecated alias for `onStart`.
+ * @param onStepStart - Callback invoked when the model call begins.
+ * @param experimental_onStepStart - Deprecated alias for `onStepStart`.
  * @param onStepEnd - Callback invoked when the model call completes with the raw result.
  * @param onStepFinish - Deprecated alias for `onStepEnd`.
  * @param onFinish - Callback invoked when the entire operation completes with the parsed object.
@@ -199,11 +201,27 @@ export async function generateObject<
        * Callback that is called when the generateObject operation begins,
        * before the LLM call is made.
        */
+      onStart?: Callback<GenerateObjectStartEvent>;
+
+      /**
+       * Callback that is called when the generateObject operation begins,
+       * before the LLM call is made.
+       *
+       * @deprecated Use `onStart` instead.
+       */
       experimental_onStart?: Callback<GenerateObjectStartEvent>;
 
       /**
        * Callback that is called when the model call (step) begins,
        * before the provider is called.
+       */
+      onStepStart?: Callback<GenerateObjectStepStartEvent>;
+
+      /**
+       * Callback that is called when the model call (step) begins,
+       * before the provider is called.
+       *
+       * @deprecated Use `onStepStart` instead.
        */
       experimental_onStepStart?: Callback<GenerateObjectStepStartEvent>;
 
@@ -252,8 +270,10 @@ export async function generateObject<
     telemetry = experimental_telemetry,
     experimental_download: download,
     providerOptions,
-    experimental_onStart: onStart,
-    experimental_onStepStart: onStepStart,
+    onStart,
+    experimental_onStart,
+    onStepStart,
+    experimental_onStepStart,
     onStepEnd,
     onStepFinish,
     onFinish,
@@ -302,6 +322,8 @@ export async function generateObject<
   const telemetryDispatcher = createTelemetryDispatcher({
     telemetry,
   });
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnStepStart = onStepStart ?? experimental_onStepStart;
   const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
 
   const jsonSchema = await outputStrategy.jsonSchema();
@@ -331,7 +353,7 @@ export async function generateObject<
       schemaName,
       schemaDescription,
     },
-    callbacks: [onStart, telemetryDispatcher.onStart],
+    callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
   });
 
   try {
@@ -360,7 +382,7 @@ export async function generateObject<
         headers: headersWithUserAgent,
         promptMessages,
       },
-      callbacks: [onStepStart, telemetryDispatcher.onObjectStepStart],
+      callbacks: [resolvedOnStepStart, telemetryDispatcher.onObjectStepStart],
     });
 
     const generateResult = await retry(() =>

--- a/packages/ai/src/generate-object/stream-object.test-d.ts
+++ b/packages/ai/src/generate-object/stream-object.test-d.ts
@@ -80,4 +80,18 @@ describe('streamObject', () => {
     >();
     expectTypeOf<typeof result.object>().toEqualTypeOf<Promise<number[]>>();
   });
+
+  it('should support stable start callbacks', () => {
+    streamObject({
+      schema: z.object({ number: z.number() }),
+      model: undefined!,
+      prompt: 'test',
+      onStart: event => {
+        expectTypeOf(event.operationId).toEqualTypeOf<string>();
+      },
+      onStepStart: event => {
+        expectTypeOf(event.stepNumber).toEqualTypeOf<0>();
+      },
+    });
+  });
 });

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -1801,7 +1801,7 @@ describe('streamObject', () => {
   });
 
   describe('callbacks', () => {
-    describe('experimental_onStart', () => {
+    describe('onStart', () => {
       it('should call onStart before the model call', async () => {
         const events: string[] = [];
 
@@ -1831,7 +1831,7 @@ describe('streamObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: () => {
+          onStart: () => {
             events.push('onStart');
           },
         });
@@ -1874,7 +1874,7 @@ describe('streamObject', () => {
           telemetry: {
             functionId: 'test-function',
           },
-          experimental_onStart: event => {
+          onStart: event => {
             startEvent = event;
           },
           _internal: {
@@ -1915,7 +1915,7 @@ describe('streamObject', () => {
             isEnabled: true,
             functionId: 'deprecated-fn',
           },
-          experimental_onStart: event => {
+          onStart: event => {
             startEvent = event;
           },
         });
@@ -1927,7 +1927,7 @@ describe('streamObject', () => {
       });
     });
 
-    describe('experimental_onStepStart', () => {
+    describe('onStepStart', () => {
       it('should call onStepStart before the model call', async () => {
         const events: string[] = [];
 
@@ -1957,7 +1957,7 @@ describe('streamObject', () => {
           model,
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStepStart: () => {
+          onStepStart: () => {
             events.push('onStepStart');
           },
         });
@@ -1993,7 +1993,7 @@ describe('streamObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStepStart: event => {
+          onStepStart: event => {
             stepStartEvent = event;
           },
         });
@@ -2123,10 +2123,10 @@ describe('streamObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: () => {
+          onStart: () => {
             events.push('onStart');
           },
-          experimental_onStepStart: () => {
+          onStepStart: () => {
             events.push('onStepStart');
           },
           onStepFinish: () => {
@@ -2172,10 +2172,10 @@ describe('streamObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: event => {
+          onStart: event => {
             callIds.push(event.callId);
           },
-          experimental_onStepStart: event => {
+          onStepStart: event => {
             callIds.push(event.callId);
           },
           onStepFinish: event => {
@@ -2216,10 +2216,10 @@ describe('streamObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_onStart: () => {
+          onStart: () => {
             throw new Error('onStart error');
           },
-          experimental_onStepStart: () => {
+          onStepStart: () => {
             throw new Error('onStepStart error');
           },
           onStepFinish: () => {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -263,11 +263,27 @@ export function streamObject<
        * Callback that is called when the streamObject operation begins,
        * before the LLM call is made.
        */
+      onStart?: Callback<GenerateObjectStartEvent>;
+
+      /**
+       * Callback that is called when the streamObject operation begins,
+       * before the LLM call is made.
+       *
+       * @deprecated Use `onStart` instead.
+       */
       experimental_onStart?: Callback<GenerateObjectStartEvent>;
 
       /**
        * Callback that is called when the model call (step) begins,
        * before the provider is called.
+       */
+      onStepStart?: Callback<GenerateObjectStepStartEvent>;
+
+      /**
+       * Callback that is called when the model call (step) begins,
+       * before the provider is called.
+       *
+       * @deprecated Use `onStepStart` instead.
        */
       experimental_onStepStart?: Callback<GenerateObjectStepStartEvent>;
 
@@ -335,8 +351,10 @@ export function streamObject<
     telemetry = experimental_telemetry,
     experimental_download: download,
     providerOptions,
-    experimental_onStart: onStart,
-    experimental_onStepStart: onStepStart,
+    onStart,
+    experimental_onStart,
+    onStepStart,
+    experimental_onStepStart,
     onStepEnd,
     onStepFinish,
     onError = ({ error }: { error: unknown }) => {
@@ -391,8 +409,8 @@ export function streamObject<
     schemaDescription,
     providerOptions,
     repairText,
-    onStart,
-    onStepStart,
+    onStart: onStart ?? experimental_onStart,
+    onStepStart: onStepStart ?? experimental_onStepStart,
     onStepFinish: onStepEnd ?? onStepFinish,
     onError,
     onFinish,

--- a/packages/ai/src/generate-object/structured-output-events.ts
+++ b/packages/ai/src/generate-object/structured-output-events.ts
@@ -11,7 +11,7 @@ import type {
 import type { LanguageModelUsage } from '../types/usage';
 
 /**
- * Event passed to the `experimental_onStart` callback of
+ * Event passed to the `onStart` callback of
  * `generateObject` and `streamObject`.
  *
  * Called when the operation begins, before any LLM call.
@@ -77,7 +77,7 @@ export interface GenerateObjectStartEvent {
 }
 
 /**
- * Event passed to the `experimental_onStepStart` callback of
+ * Event passed to the `onStepStart` callback of
  * `generateObject` and `streamObject`.
  *
  * Called when the model call (step) begins, before the provider is called.

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generateText > options.experimental_onStart > should send correct information with text prompt 1`] = `
+exports[`generateText > options.onStart > should send correct information with text prompt 1`] = `
 {
   "activeTools": undefined,
   "callId": "test-telemetry-call-id",

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -2,42 +2,6 @@
 
 exports[`streamText > errors > should swallow error to prevent server crash 1`] = `[]`;
 
-exports[`streamText > options.experimental_onStart > should send correct information with text prompt 1`] = `
-{
-  "activeTools": undefined,
-  "callId": "test-telemetry-call-id",
-  "frequencyPenalty": undefined,
-  "headers": undefined,
-  "instructions": undefined,
-  "maxOutputTokens": undefined,
-  "maxRetries": 2,
-  "messages": [
-    {
-      "content": "test-input",
-      "role": "user",
-    },
-  ],
-  "modelId": "mock-model-id",
-  "operationId": "ai.streamText",
-  "output": undefined,
-  "presencePenalty": undefined,
-  "provider": "mock-provider",
-  "providerOptions": undefined,
-  "reasoning": undefined,
-  "runtimeContext": {},
-  "seed": undefined,
-  "stopSequences": undefined,
-  "temperature": undefined,
-  "timeout": undefined,
-  "toolChoice": undefined,
-  "toolOrder": undefined,
-  "tools": undefined,
-  "toolsContext": {},
-  "topK": undefined,
-  "topP": undefined,
-}
-`;
-
 exports[`streamText > options.onStart > should send correct information with text prompt 1`] = `
 {
   "activeTools": undefined,

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -38,6 +38,42 @@ exports[`streamText > options.experimental_onStart > should send correct informa
 }
 `;
 
+exports[`streamText > options.onStart > should send correct information with text prompt 1`] = `
+{
+  "activeTools": undefined,
+  "callId": "test-telemetry-call-id",
+  "frequencyPenalty": undefined,
+  "headers": undefined,
+  "instructions": undefined,
+  "maxOutputTokens": undefined,
+  "maxRetries": 2,
+  "messages": [
+    {
+      "content": "test-input",
+      "role": "user",
+    },
+  ],
+  "modelId": "mock-model-id",
+  "operationId": "ai.streamText",
+  "output": undefined,
+  "presencePenalty": undefined,
+  "provider": "mock-provider",
+  "providerOptions": undefined,
+  "reasoning": undefined,
+  "runtimeContext": {},
+  "seed": undefined,
+  "stopSequences": undefined,
+  "temperature": undefined,
+  "timeout": undefined,
+  "toolChoice": undefined,
+  "toolOrder": undefined,
+  "tools": undefined,
+  "toolsContext": {},
+  "topK": undefined,
+  "topP": undefined,
+}
+`;
+
 exports[`streamText > programmatic tool calling > 5 steps: code_execution triggers client tool across multiple turns (dice game fixture) > step inputs > should include all previous messages in step 5 prompt (final step) 1`] = `
 [
   {

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -339,7 +339,7 @@ export type OnFinishEvent<
 > = GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>;
 
 /**
- * Callback that is set using the `experimental_onStart` option.
+ * Callback that is set using the `onStart` option.
  *
  * Called when the generateText operation begins, before any LLM calls.
  * Use this callback for logging, analytics, or initializing state at the
@@ -354,7 +354,7 @@ export type GenerateTextOnStartCallback<
 > = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
- * Callback that is set using the `experimental_onStepStart` option.
+ * Callback that is set using the `onStepStart` option.
  *
  * Called when a step (LLM call) begins, before the provider is called.
  * Each step represents a single LLM invocation. Multiple steps occur when

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -375,13 +375,13 @@ describe('generateText types', () => {
         telemetry: {
           includeRuntimeContext: { userId: true },
         },
-        experimental_onStart: ({ runtimeContext }) => {
+        onStart: ({ runtimeContext }) => {
           expectTypeOf(runtimeContext).toEqualTypeOf<{
             userId: string;
             requestId: string;
           }>();
         },
-        experimental_onStepStart: ({ runtimeContext }) => {
+        onStepStart: ({ runtimeContext }) => {
           expectTypeOf(runtimeContext).toEqualTypeOf<{
             userId: string;
             requestId: string;

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1153,7 +1153,7 @@ describe('generateText', () => {
         experimental_refineToolInput: {
           tool1: input => ({ value: input.value.trim() }),
         },
-        experimental_onLanguageModelCallEnd: event => {
+        onLanguageModelCallEnd: event => {
           modelCallEndEvents.push(event);
         },
         onToolExecutionStart: event => {
@@ -1647,7 +1647,7 @@ describe('generateText', () => {
     });
   });
 
-  describe('options.experimental_onStart', () => {
+  describe('options.onStart', () => {
     it('should send correct information with text prompt', async () => {
       let startEvent!: Parameters<
         GenerateTextOnStartCallback<any, any, any>
@@ -1668,7 +1668,7 @@ describe('generateText', () => {
           generateId: () => 'test-call-id',
           generateCallId: () => 'test-telemetry-call-id',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -1690,7 +1690,7 @@ describe('generateText', () => {
         }),
         prompt: 'test-input',
         runtimeContext: { userId: 'test-user', sessionId: '123' },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -1718,7 +1718,7 @@ describe('generateText', () => {
           isEnabled: true,
           functionId: 'deprecated-fn',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -1743,7 +1743,7 @@ describe('generateText', () => {
         messages: [{ role: 'user', content: 'test-message' }],
         maxOutputTokens: 100,
         temperature: 0.5,
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -1806,7 +1806,7 @@ describe('generateText', () => {
           },
         }),
         prompt: 'test-input',
-        experimental_onStart: async () => {
+        onStart: async () => {
           callOrder.push('onStart');
         },
       });
@@ -1823,7 +1823,7 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'test-input',
-        experimental_onStart: async () => {
+        onStart: async () => {
           throw new Error('callback error');
         },
       });
@@ -1832,7 +1832,7 @@ describe('generateText', () => {
     });
   });
 
-  describe('options.experimental_onStepStart', () => {
+  describe('options.onStepStart', () => {
     it('should be called with correct data for a single step', async () => {
       let stepStartEvent!: Parameters<
         GenerateTextOnStepStartCallback<any, any>
@@ -1846,7 +1846,7 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'test-input',
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvent = event;
         },
       });
@@ -1905,7 +1905,7 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(3),
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
       });
@@ -1931,7 +1931,7 @@ describe('generateText', () => {
           },
         }),
         prompt: 'test-input',
-        experimental_onStepStart: async () => {
+        onStepStart: async () => {
           callOrder.push('onStepStart');
         },
       });
@@ -1948,7 +1948,7 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'test-input',
-        experimental_onStepStart: async () => {
+        onStepStart: async () => {
           throw new Error('callback error');
         },
       });
@@ -2004,7 +2004,7 @@ describe('generateText', () => {
           }
           return undefined;
         },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
       });
@@ -2028,7 +2028,7 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'test-input',
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvent = event;
         },
       });
@@ -2093,7 +2093,7 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(4),
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
       });
@@ -2164,7 +2164,7 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(3),
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
       });
@@ -2189,7 +2189,7 @@ describe('generateText', () => {
         }),
         prompt: 'test-input',
         runtimeContext: { userId: 'test-user', requestId: 'req-123' },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvent = event;
         },
       });
@@ -2250,7 +2250,7 @@ describe('generateText', () => {
             },
           };
         },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
       });
@@ -2455,7 +2455,7 @@ describe('generateText', () => {
 
           return undefined;
         },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
       });
@@ -2640,7 +2640,7 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(3),
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           startStepNumbers.push(event.stepNumber);
         },
         onStepFinish: async event => {
@@ -2652,54 +2652,7 @@ describe('generateText', () => {
     });
   });
 
-  describe('stable lifecycle callback aliases', () => {
-    it('should prefer stable callbacks over deprecated experimental aliases', async () => {
-      const calls: string[] = [];
-
-      await generateText({
-        model: new MockLanguageModelV4({
-          doGenerate: async () => ({
-            content: [{ type: 'text', text: 'Hello!' }],
-            ...dummyResponseValues,
-          }),
-        }),
-        prompt: 'test-input',
-        onStart: async () => {
-          calls.push('onStart');
-        },
-        experimental_onStart: async () => {
-          calls.push('experimental_onStart');
-        },
-        onStepStart: async () => {
-          calls.push('onStepStart');
-        },
-        experimental_onStepStart: async () => {
-          calls.push('experimental_onStepStart');
-        },
-        onLanguageModelCallStart: async () => {
-          calls.push('onLanguageModelCallStart');
-        },
-        experimental_onLanguageModelCallStart: async () => {
-          calls.push('experimental_onLanguageModelCallStart');
-        },
-        onLanguageModelCallEnd: async () => {
-          calls.push('onLanguageModelCallEnd');
-        },
-        experimental_onLanguageModelCallEnd: async () => {
-          calls.push('experimental_onLanguageModelCallEnd');
-        },
-      });
-
-      expect(calls).toEqual([
-        'onStart',
-        'onStepStart',
-        'onLanguageModelCallStart',
-        'onLanguageModelCallEnd',
-      ]);
-    });
-  });
-
-  describe('options.experimental_onLanguageModelCallStart and experimental_onLanguageModelCallEnd', () => {
+  describe('options.onLanguageModelCallStart and onLanguageModelCallEnd', () => {
     it('should fire the model-call callbacks before tool execution and step finish', async () => {
       const callOrder: string[] = [];
       let modelCallStartEvent!: LanguageModelCallStartEvent;
@@ -2737,14 +2690,14 @@ describe('generateText', () => {
         stopSequences: ['stop'],
         seed: 123,
         reasoning: 'high',
-        experimental_onStepStart: async () => {
+        onStepStart: async () => {
           callOrder.push('onStepStart');
         },
-        experimental_onLanguageModelCallStart: async event => {
+        onLanguageModelCallStart: async event => {
           callOrder.push('onLanguageModelCallStart');
           modelCallStartEvent = event;
         },
-        experimental_onLanguageModelCallEnd: async () => {
+        onLanguageModelCallEnd: async () => {
           callOrder.push('onLanguageModelCallEnd');
         },
         onToolExecutionStart: async () => {
@@ -2847,7 +2800,7 @@ describe('generateText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
-        experimental_onLanguageModelCallEnd: async event => {
+        onLanguageModelCallEnd: async event => {
           modelCallEndEvents.push(event);
         },
         ...defaultSettings(),
@@ -9098,10 +9051,10 @@ describe('generateText', () => {
             requestId: true,
           },
         },
-        experimental_onStart: ({ runtimeContext }) => {
+        onStart: ({ runtimeContext }) => {
           callbackContexts.push(runtimeContext);
         },
-        experimental_onStepStart: ({ runtimeContext }) => {
+        onStepStart: ({ runtimeContext }) => {
           callbackContexts.push(runtimeContext);
         },
         onStepFinish: ({ runtimeContext }) => {
@@ -12440,7 +12393,7 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'test-input',
-        experimental_onStart: async () => {
+        onStart: async () => {
           events.push('user-onStart');
         },
         onStepFinish: async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2652,6 +2652,53 @@ describe('generateText', () => {
     });
   });
 
+  describe('stable lifecycle callback aliases', () => {
+    it('should prefer stable callbacks over deprecated experimental aliases', async () => {
+      const calls: string[] = [];
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        onStart: async () => {
+          calls.push('onStart');
+        },
+        experimental_onStart: async () => {
+          calls.push('experimental_onStart');
+        },
+        onStepStart: async () => {
+          calls.push('onStepStart');
+        },
+        experimental_onStepStart: async () => {
+          calls.push('experimental_onStepStart');
+        },
+        onLanguageModelCallStart: async () => {
+          calls.push('onLanguageModelCallStart');
+        },
+        experimental_onLanguageModelCallStart: async () => {
+          calls.push('experimental_onLanguageModelCallStart');
+        },
+        onLanguageModelCallEnd: async () => {
+          calls.push('onLanguageModelCallEnd');
+        },
+        experimental_onLanguageModelCallEnd: async () => {
+          calls.push('experimental_onLanguageModelCallEnd');
+        },
+      });
+
+      expect(calls).toEqual([
+        'onStart',
+        'onStepStart',
+        'onLanguageModelCallStart',
+        'onLanguageModelCallEnd',
+      ]);
+    });
+  });
+
   describe('options.experimental_onLanguageModelCallStart and experimental_onLanguageModelCallEnd', () => {
     it('should fire the model-call callbacks before tool execution and step finish', async () => {
       const callOrder: string[] = [];

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -197,9 +197,15 @@ export type GenerateTextInclude = {
  * @param experimental_sandbox - The sandbox environment that is passed through to tool execution.
  * @param runtimeContext - User-defined runtime context that flows through the entire generation lifecycle.
  * @param experimental_refineToolInput - Optional mapping of tool names to functions that refine parsed tool inputs before tools are executed and before outputs, callbacks, and telemetry are recorded.
- * @param experimental_onStart - Callback invoked when generation begins, before any LLM calls.
- * @param experimental_onStepStart - Callback invoked when each step begins, before the provider is called.
+ * @param onStart - Callback invoked when generation begins, before any LLM calls.
+ * @param experimental_onStart - Deprecated alias for `onStart`.
+ * @param onStepStart - Callback invoked when each step begins, before the provider is called.
+ * @param experimental_onStepStart - Deprecated alias for `onStepStart`.
  * Receives step number, messages (in ModelMessage format), tools, and runtimeContext.
+ * @param onLanguageModelCallStart - Callback invoked immediately before each provider model call begins.
+ * @param experimental_onLanguageModelCallStart - Deprecated alias for `onLanguageModelCallStart`.
+ * @param onLanguageModelCallEnd - Callback invoked after each provider model call response is normalized and parsed.
+ * @param experimental_onLanguageModelCallEnd - Deprecated alias for `onLanguageModelCallEnd`.
  * @param onToolExecutionStart - Callback invoked before each tool execution begins.
  * Receives tool name, call ID, input, and context.
  * @param experimental_onToolCallStart - Deprecated alias for `onToolExecutionStart`.
@@ -253,10 +259,14 @@ export async function generateText<
     generateCallId = originalGenerateCallId,
     now = originalNow,
   } = {},
-  experimental_onStart: onStart,
-  experimental_onStepStart: onStepStart,
-  experimental_onLanguageModelCallStart: onLanguageModelCallStart,
-  experimental_onLanguageModelCallEnd: onLanguageModelCallEnd,
+  onStart,
+  experimental_onStart,
+  onStepStart,
+  experimental_onStepStart,
+  onLanguageModelCallStart,
+  experimental_onLanguageModelCallStart,
+  onLanguageModelCallEnd,
+  experimental_onLanguageModelCallEnd,
   onToolExecutionStart,
   onToolExecutionEnd,
   experimental_onToolCallStart,
@@ -381,6 +391,18 @@ export async function generateText<
      * Callback that is called when the generateText operation begins,
      * before any LLM calls are made.
      */
+    onStart?: GenerateTextOnStartCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>,
+      NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called when the generateText operation begins,
+     * before any LLM calls are made.
+     *
+     * @deprecated Use `onStart` instead.
+     */
     experimental_onStart?: GenerateTextOnStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
@@ -391,6 +413,18 @@ export async function generateText<
      * Callback that is called when a step (LLM call) begins,
      * before the provider is called.
      */
+    onStepStart?: GenerateTextOnStepStartCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>,
+      NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called when a step (LLM call) begins,
+     * before the provider is called.
+     *
+     * @deprecated Use `onStepStart` instead.
+     */
     experimental_onStepStart?: GenerateTextOnStepStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
@@ -400,11 +434,26 @@ export async function generateText<
     /**
      * Callback that is called immediately before the provider model call begins.
      */
+    onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
+
+    /**
+     * Callback that is called immediately before the provider model call begins.
+     *
+     * @deprecated Use `onLanguageModelCallStart` instead.
+     */
     experimental_onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
 
     /**
      * Callback that is called after the model response has been normalized and parsed,
      * but before any client-side tool execution begins.
+     */
+    onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<NoInfer<TOOLS>>;
+
+    /**
+     * Callback that is called after the model response has been normalized and parsed,
+     * but before any client-side tool execution begins.
+     *
+     * @deprecated Use `onLanguageModelCallEnd` instead.
      */
     experimental_onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<
       NoInfer<TOOLS>
@@ -502,6 +551,12 @@ export async function generateText<
 
   const model = resolveLanguageModel(modelArg);
   const stopConditions = asArray(stopWhen);
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnStepStart = onStepStart ?? experimental_onStepStart;
+  const resolvedOnLanguageModelCallStart =
+    onLanguageModelCallStart ?? experimental_onLanguageModelCallStart;
+  const resolvedOnLanguageModelCallEnd =
+    onLanguageModelCallEnd ?? experimental_onLanguageModelCallEnd;
   const resolvedOnToolExecutionStart =
     onToolExecutionStart ?? experimental_onToolCallStart;
   const resolvedOnToolExecutionEnd =
@@ -579,7 +634,7 @@ export async function generateText<
       runtimeContext,
       toolsContext,
     },
-    callbacks: [onStart, telemetryDispatcher.onStart],
+    callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
   });
 
   try {
@@ -817,7 +872,7 @@ export async function generateText<
             stepToolChoice,
             toolsContext,
           },
-          callbacks: [onStepStart, telemetryDispatcher.onStepStart],
+          callbacks: [resolvedOnStepStart, telemetryDispatcher.onStepStart],
         });
 
         await notify({
@@ -831,7 +886,7 @@ export async function generateText<
             ...callSettings,
           },
           callbacks: [
-            onLanguageModelCallStart,
+            resolvedOnLanguageModelCallStart,
             telemetryDispatcher.onLanguageModelCallStart as
               | undefined
               | OnLanguageModelCallStartCallback,
@@ -939,7 +994,7 @@ export async function generateText<
             },
           },
           callbacks: [
-            onLanguageModelCallEnd,
+            resolvedOnLanguageModelCallEnd,
             telemetryDispatcher.onLanguageModelCallEnd as
               | undefined
               | OnLanguageModelCallEndCallback<TOOLS>,

--- a/packages/ai/src/generate-text/language-model-events.ts
+++ b/packages/ai/src/generate-text/language-model-events.ts
@@ -105,7 +105,7 @@ export type LanguageModelCallEndEvent<TOOLS extends ToolSet = ToolSet> =
   };
 
 /**
- * Callback that is set using the `experimental_onLanguageModelCallStart` option.
+ * Callback that is set using the `onLanguageModelCallStart` option.
  *
  * Called immediately before the provider model call begins.
  * Unlike step-start callbacks, this is scoped to model work only and
@@ -117,7 +117,7 @@ export type OnLanguageModelCallStartCallback =
   Callback<LanguageModelCallStartEvent>;
 
 /**
- * Callback that is set using the `experimental_onLanguageModelCallEnd` option.
+ * Callback that is set using the `onLanguageModelCallEnd` option.
  *
  * Called after the model response has been normalized and parsed, but before
  * any client-side tool execution begins.

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -465,13 +465,13 @@ describe('streamText types', () => {
         telemetry: {
           includeRuntimeContext: { userId: true },
         },
-        experimental_onStart: ({ runtimeContext }) => {
+        onStart: ({ runtimeContext }) => {
           expectTypeOf(runtimeContext).toEqualTypeOf<{
             userId: string;
             requestId: string;
           }>();
         },
-        experimental_onStepStart: ({ runtimeContext }) => {
+        onStepStart: ({ runtimeContext }) => {
           expectTypeOf(runtimeContext).toEqualTypeOf<{
             userId: string;
             requestId: string;

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1811,7 +1811,7 @@ describe('streamText', () => {
         experimental_refineToolInput: {
           tool1: input => ({ value: input.value.trim() }),
         },
-        experimental_onLanguageModelCallEnd: event => {
+        onLanguageModelCallEnd: event => {
           modelCallEndEvents.push(event);
         },
         onToolExecutionStart: event => {
@@ -7317,7 +7317,7 @@ describe('streamText', () => {
     });
   });
 
-  describe('options.experimental_onStart', () => {
+  describe('options.onStart', () => {
     it('should send correct information with text prompt', async () => {
       let startEvent!: Parameters<GenerateTextOnStartCallback>[0];
 
@@ -7327,7 +7327,7 @@ describe('streamText', () => {
         telemetry: {
           functionId: 'test-function',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7352,7 +7352,7 @@ describe('streamText', () => {
           isEnabled: true,
           functionId: 'deprecated-fn',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7371,7 +7371,7 @@ describe('streamText', () => {
         model: createTestModel(),
         prompt: 'test-input',
         runtimeContext: { userId: 'test-user', sessionId: '123' },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7400,10 +7400,10 @@ describe('streamText', () => {
             requestId: true,
           },
         },
-        experimental_onStart: async ({ runtimeContext }) => {
+        onStart: async ({ runtimeContext }) => {
           callbackContexts.push(runtimeContext);
         },
-        experimental_onStepStart: async ({ runtimeContext }) => {
+        onStepStart: async ({ runtimeContext }) => {
           callbackContexts.push(runtimeContext);
         },
         onStepFinish: async ({ runtimeContext }) => {
@@ -7579,7 +7579,7 @@ describe('streamText', () => {
         messages: [{ role: 'user', content: 'test-message' }],
         maxOutputTokens: 100,
         temperature: 0.5,
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7631,7 +7631,7 @@ describe('streamText', () => {
           },
         }),
         prompt: 'test-input',
-        experimental_onStart: async () => {
+        onStart: async () => {
           callOrder.push('onStart');
         },
         onError: () => {},
@@ -7646,7 +7646,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
-        experimental_onStart: async () => {
+        onStart: async () => {
           throw new Error('callback error');
         },
         onError: () => {},
@@ -7667,7 +7667,7 @@ describe('streamText', () => {
         prompt: 'test-input',
         tools: { myTool: testTool },
         toolChoice: 'auto',
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7686,7 +7686,7 @@ describe('streamText', () => {
         model: createTestModel(),
         prompt: 'test-input',
         providerOptions: { openai: { logprobs: true } },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7707,7 +7707,7 @@ describe('streamText', () => {
         prompt: 'test-input',
         timeout: { totalMs: 5000, stepMs: 1000 },
         stopWhen: isStepCount(3),
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
         onError: () => {},
@@ -7719,7 +7719,7 @@ describe('streamText', () => {
     });
   });
 
-  describe('options.experimental_onStepStart', () => {
+  describe('options.onStepStart', () => {
     it('should be called with correct data for a single step', async () => {
       let stepStartEvent!: Parameters<
         GenerateTextOnStepStartCallback<any, any>
@@ -7728,7 +7728,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvent = event;
         },
         onError: () => {},
@@ -7823,7 +7823,7 @@ describe('streamText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(3),
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
         onError: () => {},
@@ -7870,7 +7870,7 @@ describe('streamText', () => {
           },
         }),
         prompt: 'test-input',
-        experimental_onStepStart: async () => {
+        onStepStart: async () => {
           callOrder.push('onStepStart');
         },
         onError: () => {},
@@ -7885,7 +7885,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
-        experimental_onStepStart: async () => {
+        onStepStart: async () => {
           throw new Error('callback error');
         },
         onError: () => {},
@@ -7968,7 +7968,7 @@ describe('streamText', () => {
           }
           return undefined;
         },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
         onError: () => {},
@@ -7992,7 +7992,7 @@ describe('streamText', () => {
         prompt: 'test-input',
         providerOptions: { openai: { logprobs: true } },
         runtimeContext: { userId: 'test-user' },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvent = event;
         },
         onError: () => {},
@@ -8019,7 +8019,7 @@ describe('streamText', () => {
         telemetry: {
           functionId: 'test-function',
         },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvent = event;
         },
         onError: () => {},
@@ -8275,7 +8275,7 @@ describe('streamText', () => {
 
           return undefined;
         },
-        experimental_onStepStart: async event => {
+        onStepStart: async event => {
           stepStartEvents.push(event);
         },
         onError: () => {},
@@ -8297,65 +8297,7 @@ describe('streamText', () => {
     });
   });
 
-  describe('stable lifecycle callback aliases', () => {
-    it('should prefer stable callbacks over deprecated experimental aliases', async () => {
-      const calls: string[] = [];
-
-      const result = streamText({
-        model: new MockLanguageModelV4({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-start', id: '1' },
-              { type: 'text-delta', id: '1', delta: 'Hello!' },
-              { type: 'text-end', id: '1' },
-              {
-                type: 'finish',
-                finishReason: { unified: 'stop', raw: undefined },
-                usage: testUsage,
-              },
-            ]),
-          }),
-        }),
-        prompt: 'test-input',
-        onStart: async () => {
-          calls.push('onStart');
-        },
-        experimental_onStart: async () => {
-          calls.push('experimental_onStart');
-        },
-        onStepStart: async () => {
-          calls.push('onStepStart');
-        },
-        experimental_onStepStart: async () => {
-          calls.push('experimental_onStepStart');
-        },
-        onLanguageModelCallStart: async () => {
-          calls.push('onLanguageModelCallStart');
-        },
-        experimental_onLanguageModelCallStart: async () => {
-          calls.push('experimental_onLanguageModelCallStart');
-        },
-        onLanguageModelCallEnd: async () => {
-          calls.push('onLanguageModelCallEnd');
-        },
-        experimental_onLanguageModelCallEnd: async () => {
-          calls.push('experimental_onLanguageModelCallEnd');
-        },
-        onError: () => {},
-      });
-
-      await result.consumeStream();
-
-      expect(calls).toEqual([
-        'onStart',
-        'onStepStart',
-        'onLanguageModelCallStart',
-        'onLanguageModelCallEnd',
-      ]);
-    });
-  });
-
-  describe('options.experimental_onLanguageModelCallStart and experimental_onLanguageModelCallEnd', () => {
+  describe('options.onLanguageModelCallStart and onLanguageModelCallEnd', () => {
     it('should fire the model-call callbacks before tool execution and step finish', async () => {
       const callOrder: string[] = [];
       const modelCallEndEvents: LanguageModelCallEndEvent<any>[] = [];
@@ -8394,13 +8336,13 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onStepStart: async () => {
+        onStepStart: async () => {
           callOrder.push('onStepStart');
         },
-        experimental_onLanguageModelCallStart: async () => {
+        onLanguageModelCallStart: async () => {
           callOrder.push('onLanguageModelCallStart');
         },
-        experimental_onLanguageModelCallEnd: async event => {
+        onLanguageModelCallEnd: async event => {
           callOrder.push('onLanguageModelCallEnd');
           modelCallEndEvents.push(event);
         },
@@ -29172,7 +29114,7 @@ describe('streamText', () => {
         model: createTestModel(),
         prompt: 'test-input',
         onError: () => {},
-        experimental_onStart: async () => {
+        onStart: async () => {
           events.push('user-onStart');
         },
         onStepFinish: async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -8297,6 +8297,64 @@ describe('streamText', () => {
     });
   });
 
+  describe('stable lifecycle callback aliases', () => {
+    it('should prefer stable callbacks over deprecated experimental aliases', async () => {
+      const calls: string[] = [];
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello!' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: undefined },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        prompt: 'test-input',
+        onStart: async () => {
+          calls.push('onStart');
+        },
+        experimental_onStart: async () => {
+          calls.push('experimental_onStart');
+        },
+        onStepStart: async () => {
+          calls.push('onStepStart');
+        },
+        experimental_onStepStart: async () => {
+          calls.push('experimental_onStepStart');
+        },
+        onLanguageModelCallStart: async () => {
+          calls.push('onLanguageModelCallStart');
+        },
+        experimental_onLanguageModelCallStart: async () => {
+          calls.push('experimental_onLanguageModelCallStart');
+        },
+        onLanguageModelCallEnd: async () => {
+          calls.push('onLanguageModelCallEnd');
+        },
+        experimental_onLanguageModelCallEnd: async () => {
+          calls.push('experimental_onLanguageModelCallEnd');
+        },
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(calls).toEqual([
+        'onStart',
+        'onStepStart',
+        'onLanguageModelCallStart',
+        'onLanguageModelCallEnd',
+      ]);
+    });
+  });
+
   describe('options.experimental_onLanguageModelCallStart and experimental_onLanguageModelCallEnd', () => {
     it('should fire the model-call callbacks before tool execution and step finish', async () => {
       const callOrder: string[] = [];

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -306,6 +306,14 @@ export type StreamTextOnAbortCallback<
  *
  * @param onChunk - Callback that is called for each chunk of the stream. The stream processing will pause until the callback promise is resolved.
  * @param onError - Callback that is called when an error occurs during streaming. You can use it to log errors.
+ * @param onStart - Callback invoked when generation begins, before any LLM calls.
+ * @param experimental_onStart - Deprecated alias for `onStart`.
+ * @param onStepStart - Callback invoked when each step begins, before the provider is called.
+ * @param experimental_onStepStart - Deprecated alias for `onStepStart`.
+ * @param onLanguageModelCallStart - Callback invoked immediately before each provider model call begins.
+ * @param experimental_onLanguageModelCallStart - Deprecated alias for `onLanguageModelCallStart`.
+ * @param onLanguageModelCallEnd - Callback invoked after each provider model call response is normalized and parsed.
+ * @param experimental_onLanguageModelCallEnd - Deprecated alias for `onLanguageModelCallEnd`.
  * @param onToolExecutionStart - Callback invoked before each tool execution begins.
  * @param experimental_onToolCallStart - Deprecated alias for `onToolExecutionStart`.
  * @param onToolExecutionEnd - Callback invoked after each tool execution completes.
@@ -360,10 +368,14 @@ export function streamText<
   onAbort,
   onStepEnd,
   onStepFinish,
-  experimental_onStart: onStart,
-  experimental_onStepStart: onStepStart,
-  experimental_onLanguageModelCallStart: onLanguageModelCallStart,
-  experimental_onLanguageModelCallEnd: onLanguageModelCallEnd,
+  onStart,
+  experimental_onStart,
+  onStepStart,
+  experimental_onStepStart,
+  onLanguageModelCallStart,
+  experimental_onLanguageModelCallStart,
+  onLanguageModelCallEnd,
+  experimental_onLanguageModelCallEnd,
   onToolExecutionStart,
   onToolExecutionEnd,
   experimental_onToolCallStart,
@@ -575,6 +587,18 @@ export function streamText<
      * Callback that is called when the streamText operation begins,
      * before any LLM calls are made.
      */
+    onStart?: GenerateTextOnStartCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>,
+      NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called when the streamText operation begins,
+     * before any LLM calls are made.
+     *
+     * @deprecated Use `onStart` instead.
+     */
     experimental_onStart?: GenerateTextOnStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
@@ -585,6 +609,18 @@ export function streamText<
      * Callback that is called when a step (LLM call) begins,
      * before the provider is called.
      */
+    onStepStart?: GenerateTextOnStepStartCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>,
+      NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called when a step (LLM call) begins,
+     * before the provider is called.
+     *
+     * @deprecated Use `onStepStart` instead.
+     */
     experimental_onStepStart?: GenerateTextOnStepStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
@@ -594,11 +630,26 @@ export function streamText<
     /**
      * Callback that is called immediately before the provider model call begins.
      */
+    onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
+
+    /**
+     * Callback that is called immediately before the provider model call begins.
+     *
+     * @deprecated Use `onLanguageModelCallStart` instead.
+     */
     experimental_onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
 
     /**
      * Callback that is called after the model response has been normalized and parsed,
      * but before any client-side tool execution begins.
+     */
+    onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<NoInfer<TOOLS>>;
+
+    /**
+     * Callback that is called after the model response has been normalized and parsed,
+     * but before any client-side tool execution begins.
+     *
+     * @deprecated Use `onLanguageModelCallEnd` instead.
      */
     experimental_onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<
       NoInfer<TOOLS>
@@ -660,6 +711,12 @@ export function streamText<
     stepTimeoutMs != null ? new AbortController() : undefined;
   const chunkAbortController =
     chunkTimeoutMs != null ? new AbortController() : undefined;
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnStepStart = onStepStart ?? experimental_onStepStart;
+  const resolvedOnLanguageModelCallStart =
+    onLanguageModelCallStart ?? experimental_onLanguageModelCallStart;
+  const resolvedOnLanguageModelCallEnd =
+    onLanguageModelCallEnd ?? experimental_onLanguageModelCallEnd;
   const resolvedOnToolExecutionStart =
     onToolExecutionStart ?? experimental_onToolCallStart;
   const resolvedOnToolExecutionEnd =
@@ -708,10 +765,10 @@ export function streamText<
     onEnd,
     onAbort,
     onStepFinish: resolvedOnStepEnd,
-    onStart,
-    onStepStart,
-    onLanguageModelCallStart,
-    onLanguageModelCallEnd,
+    onStart: resolvedOnStart,
+    onStepStart: resolvedOnStepStart,
+    onLanguageModelCallStart: resolvedOnLanguageModelCallStart,
+    onLanguageModelCallEnd: resolvedOnLanguageModelCallEnd,
     onToolExecutionStart: resolvedOnToolExecutionStart,
     onToolExecutionEnd: resolvedOnToolExecutionEnd,
     now,

--- a/packages/ai/src/rerank/__snapshots__/rerank.test.ts.snap
+++ b/packages/ai/src/rerank/__snapshots__/rerank.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`rerank > options.experimental_onEnd > should send correct event information 1`] = `
+exports[`rerank > options.onEnd > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "documents": [
@@ -54,7 +54,7 @@ exports[`rerank > options.experimental_onEnd > should send correct event informa
 }
 `;
 
-exports[`rerank > options.experimental_onStart > should send correct event information 1`] = `
+exports[`rerank > options.onStart > should send correct event information 1`] = `
 {
   "callId": "test-call-id",
   "documents": [

--- a/packages/ai/src/rerank/rerank-events.ts
+++ b/packages/ai/src/rerank/rerank-events.ts
@@ -39,7 +39,7 @@ export type RerankStartEvent = {
 };
 
 /**
- * Event passed to the `onFinish` callback for rerank operations.
+ * Event passed to the `onEnd` callback for rerank operations.
  *
  * Called when the operation completes, after the reranking model returns.
  */

--- a/packages/ai/src/rerank/rerank.test.ts
+++ b/packages/ai/src/rerank/rerank.test.ts
@@ -345,7 +345,7 @@ describe('rerank', () => {
     });
   });
 
-  describe('options.experimental_onStart', () => {
+  describe('options.onStart', () => {
     const mockModel = new MockRerankingModelV4({
       doRerank: async () => ({
         ranking: [
@@ -380,7 +380,7 @@ describe('rerank', () => {
         _internal: {
           generateCallId: () => 'test-call-id',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -405,7 +405,7 @@ describe('rerank', () => {
           recordOutputs: true,
           functionId: 'rerank-fn',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -433,7 +433,7 @@ describe('rerank', () => {
           recordOutputs: true,
           functionId: 'rerank-fn-deprecated',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -455,7 +455,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -479,7 +479,7 @@ describe('rerank', () => {
         }),
         documents: ['test document'],
         query: 'test query',
-        experimental_onStart: async () => {
+        onStart: async () => {
           callOrder.push('onStart');
         },
       });
@@ -496,7 +496,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onStart: async () => {
+        onStart: async () => {
           throw new Error('callback error');
         },
       });
@@ -519,7 +519,7 @@ describe('rerank', () => {
         topN: 2,
         headers: { 'x-custom': 'header-value' },
         providerOptions: { myProvider: { key: 'value' } },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
       });
@@ -538,7 +538,7 @@ describe('rerank', () => {
     });
   });
 
-  describe('options.experimental_onEnd', () => {
+  describe('options.onEnd', () => {
     const mockModel = new MockRerankingModelV4({
       doRerank: async () => ({
         ranking: [
@@ -578,7 +578,7 @@ describe('rerank', () => {
         _internal: {
           generateCallId: () => 'test-call-id',
         },
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });
@@ -597,7 +597,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });
@@ -638,7 +638,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });
@@ -659,7 +659,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });
@@ -683,7 +683,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });
@@ -711,7 +711,7 @@ describe('rerank', () => {
         }),
         documents: ['test document'],
         query: 'test query',
-        experimental_onEnd: async () => {
+        onEnd: async () => {
           callOrder.push('onEnd');
         },
       });
@@ -728,7 +728,7 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onEnd: async () => {
+        onEnd: async () => {
           throw new Error('callback error');
         },
       });
@@ -738,7 +738,7 @@ describe('rerank', () => {
     });
   });
 
-  describe('options.experimental_onStart and experimental_onEnd together', () => {
+  describe('options.onStart and onEnd together', () => {
     const mockModel = new MockRerankingModelV4({
       doRerank: async () => ({
         ranking: [
@@ -768,10 +768,10 @@ describe('rerank', () => {
         _internal: {
           generateCallId: () => 'consistent-call-id',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });
@@ -795,10 +795,10 @@ describe('rerank', () => {
         }),
         documents: ['test document'],
         query: 'test query',
-        experimental_onStart: async () => {
+        onStart: async () => {
           callOrder.push('onStart');
         },
-        experimental_onEnd: async () => {
+        onEnd: async () => {
           callOrder.push('onEnd');
         },
       });
@@ -817,10 +817,10 @@ describe('rerank', () => {
           'cloudy day in the mountains',
         ],
         query: 'rainy day',
-        experimental_onStart: async () => {
+        onStart: async () => {
           throw new Error('onStart error');
         },
-        experimental_onEnd: async () => {
+        onEnd: async () => {
           endCalled = true;
         },
       });
@@ -840,10 +840,10 @@ describe('rerank', () => {
         _internal: {
           generateCallId: () => 'empty-call-id',
         },
-        experimental_onStart: async event => {
+        onStart: async event => {
           startEvent = event;
         },
-        experimental_onEnd: async event => {
+        onEnd: async event => {
           endEvent = event;
         },
       });

--- a/packages/ai/src/rerank/rerank.ts
+++ b/packages/ai/src/rerank/rerank.ts
@@ -46,8 +46,10 @@ export async function rerank<VALUE extends JSONObject | string>({
   providerOptions,
   experimental_telemetry,
   telemetry = experimental_telemetry,
-  experimental_onStart: onStart,
-  experimental_onEnd: onEnd,
+  onStart,
+  experimental_onStart,
+  onEnd,
+  experimental_onEnd,
   _internal: { generateCallId = originalGenerateCallId } = {},
 }: {
   /**
@@ -111,11 +113,27 @@ export async function rerank<VALUE extends JSONObject | string>({
    * Callback that is called when the rerank operation begins,
    * before the reranking model is called.
    */
+  onStart?: Callback<RerankStartEvent>;
+
+  /**
+   * Callback that is called when the rerank operation begins,
+   * before the reranking model is called.
+   *
+   * @deprecated Use `onStart` instead.
+   */
   experimental_onStart?: Callback<RerankStartEvent>;
 
   /**
    * Callback that is called when the rerank operation completes,
    * after the reranking model returns.
+   */
+  onEnd?: Callback<RerankEndEvent>;
+
+  /**
+   * Callback that is called when the rerank operation completes,
+   * after the reranking model returns.
+   *
+   * @deprecated Use `onEnd` instead.
    */
   experimental_onEnd?: Callback<RerankEndEvent>;
 
@@ -128,6 +146,8 @@ export async function rerank<VALUE extends JSONObject | string>({
 }): Promise<RerankResult<VALUE>> {
   const model = resolveRerankingModel(modelArg);
   const callId = generateCallId();
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnEnd = onEnd ?? experimental_onEnd;
 
   const telemetryDispatcher = createTelemetryDispatcher({
     telemetry,
@@ -147,7 +167,7 @@ export async function rerank<VALUE extends JSONObject | string>({
         headers,
         providerOptions,
       },
-      callbacks: [onStart, telemetryDispatcher.onStart],
+      callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
     });
 
     await notify({
@@ -166,7 +186,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           modelId: model.modelId,
         },
       },
-      callbacks: [onEnd, telemetryDispatcher.onEnd],
+      callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultRerankResult({
@@ -203,7 +223,7 @@ export async function rerank<VALUE extends JSONObject | string>({
       headers,
       providerOptions,
     },
-    callbacks: [onStart, telemetryDispatcher.onStart],
+    callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
   });
 
   try {
@@ -284,7 +304,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           body: response?.body,
         },
       },
-      callbacks: [onEnd, telemetryDispatcher.onEnd],
+      callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
     });
 
     return new DefaultRerankResult({


### PR DESCRIPTION
## Background

introduced in v7, the user-facing model lifecycle callbacks had to be made stable across the codebase and the docs

## Summary

the callbacks are marked stable + deprecated the experimental versions (since some of them were introduced when main was still on v6)

## Manual Verification

verified by running the example `examples/ai-functions/src/generate-text/openai/listen-to-events.ts` 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)