### PR TITLE
feat(harness): surface structured output (output schema) on HarnessAgent

### DIFF
--- a/.changeset/harness-structured-output.md
+++ b/.changeset/harness-structured-output.md
@@ -1,0 +1,25 @@
+---
+'@ai-sdk/harness': patch
+'@ai-sdk/harness-codex': patch
+'@ai-sdk/harness-claude-code': patch
+'@ai-sdk/harness-pi': patch
+---
+
+feat(harness): surface structured output on HarnessAgent
+
+`HarnessAgent.generate()` / `stream()` (and `continueGenerate()` /
+`continueStream()`) now accept a per-call `output` specification (e.g.
+`Output.object({ schema })`) and expose a typed, validated `result.output`,
+mirroring the `output` API on `generateText` / `streamText` / `ToolLoopAgent`.
+
+The schema is enforced by the underlying runtime (Codex `outputSchema`, Claude
+Code `outputFormat`) and re-validated host-side via the same
+`Output.parseCompleteOutput` core uses, throwing `NoObjectGeneratedError` on a
+parse/validation failure. On a structured-output turn both sandbox adapters
+surface the validated object as the assistant text and suppress intermediate
+streamed prose (reasoning still streams), so the host parser stays
+adapter-agnostic. Streaming structured-output surfaces (`partialOutputStream`,
+`experimental_partialOutputStream`, `elementStream`) are terminal-only because
+the runtimes materialize the object at turn-end; `elementStream` is available
+only for `Output.array`. Pi has no native schema enforcement and throws
+`HarnessCapabilityUnsupportedError` when an output schema is requested.

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -120,6 +120,88 @@ try {
 }
 ```
 
+## Structured Output
+
+Pass an `output` specification to `generate()` or `stream()` to get a validated,
+typed object back instead of free-form text. This mirrors the `output` API on
+`generateText` / `streamText` / `ToolLoopAgent`, so a `HarnessAgent` turn is a
+drop-in alternative for staged-decision steps (triage, routing, review, judging).
+
+```ts
+import { Output } from 'ai';
+import { z } from 'zod';
+
+const session = await agent.createSession();
+
+try {
+  const result = await agent.generate({
+    session,
+    prompt: 'Classify the sentiment of: "I love this!"',
+    output: Output.object({
+      schema: z.object({
+        sentiment: z.enum(['positive', 'negative', 'neutral']),
+        confidence: z.number(),
+      }),
+    }),
+  });
+
+  // `result.output` is typed as { sentiment: ...; confidence: number }
+  console.log(result.output.sentiment);
+} finally {
+  await session.destroy();
+}
+```
+
+`output` is supplied **per call**, not at construction. A single long-lived
+session can therefore use a different schema on each turn, which is what
+staged pipelines need.
+
+### How enforcement works
+
+The schema is enforced twice: the underlying runtime constrains generation
+down-path, and the framework re-validates the result host-side using the same
+`Output` specification core uses. A result that cannot be parsed or fails
+validation throws `NoObjectGeneratedError`, identical to the `generateObject` /
+`Output` path you already know.
+
+| Harness         | Enforcement                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| **Codex**       | Native `outputSchema` on the turn; the object is the final message.            |
+| **Claude Code** | Native `outputFormat: { type: 'json_schema' }`; read from `structured_output`. |
+| **Pi**          | Not supported. Requesting `output` throws `HarnessCapabilityUnsupportedError`. |
+
+Pi has no native schema enforcement and does not fall back to best-effort
+parsing, so it rejects an output schema before driving the runtime: `generate()`
+rejects at the call, and `stream()` surfaces the `HarnessCapabilityUnsupportedError`
+on the returned result (when you `await result.output` or consume the stream).
+Choose Codex or Claude Code for structured-output stages.
+
+### Streaming structured output
+
+The underlying runtimes only materialize the object at turn-end, so the
+streaming structured-output surfaces are terminal-only: they emit once and then
+close. On a structured-output turn the adapters surface the validated object as
+the assistant text and do not stream intermediate assistant prose (reasoning
+still streams); use `output` / `partialOutputStream` to read the object.
+
+```ts
+const result = await agent.stream({
+  session,
+  prompt: 'List three repository tasks.',
+  output: Output.array({ element: z.object({ title: z.string() }) }),
+});
+
+// `elementStream` emits each element at turn-end; `partialOutputStream` emits
+// the complete object once. `await result.output` resolves the validated value.
+for await (const element of result.elementStream) {
+  console.log(element.title);
+}
+```
+
+When resuming a suspended turn, re-pass the same `output` to
+`continueGenerate()` / `continueStream()` so the result is validated (and the
+schema re-enforced if the turn is re-driven).
+
 ## Messages and History
 
 A harness session owns its native conversation history. When you pass `messages`

--- a/content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx
+++ b/content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx
@@ -28,8 +28,13 @@ The AI SDK includes the following harness adapters:
 
 ## Adapter Capabilities
 
-| Adapter                                                | Runtime location | Custom tools        | Custom skills       | Built-in tool approval |
-| ------------------------------------------------------ | ---------------- | ------------------- | ------------------- | ---------------------- |
-| [Claude Code](/providers/ai-sdk-harnesses/claude-code) | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    |
-| [Codex](/providers/ai-sdk-harnesses/codex)             | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Cross size={18} />    |
-| [Pi](/providers/ai-sdk-harnesses/pi)                   | Host process     | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    |
+| Adapter                                                | Runtime location | Custom tools        | Custom skills       | Built-in tool approval | Structured output   |
+| ------------------------------------------------------ | ---------------- | ------------------- | ------------------- | ---------------------- | ------------------- |
+| [Claude Code](/providers/ai-sdk-harnesses/claude-code) | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    | <Check size={18} /> |
+| [Codex](/providers/ai-sdk-harnesses/codex)             | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Cross size={18} />    | <Check size={18} /> |
+| [Pi](/providers/ai-sdk-harnesses/pi)                   | Host process     | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    | <Cross size={18} /> |
+
+Structured output (passing `output` to `generate()` / `stream()`) is enforced
+natively by Codex and Claude Code. Pi has no native schema enforcement and
+throws `HarnessCapabilityUnsupportedError` when an output schema is requested.
+See [Structured Output](/docs/ai-sdk-harnesses/harness-agent#structured-output).

--- a/examples/ai-functions/src/harness-agent/claude-code/structured-output.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/structured-output.ts
@@ -1,0 +1,47 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({
+    harness: claudeCode,
+    sandbox,
+  });
+
+  let exitCode = 0;
+  const session = await agent.createSession();
+  try {
+    const result = await agent.generate({
+      session,
+      prompt:
+        'Classify the sentiment of this review: "The setup was painful but it works great now."',
+      output: Output.object({
+        schema: z.object({
+          sentiment: z.enum(['positive', 'negative', 'neutral', 'mixed']),
+          confidence: z.number(),
+          summary: z.string(),
+        }),
+      }),
+    });
+
+    // The framework reads Claude Code's `structured_output` side-channel and
+    // validates it host-side; `result.output` is typed and validated.
+    console.log('output:', result.output);
+    console.log('sentiment:', result.output.sentiment);
+    console.log('finishReason:', result.finishReason);
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});

--- a/examples/ai-functions/src/harness-agent/codex/structured-output.ts
+++ b/examples/ai-functions/src/harness-agent/codex/structured-output.ts
@@ -1,0 +1,46 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { codex } from '@ai-sdk/harness-codex';
+import { Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({
+    harness: codex,
+    sandbox,
+  });
+
+  let exitCode = 0;
+  const session = await agent.createSession();
+  try {
+    const result = await agent.generate({
+      session,
+      prompt:
+        'Classify the sentiment of this review: "The setup was painful but it works great now."',
+      output: Output.object({
+        schema: z.object({
+          sentiment: z.enum(['positive', 'negative', 'neutral', 'mixed']),
+          confidence: z.number(),
+          summary: z.string(),
+        }),
+      }),
+    });
+
+    // `result.output` is typed and validated against the schema.
+    console.log('output:', result.output);
+    console.log('sentiment:', result.output.sentiment);
+    console.log('finishReason:', result.finishReason);
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -344,6 +344,17 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       ...(start.model ? { model: start.model } : {}),
       ...(start.maxTurns !== undefined ? { maxTurns: start.maxTurns } : {}),
       ...(skillsOption ? { skills: skillsOption } : {}),
+      // Native schema enforcement. The runtime returns the conformant object on
+      // the terminal `result` message's `structured_output` field, which the
+      // host normalizes into the final step's assistant text.
+      ...(start.outputSchema != null
+        ? {
+            outputFormat: {
+              type: 'json_schema' as const,
+              schema: start.outputSchema as Record<string, unknown>,
+            },
+          }
+        : {}),
       ...(toThinkingConfig(start.thinking)
         ? { thinking: toThinkingConfig(start.thinking) }
         : {}),
@@ -387,6 +398,29 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     number,
     { id: string; kind: 'text' | 'thinking' }
   >();
+
+  /*
+   * Structured-output turns: when a schema is enforced the authoritative result
+   * is the runtime's `structured_output`, not the streamed assistant prose. We
+   * suppress streamed text so the final step's text is the JSON alone (reasoning
+   * still flows — the host never folds it into step text), then emit the
+   * `structured_output` as a single text part at turn-end. If the runtime
+   * reports success with no `structured_output`, no JSON text is emitted, so the
+   * host's `parseCompleteOutput` fails with `NoObjectGeneratedError`.
+   */
+  const enforceOutput = start.outputSchema != null;
+  const streamEmit: Emit = enforceOutput
+    ? part => {
+        if (
+          part.type === 'text-start' ||
+          part.type === 'text-delta' ||
+          part.type === 'text-end'
+        ) {
+          return;
+        }
+        emit(part);
+      }
+    : emit;
 
   const emitTerminalError = (message: string | undefined): void => {
     const normalized = message?.trim();
@@ -473,7 +507,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       }
 
       if (type === 'stream_event') {
-        handleStreamEvent(msg.event, partialBlocks, emit);
+        handleStreamEvent(msg.event, partialBlocks, streamEmit);
         continue;
       }
 
@@ -556,6 +590,21 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
             emitTerminalError(observedTerminalError);
             continue;
           }
+          // Normalize the authoritative structured output (when a schema was
+          // enforced) into the final step's assistant text. When the runtime
+          // reports success without a `structured_output`, nothing is emitted
+          // and the empty/non-JSON final text drives the host's
+          // `NoObjectGeneratedError`.
+          if (enforceOutput && msg.structured_output !== undefined) {
+            const id = randomUUID();
+            emit({ type: 'text-start', id });
+            emit({
+              type: 'text-delta',
+              id,
+              delta: JSON.stringify(msg.structured_output),
+            });
+            emit({ type: 'text-end', id });
+          }
           const usage = msg.usage ?? msg.message?.usage;
           const harnessUsage = mapUsage(usage);
           if (harnessUsage) stepUsage = harnessUsage;
@@ -576,10 +625,14 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
           break;
         } else {
           emitTerminalError(
-            (Array.isArray(msg.errors) ? msg.errors.join('\n') : undefined) ||
-              observedTerminalError ||
-              msg.result ||
-              'Unknown error',
+            msg.subtype === 'error_max_structured_output_retries'
+              ? 'Claude Code reached the maximum number of structured-output retries without producing a schema-conformant result.'
+              : (Array.isArray(msg.errors)
+                  ? msg.errors.join('\n')
+                  : undefined) ||
+                  observedTerminalError ||
+                  msg.result ||
+                  'Unknown error',
           );
         }
         continue;
@@ -632,6 +685,10 @@ type ClaudeMessage = {
   errors?: ReadonlyArray<string>;
   usage?: Record<string, unknown>;
   total_cost_usd?: number;
+  // Present on a terminal `result` message when the query was started with
+  // `outputFormat: { type: 'json_schema' }`: the parsed, schema-conformant
+  // object the runtime produced.
+  structured_output?: unknown;
 };
 
 function handleStreamEvent(

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -75,6 +75,22 @@ describe('inboundMessageSchema', () => {
     ).not.toThrow();
   });
 
+  it('accepts a start message carrying an outputSchema', () => {
+    const parsed = inboundMessageSchema.parse({
+      type: 'start',
+      prompt: 'classify',
+      outputSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' } },
+        required: ['ok'],
+      },
+    });
+    expect(parsed).toMatchObject({
+      type: 'start',
+      outputSchema: { type: 'object' },
+    });
+  });
+
   it('accepts a tool-result message', () => {
     expect(() =>
       inboundMessageSchema.parse({

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -285,6 +285,74 @@ describe('createClaudeCode adapter', () => {
     }
   }, 15_000);
 
+  it('forwards outputSchema on the start message when an output schema is requested', async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const port = await new Promise<number>(resolve => {
+      wss.on('listening', () => {
+        const address = wss.address();
+        if (typeof address === 'object' && address !== null) {
+          resolve(address.port);
+        }
+      });
+    });
+    try {
+      const startMessage = new Promise<Record<string, unknown>>(resolve => {
+        wss.on('connection', ws => {
+          setTimeout(() => {
+            ws.send(JSON.stringify({ type: 'bridge-hello' }));
+          }, 0);
+          ws.on('message', raw => {
+            const message = JSON.parse(raw.toString('utf8')) as Record<
+              string,
+              unknown
+            >;
+            if (message.type === 'start') {
+              resolve(message);
+              ws.send(
+                JSON.stringify({
+                  type: 'finish',
+                  finishReason: { unified: 'stop' },
+                  totalUsage: { inputTokens: {}, outputTokens: {} },
+                  seq: 1,
+                }),
+              );
+            }
+          });
+        });
+      });
+
+      const writes: Array<{ path: string; content: string }> = [];
+      const runs: string[] = [];
+      const harness = createClaudeCode({ startupTimeoutMs: 10_000 });
+      const session = await harness.doStart({
+        sessionId: 's1',
+        sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+          bridgePortUrl: `ws://127.0.0.1:${port}`,
+          writes,
+          runs,
+        }),
+        sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+      });
+      const schema = {
+        type: 'object',
+        properties: { ok: { type: 'boolean' } },
+        required: ['ok'],
+      };
+      const control = await session.doPromptTurn({
+        prompt: 'classify',
+        outputSchema: schema,
+        emit: () => {},
+      });
+      void Promise.resolve(control.done).catch(() => {});
+      await expect(startMessage).resolves.toMatchObject({
+        outputSchema: schema,
+      });
+      await session.doDestroy();
+    } finally {
+      await new Promise<void>(resolve => wss.close(() => resolve()));
+    }
+  }, 15_000);
+
   it('rejects unsafe skill names before writing skill files', async () => {
     const writes: Array<{ path: string; content: string }> = [];
     const harness = createClaudeCode();

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -395,6 +395,15 @@ const claudeCodeResumeStateSchema = z
 
 type ClaudeCodeBridgeCoords = z.infer<typeof bridgeCoordsSchema>;
 
+/**
+ * Spread helper: include `outputSchema` on a `start` message only when the turn
+ * requested one. Shared by the prompt and continue (rerun) paths so the two
+ * cannot drift.
+ */
+function withOutputSchema(outputSchema: unknown): Record<string, unknown> {
+  return outputSchema != null ? { outputSchema } : {};
+}
+
 export function createClaudeCode(
   settings: ClaudeCodeHarnessSettings = {},
 ): HarnessV1<typeof CLAUDE_CODE_BUILTIN_TOOLS> {
@@ -1307,6 +1316,7 @@ function createSession({
           ? { skills: skills.map(skill => skill.name) }
           : {}),
         ...(permissionMode ? { permissionMode } : {}),
+        ...withOutputSchema(promptOpts.outputSchema),
         ...(debug ? { debug } : {}),
         ...(pendingResumeFlag ? { continue: true } : {}),
       };
@@ -1358,6 +1368,7 @@ function createSession({
             ? { skills: skills.map(skill => skill.name) }
             : {}),
           ...(permissionMode ? { permissionMode } : {}),
+          ...withOutputSchema(continueOpts.outputSchema),
           ...(debug ? { debug } : {}),
           continue: true,
         });

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -223,9 +223,40 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   const textByItem = new Map<string, string>();
   const reasoningByItem = new Map<string, string>();
 
+  /*
+   * Structured-output turns: the authoritative result is the runtime's final
+   * `agent_message` (constrained to the schema), not the streamed prose. We
+   * suppress streamed assistant text so the final step's text is the JSON alone
+   * (reasoning still flows — the host never folds it into step text), capture
+   * the latest agent_message text, and emit it as a single assistant text part
+   * at turn end. Without this, intermediate prose in a multi-message turn would
+   * concatenate into finalStep.text and break the host's parseCompleteOutput.
+   * This mirrors the Claude bridge's structured_output normalization, keeping
+   * the host parser adapter-agnostic.
+   */
+  const enforceOutput = start.outputSchema != null;
+  const translateEmit: Emit = enforceOutput
+    ? msg => {
+        if (
+          msg.type === 'text-start' ||
+          msg.type === 'text-delta' ||
+          msg.type === 'text-end'
+        ) {
+          return;
+        }
+        emit(msg);
+      }
+    : emit;
+  let finalAgentMessageText: string | undefined;
+
   try {
     const { events } = await thread.runStreamed(userMessage, {
       signal: turn.abortSignal,
+      // Native schema enforcement. Codex constrains the turn's final
+      // `agent_message.text` to this JSON Schema; the host re-validates it.
+      ...(start.outputSchema != null
+        ? { outputSchema: start.outputSchema }
+        : {}),
     });
     for await (const event of events as AsyncIterable<CodexEvent>) {
       if (turn.abortSignal.aborted) break;
@@ -246,8 +277,25 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       ) {
         continue;
       }
+      if (enforceOutput) {
+        // Capture the latest agent_message text; the final one is the object.
+        if (
+          event.item?.type === 'agent_message' &&
+          typeof event.item.text === 'string'
+        ) {
+          finalAgentMessageText = event.item.text;
+        }
+        // Emit the captured object as the sole assistant text immediately
+        // before the turn's finish-step, so finalStep.text is exactly the JSON.
+        if (event.type === 'turn.completed' && finalAgentMessageText != null) {
+          const id = randomUUID();
+          emit({ type: 'text-start', id });
+          emit({ type: 'text-delta', id, delta: finalAgentMessageText });
+          emit({ type: 'text-end', id });
+        }
+      }
       translateAndEmit(event, {
-        send: emit,
+        send: translateEmit,
         textByItem,
         reasoningByItem,
         setTurnUsage: u => (turnUsage = u),

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -76,6 +76,22 @@ describe('inboundMessageSchema', () => {
     ).not.toThrow();
   });
 
+  it('accepts a start message carrying an outputSchema', () => {
+    const parsed = inboundMessageSchema.parse({
+      type: 'start',
+      prompt: 'classify',
+      outputSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' } },
+        required: ['ok'],
+      },
+    });
+    expect(parsed).toMatchObject({
+      type: 'start',
+      outputSchema: { type: 'object' },
+    });
+  });
+
   it('accepts a tool-result message', () => {
     expect(() =>
       inboundMessageSchema.parse({

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -151,6 +151,15 @@ const codexResumeStateSchema = z.object({
 
 type CodexBridgeCoords = z.infer<typeof bridgeCoordsSchema>;
 
+/**
+ * Spread helper: include `outputSchema` on a `start` message only when the turn
+ * requested one. Shared by the prompt and continue (rerun) paths so the two
+ * cannot drift.
+ */
+function withOutputSchema(outputSchema: unknown): Record<string, unknown> {
+  return outputSchema != null ? { outputSchema } : {};
+}
+
 export function createCodex(
   settings: CodexHarnessSettings = {},
 ): HarnessV1<typeof CODEX_BUILTIN_TOOLS> {
@@ -836,6 +845,7 @@ function createSession({
         reasoningEffort,
         webSearch,
         ...(permissionMode ? { permissionMode } : {}),
+        ...withOutputSchema(promptOpts.outputSchema),
         ...(pendingResumeThreadId
           ? { resumeThreadId: pendingResumeThreadId }
           : {}),
@@ -886,6 +896,7 @@ function createSession({
           reasoningEffort,
           webSearch,
           ...(permissionMode ? { permissionMode } : {}),
+          ...withOutputSchema(continueOpts.outputSchema),
           ...(threadId ? { resumeThreadId: threadId } : {}),
           ...(debug ? { debug } : {}),
         });

--- a/packages/harness-codex/src/codex-instructions.test.ts
+++ b/packages/harness-codex/src/codex-instructions.test.ts
@@ -335,3 +335,35 @@ describe('codex adapter — skills', () => {
     expect(writes).toEqual([]);
   });
 });
+
+describe('codex adapter — output schema forwarding', () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+    openCalls.length = 0;
+    runCommands.length = 0;
+    spawnEnvs.length = 0;
+    writes.length = 0;
+  });
+
+  const schema = {
+    type: 'object',
+    properties: { ok: { type: 'boolean' } },
+    required: ['ok'],
+  };
+
+  it('forwards outputSchema on the start message for a prompt turn', async () => {
+    const session = await startSession();
+    await session.doPromptTurn({
+      prompt: 'classify',
+      outputSchema: schema,
+      emit: () => {},
+    });
+    expect(lastStart().outputSchema).toEqual(schema);
+  });
+
+  it('omits outputSchema when no schema is requested', async () => {
+    const session = await startSession();
+    await session.doPromptTurn({ prompt: 'plain', emit: () => {} });
+    expect(lastStart().outputSchema).toBeUndefined();
+  });
+});

--- a/packages/harness-pi/src/pi-output-schema.test.ts
+++ b/packages/harness-pi/src/pi-output-schema.test.ts
@@ -1,0 +1,32 @@
+import { HarnessCapabilityUnsupportedError } from '@ai-sdk/harness';
+import { describe, expect, it } from 'vitest';
+import { rejectOutputSchema } from './pi-session';
+
+/*
+ * Pi has no native output-schema enforcement and does not fall back to a
+ * best-effort mode. The guard `doPromptTurn` / `doContinueTurn` run at the top
+ * of every turn must reject an `outputSchema` with a clear capability error so
+ * the caller fails fast rather than receiving an unvalidated object.
+ */
+describe('pi adapter — output schema capability', () => {
+  it('throws HarnessCapabilityUnsupportedError when an outputSchema is requested', () => {
+    expect(() =>
+      rejectOutputSchema({ type: 'object', properties: {} }),
+    ).toThrowError(HarnessCapabilityUnsupportedError);
+  });
+
+  it('reports the pi harness id on the error', () => {
+    try {
+      rejectOutputSchema({ type: 'object' });
+      throw new Error('expected rejectOutputSchema to throw');
+    } catch (error) {
+      expect(HarnessCapabilityUnsupportedError.isInstance(error)).toBe(true);
+      expect((error as HarnessCapabilityUnsupportedError).harnessId).toBe('pi');
+    }
+  });
+
+  it('is a no-op when no schema is requested', () => {
+    expect(() => rejectOutputSchema(undefined)).not.toThrow();
+    expect(() => rejectOutputSchema(null)).not.toThrow();
+  });
+});

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -15,18 +15,19 @@ import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { Type } from 'typebox';
-import type {
-  HarnessV1ContinueTurnOptions,
-  HarnessV1ContinueTurnState,
-  HarnessV1PromptControl,
-  HarnessV1PromptTurnOptions,
-  HarnessV1NetworkSandboxSession,
-  HarnessV1PermissionMode,
-  HarnessV1ResumeSessionState,
-  HarnessV1Session,
-  HarnessV1Skill,
-  HarnessV1StreamPart,
-  HarnessV1ToolSpec,
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1ContinueTurnOptions,
+  type HarnessV1ContinueTurnState,
+  type HarnessV1PromptControl,
+  type HarnessV1PromptTurnOptions,
+  type HarnessV1NetworkSandboxSession,
+  type HarnessV1PermissionMode,
+  type HarnessV1ResumeSessionState,
+  type HarnessV1Session,
+  type HarnessV1Skill,
+  type HarnessV1StreamPart,
+  type HarnessV1ToolSpec,
 } from '@ai-sdk/harness';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { resolvePiAuth, type PiAuthOptions } from './pi-auth';
@@ -55,6 +56,24 @@ import { PiWorkspaceVfs } from './pi-workspace-vfs';
 import { syncHostWorkspaceFromSandbox } from './pi-workspace-mirror';
 
 const HARNESS_ID = 'pi';
+
+/*
+ * Pi's public SDK exposes no native output-schema enforcement, and this harness
+ * does not fall back to best-effort prompt-injected structured output. Reject an
+ * `outputSchema` request up front — before the turn drives the runtime — so the
+ * caller fails fast rather than receiving an unvalidated best-effort object.
+ *
+ * @internal exported for unit testing the capability rejection.
+ */
+export function rejectOutputSchema(outputSchema: unknown): void {
+  if (outputSchema != null) {
+    throw new HarnessCapabilityUnsupportedError({
+      message:
+        "Harness 'pi' does not support structured output (outputSchema); its runtime has no native schema enforcement.",
+      harnessId: HARNESS_ID,
+    });
+  }
+}
 
 /*
  * Pi runs in this Node process, not behind an attachable in-sandbox bridge.
@@ -770,6 +789,7 @@ export async function createPiSession(
     doPromptTurn: async (
       promptOpts: HarnessV1PromptTurnOptions,
     ): Promise<HarnessV1PromptControl> => {
+      rejectOutputSchema(promptOpts.outputSchema);
       let text = extractUserText(promptOpts.prompt);
       if (!instructionsApplied && promptOpts.instructions) {
         text = frameInstructions(promptOpts.instructions, text);
@@ -787,6 +807,7 @@ export async function createPiSession(
     doContinueTurn: async (
       continueOpts: HarnessV1ContinueTurnOptions,
     ): Promise<HarnessV1PromptControl> => {
+      rejectOutputSchema(continueOpts.outputSchema);
       if (activeTurn != null) {
         currentEmit = continueOpts.emit;
         return createPromptControl({

--- a/packages/harness/src/agent/harness-agent-session.ts
+++ b/packages/harness/src/agent/harness-agent-session.ts
@@ -1,5 +1,6 @@
+import type { JSONValue } from '@ai-sdk/provider';
 import type { Context, ToolSet } from '@ai-sdk/provider-utils';
-import type { StreamTextResult, TelemetryOptions } from 'ai';
+import type { Output, StreamTextResult, TelemetryOptions } from 'ai';
 import type { HarnessAgentToolApprovalConfiguration } from './harness-agent-settings';
 import type {
   HarnessV1NetworkSandboxSession,
@@ -22,8 +23,9 @@ import { runPrompt } from './internal/run-prompt';
 type HarnessAgentTurnResult<
   TOOLS extends ToolSet,
   RUNTIME_CONTEXT extends Context,
+  OUTPUT extends Output.Output = never,
 > = {
-  result: StreamTextResult<TOOLS, RUNTIME_CONTEXT, never>;
+  result: StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
   done: Promise<void>;
 };
 
@@ -134,27 +136,35 @@ export class HarnessAgentSession {
     return this.sessionWorkDir;
   }
 
-  promptTurn<TOOLS extends ToolSet, RUNTIME_CONTEXT extends Context>(options: {
+  promptTurn<
+    TOOLS extends ToolSet,
+    RUNTIME_CONTEXT extends Context,
+    OUTPUT extends Output.Output = never,
+  >(options: {
     prompt: HarnessAgentPrompt;
     instructions: string | undefined;
     tools: TOOLS;
     toolSpecs: HarnessAgentToolSpec[];
+    output?: OUTPUT;
+    outputSchema?: JSONValue;
     runtimeContext: RUNTIME_CONTEXT;
     abortSignal: AbortSignal | undefined;
     telemetry: TelemetryOptions | undefined;
-  }): HarnessAgentTurnResult<TOOLS, RUNTIME_CONTEXT> {
+  }): HarnessAgentTurnResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
     const session = this.requireReusableSession();
     this.requirePromptableTurn();
     const sandboxSession = this.getSandboxSession();
     const turnId = this.startTrackedTurn();
     try {
-      const turn = runPrompt<TOOLS, RUNTIME_CONTEXT>({
+      const turn = runPrompt<TOOLS, RUNTIME_CONTEXT, OUTPUT>({
         harness: this.harness,
         session,
         prompt: options.prompt,
         instructions: options.instructions,
         tools: options.tools,
         toolSpecs: options.toolSpecs,
+        output: options.output,
+        outputSchema: options.outputSchema,
         sandboxSession: sandboxSession.restricted(),
         sessionWorkDir: this.sessionWorkDir,
         runtimeContext: options.runtimeContext,
@@ -184,29 +194,34 @@ export class HarnessAgentSession {
   continueTurn<
     TOOLS extends ToolSet,
     RUNTIME_CONTEXT extends Context,
+    OUTPUT extends Output.Output = never,
   >(options: {
     instructions: string | undefined;
     tools: TOOLS;
     toolSpecs: HarnessAgentToolSpec[];
+    output?: OUTPUT;
+    outputSchema?: JSONValue;
     runtimeContext: RUNTIME_CONTEXT;
     abortSignal: AbortSignal | undefined;
     telemetry: TelemetryOptions | undefined;
     toolApprovalContinuations?:
       | readonly HarnessAgentToolApprovalContinuation[]
       | undefined;
-  }): HarnessAgentTurnResult<TOOLS, RUNTIME_CONTEXT> {
+  }): HarnessAgentTurnResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
     const session = this.requireReusableSession();
     this.requireContinuableTurn();
     const sandboxSession = this.getSandboxSession();
     const turnId = this.startTrackedTurn();
     try {
-      const turn = runPrompt<TOOLS, RUNTIME_CONTEXT>({
+      const turn = runPrompt<TOOLS, RUNTIME_CONTEXT, OUTPUT>({
         harness: this.harness,
         session,
         mode: 'continue',
         instructions: options.instructions,
         tools: options.tools,
         toolSpecs: options.toolSpecs,
+        output: options.output,
+        outputSchema: options.outputSchema,
         sandboxSession: sandboxSession.restricted(),
         sessionWorkDir: this.sessionWorkDir,
         runtimeContext: options.runtimeContext,

--- a/packages/harness/src/agent/harness-agent.test-d.ts
+++ b/packages/harness/src/agent/harness-agent.test-d.ts
@@ -1,0 +1,61 @@
+import { Output } from 'ai';
+import { z } from 'zod';
+import { describe, expectTypeOf, test } from 'vitest';
+import type { HarnessAgent } from './harness-agent';
+import type { HarnessAgentSession } from './harness-agent-session';
+
+declare const agent: HarnessAgent;
+declare const session: HarnessAgentSession;
+
+const objectSchema = z.object({ sentiment: z.string(), score: z.number() });
+type ObjectOutput = { sentiment: string; score: number };
+
+describe('HarnessAgent output typing', () => {
+  test('generate(): output flows the inferred schema type to result.output', async () => {
+    const result = await agent.generate({
+      session,
+      prompt: 'x',
+      output: Output.object({ schema: objectSchema }),
+    });
+    expectTypeOf(result.output).toEqualTypeOf<ObjectOutput>();
+  });
+
+  test('generate(): omitting output preserves the text-only (never) typing', async () => {
+    const result = await agent.generate({ session, prompt: 'x' });
+    expectTypeOf(result.output).toEqualTypeOf<never>();
+  });
+
+  test('stream(): output flows the inferred schema type to result.output', async () => {
+    const result = await agent.stream({
+      session,
+      prompt: 'x',
+      output: Output.object({ schema: objectSchema }),
+    });
+    expectTypeOf<Awaited<typeof result.output>>().toEqualTypeOf<ObjectOutput>();
+  });
+
+  test('stream(): elementStream is typed per element for Output.array', async () => {
+    const result = await agent.stream({
+      session,
+      prompt: 'x',
+      output: Output.array({ element: z.object({ id: z.number() }) }),
+    });
+    expectTypeOf<Awaited<typeof result.output>>().toEqualTypeOf<
+      Array<{ id: number }>
+    >();
+    expectTypeOf(result.elementStream).toEqualTypeOf<
+      AsyncIterableStream<{ id: number }>
+    >();
+  });
+
+  test('continueGenerate(): output flows the inferred schema type to result.output', async () => {
+    const result = await agent.continueGenerate({
+      session,
+      output: Output.object({ schema: objectSchema }),
+    });
+    expectTypeOf(result.output).toEqualTypeOf<ObjectOutput>();
+  });
+});
+
+// Local mirror of AI SDK's `AsyncIterableStream` nominal shape.
+type AsyncIterableStream<T> = ReadableStream<T> & AsyncIterable<T>;

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -11,6 +11,7 @@ import type {
   HarnessV1StreamPart,
 } from '../v1';
 import { tool } from '@ai-sdk/provider-utils';
+import { NoObjectGeneratedError, Output } from 'ai';
 import { describe, expect, test, vi } from 'vitest';
 import { z } from 'zod';
 import { HarnessAgent } from './harness-agent';
@@ -40,6 +41,7 @@ function mockHarness(options: {
 }): {
   harness: HarnessV1;
   prompts: HarnessV1PromptTurnOptions['prompt'][];
+  outputSchemas: HarnessV1PromptTurnOptions['outputSchema'][];
   toolResults: { toolCallId: string; output: unknown }[];
   doStart: ReturnType<typeof vi.fn>;
   doDetach: ReturnType<typeof vi.fn>;
@@ -50,6 +52,7 @@ function mockHarness(options: {
   doCompact: ReturnType<typeof vi.fn>;
 } {
   const prompts: HarnessV1PromptTurnOptions['prompt'][] = [];
+  const outputSchemas: HarnessV1PromptTurnOptions['outputSchema'][] = [];
   const toolResults: { toolCallId: string; output: unknown }[] = [];
   const resumeState = {
     type: 'resume-session' as const,
@@ -69,6 +72,7 @@ function mockHarness(options: {
   const doDetach = vi.fn(async () => resumeState);
   const doSuspendTurn = vi.fn(async () => continueState);
   const doContinueTurn = vi.fn(async (opts: HarnessV1ContinueTurnOptions) => {
+    outputSchemas.push(opts.outputSchema);
     const control: HarnessV1PromptControl = {
       submitToolResult: async input => {
         toolResults.push(input);
@@ -92,6 +96,7 @@ function mockHarness(options: {
     isResume: false,
     doPromptTurn: async (opts: HarnessV1PromptTurnOptions) => {
       prompts.push(opts.prompt);
+      outputSchemas.push(opts.outputSchema);
       const control: HarnessV1PromptControl = {
         submitToolResult: async input => {
           toolResults.push(input);
@@ -123,6 +128,7 @@ function mockHarness(options: {
       doStart,
     },
     prompts,
+    outputSchemas,
     toolResults,
     doStart,
     doDetach,
@@ -1295,5 +1301,293 @@ describe('HarnessAgent', () => {
     await expect(
       agent.generate({ session, prompt: 'after stop' }),
     ).rejects.toThrow(/has ended/);
+  });
+});
+
+describe('HarnessAgent structured output', () => {
+  const zeroUsage = {
+    inputTokens: {
+      total: undefined,
+      noCache: undefined,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+  };
+
+  // A text-only turn whose single assistant text part is exactly `text` — the
+  // shape both runtimes converge on for structured output (Codex's final
+  // message, Claude's normalized `structured_output`).
+  function finalTextScript(text: string): HarnessV1StreamPart[] {
+    return [
+      { type: 'stream-start' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: text },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'stop', raw: 'end_turn' },
+        usage: zeroUsage,
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'end_turn' },
+        totalUsage: zeroUsage,
+      },
+    ];
+  }
+
+  const objectSchema = z.object({
+    sentiment: z.enum(['positive', 'negative']),
+    score: z.number(),
+  });
+
+  test('generate() returns a typed, validated result.output and forwards the schema down', async () => {
+    const { harness, outputSchemas } = mockHarness({
+      script: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'positive', score: 0.92 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.generate({
+      session,
+      prompt: 'classify',
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    expect(result.output).toEqual({ sentiment: 'positive', score: 0.92 });
+    // Schema is enforced down-path: the bare JSON Schema reaches the adapter.
+    expect(outputSchemas).toHaveLength(1);
+    expect(outputSchemas[0]).toMatchObject({ type: 'object' });
+
+    await session.destroy();
+  });
+
+  test('stream() partialOutputStream / experimental_partialOutputStream emit the object once (terminal-only)', async () => {
+    const { harness } = mockHarness({
+      script: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'negative', score: 0.1 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({
+      session,
+      prompt: 'classify',
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    const partials: unknown[] = [];
+    for await (const partial of result.partialOutputStream) {
+      partials.push(partial);
+    }
+    expect(partials).toEqual([{ sentiment: 'negative', score: 0.1 }]);
+    expect(await result.output).toEqual({ sentiment: 'negative', score: 0.1 });
+
+    await session.destroy();
+  });
+
+  test('stream() experimental_partialOutputStream mirrors partialOutputStream', async () => {
+    const { harness } = mockHarness({
+      script: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'positive', score: 1 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({
+      session,
+      prompt: 'classify',
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    const partials: unknown[] = [];
+    for await (const partial of result.experimental_partialOutputStream) {
+      partials.push(partial);
+    }
+    expect(partials).toEqual([{ sentiment: 'positive', score: 1 }]);
+
+    await session.destroy();
+  });
+
+  test('stream() elementStream emits array elements at turn-end for Output.array', async () => {
+    const elements = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const { harness } = mockHarness({
+      script: () => finalTextScript(JSON.stringify({ elements })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({
+      session,
+      prompt: 'list',
+      output: Output.array({ element: z.object({ id: z.number() }) }),
+    });
+
+    const got: unknown[] = [];
+    for await (const element of result.elementStream) {
+      got.push(element);
+    }
+    expect(got).toEqual(elements);
+    expect(await result.output).toEqual(elements);
+
+    await session.destroy();
+  });
+
+  test('generate() throws NoObjectGeneratedError when the final text is not schema-conformant', async () => {
+    const { harness } = mockHarness({
+      script: () => finalTextScript('this is not json'),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    await expect(
+      agent.generate({
+        session,
+        prompt: 'classify',
+        output: Output.object({ schema: objectSchema }),
+      }),
+    ).rejects.toThrowError(NoObjectGeneratedError);
+
+    await session.destroy();
+  });
+
+  test('stream() result.output rejects with NoObjectGeneratedError on a non-conformant result', async () => {
+    const { harness } = mockHarness({
+      script: () => finalTextScript(JSON.stringify({ sentiment: 'maybe' })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({
+      session,
+      prompt: 'classify',
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    await expect(result.output).rejects.toThrowError(NoObjectGeneratedError);
+
+    await session.destroy();
+  });
+
+  test('output surfaces throw when no output specification was supplied', async () => {
+    const { harness } = mockHarness({ script: () => finalTextScript('hi') });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({ session, prompt: 'hi' });
+    await result.consumeStream();
+    expect(() => (result as { output: unknown }).output).toThrow(
+      /no `output` specification/,
+    );
+
+    await session.destroy();
+  });
+
+  test('continueGenerate() carries the output across a suspended turn', async () => {
+    const { harness, outputSchemas, doContinueTurn, prompts } = mockHarness({
+      script: () => [],
+      continueScript: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'negative', score: 0.2 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession({
+      continueFrom: {
+        type: 'continue-turn',
+        harnessId: 'mock',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+
+    const result = await agent.continueGenerate({
+      session,
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    expect(result.output).toEqual({ sentiment: 'negative', score: 0.2 });
+    expect(outputSchemas).toHaveLength(1);
+    expect(outputSchemas[0]).toMatchObject({ type: 'object' });
+    expect(prompts).toEqual([]);
+    expect(doContinueTurn).toHaveBeenCalledTimes(1);
+
+    await session.destroy();
+  });
+
+  test('continueStream() carries the output across a suspended turn', async () => {
+    const { harness, outputSchemas } = mockHarness({
+      script: () => [],
+      continueScript: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'positive', score: 0.7 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession({
+      continueFrom: {
+        type: 'continue-turn',
+        harnessId: 'mock',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+
+    const result = await agent.continueStream({
+      session,
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    expect(await result.output).toEqual({ sentiment: 'positive', score: 0.7 });
+    expect(outputSchemas[0]).toMatchObject({ type: 'object' });
+
+    await session.destroy();
+  });
+
+  test('partialOutputStream and experimental_partialOutputStream are independent streams on one result', async () => {
+    const { harness } = mockHarness({
+      script: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'positive', score: 0.5 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({
+      session,
+      prompt: 'classify',
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    // Reading both partial aliases on the same result must not lock a shared
+    // stream — each getter builds a fresh stream.
+    const a: unknown[] = [];
+    for await (const partial of result.partialOutputStream) a.push(partial);
+    const b: unknown[] = [];
+    for await (const partial of result.experimental_partialOutputStream) {
+      b.push(partial);
+    }
+    expect(a).toEqual([{ sentiment: 'positive', score: 0.5 }]);
+    expect(b).toEqual([{ sentiment: 'positive', score: 0.5 }]);
+
+    await session.destroy();
+  });
+
+  test('elementStream throws for non-array (Output.object) output', async () => {
+    const { harness } = mockHarness({
+      script: () =>
+        finalTextScript(JSON.stringify({ sentiment: 'negative', score: 0 })),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    const result = await agent.stream({
+      session,
+      prompt: 'classify',
+      output: Output.object({ schema: objectSchema }),
+    });
+
+    expect(() => result.elementStream).toThrow(/only available for array/);
+    // The object output itself still resolves.
+    expect(await result.output).toEqual({ sentiment: 'negative', score: 0 });
+
+    await session.destroy();
   });
 });

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -4,6 +4,7 @@ import type {
   HarnessV1NetworkSandboxSession,
   HarnessV1SandboxProvider,
 } from '../v1';
+import type { JSONValue } from '@ai-sdk/provider';
 import {
   asSchema,
   generateId,
@@ -16,6 +17,7 @@ import type {
   AgentCallParameters,
   AgentStreamParameters,
   GenerateTextResult,
+  Output,
   ReasoningFileOutput,
   ReasoningOutput,
   StreamTextResult,
@@ -333,51 +335,73 @@ export class HarnessAgent<
     }
   }
 
-  async generate(
+  async generate<OUTPUT extends Output.Output = never>(
     options: AgentCallParameters<
       never,
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT
     > &
-      HarnessAgentCallExtensions,
+      HarnessAgentCallExtensions & {
+        /**
+         * Optional output specification for this turn (e.g.
+         * `Output.object({ schema })`). When present the runtime enforces the
+         * schema, the framework validates the result host-side, and
+         * `result.output` is typed as the schema's inferred type.
+         */
+        output?: OUTPUT;
+      },
   ): Promise<
     GenerateTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >
   > {
     const turnInput = this._resolveTurnInput(options);
     const runtimeContext = {} as RUNTIME_CONTEXT;
-    const { result, done } = this._startTurn({
+    const outputSchema = await this._resolveOutputSchema(options.output);
+    const { result, done } = this._startTurn<OUTPUT>({
       session: options.session,
       turnInput,
+      output: options.output,
+      outputSchema,
       runtimeContext,
       abortSignal: options.abortSignal,
     });
     await done;
-    return this._toGenerateResult(result);
+    return this._toGenerateResult<OUTPUT>(result, options.output);
   }
 
-  async stream(
+  async stream<OUTPUT extends Output.Output = never>(
     options: AgentStreamParameters<
       never,
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT
     > &
-      HarnessAgentCallExtensions,
+      HarnessAgentCallExtensions & {
+        /**
+         * Optional output specification for this turn. Same semantics as
+         * {@link generate}'s `output`; the streaming result exposes the
+         * structured-output surfaces (`output`, `partialOutputStream`,
+         * `elementStream`).
+         */
+        output?: OUTPUT;
+      },
   ): Promise<
     StreamTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >
   > {
     const turnInput = this._resolveTurnInput(options);
     const runtimeContext = {} as RUNTIME_CONTEXT;
-    const { result } = this._startTurn({
+    const outputSchema = await this._resolveOutputSchema(options.output);
+    const { result } = this._startTurn<OUTPUT>({
       session: options.session,
       turnInput,
+      output: options.output,
+      outputSchema,
       runtimeContext,
       abortSignal: options.abortSignal,
     });
@@ -389,30 +413,39 @@ export class HarnessAgent<
    * {@link generate}. Used after `createSession({ continueFrom })` to finish
    * consuming a turn that crossed a process boundary.
    */
-  async continueGenerate(options: {
+  async continueGenerate<OUTPUT extends Output.Output = never>(options: {
     session: HarnessAgentSession;
     toolApprovalContinuations?: readonly HarnessAgentToolApprovalContinuation[];
+    /**
+     * Re-pass the same output specification used to start the suspended turn.
+     * It is used host-side to validate the final result, and re-threaded to the
+     * runtime when the adapter re-drives the turn (rerun recovery).
+     */
+    output?: OUTPUT;
     abortSignal?: AbortSignal;
   }): Promise<
     GenerateTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >
   > {
     const runtimeContext = {} as RUNTIME_CONTEXT;
+    const outputSchema = await this._resolveOutputSchema(options.output);
 
-    const { result, done } = this._startTurn({
+    const { result, done } = this._startTurn<OUTPUT>({
       session: options.session,
       turnInput: {
         mode: 'continue',
         toolApprovalContinuations: options.toolApprovalContinuations ?? [],
       },
+      output: options.output,
+      outputSchema,
       runtimeContext,
       abortSignal: options.abortSignal,
     });
     await done;
-    return this._toGenerateResult(result);
+    return this._toGenerateResult<OUTPUT>(result, options.output);
   }
 
   /**
@@ -423,25 +456,33 @@ export class HarnessAgent<
    * `doContinueTurn`; what it can guarantee (lossless attach vs. lossy rerun)
    * follows from how the adapter resumed the session.
    */
-  async continueStream(options: {
+  async continueStream<OUTPUT extends Output.Output = never>(options: {
     session: HarnessAgentSession;
     toolApprovalContinuations?: readonly HarnessAgentToolApprovalContinuation[];
+    /**
+     * Re-pass the same output specification used to start the suspended turn.
+     * Same semantics as {@link continueGenerate}'s `output`.
+     */
+    output?: OUTPUT;
     abortSignal?: AbortSignal;
   }): Promise<
     StreamTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >
   > {
     const runtimeContext = {} as RUNTIME_CONTEXT;
+    const outputSchema = await this._resolveOutputSchema(options.output);
 
-    const { result } = this._startTurn({
+    const { result } = this._startTurn<OUTPUT>({
       session: options.session,
       turnInput: {
         mode: 'continue',
         toolApprovalContinuations: options.toolApprovalContinuations ?? [],
       },
+      output: options.output,
+      outputSchema,
       runtimeContext,
       abortSignal: options.abortSignal,
     });
@@ -450,7 +491,7 @@ export class HarnessAgent<
 
   // ─── Internals ──────────────────────────────────────────────────────
 
-  private _startTurn(input: {
+  private _startTurn<OUTPUT extends Output.Output = never>(input: {
     session: HarnessAgentSession;
     turnInput:
       | { mode: 'prompt'; prompt: HarnessAgentPrompt }
@@ -458,24 +499,29 @@ export class HarnessAgent<
           mode: 'continue';
           toolApprovalContinuations: readonly HarnessAgentToolApprovalContinuation[];
         };
+    output: OUTPUT | undefined;
+    outputSchema: JSONValue | undefined;
     runtimeContext: RUNTIME_CONTEXT;
     abortSignal: AbortSignal | undefined;
   }): {
     result: StreamTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >;
     done: Promise<void>;
   } {
     if (input.turnInput.mode === 'continue') {
       return input.session.continueTurn<
         HarnessAllTools<THarness, TUserTools>,
-        RUNTIME_CONTEXT
+        RUNTIME_CONTEXT,
+        OUTPUT
       >({
         instructions: this.settings.instructions,
         tools: this.tools,
         toolSpecs: this._toToolSpecs(),
+        output: input.output,
+        outputSchema: input.outputSchema,
         runtimeContext: input.runtimeContext,
         abortSignal: input.abortSignal,
         telemetry: this.settings.telemetry,
@@ -485,16 +531,37 @@ export class HarnessAgent<
 
     return input.session.promptTurn<
       HarnessAllTools<THarness, TUserTools>,
-      RUNTIME_CONTEXT
+      RUNTIME_CONTEXT,
+      OUTPUT
     >({
       prompt: input.turnInput.prompt,
       instructions: this.settings.instructions,
       tools: this.tools,
       toolSpecs: this._toToolSpecs(),
+      output: input.output,
+      outputSchema: input.outputSchema,
       runtimeContext: input.runtimeContext,
       abortSignal: input.abortSignal,
       telemetry: this.settings.telemetry,
     });
+  }
+
+  /*
+   * Resolve the bare JSON Schema to send down to the runtime from an `output`
+   * specification. Mirrors how core derives the wire schema: the spec's
+   * `responseFormat` already produces the wrapped schema for `array`/`choice`;
+   * only the bare `schema` travels (the runtimes accept neither `name` nor
+   * `description`).
+   */
+  private async _resolveOutputSchema(
+    output: Output.Output | undefined,
+  ): Promise<JSONValue | undefined> {
+    if (output == null) return undefined;
+    const responseFormat = await output.responseFormat;
+    if (responseFormat?.type === 'json') {
+      return responseFormat.schema as JSONValue | undefined;
+    }
+    return undefined;
   }
 
   private async _acquireSandbox(input: {
@@ -608,17 +675,18 @@ export class HarnessAgent<
     return specs;
   }
 
-  private async _toGenerateResult(
+  private async _toGenerateResult<OUTPUT extends Output.Output = never>(
     streamResult: StreamTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >,
+    output: OUTPUT | undefined,
   ): Promise<
     GenerateTextResult<
       HarnessAllTools<THarness, TUserTools>,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >
   > {
     // The stream is already drained by the time generate() calls this helper
@@ -630,10 +698,22 @@ export class HarnessAgent<
       streamResult.responseMessages,
     ]);
 
+    // When an output specification is present, read the validated object off
+    // the (already-settled) streaming result. A non-conformant final text
+    // rejects here with `NoObjectGeneratedError`, surfacing from `generate()`.
+    const outputValue = (
+      output != null ? await streamResult.output : undefined
+    ) as GenerateTextResult<
+      HarnessAllTools<THarness, TUserTools>,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >['output'];
+
     return new HarnessGenerateTextResult<
       HarnessAllTools<THarness, TUserTools>,
-      RUNTIME_CONTEXT
-    >({ steps, usage, responseMessages });
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >({ steps, usage, responseMessages, output: outputValue });
   }
 }
 
@@ -648,28 +728,31 @@ export class HarnessAgent<
 class HarnessGenerateTextResult<
   TOOLS extends ToolSet,
   RUNTIME_CONTEXT extends Context,
-> implements GenerateTextResult<TOOLS, RUNTIME_CONTEXT, never> {
-  readonly steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, never>['steps'];
-  readonly usage: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, never>['usage'];
+  OUTPUT extends Output.Output = never,
+> implements GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
+  readonly steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'];
+  readonly usage: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['usage'];
   readonly responseMessages: GenerateTextResult<
     TOOLS,
     RUNTIME_CONTEXT,
-    never
+    OUTPUT
   >['responseMessages'];
-  readonly output = undefined as never;
+  readonly output: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['output'];
 
   constructor(options: {
-    steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, never>['steps'];
-    usage: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, never>['usage'];
+    steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'];
+    usage: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['usage'];
     responseMessages: GenerateTextResult<
       TOOLS,
       RUNTIME_CONTEXT,
-      never
+      OUTPUT
     >['responseMessages'];
+    output: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['output'];
   }) {
     this.steps = options.steps;
     this.usage = options.usage;
     this.responseMessages = options.responseMessages;
+    this.output = options.output;
   }
 
   get finalStep() {

--- a/packages/harness/src/agent/internal/harness-stream-text-result.ts
+++ b/packages/harness/src/agent/internal/harness-stream-text-result.ts
@@ -25,8 +25,10 @@ import {
   type ContentPart,
   type FinishReason,
   type GenerateTextResult,
+  type InferGenerateOutput,
   type InferUIMessageChunk,
   type LanguageModelUsage,
+  type Output,
   type ProviderMetadata,
   type StepResult,
   type StreamTextResult,
@@ -64,7 +66,8 @@ type StreamProp<
 export class HarnessStreamTextResult<
   TOOLS extends ToolSet,
   RUNTIME_CONTEXT extends Context,
-> implements StreamTextResult<TOOLS, RUNTIME_CONTEXT, never> {
+  OUTPUT extends Output.Output = never,
+> implements StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   // Delayed promises backing every PromiseLike accessor. Each is typed
   // against the corresponding `StreamTextResult` property so the public
   // surface stays in lockstep with AI SDK's interface as it evolves.
@@ -127,6 +130,16 @@ export class HarnessStreamTextResult<
     ProviderMetadata | undefined
   >();
 
+  // ─── Structured-output surface ─────────────────────────────────────
+  // Populated only when the caller supplied an `output` specification. The
+  // complete object is parsed host-side from the final step's text at turn-end
+  // (mirroring core). The partial/element streams are derived lazily from this
+  // promise on each access, so reading them — or both partial aliases, or the
+  // same stream twice — never locks a shared instance, and a parse/validation
+  // failure surfaces as a stream error. The runtimes materialize the object
+  // only at turn-end, so those streams are terminal-only by design.
+  private readonly _output = new DelayedPromise<InferGenerateOutput<OUTPUT>>();
+
   // The driver pushes parts into this controller; consumers read via `stream`.
   private readonly fullStreamController: ReadableStreamDefaultController<
     TextStreamPart<TOOLS>
@@ -145,6 +158,7 @@ export class HarnessStreamTextResult<
   private readonly tools: TOOLS;
   private readonly runtimeContext: RUNTIME_CONTEXT;
   private readonly toolsContext: never;
+  private readonly outputSpec: OUTPUT | undefined;
   private readonly providerName: string;
   private readonly modelId: string;
 
@@ -162,10 +176,17 @@ export class HarnessStreamTextResult<
     toolsContext: never;
     harnessId: string;
     sessionId: string;
+    /**
+     * Output specification the caller passed for this turn, if any. When
+     * present, the result computes a validated `output` and the terminal
+     * partial/element streams; when absent, those surfaces throw.
+     */
+    output?: OUTPUT;
   }) {
     this.tools = options.tools;
     this.runtimeContext = options.runtimeContext;
     this.toolsContext = options.toolsContext;
+    this.outputSpec = options.output;
     this.providerName = `harness:${options.harnessId}`;
     this.modelId = options.sessionId;
 
@@ -406,6 +427,15 @@ export class HarnessStreamTextResult<
     this._response.resolve(finalStep.response);
     this._providerMetadata.resolve(this.finalProviderMetadata);
 
+    // Derive structured output concurrently with response-message
+    // construction, and do NOT block the stream's finish event / close on
+    // schema validation — core derives `output` lazily off the final step, so
+    // a large object's parse never delays `fullStream` consumers.
+    const outputSettled =
+      this.outputSpec != null
+        ? this.resolveOutput(finalStep)
+        : Promise.resolve();
+
     const responseMessages = await toResponseMessages<TOOLS>({
       content: aggregatedContent,
       tools: this.tools,
@@ -422,6 +452,37 @@ export class HarnessStreamTextResult<
     } as TextStreamPart<TOOLS>);
 
     this.fullStreamController.close();
+
+    // Keep the turn's `done` pending until `_output` has settled so the
+    // non-streaming `generate()` path observes it deterministically. Never
+    // throws: a parse/validation failure rejects `_output` instead.
+    await outputSettled;
+  }
+
+  /**
+   * Parse and validate the final step's text against the output specification
+   * and settle `_output`. Mirrors core: the runtime enforced the schema
+   * down-path; the host re-validates via the same `Output` specification. Never
+   * throws — a parse/validation failure rejects `_output` (and therefore the
+   * lazily-derived partial/element streams) with `NoObjectGeneratedError`.
+   */
+  private async resolveOutput(
+    finalStep: StepResult<TOOLS, RUNTIME_CONTEXT>,
+  ): Promise<void> {
+    if (this.outputSpec == null) return;
+    try {
+      const parsed = await this.outputSpec.parseCompleteOutput(
+        { text: finalStep.text },
+        {
+          response: finalStep.response,
+          usage: this.accumulatedUsage,
+          finishReason: this.finalFinishReason,
+        },
+      );
+      this._output.resolve(parsed as InferGenerateOutput<OUTPUT>);
+    } catch (error) {
+      this._output.reject(error);
+    }
   }
 
   /**
@@ -436,6 +497,8 @@ export class HarnessStreamTextResult<
       error,
     } as TextStreamPart<TOOLS>);
     this.fullStreamController.close();
+    // `_output` is rejected via the loop below; the lazily-derived
+    // partial/element streams observe that rejection and error on read.
     for (const dp of [
       this._content,
       this._text,
@@ -459,6 +522,7 @@ export class HarnessStreamTextResult<
       this._response,
       this._responseMessages,
       this._providerMetadata,
+      this._output,
     ]) {
       try {
         (dp as DelayedPromise<unknown>).reject(error);
@@ -540,18 +604,72 @@ export class HarnessStreamTextResult<
     return this._providerMetadata.promise;
   }
 
-  // Output-specification surfaces are not yet supported.
-  get experimental_partialOutputStream(): never {
-    throw notSupportedYet('partial output stream');
+  // Output-specification surfaces. Available only when the caller passed an
+  // `output` specification for the turn; otherwise they throw, matching the
+  // `never`-typed surface a text-only call exposes. Each access builds a fresh
+  // stream, so the two partial aliases (and repeated reads) are independent.
+  get experimental_partialOutputStream(): StreamTextResult<
+    TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  >['experimental_partialOutputStream'] {
+    return this.partialOutputStream;
   }
-  get partialOutputStream(): never {
-    throw notSupportedYet('partial output stream');
+  get partialOutputStream(): StreamTextResult<
+    TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  >['partialOutputStream'] {
+    if (this.outputSpec == null) throw noOutputSpecified();
+    // Terminal-only: emit the complete object once at turn-end, then close.
+    return this.terminalOutputStream(parsed => [parsed]) as StreamTextResult<
+      TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >['partialOutputStream'];
   }
-  get elementStream(): never {
-    throw notSupportedYet('element stream');
+  get elementStream(): StreamTextResult<
+    TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  >['elementStream'] {
+    if (this.outputSpec == null) throw noOutputSpecified();
+    // Element streams are only valid for array outputs, mirroring core (object
+    // and choice specs return no element-stream transform).
+    if (this.outputSpec.createElementStreamTransform() == null) {
+      throw notAnElementStream();
+    }
+    return this.terminalOutputStream(parsed =>
+      Array.isArray(parsed) ? parsed : [],
+    ) as StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['elementStream'];
   }
-  get output(): never {
-    throw notSupportedYet('structured output');
+  get output(): StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['output'] {
+    if (this.outputSpec == null) throw noOutputSpecified();
+    return this._output.promise;
+  }
+
+  /*
+   * Build a fresh terminal stream from the (eventual) parsed output. Each call
+   * returns an independent stream that awaits `_output`, emits the mapped
+   * chunks once, and closes — or errors if parsing/validation failed.
+   */
+  private terminalOutputStream(
+    toChunks: (parsed: InferGenerateOutput<OUTPUT>) => unknown[],
+  ): AsyncIterableStream<unknown> {
+    const outputPromise = this._output.promise;
+    return createAsyncIterableStream(
+      new ReadableStream<unknown>({
+        async start(controller) {
+          try {
+            const parsed = await outputPromise;
+            for (const chunk of toChunks(parsed)) controller.enqueue(chunk);
+            controller.close();
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+      }),
+    ) as AsyncIterableStream<unknown>;
   }
 
   async consumeStream(): Promise<void> {
@@ -706,10 +824,26 @@ function notSupportedYet(feature: string): Error {
   );
 }
 
+function noOutputSpecified(): Error {
+  return new Error(
+    'HarnessAgent: no `output` specification was provided for this turn; ' +
+      'structured-output surfaces are unavailable. Pass `output` to ' +
+      'generate()/stream() to enable them.',
+  );
+}
+
+function notAnElementStream(): Error {
+  return new Error(
+    'HarnessAgent: elementStream is only available for array output ' +
+      '(Output.array). Use output / partialOutputStream for object or choice ' +
+      'specifications.',
+  );
+}
+
 // Re-declare `AsyncIterableStream` locally to avoid pulling AI SDK's internal
-// async-iterable-stream helper. ReadableStreams already implement the
-// async-iterator contract in modern runtimes; we expose them under the same
-// nominal type AI SDK does.
+// async-iterable-stream helper into the type surface. ReadableStreams already
+// implement the async-iterator contract in modern runtimes; we expose them
+// under the same nominal type AI SDK does.
 type AsyncIterableStream<T> = ReadableStream<T> & AsyncIterable<T>;
 
 // `GenerateTextResult` is re-exported only so downstream code can keep this

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -3,7 +3,7 @@ import {
   type Experimental_SandboxSession,
   type ToolSet,
 } from '@ai-sdk/provider-utils';
-import type { TextStreamPart } from 'ai';
+import { NoObjectGeneratedError, Output, type TextStreamPart } from 'ai';
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 import type {
@@ -604,5 +604,51 @@ describe('runPrompt host tool generator results', () => {
     expect(results).toHaveLength(1);
     expect(results[0].preliminary).toBe(true);
     expect(results[0].output).toEqual({ path: 'src/foo.ts' });
+  });
+});
+
+describe('runPrompt structured output', () => {
+  const schema = z.object({ ok: z.boolean() });
+
+  function finalTextEvents(text: string): HarnessV1StreamPart[] {
+    return [{ type: 'text-delta', id: 't1', delta: text }, ...finishEvents];
+  }
+
+  test('resolves output when the final text is schema-conformant', async () => {
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession(finalTextEvents(JSON.stringify({ ok: true }))),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {} as ToolSet,
+      toolSpecs: [],
+      output: Output.object({ schema }),
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+    });
+
+    await done;
+    expect(await result.output).toEqual({ ok: true });
+  });
+
+  test('rejects output when the final text is not schema-conformant', async () => {
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession(finalTextEvents('not valid json')),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {} as ToolSet,
+      toolSpecs: [],
+      output: Output.object({ schema }),
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+    });
+
+    await done;
+    await expect(result.output).rejects.toThrowError(NoObjectGeneratedError);
   });
 });

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -18,12 +18,13 @@ import {
   type ToolSet,
 } from '@ai-sdk/provider-utils';
 import type {
+  JSONValue,
   LanguageModelV4FinishReason,
   LanguageModelV4ToolCall,
   LanguageModelV4Usage,
 } from '@ai-sdk/provider';
 import { parseToolCall } from 'ai/internal';
-import type { ContentPart, TelemetryOptions, TextStreamPart } from 'ai';
+import type { ContentPart, Output, TelemetryOptions, TextStreamPart } from 'ai';
 import type { HarnessAgentToolApprovalContinuation } from '../harness-agent-tool-approval-continuation';
 import type { HarnessAgentToolApprovalConfiguration } from '../harness-agent-settings';
 import { HarnessStreamTextResult } from './harness-stream-text-result';
@@ -47,6 +48,7 @@ import { resolveCustomToolApproval } from './permission-mode';
 export function runPrompt<
   TOOLS extends ToolSet,
   RUNTIME_CONTEXT extends Context,
+  OUTPUT extends Output.Output = never,
 >(input: {
   harness: HarnessV1;
   session: HarnessV1Session;
@@ -61,6 +63,16 @@ export function runPrompt<
   instructions: string | undefined;
   tools: TOOLS;
   toolSpecs: HarnessV1ToolSpec[];
+  /**
+   * Output specification for the turn, if any. Used host-side to parse and
+   * validate the final result. Drives the typed `result.output` surface.
+   */
+  output?: OUTPUT;
+  /**
+   * Bare JSON Schema forwarded to the runtime down-path so it enforces the
+   * schema during generation. Derived from `output` by the caller.
+   */
+  outputSchema?: JSONValue;
   sandboxSession: SandboxSession;
   sessionWorkDir: string;
   runtimeContext: RUNTIME_CONTEXT;
@@ -75,16 +87,17 @@ export function runPrompt<
   onToolApprovalSettled?: (approvalId: string) => void;
   onTurnFinished?: () => void;
 }): {
-  result: HarnessStreamTextResult<TOOLS, RUNTIME_CONTEXT>;
+  result: HarnessStreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>;
   done: Promise<void>;
 } {
-  const result = new HarnessStreamTextResult<TOOLS, RUNTIME_CONTEXT>({
+  const result = new HarnessStreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>({
     tools: input.tools,
     runtimeContext: input.runtimeContext,
     // toolsContext is not configurable for harnesses; pass undefined cast.
     toolsContext: undefined as never,
     harnessId: input.harness.harnessId,
     sessionId: input.session.sessionId,
+    output: input.output,
   });
   const pendingToolApprovals = input.pendingToolApprovals ?? [];
   const onPendingToolApproval = input.onPendingToolApproval ?? (() => {});
@@ -108,6 +121,7 @@ export function runPrompt<
             ? emit =>
                 input.session.doContinueTurn({
                   tools: input.toolSpecs,
+                  outputSchema: input.outputSchema,
                   abortSignal: input.abortSignal,
                   emit,
                 })
@@ -121,6 +135,7 @@ export function runPrompt<
                   prompt: input.prompt,
                   tools: input.toolSpecs,
                   instructions: input.instructions,
+                  outputSchema: input.outputSchema,
                   abortSignal: input.abortSignal,
                   emit,
                 });

--- a/packages/harness/src/v1/harness-v1-bridge-protocol.ts
+++ b/packages/harness/src/v1/harness-v1-bridge-protocol.ts
@@ -90,6 +90,14 @@ export const harnessV1BridgeStartBaseSchema = z.object({
   model: z.string().optional(),
   debug: harnessV1DebugConfigSchema.optional(),
   permissionMode: harnessV1BridgePermissionModeSchema.optional(),
+  /**
+   * Bare JSON Schema the runtime should enforce on its final output for this
+   * turn. Present only when the caller passed an `output` specification. Each
+   * adapter maps it to its runtime's native enforcement knob (Codex
+   * `outputSchema`, Claude Code `outputFormat`). Carried as opaque JSON because
+   * the schema shape is the provider's, not the bridge's, concern.
+   */
+  outputSchema: z.unknown().optional(),
 });
 
 // --- Transport / control frames (outbound, not consumer events) ---

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -1,3 +1,4 @@
+import type { JSONValue } from '@ai-sdk/provider';
 import type { HarnessV1NetworkSandboxSession } from './harness-v1-network-sandbox-session';
 import type { HarnessV1Observability } from './harness-v1-observability';
 import type { HarnessV1PermissionMode } from './harness-v1-permission-mode';
@@ -112,6 +113,17 @@ export type HarnessV1PromptTurnOptions = {
   readonly instructions?: string;
 
   /**
+   * Bare JSON Schema the underlying runtime should enforce on its final
+   * output for this turn. Supplied by the framework when the caller passes an
+   * `output` specification to `HarnessAgent.generate`/`stream`; it is the
+   * `schema` of the specification's resolved `responseFormat` (the wrapped
+   * schema for `array`/`choice`), with `name`/`description` dropped because the
+   * runtimes do not accept them. Adapters whose runtime cannot enforce a schema
+   * throw `HarnessCapabilityUnsupportedError`.
+   */
+  readonly outputSchema?: JSONValue;
+
+  /**
    * Signal that aborts the in-flight turn. The adapter must cancel any
    * underlying work and resolve `done` (with an error if appropriate).
    */
@@ -140,6 +152,16 @@ export type HarnessV1ContinueTurnOptions = {
    * may ignore them; an adapter that re-drives the turn (rerun) needs them.
    */
   readonly tools?: ReadonlyArray<HarnessV1ToolSpec>;
+
+  /**
+   * Bare JSON Schema the runtime should enforce on the continued turn's
+   * output. Same value and shape as `doPromptTurn`'s `outputSchema`. Used only
+   * by adapters that re-drive the turn (rerun recovery), where the runtime is
+   * started from scratch and must be re-given the schema; adapters that attach
+   * to a still-live turn (replay) may ignore it. Host-side validation of the
+   * final result is driven by the `output` specification independently.
+   */
+  readonly outputSchema?: JSONValue;
 
   /**
    * Signal that aborts the continued turn. The adapter must cancel any


### PR DESCRIPTION
## Background

`HarnessAgent` (`@ai-sdk/harness`) pinned its `OUTPUT` generic to `never`, so `generate()` / `stream()` could not accept an `output` schema and always resolved to text-only results. Developers building staged agent pipelines (triage, routing, review, judging) had to hand-parse JSON out of `result.text`, losing the compile-time types and runtime validation that `streamText` / `generateText` / `ToolLoopAgent` provide through the `output` API. This was despite the underlying runtimes already supporting schema-guided output natively (Codex `outputSchema`, Claude Code `outputFormat`) — the harness contract was discarding a capability the adapters' runtimes already expose.

## Summary

Adds per-call structured output to `HarnessAgent`, making it a drop-in alternative to the model / `ToolLoopAgent` path for structured-decision stages.

- **Per-call `output`** on `generate` / `stream` / `continueGenerate` / `continueStream` (e.g. `Output.object({ schema })`), with the `OUTPUT` generic threaded end-to-end to a typed `result.output`. It is per-call (not construction-time) so one long-lived session can vary the schema per turn — the same controlled divergence from the `Agent` interface that the required `session` already takes.
- **Runtime-native enforcement + host-side validation.** The resolved bare JSON Schema is forwarded down-path via a new optional `outputSchema` on the v1 prompt/continue turn options and the shared bridge `start` schema. Codex maps it to `outputSchema`; Claude Code to `outputFormat: { type: 'json_schema', schema }`. The host re-validates against the same `Output` specification core uses (`Output.parseCompleteOutput`) and throws `NoObjectGeneratedError` on a parse/validation mismatch.
- **Adapter-agnostic up-path.** Both adapters converge at the text layer so the host parser is verbatim core behavior: Codex's final object already arrives as the final assistant message; the Claude bridge reads the runtime's `structured_output` side-channel and normalizes it into the final step's text. On a structured-output turn both adapters suppress intermediate streamed prose (reasoning still streams) so the final step's text is the JSON alone.
- **Result surfaces.** `output`, `partialOutputStream`, `experimental_partialOutputStream`, and `elementStream` are implemented as terminal-only streams (the runtimes materialize the object only at turn-end), derived lazily from the validated output so the two partial aliases are independent; `elementStream` is array-only.
- **Capability negotiation (presence-based, no static capabilities object).** Pi has no native schema enforcement and does not fall back to best-effort parsing, so it throws `HarnessCapabilityUnsupportedError` when an output schema is requested, before driving the runtime.
- No new bridge wire message type and no new finish-part field are introduced.

Modules touched: `@ai-sdk/harness` (v1 turn/bridge contract, agent generic threading, both result classes, prompt driver), `@ai-sdk/harness-codex`, `@ai-sdk/harness-claude-code`, `@ai-sdk/harness-pi`. Docs and a runnable example per enforcing adapter are included.

## Manual Verification

Ran the new examples live against the real runtimes in a Vercel sandbox and confirmed a typed, validated `result.output` (not scraped text):

```
pnpm tsx src/harness-agent/codex/structured-output.ts
# output: { sentiment: 'mixed', confidence: 0.95, summary: '…' }  finishReason: stop

pnpm tsx src/harness-agent/claude-code/structured-output.ts
# equivalent typed object (read from Claude's structured_output side-channel)
```

Also verified: `pnpm type-check:full` and `pnpm check` pass; unit/type/bridge tests pass across the four packages (`@ai-sdk/harness` node 120 / edge 112, `harness-codex` 48, `harness-claude-code` 52, `harness-pi` 100), including a type-level test that `output` flows the inferred schema type to `result.output` and that omitting it preserves today's text-only typing.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Genuinely incremental partial-object streaming (the runtimes only materialize the object at turn-end, so partial/element surfaces are terminal-only by design).
- An explicit opt-in best-effort structured-output mode for adapters without native enforcement (Pi), as a later, separate feature.

## Related Issues

Fixes #16120.
