### PR TITLE
docs: change highlighted code lines for example

### DIFF
--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -85,7 +85,7 @@ results. If a tool needs server-side values such as credentials, scoped
 permissions, or default settings, pass them through `toolsContext` and declare
 them with the tool's `contextSchema`.
 
-```ts highlight="8-15,21-31,37-49"
+```ts highlight="12-15,20-27,31-40"
 import { ToolLoopAgent, tool } from 'ai';
 import { z } from 'zod';
 
@@ -139,7 +139,7 @@ Pass `experimental_sandbox` when an agent tool needs a command or code execution
 environment. The experimental sandbox is a per-call value, so provide it to `generate()`,
 `stream()`, or the agent UI stream helper that invokes the agent.
 
-```ts highlight="8-16,25"
+```ts highlight="13,19-23,31"
 const agent = new ToolLoopAgent({
   model: __MODEL__,
   instructions: 'You are a coding assistant. Use the shell tool when needed.',


### PR DESCRIPTION
## Background

the highlighted code lines were incorrect

<img width="1398" height="1544" alt="Screenshot 2026-06-15 at 2 12 05 PM" src="https://github.com/user-attachments/assets/4b40a7a1-cccd-4a05-a007-5dbc8f7ac087" />

<img width="1264" height="1692" alt="Screenshot 2026-06-15 at 2 12 36 PM" src="https://github.com/user-attachments/assets/7468da3d-e36b-4886-92e8-635231aceccb" />


## Summary

change the highlighted code

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

there's probably a lot of mis-highlighted code lines across the docs which should be fixed