### PR TITLE
feat(gladia): update transcription provider to align with Gladia v2 OpenAPI spec

### DIFF
--- a/.changeset/gladia-openapi-type-sync.md
+++ b/.changeset/gladia-openapi-type-sync.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gladia': patch
+---
+
+Align Gladia transcription provider options with the Gladia v2 OpenAPI spec: replace flat language options with `languageConfig`, add `piiRedaction` support, and remove request options no longer accepted by the pre-recorded init API. Also support selecting the transcription model (e.g. `solaria-1` or `solaria-3`) via `gladia.transcription(modelId)`.

--- a/content/providers/01-ai-sdk-providers/120-gladia.mdx
+++ b/content/providers/01-ai-sdk-providers/120-gladia.mdx
@@ -50,7 +50,7 @@ You can use the following optional settings to customize the Gladia provider ins
 
 - **apiKey** _string_
 
-  API key that is being sent using the `Authorization` header.
+  API key that is being sent using the `x-gladia-key` header.
   It defaults to the `GLADIA_API_KEY` environment variable.
 
 - **headers** _Record&lt;string,string&gt;_
@@ -73,7 +73,31 @@ using the `.transcription()` factory method.
 const model = gladia.transcription();
 ```
 
-You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `summarize` option will enable summaries for sections of content.
+You can optionally select the transcription model by passing its id to the
+factory method. If you omit it, the Gladia API uses its default model
+(`solaria-1`).
+
+```ts
+const model = gladia.transcription('solaria-3');
+```
+
+The following models are available:
+
+- **solaria-1** (default) — Gladia's generalist model with the broadest language
+  coverage (100+ languages). Supports code switching and multi-language
+  configuration, and is available for both pre-recorded and live transcription.
+- **solaria-3** — Gladia's latest model, tuned for the highest accuracy on
+  European real-world audio. **Pre-recorded (async) only** — not available for
+  live transcription. Supports a **single language** chosen from English,
+  French, German, Spanish, or Italian: pass exactly one language in
+  `languageConfig` and do not enable `codeSwitching`.
+
+Both models support all of Gladia's audio intelligence add-ons. Choose
+`solaria-3` when transcribing one of its five supported European languages and
+accuracy matters most; otherwise use the default `solaria-1` for the widest
+language coverage, code switching, or live transcription.
+
+You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `summarization` option will enable summaries for sections of content.
 
 ```ts highlight="7"
 import { transcribe } from 'ai';
@@ -92,19 +116,9 @@ const result = await transcribe({
 });
 ```
 
-<Note>
-  Gladia does not have various models, so you can omit the standard `model` id
-  parameter.
-</Note>
-
 The following provider options are available:
 
-- **contextPrompt** _string_
-
-  Context to feed the transcription model with for possible better accuracy.
-  Optional.
-
-- **customVocabulary** _boolean | any[]_
+- **customVocabulary** _boolean_
 
   Custom vocabulary to improve transcription accuracy.
   Optional.
@@ -116,26 +130,12 @@ The following provider options are available:
   - **vocabulary** _Array&lt;string | \{ value: string, intensity?: number, pronunciations?: string[], language?: string \}&gt;_
   - **defaultIntensity** _number_
 
-- **detectLanguage** _boolean_
+- **languageConfig** _object_
 
-  Whether to automatically detect the language.
+  Language configuration for transcription.
   Optional.
-
-- **enableCodeSwitching** _boolean_
-
-  Enable code switching for multilingual audio.
-  Optional.
-
-- **codeSwitchingConfig** _object_
-
-  Configuration for code switching.
-  Optional.
-  - **languages** _string[]_
-
-- **language** _string_
-
-  Specify the language of the audio.
-  Optional.
+  - **languages** _string[]_ — If one language is set, it is used for transcription. Otherwise, language is auto-detected.
+  - **codeSwitching** _boolean_ — If true, language is auto-detected on each utterance.
 
 - **callback** _boolean_
 
@@ -177,7 +177,6 @@ The following provider options are available:
   - **numberOfSpeakers** _number_
   - **minSpeakers** _number_
   - **maxSpeakers** _number_
-  - **enhanced** _boolean_
 
 - **translation** _boolean_
 
@@ -191,6 +190,10 @@ The following provider options are available:
   - **targetLanguages** _string[]_
   - **model** _'base' | 'enhanced'_
   - **matchOriginalUtterances** _boolean_
+  - **lipsync** _boolean_
+  - **contextAdaptation** _boolean_
+  - **context** _string_
+  - **informal** _boolean_
 
 - **summarization** _boolean_
 
@@ -203,24 +206,9 @@ The following provider options are available:
   Optional.
   - **type** _'general' | 'bullet_points' | 'concise'_
 
-- **moderation** _boolean_
-
-  Enable content moderation.
-  Optional.
-
 - **namedEntityRecognition** _boolean_
 
   Enable named entity recognition.
-  Optional.
-
-- **chapterization** _boolean_
-
-  Enable chapterization of the transcription.
-  Optional.
-
-- **nameConsistency** _boolean_
-
-  Enable name consistency in the transcription.
   Optional.
 
 - **customSpelling** _boolean_
@@ -233,17 +221,6 @@ The following provider options are available:
   Configuration for custom spelling.
   Optional.
   - **spellingDictionary** _Record&lt;string, string[]&gt;_
-
-- **structuredDataExtraction** _boolean_
-
-  Enable structured data extraction.
-  Optional.
-
-- **structuredDataExtractionConfig** _object_
-
-  Configuration for structured data extraction.
-  Optional.
-  - **classes** _string[]_
 
 - **sentimentAnalysis** _boolean_
 
@@ -260,8 +237,21 @@ The following provider options are available:
   Configuration for audio to LLM.
   Optional.
   - **prompts** _string[]_
+  - **model** _string_
 
-- **customMetadata** _Record&lt;string, any&gt;_
+- **piiRedaction** _boolean_
+
+  Enable PII redaction.
+  Optional.
+
+- **piiRedactionConfig** _object_
+
+  Configuration for PII redaction.
+  Optional.
+  - **entityTypes** _string[]_
+  - **processedTextType** _'MARKER' | 'MASK'_
+
+- **customMetadata** _Record&lt;string, unknown&gt;_
 
   Custom metadata to include with the request.
   Optional.
@@ -269,11 +259,6 @@ The following provider options are available:
 - **sentences** _boolean_
 
   Enable sentence detection.
-  Optional.
-
-- **displayMode** _boolean_
-
-  Enable display mode.
   Optional.
 
 - **punctuationEnhanced** _boolean_

--- a/packages/gladia/README.md
+++ b/packages/gladia/README.md
@@ -1,7 +1,9 @@
 # AI SDK - Gladia Provider
 
-The **[Gladia provider](https://ai-sdk.dev/providers/ai-sdk-providers/assemblyai)** for the [AI SDK](https://ai-sdk.dev/docs)
+The **[Gladia provider](https://ai-sdk.dev/providers/ai-sdk-providers/gladia)** for the [AI SDK](https://ai-sdk.dev/docs)
 contains transcription model support for the Gladia transcription API.
+
+When updating this provider, sync types from [https://api.gladia.io/openapi.json](https://api.gladia.io/openapi.json).
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Gladia (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 

--- a/packages/gladia/src/gladia-api-types.ts
+++ b/packages/gladia/src/gladia-api-types.ts
@@ -1,134 +1,192 @@
+// Source of truth: https://api.gladia.io/openapi.json → InitTranscriptionRequest
+
+import type { GladiaTranscriptionModelId } from './gladia-transcription-options';
+
+export type GladiaPiiRedactionEntityType =
+  | 'APPI'
+  | 'APPI_SENSITIVE'
+  | 'CCI'
+  | 'CORE_ENTITIES'
+  | 'CPRA'
+  | 'GDPR'
+  | 'GDPR_SENSITIVE'
+  | 'HEALTH_INFORMATION'
+  | 'HIPAA_SAFE_HARBOR'
+  | 'LIDI'
+  | 'NUMERICAL_EXCL_PCI'
+  | 'PCI'
+  | 'QUEBEC_PRIVACY_ACT'
+  | 'ACCOUNT_NUMBER'
+  | 'AGE'
+  | 'DATE'
+  | 'DATE_INTERVAL'
+  | 'DOB'
+  | 'DRIVER_LICENSE'
+  | 'DURATION'
+  | 'EMAIL_ADDRESS'
+  | 'EVENT'
+  | 'FILENAME'
+  | 'GENDER'
+  | 'HEALTHCARE_NUMBER'
+  | 'IP_ADDRESS'
+  | 'LANGUAGE'
+  | 'LOCATION'
+  | 'LOCATION_ADDRESS'
+  | 'LOCATION_ADDRESS_STREET'
+  | 'LOCATION_CITY'
+  | 'LOCATION_COORDINATE'
+  | 'LOCATION_COUNTRY'
+  | 'LOCATION_STATE'
+  | 'LOCATION_ZIP'
+  | 'MARITAL_STATUS'
+  | 'MONEY'
+  | 'NAME'
+  | 'NAME_FAMILY'
+  | 'NAME_GIVEN'
+  | 'NAME_MEDICAL_PROFESSIONAL'
+  | 'NUMERICAL_PII'
+  | 'OCCUPATION'
+  | 'ORGANIZATION'
+  | 'ORGANIZATION_MEDICAL_FACILITY'
+  | 'ORIGIN'
+  | 'PASSPORT_NUMBER'
+  | 'PASSWORD'
+  | 'PHONE_NUMBER'
+  | 'PHYSICAL_ATTRIBUTE'
+  | 'POLITICAL_AFFILIATION'
+  | 'RELIGION'
+  | 'SEXUALITY'
+  | 'SSN'
+  | 'TIME'
+  | 'URL'
+  | 'USERNAME'
+  | 'VEHICLE_ID'
+  | 'ZODIAC_SIGN'
+  | 'BLOOD_TYPE'
+  | 'CONDITION'
+  | 'DOSE'
+  | 'DRUG'
+  | 'INJURY'
+  | 'MEDICAL_PROCESS'
+  | 'STATISTICS'
+  | 'BANK_ACCOUNT'
+  | 'CREDIT_CARD'
+  | 'CREDIT_CARD_EXPIRATION'
+  | 'CVV'
+  | 'ROUTING_NUMBER'
+  | 'CORPORATE_ACTION'
+  | 'DAY'
+  | 'EFFECT'
+  | 'FINANCIAL_METRIC'
+  | 'MEDICAL_CODE'
+  | 'MONTH'
+  | 'ORGANIZATION_ID'
+  | 'PRODUCT'
+  | 'PROJECT'
+  | 'TREND'
+  | 'YEAR';
+
 export type GladiaTranscriptionInitiateAPITypes = {
   /** URL to a Gladia file or to an external audio or video file */
   audio_url: string;
-  /** [Alpha] Context to feed the transcription model with for possible better accuracy */
-  context_prompt?: string;
-  /** [Beta] Can be either boolean to enable custom_vocabulary or an array with specific vocabulary */
-  custom_vocabulary?: boolean | any[];
+  /**
+   * Transcription model to use. Defaults to `solaria-1` if omitted.
+   */
+  model?: GladiaTranscriptionModelId;
+  /** [Beta] Enable custom vocabulary for this audio */
+  custom_vocabulary?: boolean;
   /** [Beta] Custom vocabulary configuration */
   custom_vocabulary_config?: {
-    /** Vocabulary array with string or object containing value, intensity, pronunciations, and language */
     vocabulary: Array<
       | string
       | {
-          /** Vocabulary value */
           value: string;
-          /** Intensity of the vocabulary */
           intensity?: number;
-          /** Pronunciation variations */
           pronunciations?: string[];
-          /** Language of the vocabulary */
           language?: string;
         }
     >;
-    /** Default intensity for vocabulary */
     default_intensity?: number;
   };
-  /** Detect the language from the given audio */
-  detect_language?: boolean;
-  /** Detect multiple languages in the given audio */
-  enable_code_switching?: boolean;
-  /** Configuration for code-switching */
-  code_switching_config?: {
-    /** Specify the languages you want to use when detecting multiple languages */
-    languages?: string[];
-  };
-  /** The original language in iso639-1 format */
-  language?: string;
+  /** [Deprecated] Use `callback`/`callback_config` instead */
+  callback_url?: string;
   /** Enable callback for this transcription */
   callback?: boolean;
   /** Configuration for callback */
   callback_config?: {
-    /** The URL to be called with the result of the transcription */
     url: string;
-    /** The HTTP method to be used */
     method?: 'POST' | 'PUT';
   };
   /** Enable subtitles generation for this transcription */
   subtitles?: boolean;
   /** Configuration for subtitles */
   subtitles_config?: {
-    /** Subtitles formats */
     formats?: ('srt' | 'vtt')[];
-    /** Minimum duration of a subtitle in seconds */
     minimum_duration?: number;
-    /** Maximum duration of a subtitle in seconds */
     maximum_duration?: number;
-    /** Maximum number of characters per row */
     maximum_characters_per_row?: number;
-    /** Maximum number of rows per caption */
     maximum_rows_per_caption?: number;
-    /** Style of the subtitles */
     style?: 'default' | 'compliance';
   };
   /** Enable speaker recognition (diarization) for this audio */
   diarization?: boolean;
   /** Configuration for diarization */
   diarization_config?: {
-    /** Exact number of speakers in the audio */
     number_of_speakers?: number;
-    /** Minimum number of speakers in the audio */
     min_speakers?: number;
-    /** Maximum number of speakers in the audio */
     max_speakers?: number;
-    /** [Alpha] Use enhanced diarization for this audio */
-    enhanced?: boolean;
   };
   /** [Beta] Enable translation for this audio */
   translation?: boolean;
   /** Configuration for translation */
   translation_config?: {
-    /** The target language in iso639-1 format */
     target_languages: string[];
-    /** Model for translation */
     model?: 'base' | 'enhanced';
-    /** Align translated utterances with the original ones */
     match_original_utterances?: boolean;
+    lipsync?: boolean;
+    context_adaptation?: boolean;
+    context?: string;
+    informal?: boolean;
   };
   /** [Beta] Enable summarization for this audio */
   summarization?: boolean;
   /** Configuration for summarization */
   summarization_config?: {
-    /** The type of summarization to apply */
     type?: 'general' | 'bullet_points' | 'concise';
   };
-  /** [Alpha] Enable moderation for this audio */
-  moderation?: boolean;
   /** [Alpha] Enable named entity recognition for this audio */
   named_entity_recognition?: boolean;
-  /** [Alpha] Enable chapterization for this audio */
-  chapterization?: boolean;
-  /** [Alpha] Enable names consistency for this audio */
-  name_consistency?: boolean;
   /** [Alpha] Enable custom spelling for this audio */
   custom_spelling?: boolean;
   /** Configuration for custom spelling */
   custom_spelling_config?: {
-    /** The list of spelling applied on the audio transcription */
     spelling_dictionary: Record<string, string[]>;
   };
-  /** [Alpha] Enable structured data extraction for this audio */
-  structured_data_extraction?: boolean;
-  /** Configuration for structured data extraction */
-  structured_data_extraction_config?: {
-    /** The list of classes to extract from the audio transcription */
-    classes: string[];
-  };
-  /** [Alpha] Enable sentiment analysis for this audio */
+  /** Enable sentiment analysis for this audio */
   sentiment_analysis?: boolean;
   /** [Alpha] Enable audio to llm processing for this audio */
   audio_to_llm?: boolean;
   /** Configuration for audio to llm */
   audio_to_llm_config?: {
-    /** The list of prompts applied on the audio transcription */
     prompts: string[];
+    model?: string;
+  };
+  /** Enable PII redaction for this audio */
+  pii_redaction?: boolean;
+  /** PII redaction configuration */
+  pii_redaction_config?: {
+    entity_types?: string[];
+    processed_text_type?: 'MARKER' | 'MASK';
   };
   /** Custom metadata you can attach to this transcription */
-  custom_metadata?: Record<string, any>;
+  custom_metadata?: Record<string, unknown>;
   /** Enable sentences for this audio */
   sentences?: boolean;
-  /** [Alpha] Allows to change the output display_mode for this audio */
-  display_mode?: boolean;
   /** [Alpha] Use enhanced punctuation for this audio */
   punctuation_enhanced?: boolean;
+  /** Specify the language configuration */
+  language_config?: {
+    languages?: string[];
+    code_switching?: boolean;
+  };
 };

--- a/packages/gladia/src/gladia-provider.ts
+++ b/packages/gladia/src/gladia-provider.ts
@@ -9,6 +9,7 @@ import {
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
 import { GladiaTranscriptionModel } from './gladia-transcription-model';
+import type { GladiaTranscriptionModelId } from './gladia-transcription-options';
 import { VERSION } from './version';
 
 export interface GladiaProvider extends ProviderV4 {
@@ -18,8 +19,11 @@ export interface GladiaProvider extends ProviderV4 {
 
   /**
    * Creates a model for transcription.
+   *
+   * @param modelId - The transcription model to use (e.g. `solaria-1` or
+   * `solaria-3`). If omitted, the Gladia API uses its default model.
    */
-  transcription(): TranscriptionModelV4;
+  transcription(modelId?: GladiaTranscriptionModelId): TranscriptionModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -64,8 +68,10 @@ export function createGladia(
       `ai-sdk/gladia/${VERSION}`,
     );
 
-  const createTranscriptionModel = () =>
-    new GladiaTranscriptionModel('default', {
+  const createTranscriptionModel = (
+    modelId: GladiaTranscriptionModelId = 'default',
+  ) =>
+    new GladiaTranscriptionModel(modelId, {
       provider: `gladia.transcription`,
       url: ({ path }) => `https://api.gladia.io${path}`,
       headers: getHeaders,

--- a/packages/gladia/src/gladia-transcription-model-options.ts
+++ b/packages/gladia/src/gladia-transcription-model-options.ts
@@ -1,17 +1,12 @@
 import { z } from 'zod/v4';
 
 // https://docs.gladia.io/api-reference/v2/pre-recorded/init
+// Source of truth: https://api.gladia.io/openapi.json → InitTranscriptionRequest
 export const gladiaTranscriptionModelOptionsSchema = z.object({
   /**
-   * Optional context prompt to guide the transcription.
-   */
-  contextPrompt: z.string().nullish(),
-
-  /**
    * Custom vocabulary to improve transcription accuracy.
-   * Can be a boolean or an array of custom terms.
    */
-  customVocabulary: z.union([z.boolean(), z.array(z.any())]).nullish(),
+  customVocabulary: z.boolean().nullish(),
 
   /**
    * Configuration for custom vocabulary.
@@ -25,21 +20,9 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
         z.union([
           z.string(),
           z.object({
-            /**
-             * The vocabulary term.
-             */
             value: z.string(),
-            /**
-             * Intensity of the term in recognition (optional).
-             */
             intensity: z.number().nullish(),
-            /**
-             * Alternative pronunciations for the term (optional).
-             */
             pronunciations: z.array(z.string()).nullish(),
-            /**
-             * Language of the term (optional).
-             */
             language: z.string().nullish(),
           }),
         ]),
@@ -52,31 +35,20 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
     .nullish(),
 
   /**
-   * Whether to automatically detect the language of the audio.
+   * Language configuration for transcription.
    */
-  detectLanguage: z.boolean().nullish(),
-
-  /**
-   * Whether to enable code switching (multiple languages in the same audio).
-   */
-  enableCodeSwitching: z.boolean().nullish(),
-
-  /**
-   * Configuration for code switching.
-   */
-  codeSwitchingConfig: z
+  languageConfig: z
     .object({
       /**
-       * Languages to consider for code switching.
+       * Languages to use for transcription. If empty, language is auto-detected.
        */
       languages: z.array(z.string()).nullish(),
+      /**
+       * If true, language is auto-detected on each utterance.
+       */
+      codeSwitching: z.boolean().nullish(),
     })
     .nullish(),
-
-  /**
-   * Specific language for transcription.
-   */
-  language: z.string().nullish(),
 
   /**
    * Whether to enable callback when transcription is complete.
@@ -88,13 +60,7 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   callbackConfig: z
     .object({
-      /**
-       * URL to send the callback to.
-       */
       url: z.string(),
-      /**
-       * HTTP method for the callback.
-       */
       method: z.enum(['POST', 'PUT']).nullish(),
     })
     .nullish(),
@@ -109,29 +75,11 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   subtitlesConfig: z
     .object({
-      /**
-       * Subtitle file formats to generate.
-       */
       formats: z.array(z.enum(['srt', 'vtt'])).nullish(),
-      /**
-       * Minimum duration for subtitle segments.
-       */
       minimumDuration: z.number().nullish(),
-      /**
-       * Maximum duration for subtitle segments.
-       */
       maximumDuration: z.number().nullish(),
-      /**
-       * Maximum characters per row in subtitles.
-       */
       maximumCharactersPerRow: z.number().nullish(),
-      /**
-       * Maximum rows per caption in subtitles.
-       */
       maximumRowsPerCaption: z.number().nullish(),
-      /**
-       * Style of subtitles.
-       */
       style: z.enum(['default', 'compliance']).nullish(),
     })
     .nullish(),
@@ -146,22 +94,9 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   diarizationConfig: z
     .object({
-      /**
-       * Exact number of speakers to identify.
-       */
       numberOfSpeakers: z.number().nullish(),
-      /**
-       * Minimum number of speakers to identify.
-       */
       minSpeakers: z.number().nullish(),
-      /**
-       * Maximum number of speakers to identify.
-       */
       maxSpeakers: z.number().nullish(),
-      /**
-       * Whether to use enhanced diarization.
-       */
-      enhanced: z.boolean().nullish(),
     })
     .nullish(),
 
@@ -175,18 +110,13 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   translationConfig: z
     .object({
-      /**
-       * Target languages for translation.
-       */
       targetLanguages: z.array(z.string()),
-      /**
-       * Translation model to use.
-       */
       model: z.enum(['base', 'enhanced']).nullish(),
-      /**
-       * Whether to match original utterances in translation.
-       */
       matchOriginalUtterances: z.boolean().nullish(),
+      lipsync: z.boolean().nullish(),
+      contextAdaptation: z.boolean().nullish(),
+      context: z.string().nullish(),
+      informal: z.boolean().nullish(),
     })
     .nullish(),
 
@@ -200,32 +130,14 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   summarizationConfig: z
     .object({
-      /**
-       * Type of summary to generate.
-       */
       type: z.enum(['general', 'bullet_points', 'concise']).nullish(),
     })
     .nullish(),
 
   /**
-   * Whether to enable content moderation.
-   */
-  moderation: z.boolean().nullish(),
-
-  /**
    * Whether to enable named entity recognition.
    */
   namedEntityRecognition: z.boolean().nullish(),
-
-  /**
-   * Whether to enable automatic chapter creation.
-   */
-  chapterization: z.boolean().nullish(),
-
-  /**
-   * Whether to ensure consistent naming of entities.
-   */
-  nameConsistency: z.boolean().nullish(),
 
   /**
    * Whether to enable custom spelling.
@@ -237,27 +149,7 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   customSpellingConfig: z
     .object({
-      /**
-       * Dictionary of custom spellings.
-       */
       spellingDictionary: z.record(z.string(), z.array(z.string())),
-    })
-    .nullish(),
-
-  /**
-   * Whether to extract structured data from the transcription.
-   */
-  structuredDataExtraction: z.boolean().nullish(),
-
-  /**
-   * Configuration for structured data extraction.
-   */
-  structuredDataExtractionConfig: z
-    .object({
-      /**
-       * Classes of data to extract.
-       */
-      classes: z.array(z.string()),
     })
     .nullish(),
 
@@ -276,27 +168,35 @@ export const gladiaTranscriptionModelOptionsSchema = z.object({
    */
   audioToLlmConfig: z
     .object({
-      /**
-       * Prompts to send to the language model.
-       */
       prompts: z.array(z.string()),
+      model: z.string().nullish(),
+    })
+    .nullish(),
+
+  /**
+   * Whether to enable PII redaction.
+   */
+  piiRedaction: z.boolean().nullish(),
+
+  /**
+   * Configuration for PII redaction.
+   */
+  piiRedactionConfig: z
+    .object({
+      entityTypes: z.array(z.string()).nullish(),
+      processedTextType: z.enum(['MARKER', 'MASK']).nullish(),
     })
     .nullish(),
 
   /**
    * Custom metadata to include with the transcription.
    */
-  customMetadata: z.record(z.string(), z.any()).nullish(),
+  customMetadata: z.record(z.string(), z.unknown()).nullish(),
 
   /**
    * Whether to include sentence-level segmentation.
    */
   sentences: z.boolean().nullish(),
-
-  /**
-   * Whether to enable display mode.
-   */
-  displayMode: z.boolean().nullish(),
 
   /**
    * Whether to enhance punctuation in the transcription.

--- a/packages/gladia/src/gladia-transcription-model.test.ts
+++ b/packages/gladia/src/gladia-transcription-model.test.ts
@@ -64,6 +64,113 @@ describe('doGenerate', () => {
       });
     });
 
+    it('should pass provider options to pre-recorded endpoint', async () => {
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        providerOptions: {
+          gladia: {
+            languageConfig: {
+              languages: ['en'],
+              codeSwitching: true,
+            },
+            piiRedaction: true,
+            piiRedactionConfig: {
+              entityTypes: ['EMAIL_ADDRESS', 'NAME'],
+              processedTextType: 'MARKER',
+            },
+          },
+        },
+      });
+
+      expect(await server.calls[1].requestBodyJson).toMatchObject({
+        audio_url: uploadFixture.audio_url,
+        language_config: {
+          languages: ['en'],
+          code_switching: true,
+        },
+        pii_redaction: true,
+        pii_redaction_config: {
+          entity_types: ['EMAIL_ADDRESS', 'NAME'],
+          processed_text_type: 'MARKER',
+        },
+      });
+    });
+
+    it('should pass the model id to the pre-recorded endpoint', async () => {
+      await provider.transcription('solaria-3').doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        providerOptions: {
+          gladia: {
+            languageConfig: {
+              languages: ['fr'],
+            },
+          },
+        },
+      });
+
+      expect(await server.calls[1].requestBodyJson).toMatchObject({
+        audio_url: uploadFixture.audio_url,
+        model: 'solaria-3',
+        language_config: {
+          languages: ['fr'],
+        },
+      });
+    });
+
+    it('does not send a model when none is specified', async () => {
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      const requestBody = await server.calls[1].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('model');
+    });
+
+    it('warns when solaria-3 is combined with multiple languages or code switching', async () => {
+      const result = await provider.transcription('solaria-3').doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        providerOptions: {
+          gladia: {
+            languageConfig: {
+              languages: ['fr', 'en'],
+              codeSwitching: true,
+            },
+          },
+        },
+      });
+
+      expect(result.warnings).toEqual([
+        expect.objectContaining({
+          type: 'other',
+          message: expect.stringContaining('single language'),
+        }),
+        expect.objectContaining({
+          type: 'other',
+          message: expect.stringContaining('code switching'),
+        }),
+      ]);
+    });
+
+    it('does not warn when solaria-3 is used with a single language', async () => {
+      const result = await provider.transcription('solaria-3').doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        providerOptions: {
+          gladia: {
+            languageConfig: {
+              languages: ['fr'],
+            },
+          },
+        },
+      });
+
+      expect(result.warnings).toEqual([]);
+    });
+
     it('does not send the API key when the result URL is on a foreign origin', async () => {
       const foreignResultUrl =
         'https://cdn.evil.example/v2/pre-recorded/result';

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -23,6 +23,7 @@ import type { GladiaConfig } from './gladia-config';
 import { gladiaFailedResponseHandler } from './gladia-error';
 import { gladiaTranscriptionModelOptionsSchema } from './gladia-transcription-model-options';
 import type { GladiaTranscriptionInitiateAPITypes } from './gladia-api-types';
+import type { GladiaTranscriptionModelId } from './gladia-transcription-options';
 
 interface GladiaTranscriptionModelConfig extends GladiaConfig {
   _internal?: {
@@ -45,14 +46,14 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
   }
 
   static [WORKFLOW_DESERIALIZE](options: {
-    modelId: 'default';
+    modelId: GladiaTranscriptionModelId;
     config: GladiaTranscriptionModelConfig;
   }) {
     return new GladiaTranscriptionModel(options.modelId, options.config);
   }
 
   constructor(
-    readonly modelId: string,
+    readonly modelId: GladiaTranscriptionModelId,
     private readonly config: GladiaTranscriptionModelConfig,
   ) {}
 
@@ -70,35 +71,29 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
 
     const body: Omit<GladiaTranscriptionInitiateAPITypes, 'audio_url'> = {};
 
+    // Select the transcription model. `default` is the placeholder used when no
+    // model id is passed to `gladia.transcription()`; in that case we omit the
+    // field and let the Gladia API fall back to its own default (`solaria-1`).
+    if (this.modelId !== 'default') {
+      body.model = this.modelId;
+    }
+
     // Add provider-specific options
     if (gladiaOptions) {
-      body.context_prompt = gladiaOptions.contextPrompt ?? undefined;
       body.custom_vocabulary = gladiaOptions.customVocabulary ?? undefined;
-      body.detect_language = gladiaOptions.detectLanguage ?? undefined;
-      body.enable_code_switching =
-        gladiaOptions.enableCodeSwitching ?? undefined;
-      body.language = gladiaOptions.language ?? undefined;
       body.callback = gladiaOptions.callback ?? undefined;
       body.subtitles = gladiaOptions.subtitles ?? undefined;
       body.diarization = gladiaOptions.diarization ?? undefined;
       body.translation = gladiaOptions.translation ?? undefined;
       body.summarization = gladiaOptions.summarization ?? undefined;
-      body.moderation = gladiaOptions.moderation ?? undefined;
       body.named_entity_recognition =
         gladiaOptions.namedEntityRecognition ?? undefined;
-      body.chapterization = gladiaOptions.chapterization ?? undefined;
-      body.name_consistency = gladiaOptions.nameConsistency ?? undefined;
       body.custom_spelling = gladiaOptions.customSpelling ?? undefined;
-      body.structured_data_extraction =
-        gladiaOptions.structuredDataExtraction ?? undefined;
-      body.structured_data_extraction_config =
-        gladiaOptions.structuredDataExtractionConfig ?? undefined;
       body.sentiment_analysis = gladiaOptions.sentimentAnalysis ?? undefined;
       body.audio_to_llm = gladiaOptions.audioToLlm ?? undefined;
-      body.audio_to_llm_config = gladiaOptions.audioToLlmConfig ?? undefined;
+      body.pii_redaction = gladiaOptions.piiRedaction ?? undefined;
       body.custom_metadata = gladiaOptions.customMetadata ?? undefined;
       body.sentences = gladiaOptions.sentences ?? undefined;
-      body.display_mode = gladiaOptions.displayMode ?? undefined;
       body.punctuation_enhanced =
         gladiaOptions.punctuationEnhanced ?? undefined;
 
@@ -120,14 +115,35 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
         };
       }
 
-      // Handle code switching config
-      if (gladiaOptions.codeSwitchingConfig) {
-        body.code_switching_config = {
-          languages: gladiaOptions.codeSwitchingConfig.languages ?? undefined,
+      if (gladiaOptions.languageConfig) {
+        // `solaria-3` only supports a single language and no code switching.
+        // Warn rather than fail so the request still reaches the API.
+        if (this.modelId === 'solaria-3') {
+          if ((gladiaOptions.languageConfig.languages?.length ?? 0) > 1) {
+            warnings.push({
+              type: 'other',
+              message:
+                'The "solaria-3" model supports a single language only. ' +
+                'Pass exactly one language in languageConfig.languages.',
+            });
+          }
+          if (gladiaOptions.languageConfig.codeSwitching) {
+            warnings.push({
+              type: 'other',
+              message:
+                'The "solaria-3" model does not support code switching. ' +
+                'The codeSwitching option will be ignored.',
+            });
+          }
+        }
+
+        body.language_config = {
+          languages: gladiaOptions.languageConfig.languages ?? undefined,
+          code_switching:
+            gladiaOptions.languageConfig.codeSwitching ?? undefined,
         };
       }
 
-      // Handle callback config
       if (gladiaOptions.callbackConfig) {
         body.callback_config = {
           url: gladiaOptions.callbackConfig.url,
@@ -135,7 +151,6 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
         };
       }
 
-      // Handle subtitles config
       if (gladiaOptions.subtitlesConfig) {
         body.subtitles_config = {
           formats: gladiaOptions.subtitlesConfig.formats ?? undefined,
@@ -151,7 +166,6 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
         };
       }
 
-      // Handle diarization config
       if (gladiaOptions.diarizationConfig) {
         body.diarization_config = {
           number_of_speakers:
@@ -160,11 +174,9 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
             gladiaOptions.diarizationConfig.minSpeakers ?? undefined,
           max_speakers:
             gladiaOptions.diarizationConfig.maxSpeakers ?? undefined,
-          enhanced: gladiaOptions.diarizationConfig.enhanced ?? undefined,
         };
       }
 
-      // Handle translation config
       if (gladiaOptions.translationConfig) {
         body.translation_config = {
           target_languages: gladiaOptions.translationConfig.targetLanguages,
@@ -172,21 +184,40 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
           match_original_utterances:
             gladiaOptions.translationConfig.matchOriginalUtterances ??
             undefined,
+          lipsync: gladiaOptions.translationConfig.lipsync ?? undefined,
+          context_adaptation:
+            gladiaOptions.translationConfig.contextAdaptation ?? undefined,
+          context: gladiaOptions.translationConfig.context ?? undefined,
+          informal: gladiaOptions.translationConfig.informal ?? undefined,
         };
       }
 
-      // Handle summarization config
       if (gladiaOptions.summarizationConfig) {
         body.summarization_config = {
           type: gladiaOptions.summarizationConfig.type ?? undefined,
         };
       }
 
-      // Handle custom spelling config
       if (gladiaOptions.customSpellingConfig) {
         body.custom_spelling_config = {
           spelling_dictionary:
             gladiaOptions.customSpellingConfig.spellingDictionary,
+        };
+      }
+
+      if (gladiaOptions.audioToLlmConfig) {
+        body.audio_to_llm_config = {
+          prompts: gladiaOptions.audioToLlmConfig.prompts,
+          model: gladiaOptions.audioToLlmConfig.model ?? undefined,
+        };
+      }
+
+      if (gladiaOptions.piiRedactionConfig) {
+        body.pii_redaction_config = {
+          entity_types:
+            gladiaOptions.piiRedactionConfig.entityTypes ?? undefined,
+          processed_text_type:
+            gladiaOptions.piiRedactionConfig.processedTextType ?? undefined,
         };
       }
     }

--- a/packages/gladia/src/gladia-transcription-options.ts
+++ b/packages/gladia/src/gladia-transcription-options.ts
@@ -1,0 +1,17 @@
+/**
+ * Transcription model to use.
+ *
+ * - `solaria-1` (default): generalist model with the broadest language coverage
+ *   (100+ languages), supports code switching and multi-language configuration,
+ *   and is available for both pre-recorded and live transcription.
+ * - `solaria-3`: latest model, tuned for the highest accuracy on European
+ *   real-world audio. Pre-recorded (async) only. Supports a single language
+ *   chosen from English, French, German, Spanish, or Italian — pass exactly one
+ *   language in `languageConfig.languages` with no code switching.
+ *
+ * If omitted, the Gladia API uses its default model (`solaria-1`).
+ */
+export type GladiaTranscriptionModelId =
+  | 'solaria-1'
+  | 'solaria-3'
+  | (string & {});

--- a/packages/gladia/src/index.ts
+++ b/packages/gladia/src/index.ts
@@ -1,4 +1,5 @@
 export { createGladia, gladia } from './gladia-provider';
 export type { GladiaProvider, GladiaProviderSettings } from './gladia-provider';
 export type { GladiaTranscriptionModelOptions } from './gladia-transcription-model-options';
+export type { GladiaTranscriptionModelId } from './gladia-transcription-options';
 export { VERSION } from './version';


### PR DESCRIPTION
# Align Gladia transcription provider options with the v2 OpenAPI spec

Align the Gladia transcription provider options with the Gladia v2 OpenAPI spec (InitTranscriptionRequest), and add transcription model selection.

- Replaced the flat language options (language, detectLanguage, enableCodeSwitching, codeSwitchingConfig) with a single languageConfig object (languages + codeSwitching).
- Added piiRedaction and piiRedactionConfig (entityTypes, processedTextType) support.
- Removed request options no longer accepted by the pre-recorded init API: contextPrompt, moderation, chapterization, nameConsistency, structuredDataExtraction / structuredDataExtractionConfig, displayMode, and diarizationConfig.enhanced.
- Extended translationConfig (lipsync, contextAdaptation, context, informal) and audioToLlmConfig (model) to match the spec.
- Enabled transcription model selection (solaria-1, solaria-3) via gladia.transcription(modelId). When omitted, the model field is left off the request so the API uses its default. solaria-3 constraints (single language, no code switching) emit warnings rather than failing the request.

Documentation, the exported GladiaTranscriptionModelId type, and the API type definitions have been updated accordingly.

## Background

The Gladia transcription provider options had drifted from the Gladia v2 pre-recorded API. Several fields exposed by the API (e.g. contextPrompt, moderation, chapterization, structuredDataExtraction, displayMode) are no longer accepted by the init endpoint, and the language configuration shape changed from flat flags to a nested language_config object. There was also no way to select a transcription model — the provider was hardcoded to 'default' — so users could not opt into newer models such as solaria-3.

## Summary

- Re-aligned gladiaTranscriptionModelOptionsSchema with the OpenAPI InitTranscriptionRequest schema (source of truth: https://api.gladia.io/openapi.json).
- Introduced languageConfig to replace the flat language options and updated the request mapping to language_config.
- Added piiRedaction / piiRedactionConfig and the corresponding pii_redaction / pii_redaction_config request mapping.
- Extended translationConfig and audioToLlmConfig with the newly supported fields.
- Removed the deprecated options listed above.
- Added a GladiaTranscriptionModelId type (solaria-1 | solaria-3 | (string & {})) and made gladia.transcription(modelId?) accept it. The model is omitted from the body when 'default', and solaria-3 usage with multiple languages or code switching produces warnings.
- Updated the provider docs (120-gladia.mdx), the package README, and the generated API types; added a patch changeset.

## Manual Verification

- Ran the packages/gladia test suite — the new and existing transcription model tests pass.
- Sent a pre-recorded transcription request with gladia.transcription() and confirmed no model field is included in the request body.
- Sent requests with gladia.transcription('solaria-1') and gladia.transcription('solaria-3') and confirmed the model field is set, and that solaria-3 + multiple languages / code switching surfaces warnings while still issuing the request.
- Verified languageConfig and piiRedaction options are mapped to language_config / pii_redaction in the request payload.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

- Mirror these option changes in the live/streaming transcription path if/when it diverges from the pre-recorded schema.

## Related Issues