### PR TITLE
fix(examples): memoize realtime sessionConfig to keep websocket connected

### DIFF
--- a/examples/ai-e2e-next/app/realtime/page.tsx
+++ b/examples/ai-e2e-next/app/realtime/page.tsx
@@ -183,6 +183,19 @@ function RealtimeChat({
     [config],
   );
 
+  const sessionConfig = useMemo(
+    () => ({
+      instructions:
+        'You are a helpful assistant. Be concise. ' +
+        'You have access to tools for weather and dice rolling.',
+      inputAudioTranscription: {},
+      voice,
+      turnDetection: { type: 'server-vad' as const },
+      ...config.sessionConfigOverrides,
+    }),
+    [voice, config],
+  );
+
   const {
     status,
     messages,
@@ -200,15 +213,7 @@ function RealtimeChat({
     api: {
       token: `/api/realtime/setup?provider=${provider}`,
     },
-    sessionConfig: {
-      instructions:
-        'You are a helpful assistant. Be concise. ' +
-        'You have access to tools for weather and dice rolling.',
-      inputAudioTranscription: {},
-      voice,
-      turnDetection: { type: 'server-vad' },
-      ...config.sessionConfigOverrides,
-    },
+    sessionConfig,
     onEvent: event => {
       if (event.type !== 'audio-delta') {
         console.log(`[realtime:${provider}] ${event.type}`, event);


### PR DESCRIPTION
## Background

The realtime voice chat example (`examples/ai-e2e-next/app/realtime/page.tsx`) was stuck on `DISCONNECTED` for all three providers (OpenAI, Google, xAI), even though the provider WebSocket actually opened and `session-created` / `session-updated` events arrived.

Root cause: `experimental_useRealtime` recreates its internal `RealtimeStore` whenever the store key changes, and the key compares `sessionConfig` by object identity (`packages/react/src/use-realtime.ts`). The example passed a fresh inline `sessionConfig` object literal on every render, so the store was recreated on every render:

1. Clicking **Connect** flips store A to `connecting` → `connected` (its socket is the live one).
2. That state update re-renders the hook, which sees a new `sessionConfig` reference and builds store B (`disconnected`), binding the UI to it.
3. The live socket on store A is orphaned and the UI shows store B's `disconnected` state — the status never even flashed `connecting`.

`model` was already memoized in the example, so `sessionConfig` was the only unstable key.

## Summary

Memoized `sessionConfig` with `useMemo` (keyed on `voice` and the provider `config`), mirroring how `model` is already memoized. This keeps the store key stable across renders so the connected store stays bound to the UI.

## Manual Verification

Tested the e2e realtime example with all 3 providers

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (example-only change; examples are not published)
- [x] I have reviewed this pull request (self-review)

## Future Work

`experimental_useRealtime` recreates its store when `sessionConfig` changes by reference, which is fragile for the common pattern of passing an inline object. A follow-up could harden the hook (e.g. drop `sessionConfig` from the recreation key or compare it structurally) so consumers don't have to memoize it.