### PR TITLE
fix(ai): preserve chat response for onFinish

### DIFF
--- a/.changeset/tidy-chats-finish.md
+++ b/.changeset/tidy-chats-finish.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `Chat` finishing when `activeResponse` is cleared before `onFinish`.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -2952,4 +2952,78 @@ describe('Chat', () => {
       `);
     });
   });
+
+  describe('active response cleanup', () => {
+    it('calls onFinish from the request-local response when activeResponse is cleared', async () => {
+      let controller: ReadableStreamDefaultController<UIMessageChunk>;
+      const responseStream = new ReadableStream<UIMessageChunk>({
+        start: controllerArg => {
+          controller = controllerArg;
+          controller.enqueue({ type: 'start' });
+          controller.enqueue({ type: 'start-step' });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          controller.enqueue({
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'Hello',
+          });
+        },
+      });
+
+      const onFinish = vi.fn();
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => responseStream,
+          reconnectToStream: () => {
+            throw new Error('not implemented');
+          },
+        },
+        onFinish,
+      });
+
+      try {
+        const sendPromise = chat.sendMessage({
+          text: 'Hello, world!',
+        });
+
+        while ((chat.messages[1]?.parts[1] as any)?.text !== 'Hello') {
+          await vi.advanceTimersByTimeAsync(0);
+        }
+
+        (chat as any).activeResponse = undefined;
+
+        controller!.enqueue({ type: 'text-end', id: 'text-1' });
+        controller!.enqueue({ type: 'finish-step' });
+        controller!.enqueue({
+          type: 'finish',
+          finishReason: 'stop',
+        });
+        controller!.close();
+
+        await sendPromise;
+
+        expect(consoleError).not.toHaveBeenCalled();
+        expect(onFinish).toHaveBeenCalledWith(
+          expect.objectContaining({
+            finishReason: 'stop',
+            isAbort: false,
+            isDisconnect: false,
+            isError: false,
+            message: expect.objectContaining({
+              id: 'id-1',
+              role: 'assistant',
+            }),
+          }),
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
 });

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -651,8 +651,10 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     let isDisconnect = false;
     let isError = false;
 
+    let activeResponse: ActiveResponse<UI_MESSAGE> | undefined;
+
     try {
-      const activeResponse = {
+      const response = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
           messageId: this.generateId(),
@@ -660,11 +662,13 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         abortController: new AbortController(),
       } as ActiveResponse<UI_MESSAGE>;
 
-      activeResponse.abortController.signal.addEventListener('abort', () => {
+      activeResponse = response;
+
+      response.abortController.signal.addEventListener('abort', () => {
         isAbort = true;
       });
 
-      this.activeResponse = activeResponse;
+      this.activeResponse = response;
 
       let stream: ReadableStream<UIMessageChunk>;
 
@@ -674,7 +678,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         stream = await this.transport.sendMessages({
           chatId: this.id,
           messages: this.state.messages,
-          abortSignal: activeResponse.abortController.signal,
+          abortSignal: response.abortController.signal,
           metadata,
           headers,
           body,
@@ -692,21 +696,21 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         // serialize the job execution to avoid race conditions:
         this.jobExecutor.run(() =>
           job({
-            state: activeResponse.state,
+            state: response.state,
             write: () => {
               // streaming is set on first write (before it should be "submitted")
               this.setStatus({ status: 'streaming' });
 
               const replaceLastMessage =
-                activeResponse.state.message.id === this.lastMessage?.id;
+                response.state.message.id === this.lastMessage?.id;
 
               if (replaceLastMessage) {
                 this.state.replaceMessage(
                   this.state.messages.length - 1,
-                  activeResponse.state.message,
+                  response.state.message,
                 );
               } else {
-                this.state.pushMessage(activeResponse.state.message);
+                this.state.pushMessage(response.state.message);
               }
             },
           }),
@@ -755,20 +759,24 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       this.setStatus({ status: 'error', error: err as Error });
     } finally {
-      try {
-        this.onFinish?.({
-          message: this.activeResponse!.state.message,
-          messages: this.state.messages,
-          isAbort,
-          isDisconnect,
-          isError,
-          finishReason: this.activeResponse?.state.finishReason,
-        });
-      } catch (err) {
-        console.error(err);
+      if (activeResponse != null) {
+        try {
+          this.onFinish?.({
+            message: activeResponse.state.message,
+            messages: this.state.messages,
+            isAbort,
+            isDisconnect,
+            isError,
+            finishReason: activeResponse.state.finishReason,
+          });
+        } catch (err) {
+          console.error(err);
+        }
       }
 
-      this.activeResponse = undefined;
+      if (this.activeResponse === activeResponse) {
+        this.activeResponse = undefined;
+      }
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true


### PR DESCRIPTION
## Summary

Closes #15668.

- keep a request-local `activeResponse` reference for `onFinish` instead of reading the mutable instance field in `finally`
- avoid clearing `this.activeResponse` when another overlapping request has already replaced it
- add a regression test that clears `activeResponse` before stream finish and verifies `onFinish` still receives the assistant message without logging an error
- add a patch changeset for `ai`

## Tests

- `pnpm test:node src/ui/chat.test.ts`
- `pnpm --filter ai type-check`
- `pnpm check`
- `pnpm --filter ai build`