### PR TITLE
fix(amazon-bedrock): omit strict from tools for Opus 4.7/4.8

### DIFF
--- a/.changeset/many-drinks-sniff.md
+++ b/.changeset/many-drinks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+Omit strict from tool specs for Opus 4.7/4.8 on Bedrock

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
@@ -395,5 +395,41 @@ describe('prepareTools', () => {
       expect((tools[1] as any).toolSpec.strict).toBe(false);
       expect((tools[2] as any).toolSpec).not.toHaveProperty('strict');
     });
+
+    it('should not include strict for claude-opus-4-7', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId: 'us.anthropic.claude-opus-4-7',
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+    });
+
+    it('should not include strict for claude-opus-4-8', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId: 'anthropic.claude-opus-4-8',
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+    });
   });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
@@ -134,13 +134,24 @@ export async function prepareTools({
       : functionTools;
 
   for (const tool of filteredFunctionTools) {
+    // Bedrock rejects strict on tools for claude-opus-4-7 and claude-opus-4-8
+    // https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html
+    const supportsStrictOnTools =
+      !modelId.includes('claude-opus-4-7') &&
+      !modelId.includes('claude-opus-4-8');
+
+    const strictTools =
+      tool.strict != null && supportsStrictOnTools
+        ? { strict: tool.strict }
+        : {};
+
     amazonBedrockTools.push({
       toolSpec: {
         name: tool.name,
         ...(tool.description?.trim() !== ''
           ? { description: tool.description }
           : {}),
-        ...(tool.strict != null ? { strict: tool.strict } : {}),
+        ...strictTools,
         inputSchema: {
           json: tool.inputSchema as JSONObject,
         },


### PR DESCRIPTION
## Background
Opus 4.7/4.8 on Bedrock reject strict: true on tool specs with HTTP 400, which breaks structured output.

AWS documents this for Opus 4.7 in the [count-tokens bedrock-mantle note](https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html)

## Summary

strips the strict option from tool specs in prepareTools in aws bedrock for claude-opus-4-7 and claude-opus-4-8

## Manual Verification

Ran pnpm test:node src/amazon-bedrock-prepare-tools.test.ts in packages/amazon-bedrock.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes [#16121](https://github.com/vercel/ai/issues/16121)