### PR TITLE
Backport: fix(provider-utils): cancel response body on download rejection to prevent socket leak

### DIFF
--- a/.changeset/vuln-10892-cancel-response-body-on-download-rejection.md
+++ b/.changeset/vuln-10892-cancel-response-body-on-download-rejection.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+fix(provider-utils): cancel response body on download rejection to prevent socket leak
+
+When a download was rejected early — because the `Content-Length` header exceeded the size limit, the response status was not ok, or a redirect resolved to a blocked URL — the fetch response body was left unconsumed and uncancelled. With WHATWG Fetch/undici this leaves the underlying TCP socket open instead of returning it to the connection pool, allowing an attacker-controlled origin to exhaust file descriptors and cause a denial of service. The body is now cancelled on all early-rejection paths in `readResponseWithSizeLimit` and `download`, and `fetchWithValidatedRedirects` cancels each redirect hop's body before following or rejecting the next hop.

--- a/packages/ai/src/util/download/download.test.ts
+++ b/packages/ai/src/util/download/download.test.ts
@@ -30,13 +30,22 @@ describe('download SSRF redirect protection', () => {
   });
 
   it('should reject a redirect to a private IP without requesting it', async () => {
+    const onCancel = vi.fn();
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: false,
       status: 302,
       headers: new Headers({
         location: 'http://169.254.169.254/latest/meta-data/',
       }),
-      body: null,
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('redirecting'));
+          controller.close();
+        },
+        cancel() {
+          onCancel();
+        },
+      }),
     } as unknown as Response);
     globalThis.fetch = fetchMock;
 
@@ -45,14 +54,26 @@ describe('download SSRF redirect protection', () => {
     ).rejects.toThrow(DownloadError);
     // The redirect target must never be requested.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Body must be cancelled so the open-redirect rejection does not leak the
+    // underlying socket.
+    expect(onCancel).toHaveBeenCalled();
   });
 
   it('should reject a redirect to localhost without requesting it', async () => {
+    const onCancel = vi.fn();
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: false,
       status: 307,
       headers: new Headers({ location: 'http://localhost:8080/admin' }),
-      body: null,
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('redirecting'));
+          controller.close();
+        },
+        cancel() {
+          onCancel();
+        },
+      }),
     } as unknown as Response);
     globalThis.fetch = fetchMock;
 
@@ -60,6 +81,7 @@ describe('download SSRF redirect protection', () => {
       download({ url: new URL('https://evil.com/redirect') }),
     ).rejects.toThrow(DownloadError);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalled();
   });
 
   it('should let the browser follow redirects natively on an opaque redirect', async () => {
@@ -249,6 +271,58 @@ describe('download', () => {
     } catch (error: unknown) {
       expect(error).toBeInstanceOf(DownloadError);
     }
+  });
+
+  it('should cancel the body on non-ok response (prevents socket leak)', async () => {
+    const onCancel = vi.fn();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers: new Headers(),
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(10));
+          controller.close();
+        },
+        cancel() {
+          onCancel();
+        },
+      }),
+    } as unknown as Response);
+
+    await expect(
+      download({ url: new URL('http://example.com/not-found') }),
+    ).rejects.toThrow(DownloadError);
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should cancel the body when Content-Length exceeds limit (prevents socket leak)', async () => {
+    const onCancel = vi.fn();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        'content-type': 'application/octet-stream',
+        'content-length': `${3 * 1024 * 1024 * 1024}`,
+      }),
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(10));
+          controller.close();
+        },
+        cancel() {
+          onCancel();
+        },
+      }),
+    } as unknown as Response);
+
+    await expect(
+      download({ url: new URL('http://example.com/large') }),
+    ).rejects.toThrow(DownloadError);
+
+    expect(onCancel).toHaveBeenCalled();
   });
 
   it('should abort when response exceeds default size limit', async () => {

--- a/packages/ai/src/util/download/download.ts
+++ b/packages/ai/src/util/download/download.ts
@@ -1,4 +1,5 @@
 import {
+  cancelResponseBody,
   DownloadError,
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,
@@ -42,6 +43,9 @@ export const download = async ({
     });
 
     if (!response.ok) {
+      // Release the connection before rejecting so an error status from an
+      // attacker-controlled origin cannot leak open sockets.
+      await cancelResponseBody(response);
       throw new DownloadError({
         url: urlText,
         statusCode: response.status,

--- a/packages/provider-utils/src/cancel-response-body.test.ts
+++ b/packages/provider-utils/src/cancel-response-body.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { cancelResponseBody } from './cancel-response-body';
+
+function createResponse(body: ReadableStream<Uint8Array> | null): Response {
+  return { body } as unknown as Response;
+}
+
+describe('cancelResponseBody', () => {
+  it('should cancel the body to release the connection', async () => {
+    const cancel = vi.fn();
+    const response = createResponse(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+        cancel,
+      }),
+    );
+
+    await cancelResponseBody(response);
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('should be a no-op when the body is null', async () => {
+    await expect(
+      cancelResponseBody(createResponse(null)),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should swallow cancel errors so the original rejection is preserved', async () => {
+    const response = createResponse(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          throw new Error('cannot cancel');
+        },
+      }),
+    );
+
+    await expect(cancelResponseBody(response)).resolves.toBeUndefined();
+  });
+});

--- a/packages/provider-utils/src/cancel-response-body.ts
+++ b/packages/provider-utils/src/cancel-response-body.ts
@@ -1,0 +1,19 @@
+/**
+ * Cancels a response body to release the underlying connection.
+ *
+ * When a fetch Response is rejected without consuming its body (e.g. a failed
+ * status code, an open-redirect rejection, or a Content-Length that exceeds the
+ * size limit), the underlying TCP socket is not returned to the connection pool
+ * and may stay open until the process runs out of file descriptors. Cancelling
+ * the body avoids this leak.
+ *
+ * Errors thrown while cancelling are ignored: the body may already be locked,
+ * disturbed, or absent, none of which should mask the original rejection.
+ */
+export async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Ignore cancel errors so the original rejection is preserved.
+  }
+}

--- a/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
@@ -85,6 +85,38 @@ describe('fetchWithValidatedRedirects', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels the redirect response body before moving to the next hop (prevents socket leak)', async () => {
+    const onCancel = vi.fn();
+    const redirectWithBody = (location: string): Response =>
+      ({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('redirecting'));
+            controller.close();
+          },
+          cancel() {
+            onCancel();
+          },
+        }),
+      }) as unknown as Response;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectWithBody('https://cdn.example.com/file'))
+      .mockResolvedValueOnce(redirectWithBody('http://169.254.169.254/'));
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchWithValidatedRedirects({ url: 'https://example.com/file' }),
+    ).rejects.toThrow(DownloadError);
+
+    // Both the followed hop and the hop rejected by the SSRF guard must have
+    // their bodies cancelled so the redirect chain does not leak sockets.
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
   it('resolves relative redirect targets against the current URL', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/provider-utils/src/fetch-with-validated-redirects.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.ts
@@ -1,3 +1,4 @@
+import { cancelResponseBody } from './cancel-response-body';
 import { DownloadError } from './download-error';
 import { isBrowserRuntime } from './is-browser-runtime';
 import { validateDownloadUrl } from './validate-download-url';
@@ -68,6 +69,10 @@ export async function fetchWithValidatedRedirects({
 
     const location = response.headers.get('location');
     if (response.status >= 300 && response.status < 400 && location) {
+      // Release the redirect response's connection before moving to the next
+      // hop. Whether that hop is followed or rejected by the SSRF guard, an
+      // unconsumed 3xx body would leak the underlying socket.
+      await cancelResponseBody(response);
       currentUrl = new URL(location, currentUrl).toString();
       continue;
     }

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -34,6 +34,7 @@ export {
   type ProviderDefinedToolFactory,
   type ProviderDefinedToolFactoryWithOutputSchema,
 } from './provider-defined-tool-factory';
+export { cancelResponseBody } from './cancel-response-body';
 export * from './remove-undefined-entries';
 export * from './resolve';
 export * from './response-handler';

--- a/packages/provider-utils/src/read-response-with-size-limit.test.ts
+++ b/packages/provider-utils/src/read-response-with-size-limit.test.ts
@@ -8,11 +8,13 @@ function createMockResponse({
 }: {
   body?: Uint8Array | null;
   contentLength?: string;
-}): Response {
+}): { response: Response; cancelled: () => boolean } {
   const headers = new Headers();
   if (contentLength != null) {
     headers.set('content-length', contentLength);
   }
+
+  let cancelled = false;
 
   const stream =
     body != null
@@ -25,19 +27,25 @@ function createMockResponse({
             }
             controller.close();
           },
+          cancel() {
+            cancelled = true;
+          },
         })
       : null;
 
   return {
-    headers,
-    body: stream,
-  } as unknown as Response;
+    response: {
+      headers,
+      body: stream,
+    } as unknown as Response,
+    cancelled: () => cancelled,
+  };
 }
 
 describe('readResponseWithSizeLimit', () => {
   it('should read response within limit successfully', async () => {
     const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: data,
       contentLength: '8',
     });
@@ -52,7 +60,7 @@ describe('readResponseWithSizeLimit', () => {
   });
 
   it('should reject when Content-Length exceeds limit (early check)', async () => {
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: new Uint8Array(10),
       contentLength: '1000',
     });
@@ -72,12 +80,29 @@ describe('readResponseWithSizeLimit', () => {
     });
   });
 
+  it('should cancel the body when Content-Length exceeds limit (prevents socket leak)', async () => {
+    const { response, cancelled } = createMockResponse({
+      body: new Uint8Array(10),
+      contentLength: '1000',
+    });
+
+    await expect(
+      readResponseWithSizeLimit({
+        response,
+        url: 'http://example.com/large',
+        maxBytes: 100,
+      }),
+    ).rejects.toThrow();
+
+    expect(cancelled()).toBe(true);
+  });
+
   it('should abort when streamed bytes exceed limit', async () => {
     // Body is larger than maxBytes, but Content-Length is not set
     const largeBody = new Uint8Array(200);
     largeBody.fill(42);
 
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: largeBody,
     });
 
@@ -100,7 +125,7 @@ describe('readResponseWithSizeLimit', () => {
     const largeBody = new Uint8Array(200);
     largeBody.fill(42);
 
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: largeBody,
       contentLength: '10', // Claims to be small
     });
@@ -121,7 +146,7 @@ describe('readResponseWithSizeLimit', () => {
   });
 
   it('should handle empty body (null)', async () => {
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: null,
     });
 
@@ -135,7 +160,7 @@ describe('readResponseWithSizeLimit', () => {
   });
 
   it('should handle empty body (zero-length)', async () => {
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: new Uint8Array(0),
     });
 
@@ -152,7 +177,7 @@ describe('readResponseWithSizeLimit', () => {
     const data = new Uint8Array(10);
     data.fill(1);
 
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: data,
       contentLength: '10',
     });
@@ -170,7 +195,7 @@ describe('readResponseWithSizeLimit', () => {
     const data = new Uint8Array(11);
     data.fill(1);
 
-    const response = createMockResponse({
+    const { response } = createMockResponse({
       body: data,
     });
 

--- a/packages/provider-utils/src/read-response-with-size-limit.ts
+++ b/packages/provider-utils/src/read-response-with-size-limit.ts
@@ -1,3 +1,4 @@
+import { cancelResponseBody } from './cancel-response-body';
 import { DownloadError } from './download-error';
 
 /**
@@ -40,6 +41,9 @@ export async function readResponseWithSizeLimit({
   if (contentLength != null) {
     const length = parseInt(contentLength, 10);
     if (!isNaN(length) && length > maxBytes) {
+      // Cancel the body so the underlying connection is released back to the
+      // pool instead of being left open until the socket is exhausted.
+      await cancelResponseBody(response);
       throw new DownloadError({
         url,
         message: `Download of ${url} exceeded maximum size of ${maxBytes} bytes (Content-Length: ${length}).`,


### PR DESCRIPTION
This is a backport of #15968 to the `release-v5.0` branch.

The fix cancels the `fetch` response body on all early-rejection paths so undici/WHATWG Fetch returns the underlying TCP socket to the connection pool instead of leaving it open — preventing an attacker-controlled origin from exhausting file descriptors (remote DoS).

### Differences from the original PR

`release-v5.0` does not have the `downloadBlob` helper (`packages/provider-utils/src/download-blob.ts`) — it was introduced after v5.0 — so that portion of the fix is omitted as not applicable. The core protection still ports fully across the paths that exist on v5.0:

- `readResponseWithSizeLimit()` — cancels body when `Content-Length` exceeds the limit
- `download()` — cancels body on `!response.ok` and blocked-redirect (SSRF) paths
- `fetchWithValidatedRedirects()` — cancels each redirect hop's body before following or rejecting

The changeset was trimmed to drop the `downloadBlob` reference, and `index.ts` adds only the new `cancelResponseBody` export.

### Verification

- `@ai-sdk/provider-utils` builds (incl. DTS)
- provider-utils tests: 21 passed (`cancel-response-body`, `read-response-with-size-limit`, `fetch-with-validated-redirects`)
- `ai` download tests: 15 passed, no type errors