### PR TITLE
Add Exa search tool to Gateway provider

### DIFF
--- a/.changeset/exa-gateway-tool.md
+++ b/.changeset/exa-gateway-tool.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+feat (provider/gateway): add Exa search tool support

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -633,6 +633,93 @@ for await (const part of result.stream) {
 }
 ```
 
+#### Exa Search
+
+The Exa Search tool enables models to search the web using [Exa's Search API](https://exa.ai/docs/reference/search-api-guide-for-coding-agents). This tool is executed by the AI Gateway and returns token-efficient web excerpts for agent workflows.
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.4-nano',
+  prompt:
+    'Find the latest AI regulation updates and summarize the key changes.',
+  tools: {
+    exa_search: gateway.tools.exaSearch(),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+You can also configure the search with optional parameters:
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.4-nano',
+  prompt: 'Find recent AI regulation news from trusted sources.',
+  tools: {
+    exa_search: gateway.tools.exaSearch({
+      type: 'fast',
+      numResults: 5,
+      category: 'news',
+      includeDomains: ['reuters.com', 'bbc.com', 'nytimes.com'],
+      contents: {
+        highlights: true,
+        maxAgeHours: 24,
+      },
+    }),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+The Exa Search tool supports the following optional configuration options:
+
+- **type** _'auto' | 'fast' | 'instant'_
+
+  Search mode. `'auto'` is the default balance of speed and quality.
+
+- **numResults** _number_
+
+  Maximum number of results to return (1-100, default: 10).
+
+- **category** _'company' | 'people' | 'research paper' | 'news' | 'personal site' | 'financial report'_
+
+  Focus results on a specific content type.
+
+- **includeDomains** / **excludeDomains** _string[]_
+
+  Restrict or exclude search results by domain.
+
+- **startPublishedDate** / **endPublishedDate** _string_
+
+  Filter results by ISO 8601 publication date.
+
+- **contents** _object_
+
+  Control result extraction and freshness:
+  - `text` - Return full page text, optionally capped with `maxCharacters`
+  - `highlights` - Return token-efficient excerpts
+  - `maxAgeHours` - Control cached content freshness
+  - `livecrawlTimeout` - Livecrawl timeout in milliseconds
+  - `subpages` / `subpageTarget` - Crawl related subpages
+  - `extras.links` / `extras.imageLinks` - Extract links from pages
+
+The tool works with both `generateText` and `streamText`.
+
+This initial Gateway integration supports Exa's plain Search modes and
+token-efficient content controls. Deep synthesis modes and generated summaries
+are intentionally not exposed yet because they have separate pricing from
+standard Search.
+
 #### Parallel Search
 
 The Parallel Search tool enables models to search the web using [Parallel AI's Search API](https://docs.parallel.ai/api-reference/search-beta/search). This tool is optimized for LLM consumption, returning relevant excerpts from web pages that can replace multiple keyword searches with a single call.

--- a/examples/ai-functions/src/generate-text/gateway/tool-exa-search-params.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-exa-search-params.ts
@@ -1,0 +1,37 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5-nano',
+    prompt: `Search for recent AI regulation news from trusted sources.`,
+    tools: {
+      exa_search: gateway.tools.exaSearch({
+        type: 'fast',
+        numResults: 5,
+        category: 'news',
+        includeDomains: ['reuters.com', 'bbc.com', 'nytimes.com'],
+        contents: {
+          highlights: true,
+          maxAgeHours: 24,
+        },
+      }),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Reasoning:', result.reasoning);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.finalStep.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/generate-text/gateway/tool-exa-search.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-exa-search.ts
@@ -1,0 +1,29 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5-nano',
+    prompt:
+      'Use the exaSearch tool to find current information about renewable energy developments in 2025. You must search the web first before answering.',
+    tools: {
+      exa_search: gateway.tools.exaSearch(),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Reasoning:', result.reasoning);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.finalStep.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/tool-exa-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-exa-search-params.ts
@@ -1,0 +1,61 @@
+import { createGateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const gateway = createGateway({
+    baseURL: 'http://localhost:3000/v1/ai',
+  });
+
+  const result = streamText({
+    model: gateway('openai/gpt-5-nano'),
+    prompt: `Search for recent AI regulation news from trusted sources.`,
+    tools: {
+      exa_search: gateway.tools.exaSearch({
+        type: 'fast',
+        numResults: 5,
+        category: 'news',
+        includeDomains: ['reuters.com', 'bbc.com', 'nytimes.com'],
+        contents: {
+          highlights: true,
+          maxAgeHours: 24,
+        },
+      }),
+    },
+  });
+
+  for await (const part of result.stream) {
+    switch (part.type) {
+      case 'reasoning-delta':
+        process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Tool calls:', JSON.stringify(await result.toolCalls, null, 2));
+  console.log(
+    'Tool results:',
+    JSON.stringify(await result.toolResults, null, 2),
+  );
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify((await result.finalStep).providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/tool-exa-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-exa-search.ts
@@ -1,0 +1,53 @@
+import { createGateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const gateway = createGateway({
+    baseURL: 'http://localhost:3000/v1/ai',
+  });
+
+  const result = streamText({
+    model: gateway('openai/gpt-5-nano'),
+    prompt:
+      'Use the exaSearch tool to find current information about renewable energy developments in 2025. You must search the web first before answering.',
+    tools: {
+      exa_search: gateway.tools.exaSearch(),
+    },
+  });
+
+  for await (const part of result.stream) {
+    switch (part.type) {
+      case 'reasoning-delta':
+        process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Tool calls:', JSON.stringify(await result.toolCalls, null, 2));
+  console.log(
+    'Tool results:',
+    JSON.stringify(await result.toolResults, null, 2),
+  );
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify((await result.finalStep).providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-tools.ts
+++ b/packages/gateway/src/gateway-tools.ts
@@ -1,3 +1,4 @@
+import { exaSearch } from './tool/exa-search';
 import { parallelSearch } from './tool/parallel-search';
 import { perplexitySearch } from './tool/perplexity-search';
 
@@ -5,6 +6,15 @@ import { perplexitySearch } from './tool/perplexity-search';
  * Gateway-specific provider-defined tools.
  */
 export const gatewayTools = {
+  /**
+   * Search the web using Exa for current information and token-efficient
+   * excerpts optimized for agent workflows.
+   *
+   * Supports search type, category, domain, date, location, and content
+   * extraction controls.
+   */
+  exaSearch,
+
   /**
    * Search the web using Parallel AI's Search API for LLM-optimized excerpts.
    *

--- a/packages/gateway/src/tool/exa-search.ts
+++ b/packages/gateway/src/tool/exa-search.ts
@@ -1,0 +1,352 @@
+import {
+  createProviderExecutedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+
+export type ExaSearchType = 'auto' | 'fast' | 'instant';
+
+export type ExaSearchCategory =
+  | 'company'
+  | 'people'
+  | 'research paper'
+  | 'news'
+  | 'personal site'
+  | 'financial report';
+
+export type ExaTextSection =
+  | 'header'
+  | 'navigation'
+  | 'banner'
+  | 'body'
+  | 'sidebar'
+  | 'footer'
+  | 'metadata';
+
+export interface ExaSearchTextConfig {
+  maxCharacters?: number;
+  includeHtmlTags?: boolean;
+  verbosity?: 'compact' | 'standard' | 'full';
+  includeSections?: ExaTextSection[];
+  excludeSections?: ExaTextSection[];
+}
+
+export interface ExaSearchHighlightsConfig {
+  query?: string;
+  maxCharacters?: number;
+}
+
+export interface ExaSearchExtrasConfig {
+  links?: number;
+  imageLinks?: number;
+}
+
+export interface ExaSearchContentsConfig {
+  text?: boolean | ExaSearchTextConfig;
+  highlights?: boolean | ExaSearchHighlightsConfig;
+  maxAgeHours?: number;
+  livecrawlTimeout?: number;
+  subpages?: number;
+  subpageTarget?: string | string[];
+  extras?: ExaSearchExtrasConfig;
+}
+
+export interface ExaSearchConfig {
+  /**
+   * Default search method. Exa defaults to auto when omitted.
+   */
+  type?: ExaSearchType;
+
+  /**
+   * Default maximum number of results to return (1-100, default: 10).
+   */
+  numResults?: number;
+
+  /**
+   * Default category filter for result types.
+   */
+  category?: ExaSearchCategory;
+
+  /**
+   * Default two-letter ISO country code for location-aware search.
+   */
+  userLocation?: string;
+
+  /**
+   * Default domains to include or exclude.
+   */
+  includeDomains?: string[];
+  excludeDomains?: string[];
+
+  /**
+   * Default published date filters in ISO 8601 format.
+   */
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+
+  /**
+   * Default content extraction controls.
+   */
+  contents?: ExaSearchContentsConfig;
+}
+
+export interface ExaSearchResult {
+  title: string;
+  url: string;
+  id: string;
+  publishedDate?: string | null;
+  author?: string | null;
+  image?: string | null;
+  favicon?: string | null;
+  text?: string;
+  highlights?: string[];
+  highlightScores?: number[];
+  summary?: string;
+  subpages?: ExaSearchResult[];
+  extras?: {
+    links?: string[];
+    imageLinks?: string[];
+  };
+}
+
+export interface ExaSearchResponse {
+  requestId: string;
+  searchType?: string;
+  resolvedSearchType?: string;
+  results: ExaSearchResult[];
+  costDollars?: {
+    total?: number;
+    search?: Record<string, number>;
+  };
+}
+
+export interface ExaSearchError {
+  error:
+    | 'api_error'
+    | 'rate_limit'
+    | 'timeout'
+    | 'invalid_input'
+    | 'configuration_error'
+    | 'execution_error'
+    | 'unknown';
+  statusCode?: number;
+  message: string;
+}
+
+export interface ExaSearchInput {
+  query: string;
+  type?: ExaSearchType;
+  num_results?: number;
+  category?: ExaSearchCategory;
+  user_location?: string;
+  include_domains?: string[];
+  exclude_domains?: string[];
+  start_published_date?: string;
+  end_published_date?: string;
+  contents?: {
+    text?:
+      | boolean
+      | {
+          max_characters?: number;
+          include_html_tags?: boolean;
+          verbosity?: 'compact' | 'standard' | 'full';
+          include_sections?: ExaTextSection[];
+          exclude_sections?: ExaTextSection[];
+        };
+    highlights?:
+      | boolean
+      | {
+          query?: string;
+          max_characters?: number;
+        };
+    max_age_hours?: number;
+    livecrawl_timeout?: number;
+    subpages?: number;
+    subpage_target?: string | string[];
+    extras?: {
+      links?: number;
+      image_links?: number;
+    };
+  };
+}
+
+export type ExaSearchOutput = ExaSearchResponse | ExaSearchError;
+
+const exaSearchInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      query: z
+        .string()
+        .describe('Natural-language web search query. This is required.'),
+      type: z
+        .enum(['auto', 'fast', 'instant'])
+        .optional()
+        .describe(
+          'Search method. Use auto for the default balance of speed and quality.',
+        ),
+      num_results: z
+        .number()
+        .optional()
+        .describe('Maximum number of results to return (1-100, default: 10).'),
+      category: z
+        .enum([
+          'company',
+          'people',
+          'research paper',
+          'news',
+          'personal site',
+          'financial report',
+        ])
+        .optional()
+        .describe('Optional content category to focus results.'),
+      user_location: z
+        .string()
+        .optional()
+        .describe("Two-letter ISO country code such as 'US'."),
+      include_domains: z
+        .array(z.string())
+        .optional()
+        .describe('Only return results from these domains.'),
+      exclude_domains: z
+        .array(z.string())
+        .optional()
+        .describe('Exclude results from these domains.'),
+      start_published_date: z
+        .string()
+        .optional()
+        .describe('Only return links published after this ISO 8601 date.'),
+      end_published_date: z
+        .string()
+        .optional()
+        .describe('Only return links published before this ISO 8601 date.'),
+      contents: z
+        .object({
+          text: z
+            .union([
+              z.boolean(),
+              z.object({
+                max_characters: z.number().optional(),
+                include_html_tags: z.boolean().optional(),
+                verbosity: z.enum(['compact', 'standard', 'full']).optional(),
+                include_sections: z
+                  .array(
+                    z.enum([
+                      'header',
+                      'navigation',
+                      'banner',
+                      'body',
+                      'sidebar',
+                      'footer',
+                      'metadata',
+                    ]),
+                  )
+                  .optional(),
+                exclude_sections: z
+                  .array(
+                    z.enum([
+                      'header',
+                      'navigation',
+                      'banner',
+                      'body',
+                      'sidebar',
+                      'footer',
+                      'metadata',
+                    ]),
+                  )
+                  .optional(),
+              }),
+            ])
+            .optional(),
+          highlights: z
+            .union([
+              z.boolean(),
+              z.object({
+                query: z.string().optional(),
+                max_characters: z.number().optional(),
+              }),
+            ])
+            .optional(),
+          max_age_hours: z.number().optional(),
+          livecrawl_timeout: z.number().optional(),
+          subpages: z.number().optional(),
+          subpage_target: z.union([z.string(), z.array(z.string())]).optional(),
+          extras: z
+            .object({
+              links: z.number().optional(),
+              image_links: z.number().optional(),
+            })
+            .optional(),
+        })
+        .optional()
+        .describe('Controls extracted page content and freshness.'),
+    }),
+  ),
+);
+
+const exaSearchOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z.object({
+        requestId: z.string(),
+        searchType: z.string().optional(),
+        resolvedSearchType: z.string().optional(),
+        results: z.array(
+          z.object({
+            title: z.string(),
+            url: z.string(),
+            id: z.string(),
+            publishedDate: z.string().nullable().optional(),
+            author: z.string().nullable().optional(),
+            image: z.string().nullable().optional(),
+            favicon: z.string().nullable().optional(),
+            text: z.string().optional(),
+            highlights: z.array(z.string()).optional(),
+            highlightScores: z.array(z.number()).optional(),
+            summary: z.string().optional(),
+            subpages: z.array(z.any()).optional(),
+            extras: z
+              .object({
+                links: z.array(z.string()).optional(),
+                imageLinks: z.array(z.string()).optional(),
+              })
+              .optional(),
+          }),
+        ),
+        costDollars: z
+          .object({
+            total: z.number().optional(),
+            search: z.record(z.number()).optional(),
+          })
+          .optional(),
+      }),
+      z.object({
+        error: z.enum([
+          'api_error',
+          'rate_limit',
+          'timeout',
+          'invalid_input',
+          'configuration_error',
+          'execution_error',
+          'unknown',
+        ]),
+        statusCode: z.number().optional(),
+        message: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const exaSearchToolFactory = createProviderExecutedToolFactory<
+  ExaSearchInput,
+  ExaSearchOutput,
+  ExaSearchConfig
+>({
+  id: 'gateway.exa_search',
+  inputSchema: exaSearchInputSchema,
+  outputSchema: exaSearchOutputSchema,
+});
+
+export const exaSearch = (
+  config: ExaSearchConfig = {},
+): ReturnType<typeof exaSearchToolFactory> => exaSearchToolFactory(config);


### PR DESCRIPTION
## What changed

- Adds `gateway.tools.exaSearch()` to the Gateway provider API.
- Adds Exa request/response types, schema metadata, and provider-executed tool factory wiring.
- Adds docs, `generateText` examples, `streamText` examples, and a changeset.

## Related Gateway PR

- [vercel/ai-gateway#2289](https://github.com/vercel/ai-gateway/pull/2289) adds the server-side tool execution, telemetry, and billing.

## Validation

- `pnpm --filter @ai-sdk/gateway type-check`
- `pnpm --filter @ai-sdk/gateway test:node`
  - 19 files passed, 466 tests passed.
- `pnpm check`
- `pnpm validate:docs`
- `git diff --cached --check` passed before commit.
