### PR TITLE
docs(examples): add OpenAI Responses web_search multi-turn store:false example

### DIFF
--- a/examples/ai-functions/src/generate-text/openai/responses-web-search-multi-turn-store-false.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-web-search-multi-turn-store-false.ts
@@ -1,0 +1,64 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, type ModelMessage } from 'ai';
+import { run } from '../../lib/run';
+import { print } from '../../lib/print';
+
+// Demonstrates that an OpenAI provider-executed `web_search` result cannot be
+// replayed on a later turn when `store: false`.
+//
+// The Responses API only lets a prior hosted-tool result re-enter a request as
+// an `item_reference`, which requires the item to be stored server-side. With
+// `store: false` there is nothing to reference, so the AI SDK drops the
+// web_search call/result from the outgoing request and warns, once per result:
+//
+//   Results for OpenAI tool web_search are not sent to the API when store is false
+//
+// This needs more than one turn to surface: turn 1 runs the search (no prior
+// result in the input, so no warning); turn 2 replays turn 1's assistant
+// messages (which contain the provider-executed call + result) and triggers it.
+//
+// Setting `store: true` (the API default) avoids the warning, because the prior
+// search is then sent as an `item_reference`. The behavior is the same for the
+// legacy `openai.tools.webSearchPreview` tool — it is keyed on the result being
+// provider-executed, not on the specific tool.
+run(async () => {
+  const model = openai.responses('gpt-5-mini');
+  const tools = { web_search: openai.tools.webSearch({}) };
+  const providerOptions = { openai: { store: false } };
+
+  const searchPrompt: ModelMessage = {
+    role: 'user',
+    content: 'Search the web for the current Node.js LTS version.',
+  };
+
+  // Turn 1: run the hosted web_search. The input has no prior tool result yet,
+  // so this turn produces no warning.
+  console.log('Turn 1: running web_search (store: false)');
+  const search = await generateText({
+    model,
+    messages: [searchPrompt],
+    tools,
+    toolChoice: { type: 'tool', toolName: 'web_search' },
+    providerOptions,
+  });
+  print('Turn 1 warnings:', search.warnings);
+
+  // Turn 2: replay turn 1's assistant messages — which include the
+  // provider-executed web_search call + result — in the next request. Because
+  // `store: false`, the SDK cannot reference the stored items, drops them, and
+  // emits the warning. The model keeps the prior assistant text but loses the
+  // structured search context (query + source URLs).
+  console.log('\nTurn 2: replaying the search result (store: false)');
+  const followUp = await generateText({
+    model,
+    messages: [
+      searchPrompt,
+      ...search.response.messages,
+      { role: 'user', content: 'Reply only with OK.' },
+    ],
+    tools,
+    providerOptions,
+  });
+  print('Turn 2 warnings:', followUp.warnings);
+  print('Turn 2 text:', followUp.text);
+});


### PR DESCRIPTION
## What

Adds an example that reproduces a multi-turn `web_search` limitation with the OpenAI Responses provider when `store: false`.

`examples/ai-functions/src/generate-text/openai/responses-web-search-multi-turn-store-false.ts`

## Why

When a provider-executed `web_search` result is replayed on a later turn with `providerOptions.openai.store: false`, the SDK drops the web_search call/result from the outgoing request and emits, once per result:

```
Results for OpenAI tool web_search are not sent to the API when store is false
```

This is because `convertToOpenAIResponsesInput` only re-sends a prior provider-executed tool result as an `item_reference` (which requires server-side storage); with `store: false` there is nothing to reference, so it is dropped (`packages/openai/src/responses/convert-to-openai-responses-input.ts`). The behavior was introduced in #8604 (before that, provider-executed tool results in assistant history were unsupported entirely). The model keeps the prior assistant text but loses the structured search context (query + source URLs).

It surfaces in practice through proxies/gateways that force `store: false` (e.g. AI Gateway disables persistence for its system credentials), where the caller cannot override `store` back to `true`.

## Reproduction (verified, direct to OpenAI)

- `store: false` → turn 1 no warning; turn 2 warns once per dropped result.
- `store: true` (API default) → no warning (prior search sent as `item_reference`).

## Questions for maintainers

1. Is this the intended long-term behavior, or could the SDK offer an opt-in to serialize a dropped provider-executed tool result into plain input content (e.g. `input_text`) when `store: false`, so the model retains the context? The result payload is available at the drop site.
2. Does the Responses API accept an inlined `web_search_call` as an input item when `store: false`, or is `item_reference` (and therefore storage) genuinely the only supported path? OpenAI provides `reasoning.encrypted_content` for reasoning under `store: false` but appears to offer no equivalent for hosted tool results.
3. The warning text ("...when store is false") is misleading behind a gateway/proxy that forces `store: false`, since the caller can't set it to `true`. Worth softening / making it once-per-request?

Note: this is a draft to facilitate discussion; happy to adjust the example or split out the questions into an issue.
