### PR TITLE
fix(devtools): bump hono to ^4.12.25 (CVE-2026-54290)

### DIFF
--- a/.changeset/fix-hono-cve-2026-54290.md
+++ b/.changeset/fix-hono-cve-2026-54290.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/devtools": patch
+---
+
+fix: bump hono to ^4.12.25 to resolve CVE-2026-54290 (CORS Middleware reflects any Origin with credentials when origin defaults to the wildcard)

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
     "@hono/node-server": "^1.19.14",
-    "hono": "^4.12.18"
+    "hono": "^4.12.25"
   },
   "devDependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2157,10 +2157,10 @@ importers:
         version: link:../provider
       '@hono/node-server':
         specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.18)
+        version: 1.19.14(hono@4.12.25)
       hono:
-        specifier: ^4.12.18
-        version: 4.12.18
+        specifier: ^4.12.25
+        version: 4.12.25
     devDependencies:
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
@@ -14691,8 +14691,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hono@4.6.9:
@@ -24066,22 +24066,22 @@ snapshots:
     dependencies:
       hono: 4.6.9
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
 
-  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.18))(hono@4.12.18)':
+  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.25))(hono@4.12.25)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
-      hono: 4.12.18
+      '@hono/node-server': 1.19.14(hono@4.12.25)
+      hono: 4.12.25
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@hono/zod-validator@0.7.6(hono@4.12.18)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.25)(zod@3.25.76)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
       zod: 3.25.76
 
   '@humanfs/core@0.19.2':
@@ -25370,9 +25370,9 @@ snapshots:
   '@langchain/langgraph-api@1.2.1(28cc07ae81636c966ef84fa1a1f62041)':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@hono/node-server': 1.19.14(hono@4.12.18)
-      '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.18))(hono@4.12.18)
-      '@hono/zod-validator': 0.7.6(hono@4.12.18)(zod@3.25.76)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.25))(hono@4.12.25)
+      '@hono/zod-validator': 0.7.6(hono@4.12.25)(zod@3.25.76)
       '@langchain/core': 1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.211.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       '@langchain/langgraph': 1.3.0(@langchain/core@1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.211.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.211.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.20.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(svelte@5.55.7)(vue@3.5.34(typescript@5.8.3))(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
       '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.211.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))
@@ -25383,7 +25383,7 @@ snapshots:
       dedent: 1.7.2
       dotenv: 16.6.1
       exit-hook: 4.0.0
-      hono: 4.12.18
+      hono: 4.12.25
       langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.211.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
       open: 10.2.0
       semver: 7.8.4
@@ -25707,7 +25707,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -25717,7 +25717,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -25731,7 +25731,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -25741,7 +25741,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -34310,7 +34310,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.18: {}
+  hono@4.12.25: {}
 
   hono@4.6.9: {}
 


### PR DESCRIPTION
Fixes [VULN-11847](https://linear.app/vercel/issue/VULN-11847).

## Vulnerability

[CVE-2026-54290](https://nvd.nist.gov/vuln/detail/CVE-2026-54290) (High, CVSS 7.1) — **hono CORS Middleware reflects any Origin with credentials when origin defaults to the wildcard.**

With `credentials: true` and no explicit `origin` (the default wildcard), affected hono versions reflect the request's `Origin` and send `Access-Control-Allow-Credentials: true`, allowing any site to make credentialed cross-origin requests and read the responses. Affected versions: `< 4.12.25`.

`@ai-sdk/devtools` declares `hono` as a direct dependency (`packages/devtools/package.json`).

## Fix

Bump `hono` from `^4.12.18` to `^4.12.25` (the first patched release) and update the lockfile accordingly. The lockfile diff is scoped to hono only.