### PR TITLE
fix(devtools): bump hono to ^4.12.25 (CVE-2026-54290)

### DIFF
--- a/.changeset/vuln-11847-hono-cors-cve-2026-54290.md
+++ b/.changeset/vuln-11847-hono-cors-cve-2026-54290.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+fix(devtools): bump hono to ^4.12.25 to resolve CVE-2026-54290
+
+hono's CORS Middleware reflected any request `Origin` together with `Access-Control-Allow-Credentials: true` when `credentials: true` was set and `origin` was left at the default wildcard, allowing any site to make credentialed cross-origin requests and read the responses (CVE-2026-54290, CVSS 7.1). Bumped `hono` from `^4.6.14` to `^4.12.25`, the first patched release.

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
     "@hono/node-server": "^1.13.7",
-    "hono": "^4.6.14"
+    "hono": "^4.12.25"
   },
   "devDependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1913,10 +1913,10 @@ importers:
         version: link:../provider
       '@hono/node-server':
         specifier: ^1.13.7
-        version: 1.19.9(hono@4.12.3)
+        version: 1.19.9(hono@4.12.25)
       hono:
-        specifier: ^4.6.14
-        version: 4.12.3
+        specifier: ^4.12.25
+        version: 4.12.25
     devDependencies:
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
@@ -13989,6 +13989,10 @@ packages:
     resolution: {integrity: sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+    engines: {node: '>=16.9.0'}
+
   hono@4.12.3:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
     engines: {node: '>=16.9.0'}
@@ -23891,6 +23895,10 @@ snapshots:
     dependencies:
       hono: 4.11.9
 
+  '@hono/node-server@1.19.9(hono@4.12.25)':
+    dependencies:
+      hono: 4.12.25
+
   '@hono/node-server@1.19.9(hono@4.12.3)':
     dependencies:
       hono: 4.12.3
@@ -33699,6 +33707,8 @@ snapshots:
   headers-polyfill@4.0.3: {}
 
   hono@4.11.9: {}
+
+  hono@4.12.25: {}
 
   hono@4.12.3: {}
 


### PR DESCRIPTION
Fixes [VULN-11847](https://linear.app/vercel/issue/VULN-11847) on the `release-v6.0` branch (companion to the `main` fix in #16166).

## Vulnerability

[CVE-2026-54290](https://nvd.nist.gov/vuln/detail/CVE-2026-54290) (High, CVSS 7.1) — **hono CORS Middleware reflects any Origin with credentials when origin defaults to the wildcard.**

With `credentials: true` and no explicit `origin` (the default wildcard), affected hono versions reflect the request's `Origin` and send `Access-Control-Allow-Credentials: true`, allowing any site to make credentialed cross-origin requests and read the responses. Affected versions: `< 4.12.25`.

`@ai-sdk/devtools` declares `hono` as a direct dependency. On `release-v6.0` the declared range was `^4.6.14`, resolving to `4.12.3` (vulnerable).

## Fix

Bump `hono` from `^4.6.14` to `^4.12.25` (the first patched release). The lockfile change is scoped to hono only — a dedicated `hono@4.12.25` resolution was added for `@ai-sdk/devtools` while the existing `hono@4.12.3` resolution is preserved for its other (transitive) consumers.