### PR TITLE
ci: restrict GitHub Actions workflow token permissions

### DIFF
--- a/.github/workflows/ai-provider-api-changes.yml
+++ b/.github/workflows/ai-provider-api-changes.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [ai-provider-api-change]
 
+permissions:
+  contents: read
+
 jobs:
   create-issue:
     name: 'Create Issue for Provider API Change'

--- a/.github/workflows/ai-provider-models.yml
+++ b/.github/workflows/ai-provider-models.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [ai_provider_models]
 
+permissions:
+  contents: read
+
 jobs:
   create-issue:
     name: 'Create Issue for Provider Model Changes'

--- a/.github/workflows/assign-team-pull-request.yml
+++ b/.github/workflows/assign-team-pull-request.yml
@@ -5,11 +5,13 @@ on:
     types: [opened]
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   assign:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     # Only assign pull requests by team members, ignore pull requests from forks
     # And only assign if pull request was created by a user, ignore bots
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type == 'User'

--- a/.github/workflows/auto-merge-release-prs.yml
+++ b/.github/workflows/auto-merge-release-prs.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   enable-auto-merge:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,15 +21,16 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.pull_request_number }}
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   resolve-pr:
     name: Resolve backport PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.repository_owner == 'vercel'
     outputs:
       should-backport: ${{ steps.resolve.outputs.should-backport }}
@@ -307,6 +308,10 @@ jobs:
     concurrency:
       group: backport-${{ needs.resolve-pr.outputs.pr-number }}-${{ needs.find-branch.outputs.release-branch }}
       cancel-in-progress: false
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Configure Git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release-v*
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: 'Lint & Format'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,17 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
     # do not attempt running in forks
     if: github.repository_owner == 'vercel'
     steps:

--- a/.github/workflows/slack-team-review-notification.yml
+++ b/.github/workflows/slack-team-review-notification.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [review_requested]
 
+permissions:
+  contents: read
+
 jobs:
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/slack-workflow-failure-notification.yml
+++ b/.github/workflows/slack-workflow-failure-notification.yml
@@ -10,6 +10,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   notify-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-model-settings.yml
+++ b/.github/workflows/update-model-settings.yml
@@ -18,8 +18,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-models:
@@ -27,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.repository_owner == 'vercel'
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - '.changeset/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   verify-changesets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Fixes OSSF Scorecard Token-Permissions check (currently scored 0/10) by adding a top-level `permissions: contents: read` block to every workflow file under `.github/workflows/`
- Moves required write scopes from the top level to the specific jobs that need them
- Two workflows use non-default tokens for their write operations and need no job-level write block:
  - `ai-provider-api-changes.yml` and `ai-provider-models.yml` use a GitHub App token (`actions/create-github-app-token`) — the default `GITHUB_TOKEN` only needs read access
  - `auto-merge-release-prs.yml` uses a PAT (`secrets.GR2M_PR_REVIEW_TOKEN`) for merge/approve — the default token needs no write

## Per-file changes

| File | Top-level | Job-level writes added |
|------|-----------|----------------------|
| `ai-provider-api-changes.yml` | `contents: read` (added) | none (uses app token) |
| `ai-provider-models.yml` | `contents: read` (added) | none (uses app token) |
| `assign-team-pull-request.yml` | `contents: read` (was `pull-requests: write`) | `assign`: `pull-requests: write` |
| `auto-merge-release-prs.yml` | `contents: read` (removed `pull-requests: write`) | none (uses PAT) |
| `backport.yml` | `contents: read` (was `contents/issues/pull-requests: write`) | `resolve-pr`: `contents: read, pull-requests: write`; `backport`: `contents/issues/pull-requests: write` |
| `ci.yml` | `contents: read` (added) | none (read-only) |
| `release.yml` | `contents: read` (was `id-token/contents/pull-requests/issues: write`) | `release`: `id-token/contents/pull-requests/issues: write` |
| `slack-team-review-notification.yml` | `contents: read` (added) | none (curl only) |
| `slack-workflow-failure-notification.yml` | `contents: read` (added) | none (curl only) |
| `update-model-settings.yml` | `contents: read` (was `contents/pull-requests: write`) | `update-models`: `contents/pull-requests: write` |
| `verify-changesets.yml` | `contents: read` (added) | none (read-only) |