### PR TITLE
docs: sort migration guide sections

### DIFF
--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -57,7 +57,9 @@ If your `package.json` does not already include `"type": "module"`, add it or re
 
 ## AI SDK Core
 
-### Provider Management: Remove Deprecated `experimental_customProvider`
+### Core API Renames and Removals
+
+#### Provider Management: Remove Deprecated `experimental_customProvider`
 
 The deprecated `experimental_customProvider` export has been removed in AI SDK 7. Replace it with `customProvider`.
 
@@ -84,7 +86,7 @@ export const myProvider = customProvider({
 This is only an import and symbol rename. The `customProvider` options and
 behavior are unchanged.
 
-### Image Generation: Remove Deprecated `experimental_generateImage` Export
+#### Remove Deprecated `experimental_generateImage` Export
 
 The deprecated `experimental_generateImage` export has been removed in AI SDK 7. Replace it with `generateImage`.
 
@@ -112,7 +114,7 @@ const result: GenerateImageResult = await generateImage({
 });
 ```
 
-### Transcription: `experimental_transcribe` Renamed to `transcribe`
+#### `experimental_transcribe` Renamed to `transcribe`
 
 The transcription API has graduated out of experimental status and has been
 renamed to `transcribe`. The `Experimental_TranscriptionResult` type has also
@@ -142,7 +144,7 @@ const result: TranscriptionResult = await transcribe({
 The old names continue to work as deprecated aliases in AI SDK 7 and will be
 removed in a future major release.
 
-### Speech: `experimental_generateSpeech` Renamed to `generateSpeech`
+#### `experimental_generateSpeech` Renamed to `generateSpeech`
 
 The speech generation function has graduated out of experimental status and has
 been renamed to `generateSpeech`. The `Experimental_SpeechResult` type has also
@@ -170,7 +172,66 @@ The old `experimental_generateSpeech` and `Experimental_SpeechResult` exports
 continue to work as deprecated aliases in AI SDK 7 and will be removed in a
 future major release.
 
-### Prompt Instructions: `system` Renamed to `instructions`
+#### Structured Outputs: Remove Deprecated `experimental_output` Option and Result
+
+The deprecated `experimental_output` option has been removed in AI SDK 7. Replace all remaining usages with `output`.
+
+The deprecated `generateText()` result property `experimental_output` has also been removed. Read `result.output` instead.
+
+This name was deprecated in AI SDK 6, so if you already migrated to `output`, no changes are needed. Otherwise, update both the call options and any result access:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  experimental_output: Output.object({
+    schema: recipeSchema,
+  }),
+  prompt: 'Generate a recipe.',
+});
+
+console.log(result.experimental_output);
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  output: Output.object({
+    schema: recipeSchema,
+  }),
+  prompt: 'Generate a recipe.',
+});
+
+console.log(result.output);
+```
+
+#### `CallSettings` Renamed to `LanguageModelCallOptions` and `RequestOptions`
+
+`CallSettings` has been split into `LanguageModelCallOptions` (model-facing options) and `RequestOptions` (transport options). Replace usages in custom wrappers or helpers:
+
+- `CallSettings` → `LanguageModelCallOptions & Omit<RequestOptions, 'timeout'>` (note: `CallSettings` never included `timeout`)
+- `prepareCallSettings` → `prepareLanguageModelCallOptions`
+
+Both deprecated names remain available in AI SDK 7.
+
+#### Stop Condition Helper Rename: `stepCountIs` -> `isStepCount`
+
+Rename imports and usage in tool-loop stop conditions:
+
+```tsx filename="Before"
+import { stepCountIs } from 'ai';
+
+stopWhen: stepCountIs(3);
+```
+
+```tsx filename="After"
+import { isStepCount } from 'ai';
+
+stopWhen: isStepCount(3);
+```
+
+### Prompts and Step Preparation
+
+#### `system` Renamed to `instructions`
 
 The top-level prompt option for system instructions has been renamed from
 `system` to `instructions`.
@@ -299,6 +360,105 @@ const result = await generateText({
 });
 ```
 
+#### Prompt Messages: System Messages in `prompt` or `messages` Are Rejected by Default
+
+AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `instructions` option.
+
+This can break older persisted chats or custom prompt arrays that include `{ role: 'system' }` messages:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Hello!' },
+  ],
+});
+```
+
+Move system instructions to the `instructions` option when possible:
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  instructions: 'You are a helpful assistant.',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
+
+If you need to keep existing chat histories that already contain system messages, opt in to the previous behavior with `allowSystemInMessages: true`:
+
+<Note type="warning">
+  Only use `allowSystemInMessages` for trusted messages. If users can submit or
+  edit these messages, they could inject a system message that overrides or sets
+  the system prompt. In most cases, system instructions should only be set by
+  trusted server-side code through the `instructions` property.
+</Note>
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  allowSystemInMessages: true,
+  messages: persistedMessages,
+});
+```
+
+This applies to AI SDK functions that accept `prompt` or `messages`, including `generateText`, `streamText`, `generateObject`, `streamObject`, and `streamUI`.
+
+#### Remove Deprecated `experimental_prepareStep` Option
+
+The deprecated `experimental_prepareStep` option has been removed in AI SDK 7. Replace all remaining usages with `prepareStep`.
+
+This option was deprecated in AI SDK 5, so if you already migrated to `prepareStep`, no changes are needed. Otherwise, update `generateText` calls:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  tools: { weather },
+  experimental_prepareStep: ({ stepNumber }) => {
+    console.log('Preparing step', stepNumber);
+    return {
+      activeTools: ['weather'],
+    };
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  tools: { weather },
+  prepareStep: ({ stepNumber }) => {
+    console.log('Preparing step', stepNumber);
+    return {
+      activeTools: ['weather'],
+    };
+  },
+});
+```
+
+#### `prepareStep` Message Overrides Carry Forward
+
+When `prepareStep` returns `messages`, those messages are now used as the base for subsequent steps. The next step receives those messages plus the response messages from the previous step.
+
+In AI SDK 6, a `messages` override only applied to the current step. To keep that behavior, rebuild the current step's messages from `initialMessages` and `responseMessages` inside `prepareStep`:
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  tools: { weather },
+  prepareStep: ({ initialMessages, responseMessages }) => {
+    return {
+      messages: [
+        ...initialMessages,
+        ...responseMessages,
+        // add any one-step-only message changes here
+      ],
+    };
+  },
+});
+```
+
 ### Lifecycle Events
 
 #### `experimental_onStart` Renamed to `onStart`
@@ -414,43 +574,6 @@ The `onStepFinish` option is still accepted as a deprecated alias for
 user-facing callbacks. When both `onStepEnd` and `onStepFinish` are provided,
 `onStepEnd` takes precedence.
 
-#### Tool Execution Callbacks
-
-The tool execution callback options for `generateText` and `streamText` have been renamed:
-
-- `experimental_onToolCallStart` is now `onToolExecutionStart`
-- `experimental_onToolCallFinish` is now `onToolExecutionEnd`
-
-The old names continue to work as deprecated aliases in AI SDK 7 and will be removed in a future major release. They are only used as fallbacks when the new callback names are not provided.
-
-```tsx filename="AI SDK 6"
-const result = await generateText({
-  model: yourModel,
-  tools,
-  prompt: 'Hello',
-  experimental_onToolCallStart(event) {
-    console.log('Tool starting:', event.toolCall.toolName);
-  },
-  experimental_onToolCallFinish(event) {
-    console.log('Tool finished:', event.toolCall.toolName);
-  },
-});
-```
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  tools,
-  prompt: 'Hello',
-  onToolExecutionStart(event) {
-    console.log('Tool starting:', event.toolCall.toolName);
-  },
-  onToolExecutionEnd(event) {
-    console.log('Tool finished:', event.toolCall.toolName);
-  },
-});
-```
-
 #### Embed Callbacks
 
 The per-call callback option for completed `embed` and `embedMany` operations has been renamed from `experimental_onFinish` to `onEnd`.
@@ -501,82 +624,9 @@ const result = await rerank({
 });
 ```
 
-### `StreamTextResult.fullStream` Renamed to `stream`
+### Usage and Result Shape Changes
 
-The full event stream returned by `streamText` has been renamed from
-`fullStream` to `stream`.
-
-```tsx filename="AI SDK 6"
-const result = streamText({
-  model: yourModel,
-  prompt: 'Hello!',
-});
-
-for await (const part of result.fullStream) {
-  console.log(part);
-}
-```
-
-```tsx filename="AI SDK 7"
-const result = streamText({
-  model: yourModel,
-  prompt: 'Hello!',
-});
-
-for await (const part of result.stream) {
-  console.log(part);
-}
-```
-
-The `fullStream` property is still available as a deprecated alias for
-`stream`.
-
-### Prompt Messages: System Messages in `prompt` or `messages` Are Rejected by Default
-
-AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `instructions` option.
-
-This can break older persisted chats or custom prompt arrays that include `{ role: 'system' }` messages:
-
-```tsx filename="AI SDK 6"
-const result = await generateText({
-  model: yourModel,
-  messages: [
-    { role: 'system', content: 'You are a helpful assistant.' },
-    { role: 'user', content: 'Hello!' },
-  ],
-});
-```
-
-Move system instructions to the `instructions` option when possible:
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  instructions: 'You are a helpful assistant.',
-  messages: [{ role: 'user', content: 'Hello!' }],
-});
-```
-
-If you need to keep existing chat histories that already contain system messages, opt in to the previous behavior with `allowSystemInMessages: true`:
-
-<Note type="warning">
-  Only use `allowSystemInMessages` for trusted messages. If users can submit or
-  edit these messages, they could inject a system message that overrides or sets
-  the system prompt. In most cases, system instructions should only be set by
-  trusted server-side code through the `instructions` property.
-</Note>
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  allowSystemInMessages: true,
-  messages: persistedMessages,
-});
-```
-
-This applies to AI SDK functions that accept `prompt` or `messages`, including `generateText`, `streamText`, `generateObject`, `streamObject`, and `streamUI`.
-
-### `cachedInputTokens` and `reasoningTokens` Removed from `LanguageModelUsage`
+#### `cachedInputTokens` and `reasoningTokens` Removed from `LanguageModelUsage`
 
 The deprecated top-level `cachedInputTokens` and `reasoningTokens` fields have been removed from `LanguageModelUsage`.
 
@@ -825,7 +875,39 @@ const telemetry: Telemetry = {
 };
 ```
 
-### `streamText` `onChunk` Receives All Stream Parts
+### Streaming and Include Options
+
+#### `StreamTextResult.fullStream` Renamed to `stream`
+
+The full event stream returned by `streamText` has been renamed from
+`fullStream` to `stream`.
+
+```tsx filename="AI SDK 6"
+const result = streamText({
+  model: yourModel,
+  prompt: 'Hello!',
+});
+
+for await (const part of result.fullStream) {
+  console.log(part);
+}
+```
+
+```tsx filename="AI SDK 7"
+const result = streamText({
+  model: yourModel,
+  prompt: 'Hello!',
+});
+
+for await (const part of result.stream) {
+  console.log(part);
+}
+```
+
+The `fullStream` property is still available as a deprecated alias for
+`stream`.
+
+#### `streamText` `onChunk` Receives All Stream Parts
 
 In AI SDK 7, `streamText` calls `onChunk` for every `TextStreamPart` emitted by
 the stream. In AI SDK 6, `onChunk` only received a subset of stream parts such as
@@ -851,7 +933,7 @@ const result = streamText({
 `reasoning-end`, `tool-input-end`, `finish-step`, `finish`, `abort`, and
 `error`.
 
-### Streaming: Move `includeRawChunks` to `include.rawChunks`
+#### Move `includeRawChunks` to `include.rawChunks`
 
 The top-level `includeRawChunks` option on `streamText` is deprecated in AI SDK 7. Move it into the `include` options object as `rawChunks`.
 
@@ -875,7 +957,7 @@ const result = streamText({
 
 The deprecated top-level option continues to work in AI SDK 7, so you can migrate incrementally.
 
-### Rename `experimental_include` to `include`
+#### Rename `experimental_include` to `include`
 
 The `experimental_include` option for `generateText`, `streamText`, and
 `ToolLoopAgent` is now stable and has been renamed to `include`.
@@ -904,7 +986,7 @@ The deprecated `experimental_include` name continues to work for backwards
 compatibility. If both `include` and `experimental_include` are provided,
 `include` takes precedence.
 
-### Request and Response Bodies Are Excluded by Default
+#### Request and Response Bodies Are Excluded by Default
 
 In AI SDK 7, `generateText` and `streamText` no longer include request bodies in
 step results by default. `generateText` also no longer includes response bodies
@@ -937,7 +1019,9 @@ const result = streamText({
 });
 ```
 
-### Step Response Messages Are No Longer Accumulated
+### Result Message Changes
+
+#### Step Response Messages Are No Longer Accumulated
 
 In AI SDK 7, `step.response.messages` on each `StepResult` only contains the
 response messages produced by that particular step.
@@ -973,7 +1057,46 @@ Prefer `result.responseMessages` when you want the full response message history
 It also includes response messages produced before the first model step, such as
 tool results from approved tool calls in the input messages.
 
-### Context: `experimental_context` Became Tool `context`, and Shared Runtime Data Moved to `runtimeContext`
+### Tools and Tool Execution
+
+#### Tool Execution Callbacks
+
+The tool execution callback options for `generateText` and `streamText` have been renamed:
+
+- `experimental_onToolCallStart` is now `onToolExecutionStart`
+- `experimental_onToolCallFinish` is now `onToolExecutionEnd`
+
+The old names continue to work as deprecated aliases in AI SDK 7 and will be removed in a future major release. They are only used as fallbacks when the new callback names are not provided.
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  tools,
+  prompt: 'Hello',
+  experimental_onToolCallStart(event) {
+    console.log('Tool starting:', event.toolCall.toolName);
+  },
+  experimental_onToolCallFinish(event) {
+    console.log('Tool finished:', event.toolCall.toolName);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  tools,
+  prompt: 'Hello',
+  onToolExecutionStart(event) {
+    console.log('Tool starting:', event.toolCall.toolName);
+  },
+  onToolExecutionEnd(event) {
+    console.log('Tool finished:', event.toolCall.toolName);
+  },
+});
+```
+
+#### Context: `experimental_context` Became Tool `context`, and Shared Runtime Data Moved to `runtimeContext`
 
 In AI SDK 7, the tool callback option previously exposed as `experimental_context` has been renamed to `context` and is now stable.
 
@@ -1052,39 +1175,7 @@ Potential breaking issues:
 - If at least one tool declares `contextSchema`, `toolsContext` becomes required and only includes the tools that actually declare contextual data.
 - If you were relying on every tool callback seeing the same full runtime object, move shared step data to `runtimeContext`, or explicitly provide the needed per-tool data in each tool's `toolsContext` entry.
 
-### Structured Outputs: Remove Deprecated `experimental_output` Option and Result
-
-The deprecated `experimental_output` option has been removed in AI SDK 7. Replace all remaining usages with `output`.
-
-The deprecated `generateText()` result property `experimental_output` has also been removed. Read `result.output` instead.
-
-This name was deprecated in AI SDK 6, so if you already migrated to `output`, no changes are needed. Otherwise, update both the call options and any result access:
-
-```tsx filename="AI SDK 6"
-const result = await generateText({
-  model: yourModel,
-  experimental_output: Output.object({
-    schema: recipeSchema,
-  }),
-  prompt: 'Generate a recipe.',
-});
-
-console.log(result.experimental_output);
-```
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  output: Output.object({
-    schema: recipeSchema,
-  }),
-  prompt: 'Generate a recipe.',
-});
-
-console.log(result.output);
-```
-
-### Tools: Migrate Deprecated `needsApproval` to `toolApproval`
+#### Migrate Deprecated `needsApproval` to `toolApproval`
 
 The `needsApproval` property on `tool()` and `dynamicTool()` is deprecated in
 AI SDK 7 for `generateText`, `streamText`, and `ToolLoopAgent`.
@@ -1138,7 +1229,7 @@ If you were using `needsApproval: true`, migrate it to
 `SingleToolApprovalFunction` or a generic `toolApproval` callback. This
 guidance applies to `generateText`, `streamText`, and `ToolLoopAgent`.
 
-### Tools: Remove Deprecated `experimental_activeTools` Option
+#### Remove Deprecated `experimental_activeTools` Option
 
 The deprecated `experimental_activeTools` option has been removed in AI SDK 7. Replace all remaining usages with `activeTools`.
 
@@ -1160,61 +1251,7 @@ const result = await generateText({
 });
 ```
 
-### Core: Remove Deprecated `experimental_prepareStep` Option
-
-The deprecated `experimental_prepareStep` option has been removed in AI SDK 7. Replace all remaining usages with `prepareStep`.
-
-This option was deprecated in AI SDK 5, so if you already migrated to `prepareStep`, no changes are needed. Otherwise, update `generateText` calls:
-
-```tsx filename="AI SDK 6"
-const result = await generateText({
-  model: yourModel,
-  tools: { weather },
-  experimental_prepareStep: ({ stepNumber }) => {
-    console.log('Preparing step', stepNumber);
-    return {
-      activeTools: ['weather'],
-    };
-  },
-});
-```
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  tools: { weather },
-  prepareStep: ({ stepNumber }) => {
-    console.log('Preparing step', stepNumber);
-    return {
-      activeTools: ['weather'],
-    };
-  },
-});
-```
-
-### Core: `prepareStep` Message Overrides Carry Forward
-
-When `prepareStep` returns `messages`, those messages are now used as the base for subsequent steps. The next step receives those messages plus the response messages from the previous step.
-
-In AI SDK 6, a `messages` override only applied to the current step. To keep that behavior, rebuild the current step's messages from `initialMessages` and `responseMessages` inside `prepareStep`:
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  tools: { weather },
-  prepareStep: ({ initialMessages, responseMessages }) => {
-    return {
-      messages: [
-        ...initialMessages,
-        ...responseMessages,
-        // add any one-step-only message changes here
-      ],
-    };
-  },
-});
-```
-
-### Tools: Remove Deprecated `ToolCallOptions` Type
+#### Remove Deprecated `ToolCallOptions` Type
 
 The deprecated `ToolCallOptions` type has been removed in AI SDK 7. Replace all remaining usages with `ToolExecutionOptions`.
 
@@ -1236,7 +1273,9 @@ function executeWithOptions(options: ToolExecutionOptions) {
 }
 ```
 
-### UI Messages: Remove Deprecated `isToolOrDynamicToolUIPart` Function
+### UI Messages
+
+#### Remove Deprecated `isToolOrDynamicToolUIPart` Function
 
 The deprecated `isToolOrDynamicToolUIPart` function has been removed in AI SDK 7. Replace all remaining usages with `isToolUIPart`.
 
@@ -1258,13 +1297,15 @@ if (isToolUIPart(part)) {
 }
 ```
 
-### Tools: Remove Deprecated `media` Content Part Type
+### Tool and Message Content Parts
+
+#### Remove Deprecated `media` Content Part Type
 
 The deprecated tool result content part of `{ type: 'media' }` has been removed in AI SDK 7.
 
 Use `{ type: 'file-data' }` for all inline file content, including images.
 
-### Tool Result Content: Migrate Away From `image-*` and `file-*` variants to `file`
+#### Tool Result Content: Migrate Away From `image-*` and `file-*` variants to `file`
 
 All `image-*` and legacy `file-*` content part types for `toModelOutput` results are deprecated in AI SDK 7 in favor of a single canonical `file` variant that mirrors the top-level `FilePart` shape. Auto-migration is applied at runtime, so existing tool outputs continue to work without code changes. However, updating to the new shape is recommended.
 
@@ -1287,7 +1328,7 @@ The `-id` content part types (`file-id` and `image-file-id`) are also generally 
 
 `mediaType` on the new `file` variant accepts either a full IANA type (e.g. `'image/png'`) or just a top-level segment (e.g. `'image'`, `'audio'`, `'video'`, `'text'`). When only a top-level segment is provided, the subtype is auto-detected from inline bytes where possible. Update parsing/validation and discriminated unions to handle the single canonical `file` variant.
 
-### Message Parts: Migrate Away From Deprecated `image` Part
+#### Message Parts: Migrate Away From Deprecated `image` Part
 
 The `{ type: 'image', image, mediaType? }` user-message content part is deprecated. Use `{ type: 'file', data, mediaType }` with an image `mediaType` instead.
 
@@ -1301,7 +1342,7 @@ The `{ type: 'image', image, mediaType? }` user-message content part is deprecat
 
 `mediaType` on `FilePart` now accepts either a full IANA type (e.g. `'image/png'`) or just a top-level segment (e.g. `'image'`). When only a top-level segment is provided, the subtype is auto-detected from inline bytes where possible.
 
-### Message Parts: Handle New `reasoning-file` Content Type
+#### Message Parts: Handle New `reasoning-file` Content Type
 
 Some models can now return files as part of their reasoning trace, separate from regular output files. These files, which would have previously were using the `file` type, are now in a distinct `reasoning-file` type.
 
@@ -1309,7 +1350,9 @@ Update all exhaustive part handling (TypeScript unions, `switch` statements, run
 
 Also audit any code that reads generated files from `result.files` or `step.files`: files referenced in reasoning are now represented as `reasoning-file` parts in `content` / `reasoning`. In practice, this should rarely require an update because models usually reference the same file in their reasoning that they later output as regular content. Prior to supporting `reasoning-file` as a distinct type, this would result in the same files appearing in `result.files` or `step.files` as a duplicate.
 
-### Reasoning Configuration: Remove Overlapping Settings
+### Reasoning
+
+#### Reasoning Configuration: Remove Overlapping Settings
 
 The new top-level `reasoning` option is the provider-agnostic way to control reasoning effort.
 
@@ -1317,16 +1360,9 @@ When migrating to the top-level `reasoning` option, remove overlapping reasoning
 
 If both are present, provider-specific reasoning settings in `providerOptions` take precedence, which can silently bypass your new top-level `reasoning` configuration.
 
-### Settings: `CallSettings` Renamed to `LanguageModelCallOptions` and `RequestOptions`
+### Multi-Step Result Shape
 
-`CallSettings` has been split into `LanguageModelCallOptions` (model-facing options) and `RequestOptions` (transport options). Replace usages in custom wrappers or helpers:
-
-- `CallSettings` → `LanguageModelCallOptions & Omit<RequestOptions, 'timeout'>` (note: `CallSettings` never included `timeout`)
-- `prepareCallSettings` → `prepareLanguageModelCallOptions`
-
-Both deprecated names remain available in AI SDK 7.
-
-### `generateText` and `streamText` `usage` Now Includes All Steps
+#### `generateText` and `streamText` `usage` Now Includes All Steps
 
 The `usage` property on `generateText` and `streamText` results now returns the total token usage across all steps. This matches what `totalUsage` previously represented.
 
@@ -1356,7 +1392,7 @@ console.log(result.usage); // all steps
 
 `totalUsage` is deprecated. Replace `result.totalUsage` with `result.usage`.
 
-### `generateText` and `streamText` Result Properties Now Include All Steps
+#### `generateText` and `streamText` Result Properties Now Include All Steps
 
 The top-level `content`, `toolCalls`, `staticToolCalls`, `dynamicToolCalls`,
 `toolResults`, `staticToolResults`, `dynamicToolResults`, `files`, `sources`,
@@ -1427,7 +1463,7 @@ console.log(await result.warnings); // all steps
 console.log(await result.content); // all steps
 ```
 
-### Final-Step Result Properties Moved to `finalStep`
+#### Final-Step Result Properties Moved to `finalStep`
 
 The top-level `reasoning`, `reasoningText`, `request`, `response`, and `providerMetadata` result properties on `generateText` and `streamText` are deprecated in AI SDK 7.
 
@@ -1477,7 +1513,7 @@ console.log(finalStep.response.headers);
 
 The deprecated top-level aliases continue to work in AI SDK 7 so you can migrate incrementally.
 
-### `generateText` and `streamText` `onEnd` Result Properties Changed
+#### `generateText` and `streamText` `onEnd` Result Properties Changed
 
 The `onEnd` callback for `generateText`, `streamText`, and agents follows
 the same result property changes as `generateText` and `streamText` results:
@@ -1522,23 +1558,9 @@ const result = await generateText({
 The deprecated top-level aliases on the `onEnd` event continue to work in AI
 SDK 7 so you can migrate incrementally.
 
-### Stop Condition Helper Rename: `stepCountIs` -> `isStepCount`
+### Stream Response Helpers
 
-Rename imports and usage in tool-loop stop conditions:
-
-```tsx filename="Before"
-import { stepCountIs } from 'ai';
-
-stopWhen: stepCountIs(3);
-```
-
-```tsx filename="After"
-import { isStepCount } from 'ai';
-
-stopWhen: isStepCount(3);
-```
-
-### `streamText` Response Helpers Deprecated — Use Stateless Helpers
+#### `streamText` Response Helpers Deprecated — Use Stateless Helpers
 
 The `toUIMessageStream`, `toUIMessageStreamResponse`, `pipeUIMessageStreamToResponse`, `toTextStreamResponse`, and `pipeTextStreamToResponse` methods on the `streamText` result are now deprecated. They still work in v7 (with deprecation warnings) and will be removed in the next major release.
 

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -299,6 +299,8 @@ const result = await generateText({
 });
 ```
 
+### Lifecycle Events
+
 #### `experimental_onStart` Renamed to `onStart`
 
 The generation start callback for `generateText`, `streamText`, and agents has
@@ -412,7 +414,94 @@ The `onStepFinish` option is still accepted as a deprecated alias for
 user-facing callbacks. When both `onStepEnd` and `onStepFinish` are provided,
 `onStepEnd` takes precedence.
 
-#### `StreamTextResult.fullStream` Renamed to `stream`
+#### Tool Execution Callbacks
+
+The tool execution callback options for `generateText` and `streamText` have been renamed:
+
+- `experimental_onToolCallStart` is now `onToolExecutionStart`
+- `experimental_onToolCallFinish` is now `onToolExecutionEnd`
+
+The old names continue to work as deprecated aliases in AI SDK 7 and will be removed in a future major release. They are only used as fallbacks when the new callback names are not provided.
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  tools,
+  prompt: 'Hello',
+  experimental_onToolCallStart(event) {
+    console.log('Tool starting:', event.toolCall.toolName);
+  },
+  experimental_onToolCallFinish(event) {
+    console.log('Tool finished:', event.toolCall.toolName);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  tools,
+  prompt: 'Hello',
+  onToolExecutionStart(event) {
+    console.log('Tool starting:', event.toolCall.toolName);
+  },
+  onToolExecutionEnd(event) {
+    console.log('Tool finished:', event.toolCall.toolName);
+  },
+});
+```
+
+#### Embed Callbacks
+
+The per-call callback option for completed `embed` and `embedMany` operations has been renamed from `experimental_onFinish` to `onEnd`.
+
+```tsx filename="AI SDK 6"
+const result = await embed({
+  model: yourEmbeddingModel,
+  value,
+  experimental_onFinish(event) {
+    console.log('Embedding finished:', event.usage.tokens);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await embed({
+  model: yourEmbeddingModel,
+  value,
+  onEnd(event) {
+    console.log('Embedding ended:', event.usage.tokens);
+  },
+});
+```
+
+#### Rerank Callback
+
+The per-call callback option for completed `rerank` operations has been renamed from `experimental_onFinish` to `onEnd`.
+
+```tsx filename="AI SDK 6"
+const result = await rerank({
+  model: yourRerankingModel,
+  documents,
+  query,
+  experimental_onFinish(event) {
+    console.log('Rerank finished:', event.ranking.length);
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await rerank({
+  model: yourRerankingModel,
+  documents,
+  query,
+  onEnd(event) {
+    console.log('Rerank ended:', event.ranking.length);
+  },
+});
+```
+
+### `StreamTextResult.fullStream` Renamed to `stream`
 
 The full event stream returned by `streamText` has been renamed from
 `fullStream` to `stream`.
@@ -513,7 +602,9 @@ console.log(result.usage.inputTokenDetails.cacheReadTokens);
 console.log(result.usage.outputTokenDetails.reasoningTokens);
 ```
 
-### Telemetry: OpenTelemetry Moved to `@ai-sdk/otel` — Explicit Registration Required
+### Telemetry
+
+#### OpenTelemetry Moved to `@ai-sdk/otel`
 
 OpenTelemetry span collection is no longer built into the `ai` package. To continue receiving OpenTelemetry traces, you must install the new `@ai-sdk/otel` package and register the `OpenTelemetry` instance globally.
 
@@ -548,7 +639,7 @@ For Node.js applications (without Next.js), register the integration at the top 
 
 This applies to all AI SDK functions that accept `experimental_telemetry`, including `generateText`, `streamText`, `ToolLoopAgent`, `embed`, `embedMany`, and `rerank`.
 
-### Telemetry: Enabled by Default When an Integration Is Registered
+#### Enabled by Default When an Integration Is Registered
 
 In AI SDK 6, telemetry was opt-in — you had to set `experimental_telemetry: { isEnabled: true }` on every call to emit events. In AI SDK 7, telemetry is opt-out: once you register a telemetry integration (for example `OpenTelemetry` or `DevToolsTelemetry`), all AI SDK calls emit telemetry events by default.
 
@@ -612,7 +703,7 @@ To disable telemetry globally, do not register any telemetry integrations.
 
 This applies to all AI SDK functions that accept `experimental_telemetry`, including `generateText`, `streamText`, `ToolLoopAgent`, `embed`, `embedMany`, and `rerank`.
 
-### Telemetry: `tracer` Property Removed from `experimental_telemetry`
+#### `tracer` Property Removed from `experimental_telemetry`
 
 The `tracer` property on `experimental_telemetry` has been removed. If you were passing a custom OpenTelemetry `Tracer`, pass it to the `OpenTelemetry` constructor instead:
 
@@ -646,7 +737,7 @@ This applies to all AI SDK functions that accept `experimental_telemetry`, inclu
 
 If you were not passing a custom `tracer` (relying on the default global tracer), no changes are needed — the `OpenTelemetry` is registered globally by default and uses `trace.getTracer('ai')` when no custom tracer is provided.
 
-### Telemetry: `experimental_telemetry` Renamed to `telemetry`
+#### `experimental_telemetry` Renamed to `telemetry`
 
 The telemetry option has graduated out of experimental status and has been renamed to `telemetry`. The old name `experimental_telemetry` continues to work as a deprecated alias in AI SDK 7 and will be removed in a future major release.
 
@@ -678,44 +769,7 @@ This applies to all AI SDK functions and agents that accept telemetry configurat
 
 No behavior changes beyond the rename. You can migrate incrementally — mixed usage of `telemetry` and `experimental_telemetry` in the same codebase is supported during the deprecation window.
 
-### Tool Execution Callbacks: `experimental_onToolCallStart` and `experimental_onToolCallFinish` Renamed
-
-The tool execution callback options for `generateText` and `streamText` have been renamed:
-
-- `experimental_onToolCallStart` is now `onToolExecutionStart`
-- `experimental_onToolCallFinish` is now `onToolExecutionEnd`
-
-The old names continue to work as deprecated aliases in AI SDK 7 and will be removed in a future major release. They are only used as fallbacks when the new callback names are not provided.
-
-```tsx filename="AI SDK 6"
-const result = await generateText({
-  model: yourModel,
-  tools,
-  prompt: 'Hello',
-  experimental_onToolCallStart(event) {
-    console.log('Tool starting:', event.toolCall.toolName);
-  },
-  experimental_onToolCallFinish(event) {
-    console.log('Tool finished:', event.toolCall.toolName);
-  },
-});
-```
-
-```tsx filename="AI SDK 7"
-const result = await generateText({
-  model: yourModel,
-  tools,
-  prompt: 'Hello',
-  onToolExecutionStart(event) {
-    console.log('Tool starting:', event.toolCall.toolName);
-  },
-  onToolExecutionEnd(event) {
-    console.log('Tool finished:', event.toolCall.toolName);
-  },
-});
-```
-
-### Telemetry Rerank Callback: `onRerankFinish` Renamed to `onRerankEnd`
+#### `onRerankFinish` Renamed to `onRerankEnd`
 
 The telemetry integration callback for individual reranking model calls has been renamed from `onRerankFinish` to `onRerankEnd`.
 
@@ -743,7 +797,7 @@ const telemetry: Telemetry = {
 };
 ```
 
-### Telemetry Embed Callback: `onEmbedFinish` Renamed to `onEmbedEnd`
+#### `onEmbedFinish` Renamed to `onEmbedEnd`
 
 The telemetry integration callback for individual embedding model calls has been renamed from `onEmbedFinish` to `onEmbedEnd`.
 
@@ -769,56 +823,6 @@ const telemetry: Telemetry = {
     console.log('Embedding ended:', event.embeddings.length);
   },
 };
-```
-
-### Embed Callbacks: `experimental_onFinish` Renamed to `experimental_onEnd`
-
-The per-call callback option for completed `embed` and `embedMany` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.
-
-```tsx filename="AI SDK 6"
-const result = await embed({
-  model: yourEmbeddingModel,
-  value,
-  experimental_onFinish(event) {
-    console.log('Embedding finished:', event.usage.tokens);
-  },
-});
-```
-
-```tsx filename="AI SDK 7"
-const result = await embed({
-  model: yourEmbeddingModel,
-  value,
-  experimental_onEnd(event) {
-    console.log('Embedding ended:', event.usage.tokens);
-  },
-});
-```
-
-### Rerank Callback: `experimental_onFinish` Renamed to `experimental_onEnd`
-
-The per-call callback option for completed `rerank` operations has been renamed from `experimental_onFinish` to `experimental_onEnd`.
-
-```tsx filename="AI SDK 6"
-const result = await rerank({
-  model: yourRerankingModel,
-  documents,
-  query,
-  experimental_onFinish(event) {
-    console.log('Rerank finished:', event.ranking.length);
-  },
-});
-```
-
-```tsx filename="AI SDK 7"
-const result = await rerank({
-  model: yourRerankingModel,
-  documents,
-  query,
-  experimental_onEnd(event) {
-    console.log('Rerank ended:', event.ranking.length);
-  },
-});
 ```
 
 ### `streamText` `onChunk` Receives All Stream Parts


### PR DESCRIPTION
## Background

Ordering and grouping the sections in the migration guide properly

## Summary

the new structure looks like:

```
# Migrate AI SDK 6.x to 7.0

## Recommended Migration Process

## All Packages
### Minimum Node.js Version
### ESM Only — CommonJS Support Removed

## AI SDK Core
### Core API Renames and Removals
### Prompts and Step Preparation
### Lifecycle Events
### Usage and Result Shape Changes
### Telemetry
### Streaming and Include Options
### Result Message Changes
### Tools and Tool Execution
### UI Messages
### Tool and Message Content Parts
### Reasoning
### Multi-Step Result Shape
### Stream Response Helpers

## MCP Package
### MCP Transport: `redirect` Default Changed from `'follow'` to `'error'`

## Vue Package
### `Chat` Class Deprecated in Favor of `useChat` Composable

## Anthropic Provider
### `providerMetadata.anthropic.cacheCreationInputTokens` Removed

## Google Provider
### Renamed Types, Classes, and Functions: `GenerativeAI` Affix Removed
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)