### PR TITLE
Add ElevenLabs realtime agents support

### DIFF
--- a/.changeset/green-donkeys-talk.md
+++ b/.changeset/green-donkeys-talk.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': minor
+---
+
+feat(provider/elevenlabs): add experimental realtime ElevenAgents support

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -253,3 +253,34 @@ The following provider options are available:
 | ------------------------ | ------------------- | ------------------- | ------------------- | ------------------- |
 | `scribe_v1`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `scribe_v1_experimental` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
+## Realtime Models
+
+You can create realtime voice-agent models using the `.experimental_realtime()` factory method.
+
+The model id is an ElevenAgents `agent_id`, not a text-to-speech model id.
+
+```ts
+const model = elevenLabs.experimental_realtime('agent_123');
+```
+
+The realtime model uses ElevenAgents WebSockets and signed URLs for browser-safe authentication.
+It supports bidirectional audio/text, user transcripts, agent audio/text responses, and client tool calls.
+
+You can pass ElevenAgents-specific session overrides using `providerOptions.elevenlabs`:
+
+```ts
+import type { ElevenLabsRealtimeModelOptions } from '@ai-sdk/elevenlabs';
+
+const sessionConfig = {
+  instructions: 'You are a helpful support agent.',
+  voice: '21m00Tcm4TlvDq8ikWAM',
+  providerOptions: {
+    elevenlabs: {
+      dynamicVariables: {
+        user_name: 'John',
+      },
+    } satisfies ElevenLabsRealtimeModelOptions,
+  },
+};
+```

--- a/examples/ai-e2e-next/.env.local.example
+++ b/examples/ai-e2e-next/.env.local.example
@@ -2,6 +2,11 @@
 # Then get your OpenAI API Key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=xxxxxxx
 
+# Required for the ElevenLabs provider in the realtime example.
+# Create an agent at https://elevenlabs.io/app and copy its Agent ID.
+ELEVENLABS_API_KEY=xxxxxxx
+ELEVENLABS_AGENT_ID=xxxxxxx
+
 # You must first create an OpenAI Assistant here: https://platform.openai.com/assistants
 # Then get your Assistant ID here: https://platform.openai.com/assistants
 ASSISTANT_ID=xxxxxxx

--- a/examples/ai-e2e-next/app/api/realtime/[...path]/route.ts
+++ b/examples/ai-e2e-next/app/api/realtime/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { google } from '@ai-sdk/google';
 import { xai } from '@ai-sdk/xai';
+import { elevenLabs } from '@ai-sdk/elevenlabs';
 import {
   experimental_getRealtimeToolDefinitions as getRealtimeToolDefinitions,
   gateway,
@@ -51,6 +52,10 @@ const providers: Record<string, { factory: RealtimeFactory; model: string }> = {
     factory: xai.experimental_realtime,
     model: 'grok-voice-latest',
   },
+  elevenlabs: {
+    factory: elevenLabs.experimental_realtime,
+    model: process.env.ELEVENLABS_AGENT_ID ?? '',
+  },
   gateway: {
     factory: gateway.experimental_realtime,
     model: 'openai/gpt-realtime-2',
@@ -75,6 +80,13 @@ export async function POST(
     const toolDefs = await getRealtimeToolDefinitions({ tools });
 
     const { factory, model } = providers[provider] ?? providers.openai;
+    if (!model) {
+      return Response.json(
+        { error: `Missing model configuration for provider: ${provider}` },
+        { status: 400 },
+      );
+    }
+
     const tokenResult = await factory.getToken({
       model,
       sessionConfig: { ...sessionConfig, tools: toolDefs },

--- a/examples/ai-e2e-next/app/realtime/page.tsx
+++ b/examples/ai-e2e-next/app/realtime/page.tsx
@@ -4,9 +4,10 @@ import { experimental_useRealtime } from '@ai-sdk/react';
 import { openai } from '@ai-sdk/openai';
 import { google } from '@ai-sdk/google';
 import { xai } from '@ai-sdk/xai';
+import { elevenLabs } from '@ai-sdk/elevenlabs';
 import { useState, useRef, useEffect, useMemo } from 'react';
 
-type Provider = 'openai' | 'google' | 'xai';
+type Provider = 'openai' | 'google' | 'xai' | 'elevenlabs';
 
 type VoiceOption = { id: string; label: string };
 
@@ -23,6 +24,7 @@ const PROVIDER_CONFIG: Record<
     createModel: (
       modelId: string,
     ) => ReturnType<typeof openai.experimental_realtime>;
+    usesAgentConfiguration?: boolean;
     sessionConfigOverrides?: Record<string, unknown>;
   }
 > = {
@@ -58,6 +60,17 @@ const PROVIDER_CONFIG: Record<
     defaultModel: 'grok-voice-latest',
     staticVoices: toVoiceOptions(['ara', 'eve', 'leo', 'rex', 'sal']),
     createModel: modelId => xai.experimental_realtime(modelId),
+  },
+  elevenlabs: {
+    label: 'ElevenLabs',
+    defaultModel: 'configured-agent',
+    staticVoices: [],
+    createModel: modelId => elevenLabs.experimental_realtime(modelId),
+    usesAgentConfiguration: true,
+    sessionConfigOverrides: {
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      outputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    },
   },
 };
 
@@ -132,7 +145,7 @@ export default function RealtimePage() {
             style={selectStyle}
           >
             {currentVoices.length === 0 ? (
-              <option>No voices available</option>
+              <option>Agent default</option>
             ) : (
               currentVoices.map(v => (
                 <option key={v.id} value={v.id}>
@@ -185,12 +198,16 @@ function RealtimeChat({
 
   const sessionConfig = useMemo(
     () => ({
-      instructions:
-        'You are a helpful assistant. Be concise. ' +
-        'You have access to tools for weather and dice rolling.',
-      inputAudioTranscription: {},
-      voice,
-      turnDetection: { type: 'server-vad' as const },
+      ...(config.usesAgentConfiguration
+        ? {}
+        : {
+            instructions:
+              'You are a helpful assistant. Be concise. ' +
+              'You have access to tools for weather and dice rolling.',
+            inputAudioTranscription: {},
+            ...(voice ? { voice } : {}),
+            turnDetection: { type: 'server-vad' as const },
+          }),
       ...config.sessionConfigOverrides,
     }),
     [voice, config],

--- a/examples/ai-e2e-next/package.json
+++ b/examples/ai-e2e-next/package.json
@@ -14,6 +14,7 @@
     "@ai-sdk/azure": "workspace:*",
     "@ai-sdk/cohere": "workspace:*",
     "@ai-sdk/deepseek": "workspace:*",
+    "@ai-sdk/elevenlabs": "workspace:*",
     "@ai-sdk/fireworks": "workspace:*",
     "@ai-sdk/google": "workspace:*",
     "@ai-sdk/google-vertex": "workspace:*",

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -1,5 +1,7 @@
 import {
   NoSuchModelError,
+  type Experimental_RealtimeFactoryV4 as RealtimeFactoryV4,
+  type Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
   type TranscriptionModelV4,
   type SpeechModelV4,
   type ProviderV4,
@@ -13,6 +15,7 @@ import { ElevenLabsTranscriptionModel } from './elevenlabs-transcription-model';
 import type { ElevenLabsTranscriptionModelId } from './elevenlabs-transcription-options';
 import { ElevenLabsSpeechModel } from './elevenlabs-speech-model';
 import type { ElevenLabsSpeechModelId } from './elevenlabs-speech-options';
+import { ElevenLabsRealtimeModel } from './realtime/elevenlabs-realtime-model';
 import { VERSION } from './version';
 
 export interface ElevenLabsProvider extends ProviderV4 {
@@ -32,6 +35,12 @@ export interface ElevenLabsProvider extends ProviderV4 {
    * Creates a model for speech generation.
    */
   speech(modelId: ElevenLabsSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates an experimental realtime model for bidirectional audio/text
+   * communication over WebSocket.
+   */
+  experimental_realtime: RealtimeFactoryV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -92,6 +101,33 @@ export function createElevenLabs(
       fetch: options.fetch,
     });
 
+  const createRealtimeModel = (modelId: string) =>
+    new ElevenLabsRealtimeModel(modelId, {
+      provider: `elevenlabs.realtime`,
+      baseURL: 'https://api.elevenlabs.io',
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const experimentalRealtimeFactory = Object.assign(
+    (modelId: string) => createRealtimeModel(modelId),
+    {
+      getToken: async (tokenOptions: RealtimeFactoryV4GetTokenOptions) => {
+        const model = createRealtimeModel(tokenOptions.model);
+        const secret = await model.doCreateClientSecret({
+          sessionConfig: tokenOptions.sessionConfig,
+          expiresAfterSeconds: tokenOptions.expiresAfterSeconds,
+        });
+
+        return {
+          token: secret.token,
+          url: secret.url,
+          ...(secret.expiresAt != null && { expiresAt: secret.expiresAt }),
+        };
+      },
+    },
+  ) as RealtimeFactoryV4;
+
   const provider = function (modelId: ElevenLabsTranscriptionModelId) {
     return {
       transcription: createTranscriptionModel(modelId),
@@ -103,6 +139,7 @@ export function createElevenLabs(
   provider.transcriptionModel = createTranscriptionModel;
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;
+  provider.experimental_realtime = experimentalRealtimeFactory;
 
   provider.languageModel = (modelId: string) => {
     throw new NoSuchModelError({

--- a/packages/elevenlabs/src/index.ts
+++ b/packages/elevenlabs/src/index.ts
@@ -8,10 +8,16 @@ export type {
   ElevenLabsProvider,
   ElevenLabsProviderSettings,
 } from './elevenlabs-provider';
+export { ElevenLabsRealtimeModel as Experimental_ElevenLabsRealtimeModel } from './realtime/elevenlabs-realtime-model';
+export type { ElevenLabsRealtimeModelConfig as Experimental_ElevenLabsRealtimeModelConfig } from './realtime/elevenlabs-realtime-model';
 export type {
   ElevenLabsSpeechModelId,
   ElevenLabsSpeechVoiceId,
 } from './elevenlabs-speech-options';
 export type { ElevenLabsSpeechModelOptions } from './elevenlabs-speech-model-options';
 export type { ElevenLabsTranscriptionModelOptions } from './elevenlabs-transcription-model-options';
+export type {
+  ElevenLabsRealtimeModelId,
+  ElevenLabsRealtimeModelOptions,
+} from './realtime/elevenlabs-realtime-model-options';
 export { VERSION } from './version';

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-event-mapper.test.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-event-mapper.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ElevenLabsRealtimeEventMapper,
+  buildElevenLabsSessionConfig,
+} from './elevenlabs-realtime-event-mapper';
+
+describe('ElevenLabsRealtimeEventMapper', () => {
+  describe('parseServerEvent', () => {
+    it('maps conversation metadata to session-created', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      const raw = {
+        type: 'conversation_initiation_metadata',
+        conversation_initiation_metadata_event: {
+          conversation_id: 'conv_123',
+        },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'session-created',
+        sessionId: 'conv_123',
+        raw,
+      });
+    });
+
+    it('maps user transcript to input-transcription-completed', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      const raw = {
+        type: 'user_transcript',
+        user_transcription_event: {
+          user_transcript: 'hello there',
+        },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'input-transcription-completed',
+        itemId: 'elevenlabs-input-0',
+        transcript: 'hello there',
+        raw,
+      });
+    });
+
+    it('maps agent text to response-created + text-delta', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      const raw = {
+        type: 'agent_response',
+        agent_response_event: {
+          agent_response: 'Hello there.',
+        },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual([
+        {
+          type: 'response-created',
+          responseId: 'elevenlabs-resp-0',
+          raw,
+        },
+        {
+          type: 'text-delta',
+          responseId: 'elevenlabs-resp-0',
+          itemId: 'elevenlabs-item-0',
+          delta: 'Hello there.',
+          raw,
+        },
+      ]);
+    });
+
+    it('keeps audio on the same synthetic turn as text', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      mapper.parseServerEvent({
+        type: 'agent_response',
+        agent_response_event: {
+          agent_response: 'Hello there.',
+        },
+      });
+      const raw = {
+        type: 'audio',
+        audio_event: {
+          audio_base_64: 'base64audio',
+        },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'audio-delta',
+        responseId: 'elevenlabs-resp-0',
+        itemId: 'elevenlabs-item-0',
+        delta: 'base64audio',
+        raw,
+      });
+    });
+
+    it('maps tool calls to function argument events', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      const raw = {
+        type: 'client_tool_call',
+        client_tool_call: {
+          tool_name: 'check_account_status',
+          tool_call_id: 'tool_123',
+          parameters: { user_id: 'user_123' },
+        },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual([
+        {
+          type: 'response-created',
+          responseId: 'elevenlabs-resp-0',
+          raw,
+        },
+        {
+          type: 'function-call-arguments-delta',
+          responseId: 'elevenlabs-resp-0',
+          itemId: 'elevenlabs-item-0',
+          callId: 'tool_123',
+          delta: '{"user_id":"user_123"}',
+          raw,
+        },
+        {
+          type: 'function-call-arguments-done',
+          responseId: 'elevenlabs-resp-0',
+          itemId: 'elevenlabs-item-0',
+          callId: 'tool_123',
+          name: 'check_account_status',
+          arguments: '{"user_id":"user_123"}',
+          raw,
+        },
+      ]);
+    });
+
+    it('maps response completion to done events', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      mapper.parseServerEvent({
+        type: 'agent_response',
+        agent_response_event: {
+          agent_response: 'Hello',
+        },
+      });
+      mapper.parseServerEvent({
+        type: 'audio',
+        audio_event: {
+          audio_base_64: 'base64audio',
+        },
+      });
+      const raw = { type: 'agent_response_complete' };
+
+      expect(mapper.parseServerEvent(raw)).toEqual([
+        {
+          type: 'audio-done',
+          responseId: 'elevenlabs-resp-0',
+          itemId: 'elevenlabs-item-0',
+          raw,
+        },
+        {
+          type: 'text-done',
+          responseId: 'elevenlabs-resp-0',
+          itemId: 'elevenlabs-item-0',
+          text: 'Hello',
+          raw,
+        },
+        {
+          type: 'response-done',
+          responseId: 'elevenlabs-resp-0',
+          status: 'completed',
+          raw,
+        },
+      ]);
+    });
+
+    it('maps interruption to speech-started and cancels the active turn', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      mapper.parseServerEvent({
+        type: 'agent_response',
+        agent_response_event: {
+          agent_response: 'Hello',
+        },
+      });
+      const raw = { type: 'interruption' };
+
+      expect(mapper.parseServerEvent(raw)).toEqual([
+        {
+          type: 'speech-started',
+          raw,
+        },
+        {
+          type: 'text-done',
+          responseId: 'elevenlabs-resp-0',
+          itemId: 'elevenlabs-item-0',
+          text: 'Hello',
+          raw,
+        },
+        {
+          type: 'response-done',
+          responseId: 'elevenlabs-resp-0',
+          status: 'cancelled',
+          raw,
+        },
+      ]);
+    });
+
+    it('rolls over synthetic IDs after completion', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      mapper.parseServerEvent({
+        type: 'agent_response',
+        agent_response_event: { agent_response: 'First' },
+      });
+      mapper.parseServerEvent({ type: 'agent_response_complete' });
+      const raw = {
+        type: 'agent_response',
+        agent_response_event: { agent_response: 'Second' },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual([
+        {
+          type: 'response-created',
+          responseId: 'elevenlabs-resp-1',
+          raw,
+        },
+        {
+          type: 'text-delta',
+          responseId: 'elevenlabs-resp-1',
+          itemId: 'elevenlabs-item-1',
+          delta: 'Second',
+          raw,
+        },
+      ]);
+    });
+
+    it('returns custom events for unsupported provider messages', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+      const raw = {
+        type: 'vad_score',
+        vad_score_event: { vad_score: 0.95 },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'custom',
+        rawType: 'vad_score',
+        raw,
+      });
+    });
+  });
+
+  describe('getHealthCheckResponse', () => {
+    it('responds to provider ping events', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+
+      expect(
+        mapper.getHealthCheckResponse({
+          type: 'ping',
+          ping_event: { event_id: 12345 },
+        }),
+      ).toEqual({
+        type: 'pong',
+        event_id: 12345,
+      });
+    });
+  });
+
+  describe('serializeClientEvent', () => {
+    it('serializes text messages', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+
+      expect(
+        mapper.serializeClientEvent({
+          type: 'conversation-item-create',
+          item: {
+            type: 'text-message',
+            role: 'user',
+            text: 'Hello',
+          },
+        }),
+      ).toEqual({
+        type: 'user_message',
+        text: 'Hello',
+      });
+    });
+
+    it('serializes audio chunks', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+
+      expect(
+        mapper.serializeClientEvent({
+          type: 'input-audio-append',
+          audio: 'base64audio',
+        }),
+      ).toEqual({
+        user_audio_chunk: 'base64audio',
+      });
+    });
+
+    it('drops explicit response control events', () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+
+      expect(
+        mapper.serializeClientEvent({
+          type: 'response-create',
+        }),
+      ).toBeNull();
+    });
+
+    it('serializes tool outputs', async () => {
+      const mapper = new ElevenLabsRealtimeEventMapper();
+
+      await expect(
+        mapper.serializeClientEvent({
+          type: 'conversation-item-create',
+          item: {
+            type: 'function-call-output',
+            callId: 'tool_123',
+            name: 'check_account_status',
+            output: '{"active":true}',
+          },
+        }),
+      ).resolves.toEqual({
+        type: 'client_tool_result',
+        tool_call_id: 'tool_123',
+        result: { active: true },
+        is_error: false,
+      });
+    });
+  });
+
+  describe('buildElevenLabsSessionConfig', () => {
+    it('maps instructions and voice to conversation overrides', () => {
+      expect(
+        buildElevenLabsSessionConfig({
+          instructions: 'Be helpful.',
+          voice: 'voice_123',
+        }),
+      ).toEqual({
+        type: 'conversation_initiation_client_data',
+        conversation_config_override: {
+          agent: {
+            prompt: {
+              prompt: 'Be helpful.',
+            },
+          },
+          tts: {
+            voice_id: 'voice_123',
+          },
+        },
+      });
+    });
+
+    it('maps ElevenLabs provider options', () => {
+      expect(
+        buildElevenLabsSessionConfig({
+          providerOptions: {
+            elevenlabs: {
+              conversationConfigOverride: {
+                agent: {
+                  language: 'en',
+                },
+              },
+              customLlmExtraBody: {
+                temperature: 0.7,
+              },
+              dynamicVariables: {
+                user_name: 'John',
+              },
+            },
+          },
+        }),
+      ).toEqual({
+        type: 'conversation_initiation_client_data',
+        conversation_config_override: {
+          agent: {
+            language: 'en',
+          },
+        },
+        custom_llm_extra_body: {
+          temperature: 0.7,
+        },
+        dynamic_variables: {
+          user_name: 'John',
+        },
+      });
+    });
+
+    it('merges provider overrides with normalized instructions and voice', () => {
+      expect(
+        buildElevenLabsSessionConfig({
+          instructions: 'Be helpful.',
+          voice: 'voice_123',
+          providerOptions: {
+            elevenlabs: {
+              conversationConfigOverride: {
+                agent: {
+                  language: 'en',
+                },
+                tts: {
+                  speed: 1.2,
+                },
+              },
+            },
+          },
+        }),
+      ).toEqual({
+        type: 'conversation_initiation_client_data',
+        conversation_config_override: {
+          agent: {
+            prompt: {
+              prompt: 'Be helpful.',
+            },
+            language: 'en',
+          },
+          tts: {
+            voice_id: 'voice_123',
+            speed: 1.2,
+          },
+        },
+      });
+    });
+
+    it('returns null when no supported session config is supplied', () => {
+      expect(buildElevenLabsSessionConfig({})).toBeNull();
+    });
+  });
+});

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-event-mapper.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-event-mapper.ts
@@ -1,0 +1,386 @@
+import type {
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4FunctionCallOutput as RealtimeModelV4FunctionCallOutput,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+import type { ElevenLabsRealtimeModelOptions } from './elevenlabs-realtime-model-options';
+
+type ElevenLabsRealtimeWireEvent = {
+  type?: string;
+  conversation_initiation_metadata_event?: {
+    conversation_id?: string;
+  };
+  user_transcription_event?: {
+    user_transcript?: string;
+  };
+  agent_response_event?: {
+    agent_response?: string;
+  };
+  audio_event?: {
+    audio_base_64?: string;
+  };
+  ping_event?: {
+    event_id?: string | number;
+  };
+  client_tool_call?: {
+    tool_name?: string;
+    tool_call_id?: string;
+    parameters?: unknown;
+  };
+  error?: {
+    message?: string;
+    code?: string | number;
+  };
+  message?: string;
+  code?: string | number;
+};
+
+type ElevenLabsRealtimeTurn = {
+  responseId: string;
+  itemId: string;
+  hasAudio: boolean;
+  hasText: boolean;
+  started: boolean;
+  text: string;
+};
+
+/**
+ * Stateful event mapper for ElevenAgents WebSockets.
+ *
+ * ElevenLabs does not expose response or item IDs on agent events, so the
+ * mapper generates stable synthetic IDs for each agent turn.
+ */
+export class ElevenLabsRealtimeEventMapper {
+  private turnCounter = 0;
+  private inputCounter = 0;
+  private activeTurn: ElevenLabsRealtimeTurn | undefined;
+
+  parseServerEvent(
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent | RealtimeModelV4ServerEvent[] {
+    const event = raw as ElevenLabsRealtimeWireEvent;
+
+    switch (event.type) {
+      case 'conversation_initiation_metadata':
+        return {
+          type: 'session-created',
+          sessionId:
+            event.conversation_initiation_metadata_event?.conversation_id,
+          raw,
+        };
+
+      case 'user_transcript':
+        return {
+          type: 'input-transcription-completed',
+          itemId: `elevenlabs-input-${this.inputCounter++}`,
+          transcript: event.user_transcription_event?.user_transcript ?? '',
+          raw,
+        };
+
+      case 'agent_response': {
+        const turn = this.beginTurn();
+        const events = this.beginTurnEvents(turn, raw);
+        const delta = event.agent_response_event?.agent_response ?? '';
+        turn.hasText = true;
+        turn.text += delta;
+        events.push({
+          type: 'text-delta',
+          responseId: turn.responseId,
+          itemId: turn.itemId,
+          delta,
+          raw,
+        });
+        return events.length === 1 ? events[0] : events;
+      }
+
+      case 'audio': {
+        const turn = this.beginTurn();
+        const events = this.beginTurnEvents(turn, raw);
+        const delta = event.audio_event?.audio_base_64 ?? '';
+        turn.hasAudio = true;
+        events.push({
+          type: 'audio-delta',
+          responseId: turn.responseId,
+          itemId: turn.itemId,
+          delta,
+          raw,
+        });
+        return events.length === 1 ? events[0] : events;
+      }
+
+      case 'client_tool_call': {
+        const turn = this.beginTurn();
+        const events = this.beginTurnEvents(turn, raw);
+        const callId =
+          event.client_tool_call?.tool_call_id ??
+          `elevenlabs-tool-${this.turnCounter}`;
+        const name = event.client_tool_call?.tool_name ?? 'unknown';
+        const args = JSON.stringify(event.client_tool_call?.parameters ?? {});
+        events.push(
+          {
+            type: 'function-call-arguments-delta',
+            responseId: turn.responseId,
+            itemId: turn.itemId,
+            callId,
+            delta: args,
+            raw,
+          },
+          {
+            type: 'function-call-arguments-done',
+            responseId: turn.responseId,
+            itemId: turn.itemId,
+            callId,
+            name,
+            arguments: args,
+            raw,
+          },
+        );
+        return events;
+      }
+
+      case 'agent_response_complete':
+        return this.closeTurn(raw, 'completed');
+
+      case 'interruption': {
+        const events: RealtimeModelV4ServerEvent[] = [
+          {
+            type: 'speech-started',
+            raw,
+          },
+        ];
+        events.push(...this.closeTurn(raw, 'cancelled'));
+        return events.length === 1 ? events[0] : events;
+      }
+
+      case 'error':
+        return {
+          type: 'error',
+          message:
+            event.error?.message ?? event.message ?? 'Unknown ElevenLabs error',
+          ...(event.error?.code != null || event.code != null
+            ? { code: String(event.error?.code ?? event.code) }
+            : {}),
+          raw,
+        };
+
+      default:
+        return {
+          type: 'custom',
+          rawType: event.type ?? 'unknown',
+          raw,
+        };
+    }
+  }
+
+  getHealthCheckResponse(raw: unknown): unknown | null {
+    const event = raw as ElevenLabsRealtimeWireEvent;
+    if (event.type !== 'ping') return null;
+
+    return {
+      type: 'pong',
+      ...(event.ping_event?.event_id != null
+        ? { event_id: event.ping_event.event_id }
+        : {}),
+    };
+  }
+
+  serializeClientEvent(
+    event: RealtimeModelV4ClientEvent,
+  ): ReturnType<RealtimeModelV4['serializeClientEvent']> {
+    switch (event.type) {
+      case 'session-update':
+        return buildElevenLabsSessionConfig(event.config);
+
+      case 'input-audio-append':
+        return { user_audio_chunk: event.audio };
+
+      case 'input-audio-commit':
+      case 'input-audio-clear':
+      case 'response-create':
+      case 'response-cancel':
+      case 'conversation-item-truncate':
+        return null;
+
+      case 'conversation-item-create': {
+        const item = event.item;
+        switch (item.type) {
+          case 'text-message':
+            return {
+              type: 'user_message',
+              text: item.text,
+            };
+
+          case 'audio-message':
+            return { user_audio_chunk: item.audio };
+
+          case 'function-call-output':
+            return serializeFunctionCallOutput(item);
+        }
+        break;
+      }
+    }
+
+    return null;
+  }
+
+  private beginTurn(): ElevenLabsRealtimeTurn {
+    if (this.activeTurn != null) return this.activeTurn;
+
+    const turn = {
+      responseId: `elevenlabs-resp-${this.turnCounter}`,
+      itemId: `elevenlabs-item-${this.turnCounter}`,
+      hasAudio: false,
+      hasText: false,
+      started: false,
+      text: '',
+    };
+    this.activeTurn = turn;
+    return turn;
+  }
+
+  private beginTurnEvents(
+    turn: ElevenLabsRealtimeTurn,
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent[] {
+    if (turn.started) return [];
+    turn.started = true;
+    return [
+      {
+        type: 'response-created',
+        responseId: turn.responseId,
+        raw,
+      },
+    ];
+  }
+
+  private closeTurn(
+    raw: unknown,
+    status: string,
+  ): RealtimeModelV4ServerEvent[] {
+    const turn = this.activeTurn;
+    if (turn == null) return [];
+
+    const events: RealtimeModelV4ServerEvent[] = [];
+
+    if (turn.hasAudio) {
+      events.push({
+        type: 'audio-done',
+        responseId: turn.responseId,
+        itemId: turn.itemId,
+        raw,
+      });
+    }
+
+    if (turn.hasText) {
+      events.push({
+        type: 'text-done',
+        responseId: turn.responseId,
+        itemId: turn.itemId,
+        text: turn.text,
+        raw,
+      });
+    }
+
+    events.push({
+      type: 'response-done',
+      responseId: turn.responseId,
+      status,
+      raw,
+    });
+
+    this.turnCounter++;
+    this.activeTurn = undefined;
+    return events;
+  }
+}
+
+async function serializeFunctionCallOutput(
+  item: RealtimeModelV4FunctionCallOutput,
+): Promise<unknown> {
+  const parseResult = await safeParseJSON({ text: item.output });
+  return {
+    type: 'client_tool_result',
+    tool_call_id: item.callId,
+    result: parseResult.success ? parseResult.value : item.output,
+    is_error: false,
+  };
+}
+
+export function buildElevenLabsSessionConfig(
+  config: RealtimeModelV4SessionConfig,
+): Record<string, unknown> | null {
+  const conversationConfigOverride: Record<string, unknown> = {};
+  const agentOverride: Record<string, unknown> = {};
+  const ttsOverride: Record<string, unknown> = {};
+
+  if (config.instructions != null) {
+    agentOverride.prompt = { prompt: config.instructions };
+  }
+
+  if (config.voice != null) {
+    ttsOverride.voice_id = config.voice;
+  }
+
+  if (Object.keys(agentOverride).length > 0) {
+    conversationConfigOverride.agent = agentOverride;
+  }
+
+  if (Object.keys(ttsOverride).length > 0) {
+    conversationConfigOverride.tts = ttsOverride;
+  }
+
+  const payload: Record<string, unknown> = {
+    type: 'conversation_initiation_client_data',
+  };
+
+  if (Object.keys(conversationConfigOverride).length > 0) {
+    payload.conversation_config_override = conversationConfigOverride;
+  }
+
+  const elevenLabsOptions = config.providerOptions?.elevenlabs;
+  if (isRecord(elevenLabsOptions)) {
+    const options = elevenLabsOptions as ElevenLabsRealtimeModelOptions;
+
+    if (options.conversationConfigOverride != null) {
+      payload.conversation_config_override = mergeConversationOverrides(
+        isRecord(payload.conversation_config_override)
+          ? payload.conversation_config_override
+          : {},
+        options.conversationConfigOverride,
+      );
+    }
+
+    if (options.customLlmExtraBody != null) {
+      payload.custom_llm_extra_body = options.customLlmExtraBody;
+    }
+
+    if (options.dynamicVariables != null) {
+      payload.dynamic_variables = options.dynamicVariables;
+    }
+  }
+
+  return Object.keys(payload).length === 1 ? null : payload;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeConversationOverrides(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...base };
+
+  for (const [key, value] of Object.entries(override)) {
+    result[key] =
+      isRecord(result[key]) && isRecord(value)
+        ? { ...result[key], ...value }
+        : value;
+  }
+
+  return result;
+}

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-model-options.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-model-options.ts
@@ -1,0 +1,24 @@
+export type ElevenLabsRealtimeModelId = string;
+
+export type ElevenLabsRealtimeModelOptions = {
+  /**
+   * Overrides applied when the conversation starts.
+   *
+   * This maps to ElevenLabs' `conversation_config_override` payload.
+   */
+  conversationConfigOverride?: Record<string, unknown>;
+
+  /**
+   * Extra body fields forwarded to the configured LLM.
+   *
+   * This maps to ElevenLabs' `custom_llm_extra_body` payload.
+   */
+  customLlmExtraBody?: Record<string, unknown>;
+
+  /**
+   * Dynamic variables made available to the configured agent.
+   *
+   * This maps to ElevenLabs' `dynamic_variables` payload.
+   */
+  dynamicVariables?: Record<string, unknown>;
+};

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.test.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.test.ts
@@ -53,6 +53,21 @@ describe('ElevenLabsRealtimeModel', () => {
         'ElevenLabs realtime signed URL request failed: 401 unauthorized',
       );
     });
+
+    it('throws when the response does not include a signed URL', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await expect(
+        createModel(mockFetch as unknown as typeof fetch).doCreateClientSecret(
+          {},
+        ),
+      ).rejects.toThrow(
+        'ElevenLabs realtime signed URL request returned no signed_url.',
+      );
+    });
   });
 
   it('uses the signed URL directly for WebSocket connections', () => {

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.test.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ElevenLabsRealtimeModel } from './elevenlabs-realtime-model';
+
+describe('ElevenLabsRealtimeModel', () => {
+  describe('doCreateClientSecret', () => {
+    const createModel = (fetch: typeof globalThis.fetch) =>
+      new ElevenLabsRealtimeModel('agent_123', {
+        provider: 'elevenlabs.realtime',
+        baseURL: 'https://api.elevenlabs.io',
+        headers: () => ({ 'xi-api-key': 'test-key' }),
+        fetch,
+      });
+
+    it('requests a signed URL for the agent', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          signed_url:
+            'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+        }),
+      });
+
+      const result = await createModel(
+        mockFetch as unknown as typeof fetch,
+      ).doCreateClientSecret({});
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.elevenlabs.io/v1/convai/conversation/get-signed-url?agent_id=agent_123',
+        {
+          method: 'GET',
+          headers: { 'xi-api-key': 'test-key' },
+        },
+      );
+      expect(result).toEqual({
+        token: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+        url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+      });
+    });
+
+    it('throws when the signed URL request fails', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'unauthorized',
+      });
+
+      await expect(
+        createModel(mockFetch as unknown as typeof fetch).doCreateClientSecret(
+          {},
+        ),
+      ).rejects.toThrow(
+        'ElevenLabs realtime signed URL request failed: 401 unauthorized',
+      );
+    });
+  });
+
+  it('uses the signed URL directly for WebSocket connections', () => {
+    const model = new ElevenLabsRealtimeModel('agent_123', {
+      provider: 'elevenlabs.realtime',
+      baseURL: 'https://api.elevenlabs.io',
+      headers: () => ({}),
+    });
+
+    expect(
+      model.getWebSocketConfig({
+        token: 'ignored',
+        url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+      }),
+    ).toEqual({
+      url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+    });
+  });
+});

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.test.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createElevenLabs } from '../elevenlabs-provider';
 import { ElevenLabsRealtimeModel } from './elevenlabs-realtime-model';
 
 describe('ElevenLabsRealtimeModel', () => {
@@ -67,6 +68,35 @@ describe('ElevenLabsRealtimeModel', () => {
         url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
       }),
     ).toEqual({
+      url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+    });
+  });
+
+  it('exposes the realtime factory from the provider', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
+      }),
+    });
+    const provider = createElevenLabs({
+      apiKey: 'test-key',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const model = provider.experimental_realtime('agent_123');
+    expect(model.provider).toBe('elevenlabs.realtime');
+    expect(model.modelId).toBe('agent_123');
+
+    await expect(
+      provider.experimental_realtime.getToken({
+        model: 'agent_123',
+        sessionConfig: {
+          instructions: 'Be helpful.',
+        },
+      }),
+    ).resolves.toEqual({
+      token: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
       url: 'wss://api.elevenlabs.io/v1/convai/conversation?token=test',
     });
   });

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.ts
@@ -36,6 +36,8 @@ export class ElevenLabsRealtimeModel implements RealtimeModelV4 {
   async doCreateClientSecret(
     _options: RealtimeModelV4ClientSecretOptions,
   ): Promise<RealtimeModelV4ClientSecretResult> {
+    // ElevenLabs fixes the signed URL lifetime and applies session settings
+    // after the WebSocket connects, so client-secret options do not apply.
     const fetchFn = this.config.fetch ?? fetch;
     const url = new URL(
       `${this.config.baseURL}/v1/convai/conversation/get-signed-url`,
@@ -58,13 +60,8 @@ export class ElevenLabsRealtimeModel implements RealtimeModelV4 {
       );
     }
 
-    const data = (await response.json()) as {
-      signed_url?: string;
-      signedUrl?: string;
-      expires_at?: number;
-      expiresAt?: number;
-    };
-    const signedUrl = data.signed_url ?? data.signedUrl;
+    const data = (await response.json()) as { signed_url?: string };
+    const signedUrl = data.signed_url;
 
     if (!signedUrl) {
       throw new Error(
@@ -78,9 +75,6 @@ export class ElevenLabsRealtimeModel implements RealtimeModelV4 {
       // the signed URL as the opaque secret and ignore it in getWebSocketConfig.
       token: signedUrl,
       url: signedUrl,
-      ...(data.expires_at != null || data.expiresAt != null
-        ? { expiresAt: data.expires_at ?? data.expiresAt }
-        : {}),
     };
   }
 

--- a/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.ts
+++ b/packages/elevenlabs/src/realtime/elevenlabs-realtime-model.ts
@@ -1,0 +1,115 @@
+import type {
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ClientSecretOptions as RealtimeModelV4ClientSecretOptions,
+  Experimental_RealtimeModelV4ClientSecretResult as RealtimeModelV4ClientSecretResult,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  ElevenLabsRealtimeEventMapper,
+  buildElevenLabsSessionConfig,
+} from './elevenlabs-realtime-event-mapper';
+
+export type ElevenLabsRealtimeModelConfig = {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class ElevenLabsRealtimeModel implements RealtimeModelV4 {
+  readonly specificationVersion = 'v4' as const;
+  readonly provider: string;
+  readonly modelId: string;
+
+  private readonly config: ElevenLabsRealtimeModelConfig;
+  private readonly mapper = new ElevenLabsRealtimeEventMapper();
+
+  constructor(modelId: string, config: ElevenLabsRealtimeModelConfig) {
+    this.modelId = modelId;
+    this.provider = config.provider;
+    this.config = config;
+  }
+
+  async doCreateClientSecret(
+    _options: RealtimeModelV4ClientSecretOptions,
+  ): Promise<RealtimeModelV4ClientSecretResult> {
+    const fetchFn = this.config.fetch ?? fetch;
+    const url = new URL(
+      `${this.config.baseURL}/v1/convai/conversation/get-signed-url`,
+    );
+    url.searchParams.set('agent_id', this.modelId);
+
+    const response = await fetchFn(url.toString(), {
+      method: 'GET',
+      headers: Object.fromEntries(
+        Object.entries(this.config.headers()).filter(
+          (entry): entry is [string, string] => entry[1] != null,
+        ),
+      ),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `ElevenLabs realtime signed URL request failed: ${response.status} ${text}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      signed_url?: string;
+      signedUrl?: string;
+      expires_at?: number;
+      expiresAt?: number;
+    };
+    const signedUrl = data.signed_url ?? data.signedUrl;
+
+    if (!signedUrl) {
+      throw new Error(
+        'ElevenLabs realtime signed URL request returned no signed_url.',
+      );
+    }
+
+    return {
+      // ElevenLabs authenticates the socket with the signed URL itself. The
+      // token field is still required by the AI SDK realtime interface, so keep
+      // the signed URL as the opaque secret and ignore it in getWebSocketConfig.
+      token: signedUrl,
+      url: signedUrl,
+      ...(data.expires_at != null || data.expiresAt != null
+        ? { expiresAt: data.expires_at ?? data.expiresAt }
+        : {}),
+    };
+  }
+
+  getWebSocketConfig(options: { token: string; url: string }): {
+    url: string;
+    protocols?: string[];
+  } {
+    return {
+      url: options.url,
+    };
+  }
+
+  parseServerEvent(
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent | RealtimeModelV4ServerEvent[] {
+    return this.mapper.parseServerEvent(raw);
+  }
+
+  serializeClientEvent(
+    event: RealtimeModelV4ClientEvent,
+  ): ReturnType<RealtimeModelV4['serializeClientEvent']> {
+    return this.mapper.serializeClientEvent(event);
+  }
+
+  buildSessionConfig(config: RealtimeModelV4SessionConfig): unknown {
+    return buildElevenLabsSessionConfig(config);
+  }
+
+  getHealthCheckResponse(raw: unknown): unknown | null {
+    return this.mapper.getHealthCheckResponse(raw);
+  }
+}

--- a/packages/elevenlabs/src/realtime/index.ts
+++ b/packages/elevenlabs/src/realtime/index.ts
@@ -1,0 +1,6 @@
+export { ElevenLabsRealtimeModel as Experimental_ElevenLabsRealtimeModel } from './elevenlabs-realtime-model';
+export type { ElevenLabsRealtimeModelConfig as Experimental_ElevenLabsRealtimeModelConfig } from './elevenlabs-realtime-model';
+export type {
+  ElevenLabsRealtimeModelId,
+  ElevenLabsRealtimeModelOptions,
+} from './elevenlabs-realtime-model-options';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@ai-sdk/deepseek':
         specifier: workspace:*
         version: link:../../packages/deepseek
+      '@ai-sdk/elevenlabs':
+        specifier: workspace:*
+        version: link:../../packages/elevenlabs
       '@ai-sdk/fireworks':
         specifier: workspace:*
         version: link:../../packages/fireworks


### PR DESCRIPTION
## What changed

- Added `elevenLabs.experimental_realtime()` for ElevenAgents WebSocket sessions.
- Added signed URL client-secret creation for `agent_id`-based conversations.
- Added ElevenAgents event mapping for text, audio, transcripts, tool calls, ping/pong, interruptions, and response completion.
- Added ElevenLabs realtime session options for conversation overrides, dynamic variables, and custom LLM body fields.
- Added provider docs and a changeset.

## Why

ElevenLabs has realtime agent conversations, but its WebSocket protocol differs from the existing OpenAI/Google/xAI realtime protocol. This adapter normalizes ElevenAgents into the AI SDK realtime interface while preserving ElevenLabs-specific session overrides.

## Validation

- `pnpm --filter @ai-sdk/elevenlabs type-check`
- `pnpm --filter @ai-sdk/elevenlabs test:node`
- `pnpm --filter @ai-sdk/elevenlabs test:edge`
- `pnpm exec ultracite check` on changed TypeScript files
- `git diff --check`

## Follow-up

AI Gateway wiring is intentionally separate. Gateway can reuse the new exported realtime model/mapper after this package is available, rather than duplicating the ElevenAgents protocol translation.
