### PR TITLE
feat(mcp): support completion/complete in MCP client

### DIFF
--- a/.changeset/mcp-client-completions.md
+++ b/.changeset/mcp-client-completions.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+Add `complete()` to the MCP client for `completion/complete` requests, enabling autocompletion of resource-template variables and prompt arguments against servers that advertise the `completions` capability.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -8,6 +8,7 @@ import {
   ListToolsResult,
   ElicitationRequestSchema,
   type CallToolResult,
+  type CompleteResult,
   type ListResourceTemplatesResult,
   type ListResourcesResult,
   type ReadResourceResult,
@@ -741,6 +742,41 @@ describe('MCPClient', () => {
         },
       ]
     `);
+  });
+
+  it('should complete a resource template variable', async () => {
+    client = await createMCPClient({
+      transport: new MockMCPTransport({
+        completions: ['namespace-a', 'namespace-b'],
+      }),
+    });
+
+    const result = await client.complete({
+      params: {
+        ref: { type: 'ref/resource', uri: 'file:///{path}' },
+        argument: { name: 'path', value: 'name' },
+        context: { arguments: { other: 'value' } },
+      },
+    });
+
+    expectTypeOf(result).toEqualTypeOf<CompleteResult>();
+    expect(result.completion.values).toEqual(['namespace-a', 'namespace-b']);
+    expect(result.completion.hasMore).toBe(false);
+  });
+
+  it('should throw when the server does not support completions', async () => {
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    await expect(
+      client.complete({
+        params: {
+          ref: { type: 'ref/resource', uri: 'file:///{path}' },
+          argument: { name: 'path', value: '' },
+        },
+      }),
+    ).rejects.toThrow('Server does not support completions');
   });
 
   it('should list prompts from the server', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -28,6 +28,7 @@ import {
 import { getMCPAppToolMeta, MCP_APP_MIME_TYPE } from './mcp-apps';
 import {
   CallToolResultSchema,
+  CompleteResultSchema,
   ElicitationRequestSchema,
   ElicitResultSchema,
   InitializeResultSchema,
@@ -41,6 +42,8 @@ import {
   SUPPORTED_PROTOCOL_VERSIONS,
   type CallToolResult,
   type ClientCapabilities,
+  type CompleteRequestParams,
+  type CompleteResult,
   type Configuration,
   type Configuration as ClientConfiguration,
   type ElicitationRequest,
@@ -185,6 +188,16 @@ export interface MCPClient {
   listResourceTemplates(options?: {
     options?: RequestOptions;
   }): Promise<ListResourceTemplatesResult>;
+
+  /**
+   * Requests completion suggestions for a prompt argument or resource
+   * template variable. Requires the server to advertise the `completions`
+   * capability.
+   */
+  complete(args: {
+    params: CompleteRequestParams;
+    options?: RequestOptions;
+  }): Promise<CompleteResult>;
 
   experimental_listPrompts(options?: {
     params?: PaginatedRequest['params'];
@@ -376,6 +389,13 @@ class DefaultMCPClient implements MCPClient {
           });
         }
         break;
+      case 'completion/complete':
+        if (!this.serverCapabilities.completions) {
+          throw new MCPClientError({
+            message: `Server does not support completions`,
+          });
+        }
+        break;
       default:
         throw new MCPClientError({
           message: `Unsupported method: ${method}`,
@@ -534,6 +554,20 @@ class DefaultMCPClient implements MCPClient {
     } catch (error) {
       throw error;
     }
+  }
+
+  private async completeInternal({
+    params,
+    options,
+  }: {
+    params: CompleteRequestParams;
+    options?: RequestOptions;
+  }): Promise<CompleteResult> {
+    return this.request({
+      request: { method: 'completion/complete', params },
+      resultSchema: CompleteResultSchema,
+      options,
+    });
   }
 
   private async listPromptsInternal({
@@ -770,6 +804,16 @@ class DefaultMCPClient implements MCPClient {
     options?: RequestOptions;
   } = {}): Promise<ListResourceTemplatesResult> {
     return this.listResourceTemplatesInternal({ options });
+  }
+
+  complete({
+    params,
+    options,
+  }: {
+    params: CompleteRequestParams;
+    options?: RequestOptions;
+  }): Promise<CompleteResult> {
+    return this.completeInternal({ params, options });
   }
 
   experimental_listPrompts({

--- a/packages/mcp/src/tool/mock-mcp-transport.ts
+++ b/packages/mcp/src/tool/mock-mcp-transport.ts
@@ -35,6 +35,7 @@ export class MockMCPTransport implements MCPTransport {
   private resourceContents;
   private prompts;
   private promptResults;
+  private completions;
   private failOnInvalidToolParams;
   private initializeResult;
   private sendError;
@@ -93,6 +94,7 @@ export class MockMCPTransport implements MCPTransport {
         mimeType: 'text/plain',
       },
     ],
+    completions,
     failOnInvalidToolParams = false,
     initializeResult,
     sendError = false,
@@ -123,6 +125,7 @@ export class MockMCPTransport implements MCPTransport {
         _meta?: Record<string, unknown>;
       } & ({ text: string } | { blob: string })
     >;
+    completions?: string[];
     failOnInvalidToolParams?: boolean;
     initializeResult?: Record<string, unknown>;
     sendError?: boolean;
@@ -132,6 +135,7 @@ export class MockMCPTransport implements MCPTransport {
     this.resources = resources;
     this.prompts = prompts;
     this.promptResults = promptResults;
+    this.completions = completions;
     this.resourceTemplates = resourceTemplates;
     this.resourceContents = resourceContents;
     this.failOnInvalidToolParams = failOnInvalidToolParams;
@@ -167,6 +171,7 @@ export class MockMCPTransport implements MCPTransport {
               ...(this.tools.length > 0 ? { tools: {} } : {}),
               ...(this.resources.length > 0 ? { resources: {} } : {}),
               ...(this.prompts.length > 0 ? { prompts: {} } : {}),
+              ...(this.completions ? { completions: {} } : {}),
             },
           },
         });
@@ -218,6 +223,20 @@ export class MockMCPTransport implements MCPTransport {
           id: message.id,
           result: {
             resourceTemplates: this.resourceTemplates,
+          },
+        });
+      }
+
+      if (message.method === 'completion/complete') {
+        await delay(10);
+        this.onmessage?.({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            completion: {
+              values: this.completions ?? [],
+              hasMore: false,
+            },
           },
         });
       }

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -114,6 +114,7 @@ const ServerCapabilitiesSchema = z.looseObject({
       listChanged: z.optional(z.boolean()),
     }),
   ),
+  completions: z.optional(z.object({}).loose()),
   elicitation: z.optional(ElicitationCapabilitySchema),
 });
 
@@ -295,6 +296,35 @@ export const ReadResourceResultSchema = ResultSchema.extend({
   ),
 });
 export type ReadResourceResult = z.infer<typeof ReadResourceResultSchema>;
+
+// Completions
+// @see https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/completion
+export const CompleteRequestParamsSchema = z.object({
+  ref: z.union([
+    z.object({ type: z.literal('ref/prompt'), name: z.string() }),
+    z.object({ type: z.literal('ref/resource'), uri: z.string() }),
+  ]),
+  argument: z.object({
+    name: z.string(),
+    value: z.string(),
+  }),
+  context: z.optional(
+    z.object({
+      // Previously-resolved variables in a URI template or prompt.
+      arguments: z.optional(z.record(z.string(), z.string())),
+    }),
+  ),
+});
+export type CompleteRequestParams = z.infer<typeof CompleteRequestParamsSchema>;
+
+export const CompleteResultSchema = ResultSchema.extend({
+  completion: z.looseObject({
+    values: z.array(z.string()).max(100),
+    total: z.optional(z.number().int()),
+    hasMore: z.optional(z.boolean()),
+  }),
+});
+export type CompleteResult = z.infer<typeof CompleteResultSchema>;
 
 // Prompts
 const PromptArgumentSchema = z


### PR DESCRIPTION
## Summary

Adds support for MCP `completion/complete` to the `@ai-sdk/mcp` client. Servers can advertise a `completions` capability to provide autocompletion for **resource-template variables** and **prompt arguments** (e.g. resolving `{namespace}` in `kubernetes://namespaced/{plural}/{namespace}` against the live cluster). Today the client has no way to call it: there's no `complete()` method, and the generic `request()` rejects the method in `assertCapability`'s `default` case.

Closes #16178.

## Changes

- **`packages/mcp/src/tool/types.ts`**
  - Add `completions` to `ServerCapabilitiesSchema`.
  - Add `CompleteRequestParamsSchema` / `CompleteResultSchema` (+ inferred types), including the `context.arguments` field so multi-variable templates resolve correctly.
- **`packages/mcp/src/tool/mcp-client.ts`**
  - Add a `completion/complete` case to `assertCapability`, guarding on `serverCapabilities.completions`.
  - Add a public `complete({ params, options })` method (mirroring `listResources` / `readResource`) returning a parsed `CompleteResult`, and expose it on the `MCPClient` type.
- **`packages/mcp/src/tool/mock-mcp-transport.ts`**
  - Add an optional `completions` input + a `completion/complete` handler for tests.
- **`packages/mcp/src/tool/mcp-client.test.ts`**
  - Cover a successful completion (with `context`) and the unsupported-capability error path.

## Example

```ts
const client = await createMCPClient({ transport });

const { completion } = await client.complete({
  params: {
    ref: { type: 'ref/resource', uri: 'kubernetes://namespaced/{plural}/{namespace}' },
    argument: { name: 'namespace', value: 'auth' },
    context: { arguments: { plural: 'deployments' } },
  },
});
// completion.values -> ['authorization-service-usw2-pr', ...]
```

## Notes

- Spec: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/completion
- Additive and backwards-compatible — no changes to existing behavior; servers without the `completions` capability get a clear `Server does not support completions` error.
- Changeset included (`@ai-sdk/mcp`: patch).
