### PR TITLE
fix(amazon-bedrock): hash Mistral tool call IDs to avoid duplicate-ID collisions

### DIFF
--- a/.changeset/mistral-tool-call-id-collision.md
+++ b/.changeset/mistral-tool-call-id-collision.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): normalize Mistral tool call IDs by hashing the full ID instead of truncating to the first 9 characters. Truncation kept only the constant `tooluse` prefix plus ~2 variable characters, so distinct Bedrock tool call IDs collided to the same normalized ID and Bedrock rejected the request with `ValidationException: ... contain duplicate Ids`. The hash uses the full 9-character space deterministically and always produces exactly 9 alphanumeric characters.

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
@@ -33,40 +33,53 @@ describe('normalizeToolCallId', () => {
     expect(normalizeToolCallId(originalId, false)).toBe(originalId);
   });
 
-  it('should extract first 9 alphanumeric characters for Mistral models', () => {
-    // Bedrock format: tooluse_bpe71yCfRu2b5i-nKGDr5g
-    // After removing non-alphanumeric: toolusebpe71yCfRu2b5inKGDr5g
-    // First 9 chars: toolusebp
-    expect(normalizeToolCallId('tooluse_bpe71yCfRu2b5i-nKGDr5g', true)).toBe(
-      'toolusebp',
-    );
+  it('should always produce exactly 9 alphanumeric characters for Mistral models', () => {
+    const inputs = [
+      'tooluse_bpe71yCfRu2b5i-nKGDr5g',
+      'tool-use_123ABC456',
+      'abc',
+      '12345',
+      '___---___',
+      '',
+    ];
+    for (const input of inputs) {
+      expect(normalizeToolCallId(input, true)).toMatch(/^[a-zA-Z0-9]{9}$/);
+    }
   });
 
-  it('should handle IDs with various special characters', () => {
-    expect(normalizeToolCallId('tool-use_123ABC456', true)).toBe('tooluse12');
+  it('should be deterministic', () => {
+    const id = 'tooluse_bpe71yCfRu2b5i-nKGDr5g';
+    expect(normalizeToolCallId(id, true)).toBe('6VmclqrqY');
+    expect(normalizeToolCallId(id, true)).toBe(normalizeToolCallId(id, true));
+  });
+
+  it('should not collide for distinct Bedrock IDs that share the first 9 alphanumeric characters', () => {
+    // Regression test: both of these start with the constant `tooluse` prefix
+    // plus `Ac`, so first-9-character truncation maps both to `tooluseAc`,
+    // producing duplicate toolUse IDs that Bedrock rejects with
+    // `ValidationException: ... contain duplicate Ids`.
+    const a = normalizeToolCallId('tooluse_Ac1Xq9ZklmNoPq', true);
+    const b = normalizeToolCallId('tooluse_Ac2Yt7WrstUvWx', true);
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(b).toMatch(/^[a-zA-Z0-9]{9}$/);
+  });
+
+  it('should return already-normalized (9 alphanumeric char) IDs unchanged', () => {
+    // A normalized ID is returned to the caller, persisted, and re-normalized
+    // when the request is rebuilt; round-tripping must be stable so a tool call
+    // and its tool result keep the same ID.
+    expect(normalizeToolCallId('abcdefghi', true)).toBe('abcdefghi');
+    expect(normalizeToolCallId('abc123XYZ', true)).toBe('abc123XYZ');
     expect(normalizeToolCallId('___abc123DEF___', true)).toBe('abc123DEF');
   });
 
-  it('should handle IDs that are already alphanumeric', () => {
-    expect(normalizeToolCallId('abcdefghi', true)).toBe('abcdefghi');
-    expect(normalizeToolCallId('abc123XYZ', true)).toBe('abc123XYZ');
+  it('should map short IDs to exactly 9 characters', () => {
+    expect(normalizeToolCallId('abc', true)).toBe('naOMmDqz3');
+    expect(normalizeToolCallId('12345', true)).toBe('dt6dDZQCF');
   });
 
-  it('should handle short IDs', () => {
-    expect(normalizeToolCallId('abc', true)).toBe('abc');
-    expect(normalizeToolCallId('12345', true)).toBe('12345');
-  });
-
-  it('should handle IDs with only special characters', () => {
-    expect(normalizeToolCallId('___---___', true)).toBe('');
-  });
-
-  it('should produce valid Mistral tool call IDs (9 alphanumeric chars)', () => {
-    const normalizedId = normalizeToolCallId(
-      'tooluse_bpe71yCfRu2b5i-nKGDr5g',
-      true,
-    );
-    // Verify the ID matches Mistral's requirements: ^[a-zA-Z0-9]{1,9}$
-    expect(normalizedId).toMatch(/^[a-zA-Z0-9]{1,9}$/);
+  it('should map IDs with only special characters to exactly 9 characters', () => {
+    expect(normalizeToolCallId('___---___', true)).toBe('riTOazhtd');
   });
 });

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.ts
@@ -6,6 +6,40 @@ export function isMistralModel(modelId: string): boolean {
   return modelId.includes('mistral.');
 }
 
+const TOOL_CALL_ID_CHARSET =
+  '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+/**
+ * Deterministically maps an arbitrary string to exactly 9 alphanumeric
+ * characters: a 53-bit hash (cyrb53) encoded as base62.
+ *
+ * 62^9 exceeds the 2^53 hash range, so each hash maps to a distinct 9-character
+ * string, preserving all ~53 bits of entropy.
+ */
+function hashToNineAlphanumericChars(input: string): string {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  let value = 4294967296 * (2097151 & h2) + (h1 >>> 0);
+
+  let result = '';
+  for (let i = 0; i < 9; i++) {
+    result = TOOL_CALL_ID_CHARSET[value % 62] + result;
+    value = Math.floor(value / 62);
+  }
+  return result;
+}
+
 /**
  * Normalizes a tool call ID for Mistral models.
  *
@@ -16,7 +50,11 @@ export function isMistralModel(modelId: string): boolean {
  * Bedrock generates tool call IDs in formats like `tooluse_bpe71yCfRu2b5i-nKGDr5g`,
  * which are incompatible with Mistral's requirements.
  *
- * This function extracts the first 9 alphanumeric characters from the ID.
+ * The full ID is hashed into 9 characters rather than truncated: truncation
+ * keeps only the long constant prefix, so distinct IDs collide into duplicate
+ * tool IDs that Bedrock rejects. The hash must be deterministic — the normalized
+ * ID is returned to the caller, persisted, and re-normalized when the request is
+ * rebuilt, so a tool call and its result always map to the same value.
  *
  * @param toolCallId - The original tool call ID from Bedrock
  * @param isMistral - Whether the model is a Mistral model
@@ -30,7 +68,14 @@ export function normalizeToolCallId(
     return toolCallId;
   }
 
-  // Extract only alphanumeric characters and take first 9
   const alphanumericChars = toolCallId.replace(/[^a-zA-Z0-9]/g, '');
-  return alphanumericChars.slice(0, 9);
+
+  // An ID that is already exactly 9 alphanumeric characters is a previously
+  // normalized ID being round-tripped; return it unchanged so a tool call and
+  // its matching tool result keep the same ID across turns.
+  if (alphanumericChars.length === 9) {
+    return alphanumericChars;
+  }
+
+  return hashToNineAlphanumericChars(toolCallId);
 }


### PR DESCRIPTION
## Background

`@ai-sdk/amazon-bedrock` normalizes tool call IDs for Mistral models (added in #11863) so they satisfy Mistral's `^[a-zA-Z0-9]{9}$` requirement, by stripping non-alphanumeric characters and taking the first 9:

```ts
const alphanumericChars = toolCallId.replace(/[^a-zA-Z0-9]/g, '');
return alphanumericChars.slice(0, 9);
```

Bedrock tool call IDs have the form `tooluse_<random>` (e.g. `tooluse_bpe71yCfRu2b5i-nKGDr5g`). After stripping `_`/`-`, the first 9 characters are always `tooluse` (7 fixed) + 2 variable characters — so only ~2 characters of entropy survive (62² = 3,844 values). With several tool calls in a conversation (especially parallel tool calls in one turn), two distinct IDs collide to the same normalized ID via the birthday paradox, and the request ends up with two `toolUse` blocks sharing a `toolUseId`. Bedrock then rejects it:

```
ValidationException: The toolUse blocks at messages.2.content contain duplicate Ids: tooluseAc
```

`normalizeToolCallId` is applied on both the response path (`doGenerate` / `doStream`) and the request path (`convert-to-amazon-bedrock-chat-messages`), so the truncated IDs are persisted and the collision surfaces on a later turn once enough tool calls accumulate. This is unchanged on `main` and in the latest published version (4.0.116).

Fixes #16182.

## Summary

- Map the full tool call ID deterministically into 9 alphanumeric characters via a hash (cyrb53 → base62), instead of truncating to the first 9.
  - **Collision-resistant**: ~53 bits of entropy vs. the previous ~12 bits; uses the full `62⁹` space.
  - **Deterministic**: the same original ID always maps to the same normalized ID. This is required, because the normalized ID is returned to the caller, persisted, and re-normalized on the request path — a tool call and its matching tool result must map to the same value. (A random regeneration would fix the collision but break call/result pairing without a per-request ID registry, which this stateless per-ID normalizer does not have.)
  - **Always exactly 9 alphanumeric characters**: the previous code returned fewer than 9 for short inputs (e.g. `''` for a special-character-only ID), which itself violates Mistral's `^[a-zA-Z0-9]{9}$`.
- Already-normalized 9-character IDs are returned unchanged, so round-tripping across turns is stable.

## Manual Verification

- Ran the normalization over the previously-colliding production IDs: two distinct IDs sharing the first 9 alphanumeric characters (which both became `tooluseAc` under truncation) now produce distinct 9-character IDs.
- Confirmed the output always matches `^[a-zA-Z0-9]{9}$` and is stable across calls for the same input. The unit tests' golden values are computed from the implementation.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
