### PR TITLE
feat(provider): add @ai-sdk/muapi — image and video generation with 50+ models

### DIFF
--- a/packages/muapi/README.md
+++ b/packages/muapi/README.md
@@ -1,0 +1,127 @@
+# @ai-sdk/muapi
+
+[MuAPI](https://muapi.ai) provider for the [Vercel AI SDK](https://sdk.vercel.ai) — image and video generation with 50+ models including Flux, Veo3, Kling, Wan, Seedance, Midjourney, and more.
+
+## Installation
+
+```bash
+npm install @ai-sdk/muapi
+# or
+pnpm add @ai-sdk/muapi
+# or
+yarn add @ai-sdk/muapi
+```
+
+## Setup
+
+Get your API key from [muapi.ai/dashboard/api-keys](https://muapi.ai/dashboard/api-keys).
+
+```typescript
+import { createMuapi } from '@ai-sdk/muapi';
+
+const muapi = createMuapi({
+  apiKey: process.env.MUAPI_API_KEY,
+});
+```
+
+Or use the default singleton (reads `MUAPI_API_KEY` from env):
+
+```typescript
+import { muapi } from '@ai-sdk/muapi';
+```
+
+## Image Generation
+
+```typescript
+import { muapi } from '@ai-sdk/muapi';
+import { generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: muapi.image('flux-schnell'),
+  prompt: 'a sunset over the ocean, photorealistic',
+});
+
+console.log(images[0].url);
+```
+
+### Available image models
+
+| Model ID | Description |
+|----------|-------------|
+| `flux-schnell` | Flux Schnell — fast, high quality |
+| `flux-dev` | Flux Dev |
+| `flux-kontext-dev` / `flux-kontext-pro` / `flux-kontext-max` | Flux Kontext (text-to-image) |
+| `hidream-fast` / `hidream-dev` / `hidream-full` | HiDream |
+| `midjourney` / `midjourney-v7` / `midjourney-v8` | Midjourney |
+| `gpt4o` | GPT-4o image generation |
+| `gpt-image-2` | GPT Image 2 |
+| `imagen4` / `imagen4-fast` / `imagen4-ultra` | Google Imagen 4 |
+| `seedream` / `seedream-5` | Seedream |
+| `wan2.1` / `wan2.5` / `wan2.6` | Wan |
+| `qwen` / `qwen-2` / `qwen-2-pro` | Qwen |
+| `reve` | Reve |
+| `ideogram` | Ideogram v3 |
+| `hunyuan` | Hunyuan |
+
+## Video Generation
+
+```typescript
+import { muapi } from '@ai-sdk/muapi';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: muapi.video('veo3-fast'),
+  prompt: 'a timelapse of clouds moving over mountains',
+});
+
+console.log(videos[0].url);
+```
+
+### Available video models
+
+| Model ID | Description |
+|----------|-------------|
+| `veo3` / `veo3-fast` / `veo3.1` / `veo4` | Google Veo |
+| `kling-master` / `kling-v2.5-pro` / `kling-v3-pro` | Kling |
+| `wan2.1` / `wan2.2` / `wan2.5` / `wan2.6` / `wan2.7` | Wan |
+| `seedance-pro` / `seedance-pro-fast` | Seedance |
+| `runway` | Runway |
+| `pixverse` / `pixverse-v5` / `pixverse-v6` | Pixverse |
+| `sora` / `sora-2` | OpenAI Sora |
+| `hunyuan` | Hunyuan |
+| `vidu` / `vidu-q2-pro` / `vidu-q3-pro` | Vidu |
+
+## Image-to-Video
+
+```typescript
+import { muapi } from '@ai-sdk/muapi';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: muapi.imageToVideo('kling-master'),
+  prompt: 'zoom in slowly',
+  image: { type: 'url', url: 'https://example.com/photo.jpg' },
+});
+```
+
+## Provider options
+
+Pass extra model-specific parameters via `providerOptions.muapi`:
+
+```typescript
+const { images } = await generateImage({
+  model: muapi.image('flux-dev'),
+  prompt: 'a cat',
+  providerOptions: {
+    muapi: {
+      width: 1024,
+      height: 768,
+      num_inference_steps: 28,
+    },
+  },
+});
+```
+
+## License
+
+Apache-2.0

--- a/packages/muapi/package.json
+++ b/packages/muapi/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@ai-sdk/muapi",
+  "version": "1.0.0-beta.1",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist docs *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "del-cli": "^5.1.0",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "vitest": "^3.0.0",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/muapi"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "muapi",
+    "image-generation",
+    "video-generation",
+    "flux",
+    "kling",
+    "veo3",
+    "wan",
+    "seedance",
+    "midjourney"
+  ]
+}

--- a/packages/muapi/src/index.ts
+++ b/packages/muapi/src/index.ts
@@ -1,0 +1,7 @@
+export { createMuapi, muapi } from './muapi-provider';
+export type { MuApiProvider, MuApiProviderSettings } from './muapi-provider';
+export { MuApiImageModel } from './muapi-image-model';
+export type { MuApiImageModelId } from './muapi-image-model';
+export { MuApiVideoModel } from './muapi-video-model';
+export type { MuApiVideoModelId } from './muapi-video-model';
+export { VERSION } from './version';

--- a/packages/muapi/src/muapi-error.ts
+++ b/packages/muapi/src/muapi-error.ts
@@ -1,0 +1,14 @@
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const muapiErrorDataSchema = z.object({
+  detail: z.string().optional(),
+  message: z.string().optional(),
+});
+
+export type MuApiErrorData = z.infer<typeof muapiErrorDataSchema>;
+
+export const muapiFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: muapiErrorDataSchema,
+  errorToMessage: data => data.detail ?? data.message ?? 'Unknown error',
+});

--- a/packages/muapi/src/muapi-image-model.ts
+++ b/packages/muapi/src/muapi-image-model.ts
@@ -1,0 +1,235 @@
+import type { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  delay,
+  getFromApi,
+  postJsonToApi,
+  resolve,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { muapiFailedResponseHandler } from './muapi-error';
+
+export type MuApiImageModelId =
+  // Flux
+  | 'flux-dev'
+  | 'flux-schnell'
+  | 'flux-krea'
+  | 'flux-kontext-dev'
+  | 'flux-kontext-pro'
+  | 'flux-kontext-max'
+  | 'flux-2-dev'
+  | 'flux-2-pro'
+  // HiDream
+  | 'hidream-fast'
+  | 'hidream-dev'
+  | 'hidream-full'
+  // Wan
+  | 'wan2.1'
+  | 'wan2.5'
+  | 'wan2.6'
+  // GPT
+  | 'gpt4o'
+  | 'gpt-image'
+  | 'gpt-image-2'
+  // Google
+  | 'imagen4'
+  | 'imagen4-fast'
+  | 'imagen4-ultra'
+  // Midjourney
+  | 'midjourney'
+  | 'midjourney-v7'
+  | 'midjourney-v8'
+  // Seedream
+  | 'seedream'
+  | 'seedream-v3'
+  | 'seedream-v4'
+  | 'seedream-5'
+  // Qwen
+  | 'qwen'
+  | 'qwen-2'
+  | 'qwen-2-pro'
+  // Others
+  | 'hunyuan'
+  | 'ideogram'
+  | 'reve'
+  | 'sdxl'
+  | 'grok'
+  | 'kling-o1'
+  | 'kling-o3'
+  // Image-to-image
+  | 'flux-kontext-dev-i2i'
+  | 'flux-kontext-pro-i2i'
+  | 'flux-kontext-max-i2i'
+  | 'gpt4o-edit'
+  | 'seededit'
+  | 'seedream-edit'
+  | 'midjourney-style'
+  | 'qwen-edit'
+  | 'reve-edit'
+  | (string & {});
+
+// Map model IDs to MuAPI endpoint slugs
+const MODEL_ENDPOINTS: Record<string, string> = {
+  'flux-dev': 'flux-dev-image',
+  'flux-schnell': 'flux-schnell-image',
+  'flux-krea': 'flux-krea-dev',
+  'flux-kontext-dev': 'flux-kontext-dev-t2i',
+  'flux-kontext-pro': 'flux-kontext-pro-t2i',
+  'flux-kontext-max': 'flux-kontext-max-t2i',
+  'flux-2-dev': 'flux-2-dev',
+  'flux-2-pro': 'flux-2-pro',
+  'hidream-fast': 'hidream_i1_fast_image',
+  'hidream-dev': 'hidream_i1_dev_image',
+  'hidream-full': 'hidream_i1_full_image',
+  'wan2.1': 'wan2.1-text-to-image',
+  'wan2.5': 'wan2.5-text-to-image',
+  'wan2.6': 'wan2.6-text-to-image',
+  'gpt4o': 'gpt4o-text-to-image',
+  'gpt-image': 'gpt-image-1.5',
+  'gpt-image-2': 'gpt-image-2-text-to-image',
+  'imagen4': 'google-imagen4',
+  'imagen4-fast': 'google-imagen4-fast',
+  'imagen4-ultra': 'google-imagen4-ultra',
+  'midjourney': 'midjourney-v7-text-to-image',
+  'midjourney-v7': 'midjourney-v7',
+  'midjourney-v8': 'midjourney-v8',
+  'seedream': 'bytedance-seedream-v4.5',
+  'seedream-v3': 'bytedance-seedream-image',
+  'seedream-v4': 'bytedance-seedream-v4',
+  'seedream-5': 'seedream-5.0',
+  'qwen': 'qwen-image',
+  'qwen-2': 'qwen-image-2.0',
+  'qwen-2-pro': 'qwen-image-2.0-pro',
+  'hunyuan': 'hunyuan-image-2.1',
+  'ideogram': 'ideogram-v3-t2i',
+  'reve': 'reve-text-to-image',
+  'sdxl': 'sdxl-image',
+  'grok': 'grok-imagine-text-to-image',
+  'kling-o1': 'kling-o1-text-to-image',
+  'kling-o3': 'kling-o3-image',
+  // Image-to-image
+  'flux-kontext-dev-i2i': 'flux-kontext-dev-i2i',
+  'flux-kontext-pro-i2i': 'flux-kontext-pro-i2i',
+  'flux-kontext-max-i2i': 'flux-kontext-max-i2i',
+  'gpt4o-edit': 'gpt4o-edit',
+  'seededit': 'bytedance-seededit-image',
+  'seedream-edit': 'bytedance-seedream-edit-v4',
+  'midjourney-style': 'midjourney-v7-style-reference',
+  'qwen-edit': 'qwen-image-edit',
+  'reve-edit': 'reve-image-edit',
+};
+
+const submitResponseSchema = z.object({
+  request_id: z.string(),
+});
+
+const pollResponseSchema = z.object({
+  status: z.string(),
+  outputs: z.array(z.string()).optional(),
+  error: z.string().optional(),
+});
+
+export interface MuApiImageModelConfig {
+  provider: string;
+  baseURL: string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+export class MuApiImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxImagesPerCall = 1;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: MuApiImageModelId,
+    private readonly config: MuApiImageModelConfig,
+  ) {}
+
+  async doGenerate(
+    options: Parameters<ImageModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<ImageModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+
+    const endpoint = MODEL_ENDPOINTS[this.modelId] ?? this.modelId;
+
+    const body: Record<string, unknown> = {
+      prompt: options.prompt,
+      n: options.n ?? 1,
+    };
+
+    if (options.size) {
+      const [width, height] = options.size.split('x').map(Number);
+      if (width) body.width = width;
+      if (height) body.height = height;
+    }
+
+    if (options.aspectRatio) {
+      body.aspect_ratio = options.aspectRatio;
+    }
+
+    if (options.seed != null) {
+      body.seed = options.seed;
+    }
+
+    // Pass provider-specific options
+    if (options.providerOptions?.muapi) {
+      Object.assign(body, options.providerOptions.muapi);
+    }
+
+    const headers = await resolve(this.config.headers);
+
+    const { value: submitResult } = await postJsonToApi({
+      url: `${this.config.baseURL}/${endpoint}`,
+      headers: combineHeaders(headers),
+      body,
+      failedResponseHandler: muapiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(submitResponseSchema),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    // Poll for result
+    const requestId = submitResult.request_id;
+    const pollUrl = `${this.config.baseURL}/predictions/${requestId}/result`;
+
+    while (true) {
+      await delay(2000);
+
+      const { value: pollResult } = await getFromApi({
+        url: pollUrl,
+        headers: combineHeaders(headers),
+        failedResponseHandler: muapiFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(pollResponseSchema),
+        abortSignal: options.abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      if (pollResult.status === 'completed' && pollResult.outputs) {
+        return {
+          images: pollResult.outputs.map(url => ({ type: 'url' as const, url })),
+          warnings,
+          response: {
+            timestamp: currentDate,
+            modelId: this.modelId,
+            headers: {},
+          },
+        };
+      }
+
+      if (pollResult.status === 'failed') {
+        throw new Error(pollResult.error ?? 'Image generation failed');
+      }
+    }
+  }
+}

--- a/packages/muapi/src/muapi-image-model.ts
+++ b/packages/muapi/src/muapi-image-model.ts
@@ -203,7 +203,8 @@ export class MuApiImageModel implements ImageModelV4 {
     const requestId = submitResult.request_id;
     const pollUrl = `${this.config.baseURL}/predictions/${requestId}/result`;
 
-    while (true) {
+    const MAX_POLL_ATTEMPTS = 300; // 300 * 2s = 600s
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
       await delay(2000);
 
       const { value: pollResult } = await getFromApi({
@@ -217,7 +218,7 @@ export class MuApiImageModel implements ImageModelV4 {
 
       if (pollResult.status === 'completed' && pollResult.outputs) {
         return {
-          images: pollResult.outputs.map(url => ({ type: 'url' as const, url })),
+          images: pollResult.outputs,
           warnings,
           response: {
             timestamp: currentDate,
@@ -231,5 +232,9 @@ export class MuApiImageModel implements ImageModelV4 {
         throw new Error(pollResult.error ?? 'Image generation failed');
       }
     }
+
+    throw new Error(
+      `MuAPI image generation timed out after ${MAX_POLL_ATTEMPTS * 2}s (request_id=${requestId})`,
+    );
   }
 }

--- a/packages/muapi/src/muapi-image-model.ts
+++ b/packages/muapi/src/muapi-image-model.ts
@@ -1,6 +1,7 @@
 import type { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
 import {
   combineHeaders,
+  createBinaryResponseHandler,
   createJsonResponseHandler,
   delay,
   getFromApi,
@@ -217,8 +218,22 @@ export class MuApiImageModel implements ImageModelV4 {
       });
 
       if (pollResult.status === 'completed' && pollResult.outputs) {
+        const images = await Promise.all(
+          pollResult.outputs.map(async outputUrl => {
+            const { value } = await getFromApi({
+              url: outputUrl,
+              successfulResponseHandler: createBinaryResponseHandler(),
+              failedResponseHandler: muapiFailedResponseHandler,
+              abortSignal: options.abortSignal,
+              fetch: this.config.fetch,
+            });
+
+            return value;
+          }),
+        );
+
         return {
-          images: pollResult.outputs,
+          images,
           warnings,
           response: {
             timestamp: currentDate,

--- a/packages/muapi/src/muapi-provider.ts
+++ b/packages/muapi/src/muapi-provider.ts
@@ -1,0 +1,124 @@
+import {
+  NoSuchModelError,
+  type Experimental_VideoModelV4,
+  type ImageModelV4,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  loadApiKey,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { MuApiImageModel } from './muapi-image-model';
+import type { MuApiImageModelId } from './muapi-image-model';
+import { MuApiVideoModel } from './muapi-video-model';
+import type { MuApiVideoModelId } from './muapi-video-model';
+import { VERSION } from './version';
+
+const BASE_URL = 'https://api.muapi.ai/api/v1';
+
+export interface MuApiProviderSettings {
+  /**
+   * MuAPI API key. Defaults to the `MUAPI_API_KEY` environment variable.
+   * Get your key at https://muapi.ai/dashboard/api-keys
+   */
+  apiKey?: string;
+
+  /**
+   * Override the default base URL for MuAPI requests.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in all requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation for intercepting or mocking requests.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface MuApiProvider extends ProviderV4 {
+  /**
+   * Creates a MuAPI text-to-image or image-to-image model.
+   *
+   * Model IDs: 'flux-schnell', 'flux-dev', 'hidream-fast', 'midjourney', 'imagen4', etc.
+   *
+   * See https://muapi.ai/docs for the full model list.
+   */
+  image(modelId: MuApiImageModelId): ImageModelV4;
+
+  /**
+   * Creates a MuAPI text-to-video model.
+   *
+   * Model IDs: 'veo3-fast', 'kling-master', 'wan2.2', 'seedance-pro', 'runway', etc.
+   */
+  video(modelId: MuApiVideoModelId): Experimental_VideoModelV4;
+
+  /**
+   * Creates a MuAPI image-to-video model.
+   *
+   * Provide the source image via `options.image` or `providerOptions.muapi.image_url`.
+   * Model IDs: 'kling-master', 'veo3', 'wan2.5-i2v', 'seedance-2', etc.
+   */
+  imageToVideo(modelId: MuApiVideoModelId): Experimental_VideoModelV4;
+}
+
+export function createMuapi(options: MuApiProviderSettings = {}): MuApiProvider {
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        'x-api-key': loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'MUAPI_API_KEY',
+          description: 'MuAPI',
+        }),
+        ...options.headers,
+      },
+      `ai-sdk/muapi/${VERSION}`,
+    );
+
+  const baseURL = options.baseURL ?? BASE_URL;
+
+  const createImageModel = (modelId: MuApiImageModelId) =>
+    new MuApiImageModel(modelId, {
+      provider: 'muapi',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const createVideoModel = (modelId: MuApiVideoModelId, mode: 'text-to-video' | 'image-to-video' = 'text-to-video') =>
+    new MuApiVideoModel(modelId, {
+      provider: mode === 'image-to-video' ? 'muapi.image-to-video' : 'muapi.video',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+      mode,
+    });
+
+  const embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+
+  return {
+    specificationVersion: 'v4' as const,
+    image: createImageModel,
+    imageModel: createImageModel,
+    languageModel: (modelId: string) => {
+      throw new NoSuchModelError({ modelId, modelType: 'languageModel' });
+    },
+    embeddingModel,
+    textEmbeddingModel: embeddingModel,
+    video: (modelId: MuApiVideoModelId) => createVideoModel(modelId, 'text-to-video'),
+    videoModel: (modelId: MuApiVideoModelId) => createVideoModel(modelId, 'text-to-video'),
+    imageToVideo: (modelId: MuApiVideoModelId) => createVideoModel(modelId, 'image-to-video'),
+  };
+}
+
+/**
+ * Default MuAPI provider instance. Reads `MUAPI_API_KEY` from the environment.
+ */
+export const muapi = createMuapi();

--- a/packages/muapi/src/muapi-video-model.ts
+++ b/packages/muapi/src/muapi-video-model.ts
@@ -231,7 +231,8 @@ export class MuApiVideoModel implements Experimental_VideoModelV4 {
     const requestId = submitResult.request_id;
     const pollUrl = `${this.config.baseURL}/predictions/${requestId}/result`;
 
-    while (true) {
+    const MAX_POLL_ATTEMPTS = 500; // 500 * 3s = 1500s
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
       await delay(3000);
 
       const { value: pollResult } = await getFromApi({
@@ -259,5 +260,9 @@ export class MuApiVideoModel implements Experimental_VideoModelV4 {
         throw new Error(pollResult.error ?? 'Video generation failed');
       }
     }
+
+    throw new Error(
+      `MuAPI video generation timed out after ${MAX_POLL_ATTEMPTS * 3}s (request_id=${requestId})`,
+    );
   }
 }

--- a/packages/muapi/src/muapi-video-model.ts
+++ b/packages/muapi/src/muapi-video-model.ts
@@ -1,0 +1,263 @@
+import type { Experimental_VideoModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  delay,
+  getFromApi,
+  postJsonToApi,
+  resolve,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { muapiFailedResponseHandler } from './muapi-error';
+
+export type MuApiVideoModelId =
+  // Veo
+  | 'veo3'
+  | 'veo3-fast'
+  | 'veo3.1'
+  | 'veo4'
+  // Kling
+  | 'kling-master'
+  | 'kling-v2.5-pro'
+  | 'kling-v2.6-pro'
+  | 'kling-v3-pro'
+  // Wan
+  | 'wan2.1'
+  | 'wan2.2'
+  | 'wan2.5'
+  | 'wan2.6'
+  | 'wan2.7'
+  // Seedance
+  | 'seedance-pro'
+  | 'seedance-pro-fast'
+  // Others
+  | 'runway'
+  | 'pixverse'
+  | 'pixverse-v5'
+  | 'pixverse-v6'
+  | 'vidu'
+  | 'vidu-q2-pro'
+  | 'vidu-q3-pro'
+  | 'sora'
+  | 'sora-2'
+  | 'hunyuan'
+  // Image-to-video
+  | 'kling-std'
+  | 'kling-pro'
+  | 'kling-v2.5-pro-i2v'
+  | 'veo3-i2v'
+  | 'veo3.1-i2v'
+  | 'veo4-i2v'
+  | 'wan2.1-i2v'
+  | 'wan2.5-i2v'
+  | 'wan2.6-i2v'
+  | 'wan2.7-i2v'
+  | 'seedance-v2'
+  | 'seedance-2'
+  | 'runway-i2v'
+  | 'pixverse-v4.5'
+  | 'pixverse-v5-i2v'
+  | 'pixverse-v6-i2v'
+  | 'vidu-i2v'
+  | 'vidu-q2-pro-i2v'
+  | 'midjourney-v7-i2v'
+  | 'sora-2-i2v'
+  | 'hunyuan-i2v'
+  | (string & {});
+
+const T2V_ENDPOINTS: Record<string, string> = {
+  'veo3': 'veo3-text-to-video',
+  'veo3-fast': 'veo3-fast-text-to-video',
+  'veo3.1': 'veo3.1-text-to-video',
+  'veo4': 'veo-4-text-to-video',
+  'kling-master': 'kling-v2.1-master-t2v',
+  'kling-v2.5-pro': 'kling-v2.5-turbo-pro-t2v',
+  'kling-v2.6-pro': 'kling-v2.6-pro-t2v',
+  'kling-v3-pro': 'kling-v3.0-pro-text-to-video',
+  'wan2.1': 'wan2.1-text-to-video',
+  'wan2.2': 'wan2.2-text-to-video',
+  'wan2.5': 'wan2.5-text-to-video',
+  'wan2.6': 'wan2.6-text-to-video',
+  'wan2.7': 'wan2.7-text-to-video',
+  'seedance-pro': 'seedance-pro-t2v',
+  'seedance-pro-fast': 'seedance-pro-t2v-fast',
+  'runway': 'runway-text-to-video',
+  'pixverse': 'pixverse-v4.5-t2v',
+  'pixverse-v5': 'pixverse-v5-t2v',
+  'pixverse-v6': 'pixverse-v6-t2v',
+  'vidu': 'vidu-v2.0-t2v',
+  'vidu-q2-pro': 'vidu-q2-pro-text-to-video',
+  'vidu-q3-pro': 'vidu-q3-pro-text-to-video',
+  'sora': 'openai-sora',
+  'sora-2': 'openai-sora-2-text-to-video',
+  'hunyuan': 'hunyuan-text-to-video',
+};
+
+const I2V_ENDPOINTS: Record<string, string> = {
+  'kling-std': 'kling-v2.1-standard-i2v',
+  'kling-pro': 'kling-v2.1-pro-i2v',
+  'kling-master': 'kling-v2.1-master-i2v',
+  'kling-v2.5-pro': 'kling-v2.5-turbo-pro-i2v',
+  'veo3': 'veo3-image-to-video',
+  'veo3-i2v': 'veo3-image-to-video',
+  'veo3.1': 'veo3.1-image-to-video',
+  'veo3.1-i2v': 'veo3.1-image-to-video',
+  'veo4': 'veo-4-image-to-video',
+  'veo4-i2v': 'veo-4-image-to-video',
+  'wan2.1-i2v': 'wan2.1-image-to-video',
+  'wan2.5-i2v': 'wan2.5-image-to-video',
+  'wan2.6-i2v': 'wan2.6-image-to-video',
+  'wan2.7-i2v': 'wan2.7-image-to-video',
+  'seedance-pro': 'seedance-pro-i2v',
+  'seedance-v2': 'seedance-v2.0-i2v',
+  'seedance-2': 'seedance-2-image-to-video',
+  'runway-i2v': 'runway-image-to-video',
+  'pixverse-v4.5': 'pixverse-v4.5-i2v',
+  'pixverse-v5-i2v': 'pixverse-v5-i2v',
+  'pixverse-v6-i2v': 'pixverse-v6-i2v',
+  'vidu-i2v': 'vidu-v2.0-i2v',
+  'vidu-q2-pro-i2v': 'vidu-q2-pro-image-to-video',
+  'midjourney-v7-i2v': 'midjourney-v7-image-to-video',
+  'sora-2-i2v': 'openai-sora-2-image-to-video',
+  'hunyuan-i2v': 'hunyuan-image-to-video',
+};
+
+// These models accept images_list instead of image_url
+const LIST_INPUT_MODELS = new Set([
+  'wan2.1-i2v', 'wan2.5-i2v', 'wan2.6-i2v', 'wan2.7-i2v',
+  'seedance-pro', 'seedance-v2', 'seedance-2',
+  'vidu-i2v', 'vidu-q2-pro-i2v',
+  'pixverse-v4.5', 'pixverse-v5-i2v', 'pixverse-v6-i2v',
+  'sora-2-i2v',
+]);
+
+const submitResponseSchema = z.object({
+  request_id: z.string(),
+});
+
+const pollResponseSchema = z.object({
+  status: z.string(),
+  outputs: z.array(z.string()).optional(),
+  error: z.string().optional(),
+});
+
+export interface MuApiVideoModelConfig {
+  provider: string;
+  baseURL: string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  mode?: 'text-to-video' | 'image-to-video';
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+export class MuApiVideoModel implements Experimental_VideoModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxVideosPerCall = 1;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: MuApiVideoModelId,
+    private readonly config: MuApiVideoModelConfig,
+  ) {}
+
+  async doGenerate(
+    options: Parameters<Experimental_VideoModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<Experimental_VideoModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+
+    const isI2V = this.config.mode === 'image-to-video' || options.image != null;
+    const registry = isI2V ? I2V_ENDPOINTS : T2V_ENDPOINTS;
+    const endpoint = registry[this.modelId] ?? T2V_ENDPOINTS[this.modelId] ?? this.modelId;
+
+    const body: Record<string, unknown> = {
+      prompt: options.prompt,
+      aspect_ratio: options.aspectRatio ?? '16:9',
+    };
+
+    if (options.durationSeconds != null) {
+      body.duration = options.durationSeconds;
+    }
+
+    if (options.seed != null) {
+      body.seed = options.seed;
+    }
+
+    // Attach image input for image-to-video
+    if (isI2V && options.image != null) {
+      let imageUrl: string;
+      if (options.image.type === 'url') {
+        imageUrl = options.image.url;
+      } else {
+        // base64 data URI
+        imageUrl = `data:${options.image.mediaType};base64,${options.image.base64}`;
+      }
+
+      if (LIST_INPUT_MODELS.has(this.modelId)) {
+        body.images_list = [imageUrl];
+      } else {
+        body.image_url = imageUrl;
+      }
+    }
+
+    // Pass provider-specific options
+    if (options.providerOptions?.muapi) {
+      const { image_url, images_list, ...rest } = options.providerOptions.muapi as Record<string, unknown>;
+      Object.assign(body, rest);
+      // Allow explicit overrides
+      if (image_url) body.image_url = image_url;
+      if (images_list) body.images_list = images_list;
+    }
+
+    const headers = await resolve(this.config.headers);
+
+    const { value: submitResult } = await postJsonToApi({
+      url: `${this.config.baseURL}/${endpoint}`,
+      headers: combineHeaders(headers),
+      body,
+      failedResponseHandler: muapiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(submitResponseSchema),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const requestId = submitResult.request_id;
+    const pollUrl = `${this.config.baseURL}/predictions/${requestId}/result`;
+
+    while (true) {
+      await delay(3000);
+
+      const { value: pollResult } = await getFromApi({
+        url: pollUrl,
+        headers: combineHeaders(headers),
+        failedResponseHandler: muapiFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(pollResponseSchema),
+        abortSignal: options.abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      if (pollResult.status === 'completed' && pollResult.outputs) {
+        return {
+          videos: [{ type: 'url' as const, url: pollResult.outputs[0], mediaType: 'video/mp4' }],
+          warnings,
+          response: {
+            timestamp: currentDate,
+            modelId: this.modelId,
+            headers: {},
+          },
+        };
+      }
+
+      if (pollResult.status === 'failed') {
+        throw new Error(pollResult.error ?? 'Video generation failed');
+      }
+    }
+  }
+}

--- a/packages/muapi/src/version.ts
+++ b/packages/muapi/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = '1.0.0';

--- a/packages/muapi/tsconfig.build.json
+++ b/packages/muapi/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/muapi/tsconfig.json
+++ b/packages/muapi/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/muapi/tsup.config.ts
+++ b/packages/muapi/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/muapi/turbo.json
+++ b/packages/muapi/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new `packages/muapi` provider for [MuAPI](https://muapi.ai), a generative media aggregator with 50+ AI models
- Supports **image generation** (`muapi.image(modelId)`) and **video generation** (`muapi.video(modelId)` / `muapi.imageToVideo(modelId)`)
- Follows the existing `v4` provider specification pattern (matches `replicate`, `fal`, etc.)
- Auth via `MUAPI_API_KEY` env var or `apiKey` option

## Models supported

**Image:** Flux (schnell, dev, kontext, flux-2), HiDream, Midjourney v7/v8, GPT-4o, GPT-Image-2, Google Imagen 4, Seedream, Wan 2.1/2.5/2.6, Qwen, Reve, Ideogram, Hunyuan, and more

**Video (T2V):** Veo3/3.1/4, Kling master/v2.5/v3, Wan 2.1–2.7, Seedance Pro, Runway, Pixverse, Sora, Vidu, Hunyuan

**Video (I2V):** Kling std/pro/master, Veo3/4, Wan 2.1/2.5/2.6/2.7, Seedance v2/2, Runway, Pixverse, Vidu, Midjourney v7

## Usage

```typescript
import { createMuapi } from '@ai-sdk/muapi';
import { generateImage, experimental_generateVideo as generateVideo } from 'ai';

const muapi = createMuapi({ apiKey: process.env.MUAPI_API_KEY });

// Image generation
const { images } = await generateImage({
  model: muapi.image('flux-schnell'),
  prompt: 'a sunset over the ocean',
});

// Video generation
const { videos } = await generateVideo({
  model: muapi.video('veo3-fast'),
  prompt: 'a timelapse of clouds over mountains',
});

// Image-to-video
const { videos: clips } = await generateVideo({
  model: muapi.imageToVideo('kling-master'),
  prompt: 'slow zoom in',
  image: { type: 'url', url: 'https://example.com/photo.jpg' },
});
```

## API pattern

MuAPI uses a submit → poll pattern:
1. `POST /api/v1/{endpoint}` returns `{ request_id }`
2. `GET /api/v1/predictions/{id}/result` is polled until `status === 'completed'`

Both image and video models implement this using `postJsonToApi` + `getFromApi` from `@ai-sdk/provider-utils`.

## Test plan

- [ ] Install `@ai-sdk/muapi` and set `MUAPI_API_KEY`
- [ ] Run `generateImage` with `flux-schnell` — verify URL output
- [ ] Run `generateVideo` with `veo3-fast` — verify MP4 URL output
- [ ] Run `imageToVideo` with `kling-master` and an image URL — verify MP4 URL output
- [ ] Verify `NoSuchModelError` thrown for `languageModel` / `embeddingModel`
- [ ] Verify `MuApiError` surface on HTTP 4xx/5xx responses
- [ ] `pnpm build` in `packages/muapi` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)