### PR TITLE
fix(harness): fix incomplete OIDC token support for AI Gateway auth in harness adapters

### DIFF
--- a/.changeset/weak-stingrays-do.md
+++ b/.changeset/weak-stingrays-do.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-pi": patch
+"@ai-sdk/harness": patch
+---
+
+fix(harness): fix incomplete OIDC token support for AI Gateway auth in harness adapters

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -95,7 +95,7 @@ try {
 
 To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
 Vercel Sandbox, and `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` or
-`AI_GATEWAY_API_KEY` for Claude Code.
+`AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` for Claude Code.
 
 ## Adapter Settings
 

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -93,8 +93,8 @@ try {
 ```
 
 To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
-Vercel Sandbox, and `OPENAI_API_KEY` or `CODEX_API_KEY` or
-`AI_GATEWAY_API_KEY` for Codex.
+Vercel Sandbox, and `OPENAI_API_KEY` or `CODEX_API_KEY` or `AI_GATEWAY_API_KEY`
+or `VERCEL_OIDC_TOKEN` for Codex.
 
 ## Adapter Settings
 

--- a/content/providers/02-ai-sdk-harnesses/03-pi.mdx
+++ b/content/providers/02-ai-sdk-harnesses/03-pi.mdx
@@ -90,7 +90,8 @@ try {
 ```
 
 To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
-Vercel Sandbox, and `AI_GATEWAY_API_KEY` or a provider specific API key for Pi.
+Vercel Sandbox, and `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` or a provider
+specific API key for Pi.
 
 ## Adapter Settings
 

--- a/packages/harness-claude-code/src/claude-code-auth.test.ts
+++ b/packages/harness-claude-code/src/claude-code-auth.test.ts
@@ -39,6 +39,20 @@ describe('resolveClaudeCodeEnv', () => {
     expect(env.ANTHROPIC_BASE_URL).toBe('https://ai-gateway.vercel.sh');
   });
 
+  it('uses env gateway auth when gateway option only sets base URL', () => {
+    const env = resolveClaudeCodeEnv(
+      { gateway: { baseUrl: 'https://gw.example' } },
+      { VERCEL_OIDC_TOKEN: 'oidc-env' },
+      { readApiKeyHelper: noHelper },
+    );
+    expect(env).toEqual({
+      AI_GATEWAY_API_KEY: 'oidc-env',
+      ANTHROPIC_API_KEY: 'oidc-env',
+      AI_GATEWAY_BASE_URL: 'https://gw.example',
+      ANTHROPIC_BASE_URL: 'https://gw.example',
+    });
+  });
+
   it('auto-detects gateway when AI_GATEWAY_API_KEY is set', () => {
     const env = resolveClaudeCodeEnv(
       undefined,
@@ -47,6 +61,18 @@ describe('resolveClaudeCodeEnv', () => {
     );
     expect(env.AI_GATEWAY_API_KEY).toBe('gw-auto');
     expect(env.ANTHROPIC_API_KEY).toBe('gw-auto');
+  });
+
+  it('auto-detects gateway when VERCEL_OIDC_TOKEN is set', () => {
+    const env = resolveClaudeCodeEnv(
+      undefined,
+      { VERCEL_OIDC_TOKEN: 'oidc-auto' },
+      { readApiKeyHelper: noHelper },
+    );
+    expect(env.AI_GATEWAY_API_KEY).toBe('oidc-auto');
+    expect(env.ANTHROPIC_API_KEY).toBe('oidc-auto');
+    expect(env.AI_GATEWAY_BASE_URL).toBe('https://ai-gateway.vercel.sh');
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://ai-gateway.vercel.sh');
   });
 
   it('auto-detects direct anthropic when only ANTHROPIC_API_KEY is set', () => {

--- a/packages/harness-claude-code/src/claude-code-auth.ts
+++ b/packages/harness-claude-code/src/claude-code-auth.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getAiGatewayAuthFromEnv } from '@ai-sdk/harness/utils';
 
 export type ClaudeCodeAuthOptions = {
   readonly anthropic?: {
@@ -22,8 +23,8 @@ export type ClaudeCodeAuthOptions = {
  *   1. Explicit `auth.anthropic` — pin to direct Anthropic auth.
  *   2. Explicit `auth.gateway` — pin to gateway-routed auth.
  *   3. Auto-detect from the host process env: gateway first
- *      (`AI_GATEWAY_API_KEY`), then direct (`ANTHROPIC_API_KEY` /
- *      `ANTHROPIC_AUTH_TOKEN`).
+ *      (`AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN`), then direct
+ *      (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`).
  */
 export type ResolveClaudeCodeEnvOptions = {
   /**
@@ -45,12 +46,21 @@ export function resolveClaudeCodeEnv(
   if (auth?.anthropic) {
     return pickAnthropic({ explicit: auth.anthropic, processEnv, readApiKey });
   }
+
+  const gatewayAuthFromEnv = getAiGatewayAuthFromEnv({ env: processEnv });
   if (auth?.gateway) {
-    return pickGateway(auth.gateway, processEnv);
+    return pickGateway({
+      explicit: auth.gateway,
+      gatewayAuthFromEnv,
+    });
   }
-  if (processEnv.AI_GATEWAY_API_KEY) {
-    return pickGateway({}, processEnv);
+  if (gatewayAuthFromEnv.apiKey) {
+    return pickGateway({
+      explicit: {},
+      gatewayAuthFromEnv,
+    });
   }
+
   return pickAnthropic({ processEnv, readApiKey });
 }
 
@@ -111,15 +121,15 @@ function readApiKeyHelper(): string | undefined {
   }
 }
 
-function pickGateway(
-  explicit: NonNullable<ClaudeCodeAuthOptions['gateway']>,
-  processEnv: Record<string, string | undefined>,
-): Record<string, string> {
-  const apiKey = explicit.apiKey ?? processEnv.AI_GATEWAY_API_KEY;
-  const baseUrl =
-    explicit.baseUrl ??
-    processEnv.AI_GATEWAY_BASE_URL ??
-    'https://ai-gateway.vercel.sh';
+function pickGateway({
+  explicit,
+  gatewayAuthFromEnv,
+}: {
+  explicit: NonNullable<ClaudeCodeAuthOptions['gateway']>;
+  gatewayAuthFromEnv: ReturnType<typeof getAiGatewayAuthFromEnv>;
+}): Record<string, string> {
+  const apiKey = explicit.apiKey ?? gatewayAuthFromEnv.apiKey;
+  const baseUrl = explicit.baseUrl ?? gatewayAuthFromEnv.baseUrl;
   const env: Record<string, string> = {};
   if (apiKey) {
     env.AI_GATEWAY_API_KEY = apiKey;

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -158,9 +158,14 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   const codexConfig: Record<string, unknown> = {};
   if (Object.keys(mcpServers).length > 0) codexConfig.mcp_servers = mcpServers;
 
-  const apiBaseUrl = procEnv.AI_GATEWAY_API_KEY
-    ? procEnv.AI_GATEWAY_BASE_URL || 'https://ai-gateway.vercel.sh/v1'
-    : procEnv.OPENAI_BASE_URL;
+  const gatewayBaseUrl = procEnv.AI_GATEWAY_BASE_URL;
+  const hasGatewayAuth = Boolean(procEnv.AI_GATEWAY_API_KEY || gatewayBaseUrl);
+  if (hasGatewayAuth && !gatewayBaseUrl) {
+    throw new Error(
+      'AI Gateway auth was selected but AI_GATEWAY_BASE_URL is missing from the Codex bridge environment.',
+    );
+  }
+  const apiBaseUrl = hasGatewayAuth ? gatewayBaseUrl : procEnv.OPENAI_BASE_URL;
   if (apiBaseUrl) {
     codexConfig.preferred_auth_method = 'apikey';
     codexConfig.model_provider = 'agent_bridge_openai';

--- a/packages/harness-codex/src/codex-auth.test.ts
+++ b/packages/harness-codex/src/codex-auth.test.ts
@@ -38,11 +38,44 @@ describe('resolveCodexEnv', () => {
     });
   });
 
+  it('appends /v1 to gateway base URLs for Codex', () => {
+    const env = resolveCodexEnv(
+      { gateway: { baseUrl: 'https://gw.example' } },
+      { VERCEL_OIDC_TOKEN: 'oidc-env' },
+    );
+    expect(env).toEqual({
+      AI_GATEWAY_API_KEY: 'oidc-env',
+      CODEX_API_KEY: 'oidc-env',
+      AI_GATEWAY_BASE_URL: 'https://gw.example/v1',
+    });
+  });
+
+  it('uses env gateway auth when gateway option only sets base URL', () => {
+    const env = resolveCodexEnv(
+      { gateway: { baseUrl: 'https://gw.example/v1' } },
+      { VERCEL_OIDC_TOKEN: 'oidc-env' },
+    );
+    expect(env).toEqual({
+      AI_GATEWAY_API_KEY: 'oidc-env',
+      CODEX_API_KEY: 'oidc-env',
+      AI_GATEWAY_BASE_URL: 'https://gw.example/v1',
+    });
+  });
+
   it('auto-detects gateway when AI_GATEWAY_API_KEY is set', () => {
     const env = resolveCodexEnv(undefined, { AI_GATEWAY_API_KEY: 'gw-auto' });
     expect(env).toEqual({
       AI_GATEWAY_API_KEY: 'gw-auto',
       CODEX_API_KEY: 'gw-auto',
+      AI_GATEWAY_BASE_URL: 'https://ai-gateway.vercel.sh/v1',
+    });
+  });
+
+  it('auto-detects gateway when VERCEL_OIDC_TOKEN is set', () => {
+    const env = resolveCodexEnv(undefined, { VERCEL_OIDC_TOKEN: 'oidc-auto' });
+    expect(env).toEqual({
+      AI_GATEWAY_API_KEY: 'oidc-auto',
+      CODEX_API_KEY: 'oidc-auto',
       AI_GATEWAY_BASE_URL: 'https://ai-gateway.vercel.sh/v1',
     });
   });

--- a/packages/harness-codex/src/codex-auth.ts
+++ b/packages/harness-codex/src/codex-auth.ts
@@ -1,3 +1,5 @@
+import { getAiGatewayAuthFromEnv } from '@ai-sdk/harness/utils';
+
 export type CodexAuthOptions = {
   readonly openaiCompatible?: {
     readonly apiKey?: string;
@@ -24,7 +26,8 @@ export type CodexAuthOptions = {
  *   2. Explicit `auth.openai` — pin to direct OpenAI auth.
  *   3. Explicit `auth.gateway` — pin to Vercel AI Gateway.
  *   4. Auto-detect from the host process env: gateway first
- *      (`AI_GATEWAY_API_KEY`), then `CODEX_API_KEY` / `OPENAI_API_KEY`.
+ *      (`AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN`), then `CODEX_API_KEY` /
+ *      `OPENAI_API_KEY`.
  */
 export function resolveCodexEnv(
   auth: CodexAuthOptions | undefined,
@@ -36,11 +39,20 @@ export function resolveCodexEnv(
   if (auth?.openai) {
     return pickOpenAI({ explicit: auth.openai, processEnv });
   }
+  const gatewayAuthFromEnv = getAiGatewayAuthFromEnv({
+    env: processEnv,
+  });
   if (auth?.gateway) {
-    return pickGateway(auth.gateway, processEnv);
+    return pickGateway({
+      explicit: auth.gateway,
+      gatewayAuthFromEnv,
+    });
   }
-  if (processEnv.AI_GATEWAY_API_KEY) {
-    return pickGateway({}, processEnv);
+  if (gatewayAuthFromEnv.apiKey) {
+    return pickGateway({
+      explicit: {},
+      gatewayAuthFromEnv,
+    });
   }
   return pickOpenAI({ processEnv });
 }
@@ -81,15 +93,17 @@ function pickOpenAI({
   return env;
 }
 
-function pickGateway(
-  explicit: NonNullable<CodexAuthOptions['gateway']>,
-  processEnv: Record<string, string | undefined>,
-): Record<string, string> {
-  const apiKey = explicit.apiKey ?? processEnv.AI_GATEWAY_API_KEY;
-  const baseUrl =
-    explicit.baseUrl ??
-    processEnv.AI_GATEWAY_BASE_URL ??
-    'https://ai-gateway.vercel.sh/v1';
+function pickGateway({
+  explicit,
+  gatewayAuthFromEnv,
+}: {
+  explicit: NonNullable<CodexAuthOptions['gateway']>;
+  gatewayAuthFromEnv: ReturnType<typeof getAiGatewayAuthFromEnv>;
+}): Record<string, string> {
+  const apiKey = explicit.apiKey ?? gatewayAuthFromEnv.apiKey;
+  const baseUrl = toCodexGatewayBaseUrl(
+    explicit.baseUrl ?? gatewayAuthFromEnv.baseUrl,
+  );
   const env: Record<string, string> = {};
   if (apiKey) {
     env.AI_GATEWAY_API_KEY = apiKey;
@@ -97,4 +111,9 @@ function pickGateway(
   }
   env.AI_GATEWAY_BASE_URL = baseUrl;
   return env;
+}
+
+function toCodexGatewayBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
 }

--- a/packages/harness-pi/src/pi-auth.test.ts
+++ b/packages/harness-pi/src/pi-auth.test.ts
@@ -33,6 +33,24 @@ describe('resolvePiAuth', () => {
     });
   });
 
+  it('uses env gateway auth when explicit gateway only sets base URL', () => {
+    const r = makeRegistries();
+    const env = resolvePiAuth(
+      { gateway: { baseUrl: 'https://gw.example' } },
+      { VERCEL_OIDC_TOKEN: 'oidc-env' },
+      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
+    );
+    expect(env).toEqual({
+      AI_GATEWAY_API_KEY: 'oidc-env',
+      AI_GATEWAY_BASE_URL: 'https://gw.example',
+    });
+    expect(r.registerProvider).toHaveBeenCalledWith('vercel-ai-gateway', {
+      apiKey: 'oidc-env',
+      baseUrl: 'https://gw.example',
+      authHeader: true,
+    });
+  });
+
   it('uses customEnv when provided and registers all known providers', () => {
     const r = makeRegistries();
     const env = resolvePiAuth(

--- a/packages/harness-pi/src/pi-auth.ts
+++ b/packages/harness-pi/src/pi-auth.ts
@@ -2,6 +2,7 @@ import type {
   AuthStorage,
   ModelRegistry,
 } from '@earendil-works/pi-coding-agent';
+import { getAiGatewayAuthFromEnv } from '@ai-sdk/harness/utils';
 
 type ProviderConfigInput = Parameters<ModelRegistry['registerProvider']>[1];
 
@@ -63,15 +64,15 @@ export function resolvePiAuth(
   registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry },
 ): PiResolverEnv {
   const customEnvConfigured = hasConfiguredValue(options?.customEnv);
-  const gatewayConfigured = hasConfiguredValue(options?.gateway);
-
   if (customEnvConfigured) {
     return applyCustomEnv(options!.customEnv ?? {}, registries);
   }
 
+  const gatewayConfigured = hasConfiguredValue(options?.gateway);
+  const gatewayAuthFromEnv = getAiGatewayAuthFromEnv({ env });
   if (gatewayConfigured) {
-    const apiKey = options!.gateway?.apiKey;
-    const baseUrl = options!.gateway?.baseUrl ?? DEFAULT_GATEWAY_BASE_URL;
+    const apiKey = options!.gateway?.apiKey ?? gatewayAuthFromEnv.apiKey;
+    const baseUrl = options!.gateway?.baseUrl ?? gatewayAuthFromEnv.baseUrl;
     if (apiKey) {
       register(registries, 'vercel-ai-gateway', apiKey, {
         apiKey,
@@ -84,15 +85,16 @@ export function resolvePiAuth(
   }
 
   // Ambient gateway fallback.
-  const ambientKey = env.AI_GATEWAY_API_KEY || env.VERCEL_OIDC_TOKEN;
-  if (ambientKey) {
-    const baseUrl = env.AI_GATEWAY_BASE_URL ?? DEFAULT_GATEWAY_BASE_URL;
-    register(registries, 'vercel-ai-gateway', ambientKey, {
-      apiKey: ambientKey,
-      baseUrl,
+  if (gatewayAuthFromEnv.apiKey) {
+    register(registries, 'vercel-ai-gateway', gatewayAuthFromEnv.apiKey, {
+      apiKey: gatewayAuthFromEnv.apiKey,
+      baseUrl: gatewayAuthFromEnv.baseUrl,
       authHeader: true,
     });
-    return { AI_GATEWAY_API_KEY: ambientKey, AI_GATEWAY_BASE_URL: baseUrl };
+    return {
+      AI_GATEWAY_API_KEY: gatewayAuthFromEnv.apiKey,
+      AI_GATEWAY_BASE_URL: gatewayAuthFromEnv.baseUrl,
+    };
   }
 
   return {};

--- a/packages/harness-pi/src/pi-model-resolver.ts
+++ b/packages/harness-pi/src/pi-model-resolver.ts
@@ -1,4 +1,5 @@
 import type { ModelRegistry } from '@earendil-works/pi-coding-agent';
+import { getAiGatewayAuthFromEnv } from '@ai-sdk/harness/utils';
 
 type PiModel = ReturnType<ModelRegistry['getAll']>[number];
 
@@ -29,7 +30,7 @@ export function createPiModelResolver(
   };
 
   return (modelId: string | undefined): PiModel | undefined => {
-    const useGateway = Boolean(env.AI_GATEWAY_API_KEY || env.VERCEL_OIDC_TOKEN);
+    const useGateway = Boolean(getAiGatewayAuthFromEnv({ env }).apiKey);
     const effectiveId =
       modelId ?? (useGateway ? DEFAULT_PI_GATEWAY_MODEL_ID : undefined);
     if (!effectiveId) return undefined;

--- a/packages/harness/src/utils/ai-gateway-auth.test.ts
+++ b/packages/harness/src/utils/ai-gateway-auth.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getAiGatewayAuthFromEnv } from './ai-gateway-auth';
+
+describe('getAiGatewayAuthFromEnv', () => {
+  it('prefers AI_GATEWAY_API_KEY over VERCEL_OIDC_TOKEN', () => {
+    expect(
+      getAiGatewayAuthFromEnv({
+        env: {
+          AI_GATEWAY_API_KEY: 'gateway-key',
+          VERCEL_OIDC_TOKEN: 'oidc-token',
+        },
+      }),
+    ).toEqual({
+      apiKey: 'gateway-key',
+      baseUrl: 'https://ai-gateway.vercel.sh',
+    });
+  });
+
+  it('reads AI_GATEWAY_BASE_URL from env', () => {
+    expect(
+      getAiGatewayAuthFromEnv({
+        env: {
+          AI_GATEWAY_API_KEY: 'gateway-key',
+          AI_GATEWAY_BASE_URL: 'https://gateway.example.com',
+        },
+      }),
+    ).toEqual({
+      apiKey: 'gateway-key',
+      baseUrl: 'https://gateway.example.com',
+    });
+  });
+
+  it('falls back to VERCEL_OIDC_TOKEN', () => {
+    expect(
+      getAiGatewayAuthFromEnv({ env: { VERCEL_OIDC_TOKEN: 'oidc-token' } }),
+    ).toEqual({
+      apiKey: 'oidc-token',
+      baseUrl: 'https://ai-gateway.vercel.sh',
+    });
+  });
+
+  it('returns undefined apiKey when no gateway auth env is configured', () => {
+    expect(getAiGatewayAuthFromEnv({ env: {} })).toEqual({
+      apiKey: undefined,
+      baseUrl: 'https://ai-gateway.vercel.sh',
+    });
+  });
+});

--- a/packages/harness/src/utils/ai-gateway-auth.ts
+++ b/packages/harness/src/utils/ai-gateway-auth.ts
@@ -1,0 +1,15 @@
+const DEFAULT_AI_GATEWAY_BASE_URL = 'https://ai-gateway.vercel.sh';
+
+export function getAiGatewayAuthFromEnv({
+  env,
+}: {
+  env: Record<string, string | undefined>;
+}): {
+  apiKey: string | undefined;
+  baseUrl: string;
+} {
+  return {
+    apiKey: env.AI_GATEWAY_API_KEY || env.VERCEL_OIDC_TOKEN || undefined,
+    baseUrl: env.AI_GATEWAY_BASE_URL ?? DEFAULT_AI_GATEWAY_BASE_URL,
+  };
+}

--- a/packages/harness/src/utils/index.ts
+++ b/packages/harness/src/utils/index.ts
@@ -5,6 +5,7 @@ export {
   type SandboxChannelReconnectOptions,
 } from './sandbox-channel';
 export { classifyDiskLog, type DiskLogRecoveryMode } from './classify-disk-log';
+export { getAiGatewayAuthFromEnv } from './ai-gateway-auth';
 export {
   markBridgeStarting,
   waitForBridgeReady,


### PR DESCRIPTION
## Background

All 3 harness adapters already supported connecting to AI Gateway, but Claude Code and Codex were only considering `AI_GATEWAY_API_KEY` as an env var to look for credentials.

Using a `VERCEL_OIDC_TOKEN` makes the authentication path more straightforward and secure, so we should consistently support it.

## Summary

* Adds a central `@ai-sdk/harness/utils` helper to get AI Gateway auth from environment variables
* Uses the new utility in all existing harness adapters

## Manual Verification

Run the existing harness examples with only a valid `VERCEL_OIDC_TOKEN` present.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
