### PR TITLE
chore(google): remove now obsolete Interactions API `Api-Revision` header

### DIFF
--- a/.changeset/rude-wolves-hide.md
+++ b/.changeset/rude-wolves-hide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+chore(google): remove now obsolete Interactions API `Api-Revision` header

--- a/packages/google/src/interactions/google-interactions-language-model.test.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.test.ts
@@ -143,6 +143,11 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       `);
     });
 
+    it('does not send an Api-Revision header', async () => {
+      await model.doGenerate({ prompt: TEST_PROMPT });
+      expect(server.calls[0].requestHeaders).not.toHaveProperty('api-revision');
+    });
+
     it('exposes the request body via result.request.body', async () => {
       const { request } = await model.doGenerate({ prompt: TEST_PROMPT });
       expect(request?.body).toMatchInlineSnapshot(`

--- a/packages/google/src/interactions/google-interactions-language-model.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.ts
@@ -459,7 +459,6 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
     const url = `${this.config.baseURL}/interactions`;
 
     const mergedHeaders = combineHeaders(
-      INTERACTIONS_API_REVISION_HEADER,
       this.config.headers ? await resolve(this.config.headers) : undefined,
       options.headers,
     );
@@ -588,7 +587,6 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
     const url = `${this.config.baseURL}/interactions`;
 
     const mergedHeaders = combineHeaders(
-      INTERACTIONS_API_REVISION_HEADER,
       this.config.headers ? await resolve(this.config.headers) : undefined,
       options.headers,
     );
@@ -756,15 +754,6 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
     };
   }
 }
-
-/*
- * Pins the Interactions API revision the SDK targets. Sent on every request
- * the model issues so model-id calls, agent calls, polling, SSE reconnects,
- * and cancellation all hit the same schema.
- */
-const INTERACTIONS_API_REVISION_HEADER: Record<string, string> = {
-  'Api-Revision': '2026-05-20',
-};
 
 function pruneUndefined<T extends Record<string, unknown>>(obj: T): T {
   const result: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

When we implemented support for the breaking changes in the Google Interactions API from May, it was necessary to opt in to the new API shape via `Api-Revision: 2026-05-20` header. This is no longer necessary as of June 8, so this PR removes that header.

See https://ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026#raw-api-users

## Manual Verification

Run the present Interactions API examples.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
