### PR TITLE
docs(harness): minor fixes regarding auth configuration

### DIFF
--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -94,8 +94,8 @@ try {
 ```
 
 To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
-Vercel Sandbox, and `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` or
-`AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` for Claude Code.
+Vercel Sandbox, and one of the variables listed under [authentication](#authentication)
+for Claude Code.
 
 ## Adapter Settings
 
@@ -125,6 +125,7 @@ to the sandbox bridge. The adapter checks for AI Gateway and Anthropic credentia
 
 Supported environment variables:
 
+- `VERCEL_OIDC_TOKEN`
 - `AI_GATEWAY_API_KEY`
 - `AI_GATEWAY_BASE_URL`
 - `ANTHROPIC_API_KEY`

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -93,8 +93,8 @@ try {
 ```
 
 To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
-Vercel Sandbox, and `OPENAI_API_KEY` or `CODEX_API_KEY` or `AI_GATEWAY_API_KEY`
-or `VERCEL_OIDC_TOKEN` for Codex.
+Vercel Sandbox, and one of the variables listed under [authentication](#authentication)
+for Codex.
 
 ## Adapter Settings
 
@@ -124,6 +124,7 @@ to the sandbox bridge. The adapter checks for AI Gateway and OpenAI credentials.
 
 Supported environment variables:
 
+- `VERCEL_OIDC_TOKEN`
 - `AI_GATEWAY_API_KEY`
 - `AI_GATEWAY_BASE_URL`
 - `OPENAI_API_KEY`

--- a/content/providers/02-ai-sdk-harnesses/03-pi.mdx
+++ b/content/providers/02-ai-sdk-harnesses/03-pi.mdx
@@ -90,8 +90,8 @@ try {
 ```
 
 To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
-Vercel Sandbox, and `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` or a provider
-specific API key for Pi.
+Vercel Sandbox, and one of the variables listed under [authentication](#authentication)
+for Pi.
 
 ## Adapter Settings
 


### PR DESCRIPTION
## Summary

Partly related to #16212: the environment variable list supported for harness auth wasn't updated to include `VERCEL_OIDC_TOKEN` - this PR does that.

It also gets rid of the additional comma-separated list that duplicates it and instead makes that paragraph refer to the relevant section with the list.

## Manual Verification

N/A

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
