### PR TITLE
fix(react): treat id: undefined the same as omitting id in useChat

### DIFF
--- a/.changeset/shy-oranges-work.md
+++ b/.changeset/shy-oranges-work.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/react": patch
+---
+
+fix(react): treat id: undefined the same as omitting id in useChat to prevent chat recreation on every render

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -96,7 +96,9 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
 
   const shouldRecreateChat =
     ('chat' in options && options.chat !== chatRef.current) ||
-    ('id' in options && chatRef.current.id !== options.id);
+    ('id' in options &&
+      options.id != null &&
+      chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
     chatRef.current =


### PR DESCRIPTION
## Background
Passing `id: undefined` to `useChat` causes the internal `Chat` instance 
to be recreated on every render, wiping all messages and in-flight streams.
This is a common pattern: `id={conversationId ?? undefined}`.

Fixes #16226

## Summary
Added a nullish check (`options.id != null`) to the `shouldRecreateChat` 
condition so that `id: undefined` is treated the same as omitting `id`.

## Checklist
- [ ] All commits are signed
- [x] Tests passing (62/62)
- [x] Changeset added
- [x] Self-reviewed
