### PR TITLE
fix(ai): handle partial unicode escapes in fixJson

### DIFF
--- a/.changeset/polite-badgers-matter.md
+++ b/.changeset/polite-badgers-matter.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): handle partial unicode escapes in fixJson

--- a/packages/ai/src/util/fix-json.test.ts
+++ b/packages/ai/src/util/fix-json.test.ts
@@ -74,6 +74,22 @@ describe('string', () => {
     assert.strictEqual(fixJson('"value with \\'), '"value with "');
   });
 
+  test('should handle incomplete unicode escape sequences', () => {
+    assert.strictEqual(fixJson('"\\u'), '""');
+    assert.strictEqual(fixJson('"\\u12'), '""');
+    assert.strictEqual(fixJson('"text \\u00'), '"text "');
+    assert.strictEqual(fixJson('{"a":"\\u12'), '{"a":""}');
+
+    for (const json of [
+      fixJson('"\\u'),
+      fixJson('"\\u12'),
+      fixJson('"text \\u00'),
+      fixJson('{"a":"\\u12'),
+    ]) {
+      assert.doesNotThrow(() => JSON.parse(json));
+    }
+  });
+
   test('should handle unicode characters', () => {
     assert.strictEqual(
       fixJson('"value with unicode \u003C"'),

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -3,6 +3,7 @@ type State =
   | 'FINISH'
   | 'INSIDE_STRING'
   | 'INSIDE_STRING_ESCAPE'
+  | 'INSIDE_STRING_UNICODE_ESCAPE'
   | 'INSIDE_LITERAL'
   | 'INSIDE_NUMBER'
   | 'INSIDE_OBJECT_START'
@@ -28,6 +29,15 @@ export function fixJson(input: string): string {
   const stack: State[] = ['ROOT'];
   let lastValidIndex = -1;
   let literalStart: number | null = null;
+  let unicodeEscapeDigits = 0;
+
+  function isHexDigit(char: string) {
+    return (
+      (char >= '0' && char <= '9') ||
+      (char >= 'A' && char <= 'F') ||
+      (char >= 'a' && char <= 'f')
+    );
+  }
 
   function processValueStart(char: string, i: number, swapState: State) {
     {
@@ -260,7 +270,26 @@ export function fixJson(input: string): string {
 
       case 'INSIDE_STRING_ESCAPE': {
         stack.pop();
-        lastValidIndex = i;
+
+        if (char === 'u') {
+          unicodeEscapeDigits = 0;
+          stack.push('INSIDE_STRING_UNICODE_ESCAPE');
+        } else {
+          lastValidIndex = i;
+        }
+
+        break;
+      }
+
+      case 'INSIDE_STRING_UNICODE_ESCAPE': {
+        if (isHexDigit(char)) {
+          unicodeEscapeDigits++;
+
+          if (unicodeEscapeDigits === 4) {
+            stack.pop();
+            lastValidIndex = i;
+          }
+        }
 
         break;
       }


### PR DESCRIPTION
## Background

mentioned in https://github.com/vercel/ai/issues/15865

`fixJson` could produce invalid repaired JSON when streaming stopped inside a `\uXXXX` escape sequence. for example, `{"a":"\\u12` was repaired to `{"a":"\\u12"}`, which still fails JSON.parse because unicode escapes require four hex digits

## Summary

we now track unicode escape sequences separately and only mark them valid after all four hex digits are read

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15865