### PR TITLE
feat(ai): rename ui message stream onFinish to onEnd

### DIFF
--- a/.changeset/young-emus-tease.md
+++ b/.changeset/young-emus-tease.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): rename ui message stream onFinish to onEnd

--- a/content/docs/03-ai-sdk-harnesses/06-ui.mdx
+++ b/content/docs/03-ai-sdk-harnesses/06-ui.mdx
@@ -175,7 +175,7 @@ export async function POST(request: Request) {
   return createUIMessageStreamResponse({
     stream: toUIMessageStream({
       stream: result.stream,
-      onFinish: async () => {
+      onEnd: async () => {
         await detachAndPersist({ chatId, session });
       },
     }),

--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -153,7 +153,7 @@ export async function POST(req: Request) {
     stream: toUIMessageStream({
       stream: result.stream,
       originalMessages: messages,
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         saveChat({ chatId: id, messages });
       },
     }),
@@ -290,8 +290,8 @@ parts, validate them using `validateUIMessages` before processing (see the
 
 </Note>
 
-Storing messages is done in the `onFinish` callback of the `toUIMessageStream` function.
-`onFinish` receives the complete messages including the new AI response as `UIMessage[]`.
+Storing messages is done in the `onEnd` callback of the `toUIMessageStream` function.
+`onEnd` receives the complete messages including the new AI response as `UIMessage[]`.
 
 ```tsx filename="app/api/chat/route.ts" highlight="12,17-25"
 import { openai } from '@ai-sdk/openai';
@@ -317,7 +317,7 @@ export async function POST(req: Request) {
     stream: toUIMessageStream({
       stream: result.stream,
       originalMessages: messages,
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         saveChat({ chatId, messages });
       },
     }),
@@ -395,7 +395,7 @@ export async function POST(req: Request) {
         prefix: 'msg',
         size: 16,
       }),
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         saveChat({ chatId, messages });
       },
     }),
@@ -437,7 +437,7 @@ export async function POST(req: Request) {
       ); // omit start message part
     },
     originalMessages: messages,
-    onFinish: ({ responseMessage }) => {
+    onEnd: ({ responseMessage }) => {
       // save your chat here
     },
   });
@@ -527,7 +527,7 @@ export async function POST(req: Request) {
     stream: toUIMessageStream({
       stream: result.stream,
       originalMessages: validatedMessages,
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         saveChat({ chatId: id, messages });
       },
     }),
@@ -567,7 +567,7 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(messages),
   });
 
-  // consume the stream to ensure it runs to completion & triggers onFinish
+  // consume the stream to ensure it runs to completion & triggers onEnd
   // even when the client response is aborted:
   result.consumeStream(); // no await
 
@@ -575,7 +575,7 @@ export async function POST(req: Request) {
     stream: toUIMessageStream({
       stream: result.stream,
       originalMessages: messages,
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         saveChat({ chatId, messages });
       },
     }),

--- a/content/docs/04-ai-sdk-ui/03-chatbot-resume-streams.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-resume-streams.mdx
@@ -137,7 +137,7 @@ export async function POST(req: Request) {
       stream: result.stream,
       originalMessages: messages,
       generateMessageId: generateId,
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         // Clear the active stream when finished
         saveChat({ id, messages, activeStreamId: null });
       },

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -85,7 +85,7 @@ When streams are aborted, you may need to perform cleanup operations such as per
 Unlike `onFinish`, which is called when a stream completes normally, `onAbort` is specifically called when a stream is aborted via `AbortSignal`. This distinction allows you to handle normal completion and aborted streams differently.
 
 <Note>
-  For UI message streams (`toUIMessageStreamResponse`), the `onFinish` callback
+  For UI message streams (`toUIMessageStreamResponse`), the `onEnd` callback
   also receives an `isAborted` parameter that indicates whether the stream was
   aborted. This allows you to handle both completion and abort scenarios in a
   single callback.
@@ -141,7 +141,7 @@ for await (const part of result.stream) {
 
 ## UI Message Streams
 
-When using `toUIMessageStream`, you need to handle stream abortion slightly differently. The `onFinish` callback receives an `isAborted` parameter, and you should pass `consumeStream` to `createUIMessageStreamResponse` to ensure proper abort handling:
+When using `toUIMessageStream`, you need to handle stream abortion slightly differently. The `onEnd` callback receives an `isAborted` parameter, and you should pass `consumeStream` to `createUIMessageStreamResponse` to ensure proper abort handling:
 
 ```tsx highlight="3,21,24-30,34"
 import { openai } from '@ai-sdk/openai';
@@ -167,7 +167,7 @@ export async function POST(req: Request) {
   return createUIMessageStreamResponse({
     stream: toUIMessageStream({
       stream: result.stream,
-      onFinish: async ({ isAborted }) => {
+      onEnd: async ({ isAborted }) => {
         if (isAborted) {
           console.log('Stream was aborted');
           // Handle abort-specific cleanup

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -3955,10 +3955,16 @@ To see `streamText` in action, check out [these examples](#examples).
               description: 'The original messages.',
             },
             {
+              name: 'onEnd',
+              type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; isAborted: boolean; }) => void',
+              isOptional: true,
+              description: 'Callback function called when the stream ends. Provides the updated list of UI messages, whether the response is a continuation, the response message, and whether the stream was aborted.',
+            },
+            {
               name: 'onFinish',
               type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; isAborted: boolean; }) => void',
               isOptional: true,
-              description: 'Callback function called when the stream finishes. Provides the updated list of UI messages, whether the response is a continuation, the response message, and whether the stream was aborted.',
+              description: 'Deprecated alias for `onEnd`.',
             },
             {
               name: 'messageMetadata',

--- a/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
@@ -108,8 +108,7 @@ const stream = createUIMessageStream({
     {
       name: 'onEnd',
       type: '(options: { messages: UIMessage[]; isContinuation: boolean; isAborted: boolean; responseMessage: UIMessage; finishReason?: FinishReason }) => PromiseLike<void> | void',
-      description:
-        'A callback function that is called when the stream ends.',
+      description: 'A callback function that is called when the stream ends.',
       properties: [
         {
           type: 'EndOptions',

--- a/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
@@ -51,8 +51,8 @@ const stream = createUIMessageStream({
   },
   onError: error => `Custom error: ${error.message}`,
   originalMessages: existingMessages,
-  onFinish: ({ messages, isContinuation, responseMessage }) => {
-    console.log('Stream finished with messages:', messages);
+  onEnd: ({ messages, isContinuation, responseMessage }) => {
+    console.log('Stream ended with messages:', messages);
   },
 });
 ```
@@ -106,13 +106,13 @@ const stream = createUIMessageStream({
         'The original messages. If provided, persistence mode is assumed and a message ID is provided for the response message.',
     },
     {
-      name: 'onFinish',
+      name: 'onEnd',
       type: '(options: { messages: UIMessage[]; isContinuation: boolean; isAborted: boolean; responseMessage: UIMessage; finishReason?: FinishReason }) => PromiseLike<void> | void',
       description:
-        'A callback function that is called when the stream finishes.',
+        'A callback function that is called when the stream ends.',
       properties: [
         {
-          type: 'FinishOptions',
+          type: 'EndOptions',
           parameters: [
             {
               name: 'messages',
@@ -145,6 +145,11 @@ const stream = createUIMessageStream({
           ],
         },
       ],
+    },
+    {
+      name: 'onFinish',
+      type: '(options: { messages: UIMessage[]; isContinuation: boolean; isAborted: boolean; responseMessage: UIMessage; finishReason?: FinishReason }) => PromiseLike<void> | void',
+      description: 'Deprecated alias for `onEnd`.',
     },
     {
       name: 'generateId',

--- a/content/docs/09-troubleshooting/13-repeated-assistant-messages.mdx
+++ b/content/docs/09-troubleshooting/13-repeated-assistant-messages.mdx
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
       stream: result.stream,
       originalMessages: messages, // Pass the original messages here
       generateMessageId: generateId,
-      onFinish: ({ messages }) => {
+      onEnd: ({ messages }) => {
         saveChat({ id, messages });
       },
     }),

--- a/content/docs/09-troubleshooting/14-stream-abort-handling.mdx
+++ b/content/docs/09-troubleshooting/14-stream-abort-handling.mdx
@@ -1,16 +1,16 @@
 ---
-title: onFinish not called when stream is aborted
-description: Troubleshooting onFinish callback not executing when streams are aborted with toUIMessageStream
+title: onEnd not called when stream is aborted
+description: Troubleshooting onEnd callback not executing when streams are aborted with toUIMessageStream
 ---
 
-# onFinish not called when stream is aborted
+# onEnd not called when stream is aborted
 
 ## Issue
 
-When using `toUIMessageStream` with an `onFinish` callback, the callback may not execute when the stream is aborted. This happens because the abort handler immediately terminates the response, preventing the `onFinish` callback from being triggered.
+When using `toUIMessageStream` with an `onEnd` callback, the callback may not execute when the stream is aborted. This happens because the abort handler immediately terminates the response, preventing the `onEnd` callback from being triggered.
 
 ```tsx
-// Server-side code where onFinish isn't called on abort
+// Server-side code where onEnd isn't called on abort
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
   return createUIMessageStreamResponse({
     stream: toUIMessageStream({
       stream: result.stream,
-      onFinish: async ({ isAborted }) => {
+      onEnd: async ({ isAborted }) => {
         // This isn't called when the stream is aborted!
         if (isAborted) {
           console.log('Stream was aborted');
@@ -40,11 +40,11 @@ export async function POST(req: Request) {
 
 ## Background
 
-When a stream is aborted, the response is immediately terminated. Without proper handling, the `onFinish` callback has no chance to execute, preventing important cleanup operations like saving partial results or logging abort events.
+When a stream is aborted, the response is immediately terminated. Without proper handling, the `onEnd` callback has no chance to execute, preventing important cleanup operations like saving partial results or logging abort events.
 
 ## Solution
 
-Add `consumeSseStream: consumeStream` to the `createUIMessageStreamResponse` configuration. This ensures that abort events are properly captured and forwarded to the `onFinish` callback, allowing it to execute even when the stream is aborted.
+Add `consumeSseStream: consumeStream` to the `createUIMessageStreamResponse` configuration. This ensures that abort events are properly captured and forwarded to the `onEnd` callback, allowing it to execute even when the stream is aborted.
 
 ```tsx
 // other imports...
@@ -66,7 +66,7 @@ export async function POST(req: Request) {
   return createUIMessageStreamResponse({
     stream: toUIMessageStream({
       stream: result.stream,
-      onFinish: async ({ isAborted }) => {
+      onEnd: async ({ isAborted }) => {
         // Now this WILL be called even when aborted!
         if (isAborted) {
           console.log('Stream was aborted');
@@ -77,7 +77,7 @@ export async function POST(req: Request) {
         }
       },
     }),
-    consumeSseStream: consumeStream, // This enables onFinish to be called on abort
+    consumeSseStream: consumeStream, // This enables onEnd to be called on abort
   });
 }
 ```

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -11,7 +11,7 @@ import type { Source } from '../types/language-model';
 import type { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import type { LanguageModelUsage } from '../types/usage';
 import type { InferUIMessageChunk } from '../ui-message-stream/ui-message-chunks';
-import type { UIMessageStreamOnFinishCallback } from '../ui-message-stream/ui-message-stream-on-finish-callback';
+import type { UIMessageStreamOnEndCallback } from '../ui-message-stream/ui-message-stream-on-end-callback';
 import type { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import type { InferUIMessageMetadata, UIMessage } from '../ui/ui-messages';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
@@ -57,10 +57,15 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
    */
   generateMessageId?: IdGenerator;
 
-  onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
+  onEnd?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
 
   /**
-   * Extracts message metadata that will be send to the client.
+   * @deprecated Use `onEnd` instead.
+   */
+  onFinish?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
+
+  /**
+   * Extracts message metadata that will be sent to the client.
    *
    * Called on `start` and `finish` events.
    */

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -10,6 +10,11 @@ import { z } from 'zod';
 import { Output, streamText } from '../generate-text';
 import type { Instructions } from '../prompt';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import type { UIMessage } from '../ui';
+import type {
+  UIMessageStreamOnEndCallback,
+  UIMessageStreamOnFinishCallback,
+} from '../ui-message-stream';
 import type { AsyncIterableStream } from '../util';
 import type { DeepPartial } from '../util/deep-partial';
 import type { GenerateTextEndEvent } from './generate-text-events';
@@ -67,6 +72,31 @@ describe('streamText types', () => {
           >();
           expectTypeOf(event.providerMetadata).toEqualTypeOf<
             StepResult<any>['providerMetadata']
+          >();
+        },
+      });
+    });
+  });
+
+  describe('toUIMessageStream options', () => {
+    it('should support onEnd and deprecated onFinish', () => {
+      const result = streamText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+      });
+
+      result.toUIMessageStream({
+        onEnd: event => {
+          expectTypeOf(event).toMatchTypeOf<
+            Parameters<UIMessageStreamOnEndCallback<UIMessage>>[0]
+          >();
+        },
+      });
+
+      result.toUIMessageStream({
+        onFinish: event => {
+          expectTypeOf(event).toMatchTypeOf<
+            Parameters<UIMessageStreamOnFinishCallback<UIMessage>>[0]
           >();
         },
       });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2589,6 +2589,7 @@ class DefaultStreamTextResult<
   toUIMessageStream<UI_MESSAGE extends UIMessage>({
     originalMessages,
     generateMessageId,
+    onEnd,
     onFinish,
     messageMetadata,
     sendReasoning,
@@ -2605,7 +2606,7 @@ class DefaultStreamTextResult<
         tools: this.tools,
         originalMessages,
         generateMessageId,
-        onFinish,
+        onEnd: onEnd ?? onFinish,
         messageMetadata,
         sendReasoning,
         sendSources,
@@ -2621,6 +2622,7 @@ class DefaultStreamTextResult<
     {
       originalMessages,
       generateMessageId,
+      onEnd,
       onFinish,
       messageMetadata,
       sendReasoning,
@@ -2636,7 +2638,7 @@ class DefaultStreamTextResult<
       stream: this.toUIMessageStream({
         originalMessages,
         generateMessageId,
-        onFinish,
+        onEnd: onEnd ?? onFinish,
         messageMetadata,
         sendReasoning,
         sendSources,
@@ -2659,6 +2661,7 @@ class DefaultStreamTextResult<
   toUIMessageStreamResponse<UI_MESSAGE extends UIMessage>({
     originalMessages,
     generateMessageId,
+    onEnd,
     onFinish,
     messageMetadata,
     sendReasoning,
@@ -2673,7 +2676,7 @@ class DefaultStreamTextResult<
       stream: this.toUIMessageStream({
         originalMessages,
         generateMessageId,
-        onFinish,
+        onEnd: onEnd ?? onFinish,
         messageMetadata,
         sendReasoning,
         sendSources,

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -440,6 +440,41 @@ describe('createUIMessageStream', () => {
     `);
   });
 
+  it('should handle onEnd without original messages', async () => {
+    const recordedOptions: any[] = [];
+
+    const stream = createUIMessageStream({
+      execute: ({ writer }) => {
+        writer.write({ type: 'text-start', id: '1' });
+        writer.write({ type: 'text-delta', id: '1', delta: '1a' });
+        writer.write({ type: 'text-end', id: '1' });
+      },
+      onEnd: options => {
+        recordedOptions.push(options);
+      },
+      generateId: () => 'response-message-id',
+    });
+
+    await consumeStream({ stream });
+
+    expect(recordedOptions).toHaveLength(1);
+    expect(recordedOptions[0]).toMatchObject({
+      isAborted: false,
+      isContinuation: false,
+      responseMessage: {
+        id: 'response-message-id',
+        role: 'assistant',
+        parts: [
+          {
+            state: 'done',
+            text: '1a',
+            type: 'text',
+          },
+        ],
+      },
+    });
+  });
+
   it('should handle onFinish with messages', async () => {
     const recordedOptions: any[] = [];
 

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -5,7 +5,7 @@ import {
 import type { UIMessage } from '../ui/ui-messages';
 import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
 import type { InferUIMessageChunk } from './ui-message-chunks';
-import type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+import type { UIMessageStreamOnEndCallback } from './ui-message-stream-on-end-callback';
 import type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 import type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 import type { UIMessageStreamWriter } from './ui-message-stream-writer';
@@ -19,7 +19,8 @@ import type { UIMessageStreamWriter } from './ui-message-stream-writer';
  *   and a message ID is provided for the response message.
  * @param options.onStepEnd - A callback that is called when each step ends. Useful for persisting intermediate messages.
  * @param options.onStepFinish - Deprecated alias for `onStepEnd`.
- * @param options.onFinish - A callback that is called when the stream finishes.
+ * @param options.onEnd - A callback that is called when the stream ends.
+ * @param options.onFinish - Deprecated alias for `onEnd`.
  * @param options.generateId - A function that generates a unique ID. Defaults to the built-in ID generator.
  *
  * @returns A `ReadableStream` of UI message chunks.
@@ -30,6 +31,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   originalMessages,
   onStepEnd,
   onStepFinish,
+  onEnd,
   onFinish,
   generateId = generateIdFunc,
 }: {
@@ -56,7 +58,12 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
    */
   onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
-  onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
+  onEnd?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
+
+  /**
+   * @deprecated Use `onEnd` instead.
+   */
+  onFinish?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
 
   generateId?: IdGenerator;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {
@@ -148,7 +155,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
     messageId: generateId(),
     originalMessages,
     onStepEnd: onStepEnd ?? onStepFinish,
-    onFinish,
+    onEnd: onEnd ?? onFinish,
     onError,
   });
 }

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
@@ -114,6 +114,33 @@ describe('handleUIMessageStreamFinish', () => {
       expect(callArgs.messages[1]).toEqual(callArgs.responseMessage);
     });
 
+    it('should prefer onEnd over deprecated onFinish', async () => {
+      const onEndCallback = vi.fn();
+      const onFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-456' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-456',
+        onError: mockErrorHandler,
+        onEnd: onEndCallback,
+        onFinish: onFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onEndCallback).toHaveBeenCalledTimes(1);
+      expect(onFinishCallback).not.toHaveBeenCalled();
+    });
+
     it('should handle empty original messages array', async () => {
       const onFinishCallback = vi.fn();
       const inputChunks: UIMessageChunk[] = [

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -6,7 +6,7 @@ import {
 import type { UIMessage } from '../ui/ui-messages';
 import type { ErrorHandler } from '../util/error-handler';
 import type { InferUIMessageChunk, UIMessageChunk } from './ui-message-chunks';
-import type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+import type { UIMessageStreamOnEndCallback } from './ui-message-stream-on-end-callback';
 import type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 import type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 
@@ -15,6 +15,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   originalMessages = [],
   onStepEnd,
   onStepFinish,
+  onEnd,
   onFinish,
   onError,
   stream,
@@ -46,7 +47,12 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
    */
   onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
-  onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
+  onEnd?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
+
+  /**
+   * @deprecated Use `onEnd` instead.
+   */
+  onFinish?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {
   // last message is only relevant for assistant messages
   let lastMessage: UI_MESSAGE | undefined =
@@ -87,8 +93,9 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
 
   // Only process the stream if we need to track state for callbacks
   const resolvedOnStepEnd = onStepEnd ?? onStepFinish;
+  const resolvedOnEnd = onEnd ?? onFinish;
 
-  if (onFinish == null && resolvedOnStepEnd == null) {
+  if (resolvedOnEnd == null && resolvedOnStepEnd == null) {
     return idInjectedStream;
   }
 
@@ -110,14 +117,14 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
 
   let finishCalled = false;
 
-  const callOnFinish = async () => {
-    if (finishCalled || !onFinish) {
+  const callOnEnd = async () => {
+    if (finishCalled || !resolvedOnEnd) {
       return;
     }
     finishCalled = true;
 
     const isContinuation = state.message.id === lastMessage?.id;
-    await onFinish({
+    await resolvedOnEnd({
       isAborted,
       isContinuation,
       responseMessage: state.message as UI_MESSAGE,
@@ -170,11 +177,11 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
       },
       // @ts-expect-error cancel is still new and missing from types https://developer.mozilla.org/en-US/docs/Web/API/TransformStream#browser_compatibility
       async cancel() {
-        await callOnFinish();
+        await callOnEnd();
       },
 
       async flush() {
-        await callOnFinish();
+        await callOnEnd();
       },
     }),
   );

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -14,6 +14,7 @@ export {
   type UIMessageChunk,
 } from './ui-message-chunks';
 export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
+export type { UIMessageStreamOnEndCallback } from './ui-message-stream-on-end-callback';
 export type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
 export type { UIMessageStreamOnStepEndCallback } from './ui-message-stream-on-step-end-callback';
 export type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';

--- a/packages/ai/src/ui-message-stream/to-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-stream.test.ts
@@ -252,4 +252,44 @@ describe('toUIMessageStream', () => {
       ],
     });
   });
+
+  it('calls onEnd when stream finishes', async () => {
+    const parts: TextStreamPart<{}>[] = [
+      { type: 'start' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', text: 'Hello' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        rawFinishReason: 'stop',
+        totalUsage: testUsage,
+      },
+    ];
+    const onEnd = vi.fn();
+    const onFinish = vi.fn();
+
+    await convertReadableStreamToArray(
+      toUIMessageStream({
+        stream: convertArrayToReadableStream(parts),
+        tools: undefined,
+        generateMessageId: () => 'msg-123',
+        onEnd,
+        onFinish,
+      }),
+    );
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onEnd.mock.calls[0][0]).toMatchObject({
+      isAborted: false,
+      isContinuation: false,
+      finishReason: 'stop',
+      responseMessage: {
+        id: 'msg-123',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Hello' }],
+      },
+    });
+    expect(onFinish).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ai/src/ui-message-stream/to-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-stream.ts
@@ -13,7 +13,7 @@ import { toUIMessageChunk } from './to-ui-message-chunk';
  * Converts a stream of `TextStreamPart<TOOLS>` chunks (as emitted by
  * `streamText`'s `stream`) into a stream of `UIMessageChunk`s suitable for
  * UI message streaming, including response message ID injection and
- * `onFinish` handling.
+ * `onEnd` handling.
  */
 export function toUIMessageStream<
   TOOLS extends ToolSet = ToolSet,
@@ -29,6 +29,7 @@ export function toUIMessageStream<
   messageMetadata,
   originalMessages,
   generateMessageId,
+  onEnd,
   onFinish,
 }: {
   stream: ReadableStream<TextStreamPart<TOOLS>>;
@@ -84,7 +85,7 @@ export function toUIMessageStream<
     stream: uiMessageChunkStream,
     messageId: responseMessageId ?? generateMessageId?.(),
     originalMessages,
-    onFinish,
+    onEnd: onEnd ?? onFinish,
     onError,
   });
 }

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-end-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-end-callback.ts
@@ -1,0 +1,32 @@
+import type { FinishReason } from '../types/language-model';
+import type { UIMessage } from '../ui/ui-messages';
+
+export type UIMessageStreamOnEndCallback<UI_MESSAGE extends UIMessage> =
+  (event: {
+    /**
+     * The updated list of UI messages.
+     */
+    messages: UI_MESSAGE[];
+
+    /**
+     * Indicates whether the response message is a continuation of the last original message,
+     * or if a new message was created.
+     */
+    isContinuation: boolean;
+
+    /**
+     * Indicates whether the stream was aborted.
+     */
+    isAborted: boolean;
+
+    /**
+     * The message that was sent to the client as a response
+     * (including the original message if it was extended).
+     */
+    responseMessage: UI_MESSAGE;
+
+    /**
+     * The reason why the generation finished.
+     */
+    finishReason?: FinishReason;
+  }) => PromiseLike<void> | void;

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts
@@ -1,32 +1,8 @@
-import type { FinishReason } from '../types/language-model';
 import type { UIMessage } from '../ui/ui-messages';
+import type { UIMessageStreamOnEndCallback } from './ui-message-stream-on-end-callback';
 
+/**
+ * @deprecated Use `UIMessageStreamOnEndCallback` instead.
+ */
 export type UIMessageStreamOnFinishCallback<UI_MESSAGE extends UIMessage> =
-  (event: {
-    /**
-     * The updated list of UI messages.
-     */
-    messages: UI_MESSAGE[];
-
-    /**
-     * Indicates whether the response message is a continuation of the last original message,
-     * or if a new message was created.
-     */
-    isContinuation: boolean;
-
-    /**
-     * Indicates whether the stream was aborted.
-     */
-    isAborted: boolean;
-
-    /**
-     * The message that was sent to the client as a response
-     * (including the original message if it was extended).
-     */
-    responseMessage: UI_MESSAGE;
-
-    /**
-     * The reason why the generation finished.
-     */
-    finishReason?: FinishReason;
-  }) => PromiseLike<void> | void;
+  UIMessageStreamOnEndCallback<UI_MESSAGE>;


### PR DESCRIPTION
## Background

we renamed the `onFinish` hook widely across the AI SDK to `onEnd` as a part of https://github.com/vercel/ai/pull/15245 but there was a case where we missed the rename

## Summary

deprecate the `onFinish` hook and rename to `onEnd`

## Manual Verification

na

this doesn't need a codemod or a migration guide section since this is already covered under one of the migrations

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)