### PR TITLE
fix(amazon-bedrock): omit strict from tools for Opus 4.7/4.8

### DIFF
--- a/.changeset/bedrock-opus-strict-tools.md
+++ b/.changeset/bedrock-opus-strict-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Omit `strict` from tool specs for Claude Opus 4.7/4.8 on Bedrock, which reject the field on the Messages API

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
@@ -395,5 +395,41 @@ describe('prepareTools', () => {
       expect((tools[1] as any).toolSpec.strict).toBe(false);
       expect((tools[2] as any).toolSpec).not.toHaveProperty('strict');
     });
+
+    it('should omit strict for claude-opus-4-7', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId: 'us.anthropic.claude-opus-4-7',
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+    });
+
+    it('should omit strict for claude-opus-4-8', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId: 'anthropic.claude-opus-4-8',
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+    });
   });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
@@ -133,6 +133,12 @@ export async function prepareTools({
       ? functionTools.filter(t => t.name === toolChoice.toolName)
       : functionTools;
 
+  // Bedrock's Messages API rejects `strict` on tools for these models.
+  // https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html
+  const supportsStrictOnTools =
+    !modelId.includes('claude-opus-4-7') &&
+    !modelId.includes('claude-opus-4-8');
+
   for (const tool of filteredFunctionTools) {
     amazonBedrockTools.push({
       toolSpec: {
@@ -140,7 +146,9 @@ export async function prepareTools({
         ...(tool.description?.trim() !== ''
           ? { description: tool.description }
           : {}),
-        ...(tool.strict != null ? { strict: tool.strict } : {}),
+        ...(tool.strict != null && supportsStrictOnTools
+          ? { strict: tool.strict }
+          : {}),
         inputSchema: {
           json: tool.inputSchema as JSONObject,
         },


### PR DESCRIPTION
## Background

Bedrock's Messages API rejects `strict` on tools for `claude-opus-4-7` and `claude-opus-4-8`, returning `tools.0.custom.strict: Extra inputs are not permitted`. This breaks structured output (`Output.object()`/`Output.array()`) for those models.

## Summary

Strip `strict` from tool specs in `prepareTools` for Opus 4.7/4.8.

## Manual Verification

Added unit tests asserting `strict` is omitted for `claude-opus-4-7`/`claude-opus-4-8` and still passed through for other models. `pnpm vitest run src/amazon-bedrock-prepare-tools.test.ts` — 20 passed.

## Checklist

- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16121

Recreated from #16148 by @0xr3ngar (co-authored) to run full CI on a branch.