### PR TITLE
fix(google-vertex): use embedContent for Gemini embeddings

### DIFF
--- a/.changeset/vertex-gemini-embedding-content.md
+++ b/.changeset/vertex-gemini-embedding-content.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Route `gemini-embedding-2` / `gemini-embedding-2-preview` to the `:embedContent` endpoint, which is the only one those models support (`:predict` returns 400 FAILED_PRECONDITION)

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -14,11 +14,15 @@ const testValues = ['test text one', 'test text two'];
 const DEFAULT_URL =
   'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-central1/publishers/google/models/textembedding-gecko@001:predict';
 
+const GEMINI_EMBEDDING_2_URL =
+  'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent';
+
 const CUSTOM_URL =
   'https://custom-endpoint.com/models/textembedding-gecko@001:predict';
 
 const server = createTestServer({
   [DEFAULT_URL]: {},
+  [GEMINI_EMBEDDING_2_URL]: {},
   [CUSTOM_URL]: {},
 });
 
@@ -210,6 +214,56 @@ describe('GoogleVertexEmbeddingModel', () => {
           "parameters": {},
         }
       `);
+    });
+
+    it('should use embedContent for gemini-embedding-2', async () => {
+      server.urls[GEMINI_EMBEDDING_2_URL].response = {
+        type: 'json-value',
+        body: {
+          embedding: { values: [0.1, 0.2, 0.3] },
+          usageMetadata: { promptTokenCount: 4 },
+        },
+      };
+
+      const geminiEmbeddingModel = new GoogleVertexEmbeddingModel(
+        'gemini-embedding-2',
+        mockConfig,
+      );
+
+      const result = await geminiEmbeddingModel.doEmbed({
+        values: ['test text one'],
+        providerOptions: { google: mockProviderOptions },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(GEMINI_EMBEDDING_2_URL);
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "content": {
+            "parts": [
+              {
+                "text": "test text one",
+              },
+            ],
+          },
+          "embedContentConfig": {
+            "autoTruncate": false,
+            "outputDimensionality": 768,
+            "taskType": "SEMANTIC_SIMILARITY",
+            "title": "test title",
+          },
+        }
+      `);
+      expect(result.embeddings).toStrictEqual([[0.1, 0.2, 0.3]]);
+      expect(result.usage).toStrictEqual({ tokens: 4 });
+    });
+
+    it('should limit gemini-embedding-2 to one value per call', () => {
+      const geminiEmbeddingModel = new GoogleVertexEmbeddingModel(
+        'gemini-embedding-2',
+        mockConfig,
+      );
+
+      expect(geminiEmbeddingModel.maxEmbeddingsPerCall).toBe(1);
     });
   });
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -23,7 +23,6 @@ import type { GoogleVertexConfig } from './google-vertex-config';
 export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
   readonly specificationVersion = 'v4';
   readonly modelId: GoogleVertexEmbeddingModelId;
-  readonly maxEmbeddingsPerCall = 2048;
   readonly supportsParallelCalls = true;
 
   private readonly config: GoogleVertexConfig;
@@ -44,6 +43,12 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
 
   get provider(): string {
     return this.config.provider;
+  }
+
+  // gemini-embedding-2 models only support :embedContent (one value per call),
+  // not the :predict batch endpoint. https://github.com/vercel/ai/issues/15853
+  get maxEmbeddingsPerCall(): number {
+    return usesEmbedContentEndpoint(this.modelId) ? 1 : 2048;
   }
 
   constructor(
@@ -99,6 +104,42 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
       this.config.headers ? await resolve(this.config.headers) : undefined,
       headers,
     );
+
+    if (usesEmbedContentEndpoint(this.modelId)) {
+      const {
+        responseHeaders,
+        value: response,
+        rawValue,
+      } = await postJsonToApi({
+        url: `${this.config.baseURL}/models/${this.modelId}:embedContent`,
+        headers: mergedHeaders,
+        body: {
+          content: { parts: [{ text: values[0] }] },
+          embedContentConfig: {
+            outputDimensionality: googleOptions.outputDimensionality,
+            taskType: googleOptions.taskType,
+            title: googleOptions.title,
+            autoTruncate: googleOptions.autoTruncate,
+          },
+        },
+        failedResponseHandler: googleVertexFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(
+          googleVertexEmbedContentResponseSchema,
+        ),
+        abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      return {
+        warnings: [],
+        embeddings: [response.embedding.values],
+        usage:
+          response.usageMetadata?.promptTokenCount == null
+            ? undefined
+            : { tokens: response.usageMetadata.promptTokenCount },
+        response: { headers: responseHeaders, body: rawValue },
+      };
+    }
 
     const url = `${this.config.baseURL}/models/${this.modelId}:predict`;
     const {
@@ -158,3 +199,20 @@ const googleVertexTextEmbeddingResponseSchema = z.object({
     }),
   ),
 });
+
+const googleVertexEmbedContentResponseSchema = z.object({
+  embedding: z.object({
+    values: z.array(z.number()),
+  }),
+  usageMetadata: z
+    .object({
+      promptTokenCount: z.number().nullish(),
+    })
+    .nullish(),
+});
+
+function usesEmbedContentEndpoint(modelId: GoogleVertexEmbeddingModelId) {
+  return (
+    modelId === 'gemini-embedding-2' || modelId === 'gemini-embedding-2-preview'
+  );
+}


### PR DESCRIPTION
## Background

`gemini-embedding-2` / `gemini-embedding-2-preview` are registered model ids, but the Vertex provider always calls the legacy `:predict` endpoint. Google dropped `:predict` for that family, so every call fails with `400 FAILED_PRECONDITION`. (`gemini-embedding-001` still supports `:predict`.)

## Summary

- Route `gemini-embedding-2`/`-preview` to `:embedContent`.
- Cap `maxEmbeddingsPerCall` at 1 for those models (`:embedContent` takes a single value).
- Add a minimal `:embedContent` response schema.

## Manual Verification

Added unit tests asserting the request hits `:embedContent` with the right body, parses embeddings/usage, and that `maxEmbeddingsPerCall === 1`. `pnpm vitest run src/google-vertex-embedding-model.test.ts` — 15 passed.

## Checklist

- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15853

Recreated from #15887 by @he-yufeng (co-authored), adding a changeset and signed commit so full CI runs.