### PR TITLE
fix(ci): don't fail backport job when fork comment is blocked

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -186,7 +186,10 @@ jobs:
               echo '```'
             } > comment.md
 
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file comment.md
+            # Best-effort: GITHUB_TOKEN is read-only for pull_request events from
+            # forks, so commenting may fail. Don't let that fail the job.
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file comment.md \
+              || echo "::warning::could not comment on fork PR #${PR_NUMBER} (token lacks write access)"
             skip "PR #${PR_NUMBER} is from a fork and must be backported with workflow_dispatch"
           fi
 


### PR DESCRIPTION
## Background

Adding the `backport` label to a **merged fork PR** fires the `labeled` event. For `pull_request` events originating from a fork, GitHub forces `GITHUB_TOKEN` to read-only regardless of the job's declared `pull-requests: write`. The fork-guidance `gh pr comment` then fails with `GraphQL: Resource not accessible by integration (addComment)`, and under `set -euo pipefail` the step aborts before the intended `skip` (exit 0) — failing the whole job.

Example failure: https://github.com/vercel/ai/actions/runs/27725203720/job/82019805216 (firing on #15855).

## Summary

Make the fork-guidance comment best-effort (`|| echo ::warning::…`) so the job still exits cleanly via `skip`. The actual backport path (`workflow_dispatch`) is unaffected.

## Manual Verification

The change is shell-only. The failing run above hit the `gh pr comment` line and aborted; with `|| echo`, the script proceeds to `skip` and exits 0.

## Checklist

- [x] All commits are signed
- [ ] Tests have been added / updated
- [ ] Documentation has been added / updated
- [ ] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)