### PR TITLE
feat(gateway): expose ruleId on GatewayForbiddenError so callers can identify which routing rule denied a request

### DIFF
--- a/.changeset/gateway-forbidden-error-rule-id.md
+++ b/.changeset/gateway-forbidden-error-rule-id.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(gateway): expose `ruleId` on `GatewayForbiddenError` so callers can identify which routing rule denied a request

--- a/.changeset/gateway-forbidden-error-rule-id.md
+++ b/.changeset/gateway-forbidden-error-rule-id.md
@@ -2,4 +2,4 @@
 '@ai-sdk/gateway': patch
 ---
 
-feat(gateway): expose `ruleId` on `GatewayForbiddenError` so callers can identify which routing rule denied a request
+feat(gateway): expose ruleId on GatewayForbiddenError so callers can identify which routing rule denied a request

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -66,6 +66,25 @@ describe('Valid error responses', () => {
     expect(error.message).toBe('Request denied by a routing rule.');
     expect(error.statusCode).toBe(403);
     expect(error.type).toBe('forbidden');
+    expect((error as GatewayForbiddenError).ruleId).toBeUndefined();
+  });
+
+  it('exposes the ruleId on GatewayForbiddenError when present', async () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Request denied by a routing rule.',
+        type: 'forbidden',
+        ruleId: 'rule_abc123',
+      },
+    };
+
+    const error = await createGatewayErrorFromResponse({
+      response,
+      statusCode: 403,
+    });
+
+    expect(error).toBeInstanceOf(GatewayForbiddenError);
+    expect((error as GatewayForbiddenError).ruleId).toBe('rule_abc123');
   });
 
   it('should create GatewayRateLimitError for rate_limit_exceeded type', async () => {

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -69,12 +69,12 @@ describe('Valid error responses', () => {
     expect((error as GatewayForbiddenError).ruleId).toBeUndefined();
   });
 
-  it('exposes the ruleId on GatewayForbiddenError when present', async () => {
+  it('exposes the ruleId on GatewayForbiddenError when present in param', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Request denied by a routing rule.',
         type: 'forbidden',
-        ruleId: 'rule_abc123',
+        param: { ruleId: 'rule_abc123' },
       },
     };
 
@@ -85,6 +85,24 @@ describe('Valid error responses', () => {
 
     expect(error).toBeInstanceOf(GatewayForbiddenError);
     expect((error as GatewayForbiddenError).ruleId).toBe('rule_abc123');
+  });
+
+  it('leaves ruleId undefined when the forbidden param has an unexpected shape', async () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Request denied by a routing rule.',
+        type: 'forbidden',
+        param: 'model',
+      },
+    };
+
+    const error = await createGatewayErrorFromResponse({
+      response,
+      statusCode: 403,
+    });
+
+    expect(error).toBeInstanceOf(GatewayForbiddenError);
+    expect((error as GatewayForbiddenError).ruleId).toBeUndefined();
   });
 
   it('should create GatewayRateLimitError for rate_limit_exceeded type', async () => {

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -116,6 +116,7 @@ export async function createGatewayErrorFromResponse({
         statusCode,
         cause,
         generationId,
+        ruleId: validatedResponse.error.ruleId ?? undefined,
       });
     default:
       return new GatewayInternalServerError({
@@ -135,6 +136,7 @@ const gatewayErrorResponseSchema = lazySchema(() =>
         type: z.string().nullish(),
         param: z.unknown().nullish(),
         code: z.union([z.string(), z.number()]).nullish(),
+        ruleId: z.string().nullish(),
       }),
       generationId: z.string().nullish(),
     }),

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -9,7 +9,10 @@ import {
 } from './gateway-model-not-found-error';
 import { GatewayInternalServerError } from './gateway-internal-server-error';
 import { GatewayFailedDependencyError } from './gateway-failed-dependency-error';
-import { GatewayForbiddenError } from './gateway-forbidden-error';
+import {
+  GatewayForbiddenError,
+  forbiddenParamSchema,
+} from './gateway-forbidden-error';
 import { GatewayResponseError } from './gateway-response-error';
 import {
   lazySchema,
@@ -110,14 +113,20 @@ export async function createGatewayErrorFromResponse({
         cause,
         generationId,
       });
-    case 'forbidden':
+    case 'forbidden': {
+      const ruleResult = await safeValidateTypes({
+        value: validatedResponse.error.param,
+        schema: forbiddenParamSchema,
+      });
+
       return new GatewayForbiddenError({
         message,
         statusCode,
         cause,
         generationId,
-        ruleId: validatedResponse.error.ruleId ?? undefined,
+        ruleId: ruleResult.success ? ruleResult.value.ruleId : undefined,
       });
+    }
     default:
       return new GatewayInternalServerError({
         message,
@@ -136,7 +145,6 @@ const gatewayErrorResponseSchema = lazySchema(() =>
         type: z.string().nullish(),
         param: z.unknown().nullish(),
         code: z.union([z.string(), z.number()]).nullish(),
-        ruleId: z.string().nullish(),
       }),
       generationId: z.string().nullish(),
     }),

--- a/packages/gateway/src/errors/gateway-forbidden-error.ts
+++ b/packages/gateway/src/errors/gateway-forbidden-error.ts
@@ -1,8 +1,18 @@
+import { z } from 'zod/v4';
 import { GatewayError } from './gateway-error';
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 
 const name = 'GatewayForbiddenError';
 const marker = `vercel.ai.gateway.error.${name}`;
 const symbol = Symbol.for(marker);
+
+export const forbiddenParamSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      ruleId: z.string(),
+    }),
+  ),
+);
 
 /**
  * Forbidden - the request was rejected by policy (e.g. a routing rule),

--- a/packages/gateway/src/errors/gateway-forbidden-error.ts
+++ b/packages/gateway/src/errors/gateway-forbidden-error.ts
@@ -13,19 +13,23 @@ export class GatewayForbiddenError extends GatewayError {
 
   readonly name = name;
   readonly type = 'forbidden';
+  readonly ruleId?: string;
 
   constructor({
     message = 'Forbidden',
     statusCode = 403,
     cause,
     generationId,
+    ruleId,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    ruleId?: string;
   } = {}) {
     super({ message, statusCode, cause, generationId });
+    this.ruleId = ruleId;
   }
 
   static isInstance(error: unknown): error is GatewayForbiddenError {


### PR DESCRIPTION
## Why

When AI Gateway blocks a request with a routing **deny** rule, the SDK throws `GatewayForbiddenError` — but the **rule ID isn't accessible** as a property. Callers should be able to read `error.ruleId` directly to identify and manage the rule that blocked them.

## What

Per review feedback, the rule id now travels inside the error envelope's general-purpose `param` field rather than a new top-level field — the same pattern as `model_not_found` → `param.modelId`:

- The envelope schema is **unchanged** (`param` is already `z.unknown()`).
- `forbiddenParamSchema` (`{ ruleId: string }`) mirrors `modelNotFoundParamSchema`; the `forbidden` case mines `param` with `safeValidateTypes` and leaves `ruleId` undefined on any unexpected shape.
- `GatewayForbiddenError`: optional `readonly ruleId` property.

```ts
catch (e) {
  if (GatewayForbiddenError.isInstance(e)) {
    console.log(e.ruleId); // 'rule_abc123'
  }
}
```

An SDK change is still needed for access: in released versions `param` is validated but not exposed on error instances (only `model_not_found` mines it, into `modelId`), so without this PR callers can't reach the rule id regardless of the wire encoding.

Companion server change emitting `param: { ruleId }` on deny responses: vercel/ai-gateway#2515 (supersedes vercel/ai-gateway#2312, closed — its top-level `ruleId` emission had already landed on main via vercel/ai-gateway#2414 and #2515 moves it into `param`). Merge order: server first; in the gap this PR just reads `undefined`.

## Validation

Unit tests: `forbidden` with no `param` → `undefined`; `param: { ruleId }` → exposed on the error; `param` of an unexpected shape (string) → `undefined`.

## Note

Targets `main` (gateway v4 / AI SDK v7). Backports to `release-v6.0` / `release-v5.0` follow the same path as the original `GatewayForbiddenError` (vercel/ai#16105/#16106/#16108) — left for you per usual.