### PR TITLE
fix(anthropic): add advanced-tool-use-2025-11-20 beta header for tool search and deferLoading

### DIFF
--- a/.changeset/twelve-nails-divide.md
+++ b/.changeset/twelve-nails-divide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+fix(anthropic): add advanced-tool-use-2025-11-20 beta header for tool search and deferLoading

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -3796,7 +3796,7 @@ describe('AnthropicLanguageModel', () => {
         it('should include advanced-tool-use beta header', async () => {
           expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
             {
-              "anthropic-beta": "structured-outputs-2025-11-13",
+              "anthropic-beta": "advanced-tool-use-2025-11-20,structured-outputs-2025-11-13",
               "anthropic-version": "2023-06-01",
               "content-type": "application/json",
               "x-api-key": "test-api-key",
@@ -3902,7 +3902,7 @@ describe('AnthropicLanguageModel', () => {
         it('should include advanced-tool-use beta header', async () => {
           expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
             {
-              "anthropic-beta": "structured-outputs-2025-11-13",
+              "anthropic-beta": "advanced-tool-use-2025-11-20,structured-outputs-2025-11-13",
               "anthropic-version": "2023-06-01",
               "content-type": "application/json",
               "x-api-key": "test-api-key",

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -858,7 +858,9 @@ describe('prepareTools', () => {
 
       expect(result).toMatchInlineSnapshot(`
         {
-          "betas": Set {},
+          "betas": Set {
+            "advanced-tool-use-2025-11-20",
+          },
           "toolChoice": undefined,
           "toolWarnings": [],
           "tools": [
@@ -918,7 +920,9 @@ describe('prepareTools', () => {
 
       expect(result).toMatchInlineSnapshot(`
         {
-          "betas": Set {},
+          "betas": Set {
+            "advanced-tool-use-2025-11-20",
+          },
           "toolChoice": undefined,
           "toolWarnings": [],
           "tools": [
@@ -1032,6 +1036,7 @@ describe('prepareTools', () => {
         {
           "betas": Set {
             "structured-outputs-2025-11-13",
+            "advanced-tool-use-2025-11-20",
           },
           "toolChoice": undefined,
           "toolWarnings": [],
@@ -1073,6 +1078,7 @@ describe('prepareTools', () => {
         {
           "betas": Set {
             "structured-outputs-2025-11-13",
+            "advanced-tool-use-2025-11-20",
           },
           "toolChoice": undefined,
           "toolWarnings": [],

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -122,7 +122,11 @@ export async function prepareTools({
           betas.add('structured-outputs-2025-11-13');
         }
 
-        if (tool.inputExamples != null || allowedCallers != null) {
+        if (
+          tool.inputExamples != null ||
+          allowedCallers != null ||
+          deferLoading != null
+        ) {
           betas.add('advanced-tool-use-2025-11-20');
         }
 
@@ -332,6 +336,7 @@ export async function prepareTools({
           }
 
           case 'anthropic.tool_search_regex_20251119': {
+            betas.add('advanced-tool-use-2025-11-20');
             anthropicTools.push({
               type: 'tool_search_tool_regex_20251119',
               name: 'tool_search_tool_regex',
@@ -340,6 +345,7 @@ export async function prepareTools({
           }
 
           case 'anthropic.tool_search_bm25_20251119': {
+            betas.add('advanced-tool-use-2025-11-20');
             anthropicTools.push({
               type: 'tool_search_tool_bm25_20251119',
               name: 'tool_search_tool_bm25',


### PR DESCRIPTION
## Background
When using `toolSearchRegex_20251119()`, `toolSearchBm25_20251119()`, or 
tools with `deferLoading: true`, the SDK serializes the correct request 
body fields but omits the required `advanced-tool-use-2025-11-20` beta 
header. Anthropic rejects these requests without it.

Fixes #16245

## Summary
Added `betas.add('advanced-tool-use-2025-11-20')` in three places:
- `tool_search_regex_20251119` provider tool case
- `tool_search_bm25_20251119` provider tool case  
- Function tool condition when `deferLoading` is set

## Testing
- 434 tests pass
- 6 snapshots updated to reflect new expected beta header
- Pattern follows existing beta header additions in same file

## Related Issues
Fixes #16245