### PR TITLE
fix(black-forest-labs): remove duplicate parseProviderOptions call in doGenerate

### DIFF
--- a/.changeset/bfl-remove-duplicate-parse.md
+++ b/.changeset/bfl-remove-duplicate-parse.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/black-forest-labs': patch
+---
+
+fix(bfl): remove duplicate parseProviderOptions call in doGenerate

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -1,8 +1,17 @@
 import type { FetchFunction } from '@ai-sdk/provider-utils';
+import * as providerUtils from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BlackForestLabsImageModel } from './black-forest-labs-image-model';
 import type { BlackForestLabsImageModelId } from './black-forest-labs-image-settings';
+
+vi.mock('@ai-sdk/provider-utils', async importOriginal => {
+  const actual = await importOriginal<typeof providerUtils>();
+  return {
+    ...actual,
+    parseProviderOptions: vi.fn(actual.parseProviderOptions),
+  };
+});
 
 const prompt = 'A cute baby sea otter';
 
@@ -105,7 +114,28 @@ describe('BlackForestLabsImageModel', () => {
     },
   });
 
+  beforeEach(() => {
+    vi.mocked(providerUtils.parseProviderOptions).mockClear();
+  });
+
   describe('doGenerate', () => {
+    it('parses provider options only once', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(providerUtils.parseProviderOptions).toHaveBeenCalledTimes(1);
+    });
+
     it('passes the correct parameters including aspect ratio and providerOptions', async () => {
       const model = createBasicModel();
 

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -169,7 +169,7 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       webhook_url: bflOptions?.webhookUrl,
     };
 
-    return { body, warnings };
+    return { body, warnings, bflOptions };
   }
 
   async doGenerate({
@@ -185,7 +185,7 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
   }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const { body, warnings } = await this.getArgs({
+    const { body, warnings, bflOptions } = await this.getArgs({
       prompt,
       files,
       mask,
@@ -197,12 +197,6 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       headers,
       abortSignal,
     } as Parameters<ImageModelV4['doGenerate']>[0]);
-
-    const bflOptions = await parseProviderOptions({
-      provider: 'blackForestLabs',
-      providerOptions,
-      schema: blackForestLabsImageModelOptionsSchema,
-    });
 
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const combinedHeaders = combineHeaders(


### PR DESCRIPTION
## Background

`doGenerate` called `parseProviderOptions` twice: once inside `getArgs` (to build the body) and again directly in `doGenerate` (for poll interval/timeout). Redundant.

## Summary

Return `bflOptions` from `getArgs` and reuse it in `doGenerate`. Drops the second `parseProviderOptions` call.

Re-implements the still-relevant part of #14897 on signed commits, retaining original authorship (@Ricardo-M-L). The image-field fix from that PR is obsolete — already landed in #15525.

## Manual Verification

`pnpm test` in `packages/black-forest-labs` — 26 tests pass (node + edge). Behavior unchanged; same parsed options reused.

I verified that the added test is failing without the code changes

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related issues

closes https://github.com/vercel/ai/pull/14897