### PR TITLE
fix(workflow): forward provider-executed tool approvals to the provider on resume

### DIFF
--- a/.changeset/workflow-provider-executed-approvals.md
+++ b/.changeset/workflow-provider-executed-approvals.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+fix (workflow): forward provider-executed tool approvals to the provider on resume
+
+`WorkflowAgent` stripped every `tool-approval-request` and `tool-approval-response` part from the messages when resuming after a tool approval, regardless of whether the tool was locally or provider-executed. For provider-executed tools (e.g. MCP via the OpenAI Responses API) this silently dropped the approval before `convertToLanguageModelPrompt` could forward it, so the provider never learned of the approval and the tool was never executed. Local approvals are still executed and stripped, while provider-executed approvals are now preserved and forwarded to the provider, matching the discriminator core's `streamText` already uses. This is the inverse of the bug fixed in #14289.

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -3695,5 +3695,243 @@ describe('WorkflowAgent', () => {
       // Should proceed normally without any approval processing
       expect(mockIterator.next).toHaveBeenCalled();
     });
+
+    // Regression for #14292: provider-executed tool approvals (e.g. MCP via
+    // the Responses API) must be forwarded to the provider on resume rather
+    // than silently dropped. The provider owns execution, so the approval
+    // response has to survive the approval-resume cleanup and reach the model.
+    function collectApprovalResponses(
+      prompt: ReadonlyArray<{ role: string; content: unknown }>,
+    ): Array<{ approvalId: string; approved: boolean }> {
+      const responses: Array<{ approvalId: string; approved: boolean }> = [];
+      for (const message of prompt) {
+        if (message.role !== 'tool' || !Array.isArray(message.content)) {
+          continue;
+        }
+        for (const part of message.content as any[]) {
+          if (part.type === 'tool-approval-response') {
+            responses.push({
+              approvalId: part.approvalId,
+              approved: part.approved,
+            });
+          }
+        }
+      }
+      return responses;
+    }
+
+    it('should forward an approved provider-executed approval to the provider', async () => {
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // The provider-executed tool is not part of the agent's local tool set.
+      const agent = new WorkflowAgent({ model: createMockModel(), tools: {} });
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Search the docs.' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'mcp_search',
+                input: { query: 'docs' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // The agent continues, and the provider receives the approval response.
+      const call = vi.mocked(streamTextIterator).mock.calls.at(-1)!;
+      const prompt = (call[0] as { prompt: any[] }).prompt;
+      expect(collectApprovalResponses(prompt)).toContainEqual({
+        approvalId: 'approval-call-1',
+        approved: true,
+      });
+    });
+
+    it('should forward a denied provider-executed approval to the provider', async () => {
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      const agent = new WorkflowAgent({ model: createMockModel(), tools: {} });
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Search the docs.' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'mcp_search',
+                input: { query: 'docs' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: false,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      const call = vi.mocked(streamTextIterator).mock.calls.at(-1)!;
+      const prompt = (call[0] as { prompt: any[] }).prompt;
+      expect(collectApprovalResponses(prompt)).toContainEqual({
+        approvalId: 'approval-call-1',
+        approved: false,
+      });
+    });
+
+    it('should execute local approvals while forwarding provider-executed ones', async () => {
+      const toolResult = { city: 'London', temperature: 72 };
+      const executeFn = vi.fn().mockResolvedValue(toolResult);
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: executeFn,
+          needsApproval: true as const,
+        },
+      };
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      const agent = new WorkflowAgent({ model: createMockModel(), tools });
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Weather in London and search the docs.' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'local-1',
+                toolName: 'getWeather',
+                input: { city: 'London' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-local-1',
+                toolCallId: 'local-1',
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'provider-1',
+                toolName: 'mcp_search',
+                input: { query: 'docs' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-provider-1',
+                toolCallId: 'provider-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-local-1',
+                approved: true,
+              },
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-provider-1',
+                approved: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // Local approval executes locally.
+      expect(executeFn).toHaveBeenCalledTimes(1);
+      expect(executeFn).toHaveBeenCalledWith(
+        { city: 'London' },
+        expect.objectContaining({ toolCallId: 'local-1' }),
+      );
+
+      // Only the provider-executed approval response is forwarded; the local
+      // one is stripped and replaced by a tool result.
+      const call = vi.mocked(streamTextIterator).mock.calls.at(-1)!;
+      const prompt = (call[0] as { prompt: any[] }).prompt;
+      const forwarded = collectApprovalResponses(prompt);
+      expect(forwarded).toContainEqual({
+        approvalId: 'approval-provider-1',
+        approved: true,
+      });
+      expect(forwarded).not.toContainEqual({
+        approvalId: 'approval-local-1',
+        approved: true,
+      });
+    });
   });
 });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1366,6 +1366,7 @@ export class WorkflowAgent<
         toolName: collected.toolCall.toolName,
         input: collected.toolCall.input,
         reason: collected.approvalResponse.reason,
+        providerExecuted: collected.toolCall.providerExecuted === true,
         collected,
       }),
     );
@@ -1375,7 +1376,24 @@ export class WorkflowAgent<
         toolName: collected.toolCall.toolName,
         input: collected.toolCall.input,
         reason: collected.approvalResponse.reason,
+        providerExecuted: collected.toolCall.providerExecuted === true,
       }),
+    );
+
+    // Approval ids of provider-executed tool calls. Provider-executed tools
+    // (e.g. MCP via the Responses API) cannot be resolved locally — the
+    // provider owns execution. We therefore skip them from local execution
+    // and preserve their approval responses in the messages so the provider
+    // receives the approval on the next call. The discriminator is sourced
+    // from the original `tool-call` part (matching how core's stream-text.ts
+    // decides), not from the response part which may be missing the flag.
+    const providerExecutedApprovalIds = new Set<string>(
+      [
+        ...collectedApprovals.approvedToolApprovals,
+        ...collectedApprovals.deniedToolApprovals,
+      ]
+        .filter(collected => collected.toolCall.providerExecuted === true)
+        .map(collected => collected.approvalResponse.approvalId),
     );
 
     if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
@@ -1390,6 +1408,11 @@ export class WorkflowAgent<
 
       // Execute approved tools
       for (const approval of approvedToolApprovals) {
+        // Provider-executed approvals are forwarded to the provider via the
+        // preserved approval response below, not executed locally.
+        if (approval.providerExecuted) {
+          continue;
+        }
         const tool = (this.tools as ToolSet)[approval.toolName];
         if (tool && typeof tool.execute === 'function') {
           if (!tool.needsApproval) {
@@ -1564,6 +1587,11 @@ export class WorkflowAgent<
 
       // Create denial results for denied tools
       for (const denial of deniedToolApprovals) {
+        // Provider-executed denials are forwarded to the provider via the
+        // preserved approval response below, not turned into a local result.
+        if (denial.providerExecuted) {
+          continue;
+        }
         toolResultContent.push({
           type: 'tool-result' as const,
           toolCallId: denial.toolCallId,
@@ -1575,20 +1603,33 @@ export class WorkflowAgent<
         });
       }
 
-      // Strip approval parts from messages and inject tool results
+      // Strip approval parts that we resolved locally and inject tool results.
+      // Provider-executed approval parts are preserved so the next call to
+      // `convertToLanguageModelPrompt` forwards the approval response to the
+      // provider (it only forwards responses flagged `providerExecuted`).
       const cleanedMessages: ModelMessage[] = [];
       for (const msg of prompt.messages) {
         if (msg.role === 'assistant' && Array.isArray(msg.content)) {
           const filtered = (msg.content as any[]).filter(
-            (p: any) => p.type !== 'tool-approval-request',
+            (p: any) =>
+              p.type !== 'tool-approval-request' ||
+              providerExecutedApprovalIds.has(p.approvalId),
           );
           if (filtered.length > 0) {
             cleanedMessages.push({ ...msg, content: filtered });
           }
         } else if (msg.role === 'tool') {
-          const filtered = (msg.content as any[]).filter(
-            (p: any) => p.type !== 'tool-approval-response',
-          );
+          const filtered = (msg.content as any[]).flatMap((p: any) => {
+            if (p.type !== 'tool-approval-response') {
+              return [p];
+            }
+            if (!providerExecutedApprovalIds.has(p.approvalId)) {
+              return [];
+            }
+            // Re-stamp `providerExecuted` so the conversion layer forwards the
+            // response even if the client omitted the flag on the response part.
+            return [{ ...p, providerExecuted: true }];
+          });
           if (filtered.length > 0) {
             cleanedMessages.push({ ...msg, content: filtered });
           }


### PR DESCRIPTION
## Background

When a provider-executed tool (e.g. MCP via the OpenAI Responses API) requires approval, `WorkflowAgent` silently dropped the approval on resume. Its approval-resume path stripped **every** `tool-approval-request` and `tool-approval-response` part from the messages before `convertToLanguageModelPrompt` — but that conversion layer is the actual gate that forwards approvals to the provider (it only forwards responses flagged `providerExecuted`). By stripping first, the provider never learned of the approval and the tool was never executed.

This is the inverse of #14289, where local approvals were forwarded to the provider **twice**; here they were forwarded **zero** times.

Two community PRs proposed fixes — #14895 (@Genmin) and #14931 (@MyPrototypeWhat) — but both target `collectToolApprovalsFromMessages`, a local helper that was since **removed** when the approval-resume path was refactored to use core's `collectToolApprovals` + `validateApprovedToolApprovals`. Neither diff applies to current `main`. This PR reworks their approaches against the refactored code and credits both authors as co-authors.

## Summary

In `packages/workflow/src/workflow-agent.ts`, the approval-resume path now:

- Tracks `providerExecuted` per approval, sourced from the original `tool-call` part — the same discriminator core's `streamText` uses (adopted from #14931).
- Skips provider-executed approvals from local execution and from synthetic `execution-denied` results (the provider owns execution).
- Preserves provider-executed `tool-approval-request`/`tool-approval-response` parts through the message cleanup, re-stamping the response with `providerExecuted: true` (adopted from #14895) so the conversion layer forwards it to the provider.
- Leaves the local path unchanged: local approvals are still executed/denied and their approval parts stripped and replaced with tool results.

## Manual Verification

Reverting just the preservation logic in `workflow-agent.ts` makes the three new tests fail; restoring it makes them pass — confirming they exercise the real code path rather than passing vacuously. The new tests assert on the prompt handed to `streamTextIterator` (the output of `convertToLanguageModelPrompt`), verifying the provider-executed approval response is present and the local one is not.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (internal-only change; no public API or docs affected)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14292.

closes #14895 and closes #14931 (credited as co-authors).