### PR TITLE
docs(workflow): fix message persistence guidance for WorkflowAgent

### DIFF
--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -627,7 +627,9 @@ whether approval is required (see [Tool Approval](#tool-approval) above).
 
 ### `uiMessages` / `collectUIMessages` is gone
 
-`DurableAgent.stream()` returned accumulated `uiMessages` when `collectUIMessages: true` was set. `WorkflowAgent.stream()` returns `ModelMessage[]` on `result.messages` instead — persist those and convert them at the edge with `convertToModelMessages` / `convertToUIMessages` as needed.
+`DurableAgent.stream()` returned accumulated `uiMessages` when `collectUIMessages: true` was set. `WorkflowAgent.stream()` returns `ModelMessage[]` on `result.messages` instead.
+
+For persistence, store `UIMessage[]` as your source of truth and call [`convertToModelMessages`](/docs/reference/ai-sdk-ui/convert-to-model-messages) before passing them to the agent — this is the pattern described in [Chatbot Message Persistence](/docs/ai-sdk-ui/chatbot-message-persistence). There is no built-in `ModelMessage` → `UIMessage` conversion, so avoid persisting `result.messages` as your only copy if you need to render the conversation in the UI later.
 
 ```diff
   const result = await agent.stream({


### PR DESCRIPTION
## Background

[#12164 (comment)](https://github.com/vercel/ai/issues/12164#issuecomment-4472312712) reported that the WorkflowAgent migration guide recommends persisting `ModelMessage` and converting at the edge with `convertToUIMessages` — but that function doesn't exist.

The `WorkflowAgent` migration section (`content/docs/03-agents/07-workflow-agent.mdx`) said:

> `WorkflowAgent.stream()` returns `ModelMessage[]` on `result.messages` instead — persist those and convert them at the edge with `convertToModelMessages` / `convertToUIMessages` as needed.

Two problems:

1. **`convertToUIMessages` does not exist** as an SDK export. It was only ever proposed in #7180 (still open), never shipped.
2. **`convertToModelMessages` is listed for a direction it doesn't support.** It converts `UIMessage[] → ModelMessage[]`, not the reverse — so it can't convert persisted `ModelMessage`s back for the UI.

The net effect is the guide pointed readers at a persistence pattern with no working SDK function behind it.

## Summary

Replace the guidance with the established pattern from [Chatbot Message Persistence](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-message-persistence): store `UIMessage[]` as the source of truth and call `convertToModelMessages` before passing them to the agent. Also note explicitly that there is no built-in `ModelMessage` → `UIMessage` conversion, so persisting `result.messages` alone is lossy for UI rendering.

The factual migration note (`uiMessages` / `collectUIMessages` are gone; `result.messages` is now `ModelMessage[]`) and the `diff` example below it are unchanged.

## Related Issues

Addresses the docs problem reported in #12164.