### PR TITLE
Add Gemini Live Translate support

### DIFF
--- a/.changeset/gemini-live-translate.md
+++ b/.changeset/gemini-live-translate.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Add Google realtime Live Translation provider options for `gemini-3.5-live-translate-preview`.

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1091,6 +1091,38 @@ Google realtime models may require provider-specific audio formats, depending
 on the model and modality. See [Realtime](/docs/ai-sdk-core/realtime) for the
 complete setup and tool calling pattern.
 
+### Live Translation
+
+Use `gemini-3.5-live-translate-preview` for low-latency speech-to-speech
+translation. Configure the target language with
+`providerOptions.google.translationConfig` in the realtime session config you
+use when creating the token:
+
+```ts
+import { google, type GoogleRealtimeModelOptions } from '@ai-sdk/google';
+
+const token = await google.experimental_realtime.getToken({
+  model: 'gemini-3.5-live-translate-preview',
+  sessionConfig: {
+    outputModalities: ['audio'],
+    inputAudioTranscription: {},
+    outputAudioTranscription: {},
+    providerOptions: {
+      google: {
+        translationConfig: {
+          targetLanguageCode: 'pl',
+          echoTargetLanguage: true,
+        },
+      } satisfies GoogleRealtimeModelOptions,
+    },
+  },
+});
+```
+
+Gemini Live Translation accepts audio input and produces translated audio
+output. Text input, tools, and custom instructions are not supported by this
+model.
+
 ## Interactions API
 
 The [Gemini Interactions API](https://ai.google.dev/gemini-api/docs/interactions)

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1099,7 +1099,10 @@ translation. Configure the target language with
 use when creating the token:
 
 ```ts
-import { google, type GoogleRealtimeModelOptions } from '@ai-sdk/google';
+import {
+  google,
+  type Experimental_GoogleRealtimeModelOptions as GoogleRealtimeModelOptions,
+} from '@ai-sdk/google';
 
 const token = await google.experimental_realtime.getToken({
   model: 'gemini-3.5-live-translate-preview',
@@ -1118,6 +1121,10 @@ const token = await google.experimental_realtime.getToken({
   },
 });
 ```
+
+Set `targetLanguageCode` to a BCP-47 language code (defaults to `en`). When
+`echoTargetLanguage` is `true`, input audio already in the target language is
+echoed instead of producing silence.
 
 Gemini Live Translation accepts audio input and produces translated audio
 output. Text input, tools, and custom instructions are not supported by this

--- a/examples/ai-e2e-next/.env.local.example
+++ b/examples/ai-e2e-next/.env.local.example
@@ -13,5 +13,8 @@ BLOB_READ_WRITE_TOKEN=xxxxxxx
 # Required for reasoning example
 FIREWORKS_API_KEY=xxxxxxx
 
+# Required for Google realtime and Live Translate examples
+GOOGLE_GENERATIVE_AI_API_KEY=xxxxxxx
+
 # Required for resumable streams. You can create a Redis store here: https://vercel.com/marketplace/redis
 REDIS_URL=xxxxxx

--- a/examples/ai-e2e-next/app/api/realtime/[...path]/route.ts
+++ b/examples/ai-e2e-next/app/api/realtime/[...path]/route.ts
@@ -38,7 +38,10 @@ const tools = {
   }),
 };
 
-const providers: Record<string, { factory: RealtimeFactory; model: string }> = {
+const providers: Record<
+  string,
+  { factory: RealtimeFactory; model: string; includeTools?: boolean }
+> = {
   openai: {
     factory: openai.experimental_realtime,
     model: 'gpt-realtime',
@@ -46,6 +49,11 @@ const providers: Record<string, { factory: RealtimeFactory; model: string }> = {
   google: {
     factory: google.experimental_realtime,
     model: 'gemini-3.1-flash-live-preview',
+  },
+  'google-live-translate': {
+    factory: google.experimental_realtime,
+    model: 'gemini-3.5-live-translate-preview',
+    includeTools: false,
   },
   xai: {
     factory: xai.experimental_realtime,
@@ -72,15 +80,25 @@ export async function POST(
     const sessionConfig: RealtimeSessionConfig | undefined =
       body.sessionConfig ?? undefined;
 
-    const toolDefs = await getRealtimeToolDefinitions({ tools });
+    const providerConfig = providers[provider] ?? providers.openai;
+    const toolDefs =
+      providerConfig.includeTools === false
+        ? undefined
+        : await getRealtimeToolDefinitions({ tools });
 
-    const { factory, model } = providers[provider] ?? providers.openai;
+    const { factory, model } = providerConfig;
     const tokenResult = await factory.getToken({
       model,
-      sessionConfig: { ...sessionConfig, tools: toolDefs },
+      sessionConfig:
+        toolDefs == null
+          ? sessionConfig
+          : { ...sessionConfig, tools: toolDefs },
     });
 
-    return Response.json({ ...tokenResult, tools: toolDefs });
+    return Response.json({
+      ...tokenResult,
+      ...(toolDefs == null ? {} : { tools: toolDefs }),
+    });
   }
 
   if (route === 'weather') {

--- a/examples/ai-e2e-next/app/live-translate/page.tsx
+++ b/examples/ai-e2e-next/app/live-translate/page.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { experimental_useRealtime } from '@ai-sdk/react';
-import { google, type GoogleRealtimeModelOptions } from '@ai-sdk/google';
+import {
+  google,
+  type Experimental_GoogleRealtimeModelOptions as GoogleRealtimeModelOptions,
+} from '@ai-sdk/google';
 import { Activity, Languages, Mic, Pause, Power } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 

--- a/examples/ai-e2e-next/app/live-translate/page.tsx
+++ b/examples/ai-e2e-next/app/live-translate/page.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import { experimental_useRealtime } from '@ai-sdk/react';
+import { google, type GoogleRealtimeModelOptions } from '@ai-sdk/google';
+import { Activity, Languages, Mic, Pause, Power } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const languageOptions = [
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'it', label: 'Italian' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'ko', label: 'Korean' },
+  { code: 'pl', label: 'Polish' },
+  { code: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { code: 'zh-CN', label: 'Chinese (Simplified)' },
+];
+
+const statusText: Record<string, string> = {
+  disconnected: 'Not connected.',
+  connecting: 'Connecting...',
+  connected: 'Ready.',
+  error: 'Connection error.',
+};
+
+const statusColor: Record<string, string> = {
+  disconnected: 'text-zinc-500',
+  connecting: 'text-amber-700',
+  connected: 'text-emerald-700',
+  error: 'text-rose-700',
+};
+
+function CodeBadge({ children }: { children: string }) {
+  return (
+    <code className="rounded-md bg-zinc-100 px-1.5 py-0.5 font-mono text-[11px] font-medium text-zinc-500">
+      {children}
+    </code>
+  );
+}
+
+function getMessageText(message: {
+  parts: Array<{ type: string; text?: string }>;
+}): string {
+  return message.parts
+    .filter(part => part.type === 'text' && part.text != null)
+    .map(part => part.text)
+    .join('');
+}
+
+function getLatestText(
+  messages: Array<{
+    role: string;
+    parts: Array<{ type: string; text?: string }>;
+  }>,
+  role: string,
+): string {
+  const matchingMessages = messages
+    .filter(message => message.role === role)
+    .map(getMessageText)
+    .filter(text => text.length > 0);
+
+  return matchingMessages.at(-1) ?? '';
+}
+
+export default function LiveTranslatePage() {
+  const [targetLanguageCode, setTargetLanguageCode] = useState('pl');
+  const [echoTargetLanguage, setEchoTargetLanguage] = useState(true);
+  const [showEvents, setShowEvents] = useState(false);
+  const [captureStarting, setCaptureStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const holdActiveRef = useRef(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const eventsEndRef = useRef<HTMLDivElement>(null);
+
+  const model = useMemo(
+    () => google.experimental_realtime('gemini-3.5-live-translate-preview'),
+    [],
+  );
+
+  const sessionConfig = useMemo(
+    () => ({
+      outputModalities: ['audio' as const],
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      outputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+      inputAudioTranscription: {},
+      outputAudioTranscription: {},
+      providerOptions: {
+        google: {
+          translationConfig: {
+            targetLanguageCode,
+            echoTargetLanguage,
+          },
+        } satisfies GoogleRealtimeModelOptions,
+      },
+    }),
+    [echoTargetLanguage, targetLanguageCode],
+  );
+
+  const {
+    status,
+    messages,
+    events,
+    isCapturing,
+    isPlaying,
+    connect,
+    disconnect,
+    startAudioCapture,
+    stopAudioCapture,
+    stopPlayback,
+  } = experimental_useRealtime({
+    model,
+    api: {
+      token: '/api/realtime/setup?provider=google-live-translate',
+    },
+    sessionConfig,
+    maxEvents: 250,
+    onEvent: event => {
+      if (event.type !== 'audio-delta') {
+        console.log('[live-translate]', event.type, event);
+      }
+    },
+    onError: nextError => {
+      setError(nextError.message);
+      console.warn('[live-translate] error:', nextError.message);
+    },
+  });
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (showEvents && events.length > 0) {
+      eventsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [events, showEvents]);
+
+  useEffect(() => {
+    if (status !== 'error') {
+      setError(null);
+    }
+  }, [status]);
+
+  const connectOrDisconnect = async () => {
+    if (status === 'connected') {
+      holdActiveRef.current = false;
+      if (isCapturing) stopAudioCapture();
+      if (isPlaying) stopPlayback();
+      disconnect();
+      return;
+    }
+
+    setError(null);
+    await connect();
+  };
+
+  const startHoldingToTalk = async () => {
+    if (status !== 'connected' || isCapturing || captureStarting) return;
+
+    holdActiveRef.current = true;
+    setCaptureStarting(true);
+    setError(null);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+
+      if (holdActiveRef.current && status === 'connected') {
+        startAudioCapture(stream);
+      } else {
+        stream.getTracks().forEach(track => track.stop());
+      }
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : 'Microphone access failed',
+      );
+    } finally {
+      setCaptureStarting(false);
+    }
+  };
+
+  const stopHoldingToTalk = () => {
+    holdActiveRef.current = false;
+    if (isCapturing) {
+      stopAudioCapture();
+    }
+  };
+
+  const visibleEvents = events.filter(event => event.type !== 'audio-delta');
+  const controlsLocked = status === 'connected' || status === 'connecting';
+  const latestInput = getLatestText(messages, 'user');
+  const latestTranslation = getLatestText(messages, 'assistant');
+  const outputText =
+    latestTranslation || latestInput || 'Translated speech will appear here.';
+
+  const inputTranscriptCount = events.filter(
+    event => event.type === 'input-transcription-completed',
+  ).length;
+  const outputTranscriptCount = events.filter(event =>
+    event.type.startsWith('audio-transcript'),
+  ).length;
+
+  const resultStatus =
+    status === 'connected'
+      ? isCapturing
+        ? `Listening - target language: ${targetLanguageCode}.`
+        : latestTranslation
+          ? `Done - target language: ${targetLanguageCode}.`
+          : `Ready - target language: ${targetLanguageCode}.`
+      : statusText[status];
+
+  return (
+    <main className="flex min-h-screen items-start justify-center bg-[#fafafa] px-5 py-20 text-zinc-950">
+      <section className="w-full max-w-[470px] rounded-xl border border-zinc-200 bg-white p-7 shadow-[0_18px_60px_rgba(0,0,0,0.10)]">
+        <header className="mb-6">
+          <div className="mb-3 flex items-center gap-2">
+            <Languages size={18} className="text-zinc-700" aria-hidden />
+            <h1 className="text-xl font-semibold tracking-normal text-zinc-900">
+              Google Gemini Live Translate
+            </h1>
+          </div>
+          <p className="text-[13px] leading-5 text-zinc-500">
+            Speech-to-speech via <CodeBadge>@ai-sdk/google</CodeBadge> and{' '}
+            <CodeBadge>.experimental_realtime()</CodeBadge> through{' '}
+            <CodeBadge>gemini-3.5-live-translate-preview</CodeBadge>.
+          </p>
+        </header>
+
+        <div className="grid gap-4">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="grid gap-1.5 text-xs font-semibold text-zinc-700">
+              Target language
+              <select
+                value={targetLanguageCode}
+                disabled={controlsLocked}
+                onChange={event => setTargetLanguageCode(event.target.value)}
+                className="h-10 rounded-md border border-zinc-300 bg-white px-3 text-sm font-normal text-zinc-900 outline-none transition focus:border-zinc-500 disabled:cursor-not-allowed disabled:bg-zinc-50 disabled:text-zinc-500"
+              >
+                {languageOptions.map(language => (
+                  <option key={language.code} value={language.code}>
+                    {language.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="grid gap-1.5 text-xs font-semibold text-zinc-700">
+              Echo
+              <select
+                value={echoTargetLanguage ? 'on' : 'off'}
+                disabled={controlsLocked}
+                onChange={event =>
+                  setEchoTargetLanguage(event.target.value === 'on')
+                }
+                className="h-10 rounded-md border border-zinc-300 bg-white px-3 text-sm font-normal text-zinc-900 outline-none transition focus:border-zinc-500 disabled:cursor-not-allowed disabled:bg-zinc-50 disabled:text-zinc-500"
+              >
+                <option value="on">Echo target language</option>
+                <option value="off">Silence target language</option>
+              </select>
+            </label>
+          </div>
+
+          <button
+            type="button"
+            onClick={connectOrDisconnect}
+            disabled={status === 'connecting'}
+            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-zinc-950 px-4 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+          >
+            <Power size={16} aria-hidden />
+            {status === 'connected'
+              ? 'Disconnect'
+              : status === 'connecting'
+                ? 'Connecting...'
+                : 'Connect'}
+          </button>
+
+          <div className="my-5 border-t border-zinc-200" />
+
+          <div>
+            <p className="mb-4 text-[13px] leading-5 text-zinc-500">
+              Push to translate: hold the button, speak, release - audio input
+              and output transcripts are enabled.
+            </p>
+
+            <button
+              type="button"
+              onPointerDown={startHoldingToTalk}
+              onPointerUp={stopHoldingToTalk}
+              onPointerCancel={stopHoldingToTalk}
+              onPointerLeave={stopHoldingToTalk}
+              onKeyDown={event => {
+                if (event.key === ' ' || event.key === 'Enter') {
+                  void startHoldingToTalk();
+                }
+              }}
+              onKeyUp={event => {
+                if (event.key === ' ' || event.key === 'Enter') {
+                  stopHoldingToTalk();
+                }
+              }}
+              disabled={status !== 'connected' || captureStarting}
+              className={`inline-flex h-11 w-full items-center justify-center gap-2 rounded-md px-4 text-sm font-semibold transition disabled:cursor-not-allowed disabled:bg-zinc-200 disabled:text-zinc-400 ${
+                isCapturing
+                  ? 'bg-rose-700 text-white hover:bg-rose-800'
+                  : 'bg-zinc-950 text-white hover:bg-zinc-800'
+              }`}
+            >
+              <Mic size={16} aria-hidden />
+              {isCapturing
+                ? 'Release to stop'
+                : captureStarting
+                  ? 'Opening microphone...'
+                  : 'Hold to translate'}
+            </button>
+
+            <div className="mt-4 grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-xs text-zinc-400">
+              <div className="h-px bg-zinc-200" />
+              <span>or</span>
+              <div className="h-px bg-zinc-200" />
+            </div>
+
+            <div className="mt-4 grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={stopPlayback}
+                disabled={!isPlaying}
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-zinc-300 bg-white px-3 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:cursor-not-allowed disabled:bg-zinc-50 disabled:text-zinc-400"
+              >
+                <Pause size={15} aria-hidden />
+                Stop audio
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowEvents(value => !value)}
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-zinc-300 bg-white px-3 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
+              >
+                <Activity size={15} aria-hidden />
+                {showEvents ? 'Hide events' : 'Show events'}
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-1 text-[13px] font-medium">
+            <span className={statusColor[status]}>{resultStatus}</span>
+          </div>
+
+          {error != null && (
+            <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-[13px] leading-5 text-rose-800">
+              {error}
+            </div>
+          )}
+
+          <div className="rounded-md bg-zinc-100 px-4 py-3 font-mono text-[13px] leading-6 text-zinc-700">
+            {outputText}
+            <div ref={messagesEndRef} />
+          </div>
+
+          <dl className="grid grid-cols-3 gap-2 text-center text-xs text-zinc-500">
+            <div className="rounded-md border border-zinc-200 px-2 py-2">
+              <dt className="mb-1 font-medium text-zinc-700">Target</dt>
+              <dd>{targetLanguageCode}</dd>
+            </div>
+            <div className="rounded-md border border-zinc-200 px-2 py-2">
+              <dt className="mb-1 font-medium text-zinc-700">Input</dt>
+              <dd>{inputTranscriptCount}</dd>
+            </div>
+            <div className="rounded-md border border-zinc-200 px-2 py-2">
+              <dt className="mb-1 font-medium text-zinc-700">Output</dt>
+              <dd>{outputTranscriptCount}</dd>
+            </div>
+          </dl>
+
+          {showEvents && (
+            <div className="max-h-64 overflow-y-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600">
+              <div className="mb-2 font-semibold text-zinc-800">
+                Events ({visibleEvents.length})
+              </div>
+              {visibleEvents.length === 0 ? (
+                <div className="rounded-md bg-white px-3 py-2 text-zinc-400">
+                  No events yet.
+                </div>
+              ) : (
+                visibleEvents.map((event, index) => (
+                  <details
+                    key={`${event.type}-${index}`}
+                    className="border-t border-zinc-200 py-2 first:border-t-0"
+                  >
+                    <summary className="cursor-pointer font-mono text-zinc-700">
+                      {event.type}
+                    </summary>
+                    <pre className="mt-2 max-h-44 overflow-auto rounded-md bg-white p-2 font-mono text-[11px] leading-5 text-zinc-600">
+                      {JSON.stringify(event, null, 2)}
+                    </pre>
+                  </details>
+                ))
+              )}
+              <div ref={eventsEndRef} />
+            </div>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/examples/ai-e2e-next/app/live-translate/page.tsx
+++ b/examples/ai-e2e-next/app/live-translate/page.tsx
@@ -6,7 +6,7 @@ import {
   type Experimental_GoogleRealtimeModelOptions as GoogleRealtimeModelOptions,
 } from '@ai-sdk/google';
 import { Activity, Languages, Mic, Pause, Power } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const languageOptions = [
   { code: 'en', label: 'English' },
@@ -72,10 +72,16 @@ export default function LiveTranslatePage() {
   const [echoTargetLanguage, setEchoTargetLanguage] = useState(true);
   const [showEvents, setShowEvents] = useState(false);
   const [captureStarting, setCaptureStarting] = useState(false);
+  const [showConnectedPrompt, setShowConnectedPrompt] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const holdActiveRef = useRef(false);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const eventsEndRef = useRef<HTMLDivElement>(null);
+  const autoStartAttemptedRef = useRef(false);
+  const captureActiveRef = useRef(false);
+  const captureRequestIdRef = useRef(0);
+  const captureRequestPendingRef = useRef(false);
+  const captureStreamRef = useRef<MediaStream | null>(null);
+  const statusRef = useRef('disconnected');
+  const eventsContainerRef = useRef<HTMLDivElement>(null);
+  const shouldFollowEventsRef = useRef(true);
 
   const model = useMemo(
     () => google.experimental_realtime('gemini-3.5-live-translate-preview'),
@@ -109,6 +115,7 @@ export default function LiveTranslatePage() {
     isPlaying,
     connect,
     disconnect,
+    commitAudio,
     startAudioCapture,
     stopAudioCapture,
     stopPlayback,
@@ -130,41 +137,63 @@ export default function LiveTranslatePage() {
     },
   });
 
-  useEffect(() => {
-    if (messages.length > 0) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages]);
+  const realtimeActionsRef = useRef({
+    commitAudio,
+    startAudioCapture,
+    stopAudioCapture,
+  });
+  realtimeActionsRef.current = {
+    commitAudio,
+    startAudioCapture,
+    stopAudioCapture,
+  };
+
+  const visibleEvents = events.filter(event => event.type !== 'audio-delta');
+  const latestVisibleEvent = visibleEvents.at(-1);
 
   useEffect(() => {
-    if (showEvents && events.length > 0) {
-      eventsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (showEvents && shouldFollowEventsRef.current) {
+      const container = eventsContainerRef.current;
+      if (container != null) {
+        container.scrollTop = container.scrollHeight;
+      }
     }
-  }, [events, showEvents]);
+  }, [latestVisibleEvent, showEvents]);
 
   useEffect(() => {
+    statusRef.current = status;
     if (status !== 'error') {
       setError(null);
     }
   }, [status]);
 
-  const connectOrDisconnect = async () => {
-    if (status === 'connected') {
-      holdActiveRef.current = false;
-      if (isCapturing) stopAudioCapture();
-      if (isPlaying) stopPlayback();
-      disconnect();
+  const stopListening = useCallback((commit = true) => {
+    captureRequestIdRef.current += 1;
+    captureRequestPendingRef.current = false;
+    setCaptureStarting(false);
+
+    if (!captureActiveRef.current) return;
+
+    captureActiveRef.current = false;
+    captureStreamRef.current = null;
+    realtimeActionsRef.current.stopAudioCapture();
+
+    if (commit && statusRef.current === 'connected') {
+      realtimeActionsRef.current.commitAudio();
+    }
+  }, []);
+
+  const startListening = useCallback(async () => {
+    if (
+      statusRef.current !== 'connected' ||
+      captureActiveRef.current ||
+      captureRequestPendingRef.current
+    ) {
       return;
     }
 
-    setError(null);
-    await connect();
-  };
-
-  const startHoldingToTalk = async () => {
-    if (status !== 'connected' || isCapturing || captureStarting) return;
-
-    holdActiveRef.current = true;
+    const requestId = ++captureRequestIdRef.current;
+    captureRequestPendingRef.current = true;
     setCaptureStarting(true);
     setError(null);
 
@@ -177,30 +206,88 @@ export default function LiveTranslatePage() {
         },
       });
 
-      if (holdActiveRef.current && status === 'connected') {
-        startAudioCapture(stream);
-      } else {
+      if (
+        requestId !== captureRequestIdRef.current ||
+        statusRef.current !== 'connected'
+      ) {
         stream.getTracks().forEach(track => track.stop());
+        return;
       }
+
+      captureStreamRef.current = stream;
+      captureActiveRef.current = true;
+      realtimeActionsRef.current.startAudioCapture(stream);
     } catch (nextError) {
+      if (requestId !== captureRequestIdRef.current) return;
+
+      captureActiveRef.current = false;
+      captureStreamRef.current?.getTracks().forEach(track => track.stop());
+      captureStreamRef.current = null;
       setError(
         nextError instanceof Error
           ? nextError.message
           : 'Microphone access failed',
       );
     } finally {
-      setCaptureStarting(false);
+      if (requestId === captureRequestIdRef.current) {
+        captureRequestPendingRef.current = false;
+        setCaptureStarting(false);
+      }
     }
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'connected') {
+      stopListening(false);
+    }
+  }, [status, stopListening]);
+
+  useEffect(() => {
+    return () => {
+      statusRef.current = 'disconnected';
+      captureRequestIdRef.current += 1;
+      captureStreamRef.current?.getTracks().forEach(track => track.stop());
+      captureStreamRef.current = null;
+      captureActiveRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'connected') {
+      autoStartAttemptedRef.current = false;
+      setShowConnectedPrompt(false);
+      return;
+    }
+
+    setShowConnectedPrompt(true);
+    const timeout = window.setTimeout(
+      () => setShowConnectedPrompt(false),
+      5000,
+    );
+
+    return () => window.clearTimeout(timeout);
+  }, [status]);
+
+  useEffect(() => {
+    if (status !== 'connected' || autoStartAttemptedRef.current) return;
+
+    autoStartAttemptedRef.current = true;
+    void startListening();
+  }, [startListening, status]);
+
+  const connectOrDisconnect = async () => {
+    if (status === 'connected') {
+      stopListening();
+      statusRef.current = 'disconnected';
+      if (isPlaying) stopPlayback();
+      disconnect();
+      return;
+    }
+
+    setError(null);
+    await connect();
   };
 
-  const stopHoldingToTalk = () => {
-    holdActiveRef.current = false;
-    if (isCapturing) {
-      stopAudioCapture();
-    }
-  };
-
-  const visibleEvents = events.filter(event => event.type !== 'audio-delta');
   const controlsLocked = status === 'connected' || status === 'connecting';
   const latestInput = getLatestText(messages, 'user');
   const latestTranslation = getLatestText(messages, 'assistant');
@@ -225,6 +312,31 @@ export default function LiveTranslatePage() {
 
   return (
     <main className="flex min-h-screen items-start justify-center bg-[#fafafa] px-5 py-20 text-zinc-950">
+      {showConnectedPrompt && (
+        <div
+          role="status"
+          className="fixed top-5 right-5 z-50 flex max-w-sm items-start gap-3 rounded-lg border border-emerald-200 bg-white px-4 py-3 shadow-lg"
+        >
+          <span className="mt-1 h-2.5 w-2.5 shrink-0 animate-pulse rounded-full bg-emerald-500" />
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-zinc-900">
+              You&apos;re connected
+            </div>
+            <div className="mt-0.5 text-xs leading-5 text-zinc-500">
+              Start speaking. Translation will appear as you talk.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowConnectedPrompt(false)}
+            aria-label="Dismiss connected message"
+            className="ml-1 text-lg leading-none text-zinc-400 hover:text-zinc-700"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
       <section className="w-full max-w-[470px] rounded-xl border border-zinc-200 bg-white p-7 shadow-[0_18px_60px_rgba(0,0,0,0.10)]">
         <header className="mb-6">
           <div className="mb-3 flex items-center gap-2">
@@ -292,45 +404,63 @@ export default function LiveTranslatePage() {
 
           <div>
             <p className="mb-4 text-[13px] leading-5 text-zinc-500">
-              Push to translate: hold the button, speak, release - audio input
-              and output transcripts are enabled.
+              Speak naturally once connected. Audio input and translated output
+              transcripts are enabled.
             </p>
 
-            <button
-              type="button"
-              onPointerDown={startHoldingToTalk}
-              onPointerUp={stopHoldingToTalk}
-              onPointerCancel={stopHoldingToTalk}
-              onPointerLeave={stopHoldingToTalk}
-              onKeyDown={event => {
-                if (event.key === ' ' || event.key === 'Enter') {
-                  void startHoldingToTalk();
-                }
-              }}
-              onKeyUp={event => {
-                if (event.key === ' ' || event.key === 'Enter') {
-                  stopHoldingToTalk();
-                }
-              }}
-              disabled={status !== 'connected' || captureStarting}
-              className={`inline-flex h-11 w-full items-center justify-center gap-2 rounded-md px-4 text-sm font-semibold transition disabled:cursor-not-allowed disabled:bg-zinc-200 disabled:text-zinc-400 ${
+            <div
+              className={`rounded-lg border p-4 transition ${
                 isCapturing
-                  ? 'bg-rose-700 text-white hover:bg-rose-800'
-                  : 'bg-zinc-950 text-white hover:bg-zinc-800'
+                  ? 'border-emerald-200 bg-emerald-50'
+                  : 'border-zinc-200 bg-zinc-50'
               }`}
             >
-              <Mic size={16} aria-hidden />
-              {isCapturing
-                ? 'Release to stop'
-                : captureStarting
-                  ? 'Opening microphone...'
-                  : 'Hold to translate'}
-            </button>
+              <div className="flex items-center gap-3">
+                <span
+                  className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${
+                    isCapturing
+                      ? 'bg-emerald-600 text-white'
+                      : 'bg-zinc-200 text-zinc-500'
+                  }`}
+                >
+                  <Mic size={17} aria-hidden />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-semibold text-zinc-900">
+                    {isCapturing
+                      ? 'Listening...'
+                      : captureStarting
+                        ? 'Opening microphone...'
+                        : 'Listening paused'}
+                  </div>
+                  <div className="mt-0.5 text-xs text-zinc-500">
+                    {isCapturing
+                      ? 'Speak normally and translation will appear below.'
+                      : 'Start listening when you are ready to speak.'}
+                  </div>
+                </div>
+                {isCapturing && (
+                  <span className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full bg-emerald-500" />
+                )}
+              </div>
 
-            <div className="mt-4 grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-xs text-zinc-400">
-              <div className="h-px bg-zinc-200" />
-              <span>or</span>
-              <div className="h-px bg-zinc-200" />
+              <button
+                type="button"
+                onClick={isCapturing ? () => stopListening() : startListening}
+                disabled={status !== 'connected' || captureStarting}
+                className={`mt-4 inline-flex h-10 w-full items-center justify-center gap-2 rounded-md px-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:bg-zinc-200 disabled:text-zinc-400 ${
+                  isCapturing
+                    ? 'border border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50'
+                    : 'bg-zinc-950 text-white hover:bg-zinc-800'
+                }`}
+              >
+                {isCapturing ? (
+                  <Pause size={15} aria-hidden />
+                ) : (
+                  <Mic size={15} aria-hidden />
+                )}
+                {isCapturing ? 'Stop listening' : 'Start listening'}
+              </button>
             </div>
 
             <div className="mt-4 grid grid-cols-2 gap-3">
@@ -345,7 +475,10 @@ export default function LiveTranslatePage() {
               </button>
               <button
                 type="button"
-                onClick={() => setShowEvents(value => !value)}
+                onClick={() => {
+                  shouldFollowEventsRef.current = true;
+                  setShowEvents(value => !value);
+                }}
                 className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-zinc-300 bg-white px-3 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
               >
                 <Activity size={15} aria-hidden />
@@ -366,7 +499,6 @@ export default function LiveTranslatePage() {
 
           <div className="rounded-md bg-zinc-100 px-4 py-3 font-mono text-[13px] leading-6 text-zinc-700">
             {outputText}
-            <div ref={messagesEndRef} />
           </div>
 
           <dl className="grid grid-cols-3 gap-2 text-center text-xs text-zinc-500">
@@ -385,7 +517,18 @@ export default function LiveTranslatePage() {
           </dl>
 
           {showEvents && (
-            <div className="max-h-64 overflow-y-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600">
+            <div
+              ref={eventsContainerRef}
+              onScroll={event => {
+                const container = event.currentTarget;
+                shouldFollowEventsRef.current =
+                  container.scrollHeight -
+                    container.scrollTop -
+                    container.clientHeight <
+                  24;
+              }}
+              className="max-h-64 overflow-y-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600"
+            >
               <div className="mb-2 font-semibold text-zinc-800">
                 Events ({visibleEvents.length})
               </div>
@@ -408,7 +551,6 @@ export default function LiveTranslatePage() {
                   </details>
                 ))
               )}
-              <div ref={eventsEndRef} />
             </div>
           )}
         </div>

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -57,8 +57,8 @@ export type {
 export { GoogleRealtimeModel as Experimental_GoogleRealtimeModel } from './realtime/google-realtime-model';
 export type { GoogleRealtimeModelConfig as Experimental_GoogleRealtimeModelConfig } from './realtime/google-realtime-model';
 export type {
-  GoogleRealtimeModelId,
-  GoogleRealtimeModelOptions,
+  GoogleRealtimeModelId as Experimental_GoogleRealtimeModelId,
+  GoogleRealtimeModelOptions as Experimental_GoogleRealtimeModelOptions,
 } from './realtime/google-realtime-model-options';
 
 export { VERSION } from './version';

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -56,5 +56,9 @@ export type {
 } from './google-provider';
 export { GoogleRealtimeModel as Experimental_GoogleRealtimeModel } from './realtime/google-realtime-model';
 export type { GoogleRealtimeModelConfig as Experimental_GoogleRealtimeModelConfig } from './realtime/google-realtime-model';
+export type {
+  GoogleRealtimeModelId,
+  GoogleRealtimeModelOptions,
+} from './realtime/google-realtime-model-options';
 
 export { VERSION } from './version';

--- a/packages/google/src/realtime/google-realtime-event-mapper.test.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.test.ts
@@ -3,6 +3,7 @@ import {
   GoogleRealtimeEventMapper,
   buildGoogleSessionConfig,
 } from './google-realtime-event-mapper';
+import type { GoogleRealtimeModelOptions } from './google-realtime-model-options';
 
 describe('GoogleRealtimeEventMapper', () => {
   describe('parseServerEvent', () => {
@@ -442,6 +443,42 @@ describe('GoogleRealtimeEventMapper', () => {
       });
     });
 
+    it('serializes live translation config into generationConfig', () => {
+      const result = mapper.serializeClientEvent(
+        {
+          type: 'session-update',
+          config: {
+            inputAudioTranscription: {},
+            outputAudioTranscription: {},
+            providerOptions: {
+              google: {
+                translationConfig: {
+                  targetLanguageCode: 'pl',
+                  echoTargetLanguage: true,
+                },
+              } satisfies GoogleRealtimeModelOptions,
+            },
+          },
+        },
+        'gemini-3.5-live-translate-preview',
+      );
+
+      expect(result).toEqual({
+        setup: {
+          model: 'models/gemini-3.5-live-translate-preview',
+          generationConfig: {
+            responseModalities: ['AUDIO'],
+            translationConfig: {
+              targetLanguageCode: 'pl',
+              echoTargetLanguage: true,
+            },
+          },
+          inputAudioTranscription: {},
+          outputAudioTranscription: {},
+        },
+      });
+    });
+
     it('serializes input-audio-append as realtimeInput', () => {
       const result = mapper.serializeClientEvent(
         { type: 'input-audio-append', audio: 'base64data' },
@@ -692,6 +729,60 @@ describe('buildGoogleSessionConfig', () => {
     );
 
     expect(result.outputAudioTranscription).toEqual({});
+  });
+
+  it('maps providerOptions.google.translationConfig to generationConfig', () => {
+    const result = buildGoogleSessionConfig(
+      {
+        providerOptions: {
+          google: {
+            translationConfig: {
+              targetLanguageCode: 'es',
+              echoTargetLanguage: true,
+            },
+          } satisfies GoogleRealtimeModelOptions,
+        },
+      },
+      'gemini-3.5-live-translate-preview',
+    );
+
+    expect(result).toEqual({
+      model: 'models/gemini-3.5-live-translate-preview',
+      generationConfig: {
+        responseModalities: ['AUDIO'],
+        translationConfig: {
+          targetLanguageCode: 'es',
+          echoTargetLanguage: true,
+        },
+      },
+    });
+  });
+
+  it('merges translation config into raw generationConfig provider options', () => {
+    const result = buildGoogleSessionConfig(
+      {
+        providerOptions: {
+          generationConfig: {
+            responseModalities: ['AUDIO'],
+            temperature: 0.2,
+          },
+          google: {
+            translationConfig: {
+              targetLanguageCode: 'fr',
+            },
+          } satisfies GoogleRealtimeModelOptions,
+        },
+      },
+      'gemini-3.5-live-translate-preview',
+    );
+
+    expect(result.generationConfig).toEqual({
+      responseModalities: ['AUDIO'],
+      temperature: 0.2,
+      translationConfig: {
+        targetLanguageCode: 'fr',
+      },
+    });
   });
 
   it('preserves model path that already includes slash', () => {

--- a/packages/google/src/realtime/google-realtime-event-mapper.test.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.test.ts
@@ -495,10 +495,14 @@ describe('GoogleRealtimeEventMapper', () => {
       });
     });
 
-    it('returns null for input-audio-commit', () => {
+    it('serializes input-audio-commit as audioStreamEnd', () => {
       expect(
         mapper.serializeClientEvent({ type: 'input-audio-commit' }, 'model'),
-      ).toBeNull();
+      ).toEqual({
+        realtimeInput: {
+          audioStreamEnd: true,
+        },
+      });
     });
 
     it('returns null for input-audio-clear', () => {

--- a/packages/google/src/realtime/google-realtime-event-mapper.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.ts
@@ -8,6 +8,7 @@ import type {
 import { safeParseJSON } from '@ai-sdk/provider-utils';
 import { convertJSONSchemaToOpenAPISchema } from '../convert-json-schema-to-openapi-schema';
 import { getModelPath } from '../get-model-path';
+import type { GoogleRealtimeModelOptions } from './google-realtime-model-options';
 
 type GoogleRealtimeFunctionCall = {
   id: string;
@@ -37,6 +38,10 @@ type GoogleRealtimeWireEvent = {
   serverContent?: GoogleRealtimeServerContent;
   inputTranscription?: { text?: string };
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
 
 /**
  * Stateful event mapper for Google's Gemini Live API.
@@ -376,7 +381,21 @@ export function buildGoogleSessionConfig(
   }
 
   if (config?.providerOptions != null) {
-    Object.assign(setup, config.providerOptions);
+    const { google, ...providerOptions } = config.providerOptions;
+    Object.assign(setup, providerOptions);
+
+    if (isRecord(google)) {
+      const googleOptions = google as GoogleRealtimeModelOptions;
+
+      if (googleOptions.translationConfig != null) {
+        const targetGenerationConfig = isRecord(setup.generationConfig)
+          ? setup.generationConfig
+          : generationConfig;
+        targetGenerationConfig.translationConfig =
+          googleOptions.translationConfig;
+        setup.generationConfig = targetGenerationConfig;
+      }
+    }
   }
 
   return setup;

--- a/packages/google/src/realtime/google-realtime-event-mapper.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.ts
@@ -380,22 +380,25 @@ export function buildGoogleSessionConfig(
     setup.outputAudioTranscription = {};
   }
 
-  if (config?.providerOptions != null) {
-    const { google, ...providerOptions } = config.providerOptions;
-    Object.assign(setup, providerOptions);
+  if (config?.providerOptions == null) {
+    return setup;
+  }
 
-    if (isRecord(google)) {
-      const googleOptions = google as GoogleRealtimeModelOptions;
+  const { google, ...providerOptions } = config.providerOptions;
+  Object.assign(setup, providerOptions);
 
-      if (googleOptions.translationConfig != null) {
-        const targetGenerationConfig = isRecord(setup.generationConfig)
-          ? setup.generationConfig
-          : generationConfig;
-        targetGenerationConfig.translationConfig =
-          googleOptions.translationConfig;
-        setup.generationConfig = targetGenerationConfig;
-      }
-    }
+  const googleOptions = isRecord(google)
+    ? (google as GoogleRealtimeModelOptions)
+    : undefined;
+
+  if (googleOptions?.translationConfig != null) {
+    const target = isRecord(setup.generationConfig)
+      ? setup.generationConfig
+      : generationConfig;
+    setup.generationConfig = {
+      ...target,
+      translationConfig: googleOptions.translationConfig,
+    };
   }
 
   return setup;

--- a/packages/google/src/realtime/google-realtime-event-mapper.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.ts
@@ -273,6 +273,12 @@ export class GoogleRealtimeEventMapper {
         };
 
       case 'input-audio-commit':
+        return {
+          realtimeInput: {
+            audioStreamEnd: true,
+          },
+        };
+
       case 'input-audio-clear':
       case 'response-create':
       case 'response-cancel':

--- a/packages/google/src/realtime/google-realtime-model-options.ts
+++ b/packages/google/src/realtime/google-realtime-model-options.ts
@@ -1,3 +1,23 @@
 export type GoogleRealtimeModelId = string;
 
-export type GoogleRealtimeModelOptions = Record<string, never>;
+export type GoogleRealtimeModelOptions = {
+  /**
+   * Gemini Live Translation configuration.
+   *
+   * Required for `gemini-3.5-live-translate-preview` when translating speech
+   * to a target language.
+   */
+  translationConfig?: {
+    /**
+     * BCP-47 language code of the language to translate into.
+     * Defaults to `en` in the Gemini API.
+     */
+    targetLanguageCode?: string;
+
+    /**
+     * Whether input audio already in the target language should be echoed
+     * instead of producing silence.
+     */
+    echoTargetLanguage?: boolean;
+  };
+};

--- a/packages/google/src/realtime/google-realtime-model.test.ts
+++ b/packages/google/src/realtime/google-realtime-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GoogleRealtimeModel } from './google-realtime-model';
+import type { GoogleRealtimeModelOptions } from './google-realtime-model-options';
 
 describe('GoogleRealtimeModel', () => {
   describe('doCreateClientSecret', () => {
@@ -148,6 +149,45 @@ describe('GoogleRealtimeModel', () => {
       expect(body.bidiGenerateContentSetup.outputAudioTranscription).toEqual(
         {},
       );
+    });
+
+    it('embeds Google Live Translation config in auth token setup', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: 'token' }),
+      });
+
+      const model = new GoogleRealtimeModel(
+        'gemini-3.5-live-translate-preview',
+        {
+          provider: 'google.realtime',
+          baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+          headers: () => ({ 'x-goog-api-key': 'test-key' }),
+          fetch: mockFetch,
+        },
+      );
+
+      await model.doCreateClientSecret({
+        sessionConfig: {
+          providerOptions: {
+            google: {
+              translationConfig: {
+                targetLanguageCode: 'pl',
+                echoTargetLanguage: true,
+              },
+            } satisfies GoogleRealtimeModelOptions,
+          },
+        },
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(
+        body.bidiGenerateContentSetup.generationConfig.translationConfig,
+      ).toEqual({
+        targetLanguageCode: 'pl',
+        echoTargetLanguage: true,
+      });
+      expect(body.bidiGenerateContentSetup.google).toBeUndefined();
     });
 
     it('throws on missing API key', async () => {

--- a/packages/google/src/realtime/index.ts
+++ b/packages/google/src/realtime/index.ts
@@ -1,6 +1,6 @@
 export { GoogleRealtimeModel as Experimental_GoogleRealtimeModel } from './google-realtime-model';
 export type { GoogleRealtimeModelConfig as Experimental_GoogleRealtimeModelConfig } from './google-realtime-model';
 export type {
-  GoogleRealtimeModelId,
-  GoogleRealtimeModelOptions,
+  GoogleRealtimeModelId as Experimental_GoogleRealtimeModelId,
+  GoogleRealtimeModelOptions as Experimental_GoogleRealtimeModelOptions,
 } from './google-realtime-model-options';

--- a/packages/google/src/realtime/index.ts
+++ b/packages/google/src/realtime/index.ts
@@ -1,2 +1,6 @@
 export { GoogleRealtimeModel as Experimental_GoogleRealtimeModel } from './google-realtime-model';
 export type { GoogleRealtimeModelConfig as Experimental_GoogleRealtimeModelConfig } from './google-realtime-model';
+export type {
+  GoogleRealtimeModelId,
+  GoogleRealtimeModelOptions,
+} from './google-realtime-model-options';


### PR DESCRIPTION
## Background

Google's `gemini-3.5-live-translate-preview` works through the Gemini Live API, but it requires a provider-specific `translationConfig` inside `generationConfig`. The Google realtime model accepts arbitrary string model IDs today, so the missing piece was not model-ID typing; it was mapping the translation configuration into Google's setup payload.

## What changed

- Adds typed `GoogleRealtimeModelOptions.translationConfig` with target-language and echo controls.
- Maps `providerOptions.google.translationConfig` into Gemini Live's `generationConfig` for both token creation and session updates.
- Preserves raw `generationConfig` provider options while merging translation settings.
- Exports the realtime model ID/options types from `@ai-sdk/google`.
- Documents `gemini-3.5-live-translate-preview` usage.
- Adds a dedicated press-to-translate example and a setup-route entry that omits unsupported tools for this model.
- Adds a patch changeset for `@ai-sdk/google`.

## Developer impact

Developers can use the normal AI SDK realtime API with `gemini-3.5-live-translate-preview` and configure the target language through `providerOptions.google.translationConfig`, without constructing Google wire payloads themselves.

## Validation

- `pnpm --filter @ai-sdk/google test:node -- packages/google/src/realtime/google-realtime-event-mapper.test.ts packages/google/src/realtime/google-realtime-model.test.ts` — 23 files, 665 tests passed
- `pnpm --filter @ai-sdk/google type-check`
- `pnpm --filter @example/next-openai exec tsc --noEmit`
- `pnpm exec ultracite check` on changed TypeScript/TSX files
- `git diff --check`
- Previously verified the demo against the live Google API: token setup returned 200 and the realtime WebSocket connected successfully

## Future work

AI Gateway's realtime client plumbing is already merged, but translation-specific Gateway routing remains separate from this direct Google provider change.
