### PR TITLE
fix(ci): make RSC e2e Playwright install resilient to slow apt mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,19 +310,57 @@ jobs:
         if: steps.rsc-e2e.outputs.run == 'true'
         run: tar -xzf package-build-artifacts.tgz
 
-      - name: Install Playwright Browsers
+      - name: Resolve Playwright version
         if: steps.rsc-e2e.outputs.run == 'true'
+        id: playwright-version
+        working-directory: packages/rsc
         run: |
+          VERSION="$(pnpm exec playwright --version | awk '{print $2}')"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        if: steps.rsc-e2e.outputs.run == 'true'
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright system dependencies
+        if: steps.rsc-e2e.outputs.run == 'true'
+        working-directory: packages/rsc
+        run: |
+          # `playwright install --with-deps` shells out to apt-get. When the
+          # Ubuntu mirror is slow the command can exceed the timeout; `timeout`
+          # only kills the direct child, leaving an orphaned apt-get holding the
+          # dpkg lock so every retry fails instantly with exit code 100. Run each
+          # attempt in its own process group, kill the whole group on timeout,
+          # and wait for the dpkg lock to free before retrying.
           ATTEMPTS=3
-          PER_ATTEMPT_TIMEOUT=10m
+          PER_ATTEMPT_TIMEOUT=15m
+
+          wait_for_apt_lock() {
+            for _ in $(seq 1 60); do
+              if ! sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
+                return 0
+              fi
+              echo "Waiting for dpkg lock to be released..."
+              sleep 5
+            done
+          }
+
           for attempt in $(seq 1 "$ATTEMPTS"); do
             STATUS=0
-            timeout "$PER_ATTEMPT_TIMEOUT" pnpm exec playwright install --with-deps || STATUS=$?
+            # `setsid` puts the command in a new process group; `timeout
+            # --kill-after` escalates to SIGKILL so the whole group (including
+            # apt-get) is torn down on timeout.
+            setsid timeout --signal=TERM --kill-after=30s "$PER_ATTEMPT_TIMEOUT" \
+              pnpm exec playwright install-deps chromium || STATUS=$?
             if [ "$STATUS" -eq 0 ]; then
               break
             fi
             if [ "$attempt" -eq "$ATTEMPTS" ]; then
-              echo "::error::playwright install failed after $ATTEMPTS attempts (last exit code: $STATUS)"
+              echo "::error::playwright install-deps failed after $ATTEMPTS attempts (last exit code: $STATUS)"
               exit 1
             fi
             if [ "$STATUS" -eq 124 ]; then
@@ -330,6 +368,28 @@ jobs:
             else
               echo "Attempt $attempt failed with exit code $STATUS, retrying..."
             fi
+            wait_for_apt_lock
+          done
+
+      - name: Install Playwright browsers
+        if: steps.rsc-e2e.outputs.run == 'true'
+        working-directory: packages/rsc
+        run: |
+          # Browser binaries are restored from cache when available; this only
+          # downloads them on a cache miss and is fast compared to the apt step.
+          ATTEMPTS=3
+          PER_ATTEMPT_TIMEOUT=10m
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            STATUS=0
+            timeout "$PER_ATTEMPT_TIMEOUT" pnpm exec playwright install chromium || STATUS=$?
+            if [ "$STATUS" -eq 0 ]; then
+              break
+            fi
+            if [ "$attempt" -eq "$ATTEMPTS" ]; then
+              echo "::error::playwright install failed after $ATTEMPTS attempts (last exit code: $STATUS)"
+              exit 1
+            fi
+            echo "Attempt $attempt failed with exit code $STATUS, retrying..."
           done
 
       - name: Run RSC e2e tests


### PR DESCRIPTION
## Background

The **Test RSC e2e** job has been failing intermittently on `main` — e.g. runs [27791500078](https://github.com/vercel/ai/actions/runs/27791500078/job/82241942552), [27793598300](https://github.com/vercel/ai/actions/runs/27793598300/job/82248767113), and [27791984919](https://github.com/vercel/ai/actions/runs/27791984919/job/82243549135), three unrelated commits with the identical failure. It is a CI infra flake, not a code bug.

The **Install Playwright Browsers** step runs `timeout 10m pnpm exec playwright install --with-deps`. Two things compound:

1. **Attempt 1 times out.** `--with-deps` shells out to `apt-get` to install ~181 system packages from `azure.archive.ubuntu.com`. When that mirror is slow, the download blows past the 10m budget (exit 124).
2. **The retry is poisoned.** `timeout` only kills the *direct* child (`pnpm exec playwright`); the `apt-get` it spawned keeps running and holds `/var/lib/dpkg/lock-frontend`. Attempts 2 and 3 then collide with that orphan (same PID across attempts in the logs) and fail instantly:

   ```
   E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2985 (apt-get)
   Error: Installation process exited with code: 100
   ```

   So once attempt 1 times out, the retry loop can never recover.

## Summary

- **Cache browser binaries** (`~/.cache/ms-playwright`) keyed on the resolved Playwright version, removing the browser download from the hot path on most runs.
- **Split system deps from the browser install** and scope both to `chromium` — the only project in `packages/rsc/playwright.config.ts` — avoiding the WebKit/Firefox apt packages that made up most of the slow 114 MB download.
- **Run each deps attempt via `setsid timeout --kill-after`** so the whole process group (including `apt-get`) is torn down on timeout, and **wait for the dpkg lock to release** before retrying. This makes the retry loop able to recover.
- Bump the deps timeout to 15m.

## Manual Verification

CI-only change; verified by re-running the affected job on this branch. Locally validated the workflow YAML parses (`js-yaml`) and confirmed `chromium` is the only configured Playwright project, so scoping `install`/`install-deps` to it is safe.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

<!-- No changeset / tests / docs: CI-only change, no published-package code touched. -->