### PR TITLE
docs: fix GitHub capitalization in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We're always looking for suggestions to make our project better. If you have an 
 Documentation is crucial for understanding and using our project effectively.
 You can find the content of our docs under [`content`](https://github.com/vercel/ai/tree/main/content).
 
-To fix smaller typos, you can edit the code directly in GitHub or use Github.dev (press `.` in Github).
+To fix smaller typos, you can edit the code directly in GitHub or use GitHub.dev (press `.` in GitHub).
 
 If you want to make larger changes, please check out the Code Contributions section below. It also explains how to fix prettier issues that you might encounter during your docs changes.
 


### PR DESCRIPTION
### What
Fix two instances of `Github` → `GitHub` (and `Github.dev` → `GitHub.dev`) in the "Improving Documentation" section.

### Why
`GitHub` is the correct brand spelling (capital H). The current text uses `Github.dev` and `Github` which are inconsistent with the rest of the file and technically incorrect.

Small, scoped fix from kcolbchain contrib-bot.