### PR TITLE
feat(provider/openai): enable detailed reasoning summaries by default

### DIFF
--- a/.changeset/detailed-responses-reasoning-summary.md
+++ b/.changeset/detailed-responses-reasoning-summary.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Default OpenAI Responses reasoning summaries to detailed when reasoning effort is enabled.

--- a/content/docs/02-foundations/06-provider-options.mdx
+++ b/content/docs/02-foundations/06-provider-options.mdx
@@ -87,6 +87,8 @@ console.log(
 
 When working with reasoning models, you may want to see _how_ the model arrived at its answer. The `reasoningSummary` option surfaces the model's thought process.
 
+When `reasoningEffort` is set to a value other than `'none'`, the OpenAI Responses provider defaults `reasoningSummary` to `'detailed'`. Set `reasoningSummary: null` to omit reasoning summaries.
+
 #### Streaming
 
 ```ts
@@ -139,7 +141,7 @@ console.log('Reasoning:', result.finalStep.reasoning);
 
 | Value        | Behavior                       |
 | ------------ | ------------------------------ |
-| `'auto'`     | Condensed summary of reasoning |
+| `'auto'`     | Richest available summary      |
 | `'detailed'` | Comprehensive reasoning output |
 
 ### Text Verbosity

--- a/content/docs/02-foundations/06-provider-options.mdx
+++ b/content/docs/02-foundations/06-provider-options.mdx
@@ -141,7 +141,7 @@ console.log('Reasoning:', result.finalStep.reasoning);
 
 | Value        | Behavior                       |
 | ------------ | ------------------------------ |
-| `'auto'`     | Richest available summary      |
+| `'auto'`     | Condensed summary of reasoning |
 | `'detailed'` | Comprehensive reasoning output |
 
 ### Text Verbosity

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -1821,6 +1821,14 @@ const { messages, sendMessage } = useChat(() => ({
 
 The `Chat` class continues to work as a deprecated export, so you can migrate incrementally.
 
+## OpenAI Provider
+
+### Responses Reasoning Summary Defaults to Detailed
+
+For the OpenAI Responses provider, setting `reasoning` or `providerOptions.openai.reasoningEffort` to a value other than `'none'` now defaults `providerOptions.openai.reasoningSummary` to `'detailed'`.
+
+If you want to keep reasoning summaries disabled, set `providerOptions.openai.reasoningSummary` to `null`.
+
 ## Anthropic Provider
 
 ### `providerMetadata.anthropic.cacheCreationInputTokens` Removed

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -298,7 +298,7 @@ The following OpenAI-specific metadata may be returned:
 
 #### Reasoning Output
 
-For reasoning models like `gpt-5`, you can enable reasoning summaries to see the model's thought process. Different models support different summarizers—for example, `o4-mini` supports detailed summaries. Set `reasoningSummary: "auto"` to automatically receive the richest level available.
+For reasoning models like `gpt-5`, you can enable reasoning summaries to see the model's thought process. Different models support different summarizers—for example, `o4-mini` supports detailed summaries. Set `reasoningSummary: "auto"` to automatically receive the richest level available. When `reasoningEffort` is set to a value other than `'none'`, the OpenAI Responses provider defaults `reasoningSummary` to `'detailed'`; set `reasoningSummary: null` to omit reasoning summaries.
 
 ```ts highlight="8-9,16"
 import {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1048,6 +1048,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           ],
           reasoning: {
             effort: 'xhigh',
+            summary: 'detailed',
           },
         });
 
@@ -1123,6 +1124,9 @@ describe('OpenAIResponsesLanguageModel', () => {
               ],
               reasoning: {
                 effort: reasoningValue,
+                ...(reasoningValue !== 'none' && {
+                  summary: 'detailed',
+                }),
               },
             });
 
@@ -1153,6 +1157,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             ],
             reasoning: {
               effort: 'high',
+              summary: 'detailed',
             },
           });
 
@@ -1177,6 +1182,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             ],
             reasoning: {
               effort: 'medium',
+              summary: 'detailed',
             },
           });
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -198,6 +198,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
     const resolvedReasoningEffort =
       openaiOptions?.reasoningEffort ??
       (isCustomReasoning(reasoning) ? reasoning : undefined);
+    const resolvedReasoningSummary =
+      openaiOptions?.reasoningSummary !== undefined
+        ? openaiOptions.reasoningSummary
+        : resolvedReasoningEffort != null && resolvedReasoningEffort !== 'none'
+          ? 'detailed'
+          : undefined;
 
     const isReasoningModel =
       openaiOptions?.forceReasoning ?? modelCapabilities.isReasoningModel;
@@ -377,13 +383,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       // model-specific settings:
       ...(isReasoningModel &&
         (resolvedReasoningEffort != null ||
-          openaiOptions?.reasoningSummary != null) && {
+          resolvedReasoningSummary != null) && {
           reasoning: {
             ...(resolvedReasoningEffort != null && {
               effort: resolvedReasoningEffort,
             }),
-            ...(openaiOptions?.reasoningSummary != null && {
-              summary: openaiOptions.reasoningSummary,
+            ...(resolvedReasoningSummary != null && {
+              summary: resolvedReasoningSummary,
             }),
           },
         }),


### PR DESCRIPTION
## Background

It is super confusing when reasoning is set to some value and no reasoning outputs are sent.

## Summary

Enable reasoning by default when the reasoning effort is not none.