### PR TITLE
docs: add Onlist community provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -97,6 +97,7 @@ The open-source community has created the following providers:
 - [Crusoe Provider](/providers/community-providers/crusoe) (`crusoe-ai-provider`)
 - [Neon AI Gateway Provider](/providers/community-providers/neon-ai-gateway) (`@neon/ai-sdk-provider`)
 - [Interfaze Provider](/providers/community-providers/interfaze) (`@interfaze-ai/ai-sdk`)
+- [Onlist Provider](/providers/community-providers/onlist) (`@onlist/ai-sdk-provider`)
 
 ## Self-Hosted Models
 

--- a/content/providers/05-community-providers/52-onlist.mdx
+++ b/content/providers/05-community-providers/52-onlist.mdx
@@ -1,0 +1,166 @@
+---
+title: Onlist
+description: Onlist Provider for the AI SDK
+---
+
+# Onlist
+
+[Onlist](https://onlist.io) is an open AI API marketplace that aggregates 40+ upstream AI providers behind a unified OpenAI-compatible API. The Onlist provider for the AI SDK is built on `@ai-sdk/openai-compatible` and gives you access to models from OpenAI, Anthropic, Google, DeepSeek, and more through a single API key.
+
+- **40+ Providers**: Access models from major AI providers with one API key
+- **Competitive Pricing**: Compare prices across providers and route to the cheapest option
+- **Provider Routing**: Control which upstream providers handle your requests
+- **OpenAI Compatible**: Drop-in replacement for any OpenAI-compatible client
+- **Open Source**: Fully open-source under AGPL-3.0
+
+Learn more in the [Onlist Documentation](https://onlist.io/docs).
+
+## Setup
+
+The Onlist provider is available in the `@onlist/ai-sdk-provider` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+    <Snippet text="pnpm add @onlist/ai-sdk-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @onlist/ai-sdk-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @onlist/ai-sdk-provider" dark />
+  </Tab>
+</Tabs>
+
+## API Key
+
+Set your API key as an environment variable:
+
+```bash
+export ONLIST_API_KEY=your_api_key_here
+```
+
+You can get an API key from [onlist.io](https://onlist.io).
+
+## Provider Instance
+
+You can import the default provider instance `onlist` from `@onlist/ai-sdk-provider`:
+
+```typescript
+import { onlist } from '@onlist/ai-sdk-provider';
+```
+
+Or create a custom instance using `createOnlist`:
+
+```typescript
+import { createOnlist } from '@onlist/ai-sdk-provider';
+
+const onlist = createOnlist({
+  apiKey: process.env.ONLIST_API_KEY,
+  appName: 'My App',
+});
+```
+
+## Language Models
+
+You can create Onlist models using a provider instance. The first argument is the model ID in `author/model` format:
+
+```typescript
+const model = onlist('anthropic/claude-sonnet-4');
+```
+
+### Example: Generate Text
+
+```typescript
+import { onlist } from '@onlist/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: onlist('anthropic/claude-sonnet-4'),
+  prompt: 'Explain quantum computing in one paragraph.',
+});
+```
+
+### Example: Stream Text
+
+```typescript
+import { onlist } from '@onlist/ai-sdk-provider';
+import { streamText } from 'ai';
+
+const { textStream } = streamText({
+  model: onlist('anthropic/claude-sonnet-4'),
+  prompt: 'Write a short poem about the moon.',
+});
+
+for await (const chunk of textStream) {
+  process.stdout.write(chunk);
+}
+```
+
+### Example: Tool Calling
+
+```typescript
+import { onlist } from '@onlist/ai-sdk-provider';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const { text } = await generateText({
+  model: onlist('openai/gpt-4o'),
+  tools: {
+    weather: tool({
+      description: 'Get the weather in a location',
+      parameters: z.object({
+        location: z.string(),
+      }),
+      execute: async ({ location }) => `Sunny, 22C in ${location}`,
+    }),
+  },
+  prompt: 'What is the weather in Tokyo?',
+});
+```
+
+## Provider Routing
+
+Onlist supports provider routing to control how requests are distributed across upstream providers:
+
+```typescript
+import { onlist } from '@onlist/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: onlist('openai/gpt-4o'),
+  prompt: 'Hello',
+  providerOptions: {
+    onlist: {
+      provider: {
+        sort: 'price',
+        allow_fallbacks: false,
+        max_price: { prompt: 0.01, completion: 0.03 },
+      },
+    },
+  },
+});
+```
+
+## Embedding Models
+
+You can create embedding models using the `.textEmbeddingModel()` method:
+
+```typescript
+import { onlist } from '@onlist/ai-sdk-provider';
+import { embed } from 'ai';
+
+const { embedding } = await embed({
+  model: onlist.textEmbeddingModel('openai/text-embedding-3-small'),
+  value: 'The quick brown fox jumps over the lazy dog.',
+});
+```
+
+## Configuration
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `apiKey` | `string` | API key. Defaults to `ONLIST_API_KEY` env var. |
+| `baseURL` | `string` | API base URL. Defaults to `https://onlist.io/v1`. |
+| `appName` | `string` | Your app name, shown on the Onlist dashboard. |
+| `appUrl` | `string` | Your app URL, used for attribution. |
+| `headers` | `Record<string, string>` | Additional custom headers. |

--- a/content/providers/05-community-providers/55-onlist.mdx
+++ b/content/providers/05-community-providers/55-onlist.mdx
@@ -1,0 +1,134 @@
+---
+title: Onlist
+description: Learn how to use the Onlist provider for the AI SDK.
+---
+
+# Onlist Provider
+
+[@onlist/ai-sdk-provider](https://github.com/OnlistTeam/ai-sdk-provider) contains language model support for [Onlist](https://onlist.io), a marketplace that routes requests to independent providers behind a single OpenAI-compatible endpoint. Models are addressed by stable `author/model` ids and include DeepSeek, Qwen, GLM, Kimi, Llama, and gpt-oss.
+
+API keys can be obtained from the [Onlist dashboard](https://onlist.io). The full catalog and per-model pricing are listed at [onlist.io/models](https://onlist.io/models).
+
+## Setup
+
+The Onlist provider is available via the `@onlist/ai-sdk-provider` module. You can install it with:
+
+<InstallPackages packages="@onlist/ai-sdk-provider" />
+
+### Environment variables
+
+Create a `.env` file with an `ONLIST_API_KEY` variable.
+
+## Provider Instance
+
+You can import the default provider instance `onlist` from `@onlist/ai-sdk-provider`:
+
+```ts
+import { onlist } from '@onlist/ai-sdk-provider';
+```
+
+If you need a customized setup, you can import `createOnlist` and create a provider instance with your settings:
+
+```ts
+import { createOnlist } from '@onlist/ai-sdk-provider';
+
+const onlist = createOnlist({
+  appName: 'My App',
+});
+```
+
+You can use the following optional settings to customize the Onlist provider instance:
+
+- **apiKey** _string_
+
+  API key that is sent using the `Authorization` header. It defaults to the `ONLIST_API_KEY` environment variable.
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls. The default prefix is `https://onlist.io/v1`.
+
+- **appName** _string_
+
+  Application name reported for attribution.
+
+- **appUrl** _string_
+
+  Application URL reported for attribution.
+
+- **headers** _Record&lt;string, string&gt;_
+
+  Custom headers to include in the requests.
+
+## Language Models
+
+You can create models with the provider instance. The first argument is the model id:
+
+```ts
+import { onlist } from '@onlist/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: onlist('deepseek/deepseek-chat-v3.1'),
+  prompt: 'Explain quantum computing in one paragraph.',
+});
+```
+
+Onlist language models can also be used with `streamText`:
+
+```ts
+import { onlist } from '@onlist/ai-sdk-provider';
+import { streamText } from 'ai';
+
+const { textStream } = streamText({
+  model: onlist('z-ai/glm-4.7'),
+  prompt: 'Write a short poem about the moon.',
+});
+
+for await (const chunk of textStream) {
+  process.stdout.write(chunk);
+}
+```
+
+### Tool Calling
+
+```ts
+import { onlist } from '@onlist/ai-sdk-provider';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const { text } = await generateText({
+  model: onlist('qwen/qwen3-235b-a22b'),
+  tools: {
+    weather: tool({
+      description: 'Get the weather in a location',
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => `Sunny, 22C in ${location}`,
+    }),
+  },
+  prompt: 'What is the weather in Tokyo?',
+});
+```
+
+## Provider Routing
+
+More than one provider can serve the same model. Pass a `provider` object through `providerOptions.onlist` to control which one is selected:
+
+```ts
+import { onlist } from '@onlist/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: onlist('moonshotai/kimi-k2'),
+  prompt: 'Hello',
+  providerOptions: {
+    onlist: {
+      provider: {
+        sort: 'price',
+        allow_fallbacks: false,
+      },
+    },
+  },
+});
+```
+
+`sort` accepts `price` or `throughput`. `only`, `ignore`, and `order` restrict routing to named providers, and `max_price` caps the accepted price in USD per token. Unsupported fields are ignored and reported in the `X-Onlist-Warnings` response header.


### PR DESCRIPTION
## Background

Onlist is an OpenAI-compatible endpoint that routes requests to independent providers behind stable `author/model` ids. `@onlist/ai-sdk-provider` wraps it for the AI SDK, and there is currently no page for it under community providers.

## Summary

Adds `content/providers/05-community-providers/55-onlist.mdx`, covering setup, provider instance options, language models, streaming, tool calling, and provider routing through `providerOptions.onlist`.

Adds the matching entry to the community provider list in `content/docs/02-foundations/02-providers-and-models.mdx`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
