### PR TITLE
fix(ai): wrap malformed tool call input in JSON object instead of raw string

### DIFF
--- a/.changeset/fix-invalid-tool-call-input-raw-string.md
+++ b/.changeset/fix-invalid-tool-call-input-raw-string.md
@@ -1,0 +1,7 @@
+---
+"ai": patch
+---
+
+Wrap malformed tool call input in a JSON object instead of storing the raw string.
+
+When a model returns invalid JSON as tool call input, `parseToolCall` previously stored the raw string as `input`. Providers like Amazon Bedrock require `toolUse.input` to be a JSON object, so the next-step API request would be rejected before the model could see the `tool-error` and retry. The invalid input is now stored as `{ rawInvalidInput: <original string> }`, which keeps the conversation history valid for all providers.

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -471,7 +471,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -510,7 +512,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -92,9 +92,13 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       });
     }
   } catch (error) {
-    // use parsed input when possible
+    // use parsed input when possible; fall back to a JSON object wrapper so
+    // providers that require object inputs (e.g. Amazon Bedrock) don't reject
+    // the next-step conversation history when the original input was malformed.
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
     const tool = tools?.[toolCall.toolName];
 
     // TODO AI SDK 6: special invalid tool call parts


### PR DESCRIPTION
Closes #14442

---

When `parseToolCall` falls through to its catch block because the model returned unparseable JSON as a tool call's `input`, the SDK stored the raw string directly as `input` on the resulting `tool-call` part:

```ts
const input = parsedInput.success ? parsedInput.value : toolCall.input;
//                                                       ^^^^^^^^^^^^^^
//                                              raw string, not a JSON object
```

This raw string is then forwarded into the assistant message for the next API step via `to-response-messages.ts`. Providers like **Amazon Bedrock** require `toolUse.input` to be a JSON object — they reject the request before the model ever sees the `tool-error` result, breaking the retry loop entirely.

**Fix**: when JSON parsing fails, wrap the raw string in `{ rawInvalidInput: toolCall.input }` so the conversation history is always a valid JSON object for all providers.

**Tests**: updated two inline snapshots that asserted the old raw-string behavior to match the new wrapped-object shape.

*This contribution was made with AI-agent assistance (Claude Code).*