### PR TITLE
fix(replicate): poll for completion when image sync-wait times out

### DIFF
--- a/.changeset/fix-replicate-image-polling.md
+++ b/.changeset/fix-replicate-image-polling.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/replicate': patch
+---
+
+fix(replicate): poll for completion when sync-wait times out on image generation
+
+When Replicate's sync-wait API returns `status: starting` or `status: processing` (e.g. during cold starts or long inferences), the image model now polls `urls.get` until the prediction succeeds, fails, or is canceled — matching the existing behavior of the video model.
+
+Added `pollIntervalMs` (default 2000ms) and `pollTimeoutMs` (default 5 minutes) provider options to configure polling behavior.

--- a/packages/replicate/src/replicate-image-model-options.ts
+++ b/packages/replicate/src/replicate-image-model-options.ts
@@ -26,6 +26,18 @@ export const replicateImageModelOptionsSchema = lazySchema(() =>
         maxWaitTimeInSeconds: z.number().positive().nullish(),
 
         /**
+         * Polling interval in milliseconds when the prediction is still processing.
+         * Defaults to 2000 (2 seconds).
+         */
+        pollIntervalMs: z.number().positive().nullish(),
+
+        /**
+         * Polling timeout in milliseconds. Generation fails if not completed within
+         * this duration. Defaults to 300000 (5 minutes).
+         */
+        pollTimeoutMs: z.number().positive().nullish(),
+
+        /**
          * Guidance scale for classifier-free guidance.
          * Higher values make the output more closely match the prompt.
          */

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -41,7 +41,7 @@ describe('doGenerate', () => {
         output,
         data_removed: false,
         error: null,
-        status: 'processing',
+        status: 'succeeded',
         created_at: '2025-01-08T13:24:38.692Z',
         urls: {
           cancel:
@@ -300,7 +300,7 @@ describe('doGenerate', () => {
         output: ['https://replicate.delivery/xezq/abc/out-0.webp'],
         data_removed: false,
         error: null,
-        status: 'processing',
+        status: 'succeeded',
         created_at: '2025-01-08T13:24:38.692Z',
         urls: {
           cancel:
@@ -327,7 +327,7 @@ describe('doGenerate', () => {
       timestamp: testDate,
       modelId: 'black-forest-labs/flux-schnell',
       headers: {
-        'content-length': '646',
+        'content-length': '645',
         'content-type': 'application/json',
         'custom-response-header': 'response-header-value',
       },
@@ -748,5 +748,150 @@ describe('doGenerate', () => {
         'https://api.replicate.com/v1/models/black-forest-labs/flux-2-pro/predictions',
       );
     });
+  });
+
+  it('should not include pollIntervalMs or pollTimeoutMs in request body', async () => {
+    prepareResponse();
+
+    await model.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {
+        replicate: {
+          pollIntervalMs: 1000,
+          pollTimeoutMs: 60000,
+          guidance_scale: 7.5,
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.input.pollIntervalMs).toBeUndefined();
+    expect(requestBody.input.pollTimeoutMs).toBeUndefined();
+    expect(requestBody.input.guidance_scale).toBe(7.5);
+  });
+});
+
+describe('Polling (sync-wait timeout)', () => {
+  const predictionId = 'poll-test-id';
+  const pollUrl = `https://api.replicate.com/v1/predictions/${predictionId}`;
+  const imageUrl = 'https://replicate.delivery/xezq/abc/out-0.webp';
+
+  function createPollingModel({
+    pollsUntilDone = 1,
+    finalStatus = 'succeeded',
+    error,
+  }: {
+    pollsUntilDone?: number;
+    finalStatus?: string;
+    error?: string;
+  } = {}) {
+    let pollCount = 0;
+
+    return new ReplicateImageModel('black-forest-labs/flux-schnell', {
+      provider: 'replicate.image',
+      baseURL: 'https://api.replicate.com/v1',
+      fetch: async (url, init) => {
+        const urlString = url.toString();
+
+        // Initial POST
+        if (init?.method !== 'GET') {
+          return new Response(
+            JSON.stringify({
+              id: predictionId,
+              status: 'starting',
+              output: null,
+              error: null,
+              urls: { get: pollUrl },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        // Image download
+        if (urlString === imageUrl) {
+          return new Response(Buffer.from('test-binary-content'), {
+            status: 200,
+            headers: { 'Content-Type': 'image/webp' },
+          });
+        }
+
+        // Polling GET
+        pollCount++;
+        const done = pollCount >= pollsUntilDone;
+        return new Response(
+          JSON.stringify({
+            id: predictionId,
+            status: done ? finalStatus : 'processing',
+            output: done && finalStatus === 'succeeded' ? [imageUrl] : null,
+            error: done ? (error ?? null) : null,
+            urls: { get: pollUrl },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      },
+    });
+  }
+
+  it('should poll and return image when generation completes after sync-wait', async () => {
+    const pollingModel = createPollingModel({ pollsUntilDone: 2 });
+
+    const result = await pollingModel.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: { replicate: { pollIntervalMs: 1 } },
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]).toStrictEqual(
+      new Uint8Array(Buffer.from('test-binary-content')),
+    );
+  });
+
+  it('should throw when generation fails during polling', async () => {
+    const pollingModel = createPollingModel({
+      finalStatus: 'failed',
+      error: 'Out of memory',
+    });
+
+    await expect(
+      pollingModel.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: { replicate: { pollIntervalMs: 1 } },
+      }),
+    ).rejects.toThrow('Image generation failed: Out of memory');
+  });
+
+  it('should throw when generation is canceled during polling', async () => {
+    const pollingModel = createPollingModel({ finalStatus: 'canceled' });
+
+    await expect(
+      pollingModel.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: { replicate: { pollIntervalMs: 1 } },
+      }),
+    ).rejects.toThrow('Image generation was canceled');
   });
 });

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -1,10 +1,16 @@
-import type { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  AISDKError,
+  type ImageModelV4,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
 import {
   combineHeaders,
   convertImageModelFileToDataUri,
   createBinaryResponseHandler,
   createJsonResponseHandler,
+  delay,
   getFromApi,
+  isSameOrigin,
   parseProviderOptions,
   postJsonToApi,
   resolve,
@@ -141,8 +147,13 @@ export class ReplicateImageModel implements ImageModelV4 {
       }
     }
 
-    // Extract maxWaitTimeInSeconds from provider options and prepare the rest for the request body
-    const { maxWaitTimeInSeconds, ...inputOptions } = replicateOptions ?? {};
+    // Extract SDK-only options and leave the rest for the model input body
+    const {
+      maxWaitTimeInSeconds,
+      pollIntervalMs,
+      pollTimeoutMs,
+      ...inputOptions
+    } = replicateOptions ?? {};
 
     // Build the prefer header based on maxWaitTimeInSeconds:
     // - undefined/null: use default sync wait (prefer: wait)
@@ -152,10 +163,7 @@ export class ReplicateImageModel implements ImageModelV4 {
         ? { prefer: `wait=${maxWaitTimeInSeconds}` }
         : { prefer: 'wait' };
 
-    const {
-      value: { output },
-      responseHeaders,
-    } = await postJsonToApi({
+    const { value: prediction, responseHeaders } = await postJsonToApi({
       url:
         // different endpoints for versioned vs unversioned models:
         version != null
@@ -184,12 +192,82 @@ export class ReplicateImageModel implements ImageModelV4 {
       },
 
       successfulResponseHandler: createJsonResponseHandler(
-        replicateImageResponseSchema,
+        replicateImagePredictionSchema,
       ),
       failedResponseHandler: replicateFailedResponseHandler,
       abortSignal,
       fetch: this.config.fetch,
     });
+
+    // Poll if sync-wait timed out before the prediction completed
+    let finalPrediction = prediction;
+    if (
+      prediction.status === 'starting' ||
+      prediction.status === 'processing'
+    ) {
+      const resolvedPollIntervalMs = pollIntervalMs ?? 2000;
+      const resolvedPollTimeoutMs = pollTimeoutMs ?? 300000;
+      const startTime = Date.now();
+
+      while (
+        finalPrediction.status === 'starting' ||
+        finalPrediction.status === 'processing'
+      ) {
+        if (Date.now() - startTime > resolvedPollTimeoutMs) {
+          throw new AISDKError({
+            name: 'REPLICATE_IMAGE_GENERATION_TIMEOUT',
+            message: `Image generation timed out after ${resolvedPollTimeoutMs}ms`,
+          });
+        }
+
+        await delay(resolvedPollIntervalMs);
+
+        if (abortSignal?.aborted) {
+          throw new AISDKError({
+            name: 'REPLICATE_IMAGE_GENERATION_ABORTED',
+            message: 'Image generation request was aborted',
+          });
+        }
+
+        const pollUrl = finalPrediction.urls.get;
+        const { value: statusPrediction } = await getFromApi({
+          url: pollUrl,
+          headers: isSameOrigin(pollUrl, this.config.baseURL)
+            ? await resolve(this.config.headers)
+            : undefined,
+          successfulResponseHandler: createJsonResponseHandler(
+            replicateImagePredictionSchema,
+          ),
+          failedResponseHandler: replicateFailedResponseHandler,
+          abortSignal,
+          fetch: this.config.fetch,
+        });
+
+        finalPrediction = statusPrediction;
+      }
+    }
+
+    if (finalPrediction.status === 'failed') {
+      throw new AISDKError({
+        name: 'REPLICATE_IMAGE_GENERATION_FAILED',
+        message: `Image generation failed: ${finalPrediction.error ?? 'Unknown error'}`,
+      });
+    }
+
+    if (finalPrediction.status === 'canceled') {
+      throw new AISDKError({
+        name: 'REPLICATE_IMAGE_GENERATION_CANCELED',
+        message: 'Image generation was canceled',
+      });
+    }
+
+    const output = finalPrediction.output;
+    if (!output) {
+      throw new AISDKError({
+        name: 'REPLICATE_IMAGE_GENERATION_ERROR',
+        message: 'No output in response',
+      });
+    }
 
     // download the images:
     const outputArray = Array.isArray(output) ? output : [output];
@@ -218,6 +296,12 @@ export class ReplicateImageModel implements ImageModelV4 {
   }
 }
 
-const replicateImageResponseSchema = z.object({
-  output: z.union([z.array(z.string()), z.string()]),
+const replicateImagePredictionSchema = z.object({
+  id: z.string(),
+  status: z.enum(['starting', 'processing', 'succeeded', 'failed', 'canceled']),
+  output: z.union([z.array(z.string()), z.string()]).nullish(),
+  error: z.string().nullish(),
+  urls: z.object({
+    get: z.string(),
+  }),
 });


### PR DESCRIPTION
Closes #16276

---

When the Replicate provider's sync-wait window expires before an image generation job completes, the SDK returned an incomplete result instead of falling back to polling the prediction URL for the final output.

The fix adds a polling loop that kicks in when the sync response indicates the prediction is still in progress, retrying until the job reaches a terminal state (`succeeded` or `failed`).

*This contribution was made with AI-agent assistance (Claude Code).*