### PR TITLE
feat(gateway): shared speech-engine control protocol + session helper

### DIFF
--- a/.changeset/gateway-speech-engine-control.md
+++ b/.changeset/gateway-speech-engine-control.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/gateway": patch
+"ai": patch
+---
+
+Add a shared speech-engine control protocol for Gateway-owned realtime voice. Exposes the wire contract (subprotocol, event codec, capabilities, and engine descriptor) plus a `GatewaySpeechEngineSession` controller helper so a client can implement a "bring your own brain" voice endpoint in a few lines: surface finalized transcripts, stream a reply back for TTS, and get implicit barge-in (a new transcript aborts and cancels the prior turn by id). `experimental_realtime.getToken` now accepts an optional `control` config that is sealed into the minted client secret, and `GatewayRealtimeControlConfig` is re-exported from `ai`.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,7 +2,12 @@
 import './global';
 
 // re-exports:
-export { createGateway, gateway, type GatewayModelId } from '@ai-sdk/gateway';
+export {
+  createGateway,
+  gateway,
+  type GatewayModelId,
+  type GatewayRealtimeControlConfig,
+} from '@ai-sdk/gateway';
 export {
   asSchema,
   createIdGenerator,

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -36,7 +36,10 @@ import { GatewayVideoModel } from './gateway-video-model';
 import { GatewayRerankingModel } from './gateway-reranking-model';
 import { GatewaySpeechModel } from './gateway-speech-model';
 import { GatewayTranscriptionModel } from './gateway-transcription-model';
-import { GatewayRealtimeModel } from './gateway-realtime-model';
+import {
+  GatewayRealtimeModel,
+  type GatewayRealtimeControlConfig,
+} from './gateway-realtime-model';
 import type { GatewayEmbeddingModelId } from './gateway-embedding-model-settings';
 import type { GatewayImageModelId } from './gateway-image-model-settings';
 import type { GatewayRerankingModelId } from './gateway-reranking-model-settings';
@@ -60,6 +63,26 @@ import type {
   ProviderV4,
 } from '@ai-sdk/provider';
 import { VERSION } from './version';
+
+/**
+ * `getToken` options for the Gateway realtime factory, widened to accept an
+ * optional Eve voice `control` config sealed into the minted token.
+ */
+export type GatewayRealtimeGetTokenOptions =
+  RealtimeFactoryV4GetTokenOptions & {
+    control?: GatewayRealtimeControlConfig;
+  };
+
+/**
+ * The Gateway realtime factory: the standard {@link RealtimeFactoryV4} call
+ * signature plus a `getToken` that accepts the Eve voice `control` config.
+ */
+export interface GatewayRealtimeFactory {
+  (modelId: GatewayRealtimeModelId): ReturnType<RealtimeFactoryV4>;
+  getToken(
+    options: GatewayRealtimeGetTokenOptions,
+  ): ReturnType<RealtimeFactoryV4['getToken']>;
+}
 
 export interface GatewayProvider extends ProviderV4 {
   (modelId: GatewayModelId): LanguageModelV4;
@@ -170,8 +193,11 @@ export interface GatewayProvider extends ProviderV4 {
   /**
    * Creates an experimental realtime model for bidirectional audio/text
    * communication over WebSocket, normalized through the AI Gateway.
+   *
+   * `getToken` additionally accepts an Eve voice `control` config that is
+   * sealed into the minted `vcst_` token (server-side mint only).
    */
-  experimental_realtime: RealtimeFactoryV4;
+  experimental_realtime: GatewayRealtimeFactory;
 
   /**
    * Gateway-specific tools executed server-side.
@@ -298,6 +324,7 @@ export function createGateway(
   const mintRealtimeClientSecret = async (params: {
     modelId: string;
     expiresAfterSeconds?: number;
+    control?: GatewayRealtimeControlConfig;
   }): Promise<{ token: string; expiresAt?: number }> => {
     assertGatewayRealtimeServerEnvironment();
     const auth = await getRealtimeAuthToken();
@@ -312,6 +339,7 @@ export function createGateway(
           ...(params.expiresAfterSeconds != null && {
             expiresIn: params.expiresAfterSeconds,
           }),
+          ...(params.control != null && { control: params.control }),
         },
         successfulResponseHandler: createJsonResponseHandler(
           gatewayClientSecretResponseSchema,
@@ -536,7 +564,7 @@ export function createGateway(
   provider.experimental_realtime = Object.assign(
     (modelId: GatewayRealtimeModelId) => createRealtimeModel(modelId),
     {
-      getToken: async (tokenOptions: RealtimeFactoryV4GetTokenOptions) => {
+      getToken: async (tokenOptions: GatewayRealtimeGetTokenOptions) => {
         const { model: modelId, ...secretOptions } = tokenOptions;
         const model = createRealtimeModel(modelId);
         const secret = await model.doCreateClientSecret(secretOptions);
@@ -547,7 +575,7 @@ export function createGateway(
         };
       },
     },
-  ) as RealtimeFactoryV4;
+  ) as GatewayRealtimeFactory;
 
   provider.chat = provider.languageModel;
   provider.embedding = provider.embeddingModel;

--- a/packages/gateway/src/gateway-realtime-model.ts
+++ b/packages/gateway/src/gateway-realtime-model.ts
@@ -8,6 +8,19 @@ import type {
 } from '@ai-sdk/provider';
 import { getGatewayRealtimeProtocols } from './gateway-realtime-auth';
 
+/**
+ * Optional Gateway-owned realtime voice control plane configuration. When
+ * supplied at mint time, the Gateway opens one outbound control WebSocket to
+ * the given Eve `url` per live session (authenticating with `token` as
+ * `Authorization: Bearer`) and drives turns over it instead of the browser.
+ * Server-authenticated mint only; the Gateway seals it into the `vcst_` token.
+ */
+export interface GatewayRealtimeControlConfig {
+  mode: 'eve';
+  token: string;
+  url: string;
+}
+
 export type GatewayRealtimeModelConfig = {
   provider: string;
   baseURL: string;
@@ -21,6 +34,7 @@ export type GatewayRealtimeModelConfig = {
   createClientSecret: (params: {
     modelId: string;
     expiresAfterSeconds?: number;
+    control?: GatewayRealtimeControlConfig;
   }) => PromiseLike<{ token: string; expiresAt?: number }>;
 };
 
@@ -57,13 +71,16 @@ export class GatewayRealtimeModel implements RealtimeModelV4 {
    * normalized `session-update` event.
    */
   async doCreateClientSecret(
-    options?: RealtimeModelV4ClientSecretOptions,
+    options?: RealtimeModelV4ClientSecretOptions & {
+      control?: GatewayRealtimeControlConfig;
+    },
   ): Promise<RealtimeModelV4ClientSecretResult> {
     const secret = await this.config.createClientSecret({
       modelId: this.modelId,
       ...(options?.expiresAfterSeconds != null && {
         expiresAfterSeconds: options.expiresAfterSeconds,
       }),
+      ...(options?.control != null && { control: options.control }),
     });
     return {
       token: secret.token,

--- a/packages/gateway/src/gateway-speech-engine-session.ts
+++ b/packages/gateway/src/gateway-speech-engine-session.ts
@@ -1,0 +1,281 @@
+import {
+  DEFAULT_SPEECH_ENGINE_CAPABILITIES,
+  encodeSpeechEngineEvent,
+  parseSpeechEngineServerEvent,
+  type SpeechEngineCapabilities,
+  type SpeechEngineClientEvent,
+  type SpeechEngineDescriptor,
+  type SpeechEngineServerEvent,
+} from './gateway-speech-engine';
+
+/**
+ * Minimal socket the session drives. A Node `ws` socket satisfies this; adapt
+ * other transports (e.g. a framework's WS peer) to it.
+ */
+export interface SpeechEngineWebSocketLike {
+  send(data: string): void;
+  close(): void;
+  on(event: 'message', listener: (data: { toString(): string }) => void): void;
+  on(event: 'close', listener: (...args: unknown[]) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+/** Context for a `transcript` event; `signal` aborts when a newer turn supersedes it. */
+export interface SpeechEngineTranscriptContext {
+  itemId?: string;
+  signal: AbortSignal;
+}
+
+interface SpeechEngineSessionEventMap {
+  open: [engine: SpeechEngineDescriptor | undefined];
+  transcript: [text: string, context: SpeechEngineTranscriptContext];
+  'speech-started': [context: { itemId?: string }];
+  interrupted: [];
+  closed: [reason: string];
+  error: [error: Error];
+}
+
+type Listener = (...args: never[]) => void;
+
+/**
+ * Controller-side ("brain") session for the Gateway speech-engine control
+ * plane: wraps the control socket, surfaces finalized transcripts, and streams
+ * reply text back for TTS. A new transcript (or interruption) aborts the prior
+ * turn's signal and cancels it on the wire by `turnId` — the same shape as
+ * ElevenLabs' `SpeechEngineSession`, generalized to any AI Gateway engine.
+ */
+export class GatewaySpeechEngineSession {
+  readonly #ws: SpeechEngineWebSocketLike;
+  readonly #listeners = new Map<string, Set<Listener>>();
+  #seq = 0;
+  #turnSeq = 0;
+  #current: AbortController | undefined;
+  #currentTurnId: string | undefined;
+  #inTranscript = false;
+  #closed = false;
+  #sessionId: string | undefined;
+  #capabilities: SpeechEngineCapabilities = DEFAULT_SPEECH_ENGINE_CAPABILITIES;
+
+  constructor(ws: SpeechEngineWebSocketLike) {
+    this.#ws = ws;
+    this.#ws.on('message', data => {
+      const event = parseSpeechEngineServerEvent(data.toString());
+      if (event !== null) this.#handle(event);
+    });
+    this.#ws.on('close', () => {
+      this.#closed = true;
+      this.#abortCurrent();
+      this.#emit('closed', 'socket_closed');
+    });
+    this.#ws.on('error', err => this.#emit('error', err));
+  }
+
+  on<E extends keyof SpeechEngineSessionEventMap>(
+    event: E,
+    listener: (...args: SpeechEngineSessionEventMap[E]) => void,
+  ): this {
+    const set = this.#listeners.get(event) ?? new Set();
+    set.add(listener as Listener);
+    this.#listeners.set(event, set);
+    return this;
+  }
+
+  off<E extends keyof SpeechEngineSessionEventMap>(
+    event: E,
+    listener: (...args: SpeechEngineSessionEventMap[E]) => void,
+  ): this {
+    this.#listeners.get(event)?.delete(listener as Listener);
+    return this;
+  }
+
+  /** Signals readiness so the engine clears its connect/ready timeout. */
+  ready(): void {
+    this.#emitWire({ type: 'session.ready' });
+  }
+
+  /**
+   * Streams a reply for the current transcript back to the engine for TTS.
+   * Accepts a string or an async iterable of strings / LLM stream chunks
+   * (OpenAI / Anthropic / Gemini deltas are auto-extracted). Must be called in
+   * response to a `transcript` event.
+   */
+  async sendResponse(response: string | AsyncIterable<unknown>): Promise<void> {
+    if (this.#closed)
+      throw new Error('Cannot send response: session is closed');
+    if (!this.#inTranscript || this.#current === undefined) return;
+
+    const controller = this.#current;
+    const turnId = `turn_${(this.#turnSeq += 1)}`;
+    this.#currentTurnId = turnId;
+    this.#emitWire({ type: 'turn.started', data: { turnId } });
+
+    try {
+      if (typeof response === 'string') {
+        if (response.length > 0 && !controller.signal.aborted) {
+          this.#emitWire({
+            type: 'response.delta',
+            data: { text: response, turnId },
+          });
+        }
+      } else {
+        for await (const chunk of response) {
+          if (controller.signal.aborted || this.#closed) return;
+          const text = extractText(chunk);
+          if (text)
+            this.#emitWire({ type: 'response.delta', data: { text, turnId } });
+        }
+      }
+      if (!controller.signal.aborted && !this.#closed) {
+        this.#emitWire({ type: 'response.done', data: { turnId } });
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      this.#emit(
+        'error',
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#abortCurrent();
+    this.#ws.close();
+  }
+
+  get sessionId(): string | undefined {
+    return this.#sessionId;
+  }
+
+  get capabilities(): SpeechEngineCapabilities {
+    return this.#capabilities;
+  }
+
+  get isOpen(): boolean {
+    return !this.#closed;
+  }
+
+  #handle(event: SpeechEngineServerEvent): void {
+    switch (event.type) {
+      case 'session.opened':
+        this.#sessionId = event.data.sessionId;
+        if (event.data.engine)
+          this.#capabilities = event.data.engine.capabilities;
+        this.#emit('open', event.data.engine);
+        return;
+      case 'input.transcript.final': {
+        this.#supersede();
+        const controller = new AbortController();
+        this.#current = controller;
+        this.#inTranscript = true;
+        this.#emit('transcript', event.data.text, {
+          signal: controller.signal,
+          ...(event.data.itemId !== undefined && { itemId: event.data.itemId }),
+        });
+        return;
+      }
+      case 'input.speech.started':
+        this.#emit('speech-started', {
+          ...(event.data.itemId !== undefined && { itemId: event.data.itemId }),
+        });
+        return;
+      case 'input.interrupted':
+        this.#supersede();
+        this.#emit('interrupted');
+        return;
+      case 'session.closed':
+        this.#closed = true;
+        this.#abortCurrent();
+        this.#emit('closed', event.data.reason);
+        return;
+      case 'error':
+        this.#emit('error', new Error(event.data.message));
+        return;
+      default:
+        return;
+    }
+  }
+
+  // Aborts the in-flight turn and cancels it on the wire by id.
+  #supersede(): void {
+    if (this.#current !== undefined && !this.#current.signal.aborted) {
+      this.#current.abort();
+      if (
+        this.#currentTurnId !== undefined &&
+        this.#capabilities['output.cancel']
+      ) {
+        this.#emitWire({
+          type: 'response.cancel',
+          data: { turnId: this.#currentTurnId },
+        });
+      }
+    }
+    this.#currentTurnId = undefined;
+    this.#inTranscript = false;
+  }
+
+  #abortCurrent(): void {
+    this.#current?.abort();
+    this.#current = undefined;
+    this.#inTranscript = false;
+  }
+
+  #emitWire(event: SpeechEngineClientEvent): void {
+    if (this.#closed && event.type !== 'error') return;
+    this.#seq += 1;
+    this.#ws.send(encodeSpeechEngineEvent(this.#seq, event));
+  }
+
+  #emit<E extends keyof SpeechEngineSessionEventMap>(
+    event: E,
+    ...args: SpeechEngineSessionEventMap[E]
+  ): void {
+    for (const listener of this.#listeners.get(event) ?? []) {
+      (listener as (...a: SpeechEngineSessionEventMap[E]) => void)(...args);
+    }
+  }
+}
+
+/** Extracts text from a string or common LLM stream chunk shapes. */
+function extractText(chunk: unknown): string | null {
+  if (typeof chunk === 'string') return chunk;
+  if (chunk === null || typeof chunk !== 'object') return null;
+  const event = chunk as Record<string, unknown>;
+
+  // AI SDK / OpenAI Responses: { type: 'response.output_text.delta', delta }
+  if (
+    event.type === 'response.output_text.delta' &&
+    typeof event.delta === 'string'
+  ) {
+    return event.delta;
+  }
+  // OpenAI Chat Completions: { choices: [{ delta: { content } }] }
+  if (Array.isArray(event.choices)) {
+    const delta = (event.choices[0] as Record<string, unknown>)?.delta;
+    if (isRecord(delta) && typeof delta.content === 'string')
+      return delta.content;
+  }
+  // Anthropic: { type: 'content_block_delta', delta: { type: 'text_delta', text } }
+  if (event.type === 'content_block_delta' && isRecord(event.delta)) {
+    if (
+      event.delta.type === 'text_delta' &&
+      typeof event.delta.text === 'string'
+    ) {
+      return event.delta.text;
+    }
+  }
+  // Gemini: { candidates: [{ content: { parts: [{ text }] } }] }
+  if (Array.isArray(event.candidates)) {
+    const content = (event.candidates[0] as Record<string, unknown>)?.content;
+    if (isRecord(content) && Array.isArray(content.parts)) {
+      const part = content.parts[0] as Record<string, unknown>;
+      if (typeof part?.text === 'string') return part.text;
+    }
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}

--- a/packages/gateway/src/gateway-speech-engine.test.ts
+++ b/packages/gateway/src/gateway-speech-engine.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+import {
+  encodeSpeechEngineEvent,
+  parseSpeechEngineClientEvent,
+  parseSpeechEngineServerEvent,
+} from './gateway-speech-engine';
+import {
+  GatewaySpeechEngineSession,
+  type SpeechEngineWebSocketLike,
+} from './gateway-speech-engine-session';
+
+describe('speech-engine codec', () => {
+  it('round-trips a server event', () => {
+    const wire = encodeSpeechEngineEvent(1, {
+      type: 'input.transcript.final',
+      data: { text: 'hello', itemId: 'item_1' },
+    });
+    expect(parseSpeechEngineServerEvent(wire)).toEqual({
+      type: 'input.transcript.final',
+      data: { text: 'hello', itemId: 'item_1' },
+    });
+  });
+
+  it('round-trips a client event with turnId', () => {
+    const wire = encodeSpeechEngineEvent(2, {
+      type: 'response.delta',
+      data: { text: 'hi there', turnId: 'turn_1' },
+    });
+    expect(parseSpeechEngineClientEvent(wire)).toEqual({
+      type: 'response.delta',
+      data: { text: 'hi there', turnId: 'turn_1' },
+    });
+  });
+
+  it('parses the engine capability handshake', () => {
+    const wire = encodeSpeechEngineEvent(0, {
+      type: 'session.opened',
+      data: {
+        sessionId: 's1',
+        engine: {
+          provider: 'openai',
+          model: 'gpt-realtime-2',
+          protocol: 'openai',
+          capabilities: {
+            'input.transcript.final': true,
+            'input.transcript.partial': false,
+            'input.speech.started': true,
+            'input.interrupted': true,
+            'output.audio': false,
+            'output.cancel': true,
+            'output.exactReadout': false,
+          },
+        },
+      },
+    });
+    const parsed = parseSpeechEngineServerEvent(wire);
+    expect(parsed?.type).toBe('session.opened');
+    expect(
+      parsed?.type === 'session.opened' &&
+        parsed.data.engine?.capabilities['output.audio'],
+    ).toBe(false);
+  });
+
+  it('rejects malformed packets', () => {
+    expect(parseSpeechEngineServerEvent('not json')).toBeNull();
+    expect(
+      parseSpeechEngineServerEvent(
+        JSON.stringify({ v: 2, type: 'error', data: {} }),
+      ),
+    ).toBeNull();
+    // turnId is required on response.* / turn.started.
+    expect(
+      parseSpeechEngineClientEvent(
+        JSON.stringify({
+          v: 1,
+          id: 'x',
+          seq: 1,
+          type: 'response.delta',
+          data: { text: 'a' },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseSpeechEngineClientEvent(
+        JSON.stringify({
+          v: 1,
+          id: 'x',
+          seq: 1,
+          type: 'turn.started',
+          data: {},
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+class FakeSocket implements SpeechEngineWebSocketLike {
+  readonly sent: string[] = [];
+  readonly #handlers = new Map<string, ((...args: never[]) => void)[]>();
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.#fire('close');
+  }
+  on(event: string, listener: (...args: never[]) => void): void {
+    const list = this.#handlers.get(event) ?? [];
+    list.push(listener);
+    this.#handlers.set(event, list);
+  }
+  receive(packet: string): void {
+    this.#fire('message', packet as never);
+  }
+  #fire(event: string, ...args: never[]): void {
+    for (const listener of this.#handlers.get(event) ?? []) listener(...args);
+  }
+  events(): Array<{ type: string; data: Record<string, unknown> }> {
+    return this.sent.map(raw => JSON.parse(raw));
+  }
+}
+
+function opened(
+  socket: FakeSocket,
+  capabilities?: Record<string, boolean>,
+): void {
+  socket.receive(
+    encodeSpeechEngineEvent(0, {
+      type: 'session.opened',
+      data: {
+        sessionId: 's1',
+        engine: {
+          provider: 'openai',
+          model: 'gpt-realtime-2',
+          protocol: 'openai',
+          capabilities: {
+            'input.transcript.final': true,
+            'input.transcript.partial': false,
+            'input.speech.started': true,
+            'input.interrupted': true,
+            'output.audio': true,
+            'output.cancel': true,
+            'output.exactReadout': false,
+            ...capabilities,
+          },
+        },
+      },
+    }),
+  );
+}
+
+function transcript(socket: FakeSocket, text: string, itemId: string): void {
+  socket.receive(
+    encodeSpeechEngineEvent(0, {
+      type: 'input.transcript.final',
+      data: { text, itemId },
+    }),
+  );
+}
+
+describe('GatewaySpeechEngineSession', () => {
+  it('surfaces transcripts and streams a reply with a consistent turnId', async () => {
+    const socket = new FakeSocket();
+    const session = new GatewaySpeechEngineSession(socket);
+    session.ready();
+
+    const transcripts: string[] = [];
+    session.on('transcript', text => transcripts.push(text));
+
+    opened(socket);
+    transcript(socket, 'what is the weather', 'item_1');
+    expect(transcripts).toEqual(['what is the weather']);
+
+    await session.sendResponse('Sunny.');
+
+    const types = socket.events().map(e => e.type);
+    expect(types).toEqual([
+      'session.ready',
+      'turn.started',
+      'response.delta',
+      'response.done',
+    ]);
+    const turnIds = socket
+      .events()
+      .filter(e => e.type !== 'session.ready')
+      .map(e => e.data.turnId);
+    expect(new Set(turnIds).size).toBe(1);
+  });
+
+  it('extracts text from LLM stream chunks', async () => {
+    const socket = new FakeSocket();
+    const session = new GatewaySpeechEngineSession(socket);
+    opened(socket);
+    transcript(socket, 'hi', 'item_1');
+
+    async function* stream() {
+      yield { type: 'response.output_text.delta', delta: 'He' };
+      yield { type: 'response.output_text.delta', delta: 'llo' };
+    }
+    await session.sendResponse(stream());
+
+    const deltas = socket
+      .events()
+      .filter(e => e.type === 'response.delta')
+      .map(e => e.data.text);
+    expect(deltas).toEqual(['He', 'llo']);
+  });
+
+  it('supersedes the prior turn on a new transcript: aborts its signal and cancels by id', async () => {
+    const socket = new FakeSocket();
+    const session = new GatewaySpeechEngineSession(socket);
+    opened(socket);
+
+    let firstSignal: AbortSignal | undefined;
+    session.on('transcript', (_text, ctx) => {
+      firstSignal ??= ctx.signal;
+    });
+
+    transcript(socket, 'first', 'item_1');
+    await session.sendResponse('first reply');
+    transcript(socket, 'second', 'item_2');
+
+    expect(firstSignal?.aborted).toBe(true);
+    const cancel = socket.events().find(e => e.type === 'response.cancel');
+    expect(cancel?.data.turnId).toBe('turn_1');
+  });
+
+  it('does not emit response.cancel when the engine lacks output.cancel', async () => {
+    const socket = new FakeSocket();
+    const session = new GatewaySpeechEngineSession(socket);
+    opened(socket, { 'output.cancel': false });
+
+    session.on('transcript', () => {});
+    transcript(socket, 'first', 'item_1');
+    await session.sendResponse('first reply');
+    transcript(socket, 'second', 'item_2');
+
+    expect(socket.events().some(e => e.type === 'response.cancel')).toBe(false);
+  });
+});

--- a/packages/gateway/src/gateway-speech-engine.ts
+++ b/packages/gateway/src/gateway-speech-engine.ts
@@ -1,0 +1,272 @@
+/**
+ * Shared protocol for the AI Gateway speech-engine control plane: the wire
+ * contract a controller (your LLM/agent endpoint) speaks with the Gateway when
+ * the Gateway owns the realtime audio loop (STT, TTS, turn-taking) and drives
+ * turns over a server-side control socket.
+ *
+ * This is the single source of truth so the Gateway and any controller (Eve, or
+ * any other client wanting ElevenLabs-style "bring your own brain" voice) can't
+ * drift. The Gateway is the "speech engine"; the controller is the "brain".
+ * Audio never reaches the controller — only finalized transcripts in, reply
+ * text out.
+ */
+
+/** Subprotocol offered on the control-socket handshake. */
+export const GATEWAY_SPEECH_ENGINE_SUBPROTOCOL = 'ai-gateway-speech-engine.v1';
+
+/**
+ * Per-session capability hints the engine advertises in `session.opened`. A
+ * controller tunes behavior to them (e.g. skip the spoken readout when
+ * `output.audio` is false, only promise barge-in the engine can honor). Absent
+ * values default permissive for forward compatibility.
+ */
+export interface SpeechEngineCapabilities {
+  'input.transcript.final': boolean;
+  'input.transcript.partial': boolean;
+  'input.speech.started': boolean;
+  'input.interrupted': boolean;
+  'output.audio': boolean;
+  'output.cancel': boolean;
+  'output.exactReadout': boolean;
+}
+
+/** Permissive defaults used when the engine omits a capability (or all of `engine`). */
+export const DEFAULT_SPEECH_ENGINE_CAPABILITIES: SpeechEngineCapabilities = {
+  'input.transcript.final': true,
+  'input.transcript.partial': false,
+  'input.speech.started': true,
+  'input.interrupted': true,
+  'output.audio': true,
+  'output.cancel': true,
+  'output.exactReadout': false,
+};
+
+/** The speech engine the Gateway assembled for this session. */
+export interface SpeechEngineDescriptor {
+  provider: string;
+  model: string;
+  protocol: string;
+  capabilities: SpeechEngineCapabilities;
+}
+
+/** Events the engine (Gateway) sends to the controller. */
+export type SpeechEngineServerEvent =
+  | {
+      type: 'session.opened';
+      data: { sessionId: string; engine?: SpeechEngineDescriptor };
+    }
+  | { type: 'input.speech.started'; data: { itemId?: string } }
+  | { type: 'input.speech.stopped'; data: { itemId?: string } }
+  | { type: 'input.interrupted'; data: Record<string, never> }
+  | { type: 'input.transcript.final'; data: { text: string; itemId?: string } }
+  | {
+      type: 'session.stats';
+      data: {
+        durationMs: number;
+        responseDeltaCount: number;
+        transcriptFinalCount: number;
+      };
+    }
+  | { type: 'session.closed'; data: { reason: string } }
+  | { type: 'error'; data: { message: string } };
+
+/**
+ * Events the controller sends to the engine. `turnId` correlates a turn's
+ * lifecycle frames so the engine can drop frames from a superseded turn (after
+ * barge-in) by id rather than relying on ordering.
+ */
+export type SpeechEngineClientEvent =
+  | { type: 'session.ready'; data?: Record<string, never> }
+  | { type: 'turn.started'; data: { turnId: string } }
+  | { type: 'response.delta'; data: { text: string; turnId: string } }
+  | { type: 'response.done'; data: { turnId: string } }
+  | { type: 'response.cancel'; data: { turnId: string } }
+  | { type: 'error'; data: { code?: string; message?: string } };
+
+interface SpeechEngineEnvelope {
+  v: 1;
+  id: string;
+  seq: number;
+  type: string;
+  data: Record<string, unknown>;
+}
+
+/** Serializes a control event into a wire packet string. */
+export function encodeSpeechEngineEvent(
+  seq: number,
+  event: SpeechEngineServerEvent | SpeechEngineClientEvent,
+): string {
+  const packet: SpeechEngineEnvelope = {
+    v: 1,
+    id: `evt_${randomId()}`,
+    seq,
+    type: event.type,
+    data: (event.data ?? {}) as Record<string, unknown>,
+  };
+  return JSON.stringify(packet);
+}
+
+/** Parses an engine→controller wire packet, or `null` when malformed. */
+export function parseSpeechEngineServerEvent(
+  raw: string,
+): SpeechEngineServerEvent | null {
+  const data = readEnvelopeData(raw);
+  if (data === null) return null;
+  const record = data.record;
+  switch (data.type) {
+    case 'session.opened': {
+      if (typeof record.sessionId !== 'string') return null;
+      const engine = parseEngine(record.engine);
+      return {
+        type: 'session.opened',
+        data: { sessionId: record.sessionId, ...(engine && { engine }) },
+      };
+    }
+    case 'input.speech.started':
+      return { type: 'input.speech.started', data: itemIdOnly(record) };
+    case 'input.speech.stopped':
+      return { type: 'input.speech.stopped', data: itemIdOnly(record) };
+    case 'input.interrupted':
+      return { type: 'input.interrupted', data: {} };
+    case 'input.transcript.final':
+      return typeof record.text === 'string'
+        ? {
+            type: 'input.transcript.final',
+            data: { text: record.text, ...itemIdOnly(record) },
+          }
+        : null;
+    case 'session.stats':
+      return {
+        type: 'session.stats',
+        data: {
+          durationMs: numberOr(record.durationMs, 0),
+          responseDeltaCount: numberOr(record.responseDeltaCount, 0),
+          transcriptFinalCount: numberOr(record.transcriptFinalCount, 0),
+        },
+      };
+    case 'session.closed':
+      return {
+        type: 'session.closed',
+        data: {
+          reason: typeof record.reason === 'string' ? record.reason : 'unknown',
+        },
+      };
+    case 'error':
+      return {
+        type: 'error',
+        data: {
+          message:
+            typeof record.message === 'string' ? record.message : 'unknown',
+        },
+      };
+    default:
+      return null;
+  }
+}
+
+/** Parses a controller→engine wire packet, or `null` when malformed. */
+export function parseSpeechEngineClientEvent(
+  raw: string,
+): SpeechEngineClientEvent | null {
+  const data = readEnvelopeData(raw);
+  if (data === null) return null;
+  const record = data.record;
+  switch (data.type) {
+    case 'session.ready':
+      return { type: 'session.ready', data: {} };
+    case 'turn.started':
+      return typeof record.turnId === 'string'
+        ? { type: 'turn.started', data: { turnId: record.turnId } }
+        : null;
+    case 'response.delta':
+      return typeof record.text === 'string' &&
+        typeof record.turnId === 'string'
+        ? {
+            type: 'response.delta',
+            data: { text: record.text, turnId: record.turnId },
+          }
+        : null;
+    case 'response.done':
+      return typeof record.turnId === 'string'
+        ? { type: 'response.done', data: { turnId: record.turnId } }
+        : null;
+    case 'response.cancel':
+      return typeof record.turnId === 'string'
+        ? { type: 'response.cancel', data: { turnId: record.turnId } }
+        : null;
+    case 'error':
+      return {
+        type: 'error',
+        data: {
+          ...(typeof record.code === 'string' && { code: record.code }),
+          ...(typeof record.message === 'string' && {
+            message: record.message,
+          }),
+        },
+      };
+    default:
+      return null;
+  }
+}
+
+function readEnvelopeData(
+  raw: string,
+): { type: string; record: Record<string, unknown> } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || parsed.v !== 1 || typeof parsed.type !== 'string') {
+    return null;
+  }
+  return {
+    type: parsed.type,
+    record: isRecord(parsed.data) ? parsed.data : {},
+  };
+}
+
+function parseEngine(value: unknown): SpeechEngineDescriptor | undefined {
+  if (!isRecord(value)) return undefined;
+  const caps = isRecord(value.capabilities) ? value.capabilities : {};
+  return {
+    provider: typeof value.provider === 'string' ? value.provider : 'unknown',
+    model: typeof value.model === 'string' ? value.model : 'unknown',
+    protocol: typeof value.protocol === 'string' ? value.protocol : 'unknown',
+    capabilities: {
+      'input.transcript.final': boolOr(caps['input.transcript.final'], true),
+      'input.transcript.partial': boolOr(
+        caps['input.transcript.partial'],
+        false,
+      ),
+      'input.speech.started': boolOr(caps['input.speech.started'], true),
+      'input.interrupted': boolOr(caps['input.interrupted'], true),
+      'output.audio': boolOr(caps['output.audio'], true),
+      'output.cancel': boolOr(caps['output.cancel'], true),
+      'output.exactReadout': boolOr(caps['output.exactReadout'], false),
+    },
+  };
+}
+
+function boolOr(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function itemIdOnly(data: Record<string, unknown>): { itemId?: string } {
+  return typeof data.itemId === 'string' ? { itemId: data.itemId } : {};
+}
+
+function numberOr(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function randomId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -7,6 +7,22 @@ export {
   getGatewayRealtimeProtocols,
   getGatewayRealtimeTeamIdOrSlug,
 } from './gateway-realtime-auth';
+export {
+  DEFAULT_SPEECH_ENGINE_CAPABILITIES,
+  GATEWAY_SPEECH_ENGINE_SUBPROTOCOL,
+  encodeSpeechEngineEvent,
+  parseSpeechEngineClientEvent,
+  parseSpeechEngineServerEvent,
+  type SpeechEngineCapabilities,
+  type SpeechEngineClientEvent,
+  type SpeechEngineDescriptor,
+  type SpeechEngineServerEvent,
+} from './gateway-speech-engine';
+export {
+  GatewaySpeechEngineSession,
+  type SpeechEngineTranscriptContext,
+  type SpeechEngineWebSocketLike,
+} from './gateway-speech-engine-session';
 export type { GatewayRealtimeModelId } from './gateway-realtime-model-settings';
 export type { GatewayRerankingModelId } from './gateway-reranking-model-settings';
 export type { GatewaySpeechModelId } from './gateway-speech-model-settings';
@@ -36,7 +52,10 @@ export {
 export type {
   GatewayProvider,
   GatewayProviderSettings,
+  GatewayRealtimeFactory,
+  GatewayRealtimeGetTokenOptions,
 } from './gateway-provider';
+export type { GatewayRealtimeControlConfig } from './gateway-realtime-model';
 export type {
   GatewayProviderOptions,
   /** @deprecated Use `GatewayProviderOptions` instead. */


### PR DESCRIPTION
## Summary

Adds a vendor-neutral wire contract in `@ai-sdk/gateway` for **Gateway-owned realtime voice control** — the model where the Gateway owns the audio loop (STT, TTS, turn-taking) and a controller ("bring your own brain") drives turns over a server-side control socket. This makes `@ai-sdk/gateway` the single source of truth for the protocol so the Gateway and any controller can't drift.

### What's added
- **`gateway-speech-engine`** — the shared contract:
  - `GATEWAY_SPEECH_ENGINE_SUBPROTOCOL` (control-socket subprotocol)
  - engine↔controller event schemas (`SpeechEngineServerEvent` / `SpeechEngineClientEvent`, with `turnId` on client events for post-barge-in stale-frame dropping)
  - `SpeechEngineCapabilities` + `DEFAULT_SPEECH_ENGINE_CAPABILITIES`, `SpeechEngineDescriptor`
  - envelope codec: `encodeSpeechEngineEvent` / `parseSpeechEngineServerEvent` / `parseSpeechEngineClientEvent`
- **`GatewaySpeechEngineSession`** — a controller-side helper (the AI-SDK analogue of ElevenLabs' session): surface finalized transcripts, stream a reply back for TTS (string or LLM-chunk stream, with auto text extraction), and implicit barge-in (a new transcript aborts the prior turn's `AbortSignal` and cancels it on the wire by `turnId`).
- Thread an optional `control` config through `experimental_realtime.getToken` (sealed into the minted client secret; server-side mint only) and re-export `GatewayRealtimeControlConfig` from `ai`.

### Why
The protocol was being hand-mirrored across consumers. Centralizing it here lets the AI Gateway server and Eve (and any future client, including ElevenLabs-as-a-provider use cases) import one contract.

### Tests
`gateway-speech-engine.test.ts` covers the codec (round-trips, capability handshake, malformed/`turnId`-required rejection) and the session helper (transcript→reply with a consistent `turnId`, LLM-chunk extraction, supersede/cancel-by-id, no-cancel-without-capability). 8 tests, `pnpm build` clean (ESM + DTS).

### Consumers (separate PRs)
- AI Gateway server adopts the shared parser/subprotocol/types (vercel/ai-gateway#2334)
- Eve consumes it via a thin re-export shim (vercel/eve#132)

Draft until the consumers are validated end-to-end against this build.