### PR TITLE
feat(openai): add orchestration token usage details to Responses API usage

### DIFF
--- a/.changeset/openai-orchestration-usage.md
+++ b/.changeset/openai-orchestration-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add orchestration token usage details to Responses API usage

--- a/packages/openai/src/responses/convert-openai-responses-usage.ts
+++ b/packages/openai/src/responses/convert-openai-responses-usage.ts
@@ -5,9 +5,12 @@ export type OpenAIResponsesUsage = {
   output_tokens: number;
   input_tokens_details?: {
     cached_tokens?: number | null;
+    orchestration_input_tokens?: number | null;
+    orchestration_input_cached_tokens?: number | null;
   } | null;
   output_tokens_details?: {
     reasoning_tokens?: number | null;
+    orchestration_output_tokens?: number | null;
   } | null;
 };
 

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -531,11 +531,18 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
           usage: z.object({
             input_tokens: z.number(),
             input_tokens_details: z
-              .object({ cached_tokens: z.number().nullish() })
+              .object({
+                cached_tokens: z.number().nullish(),
+                orchestration_input_tokens: z.number().nullish(),
+                orchestration_input_cached_tokens: z.number().nullish(),
+              })
               .nullish(),
             output_tokens: z.number(),
             output_tokens_details: z
-              .object({ reasoning_tokens: z.number().nullish() })
+              .object({
+                reasoning_tokens: z.number().nullish(),
+                orchestration_output_tokens: z.number().nullish(),
+              })
               .nullish(),
           }),
           service_tier: z.string().nullish(),
@@ -556,11 +563,18 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             .object({
               input_tokens: z.number(),
               input_tokens_details: z
-                .object({ cached_tokens: z.number().nullish() })
+                .object({
+                  cached_tokens: z.number().nullish(),
+                  orchestration_input_tokens: z.number().nullish(),
+                  orchestration_input_cached_tokens: z.number().nullish(),
+                })
                 .nullish(),
               output_tokens: z.number(),
               output_tokens_details: z
-                .object({ reasoning_tokens: z.number().nullish() })
+                .object({
+                  reasoning_tokens: z.number().nullish(),
+                  orchestration_output_tokens: z.number().nullish(),
+                })
                 .nullish(),
             })
             .nullish(),
@@ -1416,11 +1430,18 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
         .object({
           input_tokens: z.number(),
           input_tokens_details: z
-            .object({ cached_tokens: z.number().nullish() })
+            .object({
+              cached_tokens: z.number().nullish(),
+              orchestration_input_tokens: z.number().nullish(),
+              orchestration_input_cached_tokens: z.number().nullish(),
+            })
             .nullish(),
           output_tokens: z.number(),
           output_tokens_details: z
-            .object({ reasoning_tokens: z.number().nullish() })
+            .object({
+              reasoning_tokens: z.number().nullish(),
+              orchestration_output_tokens: z.number().nullish(),
+            })
             .nullish(),
         })
         .optional(),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -357,6 +357,77 @@ describe('OpenAIResponsesLanguageModel', () => {
         `);
       });
 
+      it('should preserve orchestration usage fields in raw', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67c97c0203188190a025beb4a75242bc',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            input: [],
+            instructions: null,
+            max_output_tokens: null,
+            model: 'gpt-4o-2024-07-18',
+            output: [
+              {
+                id: 'msg_67c97c02656c81908e080dfdf4a03cd1',
+                type: 'message',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  { type: 'output_text', text: 'answer text', annotations: [] },
+                ],
+              },
+            ],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: { effort: null, summary: null },
+            store: true,
+            temperature: 1,
+            text: { format: { type: 'text' } },
+            tool_choice: 'auto',
+            tools: [],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 120,
+              input_tokens_details: {
+                cached_tokens: 0,
+                orchestration_input_tokens: 40,
+                orchestration_input_cached_tokens: 10,
+              },
+              output_tokens: 80,
+              output_tokens_details: {
+                reasoning_tokens: 0,
+                orchestration_output_tokens: 25,
+              },
+              total_tokens: 265,
+            },
+            user: null,
+            metadata: {},
+          },
+        };
+
+        const result = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        // Sakana-style orchestration usage rides through on `usage.raw` so
+        // downstream consumers (e.g. the AI Gateway) can bill it.
+        expect(result.usage.raw).toMatchObject({
+          input_tokens_details: {
+            orchestration_input_tokens: 40,
+            orchestration_input_cached_tokens: 10,
+          },
+          output_tokens_details: {
+            orchestration_output_tokens: 25,
+          },
+        });
+      });
+
       it('should extract response id metadata ', async () => {
         const result = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,


### PR DESCRIPTION
## Background

The OpenAI-compatible Responses API surface is also used by third-party providers (e.g. Sakana AI's Fugu/Fugu Ultra, routed through `createOpenAI` + a custom `baseURL`). Fugu Ultra is a multi-agent system that reports **orchestration** token usage in the standard `*_tokens_details` objects:

```json
{
  "input_tokens": 120,
  "output_tokens": 80,
  "input_tokens_details": {
    "cached_tokens": 0,
    "orchestration_input_tokens": 40,
    "orchestration_input_cached_tokens": 10
  },
  "output_tokens_details": { "orchestration_output_tokens": 25 }
}
```

These represent real, billable token usage *in addition to* `input_tokens` / `output_tokens` (`total_tokens` includes them).

## Problem

The Responses usage Zod schema modeled only `cached_tokens` / `reasoning_tokens` via plain `z.object(...)`, which **strips unknown keys**. Because `convertOpenAIResponsesUsage` sets `raw: usage` to that already-parsed object, the orchestration fields were dropped before any consumer (`usage.raw`) could see them.

## Change

Explicitly model the three orchestration fields (`.nullish()`, matching the response-schema convention) in:

- the Responses usage schema (`openai-responses-api.ts`) — all three occurrences (completed/incomplete, failed, non-streaming)
- the `OpenAIResponsesUsage` type (`convert-openai-responses-usage.ts`) so `usage.raw` is typed

They now round-trip onto `usage.raw`. No change to the structured `LanguageModelV4Usage` shape; `raw` is the appropriate home for provider-specific usage extensions, and these are no-ops (`undefined`) for first-party OpenAI.

## Test

Added a Responses language-model test asserting the orchestration fields survive parsing onto `usage.raw`.