### PR TITLE
Backport: feat(openai): add orchestration token usage details to Responses API usage

### DIFF
--- a/.changeset/openai-orchestration-usage.md
+++ b/.changeset/openai-orchestration-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add orchestration token usage details to Responses API usage

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -259,11 +259,18 @@ export const openaiResponsesChunkSchema = lazyValidator(() =>
           usage: z.object({
             input_tokens: z.number(),
             input_tokens_details: z
-              .object({ cached_tokens: z.number().nullish() })
+              .object({
+                cached_tokens: z.number().nullish(),
+                orchestration_input_tokens: z.number().nullish(),
+                orchestration_input_cached_tokens: z.number().nullish(),
+              })
               .nullish(),
             output_tokens: z.number(),
             output_tokens_details: z
-              .object({ reasoning_tokens: z.number().nullish() })
+              .object({
+                reasoning_tokens: z.number().nullish(),
+                orchestration_output_tokens: z.number().nullish(),
+              })
               .nullish(),
           }),
           service_tier: z.string().nullish(),
@@ -734,11 +741,18 @@ export const openaiResponsesResponseSchema = lazyValidator(() =>
         .object({
           input_tokens: z.number(),
           input_tokens_details: z
-            .object({ cached_tokens: z.number().nullish() })
+            .object({
+              cached_tokens: z.number().nullish(),
+              orchestration_input_tokens: z.number().nullish(),
+              orchestration_input_cached_tokens: z.number().nullish(),
+            })
             .nullish(),
           output_tokens: z.number(),
           output_tokens_details: z
-            .object({ reasoning_tokens: z.number().nullish() })
+            .object({
+              reasoning_tokens: z.number().nullish(),
+              orchestration_output_tokens: z.number().nullish(),
+            })
             .nullish(),
         })
         .optional(),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -263,6 +263,75 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
       });
 
+      it('should only include orchestration usage fields that are present', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67c97c0203188190a025beb4a75242bc',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            input: [],
+            instructions: null,
+            max_output_tokens: null,
+            model: 'gpt-4o-2024-07-18',
+            output: [
+              {
+                id: 'msg_67c97c02656c81908e080dfdf4a03cd1',
+                type: 'message',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  { type: 'output_text', text: 'answer text', annotations: [] },
+                ],
+              },
+            ],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: { effort: null, summary: null },
+            store: true,
+            temperature: 1,
+            text: { format: { type: 'text' } },
+            tool_choice: 'auto',
+            tools: [],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 120,
+              input_tokens_details: {
+                cached_tokens: 0,
+                orchestration_input_tokens: 40,
+              },
+              output_tokens: 80,
+              output_tokens_details: {
+                reasoning_tokens: 0,
+              },
+              total_tokens: 200,
+            },
+            user: null,
+            metadata: {},
+          },
+        };
+
+        const result = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.providerMetadata?.openai.usage).toStrictEqual({
+          orchestrationInputTokens: 40,
+        });
+      });
+
+      it('should not add usage to provider metadata when no orchestration usage is present', async () => {
+        const result = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.providerMetadata?.openai).not.toHaveProperty('usage');
+      });
+
       it('should extract response id metadata ', async () => {
         const result = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,
@@ -3121,6 +3190,58 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
         ]
       `);
+    });
+
+    it('should surface orchestration usage in provider metadata', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_67c9a81b6a048190a9ee441c5755a4e8","object":"response","created_at":1741269019,"status":"in_progress","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0.3,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_67c9a81dea8c8190b79651a2b3adf91e","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_67c9a81dea8c8190b79651a2b3adf91e","output_index":0,"content_index":0,"delta":"Hello!"}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_67c9a8787f4c8190b49c858d4c1cf20c","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_67c9a878139c8190aa2e3105411b408b","object":"response","created_at":1741269112,"status":"completed","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-07-18","output":[{"id":"msg_67c9a8787f4c8190b49c858d4c1cf20c","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0.3,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1,"truncation":"disabled","usage":{"input_tokens":120,"input_tokens_details":{"cached_tokens":0,"orchestration_input_tokens":40,"orchestration_input_cached_tokens":10},"output_tokens":80,"output_tokens_details":{"reasoning_tokens":0,"orchestration_output_tokens":25},"total_tokens":265},"user":null,"metadata":{}}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('gpt-4o').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const finishPart = parts.find(part => part.type === 'finish');
+
+      // Sakana-style orchestration usage is surfaced via provider metadata so
+      // downstream consumers (e.g. the AI Gateway) can bill it.
+      expect(finishPart?.providerMetadata?.openai.usage).toStrictEqual({
+        orchestrationInputTokens: 40,
+        orchestrationInputCachedTokens: 10,
+        orchestrationOutputTokens: 25,
+      });
+    });
+
+    it('should not add usage to provider metadata when no orchestration usage is present', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_67c9a81b6a048190a9ee441c5755a4e8","object":"response","created_at":1741269019,"status":"in_progress","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0.3,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_67c9a81dea8c8190b79651a2b3adf91e","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_67c9a81dea8c8190b79651a2b3adf91e","output_index":0,"content_index":0,"delta":"Hello!"}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_67c9a8787f4c8190b49c858d4c1cf20c","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_67c9a878139c8190aa2e3105411b408b","object":"response","created_at":1741269112,"status":"completed","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-07-18","output":[{"id":"msg_67c9a8787f4c8190b49c858d4c1cf20c","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0.3,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1,"truncation":"disabled","usage":{"input_tokens":120,"input_tokens_details":{"cached_tokens":0},"output_tokens":80,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":200},"user":null,"metadata":{}}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('gpt-4o').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const finishPart = parts.find(part => part.type === 'finish');
+
+      expect(finishPart?.providerMetadata?.openai).not.toHaveProperty('usage');
     });
 
     it('should send finish reason for incomplete response', async () => {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -196,6 +196,73 @@ describe('OpenAIResponsesLanguageModel', () => {
         `);
       });
 
+      it('should surface orchestration usage in provider metadata', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67c97c0203188190a025beb4a75242bc',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            input: [],
+            instructions: null,
+            max_output_tokens: null,
+            model: 'gpt-4o-2024-07-18',
+            output: [
+              {
+                id: 'msg_67c97c02656c81908e080dfdf4a03cd1',
+                type: 'message',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  { type: 'output_text', text: 'answer text', annotations: [] },
+                ],
+              },
+            ],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: { effort: null, summary: null },
+            store: true,
+            temperature: 1,
+            text: { format: { type: 'text' } },
+            tool_choice: 'auto',
+            tools: [],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 120,
+              input_tokens_details: {
+                cached_tokens: 0,
+                orchestration_input_tokens: 40,
+                orchestration_input_cached_tokens: 10,
+              },
+              output_tokens: 80,
+              output_tokens_details: {
+                reasoning_tokens: 0,
+                orchestration_output_tokens: 25,
+              },
+              total_tokens: 265,
+            },
+            user: null,
+            metadata: {},
+          },
+        };
+
+        const result = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        // Sakana-style orchestration usage is surfaced via provider metadata so
+        // downstream consumers (e.g. the AI Gateway) can bill it.
+        expect(result.providerMetadata?.openai.usage).toStrictEqual({
+          orchestrationInputTokens: 40,
+          orchestrationInputCachedTokens: 10,
+          orchestrationOutputTokens: 25,
+        });
+      });
+
       it('should extract response id metadata ', async () => {
         const result = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -47,6 +47,7 @@ import {
 } from './openai-responses-options';
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
+import type { ResponsesUsageProviderMetadata } from './openai-responses-provider-metadata';
 
 export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
   readonly specificationVersion = 'v2';
@@ -687,6 +688,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
 
     const usage = response.usage!; // defined when there is no error
 
+    const orchestrationUsage = getOrchestrationUsageMetadata(usage);
+    if (orchestrationUsage != null) {
+      providerMetadata[providerKey].usage = orchestrationUsage;
+    }
+
     return {
       content,
       finishReason: mapOpenAIResponseFinishReason({
@@ -790,6 +796,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
     > = {};
 
     let serviceTier: string | undefined;
+    let orchestrationUsage: ResponsesUsageProviderMetadata | undefined;
 
     return {
       stream: response.pipeThrough(
@@ -1270,6 +1277,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               if (typeof value.response.service_tier === 'string') {
                 serviceTier = value.response.service_tier;
               }
+              orchestrationUsage = getOrchestrationUsageMetadata(
+                value.response.usage,
+              );
             } else if (isResponseAnnotationAddedChunk(value)) {
               ongoingAnnotations.push(value.annotation);
               if (value.annotation.type === 'url_citation') {
@@ -1321,6 +1331,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
 
             if (serviceTier !== undefined) {
               providerMetadata[providerKey].serviceTier = serviceTier;
+            }
+
+            if (orchestrationUsage != null) {
+              providerMetadata[providerKey].usage = orchestrationUsage;
             }
 
             controller.enqueue({
@@ -1435,4 +1449,47 @@ function mapWebSearchOutput(
         },
       };
   }
+}
+
+/**
+ * Extracts orchestration token usage details (e.g. Sakana-style orchestration)
+ * from the Responses API usage so they can be surfaced via provider metadata.
+ * Returns `undefined` when no orchestration usage is present.
+ */
+function getOrchestrationUsageMetadata(
+  usage:
+    | {
+        input_tokens_details?: {
+          orchestration_input_tokens?: number | null;
+          orchestration_input_cached_tokens?: number | null;
+        } | null;
+        output_tokens_details?: {
+          orchestration_output_tokens?: number | null;
+        } | null;
+      }
+    | null
+    | undefined,
+): ResponsesUsageProviderMetadata | undefined {
+  const orchestrationInputTokens =
+    usage?.input_tokens_details?.orchestration_input_tokens;
+  const orchestrationInputCachedTokens =
+    usage?.input_tokens_details?.orchestration_input_cached_tokens;
+  const orchestrationOutputTokens =
+    usage?.output_tokens_details?.orchestration_output_tokens;
+
+  if (
+    orchestrationInputTokens == null &&
+    orchestrationInputCachedTokens == null &&
+    orchestrationOutputTokens == null
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(orchestrationInputTokens != null && { orchestrationInputTokens }),
+    ...(orchestrationInputCachedTokens != null && {
+      orchestrationInputCachedTokens,
+    }),
+    ...(orchestrationOutputTokens != null && { orchestrationOutputTokens }),
+  };
 }

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -15,6 +15,18 @@ export type ResponsesProviderMetadata = {
   responseId: string | null | undefined;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
+  /**
+   * Orchestration token usage details (e.g. Sakana-style orchestration) that
+   * the Responses API reports alongside the standard usage. Surfaced here so
+   * downstream consumers (e.g. the AI Gateway) can bill it.
+   */
+  usage?: ResponsesUsageProviderMetadata;
+};
+
+export type ResponsesUsageProviderMetadata = {
+  orchestrationInputTokens?: number;
+  orchestrationInputCachedTokens?: number;
+  orchestrationOutputTokens?: number;
 };
 
 export type ResponsesReasoningProviderMetadata = {


### PR DESCRIPTION
Backport of #16290 (and its v6.0 backport #16292) to the `release-v5.0` branch.

## Adaptation for v5.0

The original change relies on `usage.raw` (introduced with `LanguageModelV3Usage` in v6) to carry Sakana-style orchestration token usage through to downstream consumers. `release-v5.0` uses `LanguageModelV2Usage`, which has **no `raw` field** — its contract is that additional usage info is surfaced via provider metadata.

This backport therefore:

- Extends the Responses API zod schemas (chunk + response) with the orchestration token detail fields so they are not stripped during parsing.
- Surfaces them under `providerMetadata.openai.usage` (`orchestrationInputTokens`, `orchestrationInputCachedTokens`, `orchestrationOutputTokens`) in both `doGenerate` and `doStream`, so downstream consumers (e.g. the AI Gateway) can bill them.
- Adds a regression test asserting the orchestration fields appear in provider metadata.

`providerMetadata.<provider>.usage` matches existing v5.0 convention — anthropic, amazon-bedrock, perplexity already nest token data under `.usage`.