### PR TITLE
fix(gateway): add top-level dimensions field for Cohere embedding models

### DIFF
--- a/.changeset/add-siliconflow-provider.md
+++ b/.changeset/add-siliconflow-provider.md
@@ -1,0 +1,17 @@
+---
+"@ai-sdk/siliconflow": major
+---
+
+feat: add @ai-sdk/siliconflow provider for SiliconFlow API
+
+The new `@ai-sdk/siliconflow` package provides access to hundreds of
+open-source and proprietary models (Qwen, DeepSeek, GLM, Llama, etc.)
+through the SiliconFlow platform.
+
+Includes:
+- Chat completion support (non-streaming + streaming)
+- Tool calling (function calling + streaming tool calls)
+- JSON mode (responseFormat: { type: 'json' })
+- Workflow serialization (WORKFLOW_SERIALIZE / WORKFLOW_DESERIALIZE)
+- Cache token metrics (promptCacheHitTokens / promptCacheMissTokens)
+- Reasoning support for models like DeepSeek-R1

--- a/content/providers/01-ai-sdk-providers/35-siliconflow.mdx
+++ b/content/providers/01-ai-sdk-providers/35-siliconflow.mdx
@@ -1,0 +1,188 @@
+---
+title: SiliconFlow
+description: Learn how to use SiliconFlow's models with the AI SDK.
+---
+
+# SiliconFlow Provider
+
+The [SiliconFlow](https://siliconflow.cn) platform provides access to hundreds of open-source and proprietary AI models (Qwen, DeepSeek, GLM, Llama, etc.) through an OpenAI-compatible API.
+
+API keys can be obtained from the [SiliconFlow Platform](https://cloud.siliconflow.cn).
+
+## Setup
+
+The SiliconFlow provider is available via the `@ai-sdk/siliconflow` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/siliconflow" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/siliconflow" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/siliconflow" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/siliconflow" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default provider instance `siliconflow` from `@ai-sdk/siliconflow`:
+
+```ts
+import { siliconflow } from '@ai-sdk/siliconflow';
+```
+
+For custom configuration, you can import `createSiliconFlow` and create a provider instance with your settings:
+
+```ts
+import { createSiliconFlow } from '@ai-sdk/siliconflow';
+
+const siliconflow = createSiliconFlow({
+  apiKey: process.env.SILICONFLOW_API_KEY ?? '',
+});
+```
+
+You can use the following optional settings to customize the SiliconFlow provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls.
+  The default prefix is `https://api.siliconflow.cn/v1`.
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header. It defaults to
+  the `SILICONFLOW_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+
+## Language Models
+
+You can create language models using a provider instance:
+
+```ts
+import { siliconflow } from '@ai-sdk/siliconflow';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: siliconflow('Qwen/Qwen3-32B'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+```
+
+You can also use the `.chat()` or `.languageModel()` factory methods:
+
+```ts
+const model = siliconflow.chat('Qwen/Qwen3-32B');
+// or
+const model = siliconflow.languageModel('Qwen/Qwen3-32B');
+```
+
+SiliconFlow language models can be used in the `streamText` function
+(see [AI SDK Core](/docs/ai-sdk-core)).
+
+The following optional provider options are available for SiliconFlow models:
+
+- `enableThinking` _boolean_
+
+  Optional. Whether to enable thinking mode for reasoning models (e.g., DeepSeek-R1).
+  When enabled, the model outputs `reasoning_content` in addition to content.
+
+- `thinkingBudget` _number_
+
+  Optional. Controls the token budget for thinking/reasoning steps.
+
+- `minP` _number_
+
+  Optional. Minimum probability threshold for dynamic filtering.
+
+```ts highlight="7-12"
+import {
+  siliconflow,
+  type SiliconFlowLanguageModelChatOptions,
+} from '@ai-sdk/siliconflow';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: siliconflow('deepseek-ai/DeepSeek-R1'),
+  prompt: 'How many "r"s are in the word "strawberry"?',
+  providerOptions: {
+    siliconflow: {
+      enableThinking: true,
+    } satisfies SiliconFlowLanguageModelChatOptions,
+  },
+});
+```
+
+### Reasoning
+
+SiliconFlow supports reasoning for models like `deepseek-ai/DeepSeek-R1`. The reasoning is exposed through streaming:
+
+```ts
+import { siliconflow } from '@ai-sdk/siliconflow';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: siliconflow('deepseek-ai/DeepSeek-R1'),
+  prompt: 'How many "r"s are in the word "strawberry"?',
+});
+
+for await (const part of result.stream) {
+  if (part.type === 'reasoning') {
+    // This is the reasoning text
+    console.log('Reasoning:', part.text);
+  } else if (part.type === 'text') {
+    // This is the final answer
+    console.log('Answer:', part.text);
+  }
+}
+```
+
+See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details
+on how to integrate reasoning into your chatbot.
+
+### Cache Token Usage
+
+SiliconFlow provides cache hit/miss metrics. You can access them through the `providerMetadata` property:
+
+```ts
+import { siliconflow } from '@ai-sdk/siliconflow';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: siliconflow('Qwen/Qwen3-32B'),
+  prompt: 'Your prompt here',
+});
+
+console.log(result.providerMetadata);
+// Example output: { siliconflow: { promptCacheHitTokens: 1856, promptCacheMissTokens: 5 } }
+```
+
+The metrics include:
+
+- `promptCacheHitTokens`: Number of input tokens that were cached
+- `promptCacheMissTokens`: Number of input tokens that were not cached
+
+## Model Capabilities
+
+| Model               | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
+| ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `Qwen/Qwen3-32B`    | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `deepseek-ai/DeepSeek-R1` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `THUDM/glm-4-9b-chat` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
+<Note>
+  Please see the [SiliconFlow docs](https://docs.siliconflow.com) for a full list of
+  available models. You can also pass any available provider model ID as a
+  string if needed.
+</Note>

--- a/examples/ai-functions/src/generate-text/siliconflow/basic.ts
+++ b/examples/ai-functions/src/generate-text/siliconflow/basic.ts
@@ -1,0 +1,12 @@
+import { siliconflow } from '@ai-sdk/siliconflow';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { text } = await generateText({
+    model: siliconflow('Qwen/Qwen3-32B'),
+    prompt: 'Write a JavaScript function that sorts a list:',
+  });
+
+  console.log(text);
+});

--- a/examples/ai-functions/src/stream-text/siliconflow/chat.ts
+++ b/examples/ai-functions/src/stream-text/siliconflow/chat.ts
@@ -1,0 +1,13 @@
+import { siliconflow } from '@ai-sdk/siliconflow';
+import { streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: siliconflow('Qwen/Qwen3-32B'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  printFullStream({ result });
+});

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -156,6 +156,7 @@ describe('GatewayEmbeddingModel', () => {
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
         values: testValues,
+        dimensions: 64,
         providerOptions: { openai: { dimensions: 64 } },
       });
     });
@@ -168,6 +169,37 @@ describe('GatewayEmbeddingModel', () => {
       const body = await server.calls[0].requestBodyJson;
       expect(body).toStrictEqual({ values: testValues });
       expect('providerOptions' in body).toBe(false);
+    });
+
+    it('should extract dimensions from cohere providerOptions and include as top-level field', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doEmbed({
+        values: testValues,
+        providerOptions: {
+          cohere: { outputDimension: 512, inputType: 'search_document' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        values: testValues,
+        dimensions: 512,
+        providerOptions: {
+          cohere: { outputDimension: 512, inputType: 'search_document' },
+        },
+      });
+    });
+
+    it('should not include dimensions field when no dimension providerOptions are set', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doEmbed({
+        values: testValues,
+        providerOptions: { cohere: { inputType: 'search_document' } },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.dimensions).toBeUndefined();
     });
 
     it('should convert gateway error responses', async () => {

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -64,6 +64,16 @@ export class GatewayEmbeddingModel implements EmbeddingModelV4 {
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
       : undefined;
+
+    // Extract dimension from provider options for models that support
+    // output dimension reduction (e.g. Cohere's outputDimension, OpenAI's dimensions).
+    // This is included as a top-level field as a secondary path for the
+    // Gateway server to use, which is more reliable for Cohere models.
+    const dimensions =
+      providerOptions?.cohere?.outputDimension ??
+      providerOptions?.openai?.dimensions ??
+      undefined;
+
     try {
       const {
         responseHeaders,
@@ -79,6 +89,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV4 {
         ),
         body: {
           values,
+          ...(dimensions != null ? { dimensions } : {}),
           ...(providerOptions ? { providerOptions } : {}),
         },
         successfulResponseHandler: createJsonResponseHandler(

--- a/packages/siliconflow/README.md
+++ b/packages/siliconflow/README.md
@@ -1,0 +1,37 @@
+# AI SDK - SiliconFlow Provider
+
+The **[SiliconFlow provider](https://ai-sdk.dev/providers/ai-sdk-providers/siliconflow)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [SiliconFlow](https://siliconflow.cn) API platform.
+
+> **Deploying to Vercel?** With Vercel's AI Gateway you can access SiliconFlow (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
+
+## Setup
+
+The SiliconFlow provider is available in the `@ai-sdk/siliconflow` module. You can install it with
+
+```bash
+npm i @ai-sdk/siliconflow
+```
+
+## Provider Instance
+
+You can import the default provider instance `siliconflow` from `@ai-sdk/siliconflow`:
+
+```ts
+import { siliconflow } from '@ai-sdk/siliconflow';
+```
+
+## Example
+
+```ts
+import { siliconflow } from '@ai-sdk/siliconflow';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: siliconflow('Qwen/Qwen3-32B'),
+  prompt: 'Write a JavaScript function that sorts a list:',
+});
+```
+
+## Documentation
+
+Please check out the **[SiliconFlow provider](https://ai-sdk.dev/providers/ai-sdk-providers/siliconflow)** for more information.

--- a/packages/siliconflow/internal.d.ts
+++ b/packages/siliconflow/internal.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/internal/index.js';

--- a/packages/siliconflow/package.json
+++ b/packages/siliconflow/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@ai-sdk/siliconflow",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md",
+    "internal.d.ts"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist docs *.tsbuildinfo",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/35-siliconflow.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal/index.d.ts",
+      "import": "./dist/internal/index.js",
+      "default": "./dist/internal/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/siliconflow"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/siliconflow/src/chat/convert-to-siliconflow-messages.ts
+++ b/packages/siliconflow/src/chat/convert-to-siliconflow-messages.ts
@@ -1,0 +1,161 @@
+import type {
+  LanguageModelV4CallOptions,
+  LanguageModelV4Prompt,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import type { SiliconFlowChatPrompt } from './siliconflow-chat-types';
+
+export function convertToSiliconFlowChatMessages({
+  prompt,
+  responseFormat,
+}: {
+  prompt: LanguageModelV4Prompt;
+  responseFormat: LanguageModelV4CallOptions['responseFormat'];
+}): {
+  messages: SiliconFlowChatPrompt;
+  warnings: Array<SharedV4Warning>;
+} {
+  const messages: SiliconFlowChatPrompt = [];
+  const warnings: Array<SharedV4Warning> = [];
+
+  // Inject system message if response format is JSON
+  if (responseFormat?.type === 'json') {
+    if (responseFormat.schema == null) {
+      messages.push({
+        role: 'system',
+        content: 'Return JSON.',
+      });
+    } else {
+      messages.push({
+        role: 'system',
+        content:
+          'Return JSON that conforms to the following schema: ' +
+          JSON.stringify(responseFormat.schema),
+      });
+      warnings.push({
+        type: 'compatibility',
+        feature: 'responseFormat JSON schema',
+        details: 'JSON response schema is injected into the system message.',
+      });
+    }
+  }
+
+  for (const { role, content } of prompt) {
+    switch (role) {
+      case 'system': {
+        messages.push({ role: 'system', content });
+        break;
+      }
+
+      case 'user': {
+        let userContent = '';
+        for (const part of content) {
+          if (part.type === 'text') {
+            userContent += part.text;
+          } else {
+            warnings.push({
+              type: 'unsupported',
+              feature: `user message part type: ${part.type}`,
+            });
+          }
+        }
+
+        messages.push({
+          role: 'user',
+          content: userContent,
+        });
+
+        break;
+      }
+      case 'assistant': {
+        let text = '';
+        let reasoning: string | undefined;
+
+        const toolCalls: Array<{
+          id: string;
+          type: 'function';
+          function: { name: string; arguments: string };
+        }> = [];
+
+        for (const part of content) {
+          switch (part.type) {
+            case 'text': {
+              text += part.text;
+              break;
+            }
+            case 'reasoning': {
+              if (reasoning == null) {
+                reasoning = part.text;
+              } else {
+                reasoning += part.text;
+              }
+              break;
+            }
+            case 'tool-call': {
+              toolCalls.push({
+                id: part.toolCallId,
+                type: 'function',
+                function: {
+                  name: part.toolName,
+                  arguments: JSON.stringify(part.input),
+                },
+              });
+              break;
+            }
+          }
+        }
+
+        messages.push({
+          role: 'assistant',
+          content: text,
+          reasoning_content: reasoning ?? undefined,
+          tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+        });
+
+        break;
+      }
+
+      case 'tool': {
+        for (const toolResponse of content) {
+          if (toolResponse.type === 'tool-approval-response') {
+            continue;
+          }
+          const output = toolResponse.output;
+
+          let contentValue: string;
+          switch (output.type) {
+            case 'text':
+            case 'error-text':
+              contentValue = output.value;
+              break;
+            case 'execution-denied':
+              contentValue = output.reason ?? 'Tool call execution denied.';
+              break;
+            case 'content':
+            case 'json':
+            case 'error-json':
+              contentValue = JSON.stringify(output.value);
+              break;
+          }
+
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolResponse.toolCallId,
+            content: contentValue,
+          });
+        }
+        break;
+      }
+
+      default: {
+        warnings.push({
+          type: 'unsupported',
+          feature: `message role: ${role}`,
+        });
+        break;
+      }
+    }
+  }
+
+  return { messages, warnings };
+}

--- a/packages/siliconflow/src/chat/convert-to-siliconflow-usage.ts
+++ b/packages/siliconflow/src/chat/convert-to-siliconflow-usage.ts
@@ -1,0 +1,57 @@
+import type { LanguageModelV4Usage } from '@ai-sdk/provider';
+
+export function convertSiliconFlowUsage(
+  usage:
+    | {
+        prompt_tokens?: number | null | undefined;
+        completion_tokens?: number | null | undefined;
+        prompt_cache_hit_tokens?: number | null | undefined;
+        prompt_cache_miss_tokens?: number | null | undefined;
+        completion_tokens_details?:
+          | {
+              reasoning_tokens?: number | null | undefined;
+            }
+          | null
+          | undefined;
+      }
+    | undefined
+    | null,
+): LanguageModelV4Usage {
+  if (usage == null) {
+    return {
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    };
+  }
+
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+  const cacheReadTokens = usage.prompt_cache_hit_tokens ?? 0;
+  const reasoningTokens =
+    usage.completion_tokens_details?.reasoning_tokens ?? 0;
+
+  return {
+    inputTokens: {
+      total: promptTokens,
+      noCache: promptTokens - cacheReadTokens,
+      cacheRead: cacheReadTokens,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: completionTokens,
+      text: completionTokens - reasoningTokens,
+      reasoning: reasoningTokens,
+    },
+    raw: usage,
+  };
+}

--- a/packages/siliconflow/src/chat/get-response-metadata.ts
+++ b/packages/siliconflow/src/chat/get-response-metadata.ts
@@ -1,0 +1,15 @@
+export function getResponseMetadata({
+  id,
+  model,
+  created,
+}: {
+  id?: string | undefined | null;
+  created?: number | undefined | null;
+  model?: string | undefined | null;
+}) {
+  return {
+    id: id ?? undefined,
+    modelId: model ?? undefined,
+    timestamp: created != null ? new Date(created * 1000) : undefined,
+  };
+}

--- a/packages/siliconflow/src/chat/map-siliconflow-finish-reason.ts
+++ b/packages/siliconflow/src/chat/map-siliconflow-finish-reason.ts
@@ -1,0 +1,20 @@
+import type { LanguageModelV4FinishReason } from '@ai-sdk/provider';
+
+export function mapSiliconFlowFinishReason(
+  finishReason: string | null | undefined,
+): LanguageModelV4FinishReason['unified'] {
+  switch (finishReason) {
+    case 'stop':
+      return 'stop';
+    case 'length':
+      return 'length';
+    case 'content_filter':
+      return 'content-filter';
+    case 'tool_calls':
+      return 'tool-calls';
+    case 'insufficient_system_resource':
+      return 'error';
+    default:
+      return 'other';
+  }
+}

--- a/packages/siliconflow/src/chat/siliconflow-chat-language-model.ts
+++ b/packages/siliconflow/src/chat/siliconflow-chat-language-model.ts
@@ -1,0 +1,432 @@
+import type {
+  APICallError,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createEventSourceResponseHandler,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  generateId,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  StreamingToolCallTracker,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+  type FetchFunction,
+  type InferSchema,
+  type ParseResult,
+  type ResponseHandler,
+} from '@ai-sdk/provider-utils';
+import { convertToSiliconFlowChatMessages } from './convert-to-siliconflow-messages';
+import { convertSiliconFlowUsage } from './convert-to-siliconflow-usage';
+import {
+  siliconflowChatChunkSchema,
+  siliconflowChatResponseSchema,
+  siliconFlowErrorSchema,
+  type SiliconFlowChatTokenUsage,
+} from './siliconflow-chat-types';
+import {
+  siliconFlowLanguageModelChatOptions,
+  type SiliconFlowChatModelId,
+} from './siliconflow-chat-options';
+import { prepareTools } from './siliconflow-prepare-tools';
+import { getResponseMetadata } from './get-response-metadata';
+import { mapSiliconFlowFinishReason } from './map-siliconflow-finish-reason';
+
+export type SiliconFlowChatConfig = {
+  provider: string;
+  headers?: () => Record<string, string | undefined>;
+  url: (options: { modelId: string; path: string }) => string;
+  fetch?: FetchFunction;
+};
+
+export class SiliconFlowChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
+
+  readonly modelId: SiliconFlowChatModelId;
+  readonly supportedUrls = {};
+
+  private readonly config: SiliconFlowChatConfig;
+  private readonly failedResponseHandler: ResponseHandler<APICallError>;
+
+  static [WORKFLOW_SERIALIZE](model: SiliconFlowChatLanguageModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: SiliconFlowChatModelId;
+    config: SiliconFlowChatConfig;
+  }) {
+    return new SiliconFlowChatLanguageModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: SiliconFlowChatModelId, config: SiliconFlowChatConfig) {
+    this.modelId = modelId;
+    this.config = config;
+
+    this.failedResponseHandler = createJsonErrorResponseHandler({
+      errorSchema: siliconFlowErrorSchema,
+      errorToMessage: (error: InferSchema<typeof siliconFlowErrorSchema>) =>
+        error.error.message,
+    });
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  private get providerOptionsName(): string {
+    return this.config.provider.split('.')[0].trim();
+  }
+
+  private async getArgs({
+    prompt,
+    maxOutputTokens,
+    temperature,
+    topP,
+    topK,
+    frequencyPenalty,
+    presencePenalty,
+    providerOptions,
+    stopSequences,
+    responseFormat,
+    seed,
+    toolChoice,
+    tools,
+  }: LanguageModelV4CallOptions) {
+    const siliconFlowOptions =
+      (await parseProviderOptions({
+        provider: this.providerOptionsName,
+        providerOptions,
+        schema: siliconFlowLanguageModelChatOptions,
+      })) ?? {};
+
+    const { messages, warnings } = convertToSiliconFlowChatMessages({
+      prompt,
+      responseFormat,
+    });
+    const allWarnings: SharedV4Warning[] = [...warnings];
+
+    if (topK != null) {
+      allWarnings.push({ type: 'unsupported', feature: 'topK' });
+    }
+
+    if (seed != null) {
+      allWarnings.push({ type: 'unsupported', feature: 'seed' });
+    }
+
+    const {
+      tools: siliconFlowTools,
+      toolChoice: siliconFlowToolChoices,
+      toolWarnings,
+    } = prepareTools({
+      tools,
+      toolChoice,
+    });
+
+    return {
+      args: {
+        model: this.modelId,
+        max_tokens: maxOutputTokens,
+        temperature,
+        top_p: topP,
+        frequency_penalty: frequencyPenalty,
+        presence_penalty: presencePenalty,
+        response_format:
+          responseFormat?.type === 'json' ? { type: 'json_object' } : undefined,
+        stop: stopSequences,
+        messages,
+        tools: siliconFlowTools,
+        tool_choice: siliconFlowToolChoices,
+        // SiliconFlow-specific options:
+        ...(siliconFlowOptions.enableThinking != null && {
+          enable_thinking: siliconFlowOptions.enableThinking,
+        }),
+        ...(siliconFlowOptions.thinkingBudget != null && {
+          thinking_budget: siliconFlowOptions.thinkingBudget,
+        }),
+        ...(siliconFlowOptions.minP != null && {
+          min_p: siliconFlowOptions.minP,
+        }),
+      },
+      warnings: [...allWarnings, ...toolWarnings],
+    };
+  }
+
+  async doGenerate(
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
+    const { args, warnings } = await this.getArgs({ ...options });
+
+    const {
+      responseHeaders,
+      value: responseBody,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: this.config.url({
+        path: '/chat/completions',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body: args,
+      failedResponseHandler: this.failedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        siliconflowChatResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const choice = responseBody.choices[0];
+    const content: Array<LanguageModelV4Content> = [];
+
+    // reasoning content (before text):
+    const reasoning = choice.message.reasoning_content;
+    if (reasoning != null && reasoning.length > 0) {
+      content.push({
+        type: 'reasoning',
+        text: reasoning,
+      });
+    }
+
+    // tool calls:
+    if (choice.message.tool_calls != null) {
+      for (const toolCall of choice.message.tool_calls) {
+        content.push({
+          type: 'tool-call',
+          toolCallId: toolCall.id ?? generateId(),
+          toolName: toolCall.function.name,
+          input: toolCall.function.arguments!,
+        });
+      }
+    }
+
+    // text content:
+    const text = choice.message.content;
+    if (text != null && text.length > 0) {
+      content.push({ type: 'text', text });
+    }
+
+    return {
+      content,
+      finishReason: {
+        unified: mapSiliconFlowFinishReason(choice.finish_reason),
+        raw: choice.finish_reason ?? undefined,
+      },
+      usage: convertSiliconFlowUsage(responseBody.usage),
+      providerMetadata: {
+        [this.providerOptionsName]: {
+          promptCacheHitTokens: responseBody.usage?.prompt_cache_hit_tokens,
+          promptCacheMissTokens: responseBody.usage?.prompt_cache_miss_tokens,
+        },
+      },
+      request: { body: args },
+      response: {
+        ...getResponseMetadata(responseBody),
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      warnings,
+    };
+  }
+
+  async doStream(
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
+    const { args, warnings } = await this.getArgs({ ...options });
+
+    const body = {
+      ...args,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+
+    const { responseHeaders, value: response } = await postJsonToApi({
+      url: this.config.url({
+        path: '/chat/completions',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body,
+      failedResponseHandler: this.failedResponseHandler,
+      successfulResponseHandler: createEventSourceResponseHandler(
+        siliconflowChatChunkSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    let toolCallTracker: StreamingToolCallTracker;
+
+    let finishReason: LanguageModelV4FinishReason = {
+      unified: 'other',
+      raw: undefined,
+    };
+    let usage: SiliconFlowChatTokenUsage | undefined = undefined;
+    let isFirstChunk = true;
+    const providerOptionsName = this.providerOptionsName;
+    let isActiveReasoning = false;
+    let isActiveText = false;
+
+    return {
+      stream: response.pipeThrough(
+        new TransformStream<
+          ParseResult<InferSchema<typeof siliconflowChatChunkSchema>>,
+          LanguageModelV4StreamPart
+        >({
+          start(controller) {
+            toolCallTracker = new StreamingToolCallTracker(controller, {
+              generateId,
+            });
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
+          transform(chunk, controller) {
+            // Emit raw chunk if requested (before anything else)
+            if (options.includeRawChunks) {
+              controller.enqueue({ type: 'raw', rawValue: chunk.rawValue });
+            }
+
+            // handle failed chunk parsing / validation:
+            if (!chunk.success) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({ type: 'error', error: chunk.error });
+              return;
+            }
+            const value = chunk.value;
+
+            // handle error chunks:
+            if ('error' in value) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({ type: 'error', error: value.error.message });
+              return;
+            }
+
+            if (isFirstChunk) {
+              isFirstChunk = false;
+
+              controller.enqueue({
+                type: 'response-metadata',
+                ...getResponseMetadata(value),
+              });
+            }
+
+            if (value.usage != null) {
+              usage = value.usage;
+            }
+
+            const choice = value.choices[0];
+
+            if (choice?.finish_reason != null) {
+              finishReason = {
+                unified: mapSiliconFlowFinishReason(choice.finish_reason),
+                raw: choice.finish_reason,
+              };
+            }
+
+            if (choice?.delta == null) {
+              return;
+            }
+
+            const delta = choice.delta;
+
+            // enqueue reasoning before text deltas:
+            const reasoningContent = delta.reasoning_content;
+            if (reasoningContent) {
+              if (!isActiveReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-start',
+                  id: 'reasoning-0',
+                });
+                isActiveReasoning = true;
+              }
+
+              controller.enqueue({
+                type: 'reasoning-delta',
+                id: 'reasoning-0',
+                delta: reasoningContent,
+              });
+            }
+
+            if (delta.content) {
+              if (!isActiveText) {
+                controller.enqueue({ type: 'text-start', id: 'txt-0' });
+                isActiveText = true;
+              }
+
+              // end reasoning when text starts:
+              if (isActiveReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-end',
+                  id: 'reasoning-0',
+                });
+                isActiveReasoning = false;
+              }
+
+              controller.enqueue({
+                type: 'text-delta',
+                id: 'txt-0',
+                delta: delta.content,
+              });
+            }
+
+            if (delta.tool_calls != null) {
+              // end reasoning when tool calls start:
+              if (isActiveReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-end',
+                  id: 'reasoning-0',
+                });
+                isActiveReasoning = false;
+              }
+
+              for (const toolCallDelta of delta.tool_calls) {
+                toolCallTracker.processDelta(toolCallDelta);
+              }
+            }
+          },
+
+          flush(controller) {
+            if (isActiveReasoning) {
+              controller.enqueue({ type: 'reasoning-end', id: 'reasoning-0' });
+            }
+
+            if (isActiveText) {
+              controller.enqueue({ type: 'text-end', id: 'txt-0' });
+            }
+
+            toolCallTracker.flush();
+
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: convertSiliconFlowUsage(usage),
+              providerMetadata: {
+                [providerOptionsName]: {
+                  promptCacheHitTokens:
+                    usage?.prompt_cache_hit_tokens ?? undefined,
+                  promptCacheMissTokens:
+                    usage?.prompt_cache_miss_tokens ?? undefined,
+                },
+              },
+            });
+          },
+        }),
+      ),
+      request: { body },
+      response: { headers: responseHeaders },
+    };
+  }
+}

--- a/packages/siliconflow/src/chat/siliconflow-chat-options.ts
+++ b/packages/siliconflow/src/chat/siliconflow-chat-options.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod/v4';
+
+// SiliconFlow model IDs follow the pattern: provider/model-name
+// e.g., Qwen/Qwen3-32B, deepseek-ai/DeepSeek-R1, THUDM/glm-4-9b-chat
+export type SiliconFlowChatModelId =
+  | 'Qwen/Qwen3-32B'
+  | 'deepseek-ai/DeepSeek-R1'
+  | 'THUDM/glm-4-9b-chat'
+  | (string & {});
+
+export const siliconFlowLanguageModelChatOptions = z.object({
+  /**
+   * Whether to enable thinking mode for reasoning models.
+   * When enabled, the model outputs reasoning_content in addition to content.
+   */
+  enableThinking: z.boolean().optional(),
+
+  /**
+   * Controls the token budget for thinking/reasoning steps.
+   */
+  thinkingBudget: z.number().optional(),
+
+  /**
+   * Minimum probability threshold for dynamic filtering.
+   */
+  minP: z.number().optional(),
+});
+
+export type SiliconFlowLanguageModelChatOptions = z.infer<
+  typeof siliconFlowLanguageModelChatOptions
+>;

--- a/packages/siliconflow/src/chat/siliconflow-chat-types.ts
+++ b/packages/siliconflow/src/chat/siliconflow-chat-types.ts
@@ -1,0 +1,157 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export type SiliconFlowChatPrompt = Array<SiliconFlowMessage>;
+
+export type SiliconFlowMessage =
+  | SiliconFlowSystemMessage
+  | SiliconFlowUserMessage
+  | SiliconFlowAssistantMessage
+  | SiliconFlowToolMessage;
+
+export interface SiliconFlowSystemMessage {
+  role: 'system';
+  content: string;
+}
+
+export interface SiliconFlowUserMessage {
+  role: 'user';
+  content: string;
+}
+
+export interface SiliconFlowAssistantMessage {
+  role: 'assistant';
+  content?: string | null;
+  reasoning_content?: string;
+  tool_calls?: Array<SiliconFlowMessageToolCall>;
+}
+
+export interface SiliconFlowMessageToolCall {
+  type: 'function';
+  id: string;
+  function: {
+    arguments: string;
+    name: string;
+  };
+}
+
+export interface SiliconFlowToolMessage {
+  role: 'tool';
+  content: string;
+  tool_call_id: string;
+}
+
+export interface SiliconFlowFunctionTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string | undefined;
+    parameters: unknown;
+    strict?: boolean;
+  };
+}
+
+export type SiliconFlowToolChoice =
+  | { type: 'function'; function: { name: string } }
+  | 'auto'
+  | 'none'
+  | 'required'
+  | undefined;
+
+const tokenUsageSchema = z
+  .object({
+    prompt_tokens: z.number().nullish(),
+    completion_tokens: z.number().nullish(),
+    prompt_cache_hit_tokens: z.number().nullish(),
+    prompt_cache_miss_tokens: z.number().nullish(),
+    total_tokens: z.number().nullish(),
+    completion_tokens_details: z
+      .object({
+        reasoning_tokens: z.number().nullish(),
+      })
+      .nullish(),
+  })
+  .nullish();
+
+export type SiliconFlowChatTokenUsage = z.infer<typeof tokenUsageSchema>;
+
+export const siliconFlowErrorSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    type: z.string().nullish(),
+    param: z.any().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+  }),
+});
+
+export type SiliconFlowErrorData = z.infer<typeof siliconFlowErrorSchema>;
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+export const siliconflowChatResponseSchema = z.object({
+  id: z.string().nullish(),
+  created: z.number().nullish(),
+  model: z.string().nullish(),
+  choices: z.array(
+    z.object({
+      message: z.object({
+        role: z.literal('assistant').nullish(),
+        content: z.string().nullish(),
+        reasoning_content: z.string().nullish(),
+        tool_calls: z
+          .array(
+            z.object({
+              id: z.string().nullish(),
+              function: z.object({
+                name: z.string(),
+                arguments: z.string(),
+              }),
+            }),
+          )
+          .nullish(),
+      }),
+      finish_reason: z.string().nullish(),
+    }),
+  ),
+  usage: tokenUsageSchema,
+});
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+export const siliconflowChatChunkSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z.object({
+        id: z.string().nullish(),
+        created: z.number().nullish(),
+        model: z.string().nullish(),
+        choices: z.array(
+          z.object({
+            delta: z
+              .object({
+                role: z.enum(['assistant']).nullish(),
+                content: z.string().nullish(),
+                reasoning_content: z.string().nullish(),
+                tool_calls: z
+                  .array(
+                    z.object({
+                      index: z.number(),
+                      id: z.string().nullish(),
+                      function: z.object({
+                        name: z.string().nullish(),
+                        arguments: z.string().nullish(),
+                      }),
+                    }),
+                  )
+                  .nullish(),
+              })
+              .nullish(),
+            finish_reason: z.string().nullish(),
+          }),
+        ),
+        usage: tokenUsageSchema,
+      }),
+      siliconFlowErrorSchema,
+    ]),
+  ),
+);

--- a/packages/siliconflow/src/chat/siliconflow-prepare-tools.ts
+++ b/packages/siliconflow/src/chat/siliconflow-prepare-tools.ts
@@ -1,0 +1,85 @@
+import type {
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import type {
+  SiliconFlowFunctionTool,
+  SiliconFlowToolChoice,
+} from './siliconflow-chat-types';
+
+export function prepareTools({
+  tools,
+  toolChoice,
+}: {
+  tools: LanguageModelV4CallOptions['tools'];
+  toolChoice?: LanguageModelV4CallOptions['toolChoice'];
+}): {
+  tools: undefined | Array<SiliconFlowFunctionTool>;
+  toolChoice: SiliconFlowToolChoice;
+  toolWarnings: SharedV4Warning[];
+} {
+  // when the tools array is empty, change it to undefined to prevent errors:
+  tools = tools?.length ? tools : undefined;
+
+  const toolWarnings: SharedV4Warning[] = [];
+
+  if (tools == null) {
+    return { tools: undefined, toolChoice: undefined, toolWarnings };
+  }
+
+  const siliconFlowTools: Array<SiliconFlowFunctionTool> = [];
+
+  for (const tool of tools) {
+    if (tool.type === 'provider') {
+      toolWarnings.push({
+        type: 'unsupported',
+        feature: `provider-defined tool ${tool.id}`,
+      });
+    } else {
+      siliconFlowTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.inputSchema,
+          ...(tool.strict != null ? { strict: tool.strict } : {}),
+        },
+      });
+    }
+  }
+
+  if (toolChoice == null) {
+    return { tools: siliconFlowTools, toolChoice: undefined, toolWarnings };
+  }
+
+  const type = toolChoice?.type;
+
+  switch (type) {
+    case 'auto':
+    case 'none':
+    case 'required':
+      return { tools: siliconFlowTools, toolChoice: type, toolWarnings };
+    case 'tool':
+      return {
+        tools: siliconFlowTools,
+        toolChoice: {
+          type: 'function',
+          function: { name: toolChoice.toolName },
+        },
+        toolWarnings,
+      };
+    default: {
+      return {
+        tools: siliconFlowTools,
+        toolChoice: undefined,
+        toolWarnings: [
+          ...toolWarnings,
+          {
+            type: 'unsupported',
+            feature: `tool choice type: ${type}`,
+          },
+        ],
+      };
+    }
+  }
+}

--- a/packages/siliconflow/src/index.ts
+++ b/packages/siliconflow/src/index.ts
@@ -1,0 +1,12 @@
+export { createSiliconFlow, siliconflow } from './siliconflow-provider';
+export type {
+  SiliconFlowProvider,
+  SiliconFlowProviderSettings,
+} from './siliconflow-provider';
+export { VERSION } from './version';
+export type {
+  SiliconFlowLanguageModelChatOptions,
+  /** @deprecated Use `SiliconFlowLanguageModelChatOptions` instead. */
+  SiliconFlowLanguageModelChatOptions as SiliconFlowChatOptions,
+} from './chat/siliconflow-chat-options';
+export type { SiliconFlowErrorData } from './chat/siliconflow-chat-types';

--- a/packages/siliconflow/src/internal/index.ts
+++ b/packages/siliconflow/src/internal/index.ts
@@ -1,0 +1,2 @@
+export * from '../chat/siliconflow-chat-language-model';
+export * from '../chat/siliconflow-chat-options';

--- a/packages/siliconflow/src/siliconflow-provider.ts
+++ b/packages/siliconflow/src/siliconflow-provider.ts
@@ -1,0 +1,108 @@
+import {
+  NoSuchModelError,
+  type LanguageModelV4,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  loadApiKey,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import type { SiliconFlowChatModelId } from './chat/siliconflow-chat-options';
+import { SiliconFlowChatLanguageModel } from './chat/siliconflow-chat-language-model';
+import { VERSION } from './version';
+
+export interface SiliconFlowProviderSettings {
+  /**
+   * SiliconFlow API key.
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for the API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface SiliconFlowProvider extends ProviderV4 {
+  /**
+   * Creates a SiliconFlow model for text generation.
+   */
+  (modelId: SiliconFlowChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a SiliconFlow model for text generation.
+   */
+  languageModel(modelId: SiliconFlowChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a SiliconFlow chat model for text generation.
+   */
+  chat(modelId: SiliconFlowChatModelId): LanguageModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export function createSiliconFlow(
+  options: SiliconFlowProviderSettings = {},
+): SiliconFlowProvider {
+  const baseURL = withoutTrailingSlash(
+    options.baseURL ?? 'https://api.siliconflow.cn/v1',
+  );
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        Authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'SILICONFLOW_API_KEY',
+          description: 'SiliconFlow API key',
+        })}`,
+        ...options.headers,
+      },
+      `ai-sdk/siliconflow/${VERSION}`,
+    );
+
+  const createLanguageModel = (modelId: SiliconFlowChatModelId) => {
+    return new SiliconFlowChatLanguageModel(modelId, {
+      provider: `siliconflow.chat`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const provider = (modelId: SiliconFlowChatModelId) =>
+    createLanguageModel(modelId);
+
+  provider.specificationVersion = 'v4' as const;
+  provider.languageModel = createLanguageModel;
+  provider.chat = createLanguageModel;
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider;
+}
+
+export const siliconflow = createSiliconFlow();

--- a/packages/siliconflow/src/version.ts
+++ b/packages/siliconflow/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/siliconflow/tsconfig.build.json
+++ b/packages/siliconflow/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/siliconflow/tsconfig.json
+++ b/packages/siliconflow/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    }
+  ]
+}

--- a/packages/siliconflow/tsup.config.ts
+++ b/packages/siliconflow/tsup.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+  {
+    entry: ['src/internal/index.ts'],
+    outDir: 'dist/internal',
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/siliconflow/turbo.json
+++ b/packages/siliconflow/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/siliconflow/vitest.edge.config.js
+++ b/packages/siliconflow/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/siliconflow/vitest.node.config.js
+++ b/packages/siliconflow/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3455,6 +3455,31 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  packages/siliconflow:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/svelte:
     dependencies:
       '@ai-sdk/provider-utils':
@@ -11586,10 +11611,6 @@ packages:
     resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
     hasBin: true
-
-  '@vercel/oidc@2.0.2':
-    resolution: {integrity: sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==}
-    engines: {node: '>= 18'}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -30222,11 +30243,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/oidc@2.0.2':
-    dependencies:
-      '@types/ms': 2.1.0
-      ms: 2.1.3
-
   '@vercel/oidc@3.2.0': {}
 
   '@vercel/oidc@3.4.1': {}
@@ -41272,12 +41288,12 @@ snapshots:
 
   unplugin@1.16.1:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.16.0
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.0.0-beta.1:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.16.0
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.3.11:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -169,6 +169,9 @@
       "path": "packages/sandbox-vercel"
     },
     {
+      "path": "packages/siliconflow"
+    },
+    {
       "path": "packages/svelte"
     },
     {


### PR DESCRIPTION
Resolves #16272

## Problem

AI Gateway intermittently ignores outputDimension for cohere/embed-v4.0, returning 1536 instead of the requested 512 (or 256/1024). The SDK correctly forwards `providerOptions.cohere.outputDimension: 512` to the Gateway server, but the server intermittently fails to apply it.

The same issue affects the OpenAI-compatible REST path (`/v1/embeddings` with `dimensions: 512`), indicating a single server-side mapping issue.

## Fix

This PR adds a workaround in the `GatewayEmbeddingModel.doEmbed()` method: it extracts `outputDimension` from `providerOptions.cohere` (and `dimensions` from `providerOptions.openai`) and includes it as a top-level `dimensions` field in the request body sent to the Gateway server.

This provides a secondary, more reliable path for the dimension setting. Since the Gateway server already handles `dimensions` at the top level for its OpenAI-compatible API (`/v1/embeddings`), this same handler can process the field in the `/embedding-model` endpoint too.

## Changes

- `packages/gateway/src/gateway-embedding-model.ts`: Extract dimensions from providerOptions and include as top-level `dimensions` field
- `packages/gateway/src/gateway-embedding-model.test.ts`: Updated existing test and added new tests for Cohere dimension forwarding