### PR TITLE
fix(harness-pi): return image content from the read tool

### DIFF
--- a/.changeset/harness-pi-read-image-content.md
+++ b/.changeset/harness-pi-read-image-content.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+Return image content from the Pi `read` tool. Image files (png, jpeg, gif, webp) are now detected by magic bytes and sent to the model as `image` content parts instead of being decoded as UTF-8 text, so vision-capable models can actually see images read from the sandbox. Images whose base64 payload exceeds the inline size limit fall back to a text note.

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -155,6 +155,69 @@ describe('createPiSession', () => {
     `,
     );
   });
+
+  it('returns image content when the read tool reads an image file', async () => {
+    const pngBytes = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+    const readBinaryFile = vi.fn(async () => new Uint8Array(pngBytes));
+    let resolvedToolResult: unknown;
+    const prompt = vi.fn(async () => {
+      const readTool = piMock.customTools.find(tool => tool.name === 'read');
+      if (!readTool) throw new Error('Expected read tool.');
+      resolvedToolResult = await readTool.execute(
+        'tool-1',
+        { file_path: 'image.png' },
+        undefined,
+        undefined,
+        undefined as never,
+      );
+    });
+    piMock.session = {
+      abort: vi.fn(async () => {}),
+      compact: vi.fn(async () => {}),
+      dispose: vi.fn(),
+      getSessionStats: () => ({
+        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }),
+      prompt,
+      steer: vi.fn(async () => {}),
+      subscribe: vi.fn(() => () => {}),
+    } as unknown as AgentSession;
+
+    const sandboxSession = createSandboxSession();
+    (
+      sandboxSession.readBinaryFile as ReturnType<typeof vi.fn>
+    ).mockImplementation(readBinaryFile);
+    const session = await createPiSession({
+      sessionId: 'session-2',
+      sandboxSession,
+      sessionWorkDir: '/sandbox/work',
+      skills: [],
+      settings: {},
+      isResume: false,
+    });
+
+    const emit = vi.fn();
+    const control = await session.doPromptTurn({
+      prompt: 'go',
+      tools: [],
+      emit,
+    });
+    await control.done;
+    await expect(resolvedToolResult).toEqual({
+      content: [
+        { type: 'text', text: 'Read image file [image/png]' },
+        {
+          type: 'image',
+          data: pngBytes.toString('base64'),
+          mimeType: 'image/png',
+        },
+      ],
+      details: undefined,
+    });
+    expect(readBinaryFile).toHaveBeenCalledWith({
+      path: '/sandbox/work/image.png',
+    });
+  });
 });
 
 function createDeferred<T>() {

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -967,6 +967,44 @@ function asPiToolResult(text: string): AgentToolResult<unknown> {
   };
 }
 
+// Base64-encoded payload cap for inline images, kept below common provider
+// limits (e.g. Anthropic's 5MB). Larger images are reported as text instead.
+const INLINE_IMAGE_MAX_BASE64_BYTES = 4.5 * 1024 * 1024;
+
+// Detect common image formats from their magic bytes so the read tool can hand
+// them to the model as image content instead of decoding binary as UTF-8 text.
+function detectImageMimeType(buf: Buffer): string | undefined {
+  if (
+    buf.length >= 8 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47
+  ) {
+    return 'image/png';
+  }
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (buf.length >= 6 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) {
+    return 'image/gif';
+  }
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return undefined;
+}
+
 async function maybeDenyPiBuiltinTool(input: {
   toolCallId: string;
   nativeName: (typeof PI_NATIVE_BUILTIN_NAMES)[number];
@@ -1020,6 +1058,22 @@ function buildBuiltinToolDefinition(input: {
           });
           if (denied) return denied;
           const buf = await input.remoteOps.readBuffer(params.file_path);
+          const imageMimeType = detectImageMimeType(buf);
+          if (imageMimeType) {
+            const data = buf.toString('base64');
+            if (data.length > INLINE_IMAGE_MAX_BASE64_BYTES) {
+              return asPiToolResult(
+                `Read image file [${imageMimeType}]\n[Image omitted: exceeds the inline image size limit.]`,
+              );
+            }
+            return {
+              content: [
+                { type: 'text', text: `Read image file [${imageMimeType}]` },
+                { type: 'image', data, mimeType: imageMimeType },
+              ],
+              details: undefined,
+            };
+          }
           return asPiToolResult(buf.toString('utf8'));
         },
       });

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -960,9 +960,11 @@ function isAbortError(value: unknown): boolean {
   return /\baborted\b|AbortError|operation was aborted/i.test(text);
 }
 
-function asPiToolResult(text: string): AgentToolResult<unknown> {
+function asPiToolResult(
+  content: AgentToolResult<unknown>['content'],
+): AgentToolResult<unknown> {
   return {
-    content: [{ type: 'text', text }],
+    content,
     details: undefined,
   };
 }
@@ -983,10 +985,20 @@ function detectImageMimeType(buf: Buffer): string | undefined {
   ) {
     return 'image/png';
   }
-  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+  if (
+    buf.length >= 3 &&
+    buf[0] === 0xff &&
+    buf[1] === 0xd8 &&
+    buf[2] === 0xff
+  ) {
     return 'image/jpeg';
   }
-  if (buf.length >= 6 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) {
+  if (
+    buf.length >= 6 &&
+    buf[0] === 0x47 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46
+  ) {
     return 'image/gif';
   }
   if (
@@ -1018,12 +1030,15 @@ async function maybeDenyPiBuiltinTool(input: {
     nativeName: input.nativeName,
   });
   if (decision.approved) return undefined;
-  return asPiToolResult(
-    serializeToolOutput({
-      type: 'execution-denied',
-      reason: decision.reason,
-    }),
-  );
+  return asPiToolResult([
+    {
+      type: 'text',
+      text: serializeToolOutput({
+        type: 'execution-denied',
+        reason: decision.reason,
+      }),
+    },
+  ]);
 }
 
 function piBuiltinToolRequiresApproval(input: {
@@ -1060,21 +1075,24 @@ function buildBuiltinToolDefinition(input: {
           const buf = await input.remoteOps.readBuffer(params.file_path);
           const imageMimeType = detectImageMimeType(buf);
           if (imageMimeType) {
-            const data = buf.toString('base64');
-            if (data.length > INLINE_IMAGE_MAX_BASE64_BYTES) {
-              return asPiToolResult(
-                `Read image file [${imageMimeType}]\n[Image omitted: exceeds the inline image size limit.]`,
-              );
+            if (buf.toString('base64').length > INLINE_IMAGE_MAX_BASE64_BYTES) {
+              return asPiToolResult([
+                {
+                  type: 'text',
+                  text: `Read image file [${imageMimeType}]\n[Image omitted: exceeds the inline image size limit.]`,
+                },
+              ]);
             }
-            return {
-              content: [
-                { type: 'text', text: `Read image file [${imageMimeType}]` },
-                { type: 'image', data, mimeType: imageMimeType },
-              ],
-              details: undefined,
-            };
+            return asPiToolResult([
+              { type: 'text', text: `Read image file [${imageMimeType}]` },
+              {
+                type: 'image',
+                data: buf.toString('base64'),
+                mimeType: imageMimeType,
+              },
+            ]);
           }
-          return asPiToolResult(buf.toString('utf8'));
+          return asPiToolResult([{ type: 'text', text: buf.toString('utf8') }]);
         },
       });
     case 'write':
@@ -1094,7 +1112,9 @@ function buildBuiltinToolDefinition(input: {
           });
           if (denied) return denied;
           await input.remoteOps.writeFile(params.file_path, params.content);
-          return asPiToolResult(`Wrote ${params.file_path}`);
+          return asPiToolResult([
+            { type: 'text', text: `Wrote ${params.file_path}` },
+          ]);
         },
       });
     case 'edit':
@@ -1119,7 +1139,9 @@ function buildBuiltinToolDefinition(input: {
             params.old_string,
             params.new_string,
           );
-          return asPiToolResult(`Edited ${params.file_path}`);
+          return asPiToolResult([
+            { type: 'text', text: `Edited ${params.file_path}` },
+          ]);
         },
       });
     case 'bash':
@@ -1154,7 +1176,7 @@ function buildBuiltinToolDefinition(input: {
           const text = `${out}${
             result.exitCode != null ? `\n\n(exit ${result.exitCode})` : ''
           }`.trim();
-          return asPiToolResult(text);
+          return asPiToolResult([{ type: 'text', text }]);
         },
       });
     case 'grep':
@@ -1179,7 +1201,7 @@ function buildBuiltinToolDefinition(input: {
           });
           if (denied) return denied;
           const out = await input.remoteOps.grepFiles(params.pattern, params);
-          return asPiToolResult(out);
+          return asPiToolResult([{ type: 'text', text: out }]);
         },
       });
     case 'find':
@@ -1204,7 +1226,7 @@ function buildBuiltinToolDefinition(input: {
             params.path ?? '.',
             params.limit ?? 1_000,
           );
-          return asPiToolResult(matches.join('\n'));
+          return asPiToolResult([{ type: 'text', text: matches.join('\n') }]);
         },
       });
     case 'ls':
@@ -1227,7 +1249,7 @@ function buildBuiltinToolDefinition(input: {
             params.path ?? '.',
             params.limit ?? 500,
           );
-          return asPiToolResult(entries.join('\n'));
+          return asPiToolResult([{ type: 'text', text: entries.join('\n') }]);
         },
       });
   }
@@ -1250,7 +1272,9 @@ function buildUserToolDefinition(
     async execute(toolCallId) {
       return new Promise<unknown>(resolve => {
         pending.set(toolCallId, { resolve });
-      }).then(output => asPiToolResult(serializeToolOutput(output)));
+      }).then(output =>
+        asPiToolResult([{ type: 'text', text: serializeToolOutput(output) }]),
+      );
     },
   });
 }


### PR DESCRIPTION
## Background

The Pi harness (`@ai-sdk/harness-pi`) provides its own sandbox-backed `read` builtin tool in `pi-session.ts`. Its `execute` decodes **every** file as UTF-8 text:

```ts
const buf = await input.remoteOps.readBuffer(params.file_path);
return asPiToolResult(buf.toString('utf8'));
```

There is no image branch, so reading an image file (a screenshot, an uploaded attachment, etc.) feeds raw binary into the model as a garbled UTF-8 string. Consequences for vision-capable models:

- The model can't see the image — it only receives mojibake.
- A large image's binary bloats the context, which can trip compaction/limit errors and fail the turn.

This is a regression relative to stock `@earendil-works/pi-coding-agent`, whose own `read` tool returns `{ type: 'image', ... }` content for images.

## Change

Detect common image formats (png, jpeg, gif, webp) from their magic bytes and return them as image content parts — the same `(TextContent | ImageContent)[]` shape `AgentToolResult` already allows and that `pi-coding-agent` consumes:

```ts
return {
  content: [
    { type: 'text', text: `Read image file [${imageMimeType}]` },
    { type: 'image', data, mimeType: imageMimeType },
  ],
  details: undefined,
};
```

Non-image files are unchanged (still UTF-8 text). Images whose base64 payload exceeds an inline size cap (4.5MB, below common provider limits) fall back to a text note instead of being inlined, to avoid blowing the request size.

A changeset is included (`@ai-sdk/harness-pi`: patch).

## Notes / testing

- The change is purely additive (no behavior change for non-image reads).
- `buildBuiltinToolDefinition` is module-internal, so there's no existing unit test seam for the builtin `read` tool. Happy to add a test if maintainers prefer exporting a seam or testing through a higher-level path — guidance welcome.
- Verified end-to-end against a real sandbox + vision endpoint (Kimi K2.6): reading a PNG now yields a correct description instead of binary text. No resize/Photon dependency is pulled in; large images degrade gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)