### PR TITLE
chore(harness): enforce more structural conventions in harness adapters

### DIFF
--- a/.changeset/cool-nails-swim.md
+++ b/.changeset/cool-nails-swim.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-pi": patch
+---
+
+chore(harness): enforce more structural conventions in harness adapters

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -169,14 +169,6 @@
           }
         },
         {
-          "name": "harness-file-must-declare-builtin-tools",
-          "description": "Every harness file must declare its built-in tools.",
-          "for": { "files": ["${harnessId}-harness.ts"] },
-          "must": {
-            "declareConstants": ["${harnessId.toConstantCase()}_BUILTIN_TOOLS"]
-          }
-        },
-        {
           "name": "harness-file-with-bridge-must-declare-bridge-contracts",
           "description": "Every harness file for a bridge harness must declare its bridge contracts.",
           "for": { "files": ["${harnessId}-harness.ts"] },
@@ -199,7 +191,6 @@
           "must": {
             "useDeclarationOrder": [
               "${harnessId.toPascalCase()}HarnessSettings",
-              "${harnessId.toConstantCase()}_BUILTIN_TOOLS",
               "${harnessId.toCamelCase()}BridgeCoordsSchema",
               "${harnessId.toCamelCase()}ResumeStateSchema",
               "${harnessId.toPascalCase()}BridgeCoords",
@@ -292,14 +283,6 @@
                 "returnValueOfType": "Promise<void>"
               }
             ]
-          }
-        },
-        {
-          "name": "harness-bridge-must-not-use-parent-imports",
-          "description": "Every harness bridge file must not use parent imports, only local and external imports.",
-          "for": { "files": ["bridge/*.ts"] },
-          "mustNot": {
-            "importFromParents": true
           }
         }
       ]

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -179,9 +179,7 @@
               "${harnessId.toCamelCase()}BridgeCoordsSchema",
               "${harnessId.toCamelCase()}ResumeStateSchema"
             ],
-            "declareTypes": [
-              "${harnessId.toPascalCase()}BridgeCoords"
-            ]
+            "declareTypes": ["${harnessId.toPascalCase()}BridgeCoords"]
           }
         },
         {

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -151,6 +151,7 @@
           "description": "Every harness file must export a harness creator function and a harness settings type.",
           "for": { "files": ["${harnessId}-harness.ts"] },
           "must": {
+            "haveFiles": ["${harnessId}-auth.ts"],
             "importTypes": [
               {
                 "name": "HarnessV1",
@@ -165,6 +166,140 @@
               }
             ],
             "exportTypes": ["${harnessId.toPascalCase()}HarnessSettings"]
+          }
+        },
+        {
+          "name": "harness-file-must-declare-builtin-tools",
+          "description": "Every harness file must declare its built-in tools.",
+          "for": { "files": ["${harnessId}-harness.ts"] },
+          "must": {
+            "declareConstants": ["${harnessId.toConstantCase()}_BUILTIN_TOOLS"]
+          }
+        },
+        {
+          "name": "harness-file-with-bridge-must-declare-bridge-contracts",
+          "description": "Every harness file for a bridge harness must declare its bridge contracts.",
+          "for": { "files": ["${harnessId}-harness.ts"] },
+          "if": { "hasFile": "bridge/index.ts" },
+          "must": {
+            "haveFiles": ["${harnessId}-bridge-protocol.ts"],
+            "declareConstants": [
+              "${harnessId.toCamelCase()}BridgeCoordsSchema",
+              "${harnessId.toCamelCase()}ResumeStateSchema"
+            ],
+            "declareTypes": [
+              "${harnessId.toPascalCase()}BridgeCoords"
+            ]
+          }
+        },
+        {
+          "name": "harness-file-must-use-consistent-declaration-order",
+          "description": "Every harness file must use a consistent declaration order.",
+          "for": { "files": ["${harnessId}-harness.ts"] },
+          "must": {
+            "useDeclarationOrder": [
+              "${harnessId.toPascalCase()}HarnessSettings",
+              "${harnessId.toConstantCase()}_BUILTIN_TOOLS",
+              "${harnessId.toCamelCase()}BridgeCoordsSchema",
+              "${harnessId.toCamelCase()}ResumeStateSchema",
+              "${harnessId.toPascalCase()}BridgeCoords",
+              "create${harnessId.toPascalCase()}"
+            ]
+          }
+        },
+        {
+          "name": "harness-auth-file-must-export-relevant-symbols",
+          "description": "Every harness auth file must export the relevant symbols.",
+          "for": { "files": ["${harnessId}-auth.ts"] },
+          "must": {
+            "import": [
+              {
+                "name": "getAiGatewayAuthFromEnv",
+                "from": "@ai-sdk/harness/utils"
+              }
+            ],
+            "exportTypes": ["${harnessId.toPascalCase()}AuthOptions"],
+            "exportFunctions": [
+              {
+                "name": "resolve${harnessId.toPascalCase()}Env",
+                "returnValueOfType": "Record<string, string>"
+              }
+            ],
+            "useDeclarationOrder": [
+              "${harnessId.toPascalCase()}AuthOptions",
+              "resolve${harnessId.toPascalCase()}Env"
+            ]
+          }
+        },
+        {
+          "name": "harness-bridge-protocol-file-must-export-relevant-symbols",
+          "description": "Every harness bridge protocol file must export the relevant symbols.",
+          "for": { "files": ["${harnessId}-bridge-protocol.ts"] },
+          "must": {
+            "exportConstants": [
+              "outboundMessageSchema",
+              "startMessageSchema",
+              "inboundMessageSchema",
+              "bridgeReadySchema"
+            ],
+            "exportTypes": [
+              "OutboundMessage",
+              "StartMessage",
+              "InboundMessage",
+              "BridgeReady"
+            ],
+            "useDeclarationOrder": [
+              "outboundMessageSchema",
+              "OutboundMessage",
+              "startMessageSchema",
+              "StartMessage",
+              "inboundMessageSchema",
+              "InboundMessage",
+              "bridgeReadySchema",
+              "BridgeReady"
+            ]
+          }
+        },
+        {
+          "name": "harness-bridge-must-declare-and-use-relevant-symbols",
+          "description": "Every harness bridge index file must declare and use the relevant symbols.",
+          "for": { "files": ["bridge/index.ts"] },
+          "must": {
+            "import": [
+              {
+                "name": "runBridge",
+                "from": "@ai-sdk/harness/bridge"
+              }
+            ],
+            "importTypes": [
+              {
+                "name": "StartMessage",
+                "from": "../${harnessId}-bridge-protocol"
+              },
+              {
+                "name": "BridgeEvent",
+                "from": "@ai-sdk/harness/bridge"
+              },
+              {
+                "name": "BridgeTurn",
+                "from": "@ai-sdk/harness/bridge"
+              }
+            ],
+            "declareFunctions": [
+              {
+                "name": "runTurn",
+                "receiveParamOfType": "StartMessage",
+                "returnValueOfType": "Promise<void>"
+              }
+            ]
+          }
+        },
+        {
+          "name": "harness-bridge-must-not-use-parent-imports",
+          "description": "Every harness bridge file must not use parent imports, only local and external imports.",
+          "for": { "files": ["bridge/*.ts"] },
+          "mustNot": {
+            "importFromParents": true
           }
         }
       ]

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@playwright/test": "^1.60.0",
     "del-cli": "^5.1.0",
     "husky": "^9.1.7",
-    "konsistent": "0.0.1-alpha.20",
+    "konsistent": "0.0.1-alpha.23",
     "lint-staged": "^15.5.1",
     "next": "15.5.18",
     "oxfmt": "^0.41.0",

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -373,7 +373,7 @@ const BOOTSTRAP_DIR = '/tmp/harness/claude-code';
  * future process uses them to reopen a socket to the still-running bridge
  * (`attach`) instead of re-spawning it. Absent on a `doStop()` payload.
  */
-const bridgeCoordsSchema = z.object({
+const claudeCodeBridgeCoordsSchema = z.object({
   port: z.number(),
   token: z.string(),
   lastSeenEventId: z.number(),
@@ -390,10 +390,10 @@ const bridgeCoordsSchema = z.object({
  * cross-process `attach`. `.passthrough()` keeps both shapes valid.
  */
 const claudeCodeResumeStateSchema = z
-  .object({ bridge: bridgeCoordsSchema.optional() })
+  .object({ bridge: claudeCodeBridgeCoordsSchema.optional() })
   .passthrough();
 
-type ClaudeCodeBridgeCoords = z.infer<typeof bridgeCoordsSchema>;
+type ClaudeCodeBridgeCoords = z.infer<typeof claudeCodeBridgeCoordsSchema>;
 
 export function createClaudeCode(
   settings: ClaudeCodeHarnessSettings = {},

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -129,7 +129,7 @@ const BOOTSTRAP_DIR = '/tmp/harness/codex';
  * future process uses them to reopen a socket to the still-running bridge
  * (`attach`) instead of re-spawning it. Absent on a `doStop()` payload.
  */
-const bridgeCoordsSchema = z.object({
+const codexBridgeCoordsSchema = z.object({
   port: z.number(),
   token: z.string(),
   lastSeenEventId: z.number(),
@@ -146,10 +146,10 @@ const bridgeCoordsSchema = z.object({
  */
 const codexResumeStateSchema = z.object({
   threadId: z.string().optional(),
-  bridge: bridgeCoordsSchema.optional(),
+  bridge: codexBridgeCoordsSchema.optional(),
 });
 
-type CodexBridgeCoords = z.infer<typeof bridgeCoordsSchema>;
+type CodexBridgeCoords = z.infer<typeof codexBridgeCoordsSchema>;
 
 export function createCodex(
   settings: CodexHarnessSettings = {},

--- a/packages/harness-pi/src/pi-auth.test.ts
+++ b/packages/harness-pi/src/pi-auth.test.ts
@@ -1,6 +1,6 @@
 import { AuthStorage, ModelRegistry } from '@earendil-works/pi-coding-agent';
 import { describe, expect, it, vi } from 'vitest';
-import { resolvePiAuth } from './pi-auth';
+import { resolvePiEnv } from './pi-auth';
 
 function makeRegistries() {
   const authStorage = AuthStorage.inMemory();
@@ -10,14 +10,17 @@ function makeRegistries() {
   return { authStorage, modelRegistry, setRuntimeApiKey, registerProvider };
 }
 
-describe('resolvePiAuth', () => {
+describe('resolvePiEnv', () => {
   it('uses explicit gateway settings when configured', () => {
     const r = makeRegistries();
-    const env = resolvePiAuth(
-      { gateway: { apiKey: 'gw-key', baseUrl: 'https://gw.example' } },
-      {},
-      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
-    );
+    const env = resolvePiEnv({
+      options: { gateway: { apiKey: 'gw-key', baseUrl: 'https://gw.example' } },
+      env: {},
+      registries: {
+        authStorage: r.authStorage,
+        modelRegistry: r.modelRegistry,
+      },
+    });
     expect(env).toEqual({
       AI_GATEWAY_API_KEY: 'gw-key',
       AI_GATEWAY_BASE_URL: 'https://gw.example',
@@ -35,11 +38,14 @@ describe('resolvePiAuth', () => {
 
   it('uses env gateway auth when explicit gateway only sets base URL', () => {
     const r = makeRegistries();
-    const env = resolvePiAuth(
-      { gateway: { baseUrl: 'https://gw.example' } },
-      { VERCEL_OIDC_TOKEN: 'oidc-env' },
-      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
-    );
+    const env = resolvePiEnv({
+      options: { gateway: { baseUrl: 'https://gw.example' } },
+      env: { VERCEL_OIDC_TOKEN: 'oidc-env' },
+      registries: {
+        authStorage: r.authStorage,
+        modelRegistry: r.modelRegistry,
+      },
+    });
     expect(env).toEqual({
       AI_GATEWAY_API_KEY: 'oidc-env',
       AI_GATEWAY_BASE_URL: 'https://gw.example',
@@ -53,8 +59,8 @@ describe('resolvePiAuth', () => {
 
   it('uses customEnv when provided and registers all known providers', () => {
     const r = makeRegistries();
-    const env = resolvePiAuth(
-      {
+    const env = resolvePiEnv({
+      options: {
         customEnv: {
           AI_GATEWAY_API_KEY: 'gw',
           OPENAI_API_KEY: 'oai',
@@ -62,9 +68,12 @@ describe('resolvePiAuth', () => {
           ANTHROPIC_AUTH_TOKEN: 'tok',
         },
       },
-      {},
-      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
-    );
+      env: {},
+      registries: {
+        authStorage: r.authStorage,
+        modelRegistry: r.modelRegistry,
+      },
+    });
     expect(env.AI_GATEWAY_API_KEY).toBe('gw');
     const registeredProviders = r.registerProvider.mock.calls
       .map(call => call[0])
@@ -84,16 +93,19 @@ describe('resolvePiAuth', () => {
 
   it('registers arbitrary <PREFIX>_API_KEY + <PREFIX>_BASE_URL via customEnv', () => {
     const r = makeRegistries();
-    resolvePiAuth(
-      {
+    resolvePiEnv({
+      options: {
         customEnv: {
           MISTRAL_API_KEY: 'mk',
           MISTRAL_BASE_URL: 'https://api.mistral.example',
         },
       },
-      {},
-      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
-    );
+      env: {},
+      registries: {
+        authStorage: r.authStorage,
+        modelRegistry: r.modelRegistry,
+      },
+    });
     expect(r.setRuntimeApiKey).toHaveBeenCalledWith('mistral', 'mk');
     expect(r.registerProvider).toHaveBeenCalledWith('mistral', {
       apiKey: 'mk',
@@ -104,11 +116,17 @@ describe('resolvePiAuth', () => {
 
   it('falls back to ambient AI_GATEWAY_API_KEY when no options', () => {
     const r = makeRegistries();
-    const env = resolvePiAuth(
-      undefined,
-      { AI_GATEWAY_API_KEY: 'ambient', AI_GATEWAY_BASE_URL: 'https://amb' },
-      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
-    );
+    const env = resolvePiEnv({
+      options: undefined,
+      env: {
+        AI_GATEWAY_API_KEY: 'ambient',
+        AI_GATEWAY_BASE_URL: 'https://amb',
+      },
+      registries: {
+        authStorage: r.authStorage,
+        modelRegistry: r.modelRegistry,
+      },
+    });
     expect(env).toEqual({
       AI_GATEWAY_API_KEY: 'ambient',
       AI_GATEWAY_BASE_URL: 'https://amb',
@@ -117,24 +135,27 @@ describe('resolvePiAuth', () => {
 
   it('falls back to ambient VERCEL_OIDC_TOKEN when AI_GATEWAY_API_KEY is missing', () => {
     const r = makeRegistries();
-    const env = resolvePiAuth(
-      undefined,
-      { VERCEL_OIDC_TOKEN: 'oidc' },
-      { authStorage: r.authStorage, modelRegistry: r.modelRegistry },
-    );
+    const env = resolvePiEnv({
+      options: undefined,
+      env: { VERCEL_OIDC_TOKEN: 'oidc' },
+      registries: {
+        authStorage: r.authStorage,
+        modelRegistry: r.modelRegistry,
+      },
+    });
     expect(env.AI_GATEWAY_API_KEY).toBe('oidc');
   });
 
   it('returns {} when no auth is configured anywhere', () => {
     const r = makeRegistries();
-    const env = resolvePiAuth(
-      undefined,
-      {},
-      {
+    const env = resolvePiEnv({
+      options: undefined,
+      env: {},
+      registries: {
         authStorage: r.authStorage,
         modelRegistry: r.modelRegistry,
       },
-    );
+    });
     expect(env).toEqual({});
     expect(r.setRuntimeApiKey).not.toHaveBeenCalled();
     expect(r.registerProvider).not.toHaveBeenCalled();

--- a/packages/harness-pi/src/pi-auth.ts
+++ b/packages/harness-pi/src/pi-auth.ts
@@ -30,13 +30,6 @@ export type PiAuthOptions = {
   readonly customEnv?: Record<string, string>;
 };
 
-/**
- * Env subset returned by `resolvePiAuth` for use by the Pi model resolver
- * (it reads `AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN` to decide whether
- * to fall back to the default gateway model).
- */
-export type PiResolverEnv = Record<string, string>;
-
 const DEFAULT_GATEWAY_BASE_URL = 'https://ai-gateway.vercel.sh';
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
@@ -58,11 +51,15 @@ function hasConfiguredValue(value: unknown): boolean {
   return Object.values(value).some(hasConfiguredValue);
 }
 
-export function resolvePiAuth(
-  options: PiAuthOptions | undefined,
-  env: NodeJS.ProcessEnv,
-  registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry },
-): PiResolverEnv {
+export function resolvePiEnv({
+  options,
+  env,
+  registries,
+}: {
+  options: PiAuthOptions | undefined;
+  env: NodeJS.ProcessEnv;
+  registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry };
+}): Record<string, string> {
   const customEnvConfigured = hasConfiguredValue(options?.customEnv);
   if (customEnvConfigured) {
     return applyCustomEnv(options!.customEnv ?? {}, registries);
@@ -103,8 +100,8 @@ export function resolvePiAuth(
 function applyCustomEnv(
   customEnv: Record<string, string>,
   registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry },
-): PiResolverEnv {
-  const out: PiResolverEnv = {};
+): Record<string, string> {
+  const out: Record<string, string> = {};
 
   const gatewayKey = customEnv.AI_GATEWAY_API_KEY;
   if (gatewayKey) {

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -29,7 +29,7 @@ import type {
   HarnessV1ToolSpec,
 } from '@ai-sdk/harness';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
-import { resolvePiAuth, type PiAuthOptions } from './pi-auth';
+import { resolvePiEnv, type PiAuthOptions } from './pi-auth';
 import { getPiTerminalError, parseNativeEvent } from './pi-events';
 import { createPiModelResolver } from './pi-model-resolver';
 import { createPiPathMapper } from './pi-paths';
@@ -311,9 +311,13 @@ export async function createPiSession(
   const settingsManager = SettingsManager.inMemory();
 
   // Run-scoped env (for the model resolver's gateway fallback heuristic).
-  const resolverEnv = resolvePiAuth(input.settings.auth, process.env, {
-    authStorage,
-    modelRegistry,
+  const resolverEnv = resolvePiEnv({
+    options: input.settings.auth,
+    env: process.env,
+    registries: {
+      authStorage,
+      modelRegistry,
+    },
   });
   const resolveModel = createPiModelResolver(modelRegistry, resolverEnv);
   // Resolve once: deterministic given the configured model. This is the Pi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3813,8 +3813,8 @@ importers:
   tools/konsistent-provider:
     dependencies:
       '@konsistent/convention':
-        specifier: 0.0.1-alpha.2
-        version: 0.0.1-alpha.2(zod@4.4.3)
+        specifier: 0.0.1-alpha.5
+        version: 0.0.1-alpha.5(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 22.19.19
@@ -7479,12 +7479,6 @@ packages:
     resolution: {integrity: sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==}
     engines: {node: '>= 12'}
     deprecated: Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.
-
-  '@konsistent/convention@0.0.1-alpha.2':
-    resolution: {integrity: sha512-KqpIvSoF7MvvuYVlgqfhItjRoZAbXW2yvcZl+cVJh09wYzwp/nj4WNqV6uUUc+3GVp3VtdQKlUYKMuP14n6wEQ==}
-    hasBin: true
-    peerDependencies:
-      zod: ^4
 
   '@konsistent/convention@0.0.1-alpha.5':
     resolution: {integrity: sha512-5F6dmvZLvJKkcLvkjkdcMmTyLycZv+PyuLeDLglPCHSfOBe2qx0W8v/Ey55e4c+xeg9uaRkbT5FJVjahREIVQQ==}
@@ -25560,12 +25554,6 @@ snapshots:
       path-to-regexp: 6.3.0
     transitivePeerDependencies:
       - supports-color
-
-  '@konsistent/convention@0.0.1-alpha.2(zod@4.4.3)':
-    dependencies:
-      citty: 0.2.2
-      jiti: 2.7.0
-      zod: 4.4.3
 
   '@konsistent/convention@0.0.1-alpha.5(zod@4.4.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       konsistent:
-        specifier: 0.0.1-alpha.20
-        version: 0.0.1-alpha.20
+        specifier: 0.0.1-alpha.23
+        version: 0.0.1-alpha.23
       konsistent-provider:
         specifier: workspace:*
         version: link:tools/konsistent-provider
@@ -7482,6 +7482,13 @@ packages:
 
   '@konsistent/convention@0.0.1-alpha.2':
     resolution: {integrity: sha512-KqpIvSoF7MvvuYVlgqfhItjRoZAbXW2yvcZl+cVJh09wYzwp/nj4WNqV6uUUc+3GVp3VtdQKlUYKMuP14n6wEQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4
+
+  '@konsistent/convention@0.0.1-alpha.5':
+    resolution: {integrity: sha512-5F6dmvZLvJKkcLvkjkdcMmTyLycZv+PyuLeDLglPCHSfOBe2qx0W8v/Ey55e4c+xeg9uaRkbT5FJVjahREIVQQ==}
+    engines: {node: '>=22.11.0'}
     hasBin: true
     peerDependencies:
       zod: ^4
@@ -15909,8 +15916,9 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  konsistent@0.0.1-alpha.20:
-    resolution: {integrity: sha512-JsKjtfWSg9v0QjAQDcjYlfcZ08N7MIdMHdo2ynbjWK+UVSVxavPHAIdn/FOwvIiWDSlw2hkULeMpRFulwklxig==}
+  konsistent@0.0.1-alpha.23:
+    resolution: {integrity: sha512-/CvhCng+AX96BKcyAdfi57EeqJXX58PN089k5rRw6oHJiXs47lAIGlTRi62AOu5nsnOmpTX64vKjhi/snweCDA==}
+    engines: {node: '>=22.11.0'}
     hasBin: true
 
   kuler@2.0.0:
@@ -25554,6 +25562,12 @@ snapshots:
       - supports-color
 
   '@konsistent/convention@0.0.1-alpha.2(zod@4.4.3)':
+    dependencies:
+      citty: 0.2.2
+      jiti: 2.7.0
+      zod: 4.4.3
+
+  '@konsistent/convention@0.0.1-alpha.5(zod@4.4.3)':
     dependencies:
       citty: 0.2.2
       jiti: 2.7.0
@@ -35886,9 +35900,9 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  konsistent@0.0.1-alpha.20:
+  konsistent@0.0.1-alpha.23:
     dependencies:
-      '@konsistent/convention': 0.0.1-alpha.2(zod@4.4.3)
+      '@konsistent/convention': 0.0.1-alpha.5(zod@4.4.3)
       citty: 0.2.2
       picocolors: 1.1.1
       resolve.exports: 2.0.3

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -117,6 +117,9 @@ Add only the concerns the runtime needs:
 - lifecycle state schema;
 - bridge protocol and diagnostics.
 
+Certain structural conventions for harness adapters are being enforced via the `konsistent` CLI.
+Run `pnpm konsistent` once you're done to check for those. Fix any violations flagged before proceeding.
+
 ### 6. Write Tests
 
 Add focused Node tests for:
@@ -171,6 +174,7 @@ Update `content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx` to list the ne
 Run from the workspace root:
 
 ```bash
+pnpm konsistent
 pnpm update-references
 pnpm --filter @ai-sdk/harness-<name> build
 pnpm --filter @ai-sdk/harness-<name> test

--- a/tools/konsistent-provider/package.json
+++ b/tools/konsistent-provider/package.json
@@ -24,7 +24,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@konsistent/convention": "0.0.1-alpha.2"
+    "@konsistent/convention": "0.0.1-alpha.5"
   },
   "peerDependencies": {
     "zod": "^4"


### PR DESCRIPTION
## Summary

This adds more structural conventions for consistent harness adapters, enforced via `konsistent.json`:

- each harness must have an auth file
- each auth file must use `getAiGatewayAuthFromEnv` and export relevant symbols
- each harness that has a bridge file must also have a bridge protocol file that exports relevant symbols
- each harness bridge file must declare and use relevant symbols
- common declarations must be in a consistent order within their files

## Manual Verification

Run `pnpm konsistent`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A few key things we can't enforce yet because the `konsistent` CLI doesn't properly allow it yet, see https://github.com/vercel/ai/commit/34ea77d77ff3f89bc042eb7c74f337ac025ba509. Once those features are available in the `konsistent` CLI, we should reinstate what the linked commit removed.

## Related Issues

See #14648 for original introduction of the `konsistent` CLI.
