### PR TITLE
fix(react): fix toolMetadata mismatch

### DIFF
--- a/.changeset/stupid-boxes-impress.md
+++ b/.changeset/stupid-boxes-impress.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/react": patch
+---
+
+fix(react): fix toolMetadata mismatch

--- a/packages/react/src/mcp-apps/utils.test.ts
+++ b/packages/react/src/mcp-apps/utils.test.ts
@@ -11,13 +11,11 @@ describe('getMCPAppFromToolPart', () => {
       state: 'input-available',
       input: { topic: 'usage' },
       toolMetadata: {
-        mcp: {
-          clientName: 'local-mcp-apps',
-          app: {
-            resourceUri: 'ui://ai-sdk-e2e/dashboard',
-            mimeType: 'text/html;profile=mcp-app',
-            visibility: ['model', 'app'],
-          },
+        clientName: 'local-mcp-apps',
+        app: {
+          resourceUri: 'ui://ai-sdk-e2e/dashboard',
+          mimeType: 'text/html;profile=mcp-app',
+          visibility: ['model', 'app'],
         },
       },
     } satisfies MCPAppRendererProps['part'];
@@ -42,7 +40,7 @@ describe('getMCPAppFromToolPart', () => {
       state: 'input-available',
       input: {},
       toolMetadata: {
-        mcp: { clientName: 'local-mcp-apps' },
+        clientName: 'local-mcp-apps',
       },
     } satisfies MCPAppRendererProps['part'];
 

--- a/packages/react/src/mcp-apps/utils.ts
+++ b/packages/react/src/mcp-apps/utils.ts
@@ -13,11 +13,9 @@ import type { MCPAppMetadata, MCPAppRendererProps } from './types';
  *   state: 'input-available',
  *   input: { topic: 'usage' },
  *   toolMetadata: {
- *     mcp: {
- *       app: {
- *         resourceUri: 'ui://example/dashboard',
- *         mimeType: 'text/html;profile=mcp-app',
- *       },
+ *     app: {
+ *       resourceUri: 'ui://example/dashboard',
+ *       mimeType: 'text/html;profile=mcp-app',
  *     },
  *   },
  * });
@@ -27,10 +25,7 @@ import type { MCPAppMetadata, MCPAppRendererProps } from './types';
 export function getMCPAppFromToolPart(
   part: MCPAppRendererProps['part'],
 ): MCPAppMetadata | undefined {
-  const mcpMetadata = part.toolMetadata?.mcp;
-  const rawAppMetadata = isJSONObject(mcpMetadata)
-    ? mcpMetadata.app
-    : undefined;
+  const rawAppMetadata = part.toolMetadata?.app;
   const appMetadata = isJSONObject(rawAppMetadata) ? rawAppMetadata : undefined;
 
   if (


### PR DESCRIPTION
## Background

`@ai-sdk/mcp` emits mcp app metadata directly under `toolMetadata.app` but the react renderer was looking for `toolMetadata.mcp.app,` so it never recognized the tool part as an MCP App.

discorvered when running our mcp app e2e example again

## Summary

check the renderer info under `toolMetadata.app`

## Manual Verification

verified by running the example `http://localhost:3000/chat/mcp-apps`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)