### PR TITLE
docs(skill): add harness-authoring gotchas to add-harness-package

### DIFF
--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -60,7 +60,7 @@ src/
     └── pnpm-lock.yaml
 ```
 
-Do not create a `CHANGELOG.md` file manually.
+Add a `CHANGELOG.md` containing just the package heading (`# @ai-sdk/harness-<name>`). `konsistent` requires every package to have one, and the changeset release process fills in the rest — without it, `pnpm konsistent` fails.
 
 ### 2. Configure package.json
 
@@ -79,6 +79,13 @@ Required package basics:
 - `"engines": { "node": ">=22" }`
 
 For bridge packages, add any bridge asset copy step required for files under `src/bridge/`.
+
+Bridge dependency rules (bridge-backed harnesses):
+
+- The bridge's runtime deps live in `src/bridge/package.json` (installed in-sandbox at bootstrap), not the main package.json. After changing them, regenerate `src/bridge/pnpm-lock.yaml` with `pnpm install --lockfile-only --ignore-workspace` in that folder.
+- For every third-party import in `src/bridge/`, keep three things in sync: the import, the `external` array in `tsup.config.ts`, and the dep in `src/bridge/package.json`. A missing entry shows up only at sandbox runtime as a module-resolution error.
+- Include packages the runtime *lazily* imports — e.g. provider SDKs (`@langchain/anthropic`, `@langchain/openai`) resolved from the model id at runtime — even though nothing imports them directly. These fail only when a model of that provider is actually used.
+- Match shared dependency versions (transport, schema, tooling, runtime SDKs) to what the other harness packages currently use — copy from a sibling package rather than choosing your own pins. Stale pins drift from security patches and can desync from the shared bridge runtime; check the current versions at creation time.
 
 ### 3. Create TypeScript, Build, and Test Configs
 
@@ -103,7 +110,10 @@ Use the architecture doc for contract details. At implementation time, verify:
 - expose adapter-native built-in tools through `builtinTools`;
 - keep construction synchronous and side-effect free;
 - use `startOpts.sandboxSession` and `startOpts.sessionWorkDir`; never create a separate sandbox;
-- throw `HarnessCapabilityUnsupportedError` from the method that needs an unsupported runtime capability.
+- throw `HarnessCapabilityUnsupportedError` from the method that needs an unsupported runtime capability;
+- don't hardcode a default model — pass the model only when the consumer configured one and let the runtime apply its own default, and keep the session's `modelId` consistent with what's actually sent (don't report a model the bridge silently overrode);
+- handle the `tools` and `instructions` that `doPromptTurn`/`doContinueTurn` may receive: if the runtime can't take custom `tools`, throw `HarnessCapabilityUnsupportedError` so it's obvious rather than silently dropped; if it has no native `instructions` input, prepend them to the first user message (the Codex/Claude Code workaround);
+- quote interpolated paths (`workDir`, bridge-state dir, …) when building shell commands for `sandbox.run`/`sandbox.spawn` — they can contain spaces.
 
 If the runtime needs in-sandbox setup, expose `getBootstrap()`.
 
@@ -111,7 +121,8 @@ If the runtime needs in-sandbox setup, expose `getBootstrap()`.
 
 Add only the concerns the runtime needs:
 
-- auth resolution;
+- auth resolution — for AI Gateway support, use the central `getAiGatewayAuthFromEnv()` helper rather than reading env directly, and accept `VERCEL_OIDC_TOKEN` as a gateway credential (not just `AI_GATEWAY_API_KEY`). When the runtime resolves provider per model, resolve the provider from the model id and set that provider's env; if routing through the gateway, note that base-URL conventions differ per provider (e.g. an Anthropic client appends `/v1/messages` to a root base, an OpenAI client appends to a `/v1` base);
+- custom-tool schema translation — if you convert host tools' JSON Schema into the runtime's tool format, convert *recursively* (nested objects, array `items`, enums, descriptions); a flat top-level-only conversion silently drops the model's structured guidance. Passing the JSON Schema through directly, if the runtime accepts it, avoids the problem;
 - skill or discovery-file materialization;
 - native protocol to harness stream/control translation;
 - lifecycle state schema;
@@ -134,6 +145,8 @@ Add focused Node tests for:
 - skill materialization, if supported.
 
 Use mocked sandbox sessions and bridge/runtime boundaries where possible. Do not require live provider credentials in unit tests.
+
+`getBootstrap()` reads the *compiled* bridge assets (e.g. `dist/bridge/index.mjs`), which don't exist when tests run against `src`, so a test that calls it will hit `ENOENT`. Mock `node:fs/promises` `readFile` for the bridge asset paths (see the Codex/OpenCode harness tests for the pattern).
 
 ### 7. Add README
 
@@ -181,7 +194,9 @@ pnpm --filter @ai-sdk/harness-<name> test
 pnpm type-check:full
 ```
 
-Run relevant harness examples manually when the runtime can be exercised with available credentials.
+Add a changeset with `pnpm changeset`. For a brand-new harness package's first release, use `major` (not the usual `patch`), matching the other harness packages.
+
+Run relevant harness examples against a live sandbox **early** — don't rely on unit tests and `type-check` alone. Runtime API constraints (e.g. unexpected config-option rejections, the exact streaming event names the runtime emits, gateway base-URL format) surface only when the bridge actually drives the runtime, and they're far cheaper to find before the docs/examples are built on top.
 
 ## Checklist
 
@@ -198,9 +213,12 @@ Run relevant harness examples manually when the runtime can be exercised with av
 - [ ] Session resume and turn continuation tested
 - [ ] Unit tests written and passing
 - [ ] README.md written
+- [ ] `CHANGELOG.md` added (package heading; required by `konsistent`)
+- [ ] Changeset added (`major` for a first release)
 - [ ] Examples added
 - [ ] Documentation added in `content/providers/02-ai-sdk-harnesses/`
 - [ ] Harness adapter list updated, if public
+- [ ] Validated against a live sandbox (not just unit tests / type-check)
 - [ ] `pnpm update-references` run
 - [ ] Package build passing
 - [ ] Package tests passing

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -70,6 +70,7 @@ Required package basics:
 
 - `"name": "@ai-sdk/harness-<name>"`
 - `"type": "module"`
+- `"version": "0.0.0"` (starting point for new packages)
 - `"license": "Apache-2.0"`
 - `"sideEffects": false`
 - dependency on `@ai-sdk/harness` via `workspace:*`

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -60,7 +60,7 @@ src/
     └── pnpm-lock.yaml
 ```
 
-Add a `CHANGELOG.md` containing just the package heading (`# @ai-sdk/harness-<name>`). `konsistent` requires every package to have one, and the changeset release process fills in the rest — without it, `pnpm konsistent` fails.
+Add a `CHANGELOG.md` containing just the package heading (`# @ai-sdk/harness-<name>`). Every package is required to have one.
 
 ### 2. Configure package.json
 

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -84,7 +84,7 @@ Bridge dependency rules (bridge-backed harnesses):
 
 - The bridge's runtime deps live in `src/bridge/package.json` (installed in-sandbox at bootstrap), not the main package.json. After changing them, regenerate `src/bridge/pnpm-lock.yaml` with `pnpm install --lockfile-only --ignore-workspace` in that folder.
 - For every third-party import in `src/bridge/`, keep three things in sync: the import, the `external` array in `tsup.config.ts`, and the dep in `src/bridge/package.json`. A missing entry shows up only at sandbox runtime as a module-resolution error.
-- Include packages the runtime *lazily* imports — e.g. provider SDKs (`@langchain/anthropic`, `@langchain/openai`) resolved from the model id at runtime — even though nothing imports them directly. These fail only when a model of that provider is actually used.
+- Include packages the runtime _lazily_ imports — e.g. provider SDKs (`@langchain/anthropic`, `@langchain/openai`) resolved from the model id at runtime — even though nothing imports them directly. These fail only when a model of that provider is actually used.
 - Match shared dependency versions (transport, schema, tooling, runtime SDKs) to what the other harness packages currently use — copy from a sibling package rather than choosing your own pins. Stale pins drift from security patches and can desync from the shared bridge runtime; check the current versions at creation time.
 
 ### 3. Create TypeScript, Build, and Test Configs
@@ -122,7 +122,7 @@ If the runtime needs in-sandbox setup, expose `getBootstrap()`.
 Add only the concerns the runtime needs:
 
 - auth resolution — for AI Gateway support, use the central `getAiGatewayAuthFromEnv()` helper rather than reading env directly, and accept `VERCEL_OIDC_TOKEN` as a gateway credential (not just `AI_GATEWAY_API_KEY`). When the runtime resolves provider per model, resolve the provider from the model id and set that provider's env; if routing through the gateway, note that base-URL conventions differ per provider (e.g. an Anthropic client appends `/v1/messages` to a root base, an OpenAI client appends to a `/v1` base);
-- custom-tool schema translation — if you convert host tools' JSON Schema into the runtime's tool format, convert *recursively* (nested objects, array `items`, enums, descriptions); a flat top-level-only conversion silently drops the model's structured guidance. Passing the JSON Schema through directly, if the runtime accepts it, avoids the problem;
+- custom-tool schema translation — if you convert host tools' JSON Schema into the runtime's tool format, convert _recursively_ (nested objects, array `items`, enums, descriptions); a flat top-level-only conversion silently drops the model's structured guidance. Passing the JSON Schema through directly, if the runtime accepts it, avoids the problem;
 - skill or discovery-file materialization;
 - native protocol to harness stream/control translation;
 - lifecycle state schema;
@@ -146,7 +146,7 @@ Add focused Node tests for:
 
 Use mocked sandbox sessions and bridge/runtime boundaries where possible. Do not require live provider credentials in unit tests.
 
-`getBootstrap()` reads the *compiled* bridge assets (e.g. `dist/bridge/index.mjs`), which don't exist when tests run against `src`, so a test that calls it will hit `ENOENT`. Mock `node:fs/promises` `readFile` for the bridge asset paths (see the Codex/OpenCode harness tests for the pattern).
+`getBootstrap()` reads the _compiled_ bridge assets (e.g. `dist/bridge/index.mjs`), which don't exist when tests run against `src`, so a test that calls it will hit `ENOENT`. Mock `node:fs/promises` `readFile` for the bridge asset paths (see the Codex/OpenCode harness tests for the pattern).
 
 ### 7. Add README
 

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -83,9 +83,9 @@ For bridge packages, add any bridge asset copy step required for files under `sr
 
 Bridge dependency rules (bridge-backed harnesses):
 
-- The bridge's runtime deps live in `src/bridge/package.json` (installed in-sandbox at bootstrap), not the main package.json. After changing them, regenerate `src/bridge/pnpm-lock.yaml` with `pnpm install --lockfile-only --ignore-workspace` in that folder.
+- The bridge's runtime deps live in `src/bridge/package.json` (installed in-sandbox at bootstrap), not the main package.json. After changing them, regenerate `src/bridge/pnpm-lock.yaml` with `pnpm --dir packages/harness-<name>/src/bridge install --lockfile-only --ignore-workspace` (runnable from the repo root).
 - For every third-party import in `src/bridge/`, keep three things in sync: the import, the `external` array in `tsup.config.ts`, and the dep in `src/bridge/package.json`. A missing entry shows up only at sandbox runtime as a module-resolution error.
-- Include packages the runtime _lazily_ imports — e.g. provider SDKs (`@langchain/anthropic`, `@langchain/openai`) resolved from the model id at runtime — even though nothing imports them directly. These fail only when a model of that provider is actually used.
+- Include packages the runtime _lazily_ imports — e.g. provider SDKs (`@anthropic-ai/sdk`, `openai`) resolved from the model id at runtime — even though nothing imports them directly. These fail only when a model of that provider is actually used.
 - Match shared dependency versions (transport, schema, tooling, runtime SDKs) to what the other harness packages currently use — copy from a sibling package rather than choosing your own pins. Stale pins drift from security patches and can desync from the shared bridge runtime; check the current versions at creation time.
 
 ### 3. Create TypeScript, Build, and Test Configs
@@ -112,7 +112,7 @@ Use the architecture doc for contract details. At implementation time, verify:
 - keep construction synchronous and side-effect free;
 - use `startOpts.sandboxSession` and `startOpts.sessionWorkDir`; never create a separate sandbox;
 - throw `HarnessCapabilityUnsupportedError` from the method that needs an unsupported runtime capability;
-- don't hardcode a default model — pass the model only when the consumer configured one and let the runtime apply its own default, and keep the session's `modelId` consistent with what's actually sent (don't report a model the bridge silently overrode);
+- don't hardcode a default model unless the runtime technically requires one — some underlying SDKs have no default of their own. Otherwise pass the model only when the consumer configured one and leave the original SDK's default untouched; keep the session's `modelId` consistent with what's actually sent (don't report a model the bridge silently overrode);
 - handle the `tools` and `instructions` that `doPromptTurn`/`doContinueTurn` may receive: if the runtime can't take custom `tools`, throw `HarnessCapabilityUnsupportedError` so it's obvious rather than silently dropped; if it has no native `instructions` input, prepend them to the first user message (the Codex/Claude Code workaround);
 - quote interpolated paths (`workDir`, bridge-state dir, …) when building shell commands for `sandbox.run`/`sandbox.spawn` — they can contain spaces.
 

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -121,7 +121,7 @@ If the runtime needs in-sandbox setup, expose `getBootstrap()`.
 
 Add only the concerns the runtime needs:
 
-- auth resolution — for AI Gateway support, use the central `getAiGatewayAuthFromEnv()` helper rather than reading env directly, and accept `VERCEL_OIDC_TOKEN` as a gateway credential (not just `AI_GATEWAY_API_KEY`). When the runtime resolves provider per model, resolve the provider from the model id and set that provider's env; if routing through the gateway, note that base-URL conventions differ per provider (e.g. an Anthropic client appends `/v1/messages` to a root base, an OpenAI client appends to a `/v1` base);
+- auth resolution — for AI Gateway support, use the central `getAiGatewayAuthFromEnv()` helper rather than reading env directly. This ensures both `VERCEL_OIDC_TOKEN` and `AI_GATEWAY_API_KEY` are accepted as Gateway credential. When the runtime resolves provider per model, resolve the provider from the model id and set that provider's env; if routing through the gateway, note that base-URL conventions differ per provider (e.g. an Anthropic client appends `/v1/messages` to a root base, an OpenAI client appends to a `/v1` base);
 - custom-tool schema translation — if you convert host tools' JSON Schema into the runtime's tool format, convert _recursively_ (nested objects, array `items`, enums, descriptions); a flat top-level-only conversion silently drops the model's structured guidance. Passing the JSON Schema through directly, if the runtime accepts it, avoids the problem;
 - skill or discovery-file materialization;
 - native protocol to harness stream/control translation;


### PR DESCRIPTION
## Summary

Updates the `add-harness-package` skill with details learned while building `@ai-sdk/harness-deepagents` (and from review feedback on the in-flight harness PRs).

- **CHANGELOG.md is required** - `konsistent` fails without it.
- **Bridge dependency rules**: regenerate the bridge lockfile, keep import ↔ tsup `external` ↔ `src/bridge/package.json` in sync, include packages the runtime lazily imports (provider SDKs resolved per model id), and match shared dependency versions to the sibling harness packages rather than self-pinning.
- **Adapter**: don't hardcode a default model (defer to the runtime, keep `modelId` honest); handle unsupported `tools` (throw) / `instructions` (prepend, Codex-style); quote interpolated shell paths.
- **Auth**: use `getAiGatewayAuthFromEnv()` + accept `VERCEL_OIDC_TOKEN`; note per-provider gateway base-URL conventions.
- **Custom tools**: convert host-tool JSON Schema to the runtime's tool format recursively (or pass schema through) - flat conversion drops nested/array/enum guidance.
- **Tests**: `getBootstrap()` reads compiled bridge assets, so mock `fs` for those paths.
- **Release/validation**: first-release changeset is `major`; validate against a live sandbox early (unit tests + type-check miss runtime API constraints).

## Checklist

- [x] Docs-only change to the internal skill