### PR TITLE
feat(otel): emit performance metrics via gen ai semantics

### DIFF
--- a/.changeset/tall-suns-hang.md
+++ b/.changeset/tall-suns-hang.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/otel": patch
+---
+
+feat(otel): emit performance metrics via gen ai semantics

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -459,6 +459,9 @@ For `generateText` and `streamText`, the integration records 3 types of spans:
   - `gen_ai.usage.output_tokens`: output tokens used in this step
   - `gen_ai.usage.cache_read.input_tokens`: cached input tokens read
   - `gen_ai.usage.cache_creation.input_tokens`: cached input tokens created
+  - `gen_ai.client.operation.duration`: provider call duration, in seconds
+  - `gen_ai.client.operation.time_to_first_chunk`: time to the first streamed output chunk, in seconds (streaming calls only)
+  - `gen_ai.client.operation.time_per_output_chunk`: average time between streamed output chunks, in seconds (streaming calls with multiple output chunks only)
   - `gen_ai.output.messages`: the output in [GenAI SemConv message format](#genai-message-format) (when `recordOutputs` is enabled)
 
 - **`execute_tool {toolName}`** (tool span, `INTERNAL`): one span per tool execution, nested under the step span. See [GenAI tool call spans](#genai-tool-call-spans) for details.
@@ -545,6 +548,7 @@ Tool call spans (`execute_tool {toolName}`) are nested under the step span and c
 - `gen_ai.tool.call.id`: the tool call ID
 - `gen_ai.tool.type`: `"function"`
 - `gen_ai.tool.call.arguments`: the input arguments (stringified JSON, when `recordInputs` is enabled)
+- `gen_ai.execute_tool.duration`: the tool execution duration, in seconds
 - `gen_ai.tool.call.result`: the output result (stringified JSON, when `recordOutputs` is enabled). Only set when the tool call succeeds.
 
 ### Custom OpenTelemetry span attributes

--- a/examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts
@@ -1,8 +1,8 @@
-import { anthropic, createAnthropic } from '@ai-sdk/anthropic';
-import { generateText, isStepCount, registerTelemetry } from 'ai';
-import { LegacyOpenTelemetry } from '@ai-sdk/otel';
+import { anthropic } from '@ai-sdk/anthropic';
+import { OpenTelemetry } from '@ai-sdk/otel';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import { generateText, isStepCount, registerTelemetry } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
@@ -11,13 +11,9 @@ const sdk = new NodeSDK({
 });
 
 sdk.start();
-registerTelemetry(new LegacyOpenTelemetry());
+registerTelemetry(new OpenTelemetry());
 
 run(async () => {
-  const myCustomProvider = createAnthropic({
-    name: 'my-anthropic-proxy',
-  });
-
   const result = await generateText({
     model: anthropic('claude-sonnet-4-5-20250929'),
     prompt: 'what is the weather in Tokyo?',
@@ -38,7 +34,7 @@ run(async () => {
     reasoning: 'medium',
     stopWhen: isStepCount(5),
     telemetry: {
-      functionId: 'anthropic-custom-provider-demo',
+      functionId: 'anthropic-tool-call-step-performance',
     },
   });
 
@@ -47,6 +43,9 @@ run(async () => {
   console.log();
   console.log('Text:');
   console.log(result.text);
+  console.log();
+  console.log('Step performance:');
+  console.log(result.steps.map(step => step.performance));
 
   await sdk.shutdown();
 });

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -656,6 +656,7 @@ describe('OpenTelemetry', () => {
           },
           "name": "chat gpt-4",
           "runtimeAttributes": {
+            "gen_ai.client.operation.duration": 1,
             "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Hello world"}],"finish_reason":"stop"}]",
             "gen_ai.response.finish_reasons": [
               "stop",
@@ -664,6 +665,51 @@ describe('OpenTelemetry', () => {
             "gen_ai.usage.input_tokens": 10,
             "gen_ai.usage.output_tokens": 20,
           },
+        }
+      `);
+    });
+
+    it('sets GenAI client performance attributes on the chat span', () => {
+      integration.onStart!(makeOnStartEvent());
+      integration.onStepStart!(makeStepStartEvent());
+      integration.onLanguageModelCallStart!(makeLanguageModelCallStartEvent());
+      integration.onLanguageModelCallEnd!(
+        makeLanguageModelCallEndEvent({
+          performance: {
+            responseTimeMs: 1234,
+            effectiveOutputTokensPerSecond: 20,
+            outputTokensPerSecond: 25,
+            inputTokensPerSecond: 10,
+            effectiveTotalTokensPerSecond: 30,
+            timeToFirstOutputMs: 345,
+            timeBetweenOutputChunksMs: {
+              min: 10,
+              p10: 20,
+              median: 50,
+              avg: 67,
+              p90: 90,
+              max: 100,
+            },
+          },
+        }),
+      );
+
+      expect({
+        duration:
+          tracer.spans[2].attributes['gen_ai.client.operation.duration'],
+        timeToFirstChunk:
+          tracer.spans[2].attributes[
+            'gen_ai.client.operation.time_to_first_chunk'
+          ],
+        timePerOutputChunk:
+          tracer.spans[2].attributes[
+            'gen_ai.client.operation.time_per_output_chunk'
+          ],
+      }).toMatchInlineSnapshot(`
+        {
+          "duration": 1.234,
+          "timePerOutputChunk": 0.067,
+          "timeToFirstChunk": 0.345,
         }
       `);
     });
@@ -863,10 +909,25 @@ describe('OpenTelemetry', () => {
           },
           "name": "execute_tool myTool",
           "runtimeAttributes": {
+            "gen_ai.execute_tool.duration": 0.042,
             "gen_ai.tool.call.result": "{"result":"ok"}",
           },
         }
       `);
+    });
+
+    it('sets GenAI execute_tool duration on the tool span', () => {
+      integration.onStart!(makeOnStartEvent());
+      integration.onStepStart!(makeStepStartEvent());
+      integration.onLanguageModelCallStart!(makeLanguageModelCallStartEvent());
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+      integration.onToolExecutionEnd!(
+        makeToolCallFinishEvent(true, { toolExecutionMs: 123 }),
+      );
+
+      expect(tracer.spans[3].attributes['gen_ai.execute_tool.duration']).toBe(
+        0.123,
+      );
     });
 
     it('records error on tool failure', () => {
@@ -1312,6 +1373,7 @@ describe('OpenTelemetry', () => {
               "ai.usage.inputTokenDetails.noCacheTokens": 7,
               "ai.usage.outputTokenDetails.reasoningTokens": 5,
               "ai.usage.outputTokenDetails.textTokens": 15,
+              "gen_ai.client.operation.duration": 1,
               "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Hello world"}],"finish_reason":"stop"}]",
               "gen_ai.response.finish_reasons": [
                 "stop",
@@ -1334,6 +1396,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "execute_tool myTool",
             "runtimeAttributes": {
+              "gen_ai.execute_tool.duration": 0.042,
               "gen_ai.tool.call.result": "{"result":"ok"}",
             },
           },
@@ -1412,6 +1475,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "chat gpt-4",
             "runtimeAttributes": {
+              "gen_ai.client.operation.duration": 1,
               "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Hello world"}],"finish_reason":"stop"}]",
               "gen_ai.response.finish_reasons": [
                 "stop",
@@ -1432,6 +1496,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "execute_tool myTool",
             "runtimeAttributes": {
+              "gen_ai.execute_tool.duration": 0.042,
               "gen_ai.tool.call.result": "{"result":"ok"}",
             },
           },
@@ -1493,6 +1558,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "execute_tool myTool",
             "runtimeAttributes": {
+              "gen_ai.execute_tool.duration": 0.042,
               "gen_ai.tool.call.result": "{"result":"ok"}",
             },
           },
@@ -1761,6 +1827,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "chat gpt-4",
             "runtimeAttributes": {
+              "gen_ai.client.operation.duration": 1,
               "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Hello world"}],"finish_reason":"stop"}]",
               "gen_ai.response.finish_reasons": [
                 "stop",
@@ -1849,6 +1916,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "chat gpt-4",
             "runtimeAttributes": {
+              "gen_ai.client.operation.duration": 1,
               "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Hello world"}],"finish_reason":"tool_call"}]",
               "gen_ai.response.finish_reasons": [
                 "tool-calls",
@@ -1869,6 +1937,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "execute_tool myTool",
             "runtimeAttributes": {
+              "gen_ai.execute_tool.duration": 0.042,
               "gen_ai.tool.call.result": "{"result":"ok"}",
             },
           },
@@ -1891,6 +1960,7 @@ describe('OpenTelemetry', () => {
             },
             "name": "chat gpt-4",
             "runtimeAttributes": {
+              "gen_ai.client.operation.duration": 1,
               "gen_ai.output.messages": "[{"role":"assistant","parts":[{"type":"text","content":"Hello world"}],"finish_reason":"stop"}]",
               "gen_ai.response.finish_reasons": [
                 "stop",

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -86,6 +86,24 @@ interface CallState {
   baseSupplementalAttributes: Attributes;
 }
 
+function msToSeconds(durationMs: number | undefined): number | undefined {
+  return durationMs == null ? undefined : durationMs / 1000;
+}
+
+function getGenAIClientPerformanceAttributes(
+  performance: LanguageModelCallEndEvent<ToolSet>['performance'],
+): Attributes {
+  return {
+    'gen_ai.client.operation.duration': msToSeconds(performance.responseTimeMs),
+    'gen_ai.client.operation.time_to_first_chunk': msToSeconds(
+      performance.timeToFirstOutputMs,
+    ),
+    'gen_ai.client.operation.time_per_output_chunk': msToSeconds(
+      performance.timeBetweenOutputChunksMs?.avg,
+    ),
+  };
+}
+
 export class OpenTelemetry implements Telemetry {
   private readonly callStates = new Map<string, CallState>();
 
@@ -713,6 +731,7 @@ export class OpenTelemetry implements Telemetry {
 
     state.inferenceSpan.setAttributes(
       selectAttributes(telemetry, {
+        ...getGenAIClientPerformanceAttributes(event.performance),
         'gen_ai.response.finish_reasons': [event.finishReason],
         'gen_ai.response.id': event.responseId,
         'gen_ai.usage.input_tokens': event.usage.inputTokens,
@@ -805,6 +824,12 @@ export class OpenTelemetry implements Telemetry {
     const { telemetry } = state;
 
     const { toolOutput } = event;
+    span.setAttributes(
+      selectAttributes(telemetry, {
+        'gen_ai.execute_tool.duration': msToSeconds(event.toolExecutionMs),
+      }),
+    );
+
     if (toolOutput.type === 'tool-result') {
       try {
         span.setAttributes(


### PR DESCRIPTION
## Background

there were OTEL GenAI semantic convention attributes for metrics that we were not utilising for performance stats at each step. ref here: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-metrics.md

## Summary

map our performance stats to respective conventions in GenAI semantics

## Manual Verification

verified by running the example: `examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)