### PR TITLE
docs: add realtime Gateway guidance

### DIFF
--- a/content/docs/03-ai-sdk-core/36-realtime.mdx
+++ b/content/docs/03-ai-sdk-core/36-realtime.mdx
@@ -10,8 +10,7 @@ description: Learn how to build realtime voice conversations with the AI SDK.
 The AI SDK provides realtime models for bidirectional audio and text
 conversations over WebSockets. Realtime sessions run in the browser and connect
 directly to the provider using a short-lived token that you create on your
-server. You can connect directly to a provider's realtime API or route the
-session through [AI Gateway](/providers/ai-sdk-providers/ai-gateway#realtime).
+server. You can also route the connection through [AI Gateway](/providers/ai-sdk-providers/ai-gateway#realtime).
 
 The typical flow is:
 

--- a/content/docs/03-ai-sdk-core/36-realtime.mdx
+++ b/content/docs/03-ai-sdk-core/36-realtime.mdx
@@ -10,13 +10,14 @@ description: Learn how to build realtime voice conversations with the AI SDK.
 The AI SDK provides realtime models for bidirectional audio and text
 conversations over WebSockets. Realtime sessions run in the browser and connect
 directly to the provider using a short-lived token that you create on your
-server.
+server. You can connect directly to a provider's realtime API or route the
+session through [AI Gateway](/providers/ai-sdk-providers/ai-gateway#realtime).
 
 The typical flow is:
 
 1. The browser calls your setup endpoint.
-1. Your server creates a short-lived provider token with `experimental_realtime.getToken()`.
-1. The browser opens a WebSocket connection to the provider.
+1. Your server creates a short-lived realtime token with `experimental_realtime.getToken()`.
+1. The browser opens a WebSocket connection to the provider or AI Gateway.
 1. The model streams audio, text, and tool calls back to the browser.
 1. Tool calls are handled by your application with `onToolCall`.
 
@@ -62,13 +63,71 @@ export async function POST(request: Request) {
 
 <Note>
   In production, authenticate and rate-limit your setup endpoint. It creates
-  provider sessions using your server-side API key.
+  realtime sessions using your server-side API key.
 </Note>
+
+## AI Gateway
+
+Use [AI Gateway](/providers/ai-sdk-providers/ai-gateway) when you want the same
+realtime client code to work across supported upstream providers. The Gateway
+normalizes realtime events server-side, and the browser still receives only a
+short-lived client secret.
+
+Create the short-lived Gateway realtime token from a server-side setup endpoint:
+
+```ts filename='app/api/realtime/setup/route.ts'
+import { gateway } from 'ai';
+
+export async function POST() {
+  const token = await gateway.experimental_realtime.getToken({
+    model: 'openai/gpt-realtime-2',
+  });
+
+  return Response.json(token);
+}
+```
+
+Then use the matching Gateway realtime model in the browser:
+
+```tsx filename='app/realtime/page.tsx'
+'use client';
+
+import { experimental_useRealtime } from '@ai-sdk/react';
+import { gateway } from 'ai';
+
+export default function RealtimePage() {
+  const realtime = experimental_useRealtime({
+    model: gateway.experimental_realtime('openai/gpt-realtime-2'),
+    api: {
+      token: '/api/realtime/setup',
+    },
+    sessionConfig: {
+      instructions: 'You are a helpful assistant. Be concise.',
+      inputAudioTranscription: {},
+      voice: 'alloy',
+      turnDetection: { type: 'server-vad' },
+    },
+  });
+
+  // ...
+}
+```
+
+<Note>
+  `gateway.experimental_realtime.getToken()` must run on your server because it
+  uses your Gateway credential to mint a `vcst_` client secret. Creating the
+  realtime model with `gateway.experimental_realtime()` is safe in the browser.
+</Note>
+
+Tool definitions work the same way with AI Gateway: convert AI SDK tools with
+`experimental_getRealtimeToolDefinitions()` in your setup endpoint and return
+the definitions alongside the token. The hook includes them in the session
+update after the WebSocket opens.
 
 ## Client Session
 
-Use the `experimental_useRealtime` hook to connect to the provider, capture microphone audio,
-play model audio, send text messages, and render messages.
+Use the `experimental_useRealtime` hook to connect to a realtime model, capture
+microphone audio, play model audio, send text messages, and render messages.
 
 ```tsx filename='app/realtime/page.tsx'
 'use client';
@@ -211,8 +270,8 @@ import { gateway } from '@ai-sdk/gateway';
 const gatewayModel = gateway.experimental_realtime('openai/gpt-realtime-2');
 ```
 
-Gateway realtime v0 is server-side only and throws if used in a browser. It uses
-the resolved Gateway auth token for the WebSocket upgrade rather than a
-provider-minted short-lived client secret. See the
-[AI Gateway realtime docs](/providers/ai-sdk-providers/ai-gateway#realtime) for
-the Gateway-specific token and subprotocol details.
+`gateway.experimental_realtime.getToken()` mints a short-lived Gateway client
+secret on your server. The browser uses that token to open the Gateway
+WebSocket; the SDK handles the Gateway-specific WebSocket subprotocols for you.
+See the [AI Gateway realtime docs](/providers/ai-sdk-providers/ai-gateway#realtime)
+for Gateway-specific token and provider option details.

--- a/content/docs/07-reference/01-ai-sdk-core/23-get-realtime-tool-definitions.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-get-realtime-tool-definitions.mdx
@@ -69,6 +69,13 @@ const token = await openai.experimental_realtime.getToken({
               description:
                 'The AI SDK tools to expose to the realtime model. Function and dynamic tools are converted to realtime function definitions. Provider tools are skipped.',
             },
+            {
+              name: 'toolsContext',
+              type: 'InferToolSetContext<TOOLS>',
+              isOptional: true,
+              description:
+                'Per-tool context used when resolving dynamic tool descriptions.',
+            },
           ],
         },
       ],
@@ -115,3 +122,5 @@ Each returned definition contains:
   `onToolCall` and `addToolOutput` to execute tools and return results.
 - Provider tools are skipped because realtime providers expect regular function
   definitions in the session config.
+- Dynamic tool descriptions are resolved with the matching value from
+  `toolsContext` before the definitions are returned.

--- a/content/docs/07-reference/02-ai-sdk-ui/05-use-realtime.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/05-use-realtime.mdx
@@ -12,7 +12,7 @@ description: API reference for the experimental_useRealtime hook.
 Creates a browser-side realtime session for bidirectional audio and text
 conversations with a realtime provider model.
 
-The hook connects to a provider WebSocket using a short-lived token from your
+The hook connects to a realtime WebSocket using a short-lived token from your
 setup endpoint, returns messages as `UIMessage[]`, and provides controls for
 audio capture, playback, text input, and tool output.
 
@@ -27,6 +27,10 @@ const realtime = experimental_useRealtime({
   },
 });
 ```
+
+For AI Gateway, pass `gateway.experimental_realtime(...)` as the model and point
+`api.token` at a server-side setup endpoint that calls
+`gateway.experimental_realtime.getToken()`.
 
 ## Import
 
@@ -50,7 +54,7 @@ const realtime = experimental_useRealtime({
       name: 'api',
       type: '{ token: string }',
       description:
-        'API endpoints used by the realtime session. The token endpoint is called with POST to create the provider setup response.',
+        'API endpoints used by the realtime session. The token endpoint is called with POST to create the realtime setup response.',
       properties: [
         {
           type: 'Object',

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -251,30 +251,52 @@ const model = gateway.experimental_realtime('openai/gpt-realtime-2');
 
 The Gateway normalizes realtime the same way it normalizes every other modality: your client speaks the [normalized AI SDK realtime protocol](/docs/ai-sdk-core/realtime) and the Gateway translates to and from the upstream provider server-side. This means the same client code works regardless of which provider backs the model.
 
-Gateway realtime v0 is server-side only. Calling `gateway.experimental_realtime()` in a browser throws an error. `getToken()` returns the Gateway auth token resolved by the provider (`apiKey`, `AI_GATEWAY_API_KEY`, or Vercel OIDC token), so do not expose it to browser clients.
+Realtime sessions run in the browser and require a short-lived Gateway client secret created on your server with `gateway.experimental_realtime.getToken()`. The method uses your Gateway credential (`apiKey`, `AI_GATEWAY_API_KEY`, or Vercel OIDC token) to mint a `vcst_` client secret and returns the WebSocket URL for the model.
 
-```ts
-import { gateway } from '@ai-sdk/gateway';
+```ts filename='app/api/realtime/setup/route.ts'
+import { gateway } from 'ai';
 
-// Server-side only. Do not return this token to browser clients.
-const token = await gateway.experimental_realtime.getToken({
-  model: 'openai/gpt-realtime-2',
-});
+export async function POST() {
+  const token = await gateway.experimental_realtime.getToken({
+    model: 'openai/gpt-realtime-2',
+    expiresAfterSeconds: 60 * 10,
+  });
+
+  return Response.json(token);
+}
 ```
 
-<Note>
-  Gateway realtime v0 does not mint a provider-style short-lived client secret.
-  Gateway-minted ephemeral secrets are planned as future work; browser support
-  should wait for that flow.
-</Note>
+Use the matching Gateway realtime model in the browser. Creating the model is
+safe in browser code; only `getToken()` is server-side.
+
+```tsx filename='app/realtime/page.tsx'
+'use client';
+
+import { experimental_useRealtime } from '@ai-sdk/react';
+import { gateway } from 'ai';
+
+export default function RealtimePage() {
+  const realtime = experimental_useRealtime({
+    model: gateway.experimental_realtime('openai/gpt-realtime-2'),
+    api: {
+      token: '/api/realtime/setup',
+    },
+  });
+
+  // ...
+}
+```
+
+Do not expose your Gateway API key or OIDC token to browser clients. Only return
+the short-lived setup response from `getToken()`.
 
 <Note>
-  The Gateway WebSocket route transports auth via the versioned
-  `Sec-WebSocket-Protocol` subprotocol and the model id via the `?ai-model-id=`
-  query - the WebSocket transport of the `Authorization` and `ai-model-id`
-  headers the HTTP routes use. Subprotocol values must fit the WebSocket token
-  grammar, and the complete `Sec-WebSocket-Protocol` header should stay compact
-  (under an 8 KiB safe header budget).
+  The Gateway WebSocket route transports the short-lived auth token via the
+  versioned `Sec-WebSocket-Protocol` subprotocol and the model id via the
+  `?ai-model-id=` query - the WebSocket transport of the `Authorization` and
+  `ai-model-id` headers the HTTP routes use. Subprotocol values must fit the
+  WebSocket token grammar, and the complete `Sec-WebSocket-Protocol` header
+  should stay compact (under an 8 KiB safe header budget).
 </Note>
 
 ### Provider Options
@@ -298,10 +320,10 @@ const sessionConfig = {
 The `GatewayProviderOptions` type is exported from `@ai-sdk/gateway` for stable client-facing fields. The type also accepts service-owned option keys so the Gateway service can add or change server-side options without requiring an SDK release for every schema change. Runtime validation is owned by the Gateway service.
 
 <Note>
-  Provider options are sent in the first `session.update` frame (after the
-  socket opens), so connect-time options such as `byok` and quota selection
-  require a Gateway that resolves them from that frame. Routing knobs like
-  `order` / `only` do not apply to realtime, where the Gateway selects the
+  Provider options are sent in the initial session update after the socket
+  opens, so connect-time options such as `byok` and quota selection require a
+  Gateway that resolves them from that update. Routing knobs like `order` /
+  `only` do not apply to realtime, where the Gateway selects the
   WebSocket-capable provider.
 </Note>
 


### PR DESCRIPTION
## Summary
- document AI Gateway usage in the experimental realtime guide
- update Gateway provider docs for the current short-lived `vcst_` client secret flow
- add `experimental_useRealtime` Gateway guidance and document `toolsContext` for realtime tool definitions

## Validation
- `pnpm validate:docs`
- `pnpm exec oxfmt --check "content/docs/03-ai-sdk-core/36-realtime.mdx" "content/providers/01-ai-sdk-providers/00-ai-gateway.mdx" "content/docs/07-reference/01-ai-sdk-core/23-get-realtime-tool-definitions.mdx" "content/docs/07-reference/02-ai-sdk-ui/05-use-realtime.mdx"`
- `pnpm exec ultracite check "content/docs/03-ai-sdk-core/36-realtime.mdx" "content/providers/01-ai-sdk-providers/00-ai-gateway.mdx" "content/docs/07-reference/01-ai-sdk-core/23-get-realtime-tool-definitions.mdx" "content/docs/07-reference/02-ai-sdk-ui/05-use-realtime.mdx"`
- `pnpm --filter @ai-sdk/gateway test:node -- gateway-realtime-model.test.ts`
- type-checked a temporary app prototype mirroring the docs snippets with `pnpm exec tsc`
- live AI Gateway realtime token mint smoke test verified a `vcst_` client secret prefix and Gateway `wss://` URL without printing the key or token

## Notes
- docs-only change; no changeset