### PR TITLE
fix(rsc): use FlexibleSchema in streamUI

### DIFF
--- a/.changeset/rsc-flexible-schema-stream-ui.md
+++ b/.changeset/rsc-flexible-schema-stream-ui.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/rsc': patch
+---
+
+Replace z3/z4 schema types with FlexibleSchema in streamUI and remove zod as an optional peer dependency from @ai-sdk/rsc. Follow-up to #9372 which migrated the UI packages (react, vue, svelte, angular).

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -68,13 +68,7 @@
     "zod": "3.25.76"
   },
   "peerDependencies": {
-    "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
-    "zod": "^3.25.76 || ^4.1.8"
-  },
-  "peerDependenciesMeta": {
-    "zod": {
-      "optional": true
-    }
+    "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
   },
   "engines": {
     "node": ">=22"

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@ai-sdk/provider';
 import {
   safeParseJSON,
+  type FlexibleSchema,
   type InferSchema,
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
@@ -18,7 +19,6 @@ import {
   type LanguageModelCallOptions,
   type Prompt,
   type RequestOptions,
-  type Schema,
   type ToolChoice,
 } from 'ai';
 import {
@@ -31,8 +31,6 @@ import {
   standardizePrompt,
 } from 'ai/internal';
 import type { ReactNode } from 'react';
-import type * as z3 from 'zod/v3';
-import type * as z4 from 'zod/v4';
 import { createStreamableUI } from '../streamable-ui/create-streamable-ui';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { isAsyncGenerator } from '../util/is-async-generator';
@@ -47,9 +45,7 @@ type Renderer<T extends Array<any>> = (
   | Generator<Streamable, Streamable, void>
   | AsyncGenerator<Streamable, Streamable, void>;
 
-type RenderTool<
-  INPUT_SCHEMA extends z4.core.$ZodType | z3.Schema | Schema = any,
-> = {
+type RenderTool<INPUT_SCHEMA extends FlexibleSchema = any> = {
   description?: string;
   inputSchema: INPUT_SCHEMA;
   generate?: Renderer<
@@ -96,7 +92,7 @@ const defaultTextRenderer: RenderText = ({ content }: { content: string }) =>
  * `streamUI` is a helper function to create a streamable UI from LLMs.
  */
 export async function streamUI<
-  TOOLS extends { [name: string]: z4.core.$ZodType | z3.Schema | Schema } = {},
+  TOOLS extends { [name: string]: FlexibleSchema } = {},
 >({
   model,
   tools,


### PR DESCRIPTION
## Background

Follow-up to #9372 and closes #8573.

`@ai-sdk/rsc` still imported `zod/v3` and `zod/v4` directly in `streamUI` only to describe accepted schema types. The existing `FlexibleSchema` type already covers AI SDK schemas, lazy schemas, Zod v3/v4 schemas, and standard schemas without requiring the package to expose Zod as an optional peer dependency.

## Summary

- Replace the direct `z3.Schema | z4.core.$ZodType | Schema` type union in `streamUI` with `FlexibleSchema` from `@ai-sdk/provider-utils`.
- Remove direct `zod/v3` and `zod/v4` type imports from `packages/rsc/src/stream-ui/stream-ui.tsx`.
- Remove `zod` from `@ai-sdk/rsc` optional peer dependencies while keeping it as a dev dependency for tests.
- Add a patch changeset for `@ai-sdk/rsc`.

## Manual Verification

Executed locally with Node v22.22.2 and pnpm v10.34.4:

```bash
pnpm install
pnpm build
cd packages/rsc && pnpm type-check
cd packages/rsc && pnpm test:node
cd packages/rsc && pnpm test:ui:react
```

Results:

- `pnpm build`: 84 successful tasks.
- `pnpm type-check`: passed.
- `pnpm test:node`: 3 test files passed, 20 tests passed, no type errors.
- `pnpm test:ui:react`: 3 test files passed, 29 tests passed, including `src/stream-ui/stream-ui.ui.test.tsx`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #8573
