### PR TITLE
docs: add @xpoz/ai-sdk to ready-to-use tool packages

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -272,6 +272,7 @@ These packages provide pre-built tools you can install and use immediately:
 - **[@parallel-web/ai-sdk-tools](https://www.npmjs.com/package/@parallel-web/ai-sdk-tools)** - Web search and extract tools powered by Parallel Web API for real-time information and content extraction.
 - **[@perplexity-ai/ai-sdk](https://www.npmjs.com/package/@perplexity-ai/ai-sdk)** - Search the web with real-time results and advanced filtering powered by Perplexity's Search API.
 - **[@tavily/ai-sdk](https://www.npmjs.com/package/@tavily/ai-sdk)** - Search, extract, crawl, and map tools for enterprise-grade agents to explore the web in real-time.
+- **[@xpoz/ai-sdk](https://www.npmjs.com/package/@xpoz/ai-sdk)** - Social media data access tools for major platforms (Twitter/X, Instagram, TikTok, Reddit).
 - **[Stripe agent tools](https://docs.stripe.com/agents?framework=vercel)** - Tools for interacting with Stripe.
 - **[StackOne ToolSet](https://docs.stackone.com/agents/typescript/frameworks/vercel-ai-sdk)** - Agentic integrations for hundreds of [enterprise SaaS](https://www.stackone.com/integrations) platforms.
 - **[agentic](https://docs.agentic.so/marketplace/ts-sdks/ai-sdk)** - A collection of 20+ tools that connect to external APIs such as [Exa](https://exa.ai/) or [E2B](https://e2b.dev/).


### PR DESCRIPTION
Adds [@xpoz/ai-sdk](https://www.npmjs.com/package/@xpoz/ai-sdk) to the "Ready-to-Use Tool Packages" list on the tools foundations page.

Xpoz is a social media data platform providing AI SDK tools for Twitter/X, Instagram, TikTok, and Reddit.

- Package: [@xpoz/ai-sdk](https://www.npmjs.com/package/@xpoz/ai-sdk)
- Source: [XPOZpublic/ai-sdk](https://github.com/XPOZpublic/ai-sdk)