### PR TITLE
fix(telemetry): sanitize invalid array attributes

### DIFF
--- a/.changeset/0000-otel-invalid-array-attributes.md
+++ b/.changeset/0000-otel-invalid-array-attributes.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Sanitize OpenTelemetry array attributes so spans no longer emit invalid OTLP values (arrays containing `undefined`/`null`/objects, or arrays mixing primitive types). For example, `gen_ai.response.finish_reasons` could be emitted as `[undefined]` when a finish reason was missing. Such values previously failed telemetry ingestion with `deserializing message invalid value: map, expected map with a single key` and flooded function logs with errors.

--- a/packages/ai/src/telemetry/sanitize-attribute-value.test.ts
+++ b/packages/ai/src/telemetry/sanitize-attribute-value.test.ts
@@ -1,0 +1,50 @@
+import type { AttributeValue } from '@opentelemetry/api';
+import { describe, expect, it } from 'vitest';
+import { sanitizeAttributeValue } from './sanitize-attribute-value';
+
+describe('sanitizeAttributeValue', () => {
+  it('returns scalar values unchanged', () => {
+    expect(sanitizeAttributeValue('text')).toBe('text');
+    expect(sanitizeAttributeValue(42)).toBe(42);
+    expect(sanitizeAttributeValue(true)).toBe(true);
+  });
+
+  it('returns homogeneous primitive arrays unchanged', () => {
+    expect(sanitizeAttributeValue(['a', 'b'])).toEqual(['a', 'b']);
+    expect(sanitizeAttributeValue([1, 2])).toEqual([1, 2]);
+    expect(sanitizeAttributeValue([true, false])).toEqual([true, false]);
+  });
+
+  it('drops invalid entries from an otherwise homogeneous array', () => {
+    expect(
+      sanitizeAttributeValue([
+        'a',
+        undefined,
+        {},
+        'b',
+      ] as unknown as AttributeValue),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('drops arrays with mixed primitive types', () => {
+    expect(
+      sanitizeAttributeValue(['a', 1] as unknown as AttributeValue),
+    ).toBeUndefined();
+  });
+
+  it('drops arrays without any primitive entries', () => {
+    expect(
+      sanitizeAttributeValue([undefined, {}] as unknown as AttributeValue),
+    ).toBeUndefined();
+  });
+
+  it('drops empty arrays', () => {
+    expect(sanitizeAttributeValue([])).toBeUndefined();
+  });
+
+  it('drops a finish-reasons array containing only undefined', () => {
+    expect(
+      sanitizeAttributeValue([undefined] as unknown as AttributeValue),
+    ).toBeUndefined();
+  });
+});

--- a/packages/ai/src/telemetry/sanitize-attribute-value.ts
+++ b/packages/ai/src/telemetry/sanitize-attribute-value.ts
@@ -1,0 +1,39 @@
+import type { AttributeValue } from '@opentelemetry/api';
+
+function isPrimitiveAttributeValue(
+  value: unknown,
+): value is string | number | boolean {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+export function sanitizeAttributeValue(
+  value: AttributeValue,
+): AttributeValue | undefined {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  const primitiveTypes = new Set(
+    value.filter(isPrimitiveAttributeValue).map(item => typeof item),
+  );
+
+  if (primitiveTypes.size !== 1) {
+    return undefined;
+  }
+
+  const [primitiveType] = primitiveTypes;
+
+  if (primitiveType === 'string') {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+
+  if (primitiveType === 'number') {
+    return value.filter((item): item is number => typeof item === 'number');
+  }
+
+  return value.filter((item): item is boolean => typeof item === 'boolean');
+}

--- a/packages/ai/src/telemetry/select-telemetry-attributes.ts
+++ b/packages/ai/src/telemetry/select-telemetry-attributes.ts
@@ -1,4 +1,5 @@
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
+import { sanitizeAttributeValue } from './sanitize-attribute-value';
 import type { TelemetrySettings } from './telemetry-settings';
 
 type ResolvableAttributeValue = () =>
@@ -45,7 +46,8 @@ export async function selectTelemetryAttributes({
       const result = await value.input();
 
       if (result != null) {
-        resultAttributes[key] = result;
+        const sanitized = sanitizeAttributeValue(result);
+        if (sanitized != null) resultAttributes[key] = sanitized;
       }
 
       continue;
@@ -65,13 +67,15 @@ export async function selectTelemetryAttributes({
       const result = await value.output();
 
       if (result != null) {
-        resultAttributes[key] = result;
+        const sanitized = sanitizeAttributeValue(result);
+        if (sanitized != null) resultAttributes[key] = sanitized;
       }
       continue;
     }
 
     // value is an attribute value already:
-    resultAttributes[key] = value as AttributeValue;
+    const sanitized = sanitizeAttributeValue(value as AttributeValue);
+    if (sanitized != null) resultAttributes[key] = sanitized;
   }
 
   return resultAttributes;

--- a/packages/ai/src/telemetry/select-temetry-attributes.test.ts
+++ b/packages/ai/src/telemetry/select-temetry-attributes.test.ts
@@ -1,3 +1,4 @@
+import type { AttributeValue } from '@opentelemetry/api';
 import { selectTelemetryAttributes } from './select-telemetry-attributes';
 import { it, expect } from 'vitest';
 
@@ -110,5 +111,39 @@ it('should handle mixed attribute types correctly', async () => {
     simple: 'value',
     input: 'input value',
     output: 'output value',
+  });
+});
+
+it('drops malformed finish_reasons arrays that contain only undefined', async () => {
+  const result = await selectTelemetryAttributes({
+    telemetry: { isEnabled: true },
+    attributes: {
+      'gen_ai.response.finish_reasons': [
+        undefined,
+      ] as unknown as AttributeValue,
+      'gen_ai.response.id': 'msg_123',
+    },
+  });
+
+  expect(result).toEqual({ 'gen_ai.response.id': 'msg_123' });
+});
+
+it('sanitizes array attributes, dropping invalid entries and mixed arrays', async () => {
+  const result = await selectTelemetryAttributes({
+    telemetry: { isEnabled: true },
+    attributes: {
+      keep: ['stop', undefined, {}, 'length'] as unknown as AttributeValue,
+      valid: ['a', 'b'],
+      dropMixed: ['stop', 1] as unknown as AttributeValue,
+      fromInput: {
+        input: () => [undefined, 'value'] as unknown as AttributeValue,
+      },
+    },
+  });
+
+  expect(result).toEqual({
+    keep: ['stop', 'length'],
+    valid: ['a', 'b'],
+    fromInput: ['value'],
   });
 });


### PR DESCRIPTION
## Problem
- v6 can emit invalid OTLP array attributes when finish reason is missing.
- Node bridge/Rust decoder rejects empty AnyValue entries.

## Solution
- Sanitize telemetry array attributes before setting spans.
- Drop empty/all-invalid/mixed primitive arrays; keep homogeneous primitive arrays.
- Add regression coverage and changeset.
- Verified focused telemetry tests + package type-check.

## Related PR(s)
- v7: https://github.com/vercel/ai/pull/16322