### PR TITLE
docs: add Gonka Broker community provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -92,6 +92,7 @@ The open-source community has created the following providers:
 - [Zhipu (Z.AI) Provider](/providers/community-providers/zhipu) (`zhipu-ai-provider`)
 - [OLLM Provider](/providers/community-providers/ollm) (`@ofoundation/ollm`)
 - [ZeroEntropy Provider](/providers/community-providers/zeroentropy) (`zeroentropy-ai-provider`)
+- [Gonka Broker Provider](/providers/community-providers/gonkabroker) (`@gonkabroker/ai-sdk-provider`)
 
 ## Self-Hosted Models
 

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -96,6 +96,7 @@ The open-source community has created the following providers:
 - [OLLM Provider](/providers/community-providers/ollm) (`@ofoundation/ollm`)
 - [ZeroEntropy Provider](/providers/community-providers/zeroentropy) (`zeroentropy-ai-provider`)
 - [Neon AI Gateway Provider](/providers/community-providers/neon-ai-gateway) (`@neon/ai-sdk-provider`)
+- [Gonka Broker Provider](/providers/community-providers/gonkabroker) (`@gonkabroker/ai-sdk-provider`)
 
 ## Self-Hosted Models
 

--- a/content/providers/05-community-providers/52-gonkabroker.mdx
+++ b/content/providers/05-community-providers/52-gonkabroker.mdx
@@ -1,0 +1,97 @@
+---
+title: Gonka Broker
+description: Learn how to use the Gonka Broker provider for the AI SDK.
+---
+
+# Gonka Broker Provider
+
+[Gonka Broker](https://gonkabroker.com) provides OpenAI-compatible access to
+open-source models (Qwen, Kimi, MiniMax, and more) running on the decentralized
+[Gonka](https://gonka.ai) network — no crypto or wallet required.
+
+The [`@gonkabroker/ai-sdk-provider`](https://www.npmjs.com/package/@gonkabroker/ai-sdk-provider)
+package provides language model support for the AI SDK, built on
+[`@ai-sdk/openai-compatible`](https://www.npmjs.com/package/@ai-sdk/openai-compatible).
+
+## Setup
+
+The Gonka Broker provider is available in the `@gonkabroker/ai-sdk-provider` module.
+You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @gonkabroker/ai-sdk-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @gonkabroker/ai-sdk-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @gonkabroker/ai-sdk-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @gonkabroker/ai-sdk-provider" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default provider instance `gonkabroker` from `@gonkabroker/ai-sdk-provider`:
+
+```ts
+import { gonkabroker } from '@gonkabroker/ai-sdk-provider';
+```
+
+If you need a customized setup, you can import `createGonkaBroker` and create a
+provider instance with your settings:
+
+```ts
+import { createGonkaBroker } from '@gonkabroker/ai-sdk-provider';
+
+const gonkabroker = createGonkaBroker({
+  apiKey: process.env.GONKABROKER_API_KEY ?? '',
+  // baseURL: 'https://proxy.gonkabroker.com/v1', // optional override
+});
+```
+
+You can use the following optional settings to customize the provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls. The default prefix is
+  `https://proxy.gonkabroker.com/v1`.
+
+- **apiKey** _string_
+
+  API key sent using the `Authorization` header. Defaults to the
+  `GONKABROKER_API_KEY` environment variable. Get a key in the app at
+  [gonkabroker.com](https://gonkabroker.com).
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+## Language Models
+
+You can create language models using a provider instance. The first argument is the
+model id, e.g.:
+
+```ts
+import { gonkabroker } from '@gonkabroker/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: gonkabroker('Qwen/Qwen3-235B-A22B-Instruct-2507-FP8'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+```
+
+The authoritative, always-current list of available models is the public catalog at
+[`GET /v1/models`](https://proxy.gonkabroker.com/v1/models).
+
+Streaming (`streamText`) and tool calling are supported through the OpenAI-compatible base.
+
+## Additional Resources
+
+- [`@gonkabroker/ai-sdk-provider` on npm](https://www.npmjs.com/package/@gonkabroker/ai-sdk-provider)
+- [Source code](https://github.com/iamoeco/gonkabroker-integrations/tree/master/vercel-ai-sdk)
+- [Gonka Broker](https://gonkabroker.com)

--- a/content/providers/05-community-providers/52-gonkabroker.mdx
+++ b/content/providers/05-community-providers/52-gonkabroker.mdx
@@ -93,5 +93,5 @@ Streaming (`streamText`) and tool calling are supported through the OpenAI-compa
 ## Additional Resources
 
 - [`@gonkabroker/ai-sdk-provider` on npm](https://www.npmjs.com/package/@gonkabroker/ai-sdk-provider)
-- [Source code](https://github.com/iamoeco/gonkabroker-integrations/tree/master/vercel-ai-sdk)
+- [Source code](https://github.com/gonkabroker/gonkabroker-integrations/tree/master/vercel-ai-sdk)
 - [Gonka Broker](https://gonkabroker.com)

--- a/content/providers/05-community-providers/52-gonkabroker.mdx
+++ b/content/providers/05-community-providers/52-gonkabroker.mdx
@@ -6,7 +6,7 @@ description: Learn how to use the Gonka Broker provider for the AI SDK.
 # Gonka Broker Provider
 
 [Gonka Broker](https://gonkabroker.com) provides OpenAI-compatible access to
-open-source models (Qwen, Kimi, MiniMax, and more) running on the decentralized
+open-source models (MiniMax, Kimi, and more) running on the decentralized
 [Gonka](https://gonka.ai) network — no crypto or wallet required.
 
 The [`@gonkabroker/ai-sdk-provider`](https://www.npmjs.com/package/@gonkabroker/ai-sdk-provider)
@@ -80,7 +80,7 @@ import { gonkabroker } from '@gonkabroker/ai-sdk-provider';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: gonkabroker('Qwen/Qwen3-235B-A22B-Instruct-2507-FP8'),
+  model: gonkabroker('MiniMaxAI/MiniMax-M2.7'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```


### PR DESCRIPTION
PR title:

docs: add Gonka Broker community provider

---
PR body (paste into the vercel/ai PR template, replacing it):

## Background

The Gonka Broker provider for the AI SDK (`@gonkabroker/ai-sdk-provider`) has been
published to npm but isn't yet listed among the community providers. This adds its
documentation so AI SDK users can discover and use it.

## Summary

- Adds a new community provider page
  `content/providers/05-community-providers/52-gonkabroker.mdx`, documenting
  `@gonkabroker/ai-sdk-provider` — OpenAI-compatible access to open-source models
  (Qwen, Kimi, MiniMax, …) on the decentralized Gonka network, built on
  `@ai-sdk/openai-compatible`.
- Adds Gonka Broker to the open-source providers list in
  `content/docs/02-foundations/02-providers-and-models.mdx`.

The package is published as `@gonkabroker/ai-sdk-provider@0.1.1` and verified
end-to-end with `generateText` and `streamText`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
