### PR TITLE
feat(harness-deepagents): add workflow-harness e2e and suspend-turn examples

### DIFF
--- a/examples/ai-functions/src/harness-agent/deepagents/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/suspend-turn.ts
@@ -1,0 +1,65 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+const prompt = `
+Create a complete retro Snake game in this workspace.
+
+Requirements:
+- Write a single playable HTML file named snake.html.
+- Include keyboard controls, score, game-over and restart behavior.
+- Use a pixel-art visual style with no external assets.
+- After writing the file, inspect it and make one improvement pass.
+`;
+
+const suspendAfterMs = 10000;
+
+function wait({ ms }: { ms: number }) {
+  return new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({
+    harness: deepAgents,
+    sandbox,
+  });
+
+  let exitCode = 0;
+  let session = await agent.createSession();
+  try {
+    console.log('--- turn 1: stream ---');
+    const result = await agent.stream({ session, prompt });
+    const stream = printFullStream({ result });
+
+    await wait({ ms: suspendAfterMs });
+
+    console.log('\n--- suspend turn ---');
+    const continueFrom = await session.suspendTurn();
+    await stream;
+    console.log('continueFrom:', JSON.stringify(continueFrom));
+
+    console.log('--- continue turn ---');
+    session = await agent.createSession({
+      sessionId: session.sessionId,
+      continueFrom,
+    });
+    const continued = await agent.continueStream({ session });
+    await printFullStream({ result: continued });
+
+    console.log('finishReason:', await continued.finishReason);
+    console.log('usage:', await continued.usage);
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});

--- a/examples/harness-e2e-next/app/api/harness/deepagents/workflow/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/workflow/route.ts
@@ -1,0 +1,34 @@
+import { latestUserMessage } from '@/util/latest-user-message';
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai';
+import { start } from 'workflow/api';
+import { deepAgentsCodingWorkflow } from './workflow';
+
+// Durable multi-turn DeepAgents chat via the Workflow DevKit; the `'use workflow'` orchestration lives in `./workflow` (kept `ai`-free) and this is the plain POST handler.
+export async function POST(request: Request) {
+  const body: {
+    id?: string;
+    messages: UIMessage[];
+  } = await request.json();
+
+  if (!body.id) {
+    return new Response('Missing chat id', { status: 400 });
+  }
+  const prompt = latestUserMessage(await convertToModelMessages(body.messages));
+  if (!prompt) {
+    return new Response('No user message to run', { status: 400 });
+  }
+
+  // The chat id is the stable harness session id; the session owns history, so we send only the newest user message.
+  const run = await start(deepAgentsCodingWorkflow, [
+    { prompt, sessionId: body.id },
+  ]);
+
+  return createUIMessageStreamResponse({
+    stream: run.readable as ReadableStream<UIMessageChunk>,
+  });
+}

--- a/examples/harness-e2e-next/app/api/harness/deepagents/workflow/run-slice-step.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/workflow/run-slice-step.ts
@@ -1,0 +1,23 @@
+import {
+  runHarnessAgentSlice,
+  type HarnessWorkflowState,
+} from '@ai-sdk/workflow-harness';
+
+// Slice step in its own module; the agent is dynamically imported so its `@vercel/sandbox` deps stay out of the workflow bundle. See the claude-code slice step for the full rationale.
+
+// Demo budget lowered from the 750s production default so slicing is observable.
+const DEMO_SLICE_TIMEOUT_SECONDS = 30;
+
+export async function runDeepAgentsSlice(
+  state: HarnessWorkflowState,
+): Promise<HarnessWorkflowState> {
+  'use step';
+
+  const { deepAgentsHarnessAgent } =
+    await import('@/agent/harness/deepagents/basic-agent');
+  return runHarnessAgentSlice({
+    agent: deepAgentsHarnessAgent,
+    state,
+    sliceTimeoutSeconds: DEMO_SLICE_TIMEOUT_SECONDS,
+  });
+}

--- a/examples/harness-e2e-next/app/api/harness/deepagents/workflow/workflow.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/workflow/workflow.ts
@@ -1,0 +1,25 @@
+import {
+  loadResumeStep,
+  persistResumeStep,
+} from '@/util/workflow-resume-steps';
+import {
+  createHarnessWorkflowState,
+  finalizeHarnessWorkflow,
+  type HarnessWorkflowInput,
+} from '@ai-sdk/workflow-harness';
+import { runDeepAgentsSlice } from './run-slice-step';
+
+// The `'use workflow'` function lives in its own `ai`-free module (not `route.ts`) so the DevKit's generated step/flow bundle doesn't pull in `@ai-sdk/gateway`/`@vercel/oidc` and crash. See the claude-code workflow module for the full rationale.
+export async function deepAgentsCodingWorkflow(
+  input: Pick<HarnessWorkflowInput, 'prompt' | 'sessionId'>,
+) {
+  'use workflow';
+
+  const resumeFrom = await loadResumeStep(input.sessionId);
+  let state = createHarnessWorkflowState({ ...input, resumeFrom });
+  while (state.status === 'running' || state.status === 'timed_out') {
+    state = await runDeepAgentsSlice(state);
+  }
+  await persistResumeStep(state.sessionId, state.resumeFrom);
+  return finalizeHarnessWorkflow(state);
+}

--- a/examples/harness-e2e-next/app/harness/deepagents/workflow/page.tsx
+++ b/examples/harness-e2e-next/app/harness/deepagents/workflow/page.tsx
@@ -1,0 +1,19 @@
+import ChatIdProvider from '@/components/chat-id-provider';
+import DeepAgentsHarnessChat from '@/components/deepagents-harness-chat';
+
+export const metadata = {
+  title: 'DeepAgents — Workflow',
+};
+
+const STORAGE_KEY = 'harness-deepagents-workflow-chat-id';
+
+export default function HarnessDeepAgentsWorkflowPage() {
+  return (
+    <ChatIdProvider storageKey={STORAGE_KEY}>
+      <DeepAgentsHarnessChat
+        apiRoute="/api/harness/deepagents/workflow"
+        exampleLabel="Workflow"
+      />
+    </ChatIdProvider>
+  );
+}

--- a/examples/harness-e2e-next/app/page.tsx
+++ b/examples/harness-e2e-next/app/page.tsx
@@ -43,6 +43,7 @@ const HARNESSES = [
       'ai-sdk-coding',
       'weather',
       'weather-approval',
+      'workflow',
     ],
   },
   {


### PR DESCRIPTION
Adds the workflow-harness examples for Deep Agents — same set #16315 added for Claude Code, Codex, and Pi. Stacked on `harness-deepagents` (#16261).

New files:
- `suspend-turn.ts` example (stream → suspend → continue)
- `workflow/` route + step + workflow modules (durable multi-turn chat)
- `workflow/page.tsx` + a link on the home page

Tested live against a Vercel Sandbox: turn 1 wrote a file, turn 2 reused the warm session and read it back. Type-check, lint, and format pass.