### PR TITLE
fix(harness): ensure finish chunk's total usage is actually coming from total usage

### DIFF
--- a/.changeset/modern-sheep-attack.md
+++ b/.changeset/modern-sheep-attack.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+fix(harness): ensure finish chunk's total usage is actually coming from total usage

--- a/packages/harness/src/agent/internal/harness-stream-text-result.ts
+++ b/packages/harness/src/agent/internal/harness-stream-text-result.ts
@@ -272,9 +272,20 @@ export class HarnessStreamTextResult<
   /**
    * Resolve every delayed promise and close `fullStream`. Idempotent.
    */
-  async finish(): Promise<void> {
+  async finish(input?: {
+    finishReason: LanguageModelV4FinishReason;
+    totalUsage: LanguageModelV4Usage;
+    providerMetadata: ProviderMetadata | undefined;
+  }): Promise<void> {
     if (this.settled) return;
     this.settled = true;
+
+    if (input != null) {
+      this.finalFinishReason = input.finishReason.unified;
+      this.finalRawFinishReason = input.finishReason.raw;
+      this.finalProviderMetadata = input.providerMetadata;
+      this.accumulatedUsage = asLanguageModelUsage(input.totalUsage);
+    }
 
     // Flush any trailing content not yet captured by a finish-step. We
     // construct the step directly here (the public `finishStep` takes V4

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -166,6 +166,77 @@ describe('runPrompt workDir stripping', () => {
   });
 });
 
+describe('runPrompt usage', () => {
+  test('uses final total usage when it differs from received step usage', async () => {
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        {
+          type: 'finish-step',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: {
+            inputTokens: {
+              total: 2,
+              noCache: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+            outputTokens: {
+              total: 5,
+              text: 5,
+              reasoning: 0,
+            },
+          },
+        },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          totalUsage: {
+            inputTokens: {
+              total: 10,
+              noCache: 4,
+              cacheRead: 6,
+              cacheWrite: 0,
+            },
+            outputTokens: {
+              total: 40,
+              text: 30,
+              reasoning: 10,
+            },
+          },
+        },
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {},
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+    });
+
+    await done;
+    await result.consumeStream();
+
+    await expect(result.usage).resolves.toEqual({
+      inputTokens: 10,
+      inputTokenDetails: {
+        noCacheTokens: 4,
+        cacheReadTokens: 6,
+        cacheWriteTokens: 0,
+      },
+      outputTokens: 40,
+      outputTokenDetails: {
+        textTokens: 30,
+        reasoningTokens: 10,
+      },
+      totalTokens: 50,
+      raw: undefined,
+    });
+  });
+});
+
 type SubmittedResult = {
   toolCallId: string;
   output: unknown;

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -152,6 +152,9 @@ export function runPrompt<
       ]),
     );
     const settledApprovalToolCallIds = new Set<string>();
+    let finalFinish:
+      | Extract<HarnessV1StreamPart, { type: 'finish' }>
+      | undefined;
 
     // Accumulate the model's output content per step so telemetry can record
     // `gen_ai.output.messages` and reporters can log what was actually said.
@@ -495,6 +498,7 @@ export function runPrompt<
         }
 
         if (value.type === 'finish') {
+          finalFinish = value;
           telemetry.end({
             finishReason: value.finishReason,
             usage: value.totalUsage,
@@ -636,7 +640,15 @@ export function runPrompt<
         }
       }
       input.onTurnFinished?.();
-      await result.finish();
+      await result.finish(
+        finalFinish
+          ? {
+              finishReason: finalFinish.finishReason,
+              totalUsage: finalFinish.totalUsage,
+              providerMetadata: finalFinish.harnessMetadata,
+            }
+          : undefined,
+      );
     } catch (err) {
       telemetry.error(err);
       result.fail(err);


### PR DESCRIPTION
## Background

The harness abstraction layer was reporting `finish-step.usage` as overall usage, when in fact that value needs to come from `finish.totalUsage`.

The bug only surfaced while working on the OpenCode harness (#16255) because the previously existing harnesses were effectively only emitting `finish-step` at the same stage as the overall `finish` (so the values were correct despite the bug).

## Summary

This PR ensures `finish.totalUsage` is read from for overall usage. That value was already being used for telemetry, but not for the returned result object.

#16255 includes the same fix, I just broke it out of that PR to be an independent change here.

## Manual Verification

Run e.g. the `suspend-turn.ts` example from OpenCode in #16255.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
