### PR TITLE
backport v6: xai support 'none' and 'medium' reasoning effort + grok-4.3

### DIFF
--- a/.changeset/stupid-eagles-sniff.md
+++ b/.changeset/stupid-eagles-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+xai: support 'none' and 'medium' reasoning effort and add grok-4.3 model id

--- a/.changeset/stupid-eagles-sniff.md
+++ b/.changeset/stupid-eagles-sniff.md
@@ -2,4 +2,4 @@
 "@ai-sdk/xai": patch
 ---
 
-xai: support 'none' and 'medium' reasoning effort and add grok-4.3 model id
+xai: support 'none' and 'medium' reasoning effort and curate model ids to xai's current lineup (add grok-4.3, grok-build-0.1, grok-imagine-image-quality)

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -123,7 +123,7 @@ The following optional provider options are available for xAI chat models:
 
 - **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Reasoning effort for reasoning models. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
+  Reasoning effort for reasoning models. `'none'` disables reasoning entirely. Not all models support reasoning effort, see xAI's docs for the values each model accepts.
 
 - **logprobs** _boolean_
 
@@ -456,7 +456,7 @@ The following provider options are available:
 
 - **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
+  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage. `'none'` disables reasoning entirely. Not all models support reasoning effort, see xAI's docs for the values each model accepts.
 
 - **logprobs** _boolean_
 

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -123,7 +123,14 @@ The following optional provider options are available for xAI chat models:
 
 - **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Reasoning effort for reasoning models. `'none'` disables reasoning entirely. Not all models support reasoning effort, see xAI's docs for the values each model accepts.
+  Reasoning effort for reasoning models. `'none'` disables reasoning entirely.
+
+<Note>
+  Not every Grok model accepts every reasoning effort, for example
+  `grok-build-0.1` does not support reasoning effort. See xAI's [reasoning
+  docs](https://docs.x.ai/docs/guides/reasoning) for the values each model
+  accepts.
+</Note>
 
 - **logprobs** _boolean_
 
@@ -456,7 +463,14 @@ The following provider options are available:
 
 - **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage. `'none'` disables reasoning entirely. Not all models support reasoning effort, see xAI's docs for the values each model accepts.
+  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage. `'none'` disables reasoning entirely.
+
+<Note>
+  Not every Grok model accepts every reasoning effort, for example
+  `grok-build-0.1` does not support reasoning effort. See xAI's [reasoning
+  docs](https://docs.x.ai/docs/guides/reasoning) for the values each model
+  accepts.
+</Note>
 
 - **logprobs** _boolean_
 

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -121,9 +121,9 @@ await generateText({
 
 The following optional provider options are available for xAI chat models:
 
-- **reasoningEffort** _'low' | 'high'_
+- **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Reasoning effort for reasoning models.
+  Reasoning effort for reasoning models. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
 
 - **logprobs** _boolean_
 
@@ -454,9 +454,9 @@ const result = await generateText({
 
 The following provider options are available:
 
-- **reasoningEffort** _'low' | 'medium' | 'high'_
+- **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage.
+  Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
 
 - **logprobs** _boolean_
 

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -479,6 +479,29 @@ describe('XaiResponsesLanguageModel', () => {
           expect(requestBody.reasoning.effort).toBe('high');
         });
 
+        it('reasoningEffort none', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                reasoningEffort: 'none',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.effort).toBe('none');
+        });
+
         it('logprobs and topLogprobs', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -1,15 +1,11 @@
 import { z } from 'zod/v4';
 
 export type XaiResponsesModelId =
-  | 'grok-4-1-fast-reasoning'
-  | 'grok-4-1-fast-non-reasoning'
-  | 'grok-4'
-  | 'grok-4-fast-non-reasoning'
-  | 'grok-4-fast-reasoning'
   | 'grok-4.3'
-  | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-0309-reasoning'
+  | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-multi-agent-0309'
+  | 'grok-build-0.1'
   | (string & {});
 
 /**

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -14,9 +14,9 @@ export type XaiResponsesModelId =
 export const xaiLanguageModelResponsesOptions = z.object({
   /**
    * Constrains how hard a reasoning model thinks before responding.
-   * Possible values are `none` (disables reasoning, supported by `grok-4.3` and
-   * newer), `low` (uses fewer reasoning tokens), `medium` and `high` (uses more
-   * reasoning tokens).
+   * Possible values are `none` (disables reasoning), `low` (uses fewer reasoning
+   * tokens), `medium` and `high` (uses more reasoning tokens). Not all models
+   * support reasoning effort; see xAI's docs for the values each model accepts.
    */
   reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   logprobs: z.boolean().optional(),

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -6,6 +6,7 @@ export type XaiResponsesModelId =
   | 'grok-4'
   | 'grok-4-fast-non-reasoning'
   | 'grok-4-fast-reasoning'
+  | 'grok-4.3'
   | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-0309-reasoning'
   | 'grok-4.20-multi-agent-0309'
@@ -17,9 +18,11 @@ export type XaiResponsesModelId =
 export const xaiLanguageModelResponsesOptions = z.object({
   /**
    * Constrains how hard a reasoning model thinks before responding.
-   * Possible values are `low` (uses fewer reasoning tokens), `medium` and `high` (uses more reasoning tokens).
+   * Possible values are `none` (disables reasoning, supported by `grok-4.3` and
+   * newer), `low` (uses fewer reasoning tokens), `medium` and `high` (uses more
+   * reasoning tokens).
    */
-  reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   logprobs: z.boolean().optional(),
   topLogprobs: z.number().int().min(0).max(8).optional(),
   /**

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1230,6 +1230,30 @@ describe('XaiChatLanguageModel', () => {
       `);
     });
 
+    it('should pass reasoning_effort none parameter', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await reasoningModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: { reasoningEffort: 'none' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "grok-3-mini",
+          "reasoning_effort": "none",
+        }
+      `);
+    });
+
     it('should extract reasoning content', async () => {
       prepareJsonFixtureResponse('xai-text');
 

--- a/packages/xai/src/xai-chat-options.ts
+++ b/packages/xai/src/xai-chat-options.ts
@@ -2,22 +2,11 @@ import { z } from 'zod/v4';
 
 // https://docs.x.ai/docs/models
 export type XaiChatModelId =
-  | 'grok-4-1-fast-reasoning'
-  | 'grok-4-1-fast-non-reasoning'
-  | 'grok-4-fast-non-reasoning'
-  | 'grok-4-fast-reasoning'
   | 'grok-4.3'
-  | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-0309-reasoning'
+  | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-multi-agent-0309'
-  | 'grok-code-fast-1'
-  | 'grok-4'
-  | 'grok-4-0709'
-  | 'grok-4-latest'
-  | 'grok-3'
-  | 'grok-3-latest'
-  | 'grok-3-mini'
-  | 'grok-3-mini-latest'
+  | 'grok-build-0.1'
   | (string & {});
 
 // search source schemas

--- a/packages/xai/src/xai-chat-options.ts
+++ b/packages/xai/src/xai-chat-options.ts
@@ -6,6 +6,7 @@ export type XaiChatModelId =
   | 'grok-4-1-fast-non-reasoning'
   | 'grok-4-fast-non-reasoning'
   | 'grok-4-fast-reasoning'
+  | 'grok-4.3'
   | 'grok-4.20-0309-non-reasoning'
   | 'grok-4.20-0309-reasoning'
   | 'grok-4.20-multi-agent-0309'
@@ -61,7 +62,7 @@ const searchSourceSchema = z.discriminatedUnion('type', [
 
 // xai-specific provider options
 export const xaiLanguageModelChatOptions = z.object({
-  reasoningEffort: z.enum(['low', 'high']).optional(),
+  reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   logprobs: z.boolean().optional(),
   topLogprobs: z.number().int().min(0).max(8).optional(),
 

--- a/packages/xai/src/xai-image-settings.ts
+++ b/packages/xai/src/xai-image-settings.ts
@@ -1,4 +1,4 @@
 export type XaiImageModelId =
   | 'grok-imagine-image'
-  | 'grok-imagine-image-pro'
+  | 'grok-imagine-image-quality'
   | (string & {});


### PR DESCRIPTION
## background

backport of #15276
