### PR TITLE
feat(ai): add ai-sdk-agent user-agent tag for agent usage attribution

### DIFF
--- a/.changeset/khaki-lamps-push.md
+++ b/.changeset/khaki-lamps-push.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/workflow": patch
+"ai": patch
+---
+
+agents: tag outgoing requests with an ai-sdk-agent user-agent segment for usage attribution (tool-loop, workflow)

--- a/examples/ai-functions/src/agent/openai/agent-user-agent.ts
+++ b/examples/ai-functions/src/agent/openai/agent-user-agent.ts
@@ -1,0 +1,39 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { ToolLoopAgent } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  let userAgent: string | null = null;
+
+  const capturingFetch: typeof fetch = async (_url, init) => {
+    userAgent = new Headers(init?.headers).get('user-agent');
+    return new Response(
+      JSON.stringify({
+        id: 'response-id',
+        object: 'chat.completion',
+        created: 0,
+        model: 'gpt-4o-mini',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'hi' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  };
+
+  const openai = createOpenAI({ apiKey: 'test', fetch: capturingFetch });
+
+  const agent = new ToolLoopAgent({
+    model: openai.chat('gpt-4o-mini'),
+  });
+
+  await agent.generate({ prompt: 'hello' });
+
+  console.log('outgoing user-agent:');
+  console.log(`  ${userAgent}`);
+});

--- a/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
@@ -132,7 +132,9 @@ describe('createAgentUIStreamResponse', () => {
           {
             "abortSignal": undefined,
             "frequencyPenalty": undefined,
-            "headers": undefined,
+            "headers": {
+              "user-agent": "ai-sdk-agent/tool-loop",
+            },
             "includeRawChunks": false,
             "maxOutputTokens": undefined,
             "presencePenalty": undefined,

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -102,6 +102,29 @@ describe('ToolLoopAgent', () => {
       `);
     });
 
+    it('should tag the user-agent with the agent identifier', async () => {
+      const agent = new ToolLoopAgent({ model: mockModel });
+
+      await agent.generate({ prompt: 'Hello, world!' });
+
+      expect(doGenerateOptions?.headers?.['user-agent']).toContain(
+        'ai-sdk-agent/tool-loop',
+      );
+    });
+
+    it('should preserve a caller-provided user-agent', async () => {
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+        headers: { 'user-agent': 'my-app/1.0' },
+      });
+
+      await agent.generate({ prompt: 'Hello, world!' });
+
+      const ua = doGenerateOptions?.headers?.['user-agent'] ?? '';
+      expect(ua).toContain('my-app/1.0');
+      expect(ua).toContain('ai-sdk-agent/tool-loop');
+    });
+
     it('should forward toolOrder to generateText', async () => {
       const agent = new ToolLoopAgent({
         model: mockModel,

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,5 +1,6 @@
 import {
   validateTypes,
+  withUserAgentSuffix,
   type Context,
   type Experimental_SandboxSession as SandboxSession,
   type ModelMessage,
@@ -177,6 +178,20 @@ export class ToolLoopAgent<
   }
 
   /**
+   * Tags outgoing requests so usage can be attributed to ToolLoopAgent. Chains
+   * with the `ai/<version>` and `ai-sdk/<provider>/<version>` suffixes added
+   * downstream by generateText/streamText and the provider.
+   */
+  private agentHeaders(preparedCall: {
+    headers?: unknown;
+  }): Record<string, string> {
+    return withUserAgentSuffix(
+      (preparedCall.headers as Record<string, string | undefined>) ?? {},
+      'ai-sdk-agent/tool-loop',
+    );
+  }
+
+  /**
    * Generates an output from the agent (non-streaming).
    */
   async generate({
@@ -236,6 +251,7 @@ export class ToolLoopAgent<
     return await generate({
       ...preparedCall,
       ...callbackArgs,
+      headers: this.agentHeaders(preparedCall),
     } as unknown as Parameters<typeof generate>[0]);
   }
 
@@ -301,6 +317,7 @@ export class ToolLoopAgent<
     return await stream({
       ...preparedCall,
       ...callbackArgs,
+      headers: this.agentHeaders(preparedCall),
     } as unknown as Parameters<typeof stream>[0]);
   }
 }

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -591,7 +591,9 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
                 {
                   "abortSignal": undefined,
                   "frequencyPenalty": undefined,
-                  "headers": undefined,
+                  "headers": {
+                    "user-agent": "ai-sdk-agent/workflow",
+                  },
                   "includeRawChunks": false,
                   "maxOutputTokens": 500,
                   "presencePenalty": undefined,
@@ -762,7 +764,9 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
                 {
                   "abortSignal": undefined,
                   "frequencyPenalty": undefined,
-                  "headers": undefined,
+                  "headers": {
+                    "user-agent": "ai-sdk-agent/workflow",
+                  },
                   "includeRawChunks": false,
                   "maxOutputTokens": undefined,
                   "presencePenalty": undefined,

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -78,6 +78,39 @@ describe('WorkflowAgent', () => {
     });
   });
 
+  describe('user-agent', () => {
+    async function runStream(headers?: Record<string, string>) {
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockReturnValue({
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      } as unknown as MockIterator);
+
+      const agent = new WorkflowAgent({ model: createMockModel() });
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: new WritableStream({ write: vi.fn(), close: vi.fn() }),
+        ...(headers ? { headers } : {}),
+      });
+
+      const call = vi.mocked(streamTextIterator).mock.calls.at(-1)?.[0];
+      return (call?.generationSettings?.headers ?? {}) as Record<
+        string,
+        string
+      >;
+    }
+
+    it('should tag the user-agent with the agent identifier', async () => {
+      const headers = await runStream();
+      expect(headers['user-agent']).toContain('ai-sdk-agent/workflow');
+    });
+
+    it('should preserve a caller-provided user-agent', async () => {
+      const headers = await runStream({ 'user-agent': 'my-app/1.0' });
+      expect(headers['user-agent']).toContain('my-app/1.0');
+      expect(headers['user-agent']).toContain('ai-sdk-agent/workflow');
+    });
+  });
+
   describe('tool execution error handling', () => {
     it('should convert FatalError to tool error result', async () => {
       const errorMessage = 'This is a fatal error';

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -8,6 +8,7 @@ import type {
 import {
   getErrorMessage,
   validateTypes,
+  withUserAgentSuffix,
   type Context,
   type HasRequiredKey,
   type InferToolSetContext,
@@ -1747,6 +1748,14 @@ export class WorkflowAgent<
         providerOptions: options.providerOptions,
       }),
     };
+
+    // tag the outgoing request so usage can be attributed to WorkflowAgent.
+    // chains with the `ai/<version>` and `ai-sdk/<provider>/<version>` suffixes
+    // added downstream by the model run and the provider.
+    mergedGenerationSettings.headers = withUserAgentSuffix(
+      mergedGenerationSettings.headers ?? {},
+      'ai-sdk-agent/workflow',
+    );
 
     // Merge constructor + stream callbacks (constructor first, then stream)
     const mergedOnStepEnd = mergeCallbacks(


### PR DESCRIPTION
## background

agents (`ToolLoopAgent` in `ai`, `WorkflowAgent` in `@ai-sdk/workflow`) are thin wrappers over `generateText`/`streamText`, so today there's no way to tell which agent abstraction produced a request. the outgoing user-agent is already recorded in the gateway usage facts + telemetry, so appending an `ai-sdk-agent/<type>` segment lets usage be attributed per agent with no gateway changes

## summary

- `ToolLoopAgent` appends `ai-sdk-agent/tool-loop` to the outgoing user-agent
- `WorkflowAgent` appends `ai-sdk-agent/workflow`
- non-destructive: preserves a caller-set user-agent and chains with the existing `ai/<version>` and `ai-sdk/<provider>/<version>` segments
- `HarnessAgent` is out of scope, it has no sdk-issued model request to tag (runs through a harness adapter)