### PR TITLE
feat(openai): add support for web_search_call.results include option

### DIFF
--- a/.changeset/fuzzy-tips-sell.md
+++ b/.changeset/fuzzy-tips-sell.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(openai): add web_search_call.results to OpenAIResponsesIncludeValue and auto-include with web search tool

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -42,6 +42,7 @@ export type OpenAIResponsesInputItem =
   | OpenAIResponsesCompactionItem;
 
 export type OpenAIResponsesIncludeValue =
+  | 'web_search_call.results'
   | 'web_search_call.action.sources'
   | 'code_interpreter_call.outputs'
   | 'computer_call_output.output.image_url'

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3282,6 +3282,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           {
             "include": [
               "web_search_call.action.sources",
+              "web_search_call.results",
             ],
             "input": [
               {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -314,7 +314,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
 
     if (webSearchToolName) {
       addInclude('web_search_call.action.sources');
-      addInclude('web_search_call.results');
+      if (isReasoningModel) {
+        addInclude('web_search_call.results');
+      }
     }
 
     // when a code interpreter tool is present, automatically include the outputs:

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -314,6 +314,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
 
     if (webSearchToolName) {
       addInclude('web_search_call.action.sources');
+      addInclude('web_search_call.results');
     }
 
     // when a code interpreter tool is present, automatically include the outputs:


### PR DESCRIPTION
## Background
OpenAI responses API supports `web_search_call.results` as an `includes` 
option per the [OpenAI docs](https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response_includable%20%3E%20(schema)%20%3E%20(member)%201), 
but it was missing from the SDK type definition and was not auto-included 
when using web search tools.

## Summary
- Added `web_search_call.results` to `OpenAIResponsesIncludeValue` type union
- Auto-include `web_search_call.results` alongside `web_search_call.action.sources` 
  when a web search tool is present, following the same pattern as other includes

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A patch changeset has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #16346