### PR TITLE
fix(ui): preserve approval signature in addToolApprovalResponse

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -493,7 +493,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           ? {
               ...part,
               state: 'approval-responded',
-              approval: { id, approved, reason },
+              approval: { ...part.approval, id, approved, reason },
             }
           : part;
 


### PR DESCRIPTION
## Summary

\`addToolApprovalResponse\` rebuilt the \`approval\` object from scratch, discarding the server-issued \`signature\` (and \`isAutomatic\`) that arrived on the \`approval-requested\` part. On resume, \`convertToModelMessages\` only emits the signature when \`part.approval.signature != null\`, so the replayed \`tool-approval-request\` carried no signature. \`validateApprovedToolApprovals\` then sees \`toolApprovalSecret != null\` with \`approvalRequest.signature == null\` and throws \`InvalidToolApprovalSignatureError('missing signature')\`.

Before: \`approval: { id, approved, reason }\` — signature dropped.
After: \`approval: { ...part.approval, id, approved, reason }\` — signature preserved.

Spreading \`part.approval\` first keeps \`signature\` and \`isAutomatic\` alive while overriding the mutable response fields.

Fixes #16334

## Changes

- \`packages/ai/src/ui/chat.ts\`: spread \`part.approval\` in \`addToolApprovalResponse\` to preserve \`signature\` and \`isAutomatic\`