### PR TITLE
fix(mcp): handle server-initiated notifications instead of erroring

### DIFF
--- a/.changeset/mcp-server-notifications.md
+++ b/.changeset/mcp-server-notifications.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): handle server-initiated notifications instead of erroring
+
+The MCP client now accepts inbound JSON-RPC notifications (a message with a `method` but no `id`) instead of surfacing them as an `Unsupported message type` error. Per the MCP specification, clients must accept server-initiated notifications (such as `notifications/message`) and silently ignore any they do not handle.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -1383,6 +1383,36 @@ describe('MCPClient', () => {
     });
   });
 
+  describe('notification support', () => {
+    it('should ignore server-initiated notifications instead of erroring per MCP spec', async () => {
+      const onUncaughtError = vi.fn();
+      client = await createMCPClient({
+        transport: { type: 'sse', url: 'https://example.com/sse' },
+        onUncaughtError,
+      });
+
+      const transportInstance = createMockTransport.mock.results.at(-1)
+        ?.value as MockMCPTransport;
+      const sendSpy = vi.spyOn(transportInstance, 'send');
+
+      const notification = {
+        jsonrpc: '2.0' as const,
+        method: 'notifications/message',
+        params: { level: 'info', data: 'hello from server' },
+      };
+
+      transportInstance.onmessage?.(notification);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Notifications expect no response and unhandled ones must be ignored,
+      // so neither an error nor a reply should be emitted.
+      expect(onUncaughtError).not.toHaveBeenCalled();
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('should use onUncaughtError callback if provided', async () => {
     const onUncaughtError = vi.fn();
     const mockTransport = new MockMCPTransport({

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -232,7 +232,7 @@ export interface MCPClient {
  * This client is meant to be used to communicate with a single server. To communicate and fetch tools across multiple servers, it's recommended to create a new client instance per server.
  *
  * Not supported:
- * - Accepting notifications
+ * - Handling notifications (server-initiated notifications are accepted but ignored)
  * - Automatic session persistence for Streamable HTTP transport
  * - Resumable SSE streams
  */
@@ -285,13 +285,12 @@ class DefaultMCPClient implements MCPClient {
       if ('method' in message) {
         if ('id' in message) {
           this.onRequestMessage(message);
-        } else {
-          this.onError(
-            new MCPClientError({
-              message: 'Unsupported message type',
-            }),
-          );
         }
+        // A message with a `method` but no `id` is a JSON-RPC notification
+        // (e.g. notifications/message, notifications/cancelled). The MCP spec
+        // requires clients to accept server-initiated notifications and to
+        // ignore any they do not handle, so we drop them silently instead of
+        // surfacing an error.
         return;
       }
 


### PR DESCRIPTION
## Background

The MCP client's `onmessage` handler treated any inbound message that had a `method` but no `id` as an error, calling `onUncaughtError` with `MCPClientError: Unsupported message type`. A `method` without an `id` is a JSON-RPC notification, not a malformed message. Per the MCP specification, clients must accept server-initiated notifications (for example `notifications/message`, `notifications/cancelled`, `notifications/progress`) and silently ignore any they do not handle. As written, any server that emits such a notification triggers a spurious uncaught error on the client.

This is the notification-side counterpart to #15701, which fixed `ping` request handling in the same `onmessage` / `onRequestMessage` dispatcher.

## Summary

- `onmessage` now treats a message with a `method` and no `id` as a notification and returns without erroring, instead of routing it to `onError`.
- Updated the `DefaultMCPClient` doc comment so the "Not supported" list reflects that notifications are accepted but ignored, rather than implying they error.
- Added a `notification support` test asserting that an inbound `notifications/message` does not call `onUncaughtError` and produces no reply.

## Manual Verification

On stock `main`, I injected a `notifications/message` through the transport's `onmessage` callback and confirmed it triggered `onUncaughtError` with `MCPClientError: Unsupported message type`. After the change, the same notification is ignored: no error is raised and no response is sent. The added test encodes this behavior (it fails on the current code and passes with the fix). Package tests (`pnpm vitest run src/tool/mcp-client.test.ts`, 65 passing) and `pnpm type-check` both pass.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

An optional client-side notification handler could let consumers observe notifications they care about (for example `notifications/message` logging, `notifications/progress`, or `notifications/tools/list_changed`) instead of only dropping them. This PR intentionally keeps scope to spec-compliant acceptance.

## Related Issues

Related to #15701 (the `ping` request-handling fix in the same dispatcher). No open issue tracks the notification side.