### PR TITLE
feat(provider/fireworks): add prompt cache affinity

### DIFF
--- a/.changeset/fresh-fireworks-cache.md
+++ b/.changeset/fresh-fireworks-cache.md
@@ -1,5 +1,6 @@
 ---
-'@ai-sdk/fireworks': patch
+"@ai-sdk/fireworks": patch
 ---
 
-Add the `promptCacheKey` provider option for Fireworks prompt cache affinity.
+Add the `promptCacheKey` provider option for Fireworks prompt cache affinity
+and Kimi K2.6 model autocomplete.

--- a/.changeset/fresh-fireworks-cache.md
+++ b/.changeset/fresh-fireworks-cache.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Add the `promptCacheKey` provider option for Fireworks prompt cache affinity.

--- a/.changeset/fresh-fireworks-cache.md
+++ b/.changeset/fresh-fireworks-cache.md
@@ -3,4 +3,5 @@
 ---
 
 Add the `promptCacheKey` provider option for Fireworks prompt cache affinity
-and Kimi K2.6 model autocomplete.
+and Kimi K2.6 model autocomplete, and remove the deprecated Kimi K2.5
+serverless model from autocomplete.

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -122,7 +122,7 @@ import {
 import { generateText } from 'ai';
 
 const { text, reasoningText } = await generateText({
-  model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  model: fireworks('accounts/fireworks/models/kimi-k2p6'),
   providerOptions: {
     fireworks: {
       thinking: { type: 'enabled', budgetTokens: 4096 },
@@ -144,7 +144,7 @@ The following optional provider options are available for Fireworks chat models:
 
 - **thinking** _object_
 
-  Configuration for thinking/reasoning models like Kimi K2.5.
+  Configuration for thinking/reasoning models like Kimi K2.6.
   - **type** _'enabled' | 'disabled'_
 
     Whether to enable thinking mode.
@@ -184,7 +184,7 @@ import { z } from 'zod';
 const sessionId = 'conversation-123';
 
 const result = await generateText({
-  model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  model: fireworks('accounts/fireworks/models/kimi-k2p6'),
   providerOptions: {
     fireworks: {
       promptCacheKey: sessionId,
@@ -218,7 +218,7 @@ import { z } from 'zod';
 import { weatherTool } from './weather-tool';
 
 const agent = new ToolLoopAgent({
-  model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  model: fireworks('accounts/fireworks/models/kimi-k2p6'),
   callOptionsSchema: z.object({
     sessionId: z.string(),
   }),
@@ -278,6 +278,7 @@ const model = fireworks.completionModel(
 | `accounts/fireworks/models/kimi-k2-instruct`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2-thinking`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2p5`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
+| `accounts/fireworks/models/kimi-k2p6`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/minimax-m2`                     | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 
 <Note>

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -277,7 +277,6 @@ const model = fireworks.completionModel(
 | `accounts/fireworks/models/yi-large`                       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2-instruct`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2-thinking`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
-| `accounts/fireworks/models/kimi-k2p5`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2p6`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/minimax-m2`                     | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -135,6 +135,13 @@ const { text, reasoningText } = await generateText({
 
 The following optional provider options are available for Fireworks chat models:
 
+- **promptCacheKey** _string_
+
+  A stable, opaque key that improves prompt cache hit rates by routing requests
+  with shared prompt prefixes to the same Fireworks replica. Reuse the same key
+  for all steps and calls in one conversation, and use different keys for
+  unrelated conversations.
+
 - **thinking** _object_
 
   Configuration for thinking/reasoning models like Kimi K2.5.
@@ -152,6 +159,90 @@ The following optional provider options are available for Fireworks chat models:
   - `'disabled'`: Remove reasoning from history
   - `'interleaved'`: Include reasoning between tool calls within a single turn
   - `'preserved'`: Keep all reasoning in history
+
+### Prompt Cache Affinity
+
+[Fireworks prompt caching](https://docs.fireworks.ai/guides/prompt-caching)
+is automatic, but cached prefixes are local to a replica. Set
+`promptCacheKey` to an opaque session or conversation identifier to improve
+cache affinity. The provider sends it as Fireworks'
+[`prompt_cache_key`](https://docs.fireworks.ai/api-reference/post-chatcompletions)
+request field.
+
+The AI SDK reuses the same provider options for every model step in a
+multi-step `generateText` or `streamText` call, so one key covers the complete
+tool loop:
+
+```ts
+import {
+  fireworks,
+  type FireworksLanguageModelOptions,
+} from '@ai-sdk/fireworks';
+import { generateText, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+
+const sessionId = 'conversation-123';
+
+const result = await generateText({
+  model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  providerOptions: {
+    fireworks: {
+      promptCacheKey: sessionId,
+    } satisfies FireworksLanguageModelOptions,
+  },
+  tools: {
+    weather: tool({
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => `It is sunny in ${city}.`,
+    }),
+  },
+  stopWhen: isStepCount(5),
+  prompt: 'What is the weather in San Francisco?',
+});
+
+console.log(result.usage.inputTokenDetails.cacheReadTokens);
+```
+
+For a reusable `ToolLoopAgent`, use call options to supply a key for each
+conversation. Pass the same key again for later agent calls that continue that
+conversation:
+
+```ts
+import {
+  fireworks,
+  type FireworksLanguageModelOptions,
+} from '@ai-sdk/fireworks';
+import { ToolLoopAgent } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from './weather-tool';
+
+const agent = new ToolLoopAgent({
+  model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  callOptionsSchema: z.object({
+    sessionId: z.string(),
+  }),
+  prepareCall: ({ options, ...settings }) => ({
+    ...settings,
+    providerOptions: {
+      fireworks: {
+        promptCacheKey: options.sessionId,
+      } satisfies FireworksLanguageModelOptions,
+    },
+  }),
+  tools: { weather: weatherTool },
+});
+
+const result = await agent.generate({
+  prompt: 'What is the weather in San Francisco?',
+  options: {
+    sessionId: 'conversation-123',
+  },
+});
+```
+
+Use non-identifying values for cache keys rather than email addresses or other
+personal information.
 
 ### Completion Models
 

--- a/examples/ai-functions/src/generate-text/fireworks/kimi-k2-5-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/fireworks/kimi-k2-5-tool-call.ts
@@ -2,15 +2,14 @@ import {
   fireworks,
   type FireworksLanguageModelOptions,
 } from '@ai-sdk/fireworks';
-import { isStepCount, streamText } from 'ai';
-import { printFullStream } from '../../lib/print-full-stream';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
 run(async () => {
   const sessionId = 'weather-conversation-123';
 
-  const result = streamText({
+  const result = await generateText({
     model: fireworks('accounts/fireworks/models/kimi-k2p5'),
     providerOptions: {
       fireworks: {
@@ -24,6 +23,12 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  await printFullStream({ result });
-  console.log('Token usage:', await result.usage);
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log(
+    'Cached input tokens:',
+    result.usage.inputTokenDetails.cacheReadTokens,
+  );
+  console.log('Finish reason:', result.finishReason);
 });

--- a/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-thinking.ts
+++ b/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-thinking.ts
@@ -7,7 +7,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
         thinking: { type: 'enabled', budgetTokens: 4096 },

--- a/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-tool-call.ts
@@ -2,16 +2,15 @@ import {
   fireworks,
   type FireworksLanguageModelOptions,
 } from '@ai-sdk/fireworks';
-import { isStepCount, streamText } from 'ai';
-import { printFullStream } from '../../lib/print-full-stream';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
 run(async () => {
   const sessionId = 'weather-conversation-123';
 
-  const result = streamText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  const result = await generateText({
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
         promptCacheKey: sessionId,
@@ -24,6 +23,12 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  await printFullStream({ result });
-  console.log('Token usage:', await result.usage);
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log(
+    'Cached input tokens:',
+    result.usage.inputTokenDetails.cacheReadTokens,
+  );
+  console.log('Finish reason:', result.finishReason);
 });

--- a/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-thinking.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-thinking.ts
@@ -8,7 +8,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
         thinking: { type: 'enabled', budgetTokens: 4096 },

--- a/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-tool-call.ts
@@ -2,15 +2,16 @@ import {
   fireworks,
   type FireworksLanguageModelOptions,
 } from '@ai-sdk/fireworks';
-import { generateText, isStepCount } from 'ai';
+import { isStepCount, streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
 run(async () => {
   const sessionId = 'weather-conversation-123';
 
-  const result = await generateText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  const result = streamText({
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
         promptCacheKey: sessionId,
@@ -23,12 +24,6 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  console.log(result.text);
-  console.log();
-  console.log('Token usage:', result.usage);
-  console.log(
-    'Cached input tokens:',
-    result.usage.inputTokenDetails.cacheReadTokens,
-  );
-  console.log('Finish reason:', result.finishReason);
+  await printFullStream({ result });
+  console.log('Token usage:', await result.usage);
 });

--- a/packages/fireworks/src/fireworks-chat-options.ts
+++ b/packages/fireworks/src/fireworks-chat-options.ts
@@ -25,6 +25,12 @@ export type FireworksChatModelId =
   | (string & {});
 
 export const fireworksLanguageModelOptions = z.object({
+  /**
+   * A stable key for routing requests with shared prompt prefixes to the same
+   * prompt cache.
+   */
+  promptCacheKey: z.string().optional(),
+
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),

--- a/packages/fireworks/src/fireworks-chat-options.ts
+++ b/packages/fireworks/src/fireworks-chat-options.ts
@@ -20,7 +20,6 @@ export type FireworksChatModelId =
   | 'accounts/fireworks/models/yi-large'
   | 'accounts/fireworks/models/kimi-k2-instruct'
   | 'accounts/fireworks/models/kimi-k2-thinking'
-  | 'accounts/fireworks/models/kimi-k2p5'
   | 'accounts/fireworks/models/kimi-k2p6'
   | 'accounts/fireworks/models/minimax-m2'
   | (string & {});

--- a/packages/fireworks/src/fireworks-chat-options.ts
+++ b/packages/fireworks/src/fireworks-chat-options.ts
@@ -21,6 +21,7 @@ export type FireworksChatModelId =
   | 'accounts/fireworks/models/kimi-k2-instruct'
   | 'accounts/fireworks/models/kimi-k2-thinking'
   | 'accounts/fireworks/models/kimi-k2p5'
+  | 'accounts/fireworks/models/kimi-k2p6'
   | 'accounts/fireworks/models/minimax-m2'
   | (string & {});
 

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -168,6 +168,52 @@ describe('FireworksProvider', () => {
       });
     });
 
+    it('should map promptCacheKey to prompt_cache_key', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const transformRequestBody = config.transformRequestBody;
+
+      const result = transformRequestBody({
+        model: 'test-model',
+        messages: [],
+        promptCacheKey: 'session-123',
+      });
+
+      expect(result).toEqual({
+        model: 'test-model',
+        messages: [],
+        prompt_cache_key: 'session-123',
+      });
+      expect(result).not.toHaveProperty('promptCacheKey');
+    });
+
+    it('should prefer promptCacheKey over raw prompt_cache_key', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const transformRequestBody = config.transformRequestBody;
+
+      const result = transformRequestBody({
+        model: 'test-model',
+        messages: [],
+        prompt_cache_key: 'raw-session',
+        promptCacheKey: 'typed-session',
+      });
+
+      expect(result).toEqual({
+        model: 'test-model',
+        messages: [],
+        prompt_cache_key: 'typed-session',
+      });
+    });
+
     it('should remap reasoning_effort xhigh to high', () => {
       const provider = createFireworks();
       provider.chatModel('test-model');

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -141,10 +141,12 @@ export function createFireworks(
           | { type?: string; budgetTokens?: number }
           | undefined;
         const reasoningHistory = args.reasoningHistory as string | undefined;
+        const promptCacheKey = args.promptCacheKey as string | undefined;
 
         const {
           thinking: _,
           reasoningHistory: __,
+          promptCacheKey: ___,
           reasoning_effort,
           ...rest
         } = args;
@@ -159,6 +161,9 @@ export function createFireworks(
                 : reasoning_effort === 'xhigh'
                   ? 'high'
                   : reasoning_effort,
+          }),
+          ...(promptCacheKey !== undefined && {
+            prompt_cache_key: promptCacheKey,
           }),
           ...(thinking && {
             thinking: {


### PR DESCRIPTION
## Background

Fireworks prompt caching is automatic, but cached prefixes are local to a replica. Fireworks supports `prompt_cache_key` to route related requests to the same backend, improving cache hits for multi-step `generateText`, `streamText`, and `ToolLoopAgent` calls.

The Fireworks provider did not expose a typed option for this field. Passing `promptCacheKey` therefore left the unsupported camelCase name in the request body instead of serializing the expected snake_case field.

## Summary

- Add `promptCacheKey` to `FireworksLanguageModelOptions`
- Serialize it as `prompt_cache_key`
- Prefer the typed option over a raw `prompt_cache_key` value
- Preserve existing request behavior when the option is omitted
- Add Node and Edge tests for serialization and precedence
- Document session-scoped usage with multi-step generation and `ToolLoopAgent`
- Add `generateText` and `streamText` tool-call examples
- Update examples and model autocomplete to Kimi K2.6
- Remove Kimi K2.5 following its Fireworks serverless deprecation
- Add a patch changeset for `@ai-sdk/fireworks`

The key remains explicit rather than automatically generated, matching the existing OpenAI provider pattern.

## Manual Verification

Live verification was not performed because `FIREWORKS_API_KEY` was unavailable locally.

With credentials, the following examples can be used to verify that follow-up steps or calls using the same session key report cached tokens through `usage.inputTokenDetails.cacheReadTokens`:

- `pnpm tsx src/generate-text/fireworks/kimi-k2-6-tool-call.ts`
- `pnpm tsx src/stream-text/fireworks/kimi-k2-6-tool-call.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Automatic session-key generation remains out of scope because a reusable `ToolLoopAgent` is not necessarily scoped to one conversation. Fireworks completion models and cache-isolation headers are also out of scope.

## Related Issues

- Related to #14170 and #8166
- Similar provider support is tracked in #12827
- Follows the OpenAI `prompt_cache_key` provider-option precedent from #7964