### PR TITLE
feat(harness): allow pre-snapshot `sandboxConfig.onBootstrap` callback in `HarnessAgent`

### DIFF
--- a/.changeset/strong-toys-clap.md
+++ b/.changeset/strong-toys-clap.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+feat(harness): allow pre-snapshot `sandboxConfig.onBootstrap` callback in `HarnessAgent`

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -7,7 +7,7 @@ description: Create and run AI SDK HarnessAgent sessions.
 
 `HarnessAgent` is an AI SDK `Agent` implementation backed by a harness adapter.
 It gives you `generate()` and `stream()` methods that return AI SDK-compatible
-results while an preconfigured harness powers these results.
+results while a preconfigured harness powers these results.
 
 ## Installation
 
@@ -213,8 +213,17 @@ the continued turn and return a `GenerateTextResult`.
 
 ## Prepare the Sandbox
 
-Use `onSandboxSession` to prepare files, install lightweight utilities, or write
-configuration before the harness starts:
+Use `sandboxConfig` to prepare the sandbox before the harness starts.
+
+`sandboxConfig.onBootstrap` runs during sandbox template creation, after the
+harness adapter's own bootstrap and before snapshot-capable providers publish a
+snapshot. Use it for expensive setup that should be reused by future sessions.
+When you provide `onBootstrap`, also provide `bootstrapHash`; change the hash
+whenever the bootstrap output should invalidate the reusable snapshot.
+
+`sandboxConfig.onSession` runs after each sandbox session is acquired and its
+working directory exists, including resumed sessions. Use it for per-session
+files or lightweight configuration.
 
 ```ts
 const agent = new HarnessAgent({
@@ -223,17 +232,34 @@ const agent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/README.md`,
-      content: 'Session notes for the harness.',
-      abortSignal,
-    });
+  sandboxConfig: {
+    workDir: 'repo',
+    bootstrapHash: 'ripgrep-v1',
+    onBootstrap: async ({ session, abortSignal }) => {
+      const result = await session.run({
+        command:
+          'command -v rg >/dev/null || (apt-get update && apt-get install -y ripgrep)',
+        abortSignal,
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(`Failed to install ripgrep: ${result.stderr}`);
+      }
+    },
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/README.md`,
+        content: 'Session notes for the harness.',
+        abortSignal,
+      });
+    },
   },
 });
 ```
 
-This hook runs for fresh and resumed sessions. Keep it idempotent.
+`workDir` is optional. When provided, it must be relative to the sandbox's
+default working directory and is used as the session working directory. When
+omitted, regular sessions use the default `<harnessId>-<sessionId>` directory,
+while `onBootstrap` receives the sandbox's default working directory.
 
 ## Settings
 
@@ -247,7 +273,7 @@ This hook runs for fresh and resumed sessions. Keep it idempotent.
 - `skills`: instruction bundles surfaced by the adapter.
 - `permissionMode`: built-in tool permission mode.
 - `toolApproval`: approval status map for host-executed tools.
-- `onSandboxSession`: sandbox preparation hook.
+- `sandboxConfig`: sandbox working-directory and lifecycle hook configuration.
 - `telemetry`, `debug`, and `onLog`: observability and diagnostics.
 
 Adapter-specific settings belong on the adapter factory, for example

--- a/examples/harness-e2e-next/agent/harness/ai-sdk-coding-repo.ts
+++ b/examples/harness-e2e-next/agent/harness/ai-sdk-coding-repo.ts
@@ -1,0 +1,121 @@
+import type { Experimental_SandboxSession as SandboxSession } from 'ai';
+
+export const aiSdkCodingSandboxWorkDir = 'ai-sdk';
+export const aiSdkCodingSandboxBootstrapHash = 'vercel-ai-shallow-clone-v1';
+
+export async function bootstrapAiSdkCodingRepo({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const cloneResult = await session.run({
+    command:
+      'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
+    workingDirectory: workDir,
+    abortSignal,
+  });
+  if (cloneResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to clone vercel/ai (exit ${cloneResult.exitCode}): ${cloneResult.stderr}`,
+    );
+  }
+
+  await installAiSdkDependencies({ session, workDir, abortSignal });
+}
+
+export async function refreshAiSdkCodingRepo({
+  session,
+  sessionWorkDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly sessionWorkDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const statusResult = await session.run({
+    command: 'git status --porcelain',
+    workingDirectory: sessionWorkDir,
+    abortSignal,
+  });
+  if (statusResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to check repository status (exit ${statusResult.exitCode}): ${statusResult.stderr}`,
+    );
+  }
+  if (statusResult.stdout.trim().length > 0) return;
+
+  const beforePull = await gitHead({
+    session,
+    workDir: sessionWorkDir,
+    abortSignal,
+  });
+  const pullResult = await session.run({
+    command: 'git pull --ff-only',
+    workingDirectory: sessionWorkDir,
+    abortSignal,
+  });
+  if (pullResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to update vercel/ai (exit ${pullResult.exitCode}): ${pullResult.stderr}`,
+    );
+  }
+  const afterPull = await gitHead({
+    session,
+    workDir: sessionWorkDir,
+    abortSignal,
+  });
+  if (beforePull !== afterPull) {
+    await installAiSdkDependencies({
+      session,
+      workDir: sessionWorkDir,
+      abortSignal,
+    });
+  }
+}
+
+async function gitHead({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = await session.run({
+    command: 'git rev-parse HEAD',
+    workingDirectory: workDir,
+    abortSignal,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to resolve repository HEAD (exit ${result.exitCode}): ${result.stderr}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+async function installAiSdkDependencies({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const installResult = await session.run({
+    command: 'pnpm install',
+    workingDirectory: workDir,
+    abortSignal,
+  });
+  if (installResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
+    );
+  }
+}

--- a/examples/harness-e2e-next/agent/harness/claude-code/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/claude-code/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { claudeCode } from '@ai-sdk/harness-claude-code';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -19,29 +25,11 @@ export const aiSdkCodingHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-next/agent/harness/claude-code/weather-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/claude-code/weather-agent.ts
@@ -23,12 +23,14 @@ export const weatherClaudeCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/claude-code/weather-approval-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/claude-code/weather-approval-agent.ts
@@ -27,12 +27,14 @@ export const weatherApprovalClaudeCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/codex/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/codex/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { codex } from '@ai-sdk/harness-codex';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -19,29 +25,11 @@ export const aiSdkCodingCodexHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-next/agent/harness/codex/weather-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/codex/weather-agent.ts
@@ -23,12 +23,14 @@ export const weatherCodexHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/codex/weather-approval-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/codex/weather-approval-agent.ts
@@ -28,12 +28,14 @@ export const weatherApprovalCodexHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/opencode/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/opencode/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { openCode } from '@ai-sdk/harness-opencode';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -19,29 +25,11 @@ export const aiSdkCodingOpenCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-next/agent/harness/opencode/weather-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/opencode/weather-agent.ts
@@ -23,12 +23,14 @@ export const weatherOpenCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/opencode/weather-approval-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/opencode/weather-approval-agent.ts
@@ -27,12 +27,14 @@ export const weatherApprovalOpenCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/pi/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/pi/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { pi } from '@ai-sdk/harness-pi';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -18,29 +24,11 @@ export const aiSdkCodingPiHarnessAgent = new HarnessAgent({
   sandbox: createVercelSandbox({
     runtime: 'node24',
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-next/agent/harness/pi/weather-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/pi/weather-agent.ts
@@ -22,12 +22,14 @@ export const weatherPiHarnessAgent = new HarnessAgent({
   sandbox: createVercelSandbox({
     runtime: 'node24',
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-next/agent/harness/pi/weather-approval-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/pi/weather-approval-agent.ts
@@ -26,12 +26,14 @@ export const weatherApprovalPiHarnessAgent = new HarnessAgent({
   sandbox: createVercelSandbox({
     runtime: 'node24',
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/claude-code/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-tui/agents/claude-code/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { claudeCode } from '@ai-sdk/harness-claude-code';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../../lib/ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -19,29 +25,11 @@ export const aiSdkCodingHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-tui/agents/claude-code/weather-agent.ts
+++ b/examples/harness-e2e-tui/agents/claude-code/weather-agent.ts
@@ -23,12 +23,14 @@ export const weatherClaudeCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/claude-code/weather-approval-agent.ts
+++ b/examples/harness-e2e-tui/agents/claude-code/weather-approval-agent.ts
@@ -27,12 +27,14 @@ export const weatherApprovalClaudeCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/codex/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-tui/agents/codex/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { codex } from '@ai-sdk/harness-codex';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../../lib/ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -19,29 +25,11 @@ export const aiSdkCodingCodexHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-tui/agents/codex/weather-agent.ts
+++ b/examples/harness-e2e-tui/agents/codex/weather-agent.ts
@@ -23,12 +23,14 @@ export const weatherCodexHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/codex/weather-approval-agent.ts
+++ b/examples/harness-e2e-tui/agents/codex/weather-approval-agent.ts
@@ -28,12 +28,14 @@ export const weatherApprovalCodexHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/opencode/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-tui/agents/opencode/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { openCode } from '@ai-sdk/harness-opencode';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../../lib/ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -19,29 +25,11 @@ export const aiSdkCodingOpenCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-tui/agents/opencode/weather-agent.ts
+++ b/examples/harness-e2e-tui/agents/opencode/weather-agent.ts
@@ -23,12 +23,14 @@ export const weatherOpenCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/opencode/weather-approval-agent.ts
+++ b/examples/harness-e2e-tui/agents/opencode/weather-approval-agent.ts
@@ -27,12 +27,14 @@ export const weatherApprovalOpenCodeHarnessAgent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/pi/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-tui/agents/pi/ai-sdk-coding-agent.ts
@@ -2,6 +2,12 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { pi } from '@ai-sdk/harness-pi';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
+import {
+  aiSdkCodingSandboxBootstrapHash,
+  aiSdkCodingSandboxWorkDir,
+  bootstrapAiSdkCodingRepo,
+  refreshAiSdkCodingRepo,
+} from '../../lib/ai-sdk-coding-repo';
 
 // Default sandbox resources won't allow for a full parallel build of all packages.
 // Not worth bumping all demo sandboxes' resources for just this, we can easily
@@ -18,29 +24,11 @@ export const aiSdkCodingPiHarnessAgent = new HarnessAgent({
   sandbox: createVercelSandbox({
     runtime: 'node24',
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    const result = await session.run({
-      command:
-        'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to clone vercel/ai (exit ${result.exitCode}): ${result.stderr}`,
-      );
-    }
-
-    const installResult = await session.run({
-      command: 'test -d node_modules || pnpm install',
-      workingDirectory: sessionWorkDir,
-      abortSignal,
-    });
-    if (installResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
-      );
-    }
+  sandboxConfig: {
+    workDir: aiSdkCodingSandboxWorkDir,
+    bootstrapHash: aiSdkCodingSandboxBootstrapHash,
+    onBootstrap: bootstrapAiSdkCodingRepo,
+    onSession: refreshAiSdkCodingRepo,
   },
 });
 

--- a/examples/harness-e2e-tui/agents/pi/weather-agent.ts
+++ b/examples/harness-e2e-tui/agents/pi/weather-agent.ts
@@ -22,12 +22,14 @@ export const weatherPiHarnessAgent = new HarnessAgent({
   sandbox: createVercelSandbox({
     runtime: 'node24',
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/agents/pi/weather-approval-agent.ts
+++ b/examples/harness-e2e-tui/agents/pi/weather-approval-agent.ts
@@ -26,12 +26,14 @@ export const weatherApprovalPiHarnessAgent = new HarnessAgent({
   sandbox: createVercelSandbox({
     runtime: 'node24',
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/weather-codes.md`,
-      content: WEATHER_CODES_REFERENCE,
-      abortSignal,
-    });
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/weather-codes.md`,
+        content: WEATHER_CODES_REFERENCE,
+        abortSignal,
+      });
+    },
   },
   debug: { enabled: true },
   telemetry: {

--- a/examples/harness-e2e-tui/lib/ai-sdk-coding-repo.ts
+++ b/examples/harness-e2e-tui/lib/ai-sdk-coding-repo.ts
@@ -1,0 +1,121 @@
+import type { Experimental_SandboxSession as SandboxSession } from 'ai';
+
+export const aiSdkCodingSandboxWorkDir = 'ai-sdk';
+export const aiSdkCodingSandboxBootstrapHash = 'vercel-ai-shallow-clone-v1';
+
+export async function bootstrapAiSdkCodingRepo({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const cloneResult = await session.run({
+    command:
+      'test -d .git || git clone --depth 1 https://github.com/vercel/ai.git .',
+    workingDirectory: workDir,
+    abortSignal,
+  });
+  if (cloneResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to clone vercel/ai (exit ${cloneResult.exitCode}): ${cloneResult.stderr}`,
+    );
+  }
+
+  await installAiSdkDependencies({ session, workDir, abortSignal });
+}
+
+export async function refreshAiSdkCodingRepo({
+  session,
+  sessionWorkDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly sessionWorkDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const statusResult = await session.run({
+    command: 'git status --porcelain',
+    workingDirectory: sessionWorkDir,
+    abortSignal,
+  });
+  if (statusResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to check repository status (exit ${statusResult.exitCode}): ${statusResult.stderr}`,
+    );
+  }
+  if (statusResult.stdout.trim().length > 0) return;
+
+  const beforePull = await gitHead({
+    session,
+    workDir: sessionWorkDir,
+    abortSignal,
+  });
+  const pullResult = await session.run({
+    command: 'git pull --ff-only',
+    workingDirectory: sessionWorkDir,
+    abortSignal,
+  });
+  if (pullResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to update vercel/ai (exit ${pullResult.exitCode}): ${pullResult.stderr}`,
+    );
+  }
+  const afterPull = await gitHead({
+    session,
+    workDir: sessionWorkDir,
+    abortSignal,
+  });
+  if (beforePull !== afterPull) {
+    await installAiSdkDependencies({
+      session,
+      workDir: sessionWorkDir,
+      abortSignal,
+    });
+  }
+}
+
+async function gitHead({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = await session.run({
+    command: 'git rev-parse HEAD',
+    workingDirectory: workDir,
+    abortSignal,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to resolve repository HEAD (exit ${result.exitCode}): ${result.stderr}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+async function installAiSdkDependencies({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const installResult = await session.run({
+    command: 'pnpm install',
+    workingDirectory: workDir,
+    abortSignal,
+  });
+  if (installResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to install dependencies (exit ${installResult.exitCode}): ${installResult.stderr}`,
+    );
+  }
+}

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -27,12 +27,25 @@ const agent = new HarnessAgent({
     runtime: 'node24',
     ports: [4000],
   }),
-  onSandboxSession: async ({ session, sessionWorkDir, abortSignal }) => {
-    await session.writeTextFile({
-      path: `${sessionWorkDir}/README.md`,
-      content: 'Workspace notes for this session.',
-      abortSignal,
-    });
+  sandboxConfig: {
+    bootstrapHash: 'ripgrep-v1',
+    onBootstrap: async ({ session, abortSignal }) => {
+      const result = await session.run({
+        command:
+          'command -v rg >/dev/null || (apt-get update && apt-get install -y ripgrep)',
+        abortSignal,
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(`Failed to install ripgrep: ${result.stderr}`);
+      }
+    },
+    onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+      await session.writeTextFile({
+        path: `${sessionWorkDir}/README.md`,
+        content: 'Workspace notes for this session.',
+        abortSignal,
+      });
+    },
   },
   tools: {
     deploy: tool({
@@ -70,18 +83,17 @@ try {
 }
 ```
 
-`sandbox` is a required `HarnessV1SandboxProvider` — the agent calls `provider.createSession()` when a session starts. Use `onSandboxSession` to prepare the acquired sandbox before the harness adapter starts. The hook runs for fresh and resumed sessions, so keep it idempotent. Use `session.detach()` to park a bridge-backed session for later attach, `session.stop()` to save state and stop the sandbox, or `session.destroy()` to clean up without keeping resume state. Bridge-backed adapters (claude-code, codex) require a provider that exposes ports — `@ai-sdk/sandbox-vercel` is the supported choice today. `@ai-sdk/sandbox-just-bash` is suitable only for non-bridge flows.
+Use `session.detach()` to park a bridge-backed session for later attach, `session.stop()` to save state and stop the sandbox, or `session.destroy()` to clean up without keeping resume state. Bridge-backed adapters (claude-code, codex) require a sandbox provider that exposes ports — `@ai-sdk/sandbox-vercel` is the supported choice today. `@ai-sdk/sandbox-just-bash` is suitable only for non-bridge flows.
+
+`sandbox` is a required `HarnessV1SandboxProvider` — the agent calls `provider.createSession()` when a session starts. Use `sandboxConfig` for agent specific sandbox configuration that works independently from the sandbox provider that is used:
+
+- Use `sandboxConfig.onSession` to prepare the acquired sandbox before the harness adapter starts. The hook runs for fresh and resumed sessions, so keep it idempotent.
+- Use `sandboxConfig.onBootstrap` for expensive sandbox setup that should be baked into a reusable snapshot, such as installing tools or cloning a large repository. Provide `sandboxConfig.bootstrapHash` with it and change that value whenever the bootstrap output should invalidate the cached snapshot.
+- Use `sandboxConfig.workDir` to set a stable working directory for the agent, relative to the sandbox's default working directory; otherwise regular sessions use the existing `<harnessId>-<sessionId>` directory. In that case, the `onBootstrap` callback receives the sandbox's default working directory.
 
 ### Available harnesses
 
-- `@ai-sdk/harness-claude-code`
-- `@ai-sdk/harness-codex`
-- `@ai-sdk/harness-opencode` (WIP)
-- `@ai-sdk/harness-goose` (WIP)
-- `@ai-sdk/harness-mastra` (WIP)
-- `@ai-sdk/harness-deepagents` (WIP)
-- `@ai-sdk/harness-openai-agents` (WIP)
-- `@ai-sdk/harness-pi` (WIP)
+See the [harness adapters documentation](https://ai-sdk.dev/v7/docs/ai-sdk-harnesses/harness-adapters).
 
 ## Implementing a harness
 

--- a/packages/harness/src/agent/harness-agent-settings.ts
+++ b/packages/harness/src/agent/harness-agent-settings.ts
@@ -18,6 +18,48 @@ export type HarnessAgentToolApprovalConfiguration = Readonly<
   Record<string, ToolApprovalStatus>
 >;
 
+export type HarnessAgentSandboxConfig = {
+  /**
+   * Optional fixed working directory for all sessions, relative to the
+   * sandbox's default working directory. When omitted, sessions keep the
+   * existing `<harnessId>-<sessionId>` work directory.
+   */
+  readonly workDir?: string;
+
+  /**
+   * Caller-controlled identity for `onBootstrap`. Change this whenever the
+   * bootstrap side effects should invalidate the reusable sandbox snapshot.
+   */
+  readonly bootstrapHash?: string;
+
+  /**
+   * Called during sandbox template creation after the harness adapter's own
+   * bootstrap has run and before snapshot-capable providers publish a snapshot.
+   *
+   * `bootstrapHash` must be provided with this callback.
+   */
+  readonly onBootstrap?: (opts: {
+    readonly session: SandboxSession;
+    readonly workDir: string;
+    readonly abortSignal?: AbortSignal;
+  }) => Promise<void>;
+
+  /**
+   * Called after each sandbox session is acquired and the session work
+   * directory exists, before the harness adapter starts. Runs for fresh and
+   * resumed sessions.
+   *
+   * Use this to write per-session config, install lightweight tools, activate
+   * licenses, or prepare files in `sessionWorkDir`. Keep it idempotent if the
+   * agent may resume sessions.
+   */
+  readonly onSession?: (opts: {
+    readonly session: SandboxSession;
+    readonly sessionWorkDir: string;
+    readonly abortSignal?: AbortSignal;
+  }) => Promise<void>;
+};
+
 /**
  * Construction-time settings for a `HarnessAgent`.
  *
@@ -92,19 +134,12 @@ export type HarnessAgentSettings<
   readonly sandbox: HarnessV1SandboxProvider;
 
   /**
-   * Called after each sandbox session is acquired and the session work
-   * directory exists, before the harness adapter starts. Runs for fresh and
-   * resumed sessions.
-   *
-   * Use this to write per-session config, install lightweight tools, activate
-   * licenses, or prepare files in `sessionWorkDir`. Keep it idempotent if the
-   * agent may resume sessions.
+   * Sandbox working-directory and lifecycle hook configuration.
    */
-  readonly onSandboxSession?: (opts: {
-    readonly session: SandboxSession;
-    readonly sessionWorkDir: string;
-    readonly abortSignal?: AbortSignal;
-  }) => Promise<void>;
+  readonly sandboxConfig?: HarnessAgentSandboxConfig;
+
+  /** @deprecated Use `sandboxConfig.onSession` instead. */
+  readonly onSandboxSession?: HarnessAgentSandboxConfig['onSession'];
 
   /**
    * Telemetry configuration. The harness drives AI SDK's pluggable

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -1,5 +1,6 @@
 import type {
   HarnessV1,
+  HarnessV1Bootstrap,
   HarnessV1ContinueTurnOptions,
   HarnessV1ContinueTurnState,
   HarnessV1NetworkSandboxSession,
@@ -15,6 +16,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { z } from 'zod';
 import { HarnessAgent } from './harness-agent';
 import { HarnessAgentSession } from './harness-agent-session';
+import { hashHarnessBootstrap } from './internal/bootstrap-recipe';
 
 /**
  * Build a mock harness whose session emits a canned event script. Each
@@ -137,7 +139,7 @@ function mockHarness(options: {
 function makeSandboxSession(
   options: Partial<HarnessV1NetworkSandboxSession> = {},
 ): HarnessV1NetworkSandboxSession {
-  const run = vi.fn(async () => ({}) as never);
+  const run = vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
   const sandboxSession = {
     id: 'sandbox',
     defaultWorkingDirectory: '/work',
@@ -633,10 +635,10 @@ describe('HarnessAgent', () => {
     await session.destroy();
   });
 
-  test('onSandboxSession runs after the session work dir exists and before harness start', async () => {
+  test('sandboxConfig.onSession runs after the session work dir exists and before harness start', async () => {
     const { harness, doStart } = mockHarness({ script: () => [] });
-    const restrictedSession = { label: 'restricted' };
-    const run = vi.fn(async () => ({}) as never);
+    const run = vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+    const restrictedSession = { label: 'restricted', run };
     const sandboxSession = makeSandboxSession({
       run,
       restricted: () => restrictedSession as never,
@@ -645,13 +647,14 @@ describe('HarnessAgent', () => {
     const agent = new HarnessAgent({
       harness,
       sandbox: makeSandboxProvider(sandboxSession),
-      onSandboxSession,
+      sandboxConfig: { onSession: onSandboxSession },
     });
 
     const session = await agent.createSession({ sessionId: 's1' });
 
     expect(run).toHaveBeenCalledWith({
-      command: 'mkdir -p /work/mock-s1',
+      command: 'mkdir -p "$WORK_DIR"',
+      env: { WORK_DIR: '/work/mock-s1' },
       abortSignal: undefined,
     });
     expect(onSandboxSession).toHaveBeenCalledWith({
@@ -669,7 +672,223 @@ describe('HarnessAgent', () => {
     await session.destroy();
   });
 
-  test('onSandboxSession runs for resumed sessions', async () => {
+  test('deprecated top-level onSandboxSession warns and still runs', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { harness } = mockHarness({ script: () => [] });
+      const onSandboxSession = vi.fn(async () => {});
+      const agent = new HarnessAgent({
+        harness,
+        sandbox: makeSandboxProvider(),
+        onSandboxSession,
+      });
+
+      const session = await agent.createSession({ sessionId: 's1' });
+
+      expect(warn).toHaveBeenCalledWith(
+        'HarnessAgent: `onSandboxSession` is deprecated. Use `sandboxConfig.onSession` instead.',
+      );
+      expect(onSandboxSession).toHaveBeenCalledWith({
+        session: expect.any(Object),
+        sessionWorkDir: '/work/mock-s1',
+        abortSignal: undefined,
+      });
+
+      await session.destroy();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('validates sandbox bootstrap settings', () => {
+    const { harness } = mockHarness({ script: () => [] });
+
+    expect(
+      () =>
+        new HarnessAgent({
+          harness,
+          sandbox: makeSandboxProvider(),
+          sandboxConfig: { onBootstrap: async () => {} },
+        }),
+    ).toThrow(/must be provided together/);
+
+    expect(
+      () =>
+        new HarnessAgent({
+          harness,
+          sandbox: makeSandboxProvider(),
+          sandboxConfig: { bootstrapHash: 'hash' },
+        }),
+    ).toThrow(/must be provided together/);
+
+    expect(
+      () =>
+        new HarnessAgent({
+          harness,
+          sandbox: makeSandboxProvider(),
+          sandboxConfig: { workDir: '../repo' },
+        }),
+    ).toThrow(/workDir/);
+  });
+
+  test('sandboxConfig.onBootstrap runs during onFirstCreate and workDir becomes the session work dir', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const run = vi.fn(async (args: { command: string }) => {
+      if (args.command === 'pwd') {
+        return { exitCode: 0, stdout: '/work\n', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const restrictedSession = {
+      label: 'restricted',
+      run,
+    };
+    const sandboxSession = makeSandboxSession({
+      run,
+      restricted: () => restrictedSession as never,
+    });
+    const createSession = vi.fn(
+      async (
+        opts: Parameters<HarnessV1SandboxProvider['createSession']>[0],
+      ) => {
+        await opts?.onFirstCreate?.(restrictedSession as never, {});
+        return sandboxSession;
+      },
+    );
+    const onSandboxBootstrap = vi.fn(async () => {});
+    const onSandboxSession = vi.fn(async () => {});
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: {
+        specificationVersion: 'harness-sandbox-v1',
+        providerId: 'mock-sandbox',
+        createSession,
+      },
+      sandboxConfig: {
+        workDir: 'ai-sdk',
+        bootstrapHash: 'repo-v1',
+        onBootstrap: onSandboxBootstrap,
+        onSession: onSandboxSession,
+      },
+    });
+
+    const session = await agent.createSession({ sessionId: 's1' });
+
+    expect(createSession.mock.calls[0]![0]).toEqual({
+      sessionId: 's1',
+      abortSignal: undefined,
+      identity: expect.stringMatching(/^[0-9a-f]{16}$/),
+      onFirstCreate: expect.any(Function),
+    });
+    expect(onSandboxBootstrap).toHaveBeenCalledWith({
+      session: restrictedSession,
+      workDir: '/work/ai-sdk',
+      abortSignal: undefined,
+    });
+    expect(onSandboxSession).toHaveBeenCalledWith({
+      session: restrictedSession,
+      sessionWorkDir: '/work/ai-sdk',
+      abortSignal: undefined,
+    });
+
+    await session.destroy();
+  });
+
+  test('sandboxConfig.onBootstrap is skipped for resumed sessions while onSession still runs', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const onSandboxBootstrap = vi.fn(async () => {});
+    const onSandboxSession = vi.fn(async () => {});
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(),
+      sandboxConfig: {
+        workDir: 'ai-sdk',
+        bootstrapHash: 'repo-v1',
+        onBootstrap: onSandboxBootstrap,
+        onSession: onSandboxSession,
+      },
+    });
+
+    const session = await agent.createSession({
+      sessionId: 's1',
+      resumeFrom: {
+        type: 'resume-session',
+        harnessId: 'mock',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+
+    expect(onSandboxBootstrap).not.toHaveBeenCalled();
+    expect(onSandboxSession).toHaveBeenCalledWith({
+      session: expect.any(Object),
+      sessionWorkDir: '/work/ai-sdk',
+      abortSignal: undefined,
+    });
+
+    await session.destroy();
+  });
+
+  test('built-in bootstrap uses recipe identity while snapshot identity includes workDir', async () => {
+    const base = mockHarness({ script: () => [] });
+    const recipe: HarnessV1Bootstrap = {
+      harnessId: 'mock',
+      bootstrapDir: '/tmp/mock-bootstrap',
+      files: [],
+      commands: [],
+    };
+    const harness: HarnessV1 = {
+      ...base.harness,
+      getBootstrap: vi.fn(async () => recipe),
+    };
+    const readTextFile = vi.fn(async () => null);
+    const writeTextFile = vi.fn(async () => {});
+    const run = vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+    const restrictedSession = {
+      run,
+      readTextFile,
+      writeTextFile,
+    };
+    const sandboxSession = makeSandboxSession({
+      run,
+      restricted: () => restrictedSession as never,
+    });
+    const createSession = vi.fn(
+      async (
+        opts: Parameters<HarnessV1SandboxProvider['createSession']>[0],
+      ) => {
+        await opts?.onFirstCreate?.(restrictedSession as never, {});
+        return sandboxSession;
+      },
+    );
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: {
+        specificationVersion: 'harness-sandbox-v1',
+        providerId: 'mock-sandbox',
+        createSession,
+      },
+      sandboxConfig: { workDir: 'ai-sdk' },
+    });
+
+    const session = await agent.createSession({ sessionId: 's1' });
+
+    expect(createSession.mock.calls[0]![0]?.identity).toMatch(/^[0-9a-f]{16}$/);
+    expect(createSession.mock.calls[0]![0]?.identity).not.toBe(
+      await hashHarnessBootstrap(recipe),
+    );
+    const writeCalls = writeTextFile.mock.calls as unknown as Array<
+      [{ path: string }]
+    >;
+    const markerWrite = writeCalls.at(-1)?.[0];
+    expect(markerWrite?.path).toMatch(
+      /^\/tmp\/mock-bootstrap\/\.bootstrap-[0-9a-f]{16}\.ok$/,
+    );
+
+    await session.destroy();
+  });
+
+  test('sandboxConfig.onSession runs for resumed sessions', async () => {
     const { harness } = mockHarness({ script: () => [] });
     const sandboxSessionEvents: Array<{ sessionWorkDir: string }> = [];
     const onSandboxSession = vi.fn(async (opts: { sessionWorkDir: string }) => {
@@ -678,7 +897,7 @@ describe('HarnessAgent', () => {
     const agent = new HarnessAgent({
       harness,
       sandbox: makeSandboxProvider(),
-      onSandboxSession,
+      sandboxConfig: { onSession: onSandboxSession },
     });
 
     const session = await agent.createSession({

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -20,7 +20,10 @@ import type {
   ReasoningOutput,
   StreamTextResult,
 } from 'ai';
-import type { HarnessAgentSettings } from './harness-agent-settings';
+import type {
+  HarnessAgentSandboxConfig,
+  HarnessAgentSettings,
+} from './harness-agent-settings';
 import { HarnessAgentSession } from './harness-agent-session';
 import type {
   HarnessAgentAdapter,
@@ -34,14 +37,18 @@ import {
   collectHarnessAgentToolApprovalContinuations,
   type HarnessAgentToolApprovalContinuation,
 } from './harness-agent-tool-approval-continuation';
-import {
-  applyBootstrapRecipe,
-  hashBootstrap,
-} from './internal/bootstrap-recipe';
+import { applyBootstrapRecipe } from './internal/bootstrap-recipe';
 import {
   acquireBridgePort,
   releaseBridgePort,
 } from './internal/bridge-port-registry';
+import {
+  createSandboxBootstrapPlan,
+  ensureSandboxDirectory,
+  resolveSessionWorkDir,
+  validateSandboxBootstrapSettings,
+  type SandboxBootstrapPlan,
+} from './internal/sandbox-bootstrap';
 import { buildObservability } from './internal/resolve-observability';
 import { validateLifecycleStateData } from './internal/lifecycle-state-validation';
 import {
@@ -130,11 +137,15 @@ export class HarnessAgent<
   readonly tools: HarnessAllTools<THarness, TUserTools>;
 
   private readonly settings: HarnessAgentSettings<THarness, TUserTools>;
+  private readonly sandboxConfig: HarnessAgentSandboxConfig;
   private readonly userTools: TUserTools;
   private readonly permissionMode: HarnessAgentPermissionMode;
 
   constructor(settings: HarnessAgentSettings<THarness, TUserTools>) {
+    const sandboxConfig = resolveSandboxConfig(settings);
+    validateSandboxBootstrapSettings(sandboxConfig);
     this.settings = settings;
+    this.sandboxConfig = sandboxConfig;
     this.id = settings.id;
     this.userTools = settings.tools ?? ({} as TUserTools);
     this.permissionMode = resolvePermissionMode({
@@ -230,19 +241,25 @@ export class HarnessAgent<
       validatedResumeFrom != null || effectiveContinueFrom != null;
 
     let recipe: HarnessV1Bootstrap | undefined;
-    let identity: string | undefined;
-
     if (harness.getBootstrap != null) {
       recipe = await harness.getBootstrap({ abortSignal });
-      identity = await hashBootstrap(recipe);
     }
 
+    // Defines the hashes based on both harness bootstrap recipe and
+    // consumer-defined onBootstrap callback.
+    const sandboxBootstrapPlan = await createSandboxBootstrapPlan({
+      recipe,
+      settings: this.sandboxConfig,
+    });
+
+    // Acquires the concrete sandbox session, either by starting fresh and then
+    // creating a post-bootstrap snapshot, or by reusing a previously created
+    // snapshot based on the bootstrap-based hashes.
     const acquiredSandboxSession = await this._acquireSandbox({
       sandboxProvider,
       sessionId,
       isResume: isResumedSession,
-      recipe,
-      identity,
+      bootstrapPlan: sandboxBootstrapPlan,
       abortSignal,
     });
 
@@ -253,27 +270,37 @@ export class HarnessAgent<
     });
     const sandboxSession = leased.sandboxSession;
     const leasedBridgePort = leased.port;
-    const sessionWorkDir = `${sandboxSession.defaultWorkingDirectory}/${harness.harnessId}-${sessionId}`;
+    const sessionWorkDir = resolveSessionWorkDir({
+      defaultWorkingDirectory: sandboxSession.defaultWorkingDirectory,
+      harnessId: harness.harnessId,
+      sessionId,
+      workDir: sandboxBootstrapPlan.workDir,
+    });
 
     try {
-      /*
-       * Adapter bootstrap is one-time work for fresh sessions. The consumer
-       * hook runs for every acquired sandbox session after the work dir exists.
-       */
-      if (!isResumedSession && recipe != null && identity != null) {
+      // In case the sandbox session was created with a custom sandbox, or in
+      // case the sandbox provider doesn't respect `onFirstCreate`, we still
+      // have to ensure the harness bootstrap recipe has run. In the common
+      // scenario, this will be a cheap no-op based on just a marker check.
+      if (
+        !isResumedSession &&
+        sandboxBootstrapPlan.recipe != null &&
+        sandboxBootstrapPlan.recipeIdentity != null
+      ) {
         await applyBootstrapRecipe(
           sandboxSession.restricted(),
-          recipe,
-          identity,
+          sandboxBootstrapPlan.recipe,
+          sandboxBootstrapPlan.recipeIdentity,
           { abortSignal },
         );
       }
-      await sandboxSession.run({
-        command: `mkdir -p ${sessionWorkDir}`,
+      await ensureSandboxDirectory({
+        session: sandboxSession,
+        workDir: sessionWorkDir,
         abortSignal,
       });
-      if (this.settings.onSandboxSession != null) {
-        await this.settings.onSandboxSession({
+      if (this.sandboxConfig.onSession != null) {
+        await this.sandboxConfig.onSession({
           session: sandboxSession.restricted(),
           sessionWorkDir,
           abortSignal,
@@ -501,8 +528,7 @@ export class HarnessAgent<
     sandboxProvider: HarnessV1SandboxProvider;
     sessionId: string;
     isResume: boolean;
-    recipe: HarnessV1Bootstrap | undefined;
-    identity: string | undefined;
+    bootstrapPlan: SandboxBootstrapPlan;
     abortSignal: AbortSignal | undefined;
   }): Promise<HarnessV1NetworkSandboxSession> {
     const { sandboxProvider } = input;
@@ -521,17 +547,8 @@ export class HarnessAgent<
     return sandboxProvider.createSession({
       sessionId: input.sessionId,
       abortSignal: input.abortSignal,
-      identity: input.identity,
-      onFirstCreate:
-        input.recipe != null && input.identity != null
-          ? (session, opts) =>
-              applyBootstrapRecipe(
-                session,
-                input.recipe!,
-                input.identity!,
-                opts,
-              )
-          : undefined,
+      identity: input.bootstrapPlan.identity,
+      onFirstCreate: input.bootstrapPlan.onFirstCreate,
     });
   }
 
@@ -754,6 +771,24 @@ class HarnessGenerateTextResult<
   get providerMetadata() {
     return this.finalStep.providerMetadata;
   }
+}
+
+function resolveSandboxConfig(
+  settings: Pick<HarnessAgentSettings, 'sandboxConfig' | 'onSandboxSession'>,
+): HarnessAgentSandboxConfig {
+  if (settings.onSandboxSession != null) {
+    console.warn(
+      'HarnessAgent: `onSandboxSession` is deprecated. Use `sandboxConfig.onSession` instead.',
+    );
+  }
+
+  return {
+    ...settings.sandboxConfig,
+    ...(settings.sandboxConfig?.onSession == null &&
+    settings.onSandboxSession != null
+      ? { onSession: settings.onSandboxSession }
+      : {}),
+  };
 }
 
 /*

--- a/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
@@ -5,7 +5,7 @@ import {
   BOOTSTRAP_SCHEMA_VERSION,
   applyBootstrapRecipe,
   bootstrapMarkerPath,
-  hashBootstrap,
+  hashHarnessBootstrap,
 } from './bootstrap-recipe';
 
 const baseRecipe: HarnessV1Bootstrap = {
@@ -18,10 +18,10 @@ const baseRecipe: HarnessV1Bootstrap = {
   commands: [{ command: 'mkdir -p /tmp/harness/demo' }, { command: 'echo ok' }],
 };
 
-describe('hashBootstrap', () => {
+describe('hashHarnessBootstrap', () => {
   it('produces a deterministic 16-char hex id for the same recipe', async () => {
-    const a = await hashBootstrap(baseRecipe);
-    const b = await hashBootstrap(baseRecipe);
+    const a = await hashHarnessBootstrap(baseRecipe);
+    const b = await hashHarnessBootstrap(baseRecipe);
     expect(a).toBe(b);
     expect(a).toMatch(/^[0-9a-f]{16}$/);
   });
@@ -31,8 +31,8 @@ describe('hashBootstrap', () => {
       ...baseRecipe,
       files: [...baseRecipe.files].reverse(),
     };
-    expect(await hashBootstrap(baseRecipe)).toBe(
-      await hashBootstrap(reordered),
+    expect(await hashHarnessBootstrap(baseRecipe)).toBe(
+      await hashHarnessBootstrap(reordered),
     );
   });
 
@@ -44,8 +44,8 @@ describe('hashBootstrap', () => {
         baseRecipe.files[1],
       ],
     };
-    expect(await hashBootstrap(altered)).not.toBe(
-      await hashBootstrap(baseRecipe),
+    expect(await hashHarnessBootstrap(altered)).not.toBe(
+      await hashHarnessBootstrap(baseRecipe),
     );
   });
 
@@ -54,15 +54,15 @@ describe('hashBootstrap', () => {
       ...baseRecipe,
       commands: [{ command: 'echo different' }],
     };
-    expect(await hashBootstrap(altered)).not.toBe(
-      await hashBootstrap(baseRecipe),
+    expect(await hashHarnessBootstrap(altered)).not.toBe(
+      await hashHarnessBootstrap(baseRecipe),
     );
   });
 
   it('changes when harnessId changes', async () => {
     const altered: HarnessV1Bootstrap = { ...baseRecipe, harnessId: 'other' };
-    expect(await hashBootstrap(altered)).not.toBe(
-      await hashBootstrap(baseRecipe),
+    expect(await hashHarnessBootstrap(altered)).not.toBe(
+      await hashHarnessBootstrap(baseRecipe),
     );
   });
 
@@ -71,8 +71,8 @@ describe('hashBootstrap', () => {
       ...baseRecipe,
       bootstrapDir: '/tmp/other',
     };
-    expect(await hashBootstrap(altered)).not.toBe(
-      await hashBootstrap(baseRecipe),
+    expect(await hashHarnessBootstrap(altered)).not.toBe(
+      await hashHarnessBootstrap(baseRecipe),
     );
   });
 });

--- a/packages/harness/src/agent/internal/bootstrap-recipe.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.ts
@@ -16,7 +16,7 @@ export const BOOTSTRAP_SCHEMA_VERSION = 1;
  * Used by sandbox providers as part of the persistent sandbox name so
  * recipe changes automatically invalidate snapshots.
  */
-export async function hashBootstrap(
+export async function hashHarnessBootstrap(
   recipe: HarnessV1Bootstrap,
 ): Promise<string> {
   const encoder = new TextEncoder();

--- a/packages/harness/src/agent/internal/sandbox-bootstrap.test.ts
+++ b/packages/harness/src/agent/internal/sandbox-bootstrap.test.ts
@@ -1,0 +1,188 @@
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { HarnessV1Bootstrap } from '../../v1';
+import { hashHarnessBootstrap } from './bootstrap-recipe';
+import {
+  createSandboxBootstrapPlan,
+  normalizeSandboxWorkDir,
+  resolveSessionWorkDir,
+  runSandboxBootstrap,
+  validateSandboxBootstrapSettings,
+} from './sandbox-bootstrap';
+
+const recipe: HarnessV1Bootstrap = {
+  harnessId: 'demo',
+  bootstrapDir: '/tmp/harness/demo',
+  files: [{ path: '/tmp/harness/demo/a.txt', content: 'one' }],
+  commands: [{ command: 'echo ok' }],
+};
+
+function makeSession(): {
+  session: SandboxSession;
+  run: ReturnType<typeof vi.fn>;
+  readTextFile: ReturnType<typeof vi.fn>;
+  writeTextFile: ReturnType<typeof vi.fn>;
+} {
+  const run = vi.fn(async (args: { command: string }) => {
+    if (args.command === 'pwd') {
+      return { exitCode: 0, stdout: '/work\n', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+  const readTextFile = vi.fn(async () => null);
+  const writeTextFile = vi.fn(async () => {});
+  return {
+    session: {
+      description: 'mock',
+      run,
+      readTextFile,
+      writeTextFile,
+    } as unknown as SandboxSession,
+    run,
+    readTextFile,
+    writeTextFile,
+  };
+}
+
+describe('validateSandboxBootstrapSettings', () => {
+  it('requires onBootstrap and bootstrapHash together', () => {
+    expect(() =>
+      validateSandboxBootstrapSettings({
+        onBootstrap: async () => {},
+      }),
+    ).toThrow(/must be provided together/);
+
+    expect(() =>
+      validateSandboxBootstrapSettings({
+        bootstrapHash: 'hash',
+      }),
+    ).toThrow(/must be provided together/);
+  });
+
+  it('rejects invalid workDir values', () => {
+    for (const value of ['', '.', '/repo', '../repo', 'repo/../../x', 'a\\b']) {
+      expect(() =>
+        validateSandboxBootstrapSettings({
+          workDir: value,
+        }),
+      ).toThrow(/workDir/);
+    }
+  });
+
+  it('normalizes workDir values that stay inside the default cwd', () => {
+    expect(normalizeSandboxWorkDir('repo/../ai-sdk')).toBe('ai-sdk');
+    expect(normalizeSandboxWorkDir('./ai-sdk')).toBe('ai-sdk');
+  });
+});
+
+describe('createSandboxBootstrapPlan', () => {
+  it('preserves the built-in bootstrap identity when no new settings are used', async () => {
+    const plan = await createSandboxBootstrapPlan({
+      recipe,
+      settings: {},
+    });
+
+    expect(plan.identity).toBe(await hashHarnessBootstrap(recipe));
+  });
+
+  it('changes identity when caller bootstrap hash changes', async () => {
+    const a = await createSandboxBootstrapPlan({
+      recipe,
+      settings: {
+        bootstrapHash: 'repo-v1',
+        onBootstrap: async () => {},
+      },
+    });
+    const b = await createSandboxBootstrapPlan({
+      recipe,
+      settings: {
+        bootstrapHash: 'repo-v2',
+        onBootstrap: async () => {},
+      },
+    });
+
+    expect(a.identity).not.toBe(b.identity);
+  });
+
+  it('changes identity when workDir changes', async () => {
+    const a = await createSandboxBootstrapPlan({
+      recipe,
+      settings: { workDir: 'repo-a' },
+    });
+    const b = await createSandboxBootstrapPlan({
+      recipe,
+      settings: { workDir: 'repo-b' },
+    });
+
+    expect(a.identity).not.toBe(b.identity);
+  });
+});
+
+describe('resolveSessionWorkDir', () => {
+  it('uses the session-scoped default path when workDir is absent', () => {
+    expect(
+      resolveSessionWorkDir({
+        defaultWorkingDirectory: '/work',
+        harnessId: 'mock',
+        sessionId: 's1',
+      }),
+    ).toBe('/work/mock-s1');
+  });
+
+  it('uses the stable workDir when provided', () => {
+    expect(
+      resolveSessionWorkDir({
+        defaultWorkingDirectory: '/work',
+        harnessId: 'mock',
+        sessionId: 's1',
+        workDir: 'ai-sdk',
+      }),
+    ).toBe('/work/ai-sdk');
+  });
+});
+
+describe('runSandboxBootstrap', () => {
+  it('runs built-in bootstrap before caller bootstrap', async () => {
+    const { session, run } = makeSession();
+    const onSandboxBootstrap = vi.fn(async () => {});
+    const recipeIdentity = await hashHarnessBootstrap(recipe);
+
+    await runSandboxBootstrap({
+      session,
+      recipe,
+      recipeIdentity,
+      workDir: 'ai-sdk',
+      onBootstrap: onSandboxBootstrap,
+    });
+
+    expect(onSandboxBootstrap).toHaveBeenCalledWith({
+      session,
+      workDir: '/work/ai-sdk',
+      abortSignal: undefined,
+    });
+    expect(run.mock.calls.map(([args]) => args.command)).toEqual([
+      'echo ok',
+      'pwd',
+      'mkdir -p "$WORK_DIR"',
+    ]);
+    expect(run.mock.invocationCallOrder[0]!).toBeLessThan(
+      onSandboxBootstrap.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('uses the default cwd for caller bootstrap when workDir is absent', async () => {
+    const { session } = makeSession();
+    const onSandboxBootstrap = vi.fn(async () => {});
+
+    await runSandboxBootstrap({
+      session,
+      onBootstrap: onSandboxBootstrap,
+    });
+
+    expect(onSandboxBootstrap).toHaveBeenCalledWith({
+      session,
+      workDir: '/work',
+      abortSignal: undefined,
+    });
+  });
+});

--- a/packages/harness/src/agent/internal/sandbox-bootstrap.ts
+++ b/packages/harness/src/agent/internal/sandbox-bootstrap.ts
@@ -1,0 +1,266 @@
+import { posix } from 'node:path';
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import type { HarnessV1Bootstrap } from '../../v1';
+import type { HarnessAgentSandboxConfig } from '../harness-agent-settings';
+import { applyBootstrapRecipe, hashHarnessBootstrap } from './bootstrap-recipe';
+
+const SANDBOX_BOOTSTRAP_IDENTITY_VERSION = 1;
+
+type SandboxBootstrapSettings = Omit<HarnessAgentSandboxConfig, 'onSession'>;
+
+export type SandboxBootstrapPlan = {
+  readonly recipe?: HarnessV1Bootstrap;
+  readonly recipeIdentity?: string;
+  readonly identity?: string;
+  readonly workDir?: string;
+  readonly onFirstCreate?: (
+    session: SandboxSession,
+    opts: { abortSignal?: AbortSignal },
+  ) => Promise<void>;
+};
+
+export function validateSandboxBootstrapSettings(
+  settings: SandboxBootstrapSettings,
+): void {
+  if ((settings.onBootstrap == null) !== (settings.bootstrapHash == null)) {
+    throw new Error(
+      'HarnessAgent: `sandboxConfig.onBootstrap` and `sandboxConfig.bootstrapHash` must be provided together.',
+    );
+  }
+
+  if (settings.workDir != null) {
+    normalizeSandboxWorkDir(settings.workDir);
+  }
+}
+
+export function normalizeSandboxWorkDir(workDir: string): string {
+  if (workDir.length === 0) {
+    throw new Error('HarnessAgent: `sandboxConfig.workDir` must not be empty.');
+  }
+  if (workDir.includes('\0')) {
+    throw new Error(
+      'HarnessAgent: `sandboxConfig.workDir` must not contain NUL.',
+    );
+  }
+  if (workDir.includes('\\')) {
+    throw new Error(
+      'HarnessAgent: `sandboxConfig.workDir` must use POSIX path separators.',
+    );
+  }
+  if (posix.isAbsolute(workDir)) {
+    throw new Error('HarnessAgent: `sandboxConfig.workDir` must be relative.');
+  }
+
+  const normalized = posix.normalize(workDir);
+  if (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../')
+  ) {
+    throw new Error(
+      'HarnessAgent: `sandboxConfig.workDir` must stay inside the sandbox default working directory.',
+    );
+  }
+  return normalized;
+}
+
+export function resolveSessionWorkDir({
+  defaultWorkingDirectory,
+  harnessId,
+  sessionId,
+  workDir,
+}: {
+  readonly defaultWorkingDirectory: string;
+  readonly harnessId: string;
+  readonly sessionId: string;
+  readonly workDir?: string;
+}): string {
+  return joinSandboxPath({
+    base: defaultWorkingDirectory,
+    path: workDir ?? `${harnessId}-${sessionId}`,
+  });
+}
+
+export async function createSandboxBootstrapPlan({
+  recipe,
+  settings,
+}: {
+  readonly recipe?: HarnessV1Bootstrap;
+  readonly settings: SandboxBootstrapSettings;
+}): Promise<SandboxBootstrapPlan> {
+  const workDir =
+    settings.workDir == null
+      ? undefined
+      : normalizeSandboxWorkDir(settings.workDir);
+  const recipeIdentity =
+    recipe == null ? undefined : await hashHarnessBootstrap(recipe);
+  const hasCallerBootstrap = settings.onBootstrap != null;
+  const needsCombinedIdentity =
+    hasCallerBootstrap || (recipeIdentity != null && workDir != null);
+  const identity =
+    needsCombinedIdentity && (recipeIdentity != null || hasCallerBootstrap)
+      ? await hashSandboxBootstrapIdentity({
+          recipeIdentity,
+          bootstrapHash: settings.bootstrapHash,
+          workDir,
+        })
+      : recipeIdentity;
+
+  return {
+    ...(recipe != null ? { recipe } : {}),
+    ...(recipeIdentity != null ? { recipeIdentity } : {}),
+    ...(identity != null ? { identity } : {}),
+    ...(workDir != null ? { workDir } : {}),
+    ...(recipe != null || settings.onBootstrap != null
+      ? {
+          onFirstCreate: (session, opts) =>
+            runSandboxBootstrap({
+              session,
+              recipe,
+              recipeIdentity,
+              workDir,
+              onBootstrap: settings.onBootstrap,
+              abortSignal: opts.abortSignal,
+            }),
+        }
+      : {}),
+  };
+}
+
+export async function runSandboxBootstrap({
+  session,
+  recipe,
+  recipeIdentity,
+  workDir,
+  onBootstrap,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly recipe?: HarnessV1Bootstrap;
+  readonly recipeIdentity?: string;
+  readonly workDir?: string;
+  readonly onBootstrap?: SandboxBootstrapSettings['onBootstrap'];
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  if (recipe != null && recipeIdentity != null) {
+    await applyBootstrapRecipe(session, recipe, recipeIdentity, {
+      abortSignal,
+    });
+  }
+
+  if (onBootstrap == null) return;
+
+  const defaultWorkingDirectory = await resolveDefaultWorkingDirectory({
+    session,
+    abortSignal,
+  });
+  const bootstrapWorkDir =
+    workDir == null
+      ? defaultWorkingDirectory
+      : joinSandboxPath({
+          base: defaultWorkingDirectory,
+          path: workDir,
+        });
+
+  await ensureSandboxDirectory({
+    session,
+    workDir: bootstrapWorkDir,
+    abortSignal,
+  });
+  await onBootstrap({ session, workDir: bootstrapWorkDir, abortSignal });
+}
+
+export async function resolveDefaultWorkingDirectory({
+  session,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = await session.run({
+    command: 'pwd',
+    abortSignal,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to resolve sandbox default working directory (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+    );
+  }
+
+  const cwd = result.stdout.trim();
+  if (!posix.isAbsolute(cwd)) {
+    throw new Error(
+      `Failed to resolve sandbox default working directory: expected an absolute path, got ${JSON.stringify(cwd)}.`,
+    );
+  }
+  return cwd === '/' ? cwd : cwd.replace(/\/+$/, '');
+}
+
+export async function ensureSandboxDirectory({
+  session,
+  workDir,
+  abortSignal,
+}: {
+  readonly session: SandboxSession;
+  readonly workDir: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const result = await session.run({
+    command: 'mkdir -p "$WORK_DIR"',
+    env: { WORK_DIR: workDir },
+    abortSignal,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to create sandbox work directory ${workDir} (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+async function hashSandboxBootstrapIdentity({
+  recipeIdentity,
+  bootstrapHash,
+  workDir,
+}: {
+  readonly recipeIdentity?: string;
+  readonly bootstrapHash?: string;
+  readonly workDir?: string;
+}): Promise<string> {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  const pushString = (value: string) => {
+    chunks.push(encoder.encode(value));
+    chunks.push(encoder.encode('\0'));
+  };
+
+  pushString(String(SANDBOX_BOOTSTRAP_IDENTITY_VERSION));
+  pushString(recipeIdentity ?? '');
+  pushString(bootstrapHash ?? '');
+  pushString(workDir ?? '');
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const buffer = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  const bytes = new Uint8Array(digest);
+  let hex = '';
+  for (let i = 0; i < 8; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+function joinSandboxPath({
+  base,
+  path,
+}: {
+  readonly base: string;
+  readonly path: string;
+}): string {
+  return posix.join(base, path);
+}

--- a/packages/harness/src/agent/prewarm.test.ts
+++ b/packages/harness/src/agent/prewarm.test.ts
@@ -1,0 +1,77 @@
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { HarnessV1, HarnessV1SandboxProvider } from '../v1';
+import { prewarmHarness } from './prewarm';
+
+function makeHarness(): HarnessV1 {
+  return {
+    specificationVersion: 'harness-v1',
+    harnessId: 'mock',
+    builtinTools: {},
+    doStart: async () => {
+      throw new Error('not used');
+    },
+  };
+}
+
+function makeSession(): {
+  session: SandboxSession;
+  run: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+} {
+  const run = vi.fn(async (args: { command: string }) => {
+    if (args.command === 'pwd') {
+      return { exitCode: 0, stdout: '/work\n', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+  const stop = vi.fn(async () => {});
+  const session = {
+    description: 'mock',
+    run,
+    stop,
+    restricted: () => session,
+  } as unknown as SandboxSession & { stop: () => Promise<void> };
+  return { session, run, stop };
+}
+
+describe('prewarmHarness', () => {
+  it('runs caller bootstrap through provider onFirstCreate and stops the session', async () => {
+    const { session, stop } = makeSession();
+    const createSession = vi.fn(
+      async (
+        opts: Parameters<HarnessV1SandboxProvider['createSession']>[0],
+      ) => {
+        await opts?.onFirstCreate?.(session, {});
+        return session as never;
+      },
+    );
+    const onSandboxBootstrap = vi.fn(async () => {});
+
+    await prewarmHarness({
+      harness: makeHarness(),
+      sandboxProvider: {
+        specificationVersion: 'harness-sandbox-v1',
+        providerId: 'mock-sandbox',
+        createSession,
+      },
+      sandboxConfig: {
+        workDir: 'ai-sdk',
+        bootstrapHash: 'repo-v1',
+        onBootstrap: onSandboxBootstrap,
+      },
+    });
+
+    expect(createSession.mock.calls[0]![0]).toEqual({
+      abortSignal: undefined,
+      identity: expect.stringMatching(/^[0-9a-f]{16}$/),
+      onFirstCreate: expect.any(Function),
+    });
+    expect(onSandboxBootstrap).toHaveBeenCalledWith({
+      session,
+      workDir: '/work/ai-sdk',
+      abortSignal: undefined,
+    });
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/harness/src/agent/prewarm.ts
+++ b/packages/harness/src/agent/prewarm.ts
@@ -1,9 +1,13 @@
 import type { HarnessV1SandboxProvider } from '../v1';
 import type { HarnessAgentAdapter } from './harness-agent-types';
+import type { HarnessAgentSandboxConfig } from './harness-agent-settings';
+import { applyBootstrapRecipe } from './internal/bootstrap-recipe';
 import {
-  applyBootstrapRecipe,
-  hashBootstrap,
-} from './internal/bootstrap-recipe';
+  createSandboxBootstrapPlan,
+  validateSandboxBootstrapSettings,
+} from './internal/sandbox-bootstrap';
+
+type SandboxBootstrapSettings = Omit<HarnessAgentSandboxConfig, 'onSession'>;
 
 /**
  * Pre-build a harness's sandbox template without running an agent. Idempotent:
@@ -22,25 +26,39 @@ import {
 export async function prewarmHarness(options: {
   readonly harness: HarnessAgentAdapter;
   readonly sandboxProvider: HarnessV1SandboxProvider;
+  readonly sandboxConfig?: SandboxBootstrapSettings;
   readonly abortSignal?: AbortSignal;
 }): Promise<void> {
+  const sandboxConfig = options.sandboxConfig ?? {};
+  validateSandboxBootstrapSettings(sandboxConfig);
   const recipe = await options.harness.getBootstrap?.({
     abortSignal: options.abortSignal,
   });
-  if (recipe == null) return;
+  const bootstrapPlan = await createSandboxBootstrapPlan({
+    recipe,
+    settings: sandboxConfig,
+  });
+  if (bootstrapPlan.identity == null || bootstrapPlan.onFirstCreate == null) {
+    return;
+  }
 
-  const identity = await hashBootstrap(recipe);
   const sandboxSession = await options.sandboxProvider.createSession({
     abortSignal: options.abortSignal,
-    identity,
-    onFirstCreate: (session, opts) =>
-      applyBootstrapRecipe(session, recipe, identity, opts),
+    identity: bootstrapPlan.identity,
+    onFirstCreate: bootstrapPlan.onFirstCreate,
   });
 
   try {
-    await applyBootstrapRecipe(sandboxSession.restricted(), recipe, identity, {
-      abortSignal: options.abortSignal,
-    });
+    if (bootstrapPlan.recipe != null && bootstrapPlan.recipeIdentity != null) {
+      await applyBootstrapRecipe(
+        sandboxSession.restricted(),
+        bootstrapPlan.recipe,
+        bootstrapPlan.recipeIdentity,
+        {
+          abortSignal: options.abortSignal,
+        },
+      );
+    }
   } finally {
     await Promise.resolve(sandboxSession.stop()).catch(() => {});
   }

--- a/packages/harness/src/agent/telemetry-integration.test.ts
+++ b/packages/harness/src/agent/telemetry-integration.test.ts
@@ -74,7 +74,7 @@ function makeSandboxProvider(): HarnessV1SandboxProvider {
     defaultWorkingDirectory: '/work',
     ports: [],
     getPortUrl: async () => 'ws://example.test/',
-    run: async () => ({}),
+    run: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     stop: async () => {},
     destroy: async () => {},
     restricted: () => ({}),


### PR DESCRIPTION
## Background

So far, sandbox providers with the ability to create snapshots were only creating the snapshot based on the harness-owned `HarnessV1Bootstrap` recipe. `HarnessAgent` definitions could only run setup logic via `onSandboxSession`, which runs post-snapshot on every session. For costly and slow operations, this is far from ideal for UX.

## Summary

This PR adds the ability to define an additional callback that runs pre-snapshot:

- `onSandboxSession` is replaced by a `sandboxConfig` object, where it is now available via `sandboxConfig.onSession`
- `sandboxConfig.onBootstrap` allows defining the pre-snapshot callback
- `sandboxConfig.bootstrapHash` is necessary to specify with `sandboxConfig.onBootstrap` so that the abstraction knows when to use a fresh snapshot rather than looking up an existing one
- a minor but related new feature is `sandboxConfig.workDir` allows setting the directory where the agent harness operates in, relative to the sandbox provider's default working directory

## Manual Verification

Run the AI SDK Coding examples. The expensive repo checkout now happens in `onBootstrap` instead of `onSession`, making this _a lot_ faster after the first session.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
