### PR TITLE
Backport: feat(provider/fireworks): add prompt cache affinity

### DIFF
--- a/.changeset/fresh-fireworks-cache.md
+++ b/.changeset/fresh-fireworks-cache.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/fireworks": patch
+---
+
+Add the `promptCacheKey` provider option for Fireworks prompt cache affinity
+and Kimi K2.6 model autocomplete, and remove the deprecated Kimi K2.5
+serverless model from autocomplete.

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -122,7 +122,7 @@ import {
 import { generateText } from 'ai';
 
 const { text, reasoningText } = await generateText({
-  model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+  model: fireworks('accounts/fireworks/models/kimi-k2p6'),
   providerOptions: {
     fireworks: {
       thinking: { type: 'enabled', budgetTokens: 4096 },
@@ -135,9 +135,16 @@ const { text, reasoningText } = await generateText({
 
 The following optional provider options are available for Fireworks chat models:
 
+- **promptCacheKey** _string_
+
+  A stable, opaque key that improves prompt cache hit rates by routing requests
+  with shared prompt prefixes to the same Fireworks replica. Reuse the same key
+  for all steps and calls in one conversation, and use different keys for
+  unrelated conversations.
+
 - **thinking** _object_
 
-  Configuration for thinking/reasoning models like Kimi K2.5.
+  Configuration for thinking/reasoning models like Kimi K2.6.
 
   - **type** _'enabled' | 'disabled'_
 
@@ -154,6 +161,90 @@ The following optional provider options are available for Fireworks chat models:
   - `'disabled'`: Remove reasoning from history
   - `'interleaved'`: Include reasoning between tool calls within a single turn
   - `'preserved'`: Keep all reasoning in history
+
+### Prompt Cache Affinity
+
+[Fireworks prompt caching](https://docs.fireworks.ai/guides/prompt-caching)
+is automatic, but cached prefixes are local to a replica. Set
+`promptCacheKey` to an opaque session or conversation identifier to improve
+cache affinity. The provider sends it as Fireworks'
+[`prompt_cache_key`](https://docs.fireworks.ai/api-reference/post-chatcompletions)
+request field.
+
+The AI SDK reuses the same provider options for every model step in a
+multi-step `generateText` or `streamText` call, so one key covers the complete
+tool loop:
+
+```ts
+import {
+  fireworks,
+  type FireworksLanguageModelOptions,
+} from '@ai-sdk/fireworks';
+import { generateText, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+
+const sessionId = 'conversation-123';
+
+const result = await generateText({
+  model: fireworks('accounts/fireworks/models/kimi-k2p6'),
+  providerOptions: {
+    fireworks: {
+      promptCacheKey: sessionId,
+    } satisfies FireworksLanguageModelOptions,
+  },
+  tools: {
+    weather: tool({
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => `It is sunny in ${city}.`,
+    }),
+  },
+  stopWhen: isStepCount(5),
+  prompt: 'What is the weather in San Francisco?',
+});
+
+console.log(result.usage.inputTokenDetails.cacheReadTokens);
+```
+
+For a reusable `ToolLoopAgent`, use call options to supply a key for each
+conversation. Pass the same key again for later agent calls that continue that
+conversation:
+
+```ts
+import {
+  fireworks,
+  type FireworksLanguageModelOptions,
+} from '@ai-sdk/fireworks';
+import { ToolLoopAgent } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from './weather-tool';
+
+const agent = new ToolLoopAgent({
+  model: fireworks('accounts/fireworks/models/kimi-k2p6'),
+  callOptionsSchema: z.object({
+    sessionId: z.string(),
+  }),
+  prepareCall: ({ options, ...settings }) => ({
+    ...settings,
+    providerOptions: {
+      fireworks: {
+        promptCacheKey: options.sessionId,
+      } satisfies FireworksLanguageModelOptions,
+    },
+  }),
+  tools: { weather: weatherTool },
+});
+
+const result = await agent.generate({
+  prompt: 'What is the weather in San Francisco?',
+  options: {
+    sessionId: 'conversation-123',
+  },
+});
+```
+
+Use non-identifying values for cache keys rather than email addresses or other
+personal information.
 
 ### Completion Models
 
@@ -188,7 +279,7 @@ const model = fireworks.completionModel(
 | `accounts/fireworks/models/yi-large`                       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2-instruct`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/kimi-k2-thinking`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
-| `accounts/fireworks/models/kimi-k2p5`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
+| `accounts/fireworks/models/kimi-k2p6`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `accounts/fireworks/models/minimax-m2`                     | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 
 <Note>

--- a/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-thinking.ts
+++ b/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-thinking.ts
@@ -7,7 +7,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
         thinking: { type: 'enabled', budgetTokens: 4096 },

--- a/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-tool-call.ts
@@ -1,0 +1,34 @@
+import {
+  fireworks,
+  type FireworksLanguageModelOptions,
+} from '@ai-sdk/fireworks';
+import { generateText, isStepCount } from 'ai';
+import { run } from '../../lib/run';
+import { weatherTool } from '../../tools/weather-tool';
+
+run(async () => {
+  const sessionId = 'weather-conversation-123';
+
+  const result = await generateText({
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
+    providerOptions: {
+      fireworks: {
+        promptCacheKey: sessionId,
+        thinking: { type: 'enabled', budgetTokens: 4096 },
+        reasoningHistory: 'interleaved',
+      } satisfies FireworksLanguageModelOptions,
+    },
+    tools: { weather: weatherTool },
+    stopWhen: isStepCount(2),
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log(
+    'Cached input tokens:',
+    result.usage.inputTokenDetails.cacheReadTokens,
+  );
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/fireworks/kimi-k2-6-tool-call.ts
@@ -2,7 +2,7 @@ import {
   fireworks,
   type FireworksLanguageModelOptions,
 } from '@ai-sdk/fireworks';
-import { generateText, isStepCount } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
@@ -19,7 +19,7 @@ run(async () => {
       } satisfies FireworksLanguageModelOptions,
     },
     tools: { weather: weatherTool },
-    stopWhen: isStepCount(2),
+    stopWhen: stepCountIs(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-thinking.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-thinking.ts
@@ -8,7 +8,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
         thinking: { type: 'enabled', budgetTokens: 4096 },

--- a/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/kimi-k2-6-tool-call.ts
@@ -8,10 +8,13 @@ import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
 run(async () => {
+  const sessionId = 'weather-conversation-123';
+
   const result = streamText({
-    model: fireworks('accounts/fireworks/models/kimi-k2p5'),
+    model: fireworks('accounts/fireworks/models/kimi-k2p6'),
     providerOptions: {
       fireworks: {
+        promptCacheKey: sessionId,
         thinking: { type: 'enabled', budgetTokens: 4096 },
         reasoningHistory: 'interleaved',
       } satisfies FireworksLanguageModelOptions,
@@ -21,5 +24,6 @@ run(async () => {
     prompt: 'What is the weather in San Francisco?',
   });
 
-  printFullStream({ result });
+  await printFullStream({ result });
+  console.log('Token usage:', await result.usage);
 });

--- a/packages/fireworks/src/fireworks-chat-options.ts
+++ b/packages/fireworks/src/fireworks-chat-options.ts
@@ -20,11 +20,17 @@ export type FireworksChatModelId =
   | 'accounts/fireworks/models/yi-large'
   | 'accounts/fireworks/models/kimi-k2-instruct'
   | 'accounts/fireworks/models/kimi-k2-thinking'
-  | 'accounts/fireworks/models/kimi-k2p5'
+  | 'accounts/fireworks/models/kimi-k2p6'
   | 'accounts/fireworks/models/minimax-m2'
   | (string & {});
 
 export const fireworksLanguageModelOptions = z.object({
+  /**
+   * A stable key for routing requests with shared prompt prefixes to the same
+   * prompt cache.
+   */
+  promptCacheKey: z.string().optional(),
+
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -168,6 +168,52 @@ describe('FireworksProvider', () => {
       });
     });
 
+    it('should map promptCacheKey to prompt_cache_key', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const transformRequestBody = config.transformRequestBody;
+
+      const result = transformRequestBody({
+        model: 'test-model',
+        messages: [],
+        promptCacheKey: 'session-123',
+      });
+
+      expect(result).toEqual({
+        model: 'test-model',
+        messages: [],
+        prompt_cache_key: 'session-123',
+      });
+      expect(result).not.toHaveProperty('promptCacheKey');
+    });
+
+    it('should prefer promptCacheKey over raw prompt_cache_key', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const transformRequestBody = config.transformRequestBody;
+
+      const result = transformRequestBody({
+        model: 'test-model',
+        messages: [],
+        prompt_cache_key: 'raw-session',
+        promptCacheKey: 'typed-session',
+      });
+
+      expect(result).toEqual({
+        model: 'test-model',
+        messages: [],
+        prompt_cache_key: 'typed-session',
+      });
+    });
+
     it('should handle request without thinking options', () => {
       const provider = createFireworks();
       provider.chatModel('test-model');

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -141,11 +141,20 @@ export function createFireworks(
           | { type?: string; budgetTokens?: number }
           | undefined;
         const reasoningHistory = args.reasoningHistory as string | undefined;
+        const promptCacheKey = args.promptCacheKey as string | undefined;
 
-        const { thinking: _, reasoningHistory: __, ...rest } = args;
+        const {
+          thinking: _,
+          reasoningHistory: __,
+          promptCacheKey: ___,
+          ...rest
+        } = args;
 
         return {
           ...rest,
+          ...(promptCacheKey !== undefined && {
+            prompt_cache_key: promptCacheKey,
+          }),
           ...(thinking && {
             thinking: {
               type: thinking.type,


### PR DESCRIPTION
Backport of #16354 to the `release-v6.0` branch.

Adds Fireworks `promptCacheKey` provider option, serialized as `prompt_cache_key` to improve prompt cache hit rates by routing requests with shared prefixes to the same replica.

### Summary

- Add `promptCacheKey` to `FireworksLanguageModelOptions`, serialized as `prompt_cache_key`
- Prefer the typed option over a raw `prompt_cache_key` value
- Preserve existing request behavior when the option is omitted
- Add Node and Edge tests for serialization and precedence
- Document session-scoped usage with multi-step generation and `ToolLoopAgent`
- Add `generateText` and `streamText` tool-call examples
- Update examples and model autocomplete to Kimi K2.6, remove Kimi K2.5
- Patch changeset for `@ai-sdk/fireworks`

### Conflict resolution

The cherry-pick conflicted because `main` already has a `reasoning_effort` remapping block that does not exist on `release-v6.0`. Resolved by keeping the v6 structure and applying only the `promptCacheKey` additions from this PR (the unrelated `reasoning_effort` code and its tests were not part of #16354 and were left out).

### Verification

- `pnpm test` in `packages/fireworks`: 44 tests pass (node + edge)