### PR TITLE
fix(gateway): clarify parallel_search source_policy field descriptions

### DIFF
--- a/.changeset/parallel-search-source-policy-descriptions.md
+++ b/.changeset/parallel-search-source-policy-descriptions.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Clarify `parallel_search` `source_policy` field descriptions so the model emits
+values the Parallel API accepts: `include_domains`/`exclude_domains` must be plain
+hosts (no scheme/path/port), and `after_date` must be an ISO 8601 calendar date
+formatted `YYYY-MM-DD`.

--- a/packages/gateway/src/tool/parallel-search.ts
+++ b/packages/gateway/src/tool/parallel-search.ts
@@ -199,16 +199,20 @@ const parallelSearchInputSchema = lazySchema(() =>
           include_domains: z
             .array(z.string())
             .optional()
-            .describe('List of domains to include in search results.'),
+            .describe(
+              'Limit results to these domains. Use plain domain names only — e.g. example.com or sub.example.gov, or a bare extension like .edu. Do not include a scheme, path, or port (e.g. not https://example.com/page).',
+            ),
           exclude_domains: z
             .array(z.string())
             .optional()
-            .describe('List of domains to exclude from search results.'),
+            .describe(
+              'Exclude results from these domains. Use plain domain names only — e.g. example.com or sub.example.gov, or a bare extension like .edu. Do not include a scheme, path, or port (e.g. not https://example.com/page).',
+            ),
           after_date: z
             .string()
             .optional()
             .describe(
-              'Only include results published after this date (ISO 8601 format).',
+              'Only include results published after this date. Use an ISO 8601 calendar date formatted YYYY-MM-DD (e.g. 2025-01-01); do not include a time.',
             ),
         })
         .optional()


### PR DESCRIPTION
## Summary

The model-facing `parallel_search` `source_policy` descriptions gave **no format
guidance**, so the model emitted values the Parallel API rejects — failing the
entire search:

- domains with a scheme/path/port (`eater.com/san-francisco`, `google.com/maps`)
  → *"Invalid domain(s)… Schemes, paths, and ports are not allowed."*
- loose/US-style or empty dates (the field said only "ISO 8601 format", which
  permits datetimes and doesn't pin `YYYY-MM-DD`).

This tightens the `.describe()` text so the model produces accepted values:

- `include_domains` / `exclude_domains`: plain hosts only (no scheme/path/port);
  bare extensions like `.edu` allowed.
- `after_date`: ISO 8601 calendar date formatted `YYYY-MM-DD`.

## Why

This is the **prevention** half of a two-layer fix. The gateway service also
sanitizes `source_policy` server-side (drops/normalizes bad domains and dates) as
a safety net (ai-gateway#2384, ai-gateway#2387), but better model guidance
reduces malformed inputs at the source.

## Notes

- Descriptions only; no behavior/schema change. Patch changeset included.
- `exa`/`perplexity` tools may have similar description gaps — left as a
  follow-up (perplexity already carries some format guidance; surfacing failures
  needs exploration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)