### PR TITLE
fix: format Bedrock ARN model IDs in URLs

### DIFF
--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -49,6 +49,7 @@ import {
   type AmazonBedrockUsage,
 } from './convert-amazon-bedrock-usage';
 import { convertToAmazonBedrockChatMessages } from './convert-to-amazon-bedrock-chat-messages';
+import { formatBedrockModelId } from './format-bedrock-model-id';
 import { mapAmazonBedrockFinishReason } from './map-amazon-bedrock-finish-reason';
 import { isMistralModel, normalizeToolCallId } from './normalize-tool-call-id';
 import type { AmazonBedrockReasoningMetadata } from './amazon-bedrock-reasoning-metadata';
@@ -1049,8 +1050,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = encodeURIComponent(modelId);
-    return `${this.config.baseUrl()}/model/${encodedModelId}`;
+    return `${this.config.baseUrl()}/model/${formatBedrockModelId(modelId)}`;
   }
 }
 

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -20,6 +20,7 @@ import {
   type AmazonBedrockEmbeddingModelId,
 } from './amazon-bedrock-embedding-model-options';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
+import { formatBedrockModelId } from './format-bedrock-model-id';
 import { z } from 'zod/v4';
 
 type AmazonBedrockEmbeddingConfig = {
@@ -56,8 +57,9 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
   ) {}
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
-    return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
+    return `${this.config.baseUrl()}/model/${formatBedrockModelId(
+      modelId,
+    )}/invoke`;
   }
 
   async doEmbed({

--- a/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
@@ -21,6 +21,7 @@ import {
   type AmazonBedrockImageModelId,
 } from './amazon-bedrock-image-settings';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
+import { formatBedrockModelId } from './format-bedrock-model-id';
 import { z } from 'zod/v4';
 
 type AmazonBedrockImageModelConfig = {
@@ -55,8 +56,9 @@ export class AmazonBedrockImageModel implements ImageModelV4 {
   }
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
-    return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
+    return `${this.config.baseUrl()}/model/${formatBedrockModelId(
+      modelId,
+    )}/invoke`;
   }
 
   constructor(

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -23,6 +23,7 @@ import {
 } from '../amazon-bedrock-sigv4-fetch';
 import { createAmazonBedrockAnthropicFetch } from './amazon-bedrock-anthropic-fetch';
 import type { AmazonBedrockAnthropicModelId } from './amazon-bedrock-anthropic-options';
+import { formatBedrockModelId } from '../format-bedrock-model-id';
 import { VERSION } from '../version';
 
 // Bedrock requires newer tool versions than the default Anthropic SDK versions
@@ -258,7 +259,7 @@ export function createAmazonBedrockAnthropic(
       fetch: fetchFunction,
 
       buildRequestUrl: (baseURL, isStreaming) =>
-        `${baseURL}/model/${encodeURIComponent(modelId)}/${
+        `${baseURL}/model/${formatBedrockModelId(modelId)}/${
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 

--- a/packages/amazon-bedrock/src/format-bedrock-model-id.test.ts
+++ b/packages/amazon-bedrock/src/format-bedrock-model-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatBedrockModelId } from './format-bedrock-model-id';
+
+describe('formatBedrockModelId', () => {
+  it('encodes standard model IDs as one path segment', () => {
+    expect(formatBedrockModelId('us.amazon.nova-2-lite-v1:0')).toBe(
+      'us.amazon.nova-2-lite-v1%3A0',
+    );
+  });
+
+  it('preserves ARN delimiters for application inference profile model IDs', () => {
+    expect(
+      formatBedrockModelId(
+        'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz',
+      ),
+    ).toBe(
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz',
+    );
+  });
+
+  it('still encodes unsafe characters in Bedrock ARN model IDs', () => {
+    expect(
+      formatBedrockModelId(
+        'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc 123',
+      ),
+    ).toBe(
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc%20123',
+    );
+  });
+});

--- a/packages/amazon-bedrock/src/format-bedrock-model-id.ts
+++ b/packages/amazon-bedrock/src/format-bedrock-model-id.ts
@@ -1,0 +1,9 @@
+export function formatBedrockModelId(modelId: string): string {
+  const encodedModelId = encodeURIComponent(modelId);
+
+  if (!/^arn:aws(?:-[^:]+)?:bedrock:/.test(modelId)) {
+    return encodedModelId;
+  }
+
+  return encodedModelId.replace(/%3A/gi, ':').replace(/%2F/gi, '/');
+}


### PR DESCRIPTION
## Summary
- format Bedrock model IDs through a shared helper before building invoke URLs
- keep standard model IDs encoded as one path segment
- preserve ARN ':' and '/' delimiters for Bedrock application inference profile ARNs while still encoding unsafe characters

## Tests
- pnpm --dir packages/amazon-bedrock exec vitest --config vitest.node.config.js --run src/format-bedrock-model-id.test.ts
- pnpm --filter @ai-sdk/amazon-bedrock type-check
- git diff --check

## Notes
- Related issue: #14117
- The package script `pnpm --filter @ai-sdk/amazon-bedrock test:node -- format-bedrock-model-id.test.ts` loads the broader package suite in this checkout and hits unresolved local workspace test-server entries, so I used the focused Vitest command above.