### PR TITLE
fix(ai): stop tool loop on pending deferred result when there is no c…

### DIFF
--- a/.changeset/fix-deferred-tool-assistant-prefill.md
+++ b/.changeset/fix-deferred-tool-assistant-prefill.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): only continue the tool loop on a pending deferred provider-tool result when there is client output (or a denied approval) to send back, avoiding a malformed next request that ends on an assistant message (e.g. Anthropic "assistant message prefill not supported").

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1344,7 +1344,9 @@ export async function generateText<
         ((clientToolCalls.length > 0 &&
           clientToolOutputs.length + deniedToolApprovalResponses.length ===
             clientToolCalls.length) ||
-          pendingDeferredToolCalls.size > 0) &&
+          (pendingDeferredToolCalls.size > 0 &&
+            (clientToolOutputs.length > 0 ||
+              deniedToolApprovalResponses.length > 0))) &&
         // continue until a stop condition is met:
         !(await isStopConditionMet({ stopConditions, steps }))
       );

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -25585,7 +25585,7 @@ describe('streamText', () => {
             doStream: async () => {
               switch (responseCount++) {
                 case 0:
-                  // Step 1: tool call without result
+                  // Step 1: deferred provider tool call + client tool call (no provider result yet - it is deferred)
                   return {
                     stream: convertArrayToReadableStream([
                       {
@@ -25602,6 +25602,12 @@ describe('streamText', () => {
                         providerExecuted: true,
                       },
                       {
+                        type: 'tool-call',
+                        toolCallId: 'client-1',
+                        toolName: 'client_tool',
+                        input: `{ "value": "go" }`,
+                      },
+                      {
                         type: 'finish',
                         finishReason: { unified: 'tool-calls', raw: undefined },
                         usage: testUsage,
@@ -25610,7 +25616,7 @@ describe('streamText', () => {
                     response: {},
                   };
                 case 1:
-                  // Step 2: tool-error arrives
+                  // Step 2: deferred provider tool-error arrives
                   return {
                     stream: convertArrayToReadableStream([
                       {
@@ -25665,6 +25671,10 @@ describe('streamText', () => {
               args: {},
               supportsDeferredResults: true,
             },
+            client_tool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async () => 'client-output',
+            }),
           },
           ...defaultSettings(),
           stopWhen: isStepCount(3),
@@ -25690,6 +25700,27 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
+              "input": {
+                "value": "go",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "client-1",
+              "toolName": "client_tool",
+              "type": "tool-call",
+            },
+            {
+              "dynamic": false,
+              "input": {
+                "value": "go",
+              },
+              "output": "client-output",
+              "toolCallId": "client-1",
+              "toolName": "client_tool",
+              "type": "tool-result",
+            },
+            {
               "dynamic": undefined,
               "error": "ERROR",
               "input": undefined,
@@ -25705,6 +25736,75 @@ describe('streamText', () => {
             },
           ]
         `);
+      });
+
+      it('should not run an extra step when a deferred provider tool is pending but there is no client output to send back', async () => {
+        let responseCount = 0;
+        const result = streamText({
+          model: new MockLanguageModelV4({
+            doStream: async () => {
+              if (responseCount++ > 0) {
+                throw new Error(
+                  'streamText scheduled an extra step with no client output to send back',
+                );
+              }
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'response-metadata',
+                    id: 'msg-1',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'deferred_tool',
+                    input: `{ "value": "test" }`,
+                    providerExecuted: true,
+                  },
+                  {
+                    type: 'text-start',
+                    id: '1',
+                  },
+                  {
+                    type: 'text-delta',
+                    id: '1',
+                    delta: 'Done.',
+                  },
+                  {
+                    type: 'text-end',
+                    id: '1',
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: { unified: 'tool-calls', raw: undefined },
+                    usage: testUsage,
+                  },
+                ]),
+                response: {},
+              };
+            },
+          }),
+          tools: {
+            deferred_tool: {
+              type: 'provider',
+              isProviderExecuted: true,
+              id: 'test.deferred_tool',
+              inputSchema: z.object({ value: z.string() }),
+              outputSchema: z.object({ value: z.string() }),
+              args: {},
+              supportsDeferredResults: true,
+            },
+          },
+          ...defaultSettings(),
+          stopWhen: isStepCount(5),
+        });
+
+        await result.consumeStream();
+
+        expect((await result.steps).length).toBe(1);
+        expect(responseCount).toBe(1);
       });
     });
   });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2272,15 +2272,20 @@ class DefaultStreamTextResult<
                   clearStepTimeout();
                   clearChunkTimeout();
 
+                  const hasClientResultsToSend =
+                    clientToolOutputs.length > 0 ||
+                    deniedToolApprovalResponses.length > 0;
+
                   if (
                     // Continue if:
                     // 1. There are client tool calls that have all been executed or denied, OR
-                    // 2. There are pending deferred results from provider-executed tools, OR
+                    // 2. There are pending deferred results from provider-executed tools AND client output to send back with the next request.
                     ((clientToolCalls.length > 0 &&
                       clientToolCalls.length ===
                         clientToolOutputs.length +
                           deniedToolApprovalResponses.length) ||
-                      pendingDeferredToolCalls.size > 0) &&
+                      (pendingDeferredToolCalls.size > 0 &&
+                        hasClientResultsToSend)) &&
                     // continue until a stop condition is met:
                     !(await isStopConditionMet({
                       stopConditions,


### PR DESCRIPTION
## Background

Provider-executed tools can return deferred results, results that aren't sent in the same response, but delivered later (e.g. Anthropic's `code_execution` with `supportsDeferredResults`). A deferred result is only handed back by the provider in response to a follow-up message containing client tool output.

Fixes: https://github.com/vercel/ai/issues/13794

## Summary

A pending deferred provider-tool result now drives a continuation only when there is something to send back — i.e. client tool output, or a denied tool-approval response.

- `packages/ai/src/generate-text/generate-text.ts` — tightened the loop condition: continue on a pending deferred result only if `clientToolOutputs.length > 0 || deniedToolApprovalResponses.length > 0`.
- `packages/ai/src/generate-text/stream-text.ts` — same fix on the streaming path, via a `hasClientResultsToSend` helper, kept identical in behavior to the non-streaming path.
- `packages/ai/src/generate-text/stream-text.test.ts` — updated an existing deferred test to a realistic flow (deferred tool → client tool → output sent back → deferred result arrives next step), and added a regression test asserting that a pending deferred result with no client output does not trigger another model call.

## Manual Verification

- Ran an Anthropic `code_execution` (deferred result) flow that calls a client tool. Confirmed the loop sends the client tool output back, the deferred result is delivered in the following step, and no assistant message prefill not supported error occurs.
- Ran a deferred-tool step that produces no client output and confirmed the run now stops cleanly at that step instead of issuing a rejected follow-up request.
- `pnpm test:node` in `packages/ai` (full `stream-text` + `generate-text` suites): 659 passed, 3 skipped, 0 failures.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A patch changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)