### PR TITLE
docs: remove experimental from devtools + deadlink

### DIFF
--- a/content/docs/03-ai-sdk-core/17-mcp-apps.mdx
+++ b/content/docs/03-ai-sdk-core/17-mcp-apps.mdx
@@ -265,9 +265,5 @@ export default function Chat() {
       title: 'MCP App Renderer',
       link: '/docs/reference/ai-sdk-ui/mcp-app-renderer',
     },
-    {
-      title: 'Build MCP Apps with Next.js',
-      link: '/cookbook/next/mcp-apps',
-    },
   ]}
 />

--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -6,8 +6,8 @@ description: Debug and inspect AI SDK applications with DevTools
 # DevTools
 
 <Note type="warning">
-  AI SDK DevTools is experimental and intended for local development only. Do
-  not use in production environments.
+  AI SDK DevTools is intended for local development only. Do not use in
+  production environments.
 </Note>
 
 AI SDK DevTools gives you full visibility over your AI SDK calls with [`generateText`](/docs/reference/ai-sdk-core/generate-text), [`streamText`](/docs/reference/ai-sdk-core/stream-text), and [`ToolLoopAgent`](/docs/reference/ai-sdk-core/tool-loop-agent). It helps you debug and inspect LLM requests, responses, tool calls, and multi-step interactions through a web-based UI.


### PR DESCRIPTION
## Background

devtools was stlll marked as experimental + there was a deadlink in the mcp apps docs