### PR TITLE
fix(google): pass tools through for agent calls in google.interactions

### DIFF
--- a/.changeset/fix-google-interactions-agent-tools.md
+++ b/.changeset/fix-google-interactions-agent-tools.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google-interactions): pass tools through to agent calls instead of warning and dropping them

--- a/packages/google/src/interactions/google-interactions-language-model.test.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.test.ts
@@ -1366,7 +1366,7 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       expect(body.agent_config).toEqual({ type: 'dynamic' });
     });
 
-    it('emits a warning and drops tools when an agent is set', async () => {
+    it('passes function tools through to the request body when an agent is set', async () => {
       const agentModel = provider.interactions({ agent: AGENT_NAME });
       const result = await agentModel.doGenerate({
         prompt: TEST_PROMPT,
@@ -1387,13 +1387,64 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
         string,
         unknown
       >;
-      expect(body.tools).toBeUndefined();
-      const warning = result.warnings.find(
+      expect(body.tools).toBeDefined();
+      expect(body.tools).toEqual([
+        {
+          type: 'function',
+          name: 'getWeather',
+          description: 'Get the current weather in a location',
+          parameters: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+            required: ['location'],
+          },
+        },
+      ]);
+      const toolsDropWarning = result.warnings.find(
         w =>
           w.type === 'other' &&
-          (w as { message?: string }).message?.includes('tools'),
+          (w as { message?: string }).message?.includes(
+            'tools are not supported',
+          ),
       );
-      expect(warning).toBeDefined();
+      expect(toolsDropWarning).toBeUndefined();
+    });
+
+    it('passes file_search provider tool through to the request body when an agent is set', async () => {
+      const agentModel = provider.interactions({ agent: AGENT_NAME });
+      await agentModel.doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'provider',
+            id: 'google.file_search',
+            name: 'file_search',
+            args: {
+              fileSearchStoreNames: ['fileSearchStores/my-store'],
+            },
+          },
+        ],
+      });
+      const body = (await server.calls[0].requestBodyJson) as Record<
+        string,
+        unknown
+      >;
+      expect(body.tools).toEqual([
+        {
+          type: 'file_search',
+          file_search_store_names: ['fileSearchStores/my-store'],
+        },
+      ]);
+    });
+
+    it('omits tools from the request body when an agent is set with no tools', async () => {
+      const agentModel = provider.interactions({ agent: AGENT_NAME });
+      await agentModel.doGenerate({ prompt: TEST_PROMPT });
+      const body = (await server.calls[0].requestBodyJson) as Record<
+        string,
+        unknown
+      >;
+      expect(body.tools).toBeUndefined();
     });
 
     it('emits a warning and drops generation-config fields (temperature, topP, thinkingLevel) when an agent is set', async () => {

--- a/packages/google/src/interactions/google-interactions-language-model.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.ts
@@ -155,13 +155,7 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
     let toolsForBody: Array<GoogleInteractionsTool> | undefined;
     let toolChoiceForBody: GoogleInteractionsToolChoice | undefined;
 
-    if (hasTools && isAgent) {
-      warnings.push({
-        type: 'other',
-        message:
-          'google.interactions: tools are not supported when an agent is set; tools will be omitted from the request body.',
-      });
-    } else if (hasTools) {
+    if (hasTools) {
       const prepared = prepareGoogleInteractionsTools({
         tools: options.tools,
         toolChoice: options.toolChoice,


### PR DESCRIPTION
## Background
`google.interactions({ agent })` silently dropped all tools with a warning, making it impossible to use `file_search` with Deep Research agents even though the Gemini API supports it.

## Summary
Removed the warn-and-drop branch for agent + tools. Tools are now passed through to the request body for agent calls.

## Manual Verification
Ran the full `google-interactions-language-model` test suite — 83/83 pass including 3 new regression tests covering function tools, `file_search`, and agent-with-no-tools.

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A patch changeset has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #16368

---