### PR TITLE
fix(gateway): skip unsupported model settings types

### DIFF
--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -73,20 +73,6 @@ function generateTypeFile(modelIds: string[], typeName: string): string {
   return lines.join('\n') + '\n';
 }
 
-function getModalityConfig(type: string): {
-  outputFile: string;
-  typeName: string;
-} {
-  if (MODALITY_CONFIG[type]) {
-    return MODALITY_CONFIG[type];
-  }
-  const capitalized = type.charAt(0).toUpperCase() + type.slice(1);
-  return {
-    outputFile: `gateway-${type}-model-settings.ts`,
-    typeName: `Gateway${capitalized}ModelId`,
-  };
-}
-
 async function main() {
   const response = await fetchModels();
 
@@ -100,7 +86,14 @@ async function main() {
   }
 
   for (const [type, modelIds] of Object.entries(modelsByType)) {
-    const config = getModalityConfig(type);
+    const config = MODALITY_CONFIG[type];
+    if (!config) {
+      console.warn(
+        `Skipping unsupported model type '${type}' with ${modelIds.length} models`,
+      );
+      continue;
+    }
+
     const outputPath = path.join(OUTPUT_DIR, config.outputFile);
 
     if (!fs.existsSync(outputPath)) {


### PR DESCRIPTION
Fixes the release-v6.0 Gateway model settings update workflow when the Gateway model list includes a model type that the release branch does not support yet.

The generator now skips model types that are not explicitly present in `MODALITY_CONFIG` instead of deriving a new settings filename and throwing when that file does not exist. Configured modalities still fail if their expected output file is missing.

Failure observed in https://github.com/vercel/ai/actions/runs/28190627304/job/83503978455:

```text
Error: Output file does not exist for type 'transcription': gateway-transcription-model-settings.ts
```

Verification:
- `git diff --check`

Could not run `pnpm --dir packages/gateway generate-model-settings` locally because this workspace does not have `node_modules` installed (`tsx: command not found`).
