### PR TITLE
fix(gateway): include realtime in model metadata

### DIFF
--- a/.changeset/add-v7-gateway-realtime-model-metadata.md
+++ b/.changeset/add-v7-gateway-realtime-model-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Add realtime models to Gateway metadata and generated model settings support.

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -41,6 +41,10 @@ const MODALITY_CONFIG: Record<
     outputFile: 'gateway-video-model-settings.ts',
     typeName: 'GatewayVideoModelId',
   },
+  realtime: {
+    outputFile: 'gateway-realtime-model-settings.ts',
+    typeName: 'GatewayRealtimeModelId',
+  },
   reranking: {
     outputFile: 'gateway-reranking-model-settings.ts',
     typeName: 'GatewayRerankingModelId',

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -227,6 +227,7 @@ describe('GatewayFetchMetadata', () => {
         'embedding',
         'image',
         'language',
+        'realtime',
         'reranking',
         'speech',
         'transcription',

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -4,6 +4,7 @@ export const KNOWN_MODEL_TYPES = [
   'embedding',
   'image',
   'language',
+  'realtime',
   'reranking',
   'speech',
   'transcription',


### PR DESCRIPTION
## Summary
- Add `realtime` to Gateway metadata known model types for v7.
- Teach the Gateway model settings generator to write `gateway-realtime-model-settings.ts`.
- Add a patch changeset for `@ai-sdk/gateway`.

## Validation
- `pnpm generate-model-settings`
- `pnpm test:node -- gateway-fetch-metadata.test.ts gateway-realtime-model.test.ts`
- `pnpm type-check`