### PR TITLE
fix(gateway): add speech and transcription models

### DIFF
--- a/.changeset/add-v6-gateway-speech-transcription.md
+++ b/.changeset/add-v6-gateway-speech-transcription.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Add Gateway speech and transcription model support.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -204,6 +204,40 @@ console.log(ranking);
 
 Reranking models are useful for improving search results in retrieval-augmented generation (RAG) pipelines by re-scoring candidate documents after an initial retrieval step.
 
+## Speech Models
+
+You can create speech models using the `speechModel` method on the provider instance:
+
+```ts
+import { experimental_generateSpeech as generateSpeech } from "ai";
+import { gateway } from "@ai-sdk/gateway";
+
+const { audio } = await generateSpeech({
+  model: gateway.speechModel("openai/tts-1"),
+  text: "Hello, world!",
+  voice: "alloy",
+});
+```
+
+Speech models are useful for generating audio from text using the same Gateway authentication, routing, and observability as other Gateway model types.
+
+## Transcription Models
+
+You can create transcription models using the `transcriptionModel` method on the provider instance:
+
+```ts
+import { experimental_transcribe as transcribe } from "ai";
+import { gateway } from "@ai-sdk/gateway";
+import { readFile } from "fs/promises";
+
+const { text } = await transcribe({
+  model: gateway.transcriptionModel("openai/gpt-4o-transcribe"),
+  audio: await readFile("audio.mp3"),
+});
+```
+
+Transcription models are useful for converting audio to text through the AI Gateway.
+
 ## Available Models
 
 The AI Gateway supports models from OpenAI, Anthropic, Google, Meta, xAI, Mistral, DeepSeek, Amazon Bedrock, Cohere, Perplexity, Alibaba, and other providers.

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -40,6 +40,14 @@ const MODALITY_CONFIG: Record<
     outputFile: 'gateway-reranking-model-settings.ts',
     typeName: 'GatewayRerankingModelId',
   },
+  speech: {
+    outputFile: 'gateway-speech-model-settings.ts',
+    typeName: 'GatewaySpeechModelId',
+  },
+  transcription: {
+    outputFile: 'gateway-transcription-model-settings.ts',
+    typeName: 'GatewayTranscriptionModelId',
+  },
 };
 
 async function fetchModels(): Promise<ModelsResponse> {
@@ -93,6 +101,11 @@ async function main() {
   const modelsByType: Record<string, string[]> = {};
 
   for (const model of response.data) {
+    if (!MODALITY_CONFIG[model.type]) {
+      console.log(`Skipping unsupported model type '${model.type}'`);
+      continue;
+    }
+
     if (!modelsByType[model.type]) {
       modelsByType[model.type] = [];
     }

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -101,11 +101,6 @@ async function main() {
   const modelsByType: Record<string, string[]> = {};
 
   for (const model of response.data) {
-    if (!MODALITY_CONFIG[model.type]) {
-      console.log(`Skipping unsupported model type '${model.type}'`);
-      continue;
-    }
-
     if (!modelsByType[model.type]) {
       modelsByType[model.type] = [];
     }

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -228,6 +228,8 @@ describe('GatewayFetchMetadata', () => {
         'image',
         'language',
         'reranking',
+        'speech',
+        'transcription',
         'video',
       ];
       server.urls['https://api.example.com/*'].response = {

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -5,6 +5,8 @@ export const KNOWN_MODEL_TYPES = [
   'image',
   'language',
   'reranking',
+  'speech',
+  'transcription',
   'video',
 ] as const;
 

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -10,6 +10,8 @@ import { GatewayEmbeddingModel } from './gateway-embedding-model';
 import { GatewayImageModel } from './gateway-image-model';
 import { GatewayVideoModel } from './gateway-video-model';
 import { GatewayRerankingModel } from './gateway-reranking-model';
+import { GatewaySpeechModel } from './gateway-speech-model';
+import { GatewayTranscriptionModel } from './gateway-transcription-model';
 import { getVercelOidcToken, getVercelRequestId } from './vercel-environment';
 import { resolve } from '@ai-sdk/provider-utils';
 import { GatewayLanguageModel } from './gateway-language-model';
@@ -154,6 +156,27 @@ function assertIsGatewayRerankingModelInternalConfig(
   ) {
     throw new Error('Invalid GatewayRerankingModel configuration');
   }
+}
+
+type GatewaySpeechModelInternalConfig = GatewayRerankingModelInternalConfig;
+
+function getGatewaySpeechModelInternalConfig(
+  model: GatewaySpeechModel,
+): GatewaySpeechModelInternalConfig {
+  const config = Reflect.get(model as object, 'config');
+  assertIsGatewayRerankingModelInternalConfig(config);
+  return config;
+}
+
+type GatewayTranscriptionModelInternalConfig =
+  GatewayRerankingModelInternalConfig;
+
+function getGatewayTranscriptionModelInternalConfig(
+  model: GatewayTranscriptionModel,
+): GatewayTranscriptionModelInternalConfig {
+  const config = Reflect.get(model as object, 'config');
+  assertIsGatewayRerankingModelInternalConfig(config);
+  return config;
 }
 
 function getGatewayRerankingModelInternalConfig(
@@ -382,6 +405,66 @@ describe('GatewayProvider', () => {
 
       if (!(model instanceof GatewayRerankingModel)) {
         fail('Expected GatewayRerankingModel to be created');
+      }
+    });
+
+    it('should create GatewaySpeechModel for speechModel', () => {
+      const provider = createGatewayProvider({
+        baseURL: 'https://api.example.com',
+        apiKey: 'test-api-key',
+      });
+
+      const model = provider.speechModel('openai/tts-1');
+
+      if (!(model instanceof GatewaySpeechModel)) {
+        fail('Expected GatewaySpeechModel to be created');
+      }
+
+      const config = getGatewaySpeechModelInternalConfig(model);
+      expect(config.provider).toBe('gateway');
+      expect(config.baseURL).toBe('https://api.example.com');
+    });
+
+    it('should create GatewaySpeechModel for speech alias', () => {
+      const provider = createGatewayProvider({
+        baseURL: 'https://api.example.com',
+        apiKey: 'test-api-key',
+      });
+
+      const model = provider.speech('openai/tts-1');
+
+      if (!(model instanceof GatewaySpeechModel)) {
+        fail('Expected GatewaySpeechModel to be created');
+      }
+    });
+
+    it('should create GatewayTranscriptionModel for transcriptionModel', () => {
+      const provider = createGatewayProvider({
+        baseURL: 'https://api.example.com',
+        apiKey: 'test-api-key',
+      });
+
+      const model = provider.transcriptionModel('openai/gpt-4o-transcribe');
+
+      if (!(model instanceof GatewayTranscriptionModel)) {
+        fail('Expected GatewayTranscriptionModel to be created');
+      }
+
+      const config = getGatewayTranscriptionModelInternalConfig(model);
+      expect(config.provider).toBe('gateway');
+      expect(config.baseURL).toBe('https://api.example.com');
+    });
+
+    it('should create GatewayTranscriptionModel for transcription alias', () => {
+      const provider = createGatewayProvider({
+        baseURL: 'https://api.example.com',
+        apiKey: 'test-api-key',
+      });
+
+      const model = provider.transcription('openai/gpt-4o-transcribe');
+
+      if (!(model instanceof GatewayTranscriptionModel)) {
+        fail('Expected GatewayTranscriptionModel to be created');
       }
     });
 

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -29,9 +29,13 @@ import { GatewayEmbeddingModel } from './gateway-embedding-model';
 import { GatewayImageModel } from './gateway-image-model';
 import { GatewayVideoModel } from './gateway-video-model';
 import { GatewayRerankingModel } from './gateway-reranking-model';
+import { GatewaySpeechModel } from './gateway-speech-model';
+import { GatewayTranscriptionModel } from './gateway-transcription-model';
 import type { GatewayEmbeddingModelId } from './gateway-embedding-model-settings';
 import type { GatewayImageModelId } from './gateway-image-model-settings';
 import type { GatewayRerankingModelId } from './gateway-reranking-model-settings';
+import type { GatewaySpeechModelId } from './gateway-speech-model-settings';
+import type { GatewayTranscriptionModelId } from './gateway-transcription-model-settings';
 import type { GatewayVideoModelId } from './gateway-video-model-settings';
 import { gatewayTools } from './gateway-tools';
 import { getVercelOidcToken, getVercelRequestId } from './vercel-environment';
@@ -41,6 +45,8 @@ import type {
   EmbeddingModelV3,
   ImageModelV3,
   RerankingModelV3,
+  SpeechModelV3,
+  TranscriptionModelV3,
   Experimental_VideoModelV3,
   ProviderV3,
 } from '@ai-sdk/provider';
@@ -129,6 +135,28 @@ export interface GatewayProvider extends ProviderV3 {
    * Creates a model for reranking documents.
    */
   rerankingModel(modelId: GatewayRerankingModelId): RerankingModelV3;
+
+  /**
+   * Creates a model for text-to-speech generation.
+   */
+  speech(modelId: GatewaySpeechModelId): SpeechModelV3;
+
+  /**
+   * Creates a model for text-to-speech generation.
+   */
+  speechModel(modelId: GatewaySpeechModelId): SpeechModelV3;
+
+  /**
+   * Creates a model for audio transcription.
+   */
+  transcription(modelId: GatewayTranscriptionModelId): TranscriptionModelV3;
+
+  /**
+   * Creates a model for audio transcription.
+   */
+  transcriptionModel(
+    modelId: GatewayTranscriptionModelId,
+  ): TranscriptionModelV3;
 
   /**
    * Gateway-specific tools executed server-side.
@@ -378,6 +406,28 @@ export function createGatewayProvider(
   };
   provider.rerankingModel = createRerankingModel;
   provider.reranking = createRerankingModel;
+  const createSpeechModel = (modelId: GatewaySpeechModelId) => {
+    return new GatewaySpeechModel(modelId, {
+      provider: 'gateway',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+      o11yHeaders: createO11yHeaders(),
+    });
+  };
+  provider.speechModel = createSpeechModel;
+  provider.speech = createSpeechModel;
+  const createTranscriptionModel = (modelId: GatewayTranscriptionModelId) => {
+    return new GatewayTranscriptionModel(modelId, {
+      provider: 'gateway',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+      o11yHeaders: createO11yHeaders(),
+    });
+  };
+  provider.transcriptionModel = createTranscriptionModel;
+  provider.transcription = createTranscriptionModel;
   provider.chat = provider.languageModel;
   provider.embedding = provider.embeddingModel;
   provider.image = provider.imageModel;

--- a/packages/gateway/src/gateway-speech-model-settings.ts
+++ b/packages/gateway/src/gateway-speech-model-settings.ts
@@ -1,0 +1,5 @@
+export type GatewaySpeechModelId =
+  | 'openai/tts-1'
+  | 'openai/tts-1-hd'
+  | 'xai/grok-tts'
+  | (string & {});

--- a/packages/gateway/src/gateway-speech-model.test.ts
+++ b/packages/gateway/src/gateway-speech-model.test.ts
@@ -1,0 +1,193 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import {
+  GatewayInternalServerError,
+  GatewayInvalidRequestError,
+} from './errors';
+import type { GatewayConfig } from './gateway-config';
+import { GatewaySpeechModel } from './gateway-speech-model';
+
+const server = createTestServer({
+  'https://api.test.com/speech-model': {},
+});
+
+const createTestModel = (
+  config: Partial<
+    GatewayConfig & { o11yHeaders?: Record<string, string> }
+  > = {},
+) =>
+  new GatewaySpeechModel('openai/tts-1', {
+    provider: 'gateway',
+    baseURL: 'https://api.test.com',
+    headers: () => ({
+      Authorization: 'Bearer test-token',
+      'ai-gateway-auth-method': 'api-key',
+    }),
+    fetch: globalThis.fetch,
+    o11yHeaders: config.o11yHeaders || {},
+    ...config,
+  });
+
+describe('GatewaySpeechModel', () => {
+  function prepareJsonResponse({
+    audio = 'base64-audio',
+    headers,
+  }: {
+    audio?: string;
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls['https://api.test.com/speech-model'].response = {
+      type: 'json-value',
+      headers,
+      body: { audio },
+    };
+  }
+
+  describe('doGenerate', () => {
+    it('should pass headers correctly', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        text: 'Hello world',
+        headers: { 'Custom-Header': 'test-value' },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-token',
+        'custom-header': 'test-value',
+        'ai-speech-model-specification-version': '3',
+        'ai-model-id': 'openai/tts-1',
+      });
+    });
+
+    it('should include o11y headers', async () => {
+      prepareJsonResponse();
+
+      const o11yHeaders = {
+        'ai-o11y-deployment-id': 'deployment-1',
+        'ai-o11y-environment': 'production',
+        'ai-o11y-region': 'iad1',
+      } as const;
+
+      await createTestModel({ o11yHeaders }).doGenerate({
+        text: 'Hello world',
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject(o11yHeaders);
+    });
+
+    it('should send speech options in request body', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        text: 'Hello world',
+        voice: 'alloy',
+        outputFormat: 'mp3',
+        instructions: 'Speak clearly',
+        speed: 1.25,
+        language: 'en',
+        providerOptions: { openai: { style: 'friendly' } },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        text: 'Hello world',
+        voice: 'alloy',
+        outputFormat: 'mp3',
+        instructions: 'Speak clearly',
+        speed: 1.25,
+        language: 'en',
+        providerOptions: { openai: { style: 'friendly' } },
+      });
+    });
+
+    it('should omit optional speech options when not provided', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({ text: 'Hello world' });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        text: 'Hello world',
+      });
+    });
+
+    it('should extract audio and metadata from response', async () => {
+      server.urls['https://api.test.com/speech-model'].response = {
+        type: 'json-value',
+        headers: { 'x-request-id': 'req-123' },
+        body: {
+          audio: 'base64-audio',
+          warnings: [{ type: 'other', message: 'test warning' }],
+          providerMetadata: { gateway: { cost: '0.002' } },
+        },
+      };
+
+      const result = await createTestModel().doGenerate({
+        text: 'Hello world',
+      });
+
+      expect(result.audio).toBe('base64-audio');
+      expect(result.warnings).toStrictEqual([
+        { type: 'other', message: 'test warning' },
+      ]);
+      expect(result.providerMetadata).toStrictEqual({
+        gateway: { cost: '0.002' },
+      });
+      expect(result.response.headers?.['x-request-id']).toBe('req-123');
+      expect(result.response.modelId).toBe('openai/tts-1');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw GatewayInvalidRequestError on 400', async () => {
+      server.urls['https://api.test.com/speech-model'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          error: {
+            message: 'Invalid text format',
+            type: 'invalid_request_error',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doGenerate({ text: 'Hello world' }),
+      ).rejects.toSatisfy(
+        err =>
+          GatewayInvalidRequestError.isInstance(err) && err.statusCode === 400,
+      );
+    });
+
+    it('should throw GatewayInternalServerError on 500', async () => {
+      server.urls['https://api.test.com/speech-model'].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'Internal server error',
+            type: 'internal_server_error',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doGenerate({ text: 'Hello world' }),
+      ).rejects.toSatisfy(
+        err =>
+          GatewayInternalServerError.isInstance(err) && err.statusCode === 500,
+      );
+    });
+  });
+
+  describe('URL construction', () => {
+    it('should post to /speech-model endpoint', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({ text: 'Hello world' });
+
+      expect(server.calls[0].requestUrl).toBe(
+        'https://api.test.com/speech-model',
+      );
+    });
+  });
+});

--- a/packages/gateway/src/gateway-speech-model.ts
+++ b/packages/gateway/src/gateway-speech-model.ts
@@ -1,0 +1,138 @@
+import type {
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+  SpeechModelV3,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  postJsonToApi,
+  resolve,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { asGatewayError } from './errors';
+import { parseAuthMethod } from './errors/parse-auth-method';
+import type { GatewayConfig } from './gateway-config';
+
+export class GatewaySpeechModel implements SpeechModelV3 {
+  readonly specificationVersion = 'v3' as const;
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: GatewayConfig & {
+      provider: string;
+      o11yHeaders: Resolvable<Record<string, string>>;
+    },
+  ) {}
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  async doGenerate({
+    text,
+    voice,
+    outputFormat,
+    instructions,
+    speed,
+    language,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<SpeechModelV3['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<SpeechModelV3['doGenerate']>>
+  > {
+    const resolvedHeaders = await resolve(this.config.headers());
+    try {
+      const {
+        responseHeaders,
+        value: responseBody,
+        rawValue,
+      } = await postJsonToApi({
+        url: this.getUrl(),
+        headers: combineHeaders(
+          resolvedHeaders,
+          headers ?? {},
+          this.getModelConfigHeaders(),
+          await resolve(this.config.o11yHeaders),
+        ),
+        body: {
+          text,
+          ...(voice && { voice }),
+          ...(outputFormat && { outputFormat }),
+          ...(instructions && { instructions }),
+          ...(speed != null && { speed }),
+          ...(language && { language }),
+          ...(providerOptions && { providerOptions }),
+        },
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewaySpeechResponseSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        ...(abortSignal && { abortSignal }),
+        fetch: this.config.fetch,
+      });
+
+      return {
+        audio: responseBody.audio,
+        warnings: (responseBody.warnings ?? []) as Array<SharedV3Warning>,
+        providerMetadata:
+          responseBody.providerMetadata as SharedV3ProviderMetadata,
+        response: {
+          timestamp: new Date(),
+          modelId: this.modelId,
+          headers: responseHeaders,
+          body: rawValue,
+        },
+      };
+    } catch (error) {
+      throw await asGatewayError(
+        error,
+        await parseAuthMethod(resolvedHeaders ?? {}),
+      );
+    }
+  }
+
+  private getUrl() {
+    return `${this.config.baseURL}/speech-model`;
+  }
+
+  private getModelConfigHeaders() {
+    return {
+      'ai-speech-model-specification-version': '3',
+      'ai-model-id': this.modelId,
+    };
+  }
+}
+
+const providerMetadataEntrySchema = z.object({}).catchall(z.unknown());
+
+const gatewaySpeechWarningSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('unsupported'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('compatibility'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('other'),
+    message: z.string(),
+  }),
+]);
+
+const gatewaySpeechResponseSchema = z.object({
+  audio: z.string(),
+  warnings: z.array(gatewaySpeechWarningSchema).optional(),
+  providerMetadata: z
+    .record(z.string(), providerMetadataEntrySchema)
+    .optional(),
+});

--- a/packages/gateway/src/gateway-transcription-model-settings.ts
+++ b/packages/gateway/src/gateway-transcription-model-settings.ts
@@ -1,0 +1,6 @@
+export type GatewayTranscriptionModelId =
+  | 'openai/gpt-4o-mini-transcribe'
+  | 'openai/gpt-4o-transcribe'
+  | 'openai/whisper-1'
+  | 'xai/grok-stt'
+  | (string & {});

--- a/packages/gateway/src/gateway-transcription-model.test.ts
+++ b/packages/gateway/src/gateway-transcription-model.test.ts
@@ -1,0 +1,225 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import {
+  GatewayInternalServerError,
+  GatewayInvalidRequestError,
+} from './errors';
+import type { GatewayConfig } from './gateway-config';
+import { GatewayTranscriptionModel } from './gateway-transcription-model';
+
+const server = createTestServer({
+  'https://api.test.com/transcription-model': {},
+});
+
+const createTestModel = (
+  config: Partial<
+    GatewayConfig & { o11yHeaders?: Record<string, string> }
+  > = {},
+) =>
+  new GatewayTranscriptionModel('openai/gpt-4o-transcribe', {
+    provider: 'gateway',
+    baseURL: 'https://api.test.com',
+    headers: () => ({
+      Authorization: 'Bearer test-token',
+      'ai-gateway-auth-method': 'api-key',
+    }),
+    fetch: globalThis.fetch,
+    o11yHeaders: config.o11yHeaders || {},
+    ...config,
+  });
+
+describe('GatewayTranscriptionModel', () => {
+  function prepareJsonResponse({
+    text = 'Hello world',
+    headers,
+  }: {
+    text?: string;
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls['https://api.test.com/transcription-model'].response = {
+      type: 'json-value',
+      headers,
+      body: { text },
+    };
+  }
+
+  describe('doGenerate', () => {
+    it('should pass headers correctly', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        audio: 'base64-audio',
+        mediaType: 'audio/wav',
+        headers: { 'Custom-Header': 'test-value' },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-token',
+        'custom-header': 'test-value',
+        'ai-transcription-model-specification-version': '3',
+        'ai-model-id': 'openai/gpt-4o-transcribe',
+      });
+    });
+
+    it('should include o11y headers', async () => {
+      prepareJsonResponse();
+
+      const o11yHeaders = {
+        'ai-o11y-deployment-id': 'deployment-1',
+        'ai-o11y-environment': 'production',
+        'ai-o11y-region': 'iad1',
+      } as const;
+
+      await createTestModel({ o11yHeaders }).doGenerate({
+        audio: 'base64-audio',
+        mediaType: 'audio/wav',
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject(o11yHeaders);
+    });
+
+    it('should base64 encode byte audio in request body', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        audio: new Uint8Array([1, 2, 3]),
+        mediaType: 'audio/wav',
+        providerOptions: { openai: { language: 'en' } },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        audio: 'AQID',
+        mediaType: 'audio/wav',
+        providerOptions: { openai: { language: 'en' } },
+      });
+    });
+
+    it('should pass string audio through in request body', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        audio: 'base64-audio',
+        mediaType: 'audio/mpeg',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        audio: 'base64-audio',
+        mediaType: 'audio/mpeg',
+      });
+    });
+
+    it('should extract transcript fields and metadata from response', async () => {
+      server.urls['https://api.test.com/transcription-model'].response = {
+        type: 'json-value',
+        headers: { 'x-request-id': 'req-123' },
+        body: {
+          text: 'Hello world',
+          segments: [
+            { text: 'Hello', startSecond: 0, endSecond: 0.5 },
+            { text: 'world', startSecond: 0.5, endSecond: 1 },
+          ],
+          language: 'en',
+          durationInSeconds: 1,
+          warnings: [{ type: 'other', message: 'test warning' }],
+          providerMetadata: { gateway: { cost: '0.002' } },
+        },
+      };
+
+      const result = await createTestModel().doGenerate({
+        audio: 'base64-audio',
+        mediaType: 'audio/wav',
+      });
+
+      expect(result).toMatchObject({
+        text: 'Hello world',
+        segments: [
+          { text: 'Hello', startSecond: 0, endSecond: 0.5 },
+          { text: 'world', startSecond: 0.5, endSecond: 1 },
+        ],
+        language: 'en',
+        durationInSeconds: 1,
+        warnings: [{ type: 'other', message: 'test warning' }],
+        providerMetadata: { gateway: { cost: '0.002' } },
+      });
+      expect(result.response.headers?.['x-request-id']).toBe('req-123');
+      expect(result.response.modelId).toBe('openai/gpt-4o-transcribe');
+    });
+
+    it('should default optional transcript fields', async () => {
+      prepareJsonResponse();
+
+      const result = await createTestModel().doGenerate({
+        audio: 'base64-audio',
+        mediaType: 'audio/wav',
+      });
+
+      expect(result.segments).toStrictEqual([]);
+      expect(result.language).toBeUndefined();
+      expect(result.durationInSeconds).toBeUndefined();
+      expect(result.warnings).toStrictEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw GatewayInvalidRequestError on 400', async () => {
+      server.urls['https://api.test.com/transcription-model'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          error: {
+            message: 'Invalid audio format',
+            type: 'invalid_request_error',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doGenerate({
+          audio: 'base64-audio',
+          mediaType: 'audio/wav',
+        }),
+      ).rejects.toSatisfy(
+        err =>
+          GatewayInvalidRequestError.isInstance(err) && err.statusCode === 400,
+      );
+    });
+
+    it('should throw GatewayInternalServerError on 500', async () => {
+      server.urls['https://api.test.com/transcription-model'].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'Internal server error',
+            type: 'internal_server_error',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doGenerate({
+          audio: 'base64-audio',
+          mediaType: 'audio/wav',
+        }),
+      ).rejects.toSatisfy(
+        err =>
+          GatewayInternalServerError.isInstance(err) && err.statusCode === 500,
+      );
+    });
+  });
+
+  describe('URL construction', () => {
+    it('should post to /transcription-model endpoint', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        audio: 'base64-audio',
+        mediaType: 'audio/wav',
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        'https://api.test.com/transcription-model',
+      );
+    });
+  });
+});

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -1,0 +1,148 @@
+import type {
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+  TranscriptionModelV3,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertUint8ArrayToBase64,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  postJsonToApi,
+  resolve,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { asGatewayError } from './errors';
+import { parseAuthMethod } from './errors/parse-auth-method';
+import type { GatewayConfig } from './gateway-config';
+
+export class GatewayTranscriptionModel implements TranscriptionModelV3 {
+  readonly specificationVersion = 'v3' as const;
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: GatewayConfig & {
+      provider: string;
+      o11yHeaders: Resolvable<Record<string, string>>;
+    },
+  ) {}
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  async doGenerate({
+    audio,
+    mediaType,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<TranscriptionModelV3['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<TranscriptionModelV3['doGenerate']>>
+  > {
+    const resolvedHeaders = await resolve(this.config.headers());
+    try {
+      const {
+        responseHeaders,
+        value: responseBody,
+        rawValue,
+      } = await postJsonToApi({
+        url: this.getUrl(),
+        headers: combineHeaders(
+          resolvedHeaders,
+          headers ?? {},
+          this.getModelConfigHeaders(),
+          await resolve(this.config.o11yHeaders),
+        ),
+        body: {
+          audio:
+            audio instanceof Uint8Array
+              ? convertUint8ArrayToBase64(audio)
+              : audio,
+          mediaType,
+          ...(providerOptions && { providerOptions }),
+        },
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayTranscriptionResponseSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        ...(abortSignal && { abortSignal }),
+        fetch: this.config.fetch,
+      });
+
+      return {
+        text: responseBody.text,
+        segments: responseBody.segments ?? [],
+        language: responseBody.language ?? undefined,
+        durationInSeconds: responseBody.durationInSeconds ?? undefined,
+        warnings: (responseBody.warnings ?? []) as Array<SharedV3Warning>,
+        providerMetadata:
+          responseBody.providerMetadata as SharedV3ProviderMetadata,
+        response: {
+          timestamp: new Date(),
+          modelId: this.modelId,
+          headers: responseHeaders,
+          body: rawValue,
+        },
+      };
+    } catch (error) {
+      throw await asGatewayError(
+        error,
+        await parseAuthMethod(resolvedHeaders ?? {}),
+      );
+    }
+  }
+
+  private getUrl() {
+    return `${this.config.baseURL}/transcription-model`;
+  }
+
+  private getModelConfigHeaders() {
+    return {
+      'ai-transcription-model-specification-version': '3',
+      'ai-model-id': this.modelId,
+    };
+  }
+}
+
+const providerMetadataEntrySchema = z.object({}).catchall(z.unknown());
+
+const gatewayTranscriptionWarningSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('unsupported'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('compatibility'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('other'),
+    message: z.string(),
+  }),
+]);
+
+const gatewayTranscriptionResponseSchema = z.object({
+  text: z.string(),
+  segments: z
+    .array(
+      z.object({
+        text: z.string(),
+        startSecond: z.number(),
+        endSecond: z.number(),
+      }),
+    )
+    .optional(),
+  language: z.string().nullish(),
+  durationInSeconds: z.number().nullish(),
+  warnings: z.array(gatewayTranscriptionWarningSchema).optional(),
+  providerMetadata: z
+    .record(z.string(), providerMetadataEntrySchema)
+    .optional(),
+});

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,5 +1,7 @@
 export type { GatewayModelId } from './gateway-language-model-settings';
 export type { GatewayRerankingModelId } from './gateway-reranking-model-settings';
+export type { GatewaySpeechModelId } from './gateway-speech-model-settings';
+export type { GatewayTranscriptionModelId } from './gateway-transcription-model-settings';
 export type { GatewayVideoModelId } from './gateway-video-model-settings';
 export type {
   GatewayLanguageModelEntry,


### PR DESCRIPTION
## Summary
- Add Gateway speech and transcription model implementations for v6 / ProviderV3.
- Add speech/transcription provider factory methods, generated model ID settings, exports, and metadata known types.
- Add Gateway docs examples for speech and transcription models.

## Validation
- `pnpm --filter @ai-sdk/provider --filter @ai-sdk/provider-utils --filter @ai-sdk/test-server build`
- `pnpm test:node -- gateway-fetch-metadata.test.ts gateway-speech-model.test.ts gateway-transcription-model.test.ts gateway-provider.test.ts`
- `pnpm type-check`