### PR TITLE
fix(ai): prune orphaned tool-approval responses in pruneMessages

### DIFF
--- a/.changeset/prune-messages-orphaned-approval-response.md
+++ b/.changeset/prune-messages-orphaned-approval-response.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): prune orphaned tool-approval responses in `pruneMessages`
+
+When pruning a specific tool by name (`toolCalls: [{ type, tools: [...] }]`), `pruneMessages` left the tool's `tool-approval-response` in place while removing its `tool-approval-request` and `tool-call`. The tool name of an approval response was resolved per-message, but approval responses live in a separate `tool` message from their approval request, so the name could never be resolved and the response was always kept. Tool name resolution is now done across all messages, so approval requests and responses are pruned together.

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -716,5 +716,140 @@ describe('pruneMessages', () => {
         `);
       });
     });
+
+    describe('selective tool pruning with approvals (regression)', () => {
+      // Regression: a `tool-approval-response` lives in a separate `tool`
+      // message from its `tool-approval-request`. When pruning a specific tool
+      // by name, the response must be pruned together with its request and
+      // tool-call instead of being left orphaned.
+      it('should prune the approval response together with its request and tool-call', () => {
+        const messages: ModelMessage[] = [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Weather in Tokyo and Busan?' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'get-weather-tool-1',
+                input: '{"city": "Tokyo"}',
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-2',
+                toolName: 'get-weather-tool-2',
+                input: '{"city": "Busan"}',
+              },
+              {
+                type: 'tool-approval-request',
+                toolCallId: 'call-2',
+                approvalId: 'approval-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-1',
+                approved: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'get-weather-tool-1',
+                output: { type: 'text', value: 'sunny' },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call-2',
+                toolName: 'get-weather-tool-2',
+                output: { type: 'text', value: 'rainy' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'done' }],
+          },
+        ];
+
+        const result = pruneMessages({
+          messages,
+          toolCalls: [{ type: 'all', tools: ['get-weather-tool-2'] }],
+        });
+
+        // The approval response for the pruned tool must not survive as an
+        // orphan; only get-weather-tool-1 parts remain.
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "Weather in Tokyo and Busan?",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "content": [
+                {
+                  "input": "{"city": "Tokyo"}",
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-call",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "sunny",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+            {
+              "content": [
+                {
+                  "text": "done",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ]
+        `);
+
+        // No orphaned approval responses remain in the pruned output.
+        const approvalIds = new Set<string>();
+        const responseIds = new Set<string>();
+        for (const message of result) {
+          if (typeof message.content === 'string') continue;
+          for (const part of message.content) {
+            if (part.type === 'tool-approval-request') {
+              approvalIds.add(part.approvalId);
+            } else if (part.type === 'tool-approval-response') {
+              responseIds.add(part.approvalId);
+            }
+          }
+        }
+        for (const id of responseIds) {
+          expect(approvalIds).toContain(id);
+        }
+      });
+    });
   });
 });

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -100,6 +100,42 @@ export function pruneMessages({
       }
     }
 
+    // Build global maps from tool call id and approval id to tool name.
+    // These must be global (not per-message) because a `tool-approval-response`
+    // lives in a separate `tool` message from its `tool-approval-request`
+    // (assistant message), so the tool name of a response can only be resolved
+    // by looking across messages. Resolving names per-message left responses
+    // unresolved, which caused them to be kept while their request was pruned,
+    // producing orphaned approval responses.
+    const toolCallIdToToolName: Record<string, string> = {};
+    for (const message of messages) {
+      if (
+        (message.role === 'assistant' || message.role === 'tool') &&
+        typeof message.content !== 'string'
+      ) {
+        for (const part of message.content) {
+          if (part.type === 'tool-call' || part.type === 'tool-result') {
+            toolCallIdToToolName[part.toolCallId] = part.toolName;
+          }
+        }
+      }
+    }
+
+    const approvalIdToToolName: Record<string, string> = {};
+    for (const message of messages) {
+      if (
+        (message.role === 'assistant' || message.role === 'tool') &&
+        typeof message.content !== 'string'
+      ) {
+        for (const part of message.content) {
+          if (part.type === 'tool-approval-request') {
+            approvalIdToToolName[part.approvalId] =
+              toolCallIdToToolName[part.toolCallId];
+          }
+        }
+      }
+    }
+
     messages = messages.map((message, messageIndex) => {
       if (
         (message.role !== 'assistant' && message.role !== 'tool') ||
@@ -109,9 +145,6 @@ export function pruneMessages({
       ) {
         return message;
       }
-
-      const toolCallIdToToolName: Record<string, string> = {};
-      const approvalIdToToolName: Record<string, string> = {};
 
       return {
         ...message,
@@ -124,14 +157,6 @@ export function pruneMessages({
             part.type !== 'tool-approval-response'
           ) {
             return true;
-          }
-
-          // track tool calls and approvals:
-          if (part.type === 'tool-call') {
-            toolCallIdToToolName[part.toolCallId] = part.toolName;
-          } else if (part.type === 'tool-approval-request') {
-            approvalIdToToolName[part.approvalId] =
-              toolCallIdToToolName[part.toolCallId];
           }
 
           // keep parts that are associated with a tool call or approval that needs to be kept:


### PR DESCRIPTION
`pruneMessages` trims tool-related content from a message history while keeping it internally consistent (calls, results, and approvals are meant to be pruned together as a unit). When pruning **a specific tool by name** — `toolCalls: [{ type, tools: ['my-tool'] }]` — it removed the tool's `tool-call`, `tool-approval-request`, and `tool-result`, but **left the matching `tool-approval-response` behind**, producing an orphaned approval response with no corresponding request.

A `tool-approval-response` carries only an `approvalId` (no `toolName`), so its tool name can only be derived via `approvalId → tool-approval-request → toolCallId → tool-call.toolName`. The response lives in a `tool` message while its request lives in a **separate, earlier `assistant` message** — but the `approvalId → toolName` lookup was built **per message**, inside the `content.filter` callback. So when a response was evaluated the lookup was empty, `approvalIdToToolName[part.approvalId]` was `undefined`, and the keep condition `!tools.includes(undefined)` evaluated to `true` — keeping the response.

This is a realistic trap: any caller combining tool approvals with selective pruning ends up with a structurally inconsistent history (an approval response with no request), which can trigger provider-side validation errors and confuses the model about the tool-approval lifecycle.

```ts
const pruned = pruneMessages({
  messages, // assistant: tool-call(call-2/tool-2) + approval-request(approval-1)
            // tool:      approval-response(approval-1) + tool-result(call-2)
  toolCalls: [{ type: 'all', tools: ['get-weather-tool-2'] }],
});

// Before: tool message still contains approval-response(approval-1) — orphaned,
//         even though call-2, its approval-request, and its tool-result are gone.
// After:  approval-response(approval-1) is pruned together with its request and call.
```

### Changes

- **Resolve tool names globally, not per message.** Two lookups (`toolCallId → toolName` and `approvalId → toolName`) are now built across **all** messages once per `toolCalls` config iteration, before filtering. An approval response in a `tool` message can therefore find its request in the originating `assistant` message, so requests and responses are pruned together.
- Removed the per-message map declarations and the in-filter "track tool calls and approvals" block; the filter now reads the global maps. The keep logic, the protected trailing-window path (`keptToolCallIds` / `keptApprovalIds`), and whole-tool pruning (`tools` omitted) are unchanged.
- **Tests** asserting the full pruned output (inline snapshot) plus an invariant that every `tool-approval-response` in the result has a matching `tool-approval-request`.

No public API changes. The `undefined ⇒ keep` fallback is preserved for genuinely unresolvable parts, so the change only fixes the case where the name *should* have resolved.

**Files changed**
- `packages/ai/src/generate-text/prune-messages.ts` — build global `toolCallId`/`approvalId` → `toolName` maps; remove per-message resolution
- `packages/ai/src/generate-text/prune-messages.test.ts` — regression test for selective tool pruning with approvals
- `.changeset/prune-messages-orphaned-approval-response.md` — patch changeset

## Related issue(s)

Fixes #16385

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## How it was tested

- **New regression test** (`prune-messages.test.ts` → `selective tool pruning with approvals`) asserts the orphaned approval response is gone and that every response in the output has a matching request.
- Existing `two tool settings` test (selective pruning that *keeps* an approval via the protected window) is unchanged and still passes.
- Full file suite green (8 tests, 0 type errors); `oxlint` and `oxfmt --check` clean.
- Run locally with:
  ```bash
  pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-text/prune-messages.test.ts
  ```

## Checklist

- [ ] I have linked the related issue(s) in the description above _(pending — replace #XXXX once the issue is filed)_
- [x] I have made corresponding changes to the documentation (if applicable) _(none needed; internal helper behavior only)_
- [x] I have added tests that prove my fix is effective
- [x] I have added a changeset
- [ ] I have addressed all Coderabbit comments on this PR _(after PR is opened)_

## Diff summary

```diff
+    // Build global maps from tool call id and approval id to tool name.
+    // A `tool-approval-response` lives in a separate `tool` message from its
+    // `tool-approval-request`, so resolving names per-message left responses
+    // unresolved and orphaned. Resolve across all messages instead.
+    const toolCallIdToToolName: Record<string, string> = {};
+    for (const message of messages) {
+      if ((message.role === 'assistant' || message.role === 'tool') &&
+          typeof message.content !== 'string') {
+        for (const part of message.content) {
+          if (part.type === 'tool-call' || part.type === 'tool-result') {
+            toolCallIdToToolName[part.toolCallId] = part.toolName;
+          }
+        }
+      }
+    }
+    const approvalIdToToolName: Record<string, string> = {};
+    for (const message of messages) {
+      if ((message.role === 'assistant' || message.role === 'tool') &&
+          typeof message.content !== 'string') {
+        for (const part of message.content) {
+          if (part.type === 'tool-approval-request') {
+            approvalIdToToolName[part.approvalId] =
+              toolCallIdToToolName[part.toolCallId];
+          }
+        }
+      }
+    }
+
     messages = messages.map((message, messageIndex) => {
       ...
-      const toolCallIdToToolName: Record<string, string> = {};
-      const approvalIdToToolName: Record<string, string> = {};
-
       return {
         ...message,
         content: message.content.filter(part => {
           ...
-          // track tool calls and approvals:
-          if (part.type === 'tool-call') {
-            toolCallIdToToolName[part.toolCallId] = part.toolName;
-          } else if (part.type === 'tool-approval-request') {
-            approvalIdToToolName[part.approvalId] =
-              toolCallIdToToolName[part.toolCallId];
-          }
-
```
