### PR TITLE
feat(harness): add `prepareSandboxForHarness` utility to prepare a caller-owned sandbox for one or more harnesses

### DIFF
--- a/.changeset/honest-mayflies-bow.md
+++ b/.changeset/honest-mayflies-bow.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+feat(harness): add `prepareSandboxForHarness` utility to prepare a caller-owned sandbox for one or more harnesses

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -261,6 +261,81 @@ default working directory and is used as the session working directory. When
 omitted, regular sessions use the default `<harnessId>-<sessionId>` directory,
 while `onBootstrap` receives the sandbox's default working directory.
 
+## Prepare Reusable Sandboxes
+
+Use `prepareHarnessSandboxTemplate()` when you want the sandbox provider to
+create or refresh its reusable template for one harness ahead of time:
+
+```ts
+import { prepareHarnessSandboxTemplate } from '@ai-sdk/harness/agent';
+
+await prepareHarnessSandboxTemplate({
+  harness: claudeCode,
+  sandboxProvider: createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+  }),
+  sandboxConfig: {
+    bootstrapHash: 'ripgrep-v1',
+    onBootstrap: async ({ session, abortSignal }) => {
+      await session.run({
+        command:
+          'command -v rg >/dev/null || (apt-get update && apt-get install -y ripgrep)',
+        abortSignal,
+      });
+    },
+  },
+});
+```
+
+Use `prepareSandboxForHarness()` when you own the native sandbox lifecycle and
+want to snapshot the prepared sandbox yourself. It applies the selected harness
+bootstrap recipes and `sandboxConfig.onBootstrap`, then returns preparation
+metadata. It does not stop or snapshot the sandbox.
+
+```ts
+import { HarnessAgent, prepareSandboxForHarness } from '@ai-sdk/harness/agent';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { Sandbox } from '@vercel/sandbox';
+
+const nativeSandbox = await Sandbox.create({
+  runtime: 'node24',
+  ports: [4000],
+});
+const sandboxProvider = createVercelSandbox({ sandbox: nativeSandbox });
+const session = await sandboxProvider.createSession();
+
+const preparation = await prepareSandboxForHarness({
+  session: session.restricted(),
+  harnesses: [claudeCode, codex],
+  sandboxConfig,
+});
+
+const { snapshot } = await nativeSandbox.stop();
+if (snapshot == null) {
+  throw new Error('Prepared sandbox did not create a snapshot.');
+}
+
+const sandboxFromSnapshot = await Sandbox.create({
+  source: {
+    type: 'snapshot',
+    snapshotId: snapshot.id,
+  },
+  ports: [4000],
+});
+
+const agent = new HarnessAgent({
+  harness: claudeCode,
+  sandbox: createVercelSandbox({
+    sandbox: sandboxFromSnapshot,
+    bridgePorts: [4000],
+  }),
+  sandboxConfig,
+});
+
+console.log(preparation.identity);
+```
+
 ## Settings
 
 `HarnessAgent` accepts these main settings:

--- a/examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts
+++ b/examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts
@@ -1,0 +1,129 @@
+import {
+  HarnessAgent,
+  prepareSandboxForHarness,
+  type HarnessAgentAdapter,
+  type HarnessAgentSandboxConfig,
+} from '@ai-sdk/harness/agent';
+import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { codex } from '@ai-sdk/harness-codex';
+import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { openCode } from '@ai-sdk/harness-opencode';
+import { pi } from '@ai-sdk/harness-pi';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { Sandbox } from '@vercel/sandbox';
+import { run } from '../lib/run';
+
+const sandboxTimeout = 10 * 60 * 1000;
+const bridgePort = 4000;
+
+const harnesses = [
+  { name: 'claude-code', harness: claudeCode },
+  { name: 'codex', harness: codex },
+  { name: 'deepagents', harness: deepAgents },
+  { name: 'opencode', harness: openCode },
+  { name: 'pi', harness: pi },
+] satisfies ReadonlyArray<{
+  name: string;
+  harness: HarnessAgentAdapter;
+}>;
+
+const sandboxConfig = {
+  workDir: 'workspace',
+  bootstrapHash: 'prepare-sandbox-for-harness-example-v1',
+  onBootstrap: async ({ session, workDir, abortSignal }) => {
+    await session.writeTextFile({
+      path: `${workDir}/PREPARED.md`,
+      content: 'This file was written before the shared sandbox snapshot.\n',
+      abortSignal,
+    });
+  },
+  onSession: async ({ session, sessionWorkDir, abortSignal }) => {
+    await session.writeTextFile({
+      path: `${sessionWorkDir}/SESSION.md`,
+      content: 'This file was written for the current harness session.\n',
+      abortSignal,
+    });
+  },
+} satisfies HarnessAgentSandboxConfig;
+
+run(async () => {
+  const preparedSandbox = await Sandbox.create({
+    runtime: 'node24',
+    ports: [bridgePort],
+    timeout: sandboxTimeout,
+  });
+
+  const snapshotId = await createPreparedSnapshot(preparedSandbox);
+  console.log('prepared snapshot:', snapshotId);
+
+  for (const { name, harness } of harnesses) {
+    await runHarnessFromSnapshot({ name, harness, snapshotId });
+  }
+});
+
+async function createPreparedSnapshot(
+  preparedSandbox: Awaited<ReturnType<typeof Sandbox.create>>,
+): Promise<string> {
+  try {
+    const provider = createVercelSandbox({ sandbox: preparedSandbox });
+    const session = await provider.createSession();
+    const result = await prepareSandboxForHarness({
+      session: session.restricted(),
+      harnesses: harnesses.map(({ harness }) => harness),
+      sandboxConfig,
+    });
+
+    console.log('prepared identity:', result.identity);
+    console.log('recipe identities:', result.recipeIdentities);
+    console.log('skipped harnesses:', result.skippedHarnessIds);
+
+    const stopResult = await preparedSandbox.stop();
+    const snapshotId = stopResult.snapshot?.id;
+    if (snapshotId == null) {
+      throw new Error('Prepared sandbox stopped without creating a snapshot.');
+    }
+    return snapshotId;
+  } catch (error) {
+    await preparedSandbox.stop().catch(() => {});
+    throw error;
+  }
+}
+
+async function runHarnessFromSnapshot({
+  name,
+  harness,
+  snapshotId,
+}: {
+  readonly name: string;
+  readonly harness: HarnessAgentAdapter;
+  readonly snapshotId: string;
+}): Promise<void> {
+  const sandbox = await Sandbox.create({
+    source: { type: 'snapshot', snapshotId },
+    ports: [bridgePort],
+    timeout: sandboxTimeout,
+  });
+  const agent = new HarnessAgent({
+    harness,
+    sandbox: createVercelSandbox({
+      sandbox,
+      bridgePorts: [bridgePort],
+    }),
+    sandboxConfig,
+  });
+  const session = await agent.createSession().catch(async error => {
+    await sandbox.stop().catch(() => {});
+    throw error;
+  });
+
+  try {
+    const result = await agent.generate({
+      session,
+      prompt: 'In one sentence, what is the capital of France?',
+    });
+    console.log(`[${name}]`, result.text);
+  } finally {
+    await session.destroy().catch(() => {});
+    await sandbox.stop().catch(() => {});
+  }
+}

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -106,6 +106,12 @@
       "path": "../../packages/harness-codex"
     },
     {
+      "path": "../../packages/harness-deepagents"
+    },
+    {
+      "path": "../../packages/harness-opencode"
+    },
+    {
       "path": "../../packages/harness-pi"
     },
     {

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -91,6 +91,18 @@ Use `session.detach()` to park a bridge-backed session for later attach, `sessio
 - Use `sandboxConfig.onBootstrap` for expensive sandbox setup that should be baked into a reusable snapshot, such as installing tools or cloning a large repository. Provide `sandboxConfig.bootstrapHash` with it and change that value whenever the bootstrap output should invalidate the cached snapshot.
 - Use `sandboxConfig.workDir` to set a stable working directory for the agent, relative to the sandbox's default working directory; otherwise regular sessions use the existing `<harnessId>-<sessionId>` directory. In that case, the `onBootstrap` callback receives the sandbox's default working directory.
 
+Use `prepareHarnessSandboxTemplate()` to create or refresh the sandbox provider's
+own reusable template for one harness before serving traffic. This is the
+replacement for `prewarmHarness()`, which remains as a deprecated alias.
+
+Use `prepareSandboxForHarness()` when you own an existing sandbox and want to
+prepare it before creating your own snapshot. It applies the selected harness
+bootstrap recipes and `sandboxConfig.onBootstrap`, returns the computed
+preparation identity and per-harness recipe identities, and leaves snapshotting
+or stopping the sandbox to your code. Later, create a sandbox from that snapshot
+and pass the native sandbox object to `createVercelSandbox({ sandbox })` for the
+`HarnessAgent`.
+
 ### Available harnesses
 
 See the [harness adapters documentation](https://ai-sdk.dev/v7/docs/ai-sdk-harnesses/harness-adapters).

--- a/packages/harness/agent/index.ts
+++ b/packages/harness/agent/index.ts
@@ -1,5 +1,6 @@
 export { HarnessAgent } from '../src/agent/harness-agent';
 export type {
+  HarnessAgentSandboxConfig,
   HarnessAgentSettings,
   HarnessAgentToolApprovalConfiguration,
 } from '../src/agent/harness-agent-settings';
@@ -29,7 +30,14 @@ export {
   collectHarnessAgentToolApprovalContinuations,
   type HarnessAgentToolApprovalContinuation,
 } from '../src/agent/harness-agent-tool-approval-continuation';
-export { prewarmHarness } from '../src/agent/prewarm';
+export {
+  prepareHarnessSandboxTemplate,
+  prewarmHarness,
+} from '../src/agent/prewarm';
+export {
+  prepareSandboxForHarness,
+  type PrepareSandboxForHarnessResult,
+} from '../src/agent/prepare-sandbox-for-harness';
 export type {
   HarnessDebugConfig,
   HarnessDebugLevel,

--- a/packages/harness/src/agent/prepare-sandbox-for-harness.test.ts
+++ b/packages/harness/src/agent/prepare-sandbox-for-harness.test.ts
@@ -1,0 +1,193 @@
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { HarnessV1, HarnessV1Bootstrap } from '../v1';
+import { hashHarnessBootstrap } from './internal/bootstrap-recipe';
+import { prepareSandboxForHarness } from './prepare-sandbox-for-harness';
+
+function makeRecipe(harnessId: string): HarnessV1Bootstrap {
+  return {
+    harnessId,
+    bootstrapDir: `/tmp/harness/${harnessId}`,
+    files: [
+      {
+        path: `/tmp/harness/${harnessId}/file.txt`,
+        content: harnessId,
+      },
+    ],
+    commands: [{ command: `echo ${harnessId}` }],
+  };
+}
+
+function makeHarness({
+  harnessId,
+  recipe,
+}: {
+  readonly harnessId: string;
+  readonly recipe?: HarnessV1Bootstrap;
+}): HarnessV1 {
+  return {
+    specificationVersion: 'harness-v1',
+    harnessId,
+    builtinTools: {},
+    ...(recipe != null ? { getBootstrap: vi.fn(async () => recipe) } : {}),
+    doStart: async () => {
+      throw new Error('not used');
+    },
+  };
+}
+
+function makeSession(): {
+  session: SandboxSession;
+  run: ReturnType<typeof vi.fn>;
+  readTextFile: ReturnType<typeof vi.fn>;
+  writeTextFile: ReturnType<typeof vi.fn>;
+} {
+  const run = vi.fn(async (args: { command: string }) => {
+    if (args.command === 'pwd') {
+      return { exitCode: 0, stdout: '/work\n', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+  const readTextFile = vi.fn(async () => null);
+  const writeTextFile = vi.fn(async () => {});
+  return {
+    session: {
+      description: 'mock',
+      run,
+      readTextFile,
+      writeTextFile,
+    } as unknown as SandboxSession,
+    run,
+    readTextFile,
+    writeTextFile,
+  };
+}
+
+describe('prepareSandboxForHarness', () => {
+  it('prepares multiple harnesses in sorted order and returns metadata', async () => {
+    const { session, run } = makeSession();
+    const alphaRecipe = makeRecipe('alpha');
+    const betaRecipe = makeRecipe('beta');
+    const alpha = makeHarness({ harnessId: 'alpha', recipe: alphaRecipe });
+    const beta = makeHarness({ harnessId: 'beta', recipe: betaRecipe });
+    const onBootstrap = vi.fn(async () => {});
+
+    const result = await prepareSandboxForHarness({
+      session,
+      harnesses: [beta, alpha],
+      sandboxConfig: {
+        workDir: 'repo',
+        bootstrapHash: 'repo-v1',
+        onBootstrap,
+      },
+    });
+
+    expect(result).toEqual({
+      identity: expect.stringMatching(/^[0-9a-f]{16}$/),
+      recipeIdentities: {
+        alpha: await hashHarnessBootstrap(alphaRecipe),
+        beta: await hashHarnessBootstrap(betaRecipe),
+      },
+      skippedHarnessIds: [],
+    });
+    expect(run.mock.calls.map(([args]) => args.command)).toEqual([
+      'echo alpha',
+      'echo beta',
+      'pwd',
+      'mkdir -p "$WORK_DIR"',
+    ]);
+    expect(onBootstrap).toHaveBeenCalledWith({
+      session,
+      workDir: '/work/repo',
+      abortSignal: undefined,
+    });
+  });
+
+  it('returns the same identity for the same harnesses in a different order', async () => {
+    const alpha = makeHarness({
+      harnessId: 'alpha',
+      recipe: makeRecipe('alpha'),
+    });
+    const beta = makeHarness({
+      harnessId: 'beta',
+      recipe: makeRecipe('beta'),
+    });
+
+    const first = await prepareSandboxForHarness({
+      session: makeSession().session,
+      harnesses: [alpha, beta],
+      sandboxConfig: { workDir: 'repo' },
+    });
+    const second = await prepareSandboxForHarness({
+      session: makeSession().session,
+      harnesses: [beta, alpha],
+      sandboxConfig: { workDir: 'repo' },
+    });
+
+    expect(first.identity).toBe(second.identity);
+    expect(first.recipeIdentities).toEqual(second.recipeIdentities);
+  });
+
+  it('skips harnesses without bootstrap recipes', async () => {
+    const { session, run } = makeSession();
+    const pi = makeHarness({ harnessId: 'pi' });
+
+    const result = await prepareSandboxForHarness({
+      session,
+      harnesses: [pi],
+    });
+
+    expect(result).toEqual({
+      recipeIdentities: {},
+      skippedHarnessIds: ['pi'],
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate harness ids', async () => {
+    const first = makeHarness({ harnessId: 'alpha', recipe: makeRecipe('a') });
+    const second = makeHarness({ harnessId: 'alpha', recipe: makeRecipe('b') });
+
+    await expect(
+      prepareSandboxForHarness({
+        session: makeSession().session,
+        harnesses: [first, second],
+      }),
+    ).rejects.toThrow(/duplicate harness id/);
+  });
+
+  it('validates caller bootstrap settings', async () => {
+    await expect(
+      prepareSandboxForHarness({
+        session: makeSession().session,
+        harnesses: [makeHarness({ harnessId: 'alpha' })],
+        sandboxConfig: { onBootstrap: async () => {} },
+      }),
+    ).rejects.toThrow(/must be provided together/);
+
+    await expect(
+      prepareSandboxForHarness({
+        session: makeSession().session,
+        harnesses: [makeHarness({ harnessId: 'alpha' })],
+        sandboxConfig: { workDir: '../repo' },
+      }),
+    ).rejects.toThrow(/workDir/);
+  });
+
+  it('accepts a full HarnessAgent sandboxConfig and ignores onSession', async () => {
+    const { session } = makeSession();
+    const onSession = vi.fn(async () => {});
+
+    await prepareSandboxForHarness({
+      session,
+      harnesses: [
+        makeHarness({ harnessId: 'alpha', recipe: makeRecipe('alpha') }),
+      ],
+      sandboxConfig: {
+        onSession,
+      },
+    });
+
+    expect(onSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/harness/src/agent/prepare-sandbox-for-harness.ts
+++ b/packages/harness/src/agent/prepare-sandbox-for-harness.ts
@@ -1,0 +1,148 @@
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import type { HarnessAgentSandboxConfig } from './harness-agent-settings';
+import type { HarnessAgentAdapter } from './harness-agent-types';
+import {
+  applyBootstrapRecipe,
+  hashHarnessBootstrap,
+} from './internal/bootstrap-recipe';
+import {
+  normalizeSandboxWorkDir,
+  runSandboxBootstrap,
+  validateSandboxBootstrapSettings,
+} from './internal/sandbox-bootstrap';
+
+const PREPARED_SANDBOX_IDENTITY_VERSION = 1;
+
+export type PrepareSandboxForHarnessResult = {
+  readonly identity?: string;
+  readonly recipeIdentities: Record<string, string>;
+  readonly skippedHarnessIds: ReadonlyArray<string>;
+};
+
+export async function prepareSandboxForHarness(options: {
+  readonly session: SandboxSession;
+  readonly harnesses: ReadonlyArray<HarnessAgentAdapter>;
+  readonly sandboxConfig?: HarnessAgentSandboxConfig;
+  readonly abortSignal?: AbortSignal;
+}): Promise<PrepareSandboxForHarnessResult> {
+  const sandboxConfig = options.sandboxConfig ?? {};
+  validateSandboxBootstrapSettings(sandboxConfig);
+
+  if (options.harnesses.length === 0) {
+    throw new Error(
+      'prepareSandboxForHarness: at least one harness must be provided.',
+    );
+  }
+
+  const harnesses = [...options.harnesses].sort((a, b) =>
+    a.harnessId.localeCompare(b.harnessId),
+  );
+  assertUniqueHarnessIds(harnesses);
+
+  const workDir =
+    sandboxConfig.workDir == null
+      ? undefined
+      : normalizeSandboxWorkDir(sandboxConfig.workDir);
+  const recipeIdentities: Record<string, string> = {};
+  const skippedHarnessIds: string[] = [];
+
+  for (const harness of harnesses) {
+    const recipe = await harness.getBootstrap?.({
+      abortSignal: options.abortSignal,
+    });
+    if (recipe == null) {
+      skippedHarnessIds.push(harness.harnessId);
+      continue;
+    }
+
+    const recipeIdentity = await hashHarnessBootstrap(recipe);
+    recipeIdentities[harness.harnessId] = recipeIdentity;
+    await applyBootstrapRecipe(options.session, recipe, recipeIdentity, {
+      abortSignal: options.abortSignal,
+    });
+  }
+
+  if (sandboxConfig.onBootstrap != null) {
+    await runSandboxBootstrap({
+      session: options.session,
+      workDir,
+      onBootstrap: sandboxConfig.onBootstrap,
+      abortSignal: options.abortSignal,
+    });
+  }
+
+  const identity = await resolvePreparedSandboxIdentity({
+    recipeIdentities,
+    bootstrapHash: sandboxConfig.bootstrapHash,
+    workDir,
+  });
+
+  return {
+    ...(identity != null ? { identity } : {}),
+    recipeIdentities,
+    skippedHarnessIds,
+  };
+}
+
+function assertUniqueHarnessIds(
+  harnesses: ReadonlyArray<HarnessAgentAdapter>,
+): void {
+  const seen = new Set<string>();
+  for (const harness of harnesses) {
+    if (seen.has(harness.harnessId)) {
+      throw new Error(
+        `prepareSandboxForHarness: duplicate harness id "${harness.harnessId}".`,
+      );
+    }
+    seen.add(harness.harnessId);
+  }
+}
+
+async function resolvePreparedSandboxIdentity({
+  recipeIdentities,
+  bootstrapHash,
+  workDir,
+}: {
+  readonly recipeIdentities: Record<string, string>;
+  readonly bootstrapHash?: string;
+  readonly workDir?: string;
+}): Promise<string | undefined> {
+  const entries = Object.entries(recipeIdentities).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  if (entries.length === 0 && bootstrapHash == null) {
+    return undefined;
+  }
+
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  const pushString = (value: string) => {
+    chunks.push(encoder.encode(value));
+    chunks.push(encoder.encode('\0'));
+  };
+
+  pushString(String(PREPARED_SANDBOX_IDENTITY_VERSION));
+  pushString(workDir ?? '');
+  pushString(bootstrapHash ?? '');
+
+  for (const [harnessId, identity] of entries) {
+    pushString(harnessId);
+    pushString(identity);
+  }
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const buffer = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  const bytes = new Uint8Array(digest);
+  let hex = '';
+  for (let i = 0; i < 8; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}

--- a/packages/harness/src/agent/prewarm.test.ts
+++ b/packages/harness/src/agent/prewarm.test.ts
@@ -1,7 +1,7 @@
 import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
 import { describe, expect, it, vi } from 'vitest';
 import type { HarnessV1, HarnessV1SandboxProvider } from '../v1';
-import { prewarmHarness } from './prewarm';
+import { prepareHarnessSandboxTemplate, prewarmHarness } from './prewarm';
 
 function makeHarness(): HarnessV1 {
   return {
@@ -35,7 +35,7 @@ function makeSession(): {
   return { session, run, stop };
 }
 
-describe('prewarmHarness', () => {
+describe('prepareHarnessSandboxTemplate', () => {
   it('runs caller bootstrap through provider onFirstCreate and stops the session', async () => {
     const { session, stop } = makeSession();
     const createSession = vi.fn(
@@ -48,7 +48,7 @@ describe('prewarmHarness', () => {
     );
     const onSandboxBootstrap = vi.fn(async () => {});
 
-    await prewarmHarness({
+    await prepareHarnessSandboxTemplate({
       harness: makeHarness(),
       sandboxProvider: {
         specificationVersion: 'harness-sandbox-v1',
@@ -73,5 +73,9 @@ describe('prewarmHarness', () => {
       abortSignal: undefined,
     });
     expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps prewarmHarness as an alias for prepareHarnessSandboxTemplate', () => {
+    expect(prewarmHarness).toBe(prepareHarnessSandboxTemplate);
   });
 });

--- a/packages/harness/src/agent/prewarm.ts
+++ b/packages/harness/src/agent/prewarm.ts
@@ -10,20 +10,20 @@ import {
 type SandboxBootstrapSettings = Omit<HarnessAgentSandboxConfig, 'onSession'>;
 
 /**
- * Pre-build a harness's sandbox template without running an agent. Idempotent:
- * if the template already exists (snapshot present, or marker on a non-snapshot
+ * Prepare a harness's sandbox template without running an agent. Idempotent: if
+ * the template already exists (snapshot present, or marker on a non-snapshot
  * provider), this resolves quickly.
  *
  * Use from a CI/deploy script to amortize the first-session cost so production
  * sessions always resume from snapshot. For adapters without a bootstrap
  * recipe (no `getBootstrap`) this is a no-op.
  *
- * The temporary network sandbox session created during pre-warm is stopped
+ * The temporary network sandbox session created during preparation is stopped
  * before the function resolves; the snapshot/template state persists in the
  * provider's native storage (for Vercel: as the `currentSnapshotId` of the
  * named template sandbox).
  */
-export async function prewarmHarness(options: {
+export async function prepareHarnessSandboxTemplate(options: {
   readonly harness: HarnessAgentAdapter;
   readonly sandboxProvider: HarnessV1SandboxProvider;
   readonly sandboxConfig?: SandboxBootstrapSettings;
@@ -63,3 +63,6 @@ export async function prewarmHarness(options: {
     await Promise.resolve(sandboxSession.stop()).catch(() => {});
   }
 }
+
+/** @deprecated Use `prepareHarnessSandboxTemplate` instead. */
+export const prewarmHarness = prepareHarnessSandboxTemplate;


### PR DESCRIPTION
## Background

So far, it hasn't been possible to prepare a separately managed sandbox instance for a given harness (i.e. preconfigure the harness's bridge). Doing so would allow reusing the same sandbox image for multiple harnesses and allowing for faster startup since that setup would have already happened.

## Summary

- introduce `prepareSandboxForHarness` to prepare a caller-owned sandbox for one or more harnesses
- rename `prewarmHarness` to a more descriptive `prepareHarnessSandboxTemplate` (with the old name remaining as deprecated alias)

## Manual Verification

Run the new example.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
