### PR TITLE
docs(skill): add warning about version mismatch

### DIFF
--- a/contributing/releases.md
+++ b/contributing/releases.md
@@ -33,6 +33,10 @@ Quick reference:
 - Exit beta mode: `pnpm changeset pre exit`
 - Backport fixes: add the `backport` label to the merged PR
 
+## New Major Releases
+
+- Update version in `skills/use-ai-sdk/SKILL.md`.
+
 ## Provenance
 
 All packages are published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements). This is enabled via:

--- a/skills/use-ai-sdk/SKILL.md
+++ b/skills/use-ai-sdk/SKILL.md
@@ -5,6 +5,8 @@ description: 'Answer questions about the AI SDK and help build AI-powered featur
 
 ## Prerequisites
 
+This information is for AI SDK 7. Compare to version in `node_modules/ai/package.json`. If the versions don't match, warn the user.
+
 Before searching docs, check if `node_modules/ai/docs/` exists. If not, install **only** the `ai` package using the project's package manager (e.g., `pnpm add ai`).
 
 Do not install other packages at this stage. Provider packages (e.g., `@ai-sdk/openai`) and client packages (e.g., `@ai-sdk/react`) should be installed later when needed based on user requirements.


### PR DESCRIPTION
## Background

The `use-ai-sdk` skill contained information about a function that was renamed in AI SDK 7, while the user had an older version installed.

## Summary

Prompt agent to warn user if there's a mismatch between installed skill version and AI SDK version.

## Future Work

Need to figure out how to properly version skills for the future, but for now, this adds a warning.

## Related issues

* https://github.com/vercel/ai/issues/16267