### PR TITLE
fix(google): don't warn about missing thoughtSignature on Gemini 3 parallel function calls

### DIFF
--- a/.changeset/google-gemini3-parallel-thought-signature.md
+++ b/.changeset/google-gemini3-parallel-thought-signature.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): don't warn about a missing `thoughtSignature` on Gemini 3 parallel function calls (the model signs only the first call of a batch)

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -1686,6 +1686,99 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
     expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
   });
 
+  it('does NOT warn for unsigned parallel function calls when a sibling in the same message is signed (Gemini 3)', () => {
+    // Gemini 3 returns a single thoughtSignature for a parallel batch, carried on
+    // the first functionCall; the remaining parallel calls are legitimately
+    // unsigned. The converter must not flag those as dropped signatures.
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'Paris' },
+              providerOptions: { google: { thoughtSignature: 'real_sig' } },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_2',
+              toolName: 'weather',
+              input: { location: 'Tokyo' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    // The signed call keeps its real signature.
+    expect(assistant?.parts[0]).toMatchObject({
+      functionCall: {
+        id: 'tc_1',
+        name: 'weather',
+        args: { location: 'Paris' },
+      },
+      thoughtSignature: 'real_sig',
+    });
+    // The unsigned parallel sibling still gets the sentinel (so the request does
+    // not fail with HTTP 400) ...
+    expect(assistant?.parts[1]).toMatchObject({
+      functionCall: {
+        id: 'tc_2',
+        name: 'weather',
+        args: { location: 'Tokyo' },
+      },
+      thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    });
+    // ... but no misleading "dropped signature" warning is emitted.
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('still warns when ALL tool-calls in the message are unsigned (genuine dropped signature, Gemini 3)', () => {
+    // No signed sibling -> this is the genuine "application dropped the signature"
+    // case, which must still inject the sentinel AND warn.
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_1',
+              toolName: 'weather',
+              input: { location: 'Paris' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_2',
+              toolName: 'weather',
+              input: { location: 'Tokyo' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    const assistant = result.contents.find(c => c.role === 'model');
+    expect(assistant?.parts[0]).toMatchObject({
+      thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    });
+    expect(assistant?.parts[1]).toMatchObject({
+      thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    });
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
+  });
+
   it('does NOT inject the sentinel for non-Gemini-3 models', () => {
     const onWarning = vi.fn();
     const result = convertToGoogleMessages(promptWithToolCallMissingSignature, {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -218,9 +218,16 @@ export function convertToGoogleMessages(
 
   let sentinelInjected = false;
   const missingSignatureToolNames: string[] = [];
-  const injectSkipSignature = (toolName: string) => {
-    missingSignatureToolNames.push(toolName);
-    sentinelInjected = true;
+  // Always returns the sentinel (required so the request doesn't fail with HTTP
+  // 400), but only records the tool name for the "missing thoughtSignature"
+  // warning when `countAsMissing` is true. Gemini 3 signs only the first
+  // functionCall of a parallel batch, so unsigned siblings are expected and must
+  // not be flagged as dropped signatures.
+  const injectSkipSignature = (toolName: string, countAsMissing: boolean) => {
+    if (countAsMissing) {
+      missingSignatureToolNames.push(toolName);
+      sentinelInjected = true;
+    }
     return SKIP_THOUGHT_SIGNATURE_VALIDATOR;
   };
 
@@ -333,6 +340,17 @@ export function convertToGoogleMessages(
 
       case 'assistant': {
         systemMessagesAllowed = false;
+
+        // Gemini 3 signs only the first functionCall of a parallel batch; the
+        // remaining parallel calls in the same assistant message are legitimately
+        // unsigned. If any tool-call here carries a real thoughtSignature, treat
+        // the unsigned ones as parallel siblings: still inject the skip sentinel
+        // (so the request doesn't 400) but don't warn about them.
+        const hasSignedToolCall = content.some(
+          part =>
+            part.type === 'tool-call' &&
+            readProviderOpts(part)?.thoughtSignature != null,
+        );
 
         contents.push({
           role: 'model',
@@ -459,7 +477,12 @@ export function convertToGoogleMessages(
                   const effectiveThoughtSignature =
                     thoughtSignature ??
                     (isGemini3Model
-                      ? injectSkipSignature(part.toolName)
+                      ? injectSkipSignature(
+                          part.toolName,
+                          // Only a genuine dropped signature (no signed sibling in
+                          // this message) is worth warning about.
+                          !hasSignedToolCall,
+                        )
                       : undefined);
 
                   if (serverToolCallId && serverToolType) {


### PR DESCRIPTION
## Background

gemini 3 returns a single `thoughtSignature` for a parallel batch of function
calls — it's carried on the *first* `functionCall` part; the remaining parallel
calls legitimately have no signature (see
[thought signatures](https://ai.google.dev/gemini-api/docs/thought-signatures)).

#15560 added the `skip_thought_signature_validator` sentinel + a warning for
gemini-3 tool-call replays that lack a signature (the model returns HTTP 400
otherwise). but `convertToGoogleMessages` checks **every** tool-call part
independently, so for a parallel batch it injects the sentinel *and* warns for
each unsigned sibling — meaning any app doing parallel (or multi-step) tool calls
with gemini 3 gets the *"replayed N functionCall part(s) … without a
thoughtSignature … the likely cause is application code that drops
providerOptions.google.thoughtSignature"* warning on essentially every turn. the
suggested cause is misleading: the unsigned parts originate inside the SDK's own
parallel/multi-step loop and gemini never returned a signature for them.

## Summary

the sentinel injection is still required (it avoids the HTTP 400), so this keeps
injecting it. it only stops *warning* when the unsigned part is a legitimate
parallel sibling:

- `injectSkipSignature(toolName, countAsMissing)` always returns the sentinel, but
  only records the tool for the warning when `countAsMissing`.
- per assistant message, `hasSignedToolCall` checks whether any tool-call carries a
  real signature (via the existing `readProviderOpts`, so the google↔vertex
  namespace fallback from #13060 is preserved). unsigned siblings in a signed batch
  get the sentinel silently; a message whose tool-calls are *all* unsigned still
  warns (the genuine dropped-signature case — unchanged).

the change stays behind the existing `isGemini3Model` gate (derived from
`/^gemini-3[.-]/` upstream), so non-gemini-3 behavior is untouched.

(alternative considered: instead of suppressing the warning for parallel siblings,
reword it so it no longer blames application code. happy to switch to that if you
prefer — this PR takes the suppress-for-legitimate-parallel-calls approach.)

## Manual Verification

drove the converter with the message shape from the issue's repro — an assistant
turn with two parallel `tool-call` parts on a gemini-3 model, the first carrying
`providerOptions.google.thoughtSignature` and the second without — and confirmed
the output: the second call still carries the `skip_thought_signature_validator`
sentinel (so no HTTP 400), and no warning is emitted. on `main` the same input
emits the "replayed … without a thoughtSignature" warning.

`pnpm --filter @ai-sdk/google test` → 667 pass (node + edge); the new
parallel-batch test fails on `main` and passes with the fix.

(note: a full live `streamText` run against the Gemini API was not performed in my
environment — verification is at the converter level, which is where the bug and
fix live.)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16298
Refs #15560 (sentinel + warn-once), #13060 (google/vertex namespace fallback), #11413
