### PR TITLE
Backport: fix(gateway): clarify parallel_search source_policy field descriptions

### DIFF
--- a/.changeset/parallel-search-source-policy-descriptions.md
+++ b/.changeset/parallel-search-source-policy-descriptions.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Clarify `parallel_search` `source_policy` field descriptions so the model emits
+values the Parallel API accepts: `include_domains`/`exclude_domains` must be plain
+hosts (no scheme/path/port), and `after_date` must be an ISO 8601 calendar date
+formatted `YYYY-MM-DD`.

--- a/packages/gateway/src/tool/parallel-search.ts
+++ b/packages/gateway/src/tool/parallel-search.ts
@@ -199,16 +199,20 @@ const parallelSearchInputSchema = lazySchema(() =>
           include_domains: z
             .array(z.string())
             .optional()
-            .describe('List of domains to include in search results.'),
+            .describe(
+              'Limit results to these domains. Use plain domain names only — e.g. example.com or sub.example.gov, or a bare extension like .edu. Do not include a scheme, path, or port (e.g. not https://example.com/page).',
+            ),
           exclude_domains: z
             .array(z.string())
             .optional()
-            .describe('List of domains to exclude from search results.'),
+            .describe(
+              'Exclude results from these domains. Use plain domain names only — e.g. example.com or sub.example.gov, or a bare extension like .edu. Do not include a scheme, path, or port (e.g. not https://example.com/page).',
+            ),
           after_date: z
             .string()
             .optional()
             .describe(
-              'Only include results published after this date (ISO 8601 format).',
+              'Only include results published after this date. Use an ISO 8601 calendar date formatted YYYY-MM-DD (e.g. 2025-01-01); do not include a time.',
             ),
         })
         .optional()


### PR DESCRIPTION
Backports #16362 to `release-v6.0`.

## Summary

- Clarifies `parallel_search` `source_policy.include_domains` and `exclude_domains` descriptions to request plain domains only.
- Clarifies `source_policy.after_date` should be formatted as `YYYY-MM-DD` with no time.
- Includes the original patch changeset for `@ai-sdk/gateway`.

## Verification

- `pnpm --dir packages/gateway type-check` ✅
- `pnpm type-check:full` currently fails on unrelated release-branch issues outside this backport, including missing `@opentelemetry/api`, stale `.next/types` entries, and existing type errors in `packages/ai` / examples.
