### PR TITLE
feat(tools-registry): update Tako Search entry for the v2 SDK

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -355,33 +355,35 @@ console.log(text);`,
     slug: 'tako-search',
     name: 'Tako Search',
     description:
-      "Search Tako's knowledge base for data visualizations, insights, and well-sourced information with charts and analytics.",
+      "Tako gives AI agents real-time, well-sourced data and charts across finance, economics, sports, demographics, and more. Search Tako's curated knowledge graph and the live web, get citation-backed answers, and fetch the data behind any result.",
     packageName: '@takoviz/ai-sdk',
+    tags: ['search', 'web', 'data', 'visualization', 'analytics'],
+    apiKeyEnvName: 'TAKO_API_KEY',
     installCommand: {
       pnpm: 'pnpm install @takoviz/ai-sdk',
       npm: 'npm install @takoviz/ai-sdk',
       yarn: 'yarn add @takoviz/ai-sdk',
       bun: 'bun add @takoviz/ai-sdk',
     },
-    codeExample: `import { takoSearch } from '@takoviz/ai-sdk';
-import { generateText, isStepCount } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { takoSearch, takoAnswer, takoContents } from '@takoviz/ai-sdk';
 
 const { text } = await generateText({
   model: 'openai/gpt-5.2',
-  prompt: 'What is the stock price of Nvidia?',
+  prompt: 'How have Nvidia and AMD employee counts compared since 2013?',
   tools: {
     takoSearch: takoSearch(),
+    takoAnswer: takoAnswer(),
+    takoContents: takoContents(),
   },
   stopWhen: isStepCount(5),
 });
 
 console.log(text);`,
     docsUrl: 'https://github.com/TakoData/ai-sdk#readme',
-    npmUrl: 'https://www.npmjs.com/package/@takoviz/ai-sdk',
+    apiKeyUrl: 'https://developer.tako.com/console/api-keys',
     websiteUrl: 'https://tako.com',
-    apiKeyEnvName: 'TAKO_API_KEY',
-    apiKeyUrl: 'https://tako.com',
-    tags: ['search', 'data', 'visualization', 'analytics'],
+    npmUrl: 'https://www.npmjs.com/package/@takoviz/ai-sdk',
   },
   {
     slug: 'valyu',


### PR DESCRIPTION
## What

Updates the existing **Tako Search** entry (`slug: tako-search`) in `content/tools-registry/registry.ts` to reflect [`@takoviz/ai-sdk`](https://www.npmjs.com/package/@takoviz/ai-sdk) **v2.0.0**, which replaces the single legacy `takoSearch` tool with three tools over Tako's GA public API:

- **`takoSearch()`** — Tako knowledge cards (charts/metrics with their sources) plus web results
- **`takoAnswer()`** — a single citation-backed answer synthesized over Tako's curated knowledge graph and the live web
- **`takoContents()`** — the data behind a result (a card's CSV or a web page's text)

The `slug` is unchanged so the registry URL stays stable. Changes in this entry:

- refreshed `description` for the three-tool surface
- `tags`: added `web`
- `codeExample`: registers the three tools and uses the current `ai` API (`isStepCount`)
- `websiteUrl` / `apiKeyUrl` updated (`https://tako.com`, `https://developer.tako.com/console/api-keys`)

## Prerequisites (per `contributing/add-new-tool-to-registry.md`)

- [x] **Published to npm** — [`@takoviz/ai-sdk@2.0.0`](https://www.npmjs.com/package/@takoviz/ai-sdk)
- [x] **Documented** — usage instructions in the [README](https://github.com/TakoData/ai-sdk#readme)
- [x] **Tested with the AI SDK** — the code example was run against the live API end-to-end (search → answer → contents)

## Code example

```ts
import { generateText, isStepCount } from 'ai';
import { takoSearch, takoAnswer, takoContents } from '@takoviz/ai-sdk';

const { text } = await generateText({
  model: 'openai/gpt-5.2',
  prompt: 'How have Nvidia and AMD employee counts compared since 2013?',
  tools: {
    takoSearch: takoSearch(),
    takoAnswer: takoAnswer(),
    takoContents: takoContents(),
  },
  stopWhen: isStepCount(5),
});

console.log(text);
```
