### PR TITLE
docs: update onFinish to onEnd

### DIFF
--- a/content/cookbook/01-next/73-mcp-tools.mdx
+++ b/content/cookbook/01-next/73-mcp-tools.mdx
@@ -88,7 +88,7 @@ export async function POST(req: Request) {
       tools,
       prompt,
       // When streaming, the client should be closed after the response is finished:
-      onFinish: async () => {
+      onEnd: async () => {
         await stdioClient.close();
         await httpClient.close();
         await sseClient.close();

--- a/content/cookbook/05-node/45-stream-object-record-token-usage.mdx
+++ b/content/cookbook/05-node/45-stream-object-record-token-usage.mdx
@@ -9,9 +9,9 @@ tags: ['node', 'streaming', 'structured data', 'observability']
 When you're streaming structured data with `streamText` and `Output`,
 you may want to record the token usage for billing purposes.
 
-## `onFinish` Callback
+## `onEnd` Callback
 
-You can use the `onFinish` callback to record token usage.
+You can use the `onEnd` callback to record token usage.
 It is called when the stream is finished.
 
 ```ts file='index.ts' highlight={"15-17"}
@@ -30,7 +30,7 @@ const result = streamText({
     }),
   }),
   prompt: 'Generate a lasagna recipe.',
-  onFinish({ usage }) {
+  onEnd({ usage }) {
     console.log('Token usage:', usage);
   },
 });

--- a/content/cookbook/05-node/46-stream-object-record-final-object.mdx
+++ b/content/cookbook/05-node/46-stream-object-record-final-object.mdx
@@ -8,9 +8,9 @@ tags: ['node', 'streaming', 'structured data']
 
 When you're streaming structured data, you may want to record the final object for logging or other purposes.
 
-## `onFinish` and `output`
+## `onEnd` and `output`
 
-Use `onFinish` for metadata like token usage and await `result.output` for the final structured object.
+Use `onEnd` for metadata like token usage and await `result.output` for the final structured object.
 
 ```ts file='index.ts' highlight={"15-29"}
 import { streamText, Output } from 'ai';
@@ -28,7 +28,7 @@ const result = streamText({
     }),
   }),
   prompt: 'Generate a lasagna recipe.',
-  onFinish({ usage }) {
+  onEnd({ usage }) {
     console.log('Token usage:', usage);
   },
 });

--- a/content/docs/03-agents/06-memory.mdx
+++ b/content/docs/03-agents/06-memory.mdx
@@ -252,7 +252,7 @@ const result = await agent.generate({
 
 `isLoopFinished()` lets the agent keep running until the tool loop naturally finishes, which is useful when memory tools need to read and write before the final response.
 
-Session memory supports two modes: **tool-driven** (the LLM decides when to read/write — good for prototypes) and **hook-driven** (the runtime persists every turn via `prepareCall` + `onFinish` hooks — recommended for production). The other memory tiers (semantic, procedural, episodic, scratchpad) are always LLM-controlled and selective by design.
+Session memory supports two modes: **tool-driven** (the LLM decides when to read/write — good for prototypes) and **hook-driven** (the runtime persists every turn via `prepareCall` + `onEnd` hooks — recommended for production). The other memory tiers (semantic, procedural, episodic, scratchpad) are always LLM-controlled and selective by design.
 
 MongoDB memory works with any AI SDK model and embedding provider, with no vendor lock-in beyond MongoDB Atlas.
 

--- a/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
+++ b/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
@@ -92,7 +92,7 @@ export async function POST(req: Request) {
       const result = streamText({
         model: __MODEL__,
         messages: await convertToModelMessages(messages),
-        onFinish() {
+        onEnd() {
           // 4. Update the same data part (reconciliation)
           writer.write({
             type: 'data-weather',

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -489,7 +489,7 @@ export const AI = createAI({
 
 #### After: Save chats using callback function of `streamText`
 
-With AI SDK UI, you will save chats using the `onFinish` callback function of `streamText` in your route handler.
+With AI SDK UI, you will save chats using the `onEnd` callback function of `streamText` in your route handler.
 
 ```ts filename="@/app/api/chat/route.ts"
 import { openai } from '@ai-sdk/openai';
@@ -510,7 +510,7 @@ export async function POST(request) {
     model: __MODEL__,
     instructions: 'you are a friendly assistant!',
     messages: coreMessages,
-    onFinish: async ({ responseMessages }) => {
+    onEnd: async ({ responseMessages }) => {
       try {
         await saveChat({
           id,

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -82,7 +82,7 @@ export default function Chat() {
 
 When streams are aborted, you may need to perform cleanup operations such as persisting partial results or cleaning up resources. The `onAbort` callback provides a way to handle these scenarios on the server side.
 
-Unlike `onFinish`, which is called when a stream completes normally, `onAbort` is specifically called when a stream is aborted via `AbortSignal`. This distinction allows you to handle normal completion and aborted streams differently.
+Unlike `onEnd`, which is called when a stream completes normally, `onAbort` is specifically called when a stream is aborted via `AbortSignal`. This distinction allows you to handle normal completion and aborted streams differently.
 
 <Note>
   For UI message streams (`toUIMessageStreamResponse`), the `onEnd` callback
@@ -104,7 +104,7 @@ const result = streamText({
     await savePartialResults(steps);
     await logAbortEvent(steps.length);
   },
-  onFinish: ({ steps, totalUsage }) => {
+  onEnd: ({ steps, totalUsage }) => {
     // Called when stream completes normally
     await saveFinalResults(steps, totalUsage);
   },

--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -118,7 +118,7 @@ You can see a full example of caching with Redis in a Next.js application in our
 
 ## Using Lifecycle Callbacks
 
-Alternatively, each AI SDK Core function has special lifecycle callbacks you can use. The one of interest is likely `onFinish`, which is called when the generation is complete. This is where you can cache the full response.
+Alternatively, each AI SDK Core function has special lifecycle callbacks you can use. The one of interest is likely `onEnd`, which is called when the generation is complete. This is where you can cache the full response.
 
 Here's an example of how you can implement caching using Vercel KV and Next.js to cache the OpenAI response for 1 hour:
 
@@ -162,7 +162,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    async onFinish({ text }) {
+    async onEnd({ text }) {
       // Cache the response text:
       await redis.set(key, text);
       await redis.expire(key, 60 * 60);

--- a/examples/ai-e2e-next/app/api/chat/cache/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/cache/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     messages,
-    async onFinish({ text }) {
+    async onEnd({ text }) {
       // Cache the response text:
       cache.set(key, text);
     },

--- a/examples/ai-e2e-next/app/api/chat/mcp-elicitation/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-elicitation/route.ts
@@ -93,7 +93,7 @@ async function processMessages(
       instructions:
         'You are a helpful assistant. When asked to register a user, use the register_user tool.',
       messages: await convertToModelMessages(messages),
-      onFinish: async () => {
+      onEnd: async () => {
         await mcpClient.close();
       },
     });

--- a/examples/ai-e2e-next/app/api/chat/mcp-zapier/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-zapier/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
       model: openai('gpt-4o'),
       messages: await convertToModelMessages(messages),
       tools: zapierTools,
-      onFinish: async () => {
+      onEnd: async () => {
         await mcpClient.close();
       },
       stopWhen: isStepCount(10),

--- a/examples/ai-e2e-next/app/api/chat/openai-previous-response-id/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/openai-previous-response-id/route.ts
@@ -60,7 +60,7 @@ export async function POST(req: Request) {
             previousResponseId,
           } satisfies OpenAILanguageModelResponsesOptions,
         },
-        onFinish: ({ finalStep }) => {
+        onEnd: ({ finalStep }) => {
           const providerMetadata = finalStep.providerMetadata;
 
           if (!!providerMetadata) {

--- a/examples/ai-e2e-next/app/api/chat/reasoning/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/reasoning/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
         reasoningSummary: 'detailed', // 'auto' for condensed or 'detailed' for comprehensive
       } satisfies OpenAILanguageModelResponsesOptions,
     },
-    onFinish: ({ finalStep }) => {
+    onEnd: ({ finalStep }) => {
       console.dir(finalStep.request.body, { depth: null });
     },
   });

--- a/examples/ai-e2e-next/app/chat/mcp-apps/chat/route.ts
+++ b/examples/ai-e2e-next/app/chat/mcp-apps/chat/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
       stopWhen: isStepCount(5),
       messages: modelMessages,
       onStepFinish: logModelStep,
-      onFinish: async event => {
+      onEnd: async event => {
         console.log('[mcp-apps/chat] model finish', {
           finishReason: event.finishReason,
           text: event.text,

--- a/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
+++ b/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
       instructions:
         'You are a helpful chatbot capable of basic arithmetic problems',
       messages: await convertToModelMessages(messages),
-      onFinish: async () => {
+      onEnd: async () => {
         await client.close();
       },
       // Optional, enables immediate clean up of resources but connection will not be retained for retries:

--- a/examples/ai-functions/src/agent/openai/generate-on-finish.ts
+++ b/examples/ai-functions/src/agent/openai/generate-on-finish.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 const agent = new ToolLoopAgent({
   model: openai('gpt-4o'),
   instructions: 'You are a helpful assistant.',
-  onFinish({ text }) {
+  onEnd({ text }) {
     console.log(text);
   },
 });

--- a/examples/ai-functions/src/agent/openai/generate-runtime-context-call-options.ts
+++ b/examples/ai-functions/src/agent/openai/generate-runtime-context-call-options.ts
@@ -44,8 +44,8 @@ const agent = new ToolLoopAgent({
       },
     };
   },
-  onFinish: ({ runtimeContext }) => {
-    console.log('onFinish runtimeContext:', runtimeContext);
+  onEnd: ({ runtimeContext }) => {
+    console.log('onEnd runtimeContext:', runtimeContext);
   },
   instructions: 'You are a helpful assistant.',
 });

--- a/examples/ai-functions/src/agent/openai/generate-runtime-context.ts
+++ b/examples/ai-functions/src/agent/openai/generate-runtime-context.ts
@@ -33,8 +33,8 @@ const agent = new ToolLoopAgent({
       },
     };
   },
-  onFinish: ({ runtimeContext }) => {
-    console.log('onFinish runtimeContext:', runtimeContext);
+  onEnd: ({ runtimeContext }) => {
+    console.log('onEnd runtimeContext:', runtimeContext);
   },
   instructions: 'You are a helpful assistant.',
 });

--- a/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
+++ b/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
@@ -55,8 +55,8 @@ async function main() {
       console.log('Input tokens:', event.usage.inputTokens);
       console.log('Output tokens:', event.usage.outputTokens);
     },
-    onFinish: event => {
-      console.log('\n--- onFinish ---');
+    onEnd: event => {
+      console.log('\n--- onEnd ---');
       console.log('Total steps:', event.steps.length);
       console.log('Total input tokens:', event.usage.inputTokens);
       console.log('Total output tokens:', event.usage.outputTokens);

--- a/examples/ai-functions/src/generate-text/openai/on-finish.ts
+++ b/examples/ai-functions/src/generate-text/openai/on-finish.ts
@@ -6,7 +6,7 @@ run(async () => {
   await generateText({
     model: openai('gpt-4o'),
     prompt: 'Invent a new holiday and describe its traditions.',
-    onFinish(event) {
+    onEnd(event) {
       console.dir(event, { depth: Infinity });
     },
   });

--- a/examples/ai-functions/src/generate-text/openai/tool-call-with-runtime-context.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-call-with-runtime-context.ts
@@ -34,8 +34,8 @@ run(async () => {
         },
       };
     },
-    onFinish: ({ runtimeContext }) => {
-      console.log('onFinish runtimeContext:', runtimeContext);
+    onEnd: ({ runtimeContext }) => {
+      console.log('onEnd runtimeContext:', runtimeContext);
     },
     prompt: 'What is the weather in San Francisco?',
   });

--- a/examples/ai-functions/src/stream-text/anthropic/cache-control.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/cache-control.ts
@@ -35,9 +35,9 @@ run(async () => {
         ],
       },
     ],
-    onFinish({ finalStep }) {
+    onEnd({ finalStep }) {
       console.log();
-      console.log('=== onFinish ===');
+      console.log('=== onEnd ===');
       console.log(finalStep.providerMetadata?.anthropic);
     },
   });

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-cache-control.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-cache-control.ts
@@ -33,9 +33,9 @@ run(async () => {
         ],
       },
     ],
-    onFinish({ finalStep }) {
+    onEnd({ finalStep }) {
       console.log();
-      console.log('=== onFinish ===');
+      console.log('=== onEnd ===');
       console.log(finalStep.providerMetadata?.anthropic);
     },
   });

--- a/examples/ai-functions/src/stream-text/openai/cached-prompt-tokens.ts
+++ b/examples/ai-functions/src/stream-text/openai/cached-prompt-tokens.ts
@@ -149,7 +149,7 @@ function createCompletion() {
         maxCompletionTokens: 100,
       } satisfies OpenAILanguageModelChatOptions,
     },
-    onFinish: ({ finalStep }) => {
+    onEnd: ({ finalStep }) => {
       console.log(`metadata:`, finalStep.providerMetadata);
     },
   });

--- a/examples/ai-functions/src/stream-text/openai/on-finish-response-messages.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-finish-response-messages.ts
@@ -16,7 +16,7 @@ run(async () => {
       }),
     },
     stopWhen: isStepCount(5),
-    onFinish({ responseMessages }) {
+    onEnd({ responseMessages }) {
       console.log(JSON.stringify(responseMessages, null, 2));
     },
     prompt: 'What is the current weather in San Francisco?',

--- a/examples/ai-functions/src/stream-text/openai/on-finish-steps.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-finish-steps.ts
@@ -16,7 +16,7 @@ run(async () => {
       }),
     },
     stopWhen: isStepCount(5),
-    onFinish({ steps }) {
+    onEnd({ steps }) {
       console.log(JSON.stringify(steps, null, 2));
     },
     prompt: 'What is the current weather in San Francisco?',

--- a/examples/ai-functions/src/stream-text/openai/on-finish.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-finish.ts
@@ -6,9 +6,9 @@ run(async () => {
   const result = streamText({
     model: openai('gpt-4o'),
     prompt: 'Invent a new holiday and describe its traditions.',
-    onFinish({ usage, finishReason, text }) {
+    onEnd({ usage, finishReason, text }) {
       console.log();
-      console.log('onFinish');
+      console.log('onEnd');
       console.log('Token usage:', usage);
       console.log('Finish reason:', finishReason);
       console.log('Text:', text);

--- a/examples/ai-functions/src/stream-text/openai/output-object-on-finish.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-object-on-finish.ts
@@ -21,9 +21,9 @@ run(async () => {
     }),
     prompt:
       'Generate 3 character descriptions for a fantasy role playing game.',
-    onFinish({ usage }) {
+    onEnd({ usage }) {
       console.log();
-      console.log('onFinish');
+      console.log('onEnd');
       console.log('Token usage:', usage);
     },
   });

--- a/examples/ai-functions/src/stream-text/openai/tool-call-with-runtime-context.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-call-with-runtime-context.ts
@@ -35,8 +35,8 @@ run(async () => {
         },
       };
     },
-    onFinish: ({ runtimeContext }) => {
-      console.log('onFinish runtimeContext:', runtimeContext);
+    onEnd: ({ runtimeContext }) => {
+      console.log('onEnd runtimeContext:', runtimeContext);
     },
     prompt: 'What is the weather in San Francisco?',
   });

--- a/examples/mcp/src/shopify-mcp/client.ts
+++ b/examples/mcp/src/shopify-mcp/client.ts
@@ -26,7 +26,7 @@ async function main() {
       tools,
       instructions: 'You are a helpful chatbot',
       prompt: 'What tools are available for me to call?',
-      onFinish: async () => {
+      onEnd: async () => {
         await mcpClient.close();
       },
     });

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -132,7 +132,7 @@ const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
  * workflow. Demonstrates the two complementary context APIs:
  *
  * - `runtimeContext` — shared agent state that flows through `prepareStep`,
- *   lifecycle callbacks, and `onFinish`. Not added to the prompt.
+ *   lifecycle callbacks, and `onEnd`. Not added to the prompt.
  * - `toolsContext` — per-tool, schema-validated state. Each tool's
  *   `execute` only sees its own validated entry as `context`.
  */
@@ -160,7 +160,7 @@ export async function chat(messages: UIMessage[], request: ChatRequestContext) {
     tools,
 
     // Shared agent state. Available in `prepareStep`, lifecycle callbacks,
-    // and `onFinish`. Treat as immutable — return a new value from
+    // and `onEnd`. Treat as immutable — return a new value from
     // `prepareStep` to update it between steps.
     runtimeContext: {
       tenantId: request.tenantId,

--- a/examples/next-workflow/workflow/telemetry-agent.ts
+++ b/examples/next-workflow/workflow/telemetry-agent.ts
@@ -4,7 +4,7 @@ import {
   type ModelCallStreamPart,
   type TelemetryOptions,
   type WorkflowAgentOnErrorCallback,
-  type WorkflowAgentOnFinishCallback,
+  type WorkflowAgentOnEndCallback,
   type WorkflowAgentOnStartCallback,
   type WorkflowAgentOnStepStartCallback,
   type WorkflowAgentOnToolExecutionEndCallback,
@@ -328,11 +328,11 @@ export async function telemetryChat(
       source: 'agent-callback',
       name: 'onToolExecutionEnd',
     }) satisfies WorkflowAgentOnToolExecutionEndCallback<typeof tools>,
-    onFinish: recordCallback({
+    onEnd: recordCallback({
       telemetryRunId: request.telemetryRunId,
       source: 'agent-callback',
-      name: 'onFinish',
-    }) satisfies WorkflowAgentOnFinishCallback<typeof tools, RuntimeContext>,
+      name: 'onEnd',
+    }) satisfies WorkflowAgentOnEndCallback<typeof tools, RuntimeContext>,
   });
 
   const result = await agent.stream({

--- a/examples/nuxt-openai/server/api/chat.ts
+++ b/examples/nuxt-openai/server/api/chat.ts
@@ -21,7 +21,7 @@ export default defineLazyEventHandler(async () => {
     const result = streamText({
       model: openai('gpt-5-mini'),
       messages: await convertToModelMessages(messages),
-      async onFinish({ text, toolCalls, toolResults, usage, finishReason }) {
+      async onEnd({ text, toolCalls, toolResults, usage, finishReason }) {
         // implement your own logic here, e.g. for storing messages
         // or recording token usage
       },

--- a/examples/nuxt-openai/server/api/use-chat-request.ts
+++ b/examples/nuxt-openai/server/api/use-chat-request.ts
@@ -23,7 +23,7 @@ export default defineLazyEventHandler(async () => {
     const result = streamText({
       model: openai('gpt-4o-mini'),
       messages: await convertToModelMessages(messages),
-      async onFinish({ text, toolCalls, toolResults, usage, finishReason }) {
+      async onEnd({ text, toolCalls, toolResults, usage, finishReason }) {
         // Implement your own logic here, e.g. for storing messages
       },
     });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -76,7 +76,7 @@ const result = streamText({
   model: 'openai/gpt-5.4',
   tools: await mcpClient.tools(),
   prompt: 'Use the available tools to answer the user question.',
-  onFinish: async () => {
+  onEnd: async () => {
     await mcpClient.close();
   },
 });


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

`onFinish` was renamed to `onEnd` for AI SDK 7, and `onFinish` became a deprecated alias for `onEnd`.

* https://github.com/vercel/ai/pull/15245

## Summary

Updated docs (including examples and cookbook) to use `onEnd` instead `onFinish`.

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

AI SDK UI's React hooks use `onFinish` as an option still. I don't know if that should be renamed to `onEnd` and `onFinish` deprecated for consistency?

## Related Issues

Closes https://github.com/vercel/ai/issues/15663

Closes #15721

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
