### PR TITLE
Add MCP HTTP session hooks

### DIFF
--- a/.changeset/tall-maps-tap.md
+++ b/.changeset/tall-maps-tap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Add Streamable HTTP session hooks, cached initialize metadata, and detach-on-close support for reattaching to MCP sessions.

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -49,6 +49,53 @@ const mcpClient = await createMCPClient({
 });
 ```
 
+If the MCP server uses Streamable HTTP sessions, you can reattach to a saved
+session by restoring both the previous session id and initialize result:
+
+```typescript
+import { createMCPClient } from '@ai-sdk/mcp';
+
+const savedSession = await loadMcpSession();
+let currentSessionId = savedSession?.sessionId;
+
+const mcpClient = await createMCPClient({
+  transport: {
+    type: 'http',
+    url: 'https://your-server.com/mcp',
+    initialSessionId: savedSession?.sessionId,
+    initialProtocolVersion: savedSession?.initializeResult.protocolVersion,
+    terminateSessionOnClose: false,
+
+    onSessionIdChange: sessionId => {
+      currentSessionId = sessionId;
+    },
+
+    onSessionExpired: sessionId => {
+      if (currentSessionId === sessionId) {
+        currentSessionId = undefined;
+        void clearMcpSession();
+      }
+    },
+  },
+  initialInitializeResult: savedSession?.initializeResult,
+});
+
+if (currentSessionId) {
+  await saveMcpSession({
+    sessionId: currentSessionId,
+    initializeResult: mcpClient.initializeResult,
+  });
+}
+```
+
+When `initialInitializeResult` is provided, `createMCPClient` reuses the cached
+initialize metadata and does not send another `initialize` request. When
+`onSessionExpired` is called, the transport has already cleared the session id
+and the request still fails with the underlying HTTP error. Retry by creating a
+fresh client without `initialSessionId` or `initialInitializeResult`.
+Set `terminateSessionOnClose` to `false` when closing only the local client but
+keeping the MCP session available for a later reattach.
+
 Alternatively, you can use `StreamableHTTPClientTransport` from MCP's official TypeScript SDK:
 
 ```typescript
@@ -116,8 +163,8 @@ You can also bring your own transport by implementing the `MCPTransport` interfa
 <Note>
   The client returned by the `createMCPClient` function is a
   lightweight client intended for use in tool conversion. It currently does not
-  support all features of the full MCP client, such as: session
-  management, resumable streams, and receiving notifications.
+  support all features of the full MCP client, such as automatic session
+  persistence, resumable streams, and receiving notifications.
 
 Authorization via OAuth is supported when using the AI SDK MCP HTTP or SSE
 transports by providing an `authProvider`.

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -86,7 +86,7 @@ It currently does not support accepting notifications from an MCP server, and cu
                   parameters: [
                     {
                       name: 'type',
-                      type: "'sse' | 'http",
+                      type: "'sse' | 'http'",
                       description: 'Use Server-Sent Events for communication',
                     },
                     {
@@ -114,6 +114,48 @@ It currently does not support accepting notifications from an MCP server, and cu
                       isOptional: true,
                       description:
                         "Controls how HTTP redirects are handled for transport requests. Set to 'follow' to allow redirect responses. Defaults to 'error' to reject any redirect response, preventing servers from redirecting requests to unintended hosts.",
+                    },
+                    {
+                      name: 'initialSessionId',
+                      type: 'string',
+                      isOptional: true,
+                      description:
+                        'Initial MCP session id to send with resumed Streamable HTTP requests after initialization. Pair with initialInitializeResult when using createMCPClient. Only used by the HTTP transport.',
+                    },
+                    {
+                      name: 'initialProtocolVersion',
+                      type: 'string',
+                      isOptional: true,
+                      description:
+                        'Initial MCP protocol version to send before initialize negotiates one. Only used by the HTTP transport.',
+                    },
+                    {
+                      name: 'onSessionIdChange',
+                      type: '(sessionId: string | undefined) => void',
+                      isOptional: true,
+                      description:
+                        'Callback invoked when the Streamable HTTP server creates, changes, or clears the MCP session id. Only used by the HTTP transport.',
+                    },
+                    {
+                      name: 'onSessionExpired',
+                      type: '(sessionId: string) => void',
+                      isOptional: true,
+                      description:
+                        'Callback invoked when a Streamable HTTP request returns 404 for an existing MCP session id. The transport clears the session id before reporting the underlying HTTP error. Only used by the HTTP transport.',
+                    },
+                    {
+                      name: 'terminateSessionOnClose',
+                      type: 'boolean',
+                      isOptional: true,
+                      description:
+                        'Whether close() should send DELETE for the current MCP session id. Set to false when the application intends to reattach to the session later. Defaults to true. Only used by the HTTP transport.',
+                    },
+                    {
+                      name: 'fetch',
+                      type: 'FetchFunction',
+                      isOptional: true,
+                      description:
+                        'Optional custom fetch implementation to use for HTTP requests. Useful for runtimes that need a request-local fetch.',
                     },
                   ],
                 },
@@ -145,6 +187,13 @@ It currently does not support accepting notifications from an MCP server, and cu
               description: 'Handler for uncaught errors',
             },
             {
+              name: 'initialInitializeResult',
+              type: 'InitializeResult',
+              isOptional: true,
+              description:
+                'Initialize result from a previous MCP session. When provided, the client starts the transport and reuses this metadata without sending a new initialize request.',
+            },
+            {
               name: 'capabilities',
               type: 'ClientCapabilities',
               isOptional: true,
@@ -164,6 +213,12 @@ Returns a Promise that resolves to an `MCPClient` with the following properties 
 
 <PropertiesTable
   content={[
+    {
+      name: 'initializeResult',
+      type: 'InitializeResult',
+      description:
+        'The full initialize result used by this client, either from the server during initialization or from initialInitializeResult.',
+    },
     {
       name: 'serverInfo',
       type: 'Configuration',

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -93,12 +93,35 @@ HTTP is recommended for production deployments:
 ```ts
 import { createMCPClient } from '@ai-sdk/mcp';
 
+const savedSession = await loadMcpSession();
+let currentSessionId = savedSession?.sessionId;
+
 const mcpClient = await createMCPClient({
   transport: {
     type: 'http',
     url: 'https://your-server.com/mcp',
+    initialSessionId: savedSession?.sessionId,
+    initialProtocolVersion: savedSession?.initializeResult.protocolVersion,
+    terminateSessionOnClose: false,
+    onSessionIdChange: sessionId => {
+      currentSessionId = sessionId;
+    },
+    onSessionExpired: sessionId => {
+      if (currentSessionId === sessionId) {
+        currentSessionId = undefined;
+        void clearMcpSession();
+      }
+    },
   },
+  initialInitializeResult: savedSession?.initializeResult,
 });
+
+if (currentSessionId) {
+  await saveMcpSession({
+    sessionId: currentSessionId,
+    initializeResult: mcpClient.initializeResult,
+  });
+}
 ```
 
 SSE is also supported for MCP servers that use Server-Sent Events:

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,6 +27,7 @@ export type {
   Configuration,
   ElicitationRequest,
   ElicitResult,
+  InitializeResult,
   ListToolsResult,
   McpProviderMetadata,
   ClientCapabilities as MCPClientCapabilities,

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -7,6 +7,7 @@ import { MockMCPTransport } from './mock-mcp-transport';
 import {
   ListToolsResult,
   ElicitationRequestSchema,
+  LATEST_PROTOCOL_VERSION,
   type CallToolResult,
   type ListResourceTemplatesResult,
   type ListResourcesResult,
@@ -14,6 +15,7 @@ import {
   type ListPromptsResult,
   type GetPromptResult,
   type Configuration,
+  type InitializeResult,
 } from './types';
 import type { JSONRPCMessage, JSONRPCRequest } from './json-rpc-message';
 import {
@@ -1111,6 +1113,62 @@ describe('MCPClient', () => {
       expect(tools).toBeDefined();
       await client.close();
     }
+  });
+
+  it('should resume from an initial initialize result without reinitializing', async () => {
+    const sentMessages: JSONRPCMessage[] = [];
+    const initialInitializeResult: InitializeResult = {
+      protocolVersion: LATEST_PROTOCOL_VERSION,
+      serverInfo: {
+        name: 'resumed-server',
+        version: '1.0.0',
+      },
+      capabilities: {
+        tools: {},
+      },
+      instructions: 'Cached server instructions',
+    };
+    const transport: MCPTransport = {
+      start: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      send: vi.fn(async message => {
+        sentMessages.push(message);
+        if (
+          'method' in message &&
+          'id' in message &&
+          message.method === 'tools/list'
+        ) {
+          transport.onmessage?.({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              tools: [],
+            },
+          });
+        }
+      }),
+    };
+
+    client = await createMCPClient({
+      transport,
+      initialInitializeResult,
+    });
+
+    expect(transport.start).toHaveBeenCalledTimes(1);
+    expect(sentMessages).toEqual([]);
+    expect(transport.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(client.serverInfo).toEqual({
+      name: 'resumed-server',
+      version: '1.0.0',
+    });
+    expect(client.initializeResult).toEqual(initialInitializeResult);
+    expect(client.instructions).toBe('Cached server instructions');
+
+    await expect(client.listTools()).resolves.toEqual({ tools: [] });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]).toMatchObject({
+      method: 'tools/list',
+    });
   });
 
   it('should expose serverInfo from initialization', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -60,6 +60,7 @@ import {
   type ToolSchemas,
   type ToolMeta,
   type McpProviderMetadata,
+  type InitializeResult,
 } from './types';
 const CLIENT_VERSION = '1.0.0';
 
@@ -100,6 +101,12 @@ export interface MCPClientConfig {
   transport: MCPTransportConfig | MCPTransport;
   /** Optional callback for uncaught errors */
   onUncaughtError?: (error: unknown) => void;
+  /**
+   * Initialize result from a previous MCP session. When provided, the client
+   * starts the transport and reuses this metadata without sending a new
+   * initialize request.
+   */
+  initialInitializeResult?: InitializeResult;
   /** Optional client name, defaults to 'ai-sdk-mcp-client' */
   clientName?: string;
   /**
@@ -132,6 +139,12 @@ export interface MCPClient {
    * @see https://modelcontextprotocol.io/specification/2025-11-25/schema#implementation
    */
   readonly serverInfo: Configuration;
+
+  /**
+   * The full initialize result used by this client, either from the server
+   * during initialization or from `initialInitializeResult`.
+   */
+  readonly initializeResult: InitializeResult;
 
   /**
    * Optional instructions provided by the server during the initialize handshake.
@@ -220,7 +233,7 @@ export interface MCPClient {
  *
  * Not supported:
  * - Accepting notifications
- * - Session management (when passing a sessionId to an instance of the Streamable HTTP transport)
+ * - Automatic session persistence for Streamable HTTP transport
  * - Resumable SSE streams
  */
 class DefaultMCPClient implements MCPClient {
@@ -228,6 +241,7 @@ class DefaultMCPClient implements MCPClient {
   private onUncaughtError?: (error: unknown) => void;
   private clientInfo: ClientConfiguration;
   private clientCapabilities: ClientCapabilities;
+  private initialInitializeResult?: InitializeResult;
   private requestMessageId = 0;
   private responseHandlers: Map<
     number,
@@ -235,6 +249,11 @@ class DefaultMCPClient implements MCPClient {
   > = new Map();
   private serverCapabilities: ServerCapabilities = {};
   private _serverInfo: Configuration = { name: '', version: '' };
+  private _initializeResult: InitializeResult = {
+    protocolVersion: LATEST_PROTOCOL_VERSION,
+    capabilities: {},
+    serverInfo: this._serverInfo,
+  };
   private _serverInstructions?: string;
   private isClosed = true;
   private elicitationRequestHandler?: (
@@ -248,9 +267,11 @@ class DefaultMCPClient implements MCPClient {
     version = CLIENT_VERSION,
     onUncaughtError,
     capabilities,
+    initialInitializeResult,
   }: MCPClientConfig) {
     this.onUncaughtError = onUncaughtError;
     this.clientCapabilities = capabilities ?? {};
+    this.initialInitializeResult = initialInitializeResult;
 
     if (isCustomMcpTransport(transportConfig)) {
       this.transport = transportConfig;
@@ -287,6 +308,10 @@ class DefaultMCPClient implements MCPClient {
     return this._serverInfo;
   }
 
+  get initializeResult(): InitializeResult {
+    return this._initializeResult;
+  }
+
   get instructions(): string | undefined {
     return this._serverInstructions;
   }
@@ -295,6 +320,14 @@ class DefaultMCPClient implements MCPClient {
     try {
       await this.transport.start();
       this.isClosed = false;
+
+      if (this.initialInitializeResult) {
+        const result = InitializeResultSchema.parse(
+          this.initialInitializeResult,
+        );
+        this.applyInitializeResult(result);
+        return this;
+      }
 
       const result = await this.request({
         request: {
@@ -314,20 +347,7 @@ class DefaultMCPClient implements MCPClient {
         });
       }
 
-      if (!SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
-        throw new MCPClientError({
-          message: `Server's protocol version is not supported: ${result.protocolVersion}`,
-        });
-      }
-
-      this.serverCapabilities = result.capabilities;
-      this._serverInfo = result.serverInfo;
-      if (this.transport.setProtocolVersion) {
-        this.transport.setProtocolVersion(result.protocolVersion);
-      } else {
-        this.transport.protocolVersion = result.protocolVersion;
-      }
-      this._serverInstructions = result.instructions;
+      this.applyInitializeResult(result);
 
       // Complete initialization handshake:
       await this.notification({
@@ -339,6 +359,24 @@ class DefaultMCPClient implements MCPClient {
       await this.close();
       throw error;
     }
+  }
+
+  private applyInitializeResult(result: InitializeResult): void {
+    if (!SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
+      throw new MCPClientError({
+        message: `Server's protocol version is not supported: ${result.protocolVersion}`,
+      });
+    }
+
+    this.serverCapabilities = result.capabilities;
+    this._serverInfo = result.serverInfo;
+    this._initializeResult = result;
+    if (this.transport.setProtocolVersion) {
+      this.transport.setProtocolVersion(result.protocolVersion);
+    } else {
+      this.transport.protocolVersion = result.protocolVersion;
+    }
+    this._serverInstructions = result.instructions;
   }
 
   async close(): Promise<void> {

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -234,6 +234,236 @@ describe('HttpMCPTransport', () => {
     );
   });
 
+  it('should not DELETE to terminate session on close when disabled', async () => {
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      terminateSessionOnClose: false,
+    });
+
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return {
+            type: 'json-value',
+            headers: { 'mcp-session-id': 'xyz-session' },
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+
+    await transport.close();
+
+    expect(server.calls).toHaveLength(2);
+    expect(server.calls[0].requestMethod).toBe('GET');
+    expect(server.calls[1].requestMethod).toBe('POST');
+  });
+
+  it('should send initial session id on resumed HTTP requests', async () => {
+    const initialSessionId = 'saved-session';
+    const initialProtocolVersion = '2025-06-18';
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      initialSessionId,
+      initialProtocolVersion,
+    });
+
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+        case 2:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 2, result: { ok: true } },
+          };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'tools/list',
+      id: 2,
+      params: {},
+    });
+
+    expect(server.calls[0].requestMethod).toBe('GET');
+    expect(server.calls[0].requestHeaders['mcp-session-id']).toBe(
+      initialSessionId,
+    );
+    expect(server.calls[0].requestHeaders['mcp-protocol-version']).toBe(
+      initialProtocolVersion,
+    );
+
+    expect(server.calls[1].requestMethod).toBe('POST');
+    expect(server.calls[1].requestHeaders['mcp-session-id']).toBeUndefined();
+    expect(server.calls[1].requestHeaders['mcp-protocol-version']).toBe(
+      initialProtocolVersion,
+    );
+
+    expect(server.calls[2].requestMethod).toBe('POST');
+    expect(server.calls[2].requestHeaders['mcp-session-id']).toBe(
+      initialSessionId,
+    );
+    expect(server.calls[2].requestHeaders['mcp-protocol-version']).toBe(
+      initialProtocolVersion,
+    );
+  });
+
+  it('should notify when the server changes the session id', async () => {
+    const onSessionIdChange = vi.fn();
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      onSessionIdChange,
+    });
+
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        default:
+          return {
+            type: 'json-value',
+            headers: { 'mcp-session-id': 'new-session' },
+            body: {
+              jsonrpc: '2.0',
+              id: callNumber,
+              result: { ok: true },
+            },
+          };
+      }
+    };
+
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'tools/list',
+      id: 2,
+      params: {},
+    });
+
+    expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+    expect(onSessionIdChange).toHaveBeenCalledWith('new-session');
+    expect(server.calls[2].requestHeaders['mcp-session-id']).toBe(
+      'new-session',
+    );
+  });
+
+  it('should notify and clear the session id when POST returns 404', async () => {
+    const onSessionIdChange = vi.fn();
+    const onSessionExpired = vi.fn();
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      initialSessionId: 'expired-session',
+      onSessionIdChange,
+      onSessionExpired,
+    });
+
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return { type: 'error', status: 404, body: 'Not Found' };
+        case 2:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 2, result: { ok: true } },
+          };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+    await expect(
+      transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'tools/list',
+        id: 1,
+        params: {},
+      }),
+    ).rejects.toThrow('The MCP session expired');
+
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    expect(onSessionExpired).toHaveBeenCalledWith('expired-session');
+    expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+    expect(onSessionIdChange).toHaveBeenCalledWith(undefined);
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'tools/list',
+      id: 2,
+      params: {},
+    });
+
+    expect(server.calls[2].requestHeaders['mcp-session-id']).toBeUndefined();
+  });
+
+  it('should notify and clear the session id when inbound SSE returns 404', async () => {
+    const onSessionIdChange = vi.fn();
+    const onSessionExpired = vi.fn();
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      initialSessionId: 'expired-session',
+      onSessionIdChange,
+      onSessionExpired,
+    });
+
+    server.urls['http://localhost:4000/mcp'].response = {
+      type: 'error',
+      status: 404,
+      body: 'Not Found',
+    };
+
+    await transport.start();
+
+    await vi.waitFor(() => {
+      expect(onSessionExpired).toHaveBeenCalledWith('expired-session');
+    });
+
+    expect(server.calls[0].requestMethod).toBe('GET');
+    expect(server.calls[0].requestHeaders['mcp-session-id']).toBe(
+      'expired-session',
+    );
+    expect(onSessionIdChange).toHaveBeenCalledWith(undefined);
+  });
+
   it('should report HTTP errors from POST', async () => {
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/mcp' });
 

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -43,6 +43,9 @@ export class HttpMCPTransport implements MCPTransport {
   private redirectMode: RequestRedirect;
   private fetchFn: FetchFunction;
   private authPromise?: Promise<AuthResult>;
+  private onSessionIdChange?: (sessionId: string | undefined) => void;
+  private onSessionExpired?: (sessionId: string) => void;
+  private terminateSessionOnClose: boolean;
 
   // Inbound SSE resumption and reconnection state
   private lastInboundEventId?: string;
@@ -64,18 +67,33 @@ export class HttpMCPTransport implements MCPTransport {
     headers,
     authProvider,
     redirect = 'error',
+    initialSessionId,
+    initialProtocolVersion,
+    onSessionIdChange,
+    onSessionExpired,
+    terminateSessionOnClose = true,
     fetch: fetchFn,
   }: {
     url: string;
     headers?: Record<string, string>;
     authProvider?: OAuthClientProvider;
     redirect?: 'follow' | 'error';
+    initialSessionId?: string;
+    initialProtocolVersion?: string;
+    onSessionIdChange?: (sessionId: string | undefined) => void;
+    onSessionExpired?: (sessionId: string) => void;
+    terminateSessionOnClose?: boolean;
     fetch?: FetchFunction;
   }) {
     this.url = new URL(url);
     this.headers = headers;
     this.authProvider = authProvider;
     this.redirectMode = redirect;
+    this.sessionId = initialSessionId;
+    this.protocolVersion = initialProtocolVersion;
+    this.onSessionIdChange = onSessionIdChange;
+    this.onSessionExpired = onSessionExpired;
+    this.terminateSessionOnClose = terminateSessionOnClose;
     this.fetchFn = fetchFn ?? globalThis.fetch;
   }
 
@@ -83,16 +101,20 @@ export class HttpMCPTransport implements MCPTransport {
     this.protocolVersion = version;
   }
 
-  private async commonHeaders(
-    base: Record<string, string>,
-  ): Promise<Record<string, string>> {
+  private async commonHeaders({
+    base,
+    includeSessionId = true,
+  }: {
+    base: Record<string, string>;
+    includeSessionId?: boolean;
+  }): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
       'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
-    if (this.sessionId) {
+    if (includeSessionId && this.sessionId) {
       headers['mcp-session-id'] = this.sessionId;
     }
 
@@ -108,6 +130,30 @@ export class HttpMCPTransport implements MCPTransport {
       `ai-sdk/${VERSION}`,
       getRuntimeEnvironmentUserAgent(),
     );
+  }
+
+  private setSessionId(sessionId: string | undefined): void {
+    if (this.sessionId === sessionId) {
+      return;
+    }
+
+    this.sessionId = sessionId;
+    this.onSessionIdChange?.(sessionId);
+  }
+
+  private applySessionIdFromResponse(response: Response): void {
+    const sessionId = response.headers.get('mcp-session-id');
+    if (sessionId) {
+      this.setSessionId(sessionId);
+    }
+  }
+
+  private expireSessionId(sessionId: string): void {
+    if (this.sessionId === sessionId) {
+      this.setSessionId(undefined);
+    }
+
+    this.onSessionExpired?.(sessionId);
   }
 
   /**
@@ -148,10 +194,11 @@ export class HttpMCPTransport implements MCPTransport {
     try {
       if (
         this.sessionId &&
+        this.terminateSessionOnClose &&
         this.abortController &&
         !this.abortController.signal.aborted
       ) {
-        const headers = await this.commonHeaders({});
+        const headers = await this.commonHeaders({ base: {} });
         await this.fetchFn(this.url.href, {
           method: 'DELETE',
           headers,
@@ -168,9 +215,17 @@ export class HttpMCPTransport implements MCPTransport {
   async send(message: JSONRPCMessage): Promise<void> {
     const attempt = async (triedAuth: boolean = false): Promise<void> => {
       try {
+        const isInitializeRequest =
+          'method' in message && message.method === 'initialize';
+        const sessionIdForRequest = isInitializeRequest
+          ? undefined
+          : this.sessionId;
         const headers = await this.commonHeaders({
-          'Content-Type': 'application/json',
-          Accept: 'application/json, text/event-stream',
+          base: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+          },
+          includeSessionId: !isInitializeRequest,
         });
 
         const init = {
@@ -183,10 +238,7 @@ export class HttpMCPTransport implements MCPTransport {
 
         const response = await this.fetchFn(this.url.href, init);
 
-        const sessionId = response.headers.get('mcp-session-id');
-        if (sessionId) {
-          this.sessionId = sessionId;
-        }
+        this.applySessionIdFromResponse(response);
 
         if (response.status === 401 && this.authProvider && !triedAuth) {
           this.resourceMetadataUrl = extractResourceMetadataUrl(response);
@@ -217,10 +269,16 @@ export class HttpMCPTransport implements MCPTransport {
           const text = await response.text().catch(() => null);
           let errorMessage = `MCP HTTP Transport Error: POSTing to endpoint (HTTP ${response.status}): ${text}`;
 
-          // 404 since this is a GET request which the server does not support
           if (response.status === 404) {
-            errorMessage +=
-              '. This server does not support HTTP transport. Try using `sse` transport instead';
+            if (sessionIdForRequest) {
+              this.expireSessionId(sessionIdForRequest);
+
+              errorMessage +=
+                '. The MCP session expired. Create a new client without `initialSessionId` to start a fresh session';
+            } else {
+              errorMessage +=
+                '. This server does not support HTTP transport. Try using `sse` transport instead';
+            }
           }
 
           const error = new MCPClientError({
@@ -356,8 +414,11 @@ export class HttpMCPTransport implements MCPTransport {
     resumeToken?: string,
   ): Promise<void> {
     try {
+      const sessionIdForRequest = this.sessionId;
       const headers = await this.commonHeaders({
-        Accept: 'text/event-stream',
+        base: {
+          Accept: 'text/event-stream',
+        },
       });
       if (resumeToken) {
         headers['last-event-id'] = resumeToken;
@@ -370,10 +431,7 @@ export class HttpMCPTransport implements MCPTransport {
         redirect: this.redirectMode,
       });
 
-      const sessionId = response.headers.get('mcp-session-id');
-      if (sessionId) {
-        this.sessionId = sessionId;
-      }
+      this.applySessionIdFromResponse(response);
 
       if (response.status === 401 && this.authProvider && !triedAuth) {
         this.resourceMetadataUrl = extractResourceMetadataUrl(response);
@@ -396,6 +454,10 @@ export class HttpMCPTransport implements MCPTransport {
       }
 
       if (!response.ok || !response.body) {
+        if (response.status === 404 && sessionIdForRequest) {
+          this.expireSessionId(sessionIdForRequest);
+        }
+
         const error = new MCPClientError({
           message: `MCP HTTP Transport Error: GET SSE failed: ${response.status} ${response.statusText}`,
           statusCode: response.status,

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -79,6 +79,42 @@ export type MCPTransportConfig = {
   redirect?: 'follow' | 'error';
 
   /**
+   * Initial MCP session id to send with resumed Streamable HTTP requests after
+   * initialization.
+   * Only used by the HTTP transport.
+   */
+  initialSessionId?: string;
+
+  /**
+   * Initial MCP protocol version to send before initialize negotiates one.
+   * Only used by the HTTP transport.
+   */
+  initialProtocolVersion?: string;
+
+  /**
+   * Called when the Streamable HTTP server creates, changes, or clears the MCP
+   * session id.
+   * Only used by the HTTP transport.
+   */
+  onSessionIdChange?: (sessionId: string | undefined) => void;
+
+  /**
+   * Called when a Streamable HTTP request returns 404 for an existing MCP
+   * session id. The transport clears the session id before reporting the
+   * underlying HTTP error.
+   * Only used by the HTTP transport.
+   */
+  onSessionExpired?: (sessionId: string) => void;
+
+  /**
+   * Whether close() should send DELETE for the current MCP session id.
+   * Set to false when the application intends to reattach to the session later.
+   * Only used by the HTTP transport.
+   * @default true
+   */
+  terminateSessionOnClose?: boolean;
+
+  /**
    * Optional custom fetch implementation to use for HTTP requests.
    * Useful for runtimes that need a request-local fetch.
    * @default globalThis.fetch


### PR DESCRIPTION
## Summary

- add Streamable HTTP session options to @ai-sdk/mcp: initialSessionId, initialProtocolVersion, onSessionIdChange, onSessionExpired, and terminateSessionOnClose
- expose MCPClient.initializeResult and allow createMCPClient to reattach with initialInitializeResult without sending a fresh initialize request
- avoid sending stale MCP session ids on initialize; 404s for requests that did include a session id clear the id and notify onSessionExpired
- document manual session persistence and add a patch changeset

## Render verification

Checked render-oss/render-mcp-server and its mcp-go v0.32.0 transport:

- Render runs server.NewStreamableHTTPServer on /mcp and stores selected workspace by server.ClientSessionFromContext(ctx).SessionID()
- select_workspace writes workspace state into the session store, so reusing the MCP session id is required to preserve workspace context
- mcp-go creates a new session id for initialize and returns it in Mcp-Session-Id; subsequent requests must carry that id
- mcp-go's own client clears the session on HTTP 404 and says to re-initialize
- closing the transport sends DELETE, so persistent reattach needs terminateSessionOnClose: false to detach locally without terminating the server session

## Tests

- pnpm --filter @ai-sdk/mcp test
- pnpm --filter @ai-sdk/mcp type-check
- pnpm --filter @ai-sdk/mcp build
- pnpm validate:docs