### PR TITLE
fix (provider/google): include toolUsePromptTokenCount in input token usage

### DIFF
--- a/.changeset/google-tool-use-prompt-tokens.md
+++ b/.changeset/google-tool-use-prompt-tokens.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): include `toolUsePromptTokenCount` in input token usage
+
+Gemini reports tokens consumed by tool-use prompts — most commonly grounded
+Google Search or URL context — in a separate `toolUsePromptTokenCount` field in
+`usageMetadata`, on top of `promptTokenCount`. Both are billed at the regular
+input rate, but the provider previously dropped this field: it was not declared
+in `usageSchema` (so zod stripped it) and `convertGoogleUsage` only summed
+`promptTokenCount` into `inputTokens.total`. Grounded calls therefore
+under-reported input tokens by the exact amount Google billed for the tool-use
+prompt. This adds the field to the schema and includes it in `inputTokens.total`
+and `inputTokens.noCache`; non-grounded calls are unaffected.

--- a/packages/google/src/convert-google-usage.test.ts
+++ b/packages/google/src/convert-google-usage.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { convertGoogleUsage } from './convert-google-usage';
+
+describe('convertGoogleUsage', () => {
+  it('returns undefined fields when usage is null', () => {
+    expect(convertGoogleUsage(null)).toEqual({
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    });
+  });
+
+  it('maps prompt and candidate tokens for a basic call', () => {
+    const usage = convertGoogleUsage({
+      promptTokenCount: 100,
+      candidatesTokenCount: 50,
+      totalTokenCount: 150,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 100,
+      noCache: 100,
+      cacheRead: 0,
+      cacheWrite: undefined,
+    });
+    expect(usage.outputTokens).toEqual({
+      total: 50,
+      text: 50,
+      reasoning: 0,
+    });
+  });
+
+  it('subtracts cached tokens from noCache while keeping total accurate', () => {
+    const usage = convertGoogleUsage({
+      promptTokenCount: 100,
+      cachedContentTokenCount: 40,
+      candidatesTokenCount: 50,
+      totalTokenCount: 150,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 100,
+      noCache: 60,
+      cacheRead: 40,
+      cacheWrite: undefined,
+    });
+  });
+
+  it('reports thoughts (reasoning) tokens in output and total', () => {
+    const usage = convertGoogleUsage({
+      promptTokenCount: 10,
+      candidatesTokenCount: 15,
+      thoughtsTokenCount: 8,
+      totalTokenCount: 33,
+    });
+
+    expect(usage.outputTokens).toEqual({
+      total: 23,
+      text: 15,
+      reasoning: 8,
+    });
+  });
+
+  it('includes toolUsePromptTokenCount in input tokens', () => {
+    // Realistic shape returned by Gemini for a grounded (Google Search) call.
+    // Without this, the tool-use tokens silently disappear from the standard
+    // usage shape even though Google bills them at the input rate.
+    const usage = convertGoogleUsage({
+      promptTokenCount: 70,
+      candidatesTokenCount: 53,
+      thoughtsTokenCount: 199,
+      toolUsePromptTokenCount: 79,
+      totalTokenCount: 401,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 149,
+      noCache: 149,
+      cacheRead: 0,
+      cacheWrite: undefined,
+    });
+    expect(usage.outputTokens).toEqual({
+      total: 252,
+      text: 53,
+      reasoning: 199,
+    });
+  });
+
+  it('combines cached content and tool-use prompt tokens correctly', () => {
+    const usage = convertGoogleUsage({
+      promptTokenCount: 100,
+      cachedContentTokenCount: 30,
+      toolUsePromptTokenCount: 50,
+      candidatesTokenCount: 20,
+      totalTokenCount: 170,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 150,
+      noCache: 120,
+      cacheRead: 30,
+      cacheWrite: undefined,
+    });
+  });
+});

--- a/packages/google/src/convert-google-usage.ts
+++ b/packages/google/src/convert-google-usage.ts
@@ -11,6 +11,7 @@ export type GoogleUsageMetadata = {
   totalTokenCount?: number | null;
   cachedContentTokenCount?: number | null;
   thoughtsTokenCount?: number | null;
+  toolUsePromptTokenCount?: number | null;
   trafficType?: string | null;
   serviceTier?: string | null;
   promptTokensDetails?: GoogleTokenDetail[] | null;
@@ -41,11 +42,18 @@ export function convertGoogleUsage(
   const candidatesTokens = usage.candidatesTokenCount ?? 0;
   const cachedContentTokens = usage.cachedContentTokenCount ?? 0;
   const thoughtsTokens = usage.thoughtsTokenCount ?? 0;
+  // Tokens consumed by tool-use prompts (e.g. grounded Google Search, URL
+  // context). Google bills these at the regular input rate but reports them
+  // in a separate field, so they must be added to inputTokens for consumers
+  // that compute cost from the standard usage shape to match Google's billing.
+  // See https://ai.google.dev/api/generate-content#UsageMetadata.
+  const toolUsePromptTokens = usage.toolUsePromptTokenCount ?? 0;
+  const totalInputTokens = promptTokens + toolUsePromptTokens;
 
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cachedContentTokens,
+      total: totalInputTokens,
+      noCache: totalInputTokens - cachedContentTokens,
       cacheRead: cachedContentTokens,
       cacheWrite: undefined,
     },

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -1463,6 +1463,10 @@ const usageSchema = z.object({
   promptTokenCount: z.number().nullish(),
   candidatesTokenCount: z.number().nullish(),
   totalTokenCount: z.number().nullish(),
+  // Tokens used by tool-use prompts (e.g. grounded Google Search, URL
+  // context). Google bills this at the regular input rate; see
+  // https://ai.google.dev/api/generate-content#UsageMetadata.
+  toolUsePromptTokenCount: z.number().nullish(),
   // https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#TrafficType
   trafficType: z.string().nullish(),
   serviceTier: z.string().nullish(),


### PR DESCRIPTION
## Background

When you call Gemini with a tool that runs a tool-use prompt — most commonly grounded `google_search` or `url_context` — the model's `usageMetadata` reports those tokens in a separate field, `toolUsePromptTokenCount`, on top of `promptTokenCount`. Both are billed at the regular input rate ([Google docs](https://ai.google.dev/api/generate-content#UsageMetadata)).

Today `@ai-sdk/google` drops this field:

1. `usageSchema` in `google-language-model.ts` doesn't declare `toolUsePromptTokenCount`, so zod strips it from the parsed response.
2. `convertGoogleUsage` only sums `promptTokenCount` into `inputTokens.total`.

## Impact

`usage.inputTokens.total` is silently lower than what Google bills. We hit this in production: on `gemini-2.5-flash` with `url_context`, for example a single Wikipedia-page fetch returned `promptTokenCount: 26`, `toolUsePromptTokenCount: 12504`, `totalTokenCount: 12633` — but `usage.inputTokens` surfaced **26**. Across 10 days of our traffic this under-reported ~96% of that model's input tokens, so any cost computed from the standard `LanguageModelV4Usage` shape was off by >20× on grounded / url-context calls. Non-tool calls reconcile exactly, so the gap is specific to server-side tool fetches.

## Fix

- Declare `toolUsePromptTokenCount` on `usageSchema`.
- Add it to `GoogleUsageMetadata` and include it in `inputTokens.total` / `inputTokens.noCache` in `convertGoogleUsage` (billed at the input rate). Non-grounded calls are unaffected.
- Adds `convert-google-usage.test.ts` covering basic, cached, reasoning, grounded, and cached+tool-use cases.

Supersedes #14575 by @JamieWoodbury (rebased onto the post-refactor `convert-google-usage.ts` / `google-language-model.ts`, with the changeset + unit tests). Credit to them for the original diagnosis.
