### PR TITLE
feat(provider/gateway): support `AI_GATEWAY_BASE_URL` env for the base URL

### DIFF
--- a/.changeset/gateway-base-url-env.md
+++ b/.changeset/gateway-base-url-env.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+feat(provider/gateway): support the `AI_GATEWAY_BASE_URL` environment variable for the base URL

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -181,7 +181,8 @@ export interface GatewayProvider extends ProviderV4 {
 
 export interface GatewayProviderSettings {
   /**
-   * The base URL prefix for API calls. Defaults to `https://ai-gateway.vercel.sh/v4/ai`.
+   * The base URL prefix for API calls. Defaults to the `AI_GATEWAY_BASE_URL`
+   * environment variable, then `https://ai-gateway.vercel.sh/v4/ai`.
    */
   baseURL?: string;
 
@@ -242,7 +243,7 @@ export function createGateway(
   let lastFetchTime = 0;
 
   const baseURL =
-    withoutTrailingSlash(options.baseURL) ??
+    withoutTrailingSlash(options.baseURL ?? process.env.AI_GATEWAY_BASE_URL) ??
     'https://ai-gateway.vercel.sh/v4/ai';
 
   const createAuthHeaders = (auth: {


### PR DESCRIPTION
## Summary

The Gateway provider's base URL is only configurable via `createGateway({ baseURL })`. The **default / global** gateway provider — the one the AI SDK uses to resolve plain `provider/model` strings (e.g. `generateText({ model: 'anthropic/claude-...' })`) — is constructed internally, so callers have no way to point it at a custom endpoint without building a provider by hand and threading it through every call site.

This adds an `AI_GATEWAY_BASE_URL` environment-variable fallback, **symmetric with the existing `AI_GATEWAY_API_KEY`** env, so the gateway endpoint can be overridden process-wide — useful for a self-hosted gateway, a local proxy that injects auth/headers, testing, or enterprise egress.

## Change

```ts
const baseURL =
  withoutTrailingSlash(options.baseURL ?? process.env.AI_GATEWAY_BASE_URL) ??
  'https://ai-gateway.vercel.sh/v4/ai';
```

Precedence: explicit `options.baseURL` → `AI_GATEWAY_BASE_URL` → default. No behavior change when neither is set. The doc comment on `GatewayProviderSettings.baseURL` is updated to mention the env var, and a changeset is included.
