### PR TITLE
fix: prevent bundler from statically analyzing dynamic import for React Native compatibility

### DIFF
--- a/packages/ai/src/telemetry/tracing-channel-publisher.ts
+++ b/packages/ai/src/telemetry/tracing-channel-publisher.ts
@@ -31,10 +31,13 @@ async function loadDiagnosticsChannel(): Promise<
   }
 
   if (diagnosticsChannelPromise == null) {
+    // Use string variable to prevent bundlers from statically analyzing the import
+    // which breaks React Native / Hermes builds
+    const moduleName: string = 'node:diagnostics_channel';
     diagnosticsChannelPromise = (
       import(
         /* webpackIgnore: true */
-        'node:diagnostics_channel'
+        moduleName
       ) as Promise<DiagnosticsChannel>
     ).catch(() => undefined);
   }


### PR DESCRIPTION
## Problem

Importing anything from `ai` in a React Native / Expo app breaks the Hermes release bundle:

```
error: Invalid expression encountered
  diagnosticsChannelPromise = import(/* webpackIgnore: true */ "diagnostics_channel")
```

Even though `isNodeRuntime()` guards the call, Metro bundler still tries to parse the static string literal `'node:diagnostics_channel'` in the `import()` expression.

## Fix

Use a string variable for the module name to prevent Metro from statically analyzing the import:

```diff
  if (diagnosticsChannelPromise == null) {
+   // Use string variable to prevent bundlers from statically analyzing the import
+   // which breaks React Native / Hermes builds
+   const moduleName: string = 'node:diagnostics_channel';
    diagnosticsChannelPromise = (
      import(
        /* webpackIgnore: true */
-       'node:diagnostics_channel'
+       moduleName
      ) as Promise<DiagnosticsChannel>
    ).catch(() => undefined);
  }
```

This is a common pattern for making dynamic imports bundler-safe while keeping the same runtime behavior.

Fixes #16191
