### PR TITLE
fix(react): prevent Chat recreation when id is undefined

### DIFF
--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -96,7 +96,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
 
   const shouldRecreateChat =
     ('chat' in options && options.chat !== chatRef.current) ||
-    ('id' in options && chatRef.current.id !== options.id);
+    ('id' in options && options.id !== undefined && chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
     chatRef.current =


### PR DESCRIPTION
## Problem

Passing `id: undefined` to `useChat` causes the internal `Chat` instance to be recreated on every render. Sent messages and in-flight streams disappear immediately.

This is easy to hit because `id={conversationId ?? undefined}` is a common pattern.

### Root cause

In `useChat`:

```ts
const shouldRecreateChat =
    ('chat' in options && options.chat !== chatRef.current) ||
    ('id' in options && chatRef.current.id !== options.id);
```

When `id: undefined` is passed:
1. `'id' in options` is `true` (key exists even though value is `undefined`)
2. `chatRef.current.id` is an auto-generated UUID
3. `uuid !== undefined` is always `true`

So `shouldRecreateChat` stays `true` and a fresh `Chat` is created every render.

## Fix

Add `options.id !== undefined` check so that `id: undefined` behaves the same as omitting `id`:

```diff
  const shouldRecreateChat =
    ('chat' in options && options.chat !== chatRef.current) ||
-   ('id' in options && chatRef.current.id !== options.id);
+   ('id' in options && options.id !== undefined && chatRef.current.id !== options.id);
```

Fixes #16226
