### PR TITLE
fix: use InvalidResponseDataError instead of generic Error for audio format

### DIFF
--- a/packages/ai/src/generate-speech/generated-audio-file.ts
+++ b/packages/ai/src/generate-speech/generated-audio-file.ts
@@ -2,6 +2,7 @@ import {
   DefaultGeneratedFile,
   type GeneratedFile,
 } from '../generate-text/generated-file';
+import { InvalidResponseDataError } from '@ai-sdk/provider';
 /**
  * A generated audio file.
  */
@@ -41,10 +42,10 @@ export class DefaultGeneratedAudioFile
     }
 
     if (!format) {
-      // TODO this should be an AI SDK error
-      throw new Error(
-        'Audio format must be provided or determinable from media type',
-      );
+      throw new InvalidResponseDataError({
+        data: mediaType,
+        message: `Could not determine audio format from media type: ${mediaType}`,
+      });
     }
 
     this.format = format;


### PR DESCRIPTION
## Problem

In `DefaultGeneratedAudioFile`, when the audio format cannot be determined from the media type, the constructor throws a plain `Error` instead of an `AISDKError` subclass. There is even a `// TODO this should be an AI SDK error` comment on the line.

## Fix

Replace the generic `Error` with `InvalidResponseDataError` from `@ai-sdk/provider`:

```diff
+import { InvalidResponseDataError } from '@ai-sdk/provider';

  if (!format) {
-   // TODO this should be an AI SDK error
-   throw new Error(
-     'Audio format must be provided or determinable from media type',
-   );
+   throw new InvalidResponseDataError({
+     data: mediaType,
+     message: `Could not determine audio format from media type: ${mediaType}`,
+   });
  }
```

This makes the error consistent with the rest of the SDK's error handling pattern and allows callers to use `AISDKError.isInstance()` to distinguish SDK errors from unexpected runtime errors.

Fixes #15814
