### PR TITLE
fix: only trim when code fence was stripped in extractJsonMiddleware

### DIFF
--- a/packages/ai/src/middleware/extract-json-middleware.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.ts
@@ -9,10 +9,14 @@ import { createIdMap } from '../util/create-id-map';
  * Default transform function that strips markdown code fences from text.
  */
 function defaultTransform(text: string): string {
-  return text
+  const stripped = text
     .replace(/^```(?:json)?\s*\n?/, '')
-    .replace(/\n?```\s*$/, '')
-    .trim();
+    .replace(/\n?```\s*$/, '');
+  // Only trim if a code fence was actually stripped
+  if (stripped !== text) {
+    return stripped.trim();
+  }
+  return stripped;
 }
 
 /**


### PR DESCRIPTION
## Problem

`extractJsonMiddleware`'s `defaultTransform` calls `.trim()` unconditionally, which removes valid leading/trailing spaces from text that doesn't have a code fence.

When the suffix buffer contains a legitimate space (e.g. `" altogether?"`), `.trim()` removes the leading space, causing adjacent words to fuse (`"therealtogether?"` instead of `"there altogether?"`).

## Fix

Only trim when a code fence was actually stripped:

```diff
  function defaultTransform(text: string): string {
-   return text
-     .replace(/^```(?:json)?\s*\n?/, '')
-     .replace(/\n?```\s*$/, '')
-     .trim();
+   const stripped = text
+     .replace(/^```(?:json)?\s*\n?/, '')
+     .replace(/\n?```\s*$/, '');
+   // Only trim if a code fence was actually stripped
+   if (stripped !== text) {
+     return stripped.trim();
+   }
+   return stripped;
  }
```

Fixes #15921
