### PR TITLE
fix(openai): allow web_search_call.results include

### DIFF
--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -43,6 +43,7 @@ export type OpenAIResponsesInputItem =
 
 export type OpenAIResponsesIncludeValue =
   | 'web_search_call.action.sources'
+  | 'web_search_call.results'
   | 'code_interpreter_call.outputs'
   | 'computer_call_output.output.image_url'
   | 'file_search_call.results'

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -156,13 +156,14 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
 
       /**
        * The set of extra fields to include in the response (advanced, usually not needed).
-       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'message.output_text.logprobs'.
+       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
        */
       include: z
         .array(
           z.enum([
             'reasoning.encrypted_content', // handled internally by default, only needed for unknown reasoning models
             'file_search_call.results',
+            'web_search_call.results',
             'message.output_text.logprobs',
           ]),
         )

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1284,6 +1284,27 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send web_search_call.results include provider option', async () => {
+        const { warnings } = await createModel('o3-mini').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              include: ['web_search_call.results'],
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'o3-mini',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          include: ['web_search_call.results'],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send textVerbosity provider option', async () => {
         const { warnings } = await createModel('gpt-5').doGenerate({
           prompt: TEST_PROMPT,


### PR DESCRIPTION
## Summary
- allow `web_search_call.results` in OpenAI Responses `include` provider options
- extend the OpenAI responses include type/schema so the option passes validation
- add a request-body test covering the new include value

## Why
`vercel/ai#16346` reports that OpenAI supports `web_search_call.results` as a valid include value, but the SDK currently rejects it because the option is missing from the local type/schema allowlist.

## Testing
- `git diff --check`
- could not run `pnpm test:node` in this checkout because local dependencies are not installed (`vitest: command not found`; `node_modules missing`)

Closes #16346
