### PR TITLE
feat(elevenlabs): add scribe_v2 model id

### DIFF
--- a/.changeset/gentle-waves-hammer.md
+++ b/.changeset/gentle-waves-hammer.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/elevenlabs": patch
+---
+
+feat(elevenlabs): add scribe_v2 model id

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -17,7 +17,7 @@ import { VERSION } from './version';
 
 export interface ElevenLabsProvider extends ProviderV4 {
   (
-    modelId: 'scribe_v1',
+    modelId: ElevenLabsTranscriptionModelId,
     settings?: {},
   ): {
     transcription: ElevenLabsTranscriptionModel;

--- a/packages/elevenlabs/src/elevenlabs-transcription-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-options.ts
@@ -1,4 +1,5 @@
 export type ElevenLabsTranscriptionModelId =
   | 'scribe_v1'
   | 'scribe_v1_experimental'
+  | 'scribe_v2'
   | (string & {});


### PR DESCRIPTION
## Background

ElevenLabs released a new model and we didn't have it typed, only the older `scribe_v1`

## Summary

Added `scribe_v2` to the typed model IDs for the `elevenlabs` provider

## Manual Verification

Checked new model id works using elevenlabs `ai-functions` example

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/13556

Closes https://github.com/vercel/ai/pull/13611
Closes https://github.com/vercel/ai/pull/15039