### PR TITLE
fix(ai): prune orphaned tool approval responses

### DIFF
--- a/.changeset/prune-messages-orphaned-approval-response.md
+++ b/.changeset/prune-messages-orphaned-approval-response.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): prune orphaned tool-approval responses in `pruneMessages`
+
+When pruning a specific tool by name (`toolCalls: [{ type, tools: [...] }]`), `pruneMessages` left the tool's `tool-approval-response` in place while removing its `tool-approval-request` and `tool-call`. The tool name of an approval response was resolved per-message, but approval responses live in a separate `tool` message from their approval request, so the name could never be resolved and the response was always kept. Tool name resolution is now done across all messages, so approval requests and responses are pruned together.

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { pruneMessages } from './prune-messages';
+import { convertToModelMessages } from '../ui/convert-to-model-messages';
 import type { ModelMessage } from '@ai-sdk/provider-utils';
 
 const messagesFixture1: ModelMessage[] = [
@@ -718,73 +719,54 @@ describe('pruneMessages', () => {
     });
 
     describe('selective tool pruning with approvals (regression)', () => {
-      // Regression: a `tool-approval-response` lives in a separate `tool`
-      // message from its `tool-approval-request`. When pruning a specific tool
-      // by name, the response must be pruned together with its request and
-      // tool-call instead of being left orphaned.
-      it('should prune the approval response together with its request and tool-call', () => {
-        const messages: ModelMessage[] = [
-          {
-            role: 'user',
-            content: [{ type: 'text', text: 'Weather in Tokyo and Busan?' }],
-          },
-          {
-            role: 'assistant',
-            content: [
+      it('should prune the approval response together with its request and tool-call', async () => {
+        const messages = JSON.parse(
+          JSON.stringify(
+            await convertToModelMessages([
               {
-                type: 'tool-call',
-                toolCallId: 'call-1',
-                toolName: 'get-weather-tool-1',
-                input: '{"city": "Tokyo"}',
+                role: 'user',
+                parts: [
+                  {
+                    type: 'text',
+                    text: 'Weather in Tokyo and Busan?',
+                  },
+                ],
               },
               {
-                type: 'tool-call',
-                toolCallId: 'call-2',
-                toolName: 'get-weather-tool-2',
-                input: '{"city": "Busan"}',
+                role: 'assistant',
+                parts: [
+                  {
+                    type: 'step-start',
+                  },
+                  {
+                    type: 'tool-get-weather-tool-1',
+                    toolCallId: 'call-1',
+                    state: 'output-available',
+                    input: { city: 'Tokyo' },
+                    output: 'sunny',
+                  },
+                  {
+                    type: 'tool-get-weather-tool-2',
+                    toolCallId: 'call-2',
+                    state: 'output-available',
+                    input: { city: 'Busan' },
+                    output: 'rainy',
+                    approval: {
+                      id: 'approval-1',
+                      approved: true,
+                    },
+                  },
+                ],
               },
-              {
-                type: 'tool-approval-request',
-                toolCallId: 'call-2',
-                approvalId: 'approval-1',
-              },
-            ],
-          },
-          {
-            role: 'tool',
-            content: [
-              {
-                type: 'tool-approval-response',
-                approvalId: 'approval-1',
-                approved: true,
-              },
-              {
-                type: 'tool-result',
-                toolCallId: 'call-1',
-                toolName: 'get-weather-tool-1',
-                output: { type: 'text', value: 'sunny' },
-              },
-              {
-                type: 'tool-result',
-                toolCallId: 'call-2',
-                toolName: 'get-weather-tool-2',
-                output: { type: 'text', value: 'rainy' },
-              },
-            ],
-          },
-          {
-            role: 'assistant',
-            content: [{ type: 'text', text: 'done' }],
-          },
-        ];
+            ]),
+          ),
+        ) as ModelMessage[];
 
         const result = pruneMessages({
           messages,
           toolCalls: [{ type: 'all', tools: ['get-weather-tool-2'] }],
         });
 
-        // The approval response for the pruned tool must not survive as an
-        // orphan; only get-weather-tool-1 parts remain.
         expect(result).toMatchInlineSnapshot(`
           [
             {
@@ -799,7 +781,9 @@ describe('pruneMessages', () => {
             {
               "content": [
                 {
-                  "input": "{"city": "Tokyo"}",
+                  "input": {
+                    "city": "Tokyo",
+                  },
                   "toolCallId": "call-1",
                   "toolName": "get-weather-tool-1",
                   "type": "tool-call",
@@ -821,15 +805,6 @@ describe('pruneMessages', () => {
               ],
               "role": "tool",
             },
-            {
-              "content": [
-                {
-                  "text": "done",
-                  "type": "text",
-                },
-              ],
-              "role": "assistant",
-            },
           ]
         `);
 
@@ -849,6 +824,90 @@ describe('pruneMessages', () => {
         for (const id of responseIds) {
           expect(approvalIds).toContain(id);
         }
+      });
+
+      it('should drop unresolved approval responses during selective pruning', () => {
+        const messages: ModelMessage[] = [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Weather in Tokyo and Busan?' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'get-weather-tool-1',
+                input: { city: 'Tokyo' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'unknown-approval',
+                approved: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'get-weather-tool-1',
+                output: { type: 'text', value: 'sunny' },
+              },
+            ],
+          },
+        ];
+
+        const result = pruneMessages({
+          messages,
+          toolCalls: [{ type: 'all', tools: ['get-weather-tool-2'] }],
+        });
+
+        // The unresolved approval response must not survive as authority
+        // context; only get-weather-tool-1 parts remain.
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "Weather in Tokyo and Busan?",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "city": "Tokyo",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-call",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "sunny",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+          ]
+        `);
       });
     });
   });

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -716,5 +716,140 @@ describe('pruneMessages', () => {
         `);
       });
     });
+
+    describe('selective tool pruning with approvals (regression)', () => {
+      // Regression: a `tool-approval-response` lives in a separate `tool`
+      // message from its `tool-approval-request`. When pruning a specific tool
+      // by name, the response must be pruned together with its request and
+      // tool-call instead of being left orphaned.
+      it('should prune the approval response together with its request and tool-call', () => {
+        const messages: ModelMessage[] = [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Weather in Tokyo and Busan?' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'get-weather-tool-1',
+                input: '{"city": "Tokyo"}',
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-2',
+                toolName: 'get-weather-tool-2',
+                input: '{"city": "Busan"}',
+              },
+              {
+                type: 'tool-approval-request',
+                toolCallId: 'call-2',
+                approvalId: 'approval-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-1',
+                approved: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'get-weather-tool-1',
+                output: { type: 'text', value: 'sunny' },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call-2',
+                toolName: 'get-weather-tool-2',
+                output: { type: 'text', value: 'rainy' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'done' }],
+          },
+        ];
+
+        const result = pruneMessages({
+          messages,
+          toolCalls: [{ type: 'all', tools: ['get-weather-tool-2'] }],
+        });
+
+        // The approval response for the pruned tool must not survive as an
+        // orphan; only get-weather-tool-1 parts remain.
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "Weather in Tokyo and Busan?",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "content": [
+                {
+                  "input": "{"city": "Tokyo"}",
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-call",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "sunny",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+            {
+              "content": [
+                {
+                  "text": "done",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ]
+        `);
+
+        // No orphaned approval responses remain in the pruned output.
+        const approvalIds = new Set<string>();
+        const responseIds = new Set<string>();
+        for (const message of result) {
+          if (typeof message.content === 'string') continue;
+          for (const part of message.content) {
+            if (part.type === 'tool-approval-request') {
+              approvalIds.add(part.approvalId);
+            } else if (part.type === 'tool-approval-response') {
+              responseIds.add(part.approvalId);
+            }
+          }
+        }
+        for (const id of responseIds) {
+          expect(approvalIds).toContain(id);
+        }
+      });
+    });
   });
 });

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -107,7 +107,7 @@ export function pruneMessages({
     // by looking across messages. Resolving names per-message left responses
     // unresolved, which caused them to be kept while their request was pruned,
     // producing orphaned approval responses.
-    const toolCallIdToToolName: Record<string, string> = {};
+    const toolCallIdToToolName = new Map<string, string>();
     for (const message of messages) {
       if (
         (message.role === 'assistant' || message.role === 'tool') &&
@@ -115,13 +115,13 @@ export function pruneMessages({
       ) {
         for (const part of message.content) {
           if (part.type === 'tool-call' || part.type === 'tool-result') {
-            toolCallIdToToolName[part.toolCallId] = part.toolName;
+            toolCallIdToToolName.set(part.toolCallId, part.toolName);
           }
         }
       }
     }
 
-    const approvalIdToToolName: Record<string, string> = {};
+    const approvalIdToToolName = new Map<string, string>();
     for (const message of messages) {
       if (
         (message.role === 'assistant' || message.role === 'tool') &&
@@ -129,8 +129,10 @@ export function pruneMessages({
       ) {
         for (const part of message.content) {
           if (part.type === 'tool-approval-request') {
-            approvalIdToToolName[part.approvalId] =
-              toolCallIdToToolName[part.toolCallId];
+            const toolName = toolCallIdToToolName.get(part.toolCallId);
+            if (toolName != null) {
+              approvalIdToToolName.set(part.approvalId, toolName);
+            }
           }
         }
       }
@@ -171,13 +173,15 @@ export function pruneMessages({
           }
 
           // keep parts that are not associated with a tool that should be removed:
+          const partToolName =
+            part.type === 'tool-call' || part.type === 'tool-result'
+              ? part.toolName
+              : approvalIdToToolName.get(part.approvalId);
+
           return (
             toolCall.tools != null &&
-            !toolCall.tools.includes(
-              part.type === 'tool-call' || part.type === 'tool-result'
-                ? part.toolName
-                : approvalIdToToolName[part.approvalId],
-            )
+            partToolName != null &&
+            !toolCall.tools.includes(partToolName)
           );
         }),
       } as AssistantModelMessage | ToolModelMessage;

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -100,6 +100,42 @@ export function pruneMessages({
       }
     }
 
+    // Build global maps from tool call id and approval id to tool name.
+    // These must be global (not per-message) because a `tool-approval-response`
+    // lives in a separate `tool` message from its `tool-approval-request`
+    // (assistant message), so the tool name of a response can only be resolved
+    // by looking across messages. Resolving names per-message left responses
+    // unresolved, which caused them to be kept while their request was pruned,
+    // producing orphaned approval responses.
+    const toolCallIdToToolName: Record<string, string> = {};
+    for (const message of messages) {
+      if (
+        (message.role === 'assistant' || message.role === 'tool') &&
+        typeof message.content !== 'string'
+      ) {
+        for (const part of message.content) {
+          if (part.type === 'tool-call' || part.type === 'tool-result') {
+            toolCallIdToToolName[part.toolCallId] = part.toolName;
+          }
+        }
+      }
+    }
+
+    const approvalIdToToolName: Record<string, string> = {};
+    for (const message of messages) {
+      if (
+        (message.role === 'assistant' || message.role === 'tool') &&
+        typeof message.content !== 'string'
+      ) {
+        for (const part of message.content) {
+          if (part.type === 'tool-approval-request') {
+            approvalIdToToolName[part.approvalId] =
+              toolCallIdToToolName[part.toolCallId];
+          }
+        }
+      }
+    }
+
     messages = messages.map((message, messageIndex) => {
       if (
         (message.role !== 'assistant' && message.role !== 'tool') ||
@@ -109,9 +145,6 @@ export function pruneMessages({
       ) {
         return message;
       }
-
-      const toolCallIdToToolName: Record<string, string> = {};
-      const approvalIdToToolName: Record<string, string> = {};
 
       return {
         ...message,
@@ -124,14 +157,6 @@ export function pruneMessages({
             part.type !== 'tool-approval-response'
           ) {
             return true;
-          }
-
-          // track tool calls and approvals:
-          if (part.type === 'tool-call') {
-            toolCallIdToToolName[part.toolCallId] = part.toolName;
-          } else if (part.type === 'tool-approval-request') {
-            approvalIdToToolName[part.approvalId] =
-              toolCallIdToToolName[part.toolCallId];
           }
 
           // keep parts that are associated with a tool call or approval that needs to be kept:


### PR DESCRIPTION
## Background

`pruneMessages` should prune a tool call, its result, and its approval lifecycle as one consistent unit. PR #16386 identified that selective pruning by tool name could remove the selected tool's call/request/result while leaving its matching `tool-approval-response` behind, because approval responses only carry `approvalId` and the existing lookup was scoped per message.

This PR starts from #16386's fix and preserves Seid's authorship on the base commit. The follow-up commit is co-authored with Seid.

## Summary

- Replays #16386 as a signed, Seid-authored base commit so it can pass this repository's signed-commit branch rules.
- Resolves `toolCallId -> toolName` and `approvalId -> toolName` across the full message list before filtering, so approval responses in later tool messages can be pruned with their originating tool calls.
- Makes unresolved approval ownership explicit: if an approval request/response cannot resolve to a tool name during selective pruning, it is dropped instead of being preserved as orphan authority context.
- Updates the regression fixture to build the approval lifecycle through `convertToModelMessages`, matching the UI approval state path that produces real `ModelMessage` histories.

## Manual Verification

- Reproduced #16385 against `origin/main`: selective pruning removed `get-weather-tool-2` call/request/result while leaving `tool-approval-response(approval-1)` in the tool message.
- Confirmed the regression fixture shape is valid and realistic:
  - `tool-approval-request` is valid assistant message content.
  - `tool-approval-response` is valid tool message content.
  - `convertToModelMessages` produces that assistant/tool split from an assistant UI message with an approved tool part.
- Confirmed the updated regression fixture is generated through `convertToModelMessages`, with structured tool inputs and outputs, rather than a made-up hand-written transcript.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16385
Supersedes and closes #16386
