### PR TITLE
feat(mcp): allow MCP client to use server completions

### DIFF
--- a/.changeset/tidy-oranges-watch.md
+++ b/.changeset/tidy-oranges-watch.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): allow MCP client to use server completions

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -360,6 +360,52 @@ Resource templates are dynamic URI patterns that allow flexible queries. List al
 const templates = await mcpClient.listResourceTemplates();
 ```
 
+## Using MCP Completions
+
+MCP servers can provide autocompletion suggestions for prompt arguments and
+resource template variables when they advertise the `completions` capability.
+Use `complete` to ask the server for suggestions based on the current partial
+argument value:
+
+```typescript
+const completion = await mcpClient.complete({
+  ref: {
+    type: 'ref/resource',
+    uri: 'file:///{path}',
+  },
+  argument: {
+    name: 'path',
+    value: 'doc',
+  },
+});
+
+console.log(completion.completion.values);
+```
+
+For resource templates or prompts with multiple arguments, pass already resolved
+values through `context.arguments`:
+
+```typescript
+const completion = await mcpClient.complete({
+  ref: {
+    type: 'ref/resource',
+    uri: 'kubernetes://namespaced/{plural}/{namespace}',
+  },
+  argument: {
+    name: 'namespace',
+    value: 'auth',
+  },
+  context: {
+    arguments: {
+      plural: 'deployments',
+    },
+  },
+});
+```
+
+If the connected server does not advertise `capabilities.completions`, the
+client throws an `MCPClientError`.
+
 ## Using MCP Prompts
 
 <Note type="warning">

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -466,7 +466,7 @@ Returns a Promise that resolves to an `MCPClient` with the following properties 
             },
             {
               name: 'context',
-              type: "{ arguments: Record<string, string> }",
+              type: '{ arguments: Record<string, string> }',
               isOptional: true,
               description:
                 'Previously resolved argument values used to provide context for multi-argument prompts or resource templates.',

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -10,6 +10,7 @@ Creates a lightweight Model Context Protocol (MCP) client that connects to an MC
 - **Tools**: Automatic conversion between MCP tools and AI SDK tools
 - **Resources**: Methods to list, read, and discover resource templates from MCP servers
 - **Prompts**: Methods to list available prompts and retrieve prompt messages
+- **Completions**: Methods to request autocompletion suggestions for prompt arguments and resource template variables
 - **Elicitation**: Support for handling server requests for additional input during tool execution
 
 It currently does not support accepting notifications from an MCP server, and custom configuration of the client.
@@ -429,6 +430,47 @@ Returns a Promise that resolves to an `MCPClient` with the following properties 
         {
           type: 'options',
           parameters: [
+            {
+              name: 'options',
+              type: 'RequestOptions',
+              isOptional: true,
+              description:
+                'Optional request options including signal and timeout.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'complete',
+      type: `async (args: CompleteRequestParams & {
+        options?: RequestOptions;
+      }) => Promise<CompleteResult>`,
+      description:
+        'Requests autocompletion suggestions for a prompt argument or resource template variable. The server must advertise the completions capability.',
+      properties: [
+        {
+          type: 'args',
+          parameters: [
+            {
+              name: 'ref',
+              type: "{ type: 'ref/prompt'; name: string } | { type: 'ref/resource'; uri: string }",
+              description:
+                'Reference to the prompt or resource template being completed.',
+            },
+            {
+              name: 'argument',
+              type: '{ name: string; value: string }',
+              description:
+                'Argument name and current partial value to complete.',
+            },
+            {
+              name: 'context',
+              type: "{ arguments: Record<string, string> }",
+              isOptional: true,
+              description:
+                'Previously resolved argument values used to provide context for multi-argument prompts or resource templates.',
+            },
             {
               name: 'options',
               type: 'RequestOptions',

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -24,6 +24,8 @@ export {
 export { ElicitationRequestSchema, ElicitResultSchema } from './tool/types';
 export type {
   CallToolResult,
+  CompleteRequestParams,
+  CompleteResult,
   Configuration,
   ElicitationRequest,
   ElicitResult,

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -9,6 +9,7 @@ import {
   ElicitationRequestSchema,
   LATEST_PROTOCOL_VERSION,
   type CallToolResult,
+  type CompleteResult,
   type ListResourceTemplatesResult,
   type ListResourcesResult,
   type ReadResourceResult,
@@ -743,6 +744,101 @@ describe('MCPClient', () => {
         },
       ]
     `);
+  });
+
+  it('should request completions from the server', async () => {
+    const mockTransport = new MockMCPTransport({
+      completionResult: {
+        completion: {
+          values: ['auth', 'auth-staging'],
+          total: 2,
+          hasMore: false,
+        },
+      },
+    });
+    const sendSpy = vi.spyOn(mockTransport, 'send');
+
+    client = await createMCPClient({
+      transport: mockTransport,
+    });
+
+    const completion = await client.complete({
+      ref: {
+        type: 'ref/resource',
+        uri: 'kubernetes://namespaced/{plural}/{namespace}',
+      },
+      argument: {
+        name: 'namespace',
+        value: 'auth',
+      },
+      context: {
+        arguments: {
+          plural: 'deployments',
+        },
+      },
+    });
+
+    expectTypeOf(completion).toEqualTypeOf<CompleteResult>();
+
+    expect(completion).toMatchInlineSnapshot(`
+      {
+        "completion": {
+          "hasMore": false,
+          "total": 2,
+          "values": [
+            "auth",
+            "auth-staging",
+          ],
+        },
+      }
+    `);
+    expect(sendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'completion/complete',
+        params: {
+          ref: {
+            type: 'ref/resource',
+            uri: 'kubernetes://namespaced/{plural}/{namespace}',
+          },
+          argument: {
+            name: 'namespace',
+            value: 'auth',
+          },
+          context: {
+            arguments: {
+              plural: 'deployments',
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should throw if the server does not support completions', async () => {
+    const mockTransport = new MockMCPTransport();
+    const sendSpy = vi.spyOn(mockTransport, 'send');
+
+    client = await createMCPClient({
+      transport: mockTransport,
+    });
+
+    await expect(
+      client.complete({
+        ref: {
+          type: 'ref/prompt',
+          name: 'code_review',
+        },
+        argument: {
+          name: 'language',
+          value: 'py',
+        },
+      }),
+    ).rejects.toThrow(MCPClientError);
+    expect(sendSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'completion/complete',
+      }),
+    );
   });
 
   it('should list prompts from the server', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -634,15 +634,11 @@ class DefaultMCPClient implements MCPClient {
   }: CompleteRequestParams & {
     options?: RequestOptions;
   }): Promise<CompleteResult> {
-    try {
-      return this.request({
-        request: { method: 'completion/complete', params },
-        resultSchema: CompleteResultSchema,
-        options,
-      });
-    } catch (error) {
-      throw error;
-    }
+    return this.request({
+      request: { method: 'completion/complete', params },
+      resultSchema: CompleteResultSchema,
+      options,
+    });
   }
 
   private async notification(notification: Notification): Promise<void> {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -28,6 +28,7 @@ import {
 import { getMCPAppToolMeta, MCP_APP_MIME_TYPE } from './mcp-apps';
 import {
   CallToolResultSchema,
+  CompleteResultSchema,
   ElicitationRequestSchema,
   ElicitResultSchema,
   InitializeResultSchema,
@@ -41,6 +42,8 @@ import {
   SUPPORTED_PROTOCOL_VERSIONS,
   type CallToolResult,
   type ClientCapabilities,
+  type CompleteRequestParams,
+  type CompleteResult,
   type Configuration,
   type Configuration as ClientConfiguration,
   type ElicitationRequest,
@@ -209,6 +212,12 @@ export interface MCPClient {
     arguments?: Record<string, unknown>;
     options?: RequestOptions;
   }): Promise<GetPromptResult>;
+
+  complete(
+    args: CompleteRequestParams & {
+      options?: RequestOptions;
+    },
+  ): Promise<CompleteResult>;
 
   onElicitationRequest(
     schema: typeof ElicitationRequestSchema,
@@ -388,6 +397,13 @@ class DefaultMCPClient implements MCPClient {
   private assertCapability(method: string): void {
     switch (method) {
       case 'initialize':
+        break;
+      case 'completion/complete':
+        if (!this.serverCapabilities.completions) {
+          throw new MCPClientError({
+            message: `Server does not support completions`,
+          });
+        }
         break;
       case 'tools/list':
       case 'tools/call':
@@ -605,6 +621,23 @@ class DefaultMCPClient implements MCPClient {
       return this.request({
         request: { method: 'prompts/get', params: { name, arguments: args } },
         resultSchema: GetPromptResultSchema,
+        options,
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  private async completeInternal({
+    options,
+    ...params
+  }: CompleteRequestParams & {
+    options?: RequestOptions;
+  }): Promise<CompleteResult> {
+    try {
+      return this.request({
+        request: { method: 'completion/complete', params },
+        resultSchema: CompleteResultSchema,
         options,
       });
     } catch (error) {
@@ -830,6 +863,14 @@ class DefaultMCPClient implements MCPClient {
     options?: RequestOptions;
   }): Promise<GetPromptResult> {
     return this.getPromptInternal({ name, args, options });
+  }
+
+  complete(
+    args: CompleteRequestParams & {
+      options?: RequestOptions;
+    },
+  ): Promise<CompleteResult> {
+    return this.completeInternal(args);
   }
 
   onElicitationRequest(

--- a/packages/mcp/src/tool/mock-mcp-transport.ts
+++ b/packages/mcp/src/tool/mock-mcp-transport.ts
@@ -7,6 +7,7 @@ import {
   type MCPResource,
   type MCPPrompt,
   type CallToolResult,
+  type CompleteResult,
 } from './types';
 const DEFAULT_TOOLS: MCPTool[] = [
   {
@@ -39,6 +40,7 @@ export class MockMCPTransport implements MCPTransport {
   private initializeResult;
   private sendError;
   private toolCallResults;
+  private completionResult;
 
   onmessage?: (message: JSONRPCMessage) => void;
   onclose?: () => void;
@@ -97,6 +99,7 @@ export class MockMCPTransport implements MCPTransport {
     initializeResult,
     sendError = false,
     toolCallResults = {} as Record<string, CallToolResult>,
+    completionResult,
   }: {
     overrideTools?: MCPTool[];
     resources?: MCPResource[];
@@ -127,6 +130,7 @@ export class MockMCPTransport implements MCPTransport {
     initializeResult?: Record<string, unknown>;
     sendError?: boolean;
     toolCallResults?: Record<string, CallToolResult>;
+    completionResult?: CompleteResult;
   } = {}) {
     this.tools = overrideTools;
     this.resources = resources;
@@ -138,6 +142,7 @@ export class MockMCPTransport implements MCPTransport {
     this.initializeResult = initializeResult;
     this.sendError = sendError;
     this.toolCallResults = toolCallResults;
+    this.completionResult = completionResult;
   }
 
   async start(): Promise<void> {
@@ -167,8 +172,30 @@ export class MockMCPTransport implements MCPTransport {
               ...(this.tools.length > 0 ? { tools: {} } : {}),
               ...(this.resources.length > 0 ? { resources: {} } : {}),
               ...(this.prompts.length > 0 ? { prompts: {} } : {}),
+              ...(this.completionResult ? { completions: {} } : {}),
             },
           },
+        });
+      }
+
+      if (message.method === 'completion/complete') {
+        await delay(10);
+        if (!this.completionResult) {
+          this.onmessage?.({
+            jsonrpc: '2.0',
+            id: message.id,
+            error: {
+              code: -32601,
+              message: 'Method not supported',
+            },
+          });
+          return;
+        }
+
+        this.onmessage?.({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: this.completionResult,
         });
       }
 

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -98,6 +98,7 @@ const ElicitationCapabilitySchema = z
 const ServerCapabilitiesSchema = z.looseObject({
   experimental: z.optional(z.object({}).loose()),
   logging: z.optional(z.object({}).loose()),
+  completions: z.optional(z.object({}).loose()),
   prompts: z.optional(
     z.looseObject({
       listChanged: z.optional(z.boolean()),
@@ -295,6 +296,52 @@ export const ReadResourceResultSchema = ResultSchema.extend({
   ),
 });
 export type ReadResourceResult = z.infer<typeof ReadResourceResultSchema>;
+
+// Completions
+const PromptReferenceSchema = z
+  .object({
+    type: z.literal('ref/prompt'),
+    name: z.string(),
+  })
+  .loose();
+
+const ResourceReferenceSchema = z
+  .object({
+    type: z.literal('ref/resource'),
+    uri: z.string(),
+  })
+  .loose();
+
+const CompletionArgumentSchema = z
+  .object({
+    name: z.string(),
+    value: z.string(),
+  })
+  .loose();
+
+export const CompleteRequestParamsSchema = BaseParamsSchema.extend({
+  ref: z.union([PromptReferenceSchema, ResourceReferenceSchema]),
+  argument: CompletionArgumentSchema,
+  context: z.optional(
+    z
+      .object({
+        arguments: z.record(z.string(), z.string()),
+      })
+      .loose(),
+  ),
+});
+export type CompleteRequestParams = z.infer<typeof CompleteRequestParamsSchema>;
+
+export const CompleteResultSchema = ResultSchema.extend({
+  completion: z
+    .object({
+      values: z.array(z.string()).max(100),
+      total: z.optional(z.number().int()),
+      hasMore: z.optional(z.boolean()),
+    })
+    .loose(),
+});
+export type CompleteResult = z.infer<typeof CompleteResultSchema>;
 
 // Prompts
 const PromptArgumentSchema = z


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/16178

MCP servers can advertise the completions capability which allows for resource-template and prompt-argument autocompletion: https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion

Our mcp client didn't have support for this spec yet

## Summary

adds support for MCP completion/complete to the `@ai-sdk/mcp` client

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #16178

Co-authored-by: "Brett C. Dudo" <brett@dudo.io>