### PR TITLE
feat(openai): report Chat Completions stream mismatch

### DIFF
--- a/.changeset/openai-chat-stream-mismatch.md
+++ b/.changeset/openai-chat-stream-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Return a helpful error when the Responses stream parser receives Chat Completions chunks.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -54,6 +54,10 @@ You can use the following optional settings to customize the OpenAI provider ins
 
   Use a different URL prefix for API calls, e.g. to use proxy servers.
   The default prefix is `https://api.openai.com/v1`.
+  The default OpenAI model factory (`openai('model-id')`) uses the Responses
+  API. If your custom base URL only supports the Chat Completions API, create
+  chat models with `openai.chat('model-id')` instead, or use the
+  [OpenAI-compatible provider](/providers/openai-compatible-providers).
 
 - **apiKey** _string_
 
@@ -1721,6 +1725,8 @@ The metadata includes the following fields:
 You can create models that call the [OpenAI chat API](https://platform.openai.com/docs/api-reference/chat) using the `.chat()` factory method.
 The first argument is the model id, e.g. `gpt-4`.
 The OpenAI chat models support tool calls and some have multi-modal capabilities.
+Use this factory when a custom `baseURL` points at an OpenAI-compatible endpoint
+that implements Chat Completions but not the Responses API.
 
 ```ts
 const model = openai.chat('gpt-5');

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2187,6 +2187,32 @@ describe('doGenerate', () => {
 });
 
 describe('doStream', () => {
+  it('should stream text after Azure content filter chunks', async () => {
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{}}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n`,
+        `data: {"choices":[{"content_filter_offsets":{},"content_filter_results":{},"finish_reason":null,"index":0}],"created":0,"id":"","model":"","object":""}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    expect(events.filter(event => event.type === 'text-delta')).toStrictEqual([
+      { type: 'text-delta', id: '0', delta: '' },
+      { type: 'text-delta', id: '0', delta: 'Hello' },
+    ]);
+  });
+
   it('should stream text deltas', async () => {
     server.urls['https://api.openai.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai/src/openai-provider.test.ts
+++ b/packages/openai/src/openai-provider.test.ts
@@ -94,5 +94,57 @@ describe('createOpenAI', () => {
       const call = fetchMock.mock.calls[0]!;
       expect(call[0]).toBe('https://option.openai.example/v1/embeddings');
     });
+
+    it('uses the Responses API for the default language model', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'test error' } }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const provider = createOpenAI({
+        apiKey: 'test-api-key',
+        baseURL: 'https://proxy.openai.example/v1/',
+        fetch: fetchMock,
+      });
+
+      try {
+        await provider('gpt-4o-mini').doGenerate({
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        });
+      } catch {}
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const call = fetchMock.mock.calls[0]!;
+      expect(call[0]).toBe('https://proxy.openai.example/v1/responses');
+    });
+
+    it('uses the Chat Completions API for chat models', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'test error' } }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const provider = createOpenAI({
+        apiKey: 'test-api-key',
+        baseURL: 'https://proxy.openai.example/v1/',
+        fetch: fetchMock,
+      });
+
+      try {
+        await provider.chat('gpt-4o-mini').doGenerate({
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        });
+      } catch {}
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const call = fetchMock.mock.calls[0]!;
+      expect(call[0]).toBe('https://proxy.openai.example/v1/chat/completions');
+    });
   });
 });

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -5638,6 +5638,34 @@ describe('OpenAIResponsesLanguageModel', () => {
   });
 
   describe('doStream', () => {
+    it('should return helpful error when Chat Completions stream is received', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{}}]}\n\n`,
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await createModel('gpt-4o').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const events = await convertReadableStreamToArray(stream);
+      const error = events.find(event => event.type === 'error')?.error;
+
+      expect(error).toMatchObject({
+        name: 'AI_APICallError',
+        message:
+          'Received a Chat Completions stream while using the OpenAI Responses API. ' +
+          "The default OpenAI provider model uses the Responses API. If your custom baseURL targets a Chat Completions-compatible endpoint, use openai.chat('model-id') or createOpenAI(...).chat('model-id') instead. " +
+          'You can also use @ai-sdk/openai-compatible for OpenAI-compatible providers.',
+        responseBody:
+          '{"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{}}]}',
+      });
+    });
+
     it('should stream text deltas', async () => {
       server.urls['https://api.openai.com/v1/responses'].response = {
         type: 'stream-chunks',

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1199,8 +1199,18 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
 
             // handle failed chunk parsing / validation:
             if (!chunk.success) {
+              const error = isOpenAIChatCompletionChunk(chunk.rawValue)
+                ? createOpenAIResponsesChatCompletionsMismatchError({
+                    value: chunk.rawValue,
+                    cause: chunk.error,
+                    url,
+                    requestBodyValues: body,
+                    responseHeaders,
+                  })
+                : chunk.error;
+
               finishReason = { unified: 'error', raw: undefined };
-              controller.enqueue({ type: 'error', error: chunk.error });
+              controller.enqueue({ type: 'error', error });
               return;
             }
 
@@ -2233,6 +2243,50 @@ function isTextDeltaChunk(
   chunk: OpenAIResponsesChunk,
 ): chunk is OpenAIResponsesChunk & { type: 'response.output_text.delta' } {
   return chunk.type === 'response.output_text.delta';
+}
+
+function isOpenAIChatCompletionChunk(value: unknown): boolean {
+  const chunk = asRecord(value);
+
+  return (
+    chunk != null &&
+    Array.isArray(chunk.choices) &&
+    typeof chunk.type !== 'string'
+  );
+}
+
+function createOpenAIResponsesChatCompletionsMismatchError({
+  value,
+  cause,
+  url,
+  requestBodyValues,
+  responseHeaders,
+}: {
+  value: unknown;
+  cause: unknown;
+  url: string;
+  requestBodyValues: unknown;
+  responseHeaders?: Record<string, string>;
+}): APICallError {
+  return new APICallError({
+    message:
+      'Received a Chat Completions stream while using the OpenAI Responses API. ' +
+      "The default OpenAI provider model uses the Responses API. If your custom baseURL targets a Chat Completions-compatible endpoint, use openai.chat('model-id') or createOpenAI(...).chat('model-id') instead. " +
+      'You can also use @ai-sdk/openai-compatible for OpenAI-compatible providers.',
+    url,
+    requestBodyValues,
+    responseHeaders,
+    responseBody: JSON.stringify(value),
+    cause,
+    data: value,
+    isRetryable: false,
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value != null
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 function isResponseOutputItemDoneChunk(


### PR DESCRIPTION
## Background

Issue #16408 reports that after migrating to AI SDK v7, `streamText` with tools can execute tool calls but the final assistant text does not appear when using `createOpenAI({ baseURL })` against a custom OpenAI-compatible endpoint.

The reproduced mismatch is that `provider('gpt-4o-mini')` uses the OpenAI Responses API in v7, while the custom endpoint returns Chat Completions SSE chunks. Those chunks were previously parsed by the Responses stream parser, producing a generic validation error instead of telling the user that the wrong OpenAI API surface was selected.

Using `provider.chat('gpt-4o-mini')` against the same mocked Chat Completions chunks preserves the tool call, executes the tool, and streams the final UI text. I also checked the related #12056 Azure-style chunks (`choices: []`, empty assistant content prelude, and trailing content filter chunk); the OpenAI Chat parser already streams the text delta for that shape.

Credit to @itisvincent for #16408, @mac-110 for the raw Azure-compatible stream fixture in #12056, and @PaulyBearCoding for the related no-argument tool-call investigation in #10283. #10283 is a separate empty-tool-arguments issue and is not fixed here.

## Summary

- Detect Chat Completions stream chunks that reach the OpenAI Responses stream parser and return a targeted `APICallError` explaining the API mismatch.
- Document that `openai('model-id')` / `createOpenAI()('model-id')` uses the Responses API, including when `baseURL` is customized.
- Document that Chat Completions-only custom endpoints should use `openai.chat('model-id')` or the OpenAI-compatible provider.
- Add provider tests for custom `baseURL` routing, Azure-compatible Chat Completions stream chunks, and the new mismatch error.
- Add a patch changeset for `@ai-sdk/openai`.

## Manual Verification

Reproduced the reported setup locally with `streamText`, `createOpenAI({ baseURL, fetch })`, a tool call step, and a follow-up Chat Completions SSE text step. With `provider('gpt-4o-mini')`, the mocked Chat Completions stream is routed through the Responses parser and now reports a helpful mismatch error. Switching only the model to `provider.chat('gpt-4o-mini')` executes the tool and yields `text: "Created test."`, `finishReason: "stop"`, and a UI stream containing the final `text-delta`.

Also confirmed that the Azure/content-filter stream fixture based on #12056 is realistic and is handled by the OpenAI Chat parser. The Responses parser mismatch detection covers Azure-style `choices: []` chunks.

Automated focused test run:

```sh
pnpm --filter @ai-sdk/openai exec vitest --config vitest.node.config.js --run src/openai-provider.test.ts src/chat/openai-chat-language-model.test.ts src/responses/openai-responses-language-model.test.ts -t "baseURL configuration|should stream text after Azure content filter chunks|should return helpful error when Chat Completions stream is received"
pnpm --filter @ai-sdk/openai type-check
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The no-argument tool call behavior from #10283 should remain a separate fix path.

## Related Issues

Closes #16408.
Related to #12056 and #10283.
