### PR TITLE
feat(openai): add support for web_search_call.results include option

### DIFF
--- a/.changeset/fluffy-rules-attack.md
+++ b/.changeset/fluffy-rules-attack.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(openai): add support for web_search_call.results include option

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -43,6 +43,7 @@ export type OpenAIResponsesInputItem =
 
 export type OpenAIResponsesIncludeValue =
   | 'web_search_call.action.sources'
+  | 'web_search_call.results'
   | 'code_interpreter_call.outputs'
   | 'computer_call_output.output.image_url'
   | 'file_search_call.results'

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -156,13 +156,14 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
 
       /**
        * The set of extra fields to include in the response (advanced, usually not needed).
-       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'message.output_text.logprobs'.
+       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
        */
       include: z
         .array(
           z.enum([
             'reasoning.encrypted_content', // handled internally by default, only needed for unknown reasoning models
             'file_search_call.results',
+            'web_search_call.results',
             'message.output_text.logprobs',
           ]),
         )

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1345,6 +1345,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               include: [
                 'reasoning.encrypted_content',
                 'file_search_call.results',
+                'web_search_call.results',
               ],
             },
           },
@@ -1355,7 +1356,11 @@ describe('OpenAIResponsesLanguageModel', () => {
           input: [
             { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
           ],
-          include: ['reasoning.encrypted_content', 'file_search_call.results'],
+          include: [
+            'reasoning.encrypted_content',
+            'file_search_call.results',
+            'web_search_call.results',
+          ],
         });
 
         expect(warnings).toStrictEqual([]);


### PR DESCRIPTION
## Background

#16346 

According to the OpenAI [docs](https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response_includable%20%3E%20(schema)%20%3E%20(member)%201), the enum `web_search_call.results` is supported as an `includes` option. AI-SDK does not currently support this.

## Summary

added `web_search_call.results` to `OpenAIResponsesIncludeValue` type union

## Manual Verification

<details>
<summary>repro:</summary>

```ts
import {
  openai,
  type OpenAILanguageModelResponsesOptions,
} from '@ai-sdk/openai';
import { generateText } from 'ai';
import { print } from '../../lib/print';
import { run } from '../../lib/run';

run(async () => {
  const result = await generateText({
    model: openai.responses('gpt-5-mini'),
    prompt:
      'Search for recent images and supporting text sources about the Golden Gate Bridge at sunset.',
    tools: {
      web_search: openai.tools.webSearch({
        searchContextSize: 'medium',
      }),
    },
    providerOptions: {
      openai: {
        include: ['web_search_call.results'],
      } satisfies OpenAILanguageModelResponsesOptions,
    },
  });

  print('Response body:', result.response.body);
  print('Tool results:', result.toolResults);
  console.log(result.text);
});

```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #16346

Co-authored-by: Mia Miu <xmia665@aucklanduni.ac.nz>