### PR TITLE
fix: pass codex tool schemas by file

### DIFF
--- a/packages/harness-codex/src/bridge/host-tool-mcp.ts
+++ b/packages/harness-codex/src/bridge/host-tool-mcp.ts
@@ -4,7 +4,8 @@
 // over MCP-stdio and round-trips each call to the bridge's HTTP relay.
 //
 // Env vars (set by the bridge when starting a turn):
-//   TOOL_SCHEMAS    — JSON array of { name, description, inputSchema }
+//   TOOL_SCHEMAS_PATH — path to JSON array of { name, description, inputSchema }
+//   TOOL_SCHEMAS      — JSON array fallback for older bridge versions
 //   TOOL_RELAY_URL  — http://127.0.0.1:<port> of the bridge relay server
 // Relay authorization is issued by bridge runtime events, not an env token.
 
@@ -27,6 +28,7 @@
  */
 import * as mcpServerModule from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as mcpStdioModule from '@modelcontextprotocol/sdk/server/stdio.js';
+import { readFileSync } from 'node:fs';
 import { z } from 'zod/v4';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,12 +56,20 @@ type JsonSchemaObject = {
   nullable?: boolean;
 };
 
-const schemas: ToolSchema[] = JSON.parse(process.env.TOOL_SCHEMAS || '[]');
+function readToolSchemas(): ToolSchema[] {
+  const schemaPath = process.env.TOOL_SCHEMAS_PATH;
+  const schemasJson = schemaPath
+    ? readFileSync(schemaPath, 'utf8')
+    : process.env.TOOL_SCHEMAS || '[]';
+  return JSON.parse(schemasJson);
+}
+
+const schemas: ToolSchema[] = readToolSchemas();
 const relayUrl = process.env.TOOL_RELAY_URL || '';
 
 if (!schemas.length || !relayUrl) {
   process.stderr.write(
-    '[host-tool-mcp] Missing TOOL_SCHEMAS or TOOL_RELAY_URL; exiting\n',
+    '[host-tool-mcp] Missing TOOL_SCHEMAS_PATH/TOOL_SCHEMAS or TOOL_RELAY_URL; exiting\n',
   );
   process.exit(0);
 }

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -53,6 +53,8 @@ import { argv, env as procEnv, stdout } from 'node:process';
  */
 import * as codexSdkModule from '@openai/codex-sdk';
 
+const TOOL_SCHEMAS_FILENAME = '.ai-sdk-harness-tool-schemas.json';
+
 /*
  * Native Codex tool name → cross-harness common name. Tools outside this map
  * (e.g. MCP tools the model invokes by name) have no common equivalent; their
@@ -130,6 +132,18 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   let cliShimPath: string | undefined;
   if (start.tools && start.tools.length > 0) {
     cliShimPath = `${cliShimDir}/${CLI_SHIM_FILENAME}`;
+    const toolSchemasPath = `${workdir}/${TOOL_SCHEMAS_FILENAME}`;
+    await writeFile(
+      toolSchemasPath,
+      JSON.stringify(
+        start.tools.map(t => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      ),
+      'utf8',
+    );
     relay = await startToolRelay({
       tools: start.tools,
       emit,
@@ -140,13 +154,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       command: 'node',
       args: [`${bootstrapDir}/host-tool-mcp.mjs`],
       env: {
-        TOOL_SCHEMAS: JSON.stringify(
-          start.tools.map(t => ({
-            name: t.name,
-            description: t.description,
-            inputSchema: t.inputSchema,
-          })),
-        ),
+        TOOL_SCHEMAS_PATH: toolSchemasPath,
         TOOL_RELAY_URL: `http://127.0.0.1:${relay.port}`,
       },
     };


### PR DESCRIPTION
Summary
- Write harness-codex host tool schemas to a workspace file instead of embedding the full schema catalog in the child process environment.
- Pass TOOL_SCHEMAS_PATH to the host tool MCP bridge and keep TOOL_SCHEMAS as a backward-compatible fallback.

Tests
- pnpm --filter @ai-sdk/harness-codex type-check

Notes
- pnpm --filter @ai-sdk/harness-codex test currently fails before the changed bridge path because local workspace package resolution cannot load @ai-sdk/harness/utils / @ai-sdk/harness in this checkout.

Fixes #16379