### PR TITLE
fix(harness-pi): fix potential path traversal issues in Pi harness adapter

### DIFF
--- a/.changeset/khaki-maps-protect.md
+++ b/.changeset/khaki-maps-protect.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+fix(harness-pi): fix potential path traversal issues in Pi harness adapter

--- a/packages/harness-pi/src/pi-resume-state.test.ts
+++ b/packages/harness-pi/src/pi-resume-state.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  persistSessionFileToSandbox,
+  piResumeStateSchema,
+  pullSessionFileFromSandbox,
+  safePiSessionFileName,
+} from './pi-resume-state';
+
+type RunCalls = Array<{ command: string }>;
+type ReadCalls = string[];
+type WriteCalls = Array<{ path: string; content: Uint8Array }>;
+
+function makeSandbox(
+  input: {
+    readonly readBinary?: (path: string) => Uint8Array | undefined;
+  } = {},
+): {
+  readonly sandbox: Experimental_SandboxSession;
+  readonly run: ReturnType<typeof vi.fn>;
+  readonly readBinaryFile: ReturnType<typeof vi.fn>;
+  readonly writeBinaryFile: ReturnType<typeof vi.fn>;
+  readonly runCalls: RunCalls;
+  readonly readCalls: ReadCalls;
+  readonly writeCalls: WriteCalls;
+} {
+  const runCalls: RunCalls = [];
+  const readCalls: ReadCalls = [];
+  const writeCalls: WriteCalls = [];
+
+  const run = vi.fn(async ({ command }: { command: string }) => {
+    runCalls.push({ command });
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+  const readBinaryFile = vi.fn(async ({ path }: { path: string }) => {
+    readCalls.push(path);
+    return input.readBinary?.(path);
+  });
+  const writeBinaryFile = vi.fn(
+    async ({ path, content }: { path: string; content: Uint8Array }) => {
+      writeCalls.push({ path, content });
+    },
+  );
+
+  const sandbox = {
+    description: 'mock',
+    run,
+    readBinaryFile,
+    readFile: vi.fn(),
+    readTextFile: vi.fn(),
+    writeFile: vi.fn(),
+    writeBinaryFile,
+    writeTextFile: vi.fn(),
+    spawn: vi.fn(),
+  } as unknown as Experimental_SandboxSession;
+
+  return {
+    sandbox,
+    run,
+    readBinaryFile,
+    writeBinaryFile,
+    runCalls,
+    readCalls,
+    writeCalls,
+  };
+}
+
+let hostSessionDir: string;
+
+beforeEach(() => {
+  hostSessionDir = mkdtempSync(path.join(tmpdir(), 'pi-resume-state-'));
+});
+
+afterEach(() => {
+  rmSync(hostSessionDir, { recursive: true, force: true });
+});
+
+describe('safePiSessionFileName', () => {
+  it('accepts current and legacy Pi session file basenames', () => {
+    expect(
+      safePiSessionFileName(
+        '2026-06-26T19-14-21-123Z_01931337-1111-7222-8333-abcdefabcdef.jsonl',
+      ),
+    ).toBe(
+      '2026-06-26T19-14-21-123Z_01931337-1111-7222-8333-abcdefabcdef.jsonl',
+    );
+    expect(safePiSessionFileName('session_123.json')).toBe('session_123.json');
+  });
+
+  it('rejects traversal, separators, shell-sensitive names, and other extensions', () => {
+    const unsafeNames = [
+      '../session.jsonl',
+      '..',
+      '.',
+      '/tmp/session.jsonl',
+      'nested/session.jsonl',
+      'nested\\session.jsonl',
+      'session name.jsonl',
+      'session;touch.jsonl',
+      'session$(touch).jsonl',
+      'session.txt',
+      '.session.jsonl',
+    ];
+
+    for (const sessionFileName of unsafeNames) {
+      expect(() => safePiSessionFileName(sessionFileName)).toThrow(
+        'Invalid Pi session file name',
+      );
+    }
+  });
+});
+
+describe('piResumeStateSchema', () => {
+  it('accepts safe session files and preserves unknown fields', () => {
+    expect(
+      piResumeStateSchema.parse({
+        sessionFileName: 'session.jsonl',
+        other: true,
+      }),
+    ).toEqual({
+      sessionFileName: 'session.jsonl',
+      other: true,
+    });
+  });
+
+  it('rejects unsafe session files', () => {
+    expect(
+      piResumeStateSchema.safeParse({
+        sessionFileName: '../session.jsonl',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('pullSessionFileFromSandbox', () => {
+  it('copies a safe sandbox session file into the host session directory', async () => {
+    const bytes = new TextEncoder().encode('session data');
+    const sandbox = makeSandbox({
+      readBinary: requestedPath =>
+        requestedPath === '/sandbox/work/.pi-sessions/session.jsonl'
+          ? bytes
+          : undefined,
+    });
+
+    const hostPath = await pullSessionFileFromSandbox({
+      sandbox: sandbox.sandbox,
+      sessionWorkDir: '/sandbox/work',
+      hostSessionDir,
+      sessionFileName: 'session.jsonl',
+    });
+
+    expect(hostPath).toBe(path.join(hostSessionDir, 'session.jsonl'));
+    expect(readFileSync(hostPath!, 'utf8')).toBe('session data');
+    expect(sandbox.readCalls).toEqual([
+      '/sandbox/work/.pi-sessions/session.jsonl',
+    ]);
+  });
+
+  it('rejects unsafe filenames before reading from the sandbox', async () => {
+    const sandbox = makeSandbox();
+
+    await expect(
+      pullSessionFileFromSandbox({
+        sandbox: sandbox.sandbox,
+        sessionWorkDir: '/sandbox/work',
+        hostSessionDir,
+        sessionFileName: '../session.jsonl',
+      }),
+    ).rejects.toThrow('Invalid Pi session file name');
+
+    expect(sandbox.readBinaryFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('persistSessionFileToSandbox', () => {
+  it('copies a safe host session file into the sandbox session directory', async () => {
+    const sandbox = makeSandbox();
+    writeFileSync(path.join(hostSessionDir, 'session.jsonl'), 'session data');
+
+    await persistSessionFileToSandbox({
+      sandbox: sandbox.sandbox,
+      sessionWorkDir: '/sandbox/work',
+      hostSessionDir,
+      sessionFileName: 'session.jsonl',
+    });
+
+    expect(sandbox.runCalls).toEqual([
+      { command: "mkdir -p '/sandbox/work/.pi-sessions'" },
+    ]);
+    expect(sandbox.writeCalls[0]?.path).toBe(
+      '/sandbox/work/.pi-sessions/session.jsonl',
+    );
+    expect(Buffer.from(sandbox.writeCalls[0]!.content).toString('utf8')).toBe(
+      'session data',
+    );
+  });
+
+  it('rejects unsafe filenames before writing to the sandbox', async () => {
+    const sandbox = makeSandbox();
+
+    await expect(
+      persistSessionFileToSandbox({
+        sandbox: sandbox.sandbox,
+        sessionWorkDir: '/sandbox/work',
+        hostSessionDir,
+        sessionFileName: '../session.jsonl',
+      }),
+    ).rejects.toThrow('Invalid Pi session file name');
+
+    expect(sandbox.run).not.toHaveBeenCalled();
+    expect(sandbox.writeBinaryFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/harness-pi/src/pi-resume-state.ts
+++ b/packages/harness-pi/src/pi-resume-state.ts
@@ -2,6 +2,23 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { shellQuote } from './pi-utils';
+
+const PI_SESSION_FILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*\.jsonl?$/;
+
+export function safePiSessionFileName(sessionFileName: string): string {
+  if (!PI_SESSION_FILE_NAME_PATTERN.test(sessionFileName)) {
+    throw new Error(`Invalid Pi session file name: ${sessionFileName}`);
+  }
+  return sessionFileName;
+}
+
+const piSessionFileNameSchema = z
+  .string()
+  .refine(
+    sessionFileName => PI_SESSION_FILE_NAME_PATTERN.test(sessionFileName),
+    'Pi sessionFileName must be a safe .jsonl or .json basename.',
+  );
 
 /**
  * Schema for the adapter-specific portion of lifecycle state `data` produced
@@ -11,12 +28,52 @@ import { z } from 'zod/v4';
  * they survive cross-process resume via the sandbox snapshot.
  */
 export const piResumeStateSchema = z.looseObject({
-  sessionFileName: z.string().optional(),
+  sessionFileName: piSessionFileNameSchema.optional(),
 });
 
 export type PiResumeStateData = z.infer<typeof piResumeStateSchema>;
 
 const PI_SESSIONS_DIR = '.pi-sessions';
+
+function resolveContainedHostPath(input: {
+  readonly baseDir: string;
+  readonly sessionFileName: string;
+}): string {
+  const baseDir = path.resolve(input.baseDir);
+  const filePath = path.resolve(
+    baseDir,
+    safePiSessionFileName(input.sessionFileName),
+  );
+  const relativePath = path.relative(baseDir, filePath);
+  if (
+    relativePath === '' ||
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Invalid Pi session file name: ${input.sessionFileName}`);
+  }
+  return filePath;
+}
+
+function resolveContainedSandboxPath(input: {
+  readonly sessionWorkDir: string;
+  readonly sessionFileName: string;
+}): string {
+  const sessionDir = path.posix.resolve(input.sessionWorkDir, PI_SESSIONS_DIR);
+  const filePath = path.posix.resolve(
+    sessionDir,
+    safePiSessionFileName(input.sessionFileName),
+  );
+  const relativePath = path.posix.relative(sessionDir, filePath);
+  if (
+    relativePath === '' ||
+    relativePath.startsWith('..') ||
+    path.posix.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Invalid Pi session file name: ${input.sessionFileName}`);
+  }
+  return filePath;
+}
 
 /**
  * Copy the Pi session file from the host's local mirror to a stable location
@@ -30,16 +87,18 @@ export async function persistSessionFileToSandbox(args: {
   readonly sessionFileName: string;
   readonly abortSignal?: AbortSignal;
 }): Promise<void> {
-  const hostPath = path.join(args.hostSessionDir, args.sessionFileName);
+  const hostPath = resolveContainedHostPath({
+    baseDir: args.hostSessionDir,
+    sessionFileName: args.sessionFileName,
+  });
   const content = await readFile(hostPath);
-  const remotePath = path.posix.join(
-    args.sessionWorkDir,
-    PI_SESSIONS_DIR,
-    args.sessionFileName,
-  );
+  const remotePath = resolveContainedSandboxPath({
+    sessionWorkDir: args.sessionWorkDir,
+    sessionFileName: args.sessionFileName,
+  });
   // Ensure the parent dir exists in the sandbox before writing.
   await args.sandbox.run({
-    command: `mkdir -p ${path.posix.dirname(remotePath)}`,
+    command: `mkdir -p ${shellQuote(path.posix.dirname(remotePath))}`,
     ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
   });
   await args.sandbox.writeBinaryFile({
@@ -62,18 +121,20 @@ export async function pullSessionFileFromSandbox(args: {
   readonly sessionFileName: string;
   readonly abortSignal?: AbortSignal;
 }): Promise<string | undefined> {
-  const remotePath = path.posix.join(
-    args.sessionWorkDir,
-    PI_SESSIONS_DIR,
-    args.sessionFileName,
-  );
+  const remotePath = resolveContainedSandboxPath({
+    sessionWorkDir: args.sessionWorkDir,
+    sessionFileName: args.sessionFileName,
+  });
   const bytes = await args.sandbox.readBinaryFile({
     path: remotePath,
     ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
   });
   if (!bytes) return undefined;
   await mkdir(args.hostSessionDir, { recursive: true });
-  const hostPath = path.join(args.hostSessionDir, args.sessionFileName);
+  const hostPath = resolveContainedHostPath({
+    baseDir: args.hostSessionDir,
+    sessionFileName: args.sessionFileName,
+  });
   await writeFile(hostPath, bytes);
   return hostPath;
 }

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -62,6 +62,24 @@ describe('createPiSession', () => {
     });
   });
 
+  it('rejects unsafe resume session filenames before sandbox restore', async () => {
+    const sandboxSession = createSandboxSession();
+
+    await expect(
+      createPiSession({
+        sessionId: 'session-unsafe',
+        sandboxSession,
+        sessionWorkDir: '/sandbox/work',
+        skills: [],
+        settings: {},
+        isResume: true,
+        resumeSessionFileName: '../session.jsonl',
+      }),
+    ).rejects.toThrow('Invalid Pi session file name');
+
+    expect(sandboxSession.readBinaryFile).not.toHaveBeenCalled();
+  });
+
   it('parks a pending tool turn on suspend and resumes it in-process', async () => {
     const toolStarted = createDeferred<void>();
     let resolvedToolResult: unknown;

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -38,6 +38,7 @@ import { writePiSkills } from './pi-skills';
 import {
   persistSessionFileToSandbox,
   pullSessionFileFromSandbox,
+  safePiSessionFileName,
 } from './pi-resume-state';
 import {
   createPiTranslatorState,
@@ -268,11 +269,14 @@ export async function createPiSession(
   // host mirror so SessionManager.open can read it.
   let resumeSessionFilePath: string | undefined;
   if (input.isResume && input.resumeSessionFileName) {
+    const resumeSessionFileName = safePiSessionFileName(
+      input.resumeSessionFileName,
+    );
     resumeSessionFilePath = await pullSessionFileFromSandbox({
       sandbox,
       sessionWorkDir: input.sessionWorkDir,
       hostSessionDir,
-      sessionFileName: input.resumeSessionFileName,
+      sessionFileName: resumeSessionFileName,
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });
   }
@@ -569,7 +573,7 @@ export async function createPiSession(
     // round-trip it without guessing the extension.
     const candidatePath = sessionManager.getSessionFile();
     if (candidatePath) {
-      sessionFileName = path.basename(candidatePath);
+      sessionFileName = safePiSessionFileName(path.basename(candidatePath));
     }
 
     translatorState = createPiTranslatorState({


### PR DESCRIPTION
## Background

The Pi harness resume flow stores the Pi session file name in adapter state and uses it to restore the session file between host and sandbox storage. That file name needs to be constrained to the expected session basename before any file I/O.

## Summary

- Validate Pi session file names as safe `.jsonl` or legacy `.json` basenames when parsing resume state, restoring sessions, and recording generated session files.
- Resolve host and sandbox session file paths through containment checks before reading or writing.
- Quote the sandbox session directory creation command and add regression coverage for unsafe file names.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
