### PR TITLE
fix: pass opencode tool schemas by file

### DIFF
--- a/packages/harness-opencode/src/bridge/host-tool-mcp.ts
+++ b/packages/harness-opencode/src/bridge/host-tool-mcp.ts
@@ -6,6 +6,7 @@
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { readFileSync } from 'node:fs';
 import { z } from 'zod/v4';
 
 type ToolSchema = {
@@ -30,12 +31,12 @@ type JsonSchemaObject = {
 
 type ZodShape = Record<string, z.ZodTypeAny>;
 
-const schemas: ToolSchema[] = JSON.parse(process.env.TOOL_SCHEMAS || '[]');
+const schemas: ToolSchema[] = loadToolSchemas();
 const relayUrl = process.env.TOOL_RELAY_URL || '';
 
 if (!schemas.length || !relayUrl) {
   process.stderr.write(
-    '[host-tool-mcp] Missing TOOL_SCHEMAS or TOOL_RELAY_URL; exiting\n',
+    '[host-tool-mcp] Missing TOOL_SCHEMAS_PATH/TOOL_SCHEMAS or TOOL_RELAY_URL; exiting\n',
   );
   process.exit(0);
 }
@@ -81,6 +82,14 @@ for (const schema of schemas) {
       }
     },
   );
+}
+
+function loadToolSchemas(): ToolSchema[] {
+  const schemasPath = process.env.TOOL_SCHEMAS_PATH;
+  if (schemasPath) {
+    return JSON.parse(readFileSync(schemasPath, 'utf8')) as ToolSchema[];
+  }
+  return JSON.parse(process.env.TOOL_SCHEMAS || '[]') as ToolSchema[];
 }
 
 function toZodShape(schema: JsonSchemaObject | undefined): ZodShape {

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -4,7 +4,7 @@ import {
   type BridgeTurn,
 } from '@ai-sdk/harness/bridge';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { argv, env as procEnv } from 'node:process';
 import type { StartMessage } from '../opencode-bridge-protocol';
@@ -40,6 +40,8 @@ type Emit = (msg: Record<string, unknown>) => void;
 
 type OpenCodeClient = ReturnType<typeof createOpencodeClient>;
 type OpenCodeServer = Awaited<ReturnType<typeof createOpencodeServer>>;
+
+const TOOL_SCHEMAS_FILE = '.ai-sdk-harness-tool-schemas.json';
 
 type RuntimeState = {
   server?: OpenCodeServer;
@@ -224,19 +226,24 @@ function buildOpenCodeConfig({
   const provider = buildProviderConfig(start);
   if (provider) config.provider = provider;
   if (relayPort && start.tools && start.tools.length > 0) {
+    const toolSchemasPath = path.join(workdir, TOOL_SCHEMAS_FILE);
+    writeFileSync(
+      toolSchemasPath,
+      JSON.stringify(
+        start.tools.map(t => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      ),
+    );
     config.mcp = {
       'harness-tools': {
         type: 'local',
         enabled: true,
         command: ['node', `${bootstrapDir}/host-tool-mcp.mjs`],
         environment: {
-          TOOL_SCHEMAS: JSON.stringify(
-            start.tools.map(t => ({
-              name: t.name,
-              description: t.description,
-              inputSchema: t.inputSchema,
-            })),
-          ),
+          TOOL_SCHEMAS_PATH: toolSchemasPath,
           TOOL_RELAY_URL: `http://127.0.0.1:${relayPort}`,
         },
       },


### PR DESCRIPTION
Summary
- Write harness-opencode host tool schemas to a workspace file instead of embedding the full schema catalog in the local MCP process environment.
- Pass TOOL_SCHEMAS_PATH to the host tool MCP bridge and keep TOOL_SCHEMAS as a backward-compatible fallback.

Tests
- git diff --check
- pnpm --filter @ai-sdk/harness-opencode type-check (blocked: this checkout is missing packages/harness-opencode/node_modules/@vercel/ai-tsconfig/ts-library.json and workspace type resolution)
- pnpm --filter @ai-sdk/harness-opencode test -- opencode-harness.test.ts (blocked by the same missing tsconfig package before tests run)

Notes
- This PR addresses the E2BIG schema transport failure path from #16380. The separate permission behavior mentioned in the issue is left for a follow-up so this change stays scoped.

Fixes #16380