### PR TITLE
perf(workflow): reduce doStreamStep step-boundary payload

### DIFF
--- a/.changeset/reduce-workflow-do-stream-step-payload.md
+++ b/.changeset/reduce-workflow-do-stream-step-payload.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/workflow": patch
+---
+
+Reduce the `doStreamStep` step-boundary payload by returning minimal raw aggregates and reconstructing the `StepResult` outside the step, instead of serializing the full `StepResult` plus the per-chunk array into the durable event log.

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -2,7 +2,6 @@ import type {
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
-import type { Context } from '@ai-sdk/provider-utils';
 import {
   experimental_streamLanguageModelCall as streamModelCall,
   gateway,
@@ -11,7 +10,6 @@ import {
   type LanguageModel,
   type LanguageModelUsage,
   type ModelMessage,
-  type StepResult,
   type StopCondition,
   type ToolCallRepairFunction,
   type ToolChoice,
@@ -56,13 +54,6 @@ export interface DoStreamStepOptions {
   includeRawChunks?: boolean;
   repairToolCall?: ToolCallRepairFunction<ToolSet>;
   responseFormat?: LanguageModelV4CallOptions['responseFormat'];
-  runtimeContext?: Context;
-  toolsContext?: Record<string, Context | undefined>;
-  /**
-   * The step number for the returned StepResult. Defaults to 0 for direct
-   * callers; stream iterators pass their current index. See #15151.
-   */
-  stepNumber?: number;
 }
 
 /**
@@ -90,6 +81,23 @@ export interface StreamFinish {
   providerMetadata?: Record<string, unknown>;
 }
 
+/**
+ * Minimal aggregates needed to reconstruct a `StepResult` outside the step
+ * boundary. By returning only these fields (instead of a fully-populated
+ * StepResult plus the raw `chunks[]` array), the durable event log doesn't
+ * carry StepResult's redundant copies — `content`, the duplicate
+ * `toolCalls`/`dynamicToolCalls` lists, `reasoningText`, the always-empty
+ * `*ToolResults` arrays, and the per-chunk `chunks[]` snapshot the iterator
+ * never reads. The caller reconstructs the full StepResult via
+ * `buildStepResult`.
+ */
+export interface DoStreamStepRawResult {
+  text: string;
+  reasoning: Array<{ text: string }>;
+  responseMetadata?: { id?: string; timestamp?: Date; modelId?: string };
+  warnings?: unknown[];
+}
+
 export async function doStreamStep(
   conversationPrompt: LanguageModelV4Prompt,
   modelInit: LanguageModel,
@@ -99,8 +107,7 @@ export async function doStreamStep(
 ): Promise<{
   toolCalls: ParsedToolCall[];
   finish: StreamFinish | undefined;
-  step: StepResult<ToolSet, any>;
-  chunks?: unknown[];
+  raw: DoStreamStepRawResult;
   providerExecutedToolResults: Map<string, ProviderExecutedToolResult>;
 }> {
   'use step';
@@ -153,10 +160,9 @@ export async function doStreamStep(
   >();
   let finish: StreamFinish | undefined;
 
-  // Aggregation for StepResult
+  // Minimal aggregation — only what buildStepResult needs outside the step.
   let text = '';
   const reasoningParts: Array<{ text: string }> = [];
-  const chunks: unknown[] = [];
   let responseMetadata:
     | { id?: string; timestamp?: Date; modelId?: string }
     | undefined;
@@ -167,14 +173,6 @@ export async function doStreamStep(
 
   try {
     for await (const part of modelStream) {
-      if (
-        part.type !== 'model-call-start' &&
-        part.type !== 'model-call-end' &&
-        part.type !== 'model-call-response-metadata'
-      ) {
-        chunks.push(part);
-      }
-
       switch (part.type) {
         case 'text-delta':
           text += part.text;
@@ -251,109 +249,15 @@ export async function doStreamStep(
     writer?.releaseLock();
   }
 
-  // Build StepResult
-  const reasoningText = reasoningParts.map(r => r.text).join('') || undefined;
-
-  const step: StepResult<ToolSet, any> = {
-    callId: 'workflow-agent',
-    stepNumber: options?.stepNumber ?? 0,
-    model: {
-      provider: responseMetadata?.modelId?.split(':')[0] ?? 'unknown',
-      modelId: responseMetadata?.modelId ?? 'unknown',
-    },
-    functionId: undefined,
-    metadata: undefined,
-    runtimeContext: options?.runtimeContext ?? {},
-    toolsContext: options?.toolsContext ?? {},
-    content: [
-      ...(text ? [{ type: 'text' as const, text }] : []),
-      ...toolCalls
-        .filter(tc => !tc.invalid)
-        .map(tc => ({
-          type: 'tool-call' as const,
-          toolCallId: tc.toolCallId,
-          toolName: tc.toolName,
-          input: tc.input,
-          ...(tc.dynamic ? { dynamic: true as const } : {}),
-        })),
-    ],
-    text,
-    reasoning: reasoningParts.map(r => ({
-      type: 'reasoning' as const,
-      text: r.text,
-    })),
-    reasoningText,
-    files: [],
-    sources: [],
-    toolCalls: toolCalls
-      .filter(tc => !tc.invalid)
-      .map(tc => ({
-        type: 'tool-call' as const,
-        toolCallId: tc.toolCallId,
-        toolName: tc.toolName,
-        input: tc.input,
-        ...(tc.dynamic ? { dynamic: true as const } : {}),
-      })),
-    staticToolCalls: [],
-    dynamicToolCalls: toolCalls
-      .filter(tc => !tc.invalid && tc.dynamic)
-      .map(tc => ({
-        type: 'tool-call' as const,
-        toolCallId: tc.toolCallId,
-        toolName: tc.toolName,
-        input: tc.input,
-        dynamic: true as const,
-      })),
-    toolResults: [],
-    staticToolResults: [],
-    dynamicToolResults: [],
-    finishReason: finish?.finishReason ?? 'other',
-    rawFinishReason: finish?.rawFinishReason,
-    usage:
-      finish?.usage ??
-      ({
-        inputTokens: 0,
-        inputTokenDetails: {
-          noCacheTokens: undefined,
-          cacheReadTokens: undefined,
-          cacheWriteTokens: undefined,
-        },
-        outputTokens: 0,
-        outputTokenDetails: {
-          textTokens: undefined,
-          reasoningTokens: undefined,
-        },
-        totalTokens: 0,
-      } as LanguageModelUsage),
-    performance: {
-      effectiveOutputTokensPerSecond: 0,
-      outputTokensPerSecond: undefined,
-      inputTokensPerSecond: undefined,
-      effectiveTotalTokensPerSecond: 0,
-      stepTimeMs: 0,
-      responseTimeMs: 0,
-      toolExecutionMs: {},
-      timeToFirstOutputMs: undefined,
-    },
-    warnings,
-    request: {
-      body: '',
-      messages: [], // TODO implement step request messages
-    },
-    response: {
-      id: responseMetadata?.id ?? 'unknown',
-      timestamp: responseMetadata?.timestamp ?? new Date(),
-      modelId: responseMetadata?.modelId ?? 'unknown',
-      messages: [],
-    },
-    providerMetadata: finish?.providerMetadata ?? {},
-  } as StepResult<ToolSet, any>;
-
   return {
     toolCalls,
     finish,
-    step,
-    chunks,
+    raw: {
+      text,
+      reasoning: reasoningParts,
+      responseMetadata,
+      warnings,
+    },
     providerExecutedToolResults,
   };
 }

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -18,7 +18,10 @@ import type {
   ToolSet,
 } from 'ai';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import type { ParsedToolCall } from './do-stream-step.js';
+import type {
+  DoStreamStepRawResult,
+  ParsedToolCall,
+} from './do-stream-step.js';
 import type { StreamTextIteratorYieldValue } from './stream-text-iterator.js';
 
 // Mock doStreamStep
@@ -40,53 +43,6 @@ function createMockWritable(): WritableStream<
     write: vi.fn(),
     close: vi.fn(),
   });
-}
-
-/**
- * Helper to create a minimal step result for testing
- */
-function createMockStepResult(
-  overrides: Partial<StepResult<ToolSet, any>> = {},
-): StepResult<ToolSet, any> {
-  return {
-    content: [],
-    text: '',
-    reasoning: [],
-    reasoningText: undefined,
-    files: [],
-    sources: [],
-    toolCalls: [],
-    staticToolCalls: [],
-    dynamicToolCalls: [],
-    toolResults: [],
-    staticToolResults: [],
-    dynamicToolResults: [],
-    finishReason: 'stop',
-    usage: {
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      inputTokenDetails: {
-        noCacheTokens: undefined,
-        cacheReadTokens: undefined,
-        cacheWriteTokens: undefined,
-      },
-      outputTokenDetails: {
-        textTokens: undefined,
-        reasoningTokens: undefined,
-      },
-    },
-    warnings: [],
-    request: { body: '' },
-    response: {
-      id: 'test',
-      timestamp: new Date(),
-      modelId: 'test',
-      messages: [],
-    },
-    providerMetadata: {},
-    ...overrides,
-  } as StepResult<ToolSet, any>;
 }
 
 const mockUsage = {
@@ -119,20 +75,25 @@ function createMockDoStreamStepResult({
   toolCalls = [] as ParsedToolCall[],
   finishReason = 'stop' as 'stop' | 'tool-calls',
   finishRaw = 'stop',
-  stepOverrides = {},
+  rawOverrides = {},
 }: {
   toolCalls?: ParsedToolCall[];
   finishReason?: 'stop' | 'tool-calls';
   finishRaw?: string;
-  stepOverrides?: Partial<StepResult<ToolSet, any>>;
+  rawOverrides?: Partial<DoStreamStepRawResult>;
 } = {}) {
   return {
     toolCalls,
     finish: createMockFinish(finishReason, finishRaw),
-    step: createMockStepResult({
-      finishReason,
-      ...stepOverrides,
-    }),
+    // doStreamStep now returns minimal raw aggregates; the iterator
+    // reconstructs the StepResult via buildStepResult.
+    raw: {
+      text: '',
+      reasoning: [],
+      responseMetadata: undefined,
+      warnings: [],
+      ...rawOverrides,
+    } as DoStreamStepRawResult,
     providerExecutedToolResults: new Map(),
   };
 }
@@ -725,17 +686,13 @@ describe('streamTextIterator', () => {
   });
 
   describe('runtimeContext and toolsContext', () => {
-    it('should pass current contexts to doStreamStep and yielded steps', async () => {
+    it('applies current contexts to the reconstructed step and yield value', async () => {
       const runtimeContext = { tenantId: 'tenant_123' };
       const toolsContext = { weather: { unit: 'celsius' } };
-      const step = createMockStepResult();
 
-      vi.mocked(doStreamStep).mockResolvedValueOnce({
-        toolCalls: [],
-        finish: createMockFinish('stop'),
-        step,
-        providerExecutedToolResults: new Map(),
-      });
+      vi.mocked(doStreamStep).mockResolvedValueOnce(
+        createMockDoStreamStepResult({ finishReason: 'stop' }),
+      );
 
       const iterator = streamTextIterator({
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
@@ -747,20 +704,23 @@ describe('streamTextIterator', () => {
       });
 
       const result = await iterator.next();
+      const yielded = result.value as StreamTextIteratorYieldValue;
 
+      // Contexts are no longer serialized across the step boundary; the
+      // iterator applies them when it reconstructs the StepResult outside.
       expect(doStreamStep).toHaveBeenCalledWith(
         expect.any(Array),
         expect.any(Function),
         expect.any(WritableStream),
         expect.any(Object),
-        expect.objectContaining({
-          runtimeContext,
-          toolsContext,
-          stepNumber: 0,
-        }),
+        expect.not.objectContaining({ runtimeContext }),
       );
-      expect(result.value).toMatchObject({
-        step,
+      expect(yielded).toMatchObject({
+        runtimeContext,
+        toolsContext,
+      });
+      expect(yielded.step).toMatchObject({
+        stepNumber: 0,
         runtimeContext,
         toolsContext,
       });

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -9,6 +9,7 @@ import {
   type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   type Experimental_SandboxSession as SandboxSession,
   type LanguageModel,
+  type LanguageModelUsage,
   type ModelMessage,
   type StepResult,
   type ToolCallRepairFunction,
@@ -17,10 +18,12 @@ import {
 } from 'ai';
 import { createRestrictedTelemetryDispatcher } from 'ai/internal';
 import {
+  type DoStreamStepRawResult,
   doStreamStep,
   type ModelStopCondition,
   type ParsedToolCall,
   type ProviderExecutedToolResult,
+  type StreamFinish,
 } from './do-stream-step.js';
 import { serializeToolSet } from './serializable-schema.js';
 import type {
@@ -337,7 +340,7 @@ export async function* streamTextIterator({
         headers: currentGenerationSettings.headers,
       } as never);
 
-      const { toolCalls, finish, step, providerExecutedToolResults } =
+      const { toolCalls, finish, raw, providerExecutedToolResults } =
         await doStreamStep(
           conversationPrompt,
           currentModel,
@@ -349,11 +352,16 @@ export async function* streamTextIterator({
             includeRawChunks,
             repairToolCall,
             responseFormat,
-            runtimeContext: currentRuntimeContext,
-            toolsContext: currentToolsContext,
-            stepNumber,
           },
         );
+      // Reconstruct the full StepResult outside the step boundary so the
+      // durable event log doesn't carry StepResult's redundant copies (or the
+      // per-chunk snapshot the step used to return).
+      const step = buildStepResult(raw, toolCalls, finish, {
+        stepNumber,
+        runtimeContext: currentRuntimeContext,
+        toolsContext: currentToolsContext,
+      });
 
       await telemetryDispatcher.onLanguageModelCallEnd?.({
         callId: step.callId,
@@ -505,6 +513,108 @@ function normalizeStepForTelemetry(step: StepResult<any, any>) {
     ...step,
     model: step.model ?? { provider: 'unknown', modelId: 'unknown' },
   };
+}
+
+/**
+ * Reconstruct a full `StepResult` from the minimal aggregates returned by
+ * `doStreamStep`. Runs outside the step boundary so StepResult's redundant
+ * fields (duplicate tool-call lists, `content`, `reasoningText`, the
+ * always-empty `*ToolResults` arrays) and the per-chunk snapshot don't cross
+ * it. The shape matches what the AI SDK's `streamText` exposes to callers.
+ */
+function buildStepResult(
+  raw: DoStreamStepRawResult,
+  toolCalls: ParsedToolCall[],
+  finish: StreamFinish | undefined,
+  opts: {
+    stepNumber: number;
+    runtimeContext: Context;
+    toolsContext: Record<string, Context | undefined>;
+  },
+): StepResult<ToolSet, any> {
+  const { text, reasoning: reasoningParts, responseMetadata, warnings } = raw;
+  const reasoningText = reasoningParts.map(r => r.text).join('') || undefined;
+
+  const validToolCalls = toolCalls
+    .filter(tc => !tc.invalid)
+    .map(tc => ({
+      type: 'tool-call' as const,
+      toolCallId: tc.toolCallId,
+      toolName: tc.toolName,
+      input: tc.input,
+      ...(tc.dynamic ? { dynamic: true as const } : {}),
+    }));
+
+  return {
+    callId: 'workflow-agent',
+    stepNumber: opts.stepNumber,
+    model: {
+      provider: responseMetadata?.modelId?.split(':')[0] ?? 'unknown',
+      modelId: responseMetadata?.modelId ?? 'unknown',
+    },
+    functionId: undefined,
+    metadata: undefined,
+    runtimeContext: opts.runtimeContext ?? {},
+    toolsContext: opts.toolsContext ?? {},
+    content: [
+      ...(text ? [{ type: 'text' as const, text }] : []),
+      ...validToolCalls,
+    ],
+    text,
+    reasoning: reasoningParts.map(r => ({
+      type: 'reasoning' as const,
+      text: r.text,
+    })),
+    reasoningText,
+    files: [],
+    sources: [],
+    toolCalls: validToolCalls,
+    staticToolCalls: [],
+    dynamicToolCalls: validToolCalls.filter(tc => tc.dynamic),
+    toolResults: [],
+    staticToolResults: [],
+    dynamicToolResults: [],
+    finishReason: finish?.finishReason ?? 'other',
+    rawFinishReason: finish?.rawFinishReason,
+    usage:
+      finish?.usage ??
+      ({
+        inputTokens: 0,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: 0,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: 0,
+      } as LanguageModelUsage),
+    performance: {
+      effectiveOutputTokensPerSecond: 0,
+      outputTokensPerSecond: undefined,
+      inputTokensPerSecond: undefined,
+      effectiveTotalTokensPerSecond: 0,
+      stepTimeMs: 0,
+      responseTimeMs: 0,
+      toolExecutionMs: {},
+      timeToFirstOutputMs: undefined,
+    },
+    warnings,
+    request: {
+      body: '',
+      messages: [], // TODO implement step request messages
+    },
+    response: {
+      id: responseMetadata?.id ?? 'unknown',
+      timestamp: responseMetadata?.timestamp ?? new Date(),
+      modelId: responseMetadata?.modelId ?? 'unknown',
+      messages: [],
+    },
+    providerMetadata: finish?.providerMetadata ?? {},
+  } as StepResult<ToolSet, any>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Port of **vercel/workflow#1932** to `@ai-sdk/workflow`.

`doStreamStep` built the full `StepResult` *inside* the step and also returned a per-chunk snapshot array. Both were serialized into the durable event log on every step. But:

- the iterator never read the chunk array (pure dead payload), and
- `StepResult` carries redundant copies of data: `content` (= `text` + tool calls), the duplicate `toolCalls`/`dynamicToolCalls` lists, `reasoningText` (= joined `reasoning`), and the always-empty `*ToolResults` arrays.

## Change

The step now returns only the minimal raw aggregates needed to rebuild the `StepResult` — `text`, `reasoning`, `responseMetadata`, `warnings` — alongside the existing `finish` and `toolCalls`. The iterator reconstructs the full `StepResult` via a new `buildStepResult` helper **outside** the step boundary.

- The user-facing `StepResult` (yielded steps, `onStepEnd`, telemetry) is byte-for-byte the same shape; only the durable event-log payload shrinks.
- `runtimeContext` / `toolsContext` / `stepNumber` no longer cross the boundary either — the iterator already holds them and applies them during reconstruction.

## Tests

- `stream-text-iterator.test.ts` mocks updated to the new `{ toolCalls, finish, raw, providerExecutedToolResults }` shape; the contexts test now asserts the contexts are applied to the reconstructed step and yield value (rather than passed across the boundary).
- The unmocked end-to-end `workflow-agent` tests exercise the real `doStreamStep` → `buildStepResult` path and pass unchanged, confirming the reconstruction is faithful.
- `pnpm --filter @ai-sdk/workflow build && test` pass (node + edge).

## Related

- Sibling PR: vercel/workflow#1932 (the `@workflow/ai` copy)
- Original issue: vercel/workflow#1929

Opened as a draft — this is an AI-assisted port. The two copies of this package have diverged (vercel/ai's `doStreamStep` is `streamModelCall`-based and built the `StepResult` inline, with no separate `chunksToStep`), so this applies the same optimization rather than cherry-picking the diff; please review the adaptation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
