### PR TITLE
feat(moonshotai): support structured outputs for kimi-2.6 and 2.7-code

### DIFF
--- a/.changeset/mighty-timers-battle.md
+++ b/.changeset/mighty-timers-battle.md
@@ -2,4 +2,4 @@
 "@ai-sdk/moonshotai": patch
 ---
 
-feat(moonshotai): support structured outputs for kimi models
+feat(moonshotai): support structured outputs for kimi-2.6 and 2.7-code

--- a/.changeset/mighty-timers-battle.md
+++ b/.changeset/mighty-timers-battle.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/moonshotai": patch
+---
+
+feat(moonshotai): support structured outputs for kimi models

--- a/packages/moonshotai/src/moonshotai-provider.test.ts
+++ b/packages/moonshotai/src/moonshotai-provider.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { createMoonshotAI } from './moonshotai-provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { MoonshotAIChatLanguageModel } from './moonshotai-chat-language-model';
+import {
+  createMoonshotAI,
+  getModelStructuredOutputSupport,
+} from './moonshotai-provider';
 
 const MoonshotAIChatLanguageModelMock =
   MoonshotAIChatLanguageModel as unknown as Mock;
@@ -164,4 +167,25 @@ describe('MoonshotAIProvider', () => {
       expect(model).toBeInstanceOf(MoonshotAIChatLanguageModel);
     });
   });
+});
+
+describe('getMoonshotAILanguageModelCapabilities', () => {
+  it.each([
+    ['kimi-k2.5', true],
+    ['kimi-k2.5-turbo', true],
+    ['kimi-k2.5-custom-suffix', true],
+    ['kimi-k2', true],
+    ['kimi-k2-thinking', true],
+    ['moonshot-v1-8k', false],
+    ['moonshot-v1-32k', false],
+    ['moonshot-v1-128k', false],
+    ['custom-model-id', false],
+  ])(
+    'supportsStructuredOutputs for %s is %s',
+    (modelId, expectedSupportsStructuredOutputs) => {
+      expect(getModelStructuredOutputSupport(modelId)).toBe(
+        expectedSupportsStructuredOutputs,
+      );
+    },
+  );
 });

--- a/packages/moonshotai/src/moonshotai-provider.test.ts
+++ b/packages/moonshotai/src/moonshotai-provider.test.ts
@@ -171,11 +171,9 @@ describe('MoonshotAIProvider', () => {
 
 describe('getMoonshotAILanguageModelCapabilities', () => {
   it.each([
-    ['kimi-k2.5', true],
-    ['kimi-k2.5-turbo', true],
-    ['kimi-k2.5-custom-suffix', true],
-    ['kimi-k2', true],
-    ['kimi-k2-thinking', true],
+    ['kimi-k2.5', false],
+    ['kimi-k2.6', true],
+    ['kimi-k2.7-code', true],
     ['moonshot-v1-8k', false],
     ['moonshot-v1-32k', false],
     ['moonshot-v1-128k', false],

--- a/packages/moonshotai/src/moonshotai-provider.ts
+++ b/packages/moonshotai/src/moonshotai-provider.ts
@@ -72,7 +72,8 @@ const defaultBaseURL = 'https://api.moonshot.ai/v1';
 export function getModelStructuredOutputSupport(
   modelId: MoonshotAIChatModelId,
 ): boolean {
-  if (modelId.startsWith('kimi-')) return true;
+  if (modelId === 'kimi-k2.5') return false;
+  if (modelId.startsWith('kimi-k')) return true;
   return false;
 }
 

--- a/packages/moonshotai/src/moonshotai-provider.ts
+++ b/packages/moonshotai/src/moonshotai-provider.ts
@@ -69,6 +69,13 @@ export interface MoonshotAIProvider extends ProviderV4 {
 
 const defaultBaseURL = 'https://api.moonshot.ai/v1';
 
+export function getModelStructuredOutputSupport(
+  modelId: MoonshotAIChatModelId,
+): boolean {
+  if (modelId.startsWith('kimi-')) return true;
+  return false;
+}
+
 export function createMoonshotAI(
   options: MoonshotAIProviderSettings = {},
 ): MoonshotAIProvider {
@@ -105,6 +112,7 @@ export function createMoonshotAI(
       ...getCommonModelConfig('chat'),
       includeUsage: true,
       errorStructure: moonshotaiErrorStructure,
+      supportsStructuredOutputs: getModelStructuredOutputSupport(modelId),
       transformRequestBody: (args: Record<string, any>) => {
         const thinking = args.thinking as
           | { type?: string; budgetTokens?: number }


### PR DESCRIPTION
## Background

Some Kimi models support structured outputs, but it wasn't enabled in AI SDK

## Summary

Added support for structured outputs for `kimi-k2.6` and `kimi-k2.7-code`

## Manual Verification

```ts
  const result = await generateText({
    model: moonshotai('kimi-k2.6'),
    prompt: 'Invent a new holiday and describe its traditions.',
    output: Output.object({
      schema: z.object({
        holiday: z.string(),
        traditions: z.array(z.string()),
      }),
    }),
  });
```

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Remove [obsolete models](https://platform.kimi.ai/docs/models#deprecated-models) from types.

## Related Issues

Fixes https://github.com/vercel/ai/issues/12871

Closes https://github.com/vercel/ai/pull/12872