### PR TITLE
fix(examples): use default gateway instance in search tool examples

### DIFF
--- a/examples/ai-functions/src/stream-text/gateway/tool-exa-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-exa-search-params.ts
@@ -1,13 +1,9 @@
-import { createGateway, streamText } from 'ai';
+import { gateway, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const gateway = createGateway({
-    baseURL: 'http://localhost:3000/v1/ai',
-  });
-
   const result = streamText({
-    model: gateway('openai/gpt-5-nano'),
+    model: 'openai/gpt-5-nano',
     prompt: `Search for recent AI regulation news from trusted sources.`,
     tools: {
       exa_search: gateway.tools.exaSearch({

--- a/examples/ai-functions/src/stream-text/gateway/tool-exa-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-exa-search.ts
@@ -1,13 +1,9 @@
-import { createGateway, streamText } from 'ai';
+import { gateway, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const gateway = createGateway({
-    baseURL: 'http://localhost:3000/v1/ai',
-  });
-
   const result = streamText({
-    model: gateway('openai/gpt-5-nano'),
+    model: 'openai/gpt-5-nano',
     prompt:
       'Use the exaSearch tool to find current information about renewable energy developments in 2025. You must search the web first before answering.',
     tools: {

--- a/examples/ai-functions/src/stream-text/gateway/tool-parallel-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-parallel-search-params.ts
@@ -1,13 +1,9 @@
-import { createGateway, streamText } from 'ai';
+import { gateway, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const gateway = createGateway({
-    baseURL: 'http://localhost:3000/v1/ai',
-  });
-
   const result = streamText({
-    model: gateway('openai/gpt-5-nano'),
+    model: 'openai/gpt-5-nano',
     prompt: `Search for the latest research on quantum computing breakthroughs.`,
     tools: {
       parallel_search: gateway.tools.parallelSearch({

--- a/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search-params.ts
@@ -1,13 +1,9 @@
-import { createGateway, streamText } from 'ai';
+import { gateway, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const gateway = createGateway({
-    baseURL: 'http://localhost:3000/v1/ai',
-  });
-
   const result = streamText({
-    model: gateway('openai/gpt-5-nano'),
+    model: 'openai/gpt-5-nano',
     prompt: `Search for news about AI regulations from the first week of January 2025.`,
     tools: {
       perplexity_search: gateway.tools.perplexitySearch({


### PR DESCRIPTION
## Summary

A few recently-added gateway search-tool examples under `examples/ai-functions/src/stream-text/gateway/` were created with a local `createGateway({ baseURL: 'http://localhost:3000/v1/ai' })` instance pointed at a dev server. This was a mistake — they should use the default `gateway` instance from `'ai'` like the other gateway examples.

This PR corrects:

- `tool-exa-search.ts`
- `tool-exa-search-params.ts`
- `tool-perplexity-search-params.ts`
- `tool-parallel-search-params.ts`

Each now imports the default `gateway` instance, drops the `createGateway`/`localhost:3000` setup, and uses a plain model string (`model: 'openai/gpt-5-nano'`), matching the sibling `tool-perplexity-search.ts` / `tool-parallel-search.ts` examples. The `gateway.tools.*()` calls are unchanged.

The `timeout.ts` examples were intentionally left untouched — they use `createGateway` deliberately to wire a custom undici fetch for demonstrating timeout handling, and don't reference `localhost`.

## Notes

No changeset — these are example-only changes (examples are not published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)