### PR TITLE
fix(harness-codex): fix Codex sometimes stopping after a single text response when using `workflow-harness`

### DIFF
--- a/.changeset/brown-ghosts-kneel.md
+++ b/.changeset/brown-ghosts-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-codex": patch
+---
+
+fix(harness-codex): fix Codex sometimes stopping after a single text response when using `workflow-harness`

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -685,7 +685,10 @@ function createSession({
   const wireTurn = (turnOpts: {
     emit: (event: HarnessV1StreamPart) => void;
     abortSignal?: AbortSignal;
-  }): HarnessV1PromptControl => {
+  }): {
+    control: HarnessV1PromptControl;
+    sendStart: (send: () => void) => void;
+  } => {
     let pendingResolve: (() => void) | undefined;
     let pendingReject: ((err: unknown) => void) | undefined;
     const done = new Promise<void>((resolve, reject) => {
@@ -785,7 +788,7 @@ function createSession({
       }
     }
 
-    return {
+    const control: HarnessV1PromptControl = {
       submitToolResult: async input => {
         channel.send({
           type: 'tool-result',
@@ -807,6 +810,26 @@ function createSession({
       },
       done,
     };
+
+    return {
+      control,
+      sendStart: send => {
+        /*
+         * Codex can complete short turns without using tools. Deferring the
+         * start frame gives the harness runner one event-loop turn to finish
+         * wiring the prompt control and stream output before Codex can settle.
+         */
+        const timer = setTimeout(() => {
+          if (isSettled) return;
+          try {
+            send();
+          } catch (err) {
+            settleError(err);
+          }
+        }, 0);
+        timer.unref?.();
+      },
+    };
   };
 
   return {
@@ -814,7 +837,7 @@ function createSession({
     isResume,
     modelId: model,
     doPromptTurn: async promptOpts => {
-      const control = wireTurn({
+      const turn = wireTurn({
         emit: promptOpts.emit,
         abortSignal: promptOpts.abortSignal,
       });
@@ -842,12 +865,12 @@ function createSession({
         ...(debug ? { debug } : {}),
       };
       pendingResumeThreadId = undefined;
-      channel.send(startMessage);
+      turn.sendStart(() => channel.send(startMessage));
 
-      return control;
+      return turn.control;
     },
     doContinueTurn: async continueOpts => {
-      const control = wireTurn({
+      const turn = wireTurn({
         emit: continueOpts.emit,
         abortSignal: continueOpts.abortSignal,
       });
@@ -867,31 +890,33 @@ function createSession({
       if (rerunContinue) {
         const threadId = pendingResumeThreadId ?? latestThreadId;
         pendingResumeThreadId = undefined;
-        channel.send({
-          type: 'start' as const,
-          /*
-           * A continuation nudge rather than an empty prompt: `resumeThreadId`
-           * rehydrates the prior thread, and this is the new user turn that
-           * drives it forward. Keeping it non-empty avoids handing the runtime
-           * an empty user message (and mirrors the claude-code adapter, where an
-           * empty text block trips the Anthropic API's `cache_control` rule).
-           */
-          prompt: 'Continue.',
-          tools: (continueOpts.tools ?? []).map(t => ({
-            name: t.name,
-            description: t.description,
-            inputSchema: t.inputSchema,
-          })),
-          model,
-          reasoningEffort,
-          webSearch,
-          ...(permissionMode ? { permissionMode } : {}),
-          ...(threadId ? { resumeThreadId: threadId } : {}),
-          ...(debug ? { debug } : {}),
-        });
+        turn.sendStart(() =>
+          channel.send({
+            type: 'start' as const,
+            /*
+             * A continuation nudge rather than an empty prompt: `resumeThreadId`
+             * rehydrates the prior thread, and this is the new user turn that
+             * drives it forward. Keeping it non-empty avoids handing the runtime
+             * an empty user message (and mirrors the claude-code adapter, where an
+             * empty text block trips the Anthropic API's `cache_control` rule).
+             */
+            prompt: 'Continue.',
+            tools: (continueOpts.tools ?? []).map(t => ({
+              name: t.name,
+              description: t.description,
+              inputSchema: t.inputSchema,
+            })),
+            model,
+            reasoningEffort,
+            webSearch,
+            ...(permissionMode ? { permissionMode } : {}),
+            ...(threadId ? { resumeThreadId: threadId } : {}),
+            ...(debug ? { debug } : {}),
+          }),
+        );
       }
 
-      return control;
+      return turn.control;
     },
     doCompact: async () => {
       /*

--- a/packages/harness-codex/src/codex-instructions.test.ts
+++ b/packages/harness-codex/src/codex-instructions.test.ts
@@ -128,6 +128,17 @@ function lastStart(): Record<string, unknown> {
   return start;
 }
 
+async function waitForStart({
+  count,
+}: {
+  count: number;
+}): Promise<Record<string, unknown>> {
+  await vi.waitFor(() => {
+    expect(sentMessages.filter(m => m.type === 'start')).toHaveLength(count);
+  });
+  return lastStart();
+}
+
 describe('codex adapter — instructions gating', () => {
   beforeEach(() => {
     sentMessages.length = 0;
@@ -135,6 +146,18 @@ describe('codex adapter — instructions gating', () => {
     runCommands.length = 0;
     spawnEnvs.length = 0;
     writes.length = 0;
+  });
+
+  it('defers the start frame until after prompt control is returned', async () => {
+    const session = await startSession();
+
+    await session.doPromptTurn({
+      prompt: 'first turn',
+      emit: () => {},
+    });
+
+    expect(sentMessages.some(message => message.type === 'start')).toBe(false);
+    await waitForStart({ count: 1 });
   });
 
   it('prepends instructions on the first user message only', async () => {
@@ -145,14 +168,16 @@ describe('codex adapter — instructions gating', () => {
       instructions: 'Use turbo build --concurrency=4.',
       emit: () => {},
     });
-    expect(lastStart().instructions).toBe('Use turbo build --concurrency=4.');
+    expect((await waitForStart({ count: 1 })).instructions).toBe(
+      'Use turbo build --concurrency=4.',
+    );
 
     await session.doPromptTurn({
       prompt: 'second turn',
       instructions: 'Use turbo build --concurrency=4.',
       emit: () => {},
     });
-    expect(lastStart().instructions).toBeUndefined();
+    expect((await waitForStart({ count: 2 })).instructions).toBeUndefined();
   });
 
   it('does not apply instructions when resuming a session', async () => {
@@ -170,7 +195,7 @@ describe('codex adapter — instructions gating', () => {
       instructions: 'Use turbo build --concurrency=4.',
       emit: () => {},
     });
-    expect(lastStart().instructions).toBeUndefined();
+    expect((await waitForStart({ count: 1 })).instructions).toBeUndefined();
   });
 });
 
@@ -206,11 +231,12 @@ describe('codex adapter — attach replay mode', () => {
       prompt: 'next user turn',
       emit: () => {},
     });
-    expect(lastStart()).toMatchObject({
+    const start = await waitForStart({ count: 1 });
+    expect(start).toMatchObject({
       type: 'start',
       prompt: 'next user turn',
     });
-    expect(lastStart().resumeThreadId).toBeUndefined();
+    expect(start.resumeThreadId).toBeUndefined();
   });
 
   it('attaches a suspended turn by requesting replay from the cursor', async () => {
@@ -313,10 +339,11 @@ describe('codex adapter — skills', () => {
     ]);
     expect(spawnEnvs.at(-1)?.HOME).toBe('/home/vercel-sandbox');
     expect(spawnEnvs.at(-1)?.CODEX_HOME).toBe('/home/vercel-sandbox/.codex');
-    expect(lastStart().skills).toBeUndefined();
-    expect(JSON.stringify(lastStart())).not.toContain('Demo skill.');
-    expect(JSON.stringify(lastStart())).not.toContain('Use reference.md.');
-    expect(JSON.stringify(lastStart())).not.toContain('# Reference');
+    const start = await waitForStart({ count: 1 });
+    expect(start.skills).toBeUndefined();
+    expect(JSON.stringify(start)).not.toContain('Demo skill.');
+    expect(JSON.stringify(start)).not.toContain('Use reference.md.');
+    expect(JSON.stringify(start)).not.toContain('# Reference');
   });
 
   it('rejects unsafe skill file paths before writing files', async () => {


### PR DESCRIPTION
## Background

The Codex workflow harness could stop after a first text-only response before any tool calls were emitted. This made `workflow-harness` runs finish immediately while the same Codex prompt worked through the basic harness path.

## Summary

- Defer the Codex bridge `start` frame until after prompt control and stream output have been wired.
- Apply the same start-frame path to rerun continuations.
- Add regression coverage for the deferred start behavior and update existing start-frame assertions.

## Manual Verification

Test with the `http://localhost:3000/harness/codex/workflow` example from `examples/harness-e2e-next`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
