### PR TITLE
feat (provider-utils): detect SVG (image/svg+xml) in detectMediaType

### DIFF
--- a/.changeset/detect-svg-media-type.md
+++ b/.changeset/detect-svg-media-type.md
@@ -3,5 +3,3 @@
 ---
 
 feat (provider-utils): detect SVG (image/svg+xml) in detectMediaType
-
-`detectMediaType` is signature-based and previously had no entry for SVG, so SVG bytes returned `undefined` and callers like `generateImage` fell back to `image/png`. Add `<svg` and `<?xml` prefixes so SVG image output is detected correctly.

--- a/.changeset/detect-svg-media-type.md
+++ b/.changeset/detect-svg-media-type.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat (provider-utils): detect SVG (image/svg+xml) in detectMediaType
+
+`detectMediaType` is signature-based and previously had no entry for SVG, so SVG bytes returned `undefined` and callers like `generateImage` fell back to `image/png`. Add `<svg` and `<?xml` prefixes so SVG image output is detected correctly.

--- a/packages/provider-utils/src/detect-media-type.test.ts
+++ b/packages/provider-utils/src/detect-media-type.test.ts
@@ -51,6 +51,42 @@ describe('detectMediaType signature matching', () => {
     });
   });
 
+  describe('SVG', () => {
+    it('should detect SVG from bytes starting with <svg', () => {
+      const svgBytes = new Uint8Array(
+        new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg">'),
+      );
+      expect(
+        detectMediaType({
+          data: svgBytes,
+          topLevelType: 'image',
+        }),
+      ).toBe('image/svg+xml');
+    });
+
+    it('should detect SVG from bytes starting with an XML prolog', () => {
+      const svgBytes = new Uint8Array(
+        new TextEncoder().encode('<?xml version="1.0"?><svg></svg>'),
+      );
+      expect(
+        detectMediaType({
+          data: svgBytes,
+          topLevelType: 'image',
+        }),
+      ).toBe('image/svg+xml');
+    });
+
+    it('should detect SVG from base64', () => {
+      const svgBase64 = Buffer.from('<svg></svg>').toString('base64');
+      expect(
+        detectMediaType({
+          data: svgBase64,
+          topLevelType: 'image',
+        }),
+      ).toBe('image/svg+xml');
+    });
+  });
+
   describe('JPEG', () => {
     it('should detect JPEG from bytes', () => {
       const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xff]);

--- a/packages/provider-utils/src/detect-media-type.ts
+++ b/packages/provider-utils/src/detect-media-type.ts
@@ -54,6 +54,14 @@ const imageMediaTypeSignatures = [
       0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63,
     ],
   },
+  {
+    mediaType: 'image/svg+xml' as const,
+    bytesPrefix: [0x3c, 0x73, 0x76, 0x67], // "<svg"
+  },
+  {
+    mediaType: 'image/svg+xml' as const,
+    bytesPrefix: [0x3c, 0x3f, 0x78, 0x6d, 0x6c], // "<?xml" (SVG with XML prolog)
+  },
 ] as const;
 
 const documentMediaTypeSignatures = [


### PR DESCRIPTION
## Background

`detectMediaType` is signature-based (PNG, JPEG, WebP, GIF, BMP, TIFF, AVIF, HEIC) and has no entry for SVG. SVG is XML text with no binary magic number, so it matches nothing and `detectMediaType` returns `undefined`.

`generateImage` builds each `GeneratedFile` with:

```ts
mediaType: detectMediaType({ data: image, signatures: imageMediaTypeSignatures }) ?? 'image/png'
```

so for image models that return **SVG** (e.g. SVG generators), the output is reported as `image/png`. Consumers then build `data:image/png;base64,<svg>` URLs (which don't render) and download `.png` files containing SVG (which won't open). Today the only way to get the correct type is to sniff the bytes downstream.

## Change

Add two SVG prefixes to `imageMediaTypeSignatures`:

- `<svg` → `image/svg+xml`
- `<?xml` → `image/svg+xml` (covers SVGs that begin with an XML prolog)

This is consistent with the existing byte-prefix signature mechanism and is only consulted in image contexts (and the combined detector). With this, `generateImage` reports `image/svg+xml` for SVG outputs and consumers no longer need to special-case it.

## Tests

Added SVG cases to `detect-media-type.test.ts` (`<svg` bytes, XML-prolog bytes, base64). All 179 media-type tests pass; oxlint/oxfmt clean. Changeset included (`@ai-sdk/provider-utils` patch).