### PR TITLE
Add Fireworks service tier provider option

### DIFF
--- a/.changeset/fireworks-service-tier.md
+++ b/.changeset/fireworks-service-tier.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Add `serviceTier` provider option for Fireworks chat models.

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -142,6 +142,11 @@ The following optional provider options are available for Fireworks chat models:
   for all steps and calls in one conversation, and use different keys for
   unrelated conversations.
 
+- **serviceTier** _'priority'_
+
+  Uses the Fireworks Priority serving path for higher reliability during peak
+  traffic. The provider sends it as Fireworks' `service_tier` request field.
+
 - **thinking** _object_
 
   Configuration for thinking/reasoning models like Kimi K2.6.
@@ -243,6 +248,30 @@ const result = await agent.generate({
 
 Use non-identifying values for cache keys rather than email addresses or other
 personal information.
+
+### Priority Service Tier
+
+[Fireworks Priority tier](https://docs.fireworks.ai/serverless/serving-paths)
+prioritizes supported models above Standard traffic. Set `serviceTier` to
+`'priority'` to send Fireworks' `service_tier` request field:
+
+```ts
+import {
+  fireworks,
+  type FireworksLanguageModelOptions,
+} from '@ai-sdk/fireworks';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: fireworks('accounts/fireworks/models/glm-5p2'),
+  providerOptions: {
+    fireworks: {
+      serviceTier: 'priority',
+    } satisfies FireworksLanguageModelOptions,
+  },
+  prompt: 'Write a haiku about reliable inference.',
+});
+```
 
 ### Completion Models
 

--- a/packages/fireworks/src/fireworks-chat-options.ts
+++ b/packages/fireworks/src/fireworks-chat-options.ts
@@ -31,6 +31,11 @@ export const fireworksLanguageModelOptions = z.object({
    */
   promptCacheKey: z.string().optional(),
 
+  /**
+   * Use Fireworks Priority serving path for higher reliability during peak traffic.
+   */
+  serviceTier: z.enum(['priority']).optional(),
+
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -214,6 +214,52 @@ describe('FireworksProvider', () => {
       });
     });
 
+    it('should map serviceTier to service_tier', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const transformRequestBody = config.transformRequestBody;
+
+      const result = transformRequestBody({
+        model: 'test-model',
+        messages: [],
+        serviceTier: 'priority',
+      });
+
+      expect(result).toEqual({
+        model: 'test-model',
+        messages: [],
+        service_tier: 'priority',
+      });
+      expect(result).not.toHaveProperty('serviceTier');
+    });
+
+    it('should prefer serviceTier over raw service_tier', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const transformRequestBody = config.transformRequestBody;
+
+      const result = transformRequestBody({
+        model: 'test-model',
+        messages: [],
+        service_tier: 'standard',
+        serviceTier: 'priority',
+      });
+
+      expect(result).toEqual({
+        model: 'test-model',
+        messages: [],
+        service_tier: 'priority',
+      });
+    });
+
     it('should remap reasoning_effort xhigh to high', () => {
       const provider = createFireworks();
       provider.chatModel('test-model');

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -142,11 +142,13 @@ export function createFireworks(
           | undefined;
         const reasoningHistory = args.reasoningHistory as string | undefined;
         const promptCacheKey = args.promptCacheKey as string | undefined;
+        const serviceTier = args.serviceTier as string | undefined;
 
         const {
           thinking: _,
           reasoningHistory: __,
           promptCacheKey: ___,
+          serviceTier: ____,
           reasoning_effort,
           ...rest
         } = args;
@@ -164,6 +166,9 @@ export function createFireworks(
           }),
           ...(promptCacheKey !== undefined && {
             prompt_cache_key: promptCacheKey,
+          }),
+          ...(serviceTier !== undefined && {
+            service_tier: serviceTier,
           }),
           ...(thinking && {
             thinking: {


### PR DESCRIPTION
## Background

Fireworks supports selecting the Priority serving path by sending `service_tier: "priority"` on supported chat completion requests. The Fireworks provider already maps typed provider options like `promptCacheKey` to Fireworks request body fields, so this adds a typed SDK option for the Priority tier instead of requiring users to pass raw snake_case request fields.

## Summary

- Add `serviceTier: "priority"` to `FireworksLanguageModelOptions`.
- Map `providerOptions.fireworks.serviceTier` to Fireworks request body `service_tier`.
- Add Fireworks provider tests for the mapping and typed option precedence over raw `service_tier`.
- Document `serviceTier` in the Fireworks provider docs with a link to Fireworks serving-path docs for more information.
- Add a patch changeset for `@ai-sdk/fireworks`.

## Manual Verification

Manually matched the SDK option to Fireworks docs: https://docs.fireworks.ai/serverless/serving-paths. The docs show `service_tier: "priority"` in the request body for `accounts/fireworks/models/glm-5p2`; this PR exposes that as `serviceTier: "priority"` and maps it to the documented request field.

Automated verification:

- `pnpm --filter "@ai-sdk/provider" --filter "@ai-sdk/provider-utils" --filter "@ai-sdk/test-server" --filter "@ai-sdk/openai-compatible" --filter "@ai-sdk/fireworks" build`
- `pnpm test:node` in `packages/fireworks`
- `pnpm type-check` in `packages/fireworks`
- `pnpm check`

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A v6 backport is prepared locally in `/Users/kdawkins/Development/worktrees/ai/kevindawkins-kda-155-fireworks-service-tier-v6` and can be opened separately.

## Related Issues

KDA-155