### PR TITLE
docs: add app.nz OpenAI-compatible provider page

### DIFF
--- a/content/providers/04-openai-compatible-providers/55-app-nz.mdx
+++ b/content/providers/04-openai-compatible-providers/55-app-nz.mdx
@@ -1,0 +1,111 @@
+---
+title: app.nz
+description: Use the app.nz OpenAI compatible API with the AI SDK.
+---
+
+# app.nz Provider
+
+[app.nz](https://app.nz) is a hosted, OpenAI-compatible LLM gateway that routes requests across many model providers through a single API. You can use it with the AI SDK through the `@ai-sdk/openai-compatible` module.
+
+## Setup
+
+The app.nz provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+To use app.nz, you can create a custom provider instance with the `createOpenAICompatible` function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const appnz = createOpenAICompatible({
+  name: 'app-nz',
+  baseURL: 'https://app.nz/v1',
+  apiKey: process.env.APP_NZ_API_KEY,
+});
+```
+
+<Note>
+  You can create an API key (in the form `app_live_...`) in [app.nz](https://app.nz).
+  Make sure to set the `APP_NZ_API_KEY` environment variable with your API key.
+</Note>
+
+## Language Models
+
+You can create app.nz models using a provider instance. The first argument is the model ID.
+
+app.nz provides an auto-router that selects an appropriate underlying model for you:
+
+- `app/auto` - automatically routes to a suitable model
+- `app/auto-code` - tuned for coding tasks
+- `app/auto-reasoning` - tuned for reasoning tasks
+- `app/auto-fast` - optimized for low latency
+- `app/auto-cheap` - optimized for cost
+- `app/auto-vision` - tuned for image inputs
+
+You can also target a specific model directly using the `provider/model` format. See the [app.nz docs](https://app.nz/docs) for the full model catalog.
+
+```ts
+const model = appnz('app/auto');
+```
+
+### Example
+
+You can use app.nz language models to generate text with the `generateText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const appnz = createOpenAICompatible({
+  name: 'app-nz',
+  baseURL: 'https://app.nz/v1',
+  apiKey: process.env.APP_NZ_API_KEY,
+});
+
+const { text } = await generateText({
+  model: appnz('app/auto'),
+  prompt: 'Tell me about yourself in one sentence.',
+});
+
+console.log(text);
+```
+
+app.nz language models can also generate text in a streaming fashion with the `streamText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+
+const appnz = createOpenAICompatible({
+  name: 'app-nz',
+  baseURL: 'https://app.nz/v1',
+  apiKey: process.env.APP_NZ_API_KEY,
+});
+
+const result = streamText({
+  model: appnz('app/auto'),
+  prompt: 'Write a short haiku about hosted inference.',
+});
+
+for await (const message of result.textStream) {
+  console.log(message);
+}
+```
+
+You can use any supported `modelId` from the app.nz model catalog, including the `app/auto` auto-router variants or a specific `provider/model`.

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -16,6 +16,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [Heroku](/providers/openai-compatible-providers/heroku)
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
 - [NEAR AI Cloud](/providers/openai-compatible-providers/nearai)
+- [app.nz](/providers/openai-compatible-providers/app-nz)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
Adds documentation for app.nz, a hosted OpenAI-compatible LLM gateway, under `content/providers/04-openai-compatible-providers/`.

- New `55-app-nz.mdx` mirroring the existing NEAR AI Cloud / Heroku pages (setup, provider instance via `createOpenAICompatible`, `generateText` + `streamText` examples).
- Documents the `app/auto` auto-router and the `app/auto-code|reasoning|fast|cheap|vision` variants, plus direct `provider/model` targeting.
- Adds the bullet to the openai-compatible-providers `index.mdx` list.

Docs-only change; no changeset required per CONTRIBUTING.md.
