### PR TITLE
fix(provider/google): include usageMetadata in providerMetadata for non-streaming generate

### DIFF
--- a/.changeset/google-generate-usage-metadata.md
+++ b/.changeset/google-generate-usage-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): include usageMetadata in providerMetadata for non-streaming generate

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -625,6 +625,40 @@ describe('doGenerate', () => {
     expect(providerMetadata?.google.serviceTier).toBeNull();
   });
 
+  it('should expose usageMetadata (incl. promptTokensDetails) in provider metadata', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'test response' }], role: 'model' },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 2415,
+          candidatesTokenCount: 50,
+          totalTokenCount: 2465,
+          promptTokensDetails: [
+            { modality: 'TEXT', tokenCount: 15 },
+            { modality: 'AUDIO', tokenCount: 2400 },
+          ],
+        },
+      },
+    };
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.usageMetadata).toMatchObject({
+      promptTokensDetails: [
+        { modality: 'TEXT', tokenCount: 15 },
+        { modality: 'AUDIO', tokenCount: 2400 },
+      ],
+    });
+  });
+
   it('should extract tool calls', async () => {
     server.urls[TEST_URL_GEMINI_PRO].response = {
       type: 'json-value',

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -332,6 +332,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
           urlContextMetadata: candidate.urlContextMetadata ?? null,
           safetyRatings: candidate.safetyRatings ?? null,
           serviceTier: response.serviceTier ?? null,
+          usageMetadata: usageMetadata ?? null,
         },
       },
       request: { body },


### PR DESCRIPTION
TODO:
- [ ] Test

## Background

`doStream` attaches `usageMetadata` (including `promptTokensDetails`) to `providerMetadata.google`, and v6/v7 do so in **both** `generate` and `stream`. But on the v5 line, `doGenerate` omitted it — so non-streaming consumers got no per-modality token breakdown in `providerMetadata`.

This matters because `LanguageModelV2Usage` has no `raw` field (unlike v3/v4), so `providerMetadata.google.usageMetadata` is the only place a consumer can recover `promptTokensDetails` for a non-streaming v5 request. The result was that per-modality usage (e.g. audio vs text input tokens, which Gemini prices differently) was unavailable for `generateText` calls.

## Change

Mirror the streaming path: add `usageMetadata: usageMetadata ?? null` to `doGenerate`'s `providerMetadata.google` block. The `usageMetadata` variable is already in scope. This brings v5 `doGenerate` in line with its own `doStream` and with v6/v7.

## Testing

- New unit test asserting `doGenerate` exposes `usageMetadata` (incl. `promptTokensDetails`) in `providerMetadata`.
- Full `google-generative-ai-language-model.test.ts` passes (100 tests); no snapshot changes (existing tests assert specific `providerMetadata.google` fields rather than the whole object).