### PR TITLE
fix(ai): type agent tool call callback aliases

### DIFF
--- a/.changeset/tidy-agent-tool-callbacks.md
+++ b/.changeset/tidy-agent-tool-callbacks.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Add ToolLoopAgent types for deprecated tool call callback aliases.

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -107,9 +107,23 @@ export type AgentCallParameters<
     onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
 
     /**
+     * Callback that is called before each tool execution begins.
+     *
+     * @deprecated Use `onToolExecutionStart` instead.
+     */
+    experimental_onToolCallStart?: OnToolExecutionStartCallback<TOOLS>;
+
+    /**
      * Callback that is called after each tool execution completes.
      */
     onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
+
+    /**
+     * Callback that is called after each tool execution completes.
+     *
+     * @deprecated Use `onToolExecutionEnd` instead.
+     */
+    experimental_onToolCallFinish?: OnToolExecutionEndCallback<TOOLS>;
 
     /**
      * Callback that is called when each step (LLM call) ends, including intermediate steps.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -161,6 +161,29 @@ describe('ToolLoopAgent', () => {
         },
       });
     });
+
+    it('should support deprecated tool call callbacks', async () => {
+      const tools = {
+        calculator: tool({
+          inputSchema: z.object({ expression: z.string() }),
+          execute: async () => 'result',
+        }),
+      };
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools,
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        experimental_onToolCallStart: event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+        },
+        experimental_onToolCallFinish: event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -227,6 +250,29 @@ describe('ToolLoopAgent', () => {
         },
         onStepStart: event => {
           expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+      });
+    });
+
+    it('should support deprecated tool call callbacks', async () => {
+      const tools = {
+        calculator: tool({
+          inputSchema: z.object({ expression: z.string() }),
+          execute: async () => 'result',
+        }),
+      };
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools,
+      });
+
+      await agent.stream({
+        prompt: 'Hello, world!',
+        experimental_onToolCallStart: event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+        },
+        experimental_onToolCallFinish: event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
         },
       });
     });


### PR DESCRIPTION
Fixes #14278.

## Summary
- add deprecated ToolLoopAgent tool call callback aliases to AgentCallParameters
- cover generate() and stream() type acceptance in ToolLoopAgent type tests
- add a patch changeset for ai

## Validation
- pnpm --filter ai type-check
- pnpm exec vitest --config vitest.node.config.js --typecheck --run src/agent/tool-loop-agent.test-d.ts
- pnpm exec vitest --config vitest.node.config.js --run src/agent/tool-loop-agent.test.ts
- pnpm exec oxfmt --check packages/ai/src/agent/agent.ts packages/ai/src/agent/tool-loop-agent.test-d.ts
- pnpm exec oxlint packages/ai/src/agent/agent.ts packages/ai/src/agent/tool-loop-agent.test-d.ts
- git diff --check