### PR TITLE
fix(ai): prune matching tool approval responses

### DIFF
--- a/.changeset/fix-prune-tool-approval-response.md
+++ b/.changeset/fix-prune-tool-approval-response.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix selective tool pruning so matching tool approval responses are removed too.

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -716,5 +716,70 @@ describe('pruneMessages', () => {
         `);
       });
     });
+
+    describe('specific tool pruning', () => {
+      it('should also prune matching tool-approval-response parts', () => {
+        const result = pruneMessages({
+          messages: messagesFixture1,
+          toolCalls: [{ type: 'all', tools: ['get-weather-tool-2'] }],
+        });
+
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "Weather in Tokyo and Busan?",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "content": [
+                {
+                  "text": "I need to get the weather in Tokyo and Busan.",
+                  "type": "reasoning",
+                },
+                {
+                  "input": "{"city": "Tokyo"}",
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-call",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "sunny",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "get-weather-tool-1",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+            {
+              "content": [
+                {
+                  "text": "I have got the weather in Tokyo and Busan.",
+                  "type": "reasoning",
+                },
+                {
+                  "text": "The weather in Tokyo is sunny. I could not get the weather in Busan.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ]
+        `);
+      });
+    });
   });
 });

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -159,13 +159,18 @@ export function pruneMessages({
           }
 
           // keep parts that are not associated with a tool that should be removed:
+          if (toolCall.tools == null) {
+            return false;
+          }
+
+          const associatedToolName =
+            part.type === 'tool-call' || part.type === 'tool-result'
+              ? part.toolName
+              : approvalIdToToolName.get(part.approvalId);
+
           return (
-            toolCall.tools != null &&
-            !toolCall.tools.includes(
-              part.type === 'tool-call' || part.type === 'tool-result'
-                ? part.toolName
-                : approvalIdToToolName.get(part.approvalId),
-            )
+            associatedToolName == null ||
+            !toolCall.tools.includes(associatedToolName)
           );
         }),
       } as AssistantModelMessage | ToolModelMessage;

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -64,6 +64,30 @@ export function pruneMessages({
   }
 
   for (const toolCall of toolCalls) {
+    const toolCallIdToToolName = new Map<string, string>();
+    const approvalIdToToolName = new Map<string, string>();
+
+    for (const message of messages) {
+      if (
+        (message.role !== 'assistant' && message.role !== 'tool') ||
+        typeof message.content === 'string'
+      ) {
+        continue;
+      }
+
+      for (const part of message.content) {
+        if (part.type === 'tool-call') {
+          toolCallIdToToolName.set(part.toolCallId, part.toolName);
+        } else if (part.type === 'tool-approval-request') {
+          const toolName = toolCallIdToToolName.get(part.toolCallId);
+
+          if (toolName != null) {
+            approvalIdToToolName.set(part.approvalId, toolName);
+          }
+        }
+      }
+    }
+
     // determine how many trailing messages to keep:
     const keepLastMessagesCount =
       toolCall.type === 'all'
@@ -110,9 +134,6 @@ export function pruneMessages({
         return message;
       }
 
-      const toolCallIdToToolName: Record<string, string> = {};
-      const approvalIdToToolName: Record<string, string> = {};
-
       return {
         ...message,
         content: message.content.filter(part => {
@@ -124,14 +145,6 @@ export function pruneMessages({
             part.type !== 'tool-approval-response'
           ) {
             return true;
-          }
-
-          // track tool calls and approvals:
-          if (part.type === 'tool-call') {
-            toolCallIdToToolName[part.toolCallId] = part.toolName;
-          } else if (part.type === 'tool-approval-request') {
-            approvalIdToToolName[part.approvalId] =
-              toolCallIdToToolName[part.toolCallId];
           }
 
           // keep parts that are associated with a tool call or approval that needs to be kept:
@@ -151,7 +164,7 @@ export function pruneMessages({
             !toolCall.tools.includes(
               part.type === 'tool-call' || part.type === 'tool-result'
                 ? part.toolName
-                : approvalIdToToolName[part.approvalId],
+                : approvalIdToToolName.get(part.approvalId),
             )
           );
         }),

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -43,6 +43,7 @@ export type OpenAIResponsesInputItem =
 
 export type OpenAIResponsesIncludeValue =
   | 'web_search_call.action.sources'
+  | 'web_search_call.results'
   | 'code_interpreter_call.outputs'
   | 'computer_call_output.output.image_url'
   | 'file_search_call.results'

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -156,13 +156,14 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
 
       /**
        * The set of extra fields to include in the response (advanced, usually not needed).
-       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'message.output_text.logprobs'.
+       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
        */
       include: z
         .array(
           z.enum([
             'reasoning.encrypted_content', // handled internally by default, only needed for unknown reasoning models
             'file_search_call.results',
+            'web_search_call.results',
             'message.output_text.logprobs',
           ]),
         )

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1284,6 +1284,27 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send web_search_call.results include provider option', async () => {
+        const { warnings } = await createModel('o3-mini').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              include: ['web_search_call.results'],
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'o3-mini',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          include: ['web_search_call.results'],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send textVerbosity provider option', async () => {
         const { warnings } = await createModel('gpt-5').doGenerate({
           prompt: TEST_PROMPT,


### PR DESCRIPTION
## Summary
- build the approval-to-tool lookup across the full message history before pruning
- prune `tool-approval-response` parts together with the matching tool when selective tool pruning is used
- add a regression test for pruning `get-weather-tool-2` so the approval response does not survive as an orphan

## Why
`vercel/ai#16385` reports that selective tool pruning can leave behind `tool-approval-response` parts because the current implementation only resolves `approvalId -> toolName` inside each individual message.

Since approval requests live in an earlier assistant message while approval responses live in a later tool message, that per-message lookup misses the association and incorrectly keeps the response.

## Testing
- `git diff --check`
- could not run package tests in this checkout because local dependencies are not installed (`vitest: command not found`; `node_modules missing`)

Closes #16385
