### PR TITLE
Fix verify-changesets diff base

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -32,8 +32,17 @@ jobs:
       - name: get all changed files
         id: changed-files
         run: |
-          echo "changeset-files=$(git diff --diff-filter=dr --name-only $BASE_SHA -- '.changeset/*.md' | tr '\n' ' ')" >> $GITHUB_OUTPUT
-          echo "package-files=$(git diff --name-only $BASE_SHA -- 'packages/**' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          if git rev-parse HEAD^2 >/dev/null 2>&1; then
+            DIFF_BASE="$(git rev-parse HEAD^1)"
+          else
+            DIFF_BASE="$BASE_SHA"
+          fi
+
+          changeset_files="$(git diff --diff-filter=dr --name-only "$DIFF_BASE" HEAD -- '.changeset/*.md' | tr '\n' ' ')"
+          package_files="$(git diff --name-only "$DIFF_BASE" HEAD -- 'packages/**' | tr '\n' ' ')"
+
+          echo "changeset-files=$changeset_files" >> $GITHUB_OUTPUT
+          echo "package-files=$package_files" >> $GITHUB_OUTPUT
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
       - name: Verify changesets


### PR DESCRIPTION
## Background

The verify-changesets workflow can include unrelated package changes when the PR merge ref is based on a newer main commit than github.event.pull_request.base.sha.

## Summary

Use the checked-out merge commit's first parent as the diff base when available, with the event base SHA as a fallback.

## Manual Verification

Ran `git diff --check` and parsed the updated shell block with `bash -n`. Confirmed the failed run's merge-base diff excludes `packages/harness-deepagents` and includes only the PR's moonshot package files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16477