### PR TITLE
Backport: add `caching` provider option to `GatewayProviderOptions`

### DIFF
--- a/.changeset/gateway-caching-provider-option.md
+++ b/.changeset/gateway-caching-provider-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+feat(gateway): add `caching` provider option to `GatewayProviderOptions`

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -108,6 +108,15 @@ const gatewayProviderOptions = lazySchema(() =>
        * default.
        */
       serviceTier: z.enum(['flex', 'priority']).optional(),
+      /**
+       * Enables automatic prompt caching across providers. When set to
+       * `'auto'`, the gateway applies the appropriate caching strategy for
+       * the routed provider: it adds a `cache_control` breakpoint to static
+       * content for providers that require explicit markers (such as
+       * Anthropic), while providers with implicit caching cache
+       * automatically. Leave unset to pass requests through unmodified.
+       */
+      caching: z.literal('auto').optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

The `caching` provider option for the AI Gateway was previously untyped despite being in AI Gateway docs.

https://github.com/vercel/ai/pull/15768 added it, but only to v7

## Summary

Backported that change by updating the `gatewayProviderOptions` zod schema in v6.

## Manual Verification

This is properly typed in v6 now with intellisense working and no errors:

```typescript
  const result = streamText({
    model: 'anthropic/claude-sonnet-4.6',
    system:
      'You are a helpful assistant with access to a large knowledge base...',
    prompt: 'What is the capital of France?',
    providerOptions: {
        gateway: {
            caching: 'auto',
        } satisfies GatewayProviderOptions,
    },
  });
```

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixed https://github.com/vercel/ai/issues/14595

Closes https://github.com/vercel/ai/pull/14609
Closes https://github.com/vercel/ai/pull/14632
Closes https://github.com/vercel/ai/pull/14664
Closes https://github.com/vercel/ai/pull/14886
Closes https://github.com/vercel/ai/pull/15298
Closes https://github.com/vercel/ai/pull/15329
Closes https://github.com/vercel/ai/pull/15458
Closes https://github.com/vercel/ai/pull/15500
Closes https://github.com/vercel/ai/pull/15857
