### PR TITLE
docs: fix language model middleware spec links

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -271,15 +271,15 @@ Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-m
 <Note>
   Implementing language model middleware is advanced functionality and requires
   a solid understanding of the [language model
-  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+  specification](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts).
 </Note>
 
 You can implement any of the following three function to modify the behavior of the language model:
 
 1. `transformParams`: Transforms the parameters before they are passed to the language model, for both `doGenerate` and `doStream`.
-2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts).
    You can modify the parameters, call the language model, and modify the result.
-3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts).
    You can modify the parameters, call the language model, and modify the result.
 
 Here are some examples of how to implement language model middleware:

--- a/content/docs/07-reference/01-ai-sdk-core/65-language-model-v2-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/65-language-model-v2-middleware.mdx
@@ -28,8 +28,8 @@ See [Language Model Middleware](/docs/ai-sdk-core/middleware) for more informati
   content={[
     {
       name: 'specificationVersion',
-      type: "'v3'",
-      description: 'The specification version of the middleware. Must be "v3".',
+      type: "'v4'",
+      description: 'The specification version of the middleware. Must be "v4".',
     },
     {
       name: 'transformParams',


### PR DESCRIPTION
## Background

The language model middleware docs linked to `LanguageModelV2` on the non-existent `v5` branch, so all three source links returned 404s. The page now documents `LanguageModelV4Middleware`, and the examples on the same page already use `LanguageModelV4Middleware`, so the links should point to the current `LanguageModelV4` specification instead of only changing the branch.

## Summary

- Updated the three language model specification links in the middleware guide to point at `packages/provider/src/language-model/v4/language-model-v4.ts` on `main`.
- Updated the `LanguageModelV4Middleware` API reference table so `specificationVersion` says `'v4'`, matching the exported provider type.

## Manual Verification

- `rg -n "blob/v5|language-model/v2/language-model-v2|specificationVersion.*'v3'|Must be \"v3\"" content/docs/03-ai-sdk-core/40-middleware.mdx content/docs/07-reference/01-ai-sdk-core/65-language-model-v2-middleware.mdx`
- `curl -fsSIL https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts`
- `pnpm check`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #12617.
Closes #12635.
Closes #12985.
Closes #13164.
Closes #13846.
Closes #14475.
Closes #15923.

Co-authored-by: Shurik <shurik@openclaw.ai>
Co-authored-by: Niels Kaspers <kaspersniels@gmail.com>
Co-authored-by: Frank <97429702+tsubasakong@users.noreply.github.com>
Co-authored-by: Raashish Aggarwal <94279692+raashish1601@users.noreply.github.com>
Co-authored-by: smorchj <smorchj@users.noreply.github.com>
Co-authored-by: Narutama Aurum <narutamaaurum@gmail.com>
