### PR TITLE
docs: backport middleware spec links to v5

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -157,15 +157,15 @@ Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-m
 <Note>
   Implementing language model middleware is advanced functionality and requires
   a solid understanding of the [language model
-  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+  specification](https://github.com/vercel/ai/blob/release-v5.0/packages/provider/src/language-model/v2/language-model-v2.ts).
 </Note>
 
 You can implement any of the following three function to modify the behavior of the language model:
 
 1. `transformParams`: Transforms the parameters before they are passed to the language model, for both `doGenerate` and `doStream`.
-2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/release-v5.0/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
-3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/release-v5.0/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
 
 Here are some examples of how to implement language model middleware:


### PR DESCRIPTION
## Background

Backport of #16487 for the v5 release branch. The middleware docs on `release-v5.0` still link to `LanguageModelV2` on the non-existent `v5` branch, so all three source links return 404s. The v5 docs use `LanguageModelV2Middleware`, so this backport points those links at the v5 `LanguageModelV2` specification.

## Summary

- Updated the three language model specification links in the v5 middleware guide to point at `packages/provider/src/language-model/v2/language-model-v2.ts` on `release-v5.0`.

## Manual Verification

- `rg -n "blob/v5" content/docs/03-ai-sdk-core/40-middleware.mdx content/docs/07-reference/01-ai-sdk-core/65-language-model-v2-middleware.mdx`
- `curl -fsSIL https://github.com/vercel/ai/blob/release-v5.0/packages/provider/src/language-model/v2/language-model-v2.ts`
- `git diff --check`

`pnpm check` was also run, but the release branch currently reports an unrelated formatting issue in `examples/next-workflow/.devtools/generations.json`, which is not touched by this PR.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Backport of #16487.
Refs #12617.

Co-authored-by: Shurik <shurik@openclaw.ai>
Co-authored-by: Niels Kaspers <kaspersniels@gmail.com>
Co-authored-by: Frank <97429702+tsubasakong@users.noreply.github.com>
Co-authored-by: Raashish Aggarwal <94279692+raashish1601@users.noreply.github.com>
Co-authored-by: smorchj <smorchj@users.noreply.github.com>
Co-authored-by: Narutama Aurum <narutamaaurum@gmail.com>
