### PR TITLE
docs: fix MLflow video embed

### DIFF
--- a/content/providers/03-observability/mlflow.mdx
+++ b/content/providers/03-observability/mlflow.mdx
@@ -5,7 +5,19 @@ description: Track, visualize, and debug Vercel AI SDK traces with MLflow Tracin
 
 # MLflow Observability
 
-![MLflow Tracing Vercel AI SDK](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
+<video
+  src="https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4"
+  autoplay
+  muted
+  loop
+  controls
+  playsinline
+  aria-label="MLflow Tracing Vercel AI SDK"
+>
+  <a href="https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4">
+    MLflow Tracing Vercel AI SDK demo video
+  </a>
+</video>
 
 [MLflow Tracing](https://mlflow.org/docs/latest/genai/tracing) provides automatic tracing for applications built with the [Vercel AI SDK](https://ai-sdk.dev/) (the `ai` package) via OpenTelemetry, unlocking observability for TypeScript and JavaScript apps.
 


### PR DESCRIPTION
## Background

The MLflow observability page used Markdown image syntax for an `.mp4` asset:

```md
![MLflow Tracing Vercel AI SDK](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
```

That produces an image element, so the browser renders the hero media as a broken image even though the asset itself returns `200 OK` with `content-type: video/mp4`.

I compared the two open PRs for #12472:

- #12677 has the correct approach: render the MP4 as an HTML `<video>` element. It is stale because it edits the old `content/providers/05-observability/mlflow.mdx` path.
- #15924 correctly identifies the broken Markdown image embed and includes the useful idea of preserving a direct link, but it changes the hero media to a plain link and includes unrelated middleware documentation changes.

## Summary

This updates the current MLflow observability page at `content/providers/03-observability/mlflow.mdx` to render the MP4 with a `<video>` element. The video keeps controls, uses `muted` for reliable autoplay, loops like a hero demo, and includes a fallback link inside the element.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12472.
Supersedes and closes #12677.
Supersedes and closes #15924.

Co-authored-by: Shurik <shurik@openclaw.ai>
Co-authored-by: Narutama Aurum <narutamaaurum@gmail.com>
