### PR TITLE
fix(amazon-bedrock): send correct bedrockRerankingConfiguration key for reranking

### DIFF
--- a/.changeset/fix-bedrock-reranking-wire-key.md
+++ b/.changeset/fix-bedrock-reranking-wire-key.md
@@ -3,5 +3,3 @@
 ---
 
 fix (amazon-bedrock): send the correct `bedrockRerankingConfiguration` request key for reranking
-
-The Bedrock Agent Runtime `Rerank` API requires the request member to be named `bedrockRerankingConfiguration`. A consistency rename had changed it to `amazonBedrockRerankingConfiguration`, causing AWS to reject every reranking call with `Value null at 'rerankingConfiguration.bedrockRerankingConfiguration' failed to satisfy constraint: Member must not be null` (HTTP 400). The wire key is now restored to match the AWS contract.

--- a/.changeset/fix-bedrock-reranking-wire-key.md
+++ b/.changeset/fix-bedrock-reranking-wire-key.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix (amazon-bedrock): send the correct `bedrockRerankingConfiguration` request key for reranking
+
+The Bedrock Agent Runtime `Rerank` API requires the request member to be named `bedrockRerankingConfiguration`. A consistency rename had changed it to `amazonBedrockRerankingConfiguration`, causing AWS to reject every reranking call with `Value null at 'rerankingConfiguration.bedrockRerankingConfiguration' failed to satisfy constraint: Member must not be null` (HTTP 400). The wire key is now restored to match the AWS contract.

--- a/packages/amazon-bedrock/src/reranking/amazon-bedrock-reranking-api.ts
+++ b/packages/amazon-bedrock/src/reranking/amazon-bedrock-reranking-api.ts
@@ -7,7 +7,7 @@ export type AmazonBedrockRerankingInput = {
   queries: [{ type: 'TEXT'; textQuery: { text: string } }];
   rerankingConfiguration: {
     type: 'BEDROCK_RERANKING_MODEL';
-    amazonBedrockRerankingConfiguration: {
+    bedrockRerankingConfiguration: {
       modelConfiguration: {
         modelArn: string;
         additionalModelRequestFields?: Record<string, unknown>;

--- a/packages/amazon-bedrock/src/reranking/amazon-bedrock-reranking-model.test.ts
+++ b/packages/amazon-bedrock/src/reranking/amazon-bedrock-reranking-model.test.ts
@@ -74,7 +74,7 @@ describe('doRerank', () => {
             },
           ],
           "rerankingConfiguration": {
-            "amazonBedrockRerankingConfiguration": {
+            "bedrockRerankingConfiguration": {
               "modelConfiguration": {
                 "additionalModelRequestFields": {
                   "test": "test-value",
@@ -107,6 +107,19 @@ describe('doRerank', () => {
           ],
         }
       `);
+    });
+
+    it('should send the AWS-required `bedrockRerankingConfiguration` wire key', async () => {
+      const body = await server.calls[0].requestBodyJson;
+      // The Bedrock Agent Runtime Rerank API requires this exact member name;
+      // renaming it sends the required member as null and AWS rejects the
+      // request with HTTP 400. Asserted explicitly (not via the body snapshot
+      // above, which `--update` would silently regenerate) so a future rename
+      // fails loudly instead of locking in a broken wire contract.
+      // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RerankingConfiguration.html
+      expect(body).toHaveProperty(
+        'rerankingConfiguration.bedrockRerankingConfiguration',
+      );
     });
 
     it('should send request with the correct headers', async () => {
@@ -204,7 +217,7 @@ describe('doRerank', () => {
             },
           ],
           "rerankingConfiguration": {
-            "amazonBedrockRerankingConfiguration": {
+            "bedrockRerankingConfiguration": {
               "modelConfiguration": {
                 "additionalModelRequestFields": {
                   "test": "test-value",

--- a/packages/amazon-bedrock/src/reranking/amazon-bedrock-reranking-model.ts
+++ b/packages/amazon-bedrock/src/reranking/amazon-bedrock-reranking-model.ts
@@ -76,7 +76,7 @@ export class AmazonBedrockRerankingModel implements RerankingModelV4 {
           },
         ],
         rerankingConfiguration: {
-          amazonBedrockRerankingConfiguration: {
+          bedrockRerankingConfiguration: {
             modelConfiguration: {
               modelArn: `arn:aws:bedrock:${this.config.region}::foundation-model/${this.modelId}`,
               additionalModelRequestFields:


### PR DESCRIPTION
## Background

`rerank()` with an Amazon Bedrock reranking model fails with HTTP 400. AWS responds with:

> 1 validation error detected: Value null at 'rerankingConfiguration.bedrockRerankingConfiguration' failed to satisfy constraint: Member must not be null

The Bedrock Agent Runtime Rerank API requires the member `rerankingConfiguration.bedrockRerankingConfiguration`, but the provider was sending it as `amazonBedrockRerankingConfiguration`. AWS therefore sees the required member as `null` and rejects every reranking request.

The rename was introduced by #14648 (a `konsistent` consistency pass) that treated this AWS-defined wire key as if it were an internal identifier. Reranking has been broken since `@ai-sdk/amazon-bedrock@5.0.0-beta.46` and remains broken through the latest release. The original implementation (#3764) used the correct key.

## Summary

- Restore the request-body key to `bedrockRerankingConfiguration` in `amazon-bedrock-reranking-model.ts` and its type mirror `amazon-bedrock-reranking-api.ts`.
- Update the two request-body inline snapshots in `amazon-bedrock-reranking-model.test.ts` to match.
- Add a focused test asserting the request carries the AWS-required `rerankingConfiguration.bedrockRerankingConfiguration` member, using an explicit `toHaveProperty` assertion rather than the full-body snapshot so a future rename fails loudly instead of being silently absorbed by `--update`.
- Internal symbol names (`AmazonBedrockRerankingInput`, `AmazonBedrockRerankingModel`, etc.) are intentionally left unchanged — only the on-the-wire key reverts.
- No codemod needed — this restores the original wire key and is neither a breaking change nor a deprecation.

## Manual Verification

- Reproduced the failure: calling `rerank()` against a Bedrock reranking model (e.g. `cohere.rerank-v3-5:0`) returns HTTP 400 with the AWS validation error above, naming `bedrockRerankingConfiguration` as the missing required member.
- Confirmed against the AWS Bedrock Agent Runtime API reference that `bedrockRerankingConfiguration` is the **Required** member of `rerankingConfiguration`: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RerankingConfiguration.html
- Confirmed the corrected request body matches the shape sent by pre-regression releases (≤ `5.0.0-beta.45`), which succeed with identical model/query/documents.
- Note: exercising the corrected provider directly against live AWS Bedrock requires AWS credentials; the serialized request body is otherwise pinned by the new unit test, which now matches the documented AWS contract.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Suggestions

- Harden usage of `konsistent` so renames are scoped to compiler-tracked symbols (types, classes, exported identifiers, filenames) and never rewrite object-literal keys or string literals, which may be serialized wire contracts. Tracked in #14859.
- Consider applying the same "pin the wire key with an explicit assertion" pattern to other providers' request bodies, and adding credential-gated e2e coverage/

## Related Issues

- Introduced by #14648.
- Related: #14859 (`konsistent` consistency follow-up).
- No existing issue tracks this specific 400, so there is no `Fixes #` to reference.
