### PR TITLE
fix (gateway): forward non-gateway provider options under gateway.providerOptions for fallback model support

### DIFF
--- a/.changeset/sixty-suns-mix.md
+++ b/.changeset/sixty-suns-mix.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix (gateway): forward non-gateway provider options under gateway.providerOptions for fallback support

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1652,6 +1652,142 @@ describe('GatewayLanguageModel', () => {
       });
     });
 
+    it('should nest non-gateway provider options under gateway.providerOptions for doGenerate', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          google: {
+            thinkingConfig: {
+              thinkingBudget: 128,
+              includeThoughts: false,
+            },
+          },
+          gateway: {
+            models: ['google/gemini-2.5-flash', 'openai/gpt-5-mini'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        google: {
+          thinkingConfig: {
+            thinkingBudget: 128,
+            includeThoughts: false,
+          },
+        },
+        gateway: {
+          models: ['google/gemini-2.5-flash', 'openai/gpt-5-mini'],
+          providerOptions: {
+            google: {
+              thinkingConfig: {
+                thinkingBudget: 128,
+                includeThoughts: false,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should nest non-gateway provider options under gateway.providerOptions for doStream', async () => {
+      prepareStreamResponse({
+        content: ['Hello', ' world'],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral' },
+          },
+          gateway: {
+            order: ['bedrock', 'anthropic'],
+          },
+        },
+      });
+
+      await convertReadableStreamToArray(stream);
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        anthropic: {
+          cacheControl: { type: 'ephemeral' },
+        },
+        gateway: {
+          order: ['bedrock', 'anthropic'],
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+      });
+    });
+
+    it('should not modify providerOptions when no non-gateway options exist', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            order: ['openai'],
+            zeroDataRetention: true,
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          order: ['openai'],
+          zeroDataRetention: true,
+        },
+      });
+      expect(
+        (requestBody.providerOptions as Record<string, unknown>).gateway,
+      ).not.toHaveProperty('providerOptions');
+    });
+
+    it('should preserve original top-level non-gateway options for backward compatibility', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          google: {
+            thinkingConfig: {
+              thinkingBudget: 128,
+              includeThoughts: false,
+            },
+          },
+          gateway: {
+            models: ['google/gemini-2.5-flash'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(
+        (requestBody.providerOptions as Record<string, unknown>).google,
+      ).toEqual({
+        thinkingConfig: {
+          thinkingBudget: 128,
+          includeThoughts: false,
+        },
+      });
+    });
+
     it('should pass both zeroDataRetention and hipaaCompliant options', async () => {
       prepareJsonResponse({
         content: { type: 'text', text: 'Test response' },

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -4,6 +4,7 @@ import type {
   LanguageModelV4StreamPart,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamResult,
+  JSONObject,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -58,6 +59,30 @@ export class GatewayLanguageModel implements LanguageModelV4 {
 
   private async getArgs(options: LanguageModelV4CallOptions) {
     const { abortSignal: _abortSignal, ...optionsWithoutSignal } = options;
+
+    if (optionsWithoutSignal.providerOptions) {
+      const { gateway: gatewayOpts, ...otherProviderOpts } =
+        optionsWithoutSignal.providerOptions;
+
+      if (
+        gatewayOpts != null &&
+        typeof gatewayOpts === 'object' &&
+        !Array.isArray(gatewayOpts)
+      ) {
+        const updatedGateway: Record<string, unknown> = {
+          ...(gatewayOpts as Record<string, unknown>),
+        };
+
+        if (Object.keys(otherProviderOpts).length > 0) {
+          updatedGateway['providerOptions'] = otherProviderOpts;
+
+          optionsWithoutSignal.providerOptions = {
+            ...optionsWithoutSignal.providerOptions,
+            gateway: updatedGateway as JSONObject,
+          };
+        }
+      }
+    }
 
     return {
       args: this.maybeEncodeFileParts(optionsWithoutSignal),

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -55,4 +55,7 @@ export type GatewayProviderOptions = {
 
   /** Filter to providers with zero data retention agreements. */
   zeroDataRetention?: boolean;
+
+  /** Provider options keyed by provider name, used for fallback model support. */
+  providerOptions?: Record<string, Record<string, unknown>>;
 };


### PR DESCRIPTION
## Description

Provider-specific options (e.g., `google.thinkingConfig`) specified at the top level of `providerOptions` were being ignored when the gateway routed to a fallback model from `gateway.models` or `gateway.order`. The gateway API server applies `providerOptions.<provider>` only for the primary model, not for any fallback model selected at runtime.

## Changes

A new `providerOptions` field was added to the `GatewayProviderOptions` type, providing a mechanism to associate options with any provider the gateway might route to.  `GatewayLanguageModel.getArgs()` was updated to auto-nest all non-gateway provider options under `gateway.providerOptions` before sending the request, so the server can read and apply the correct options regardless of which model (primary or fallback) is selected.  4 regression tests were added covering nesting for doGenerate, nesting for doStream, no-op when no non-gateway options exist, and preservation of top-level options for backward compatibility.

The change is transparent to users: the public API is unchanged, and the SDK automatically populates the new field from existing top-level provider options.

Closes https://github.com/vercel/ai/issues/14377