### PR TITLE
Backport: feat (video): add first-class frameImages and inputReferences call options for video generation

### DIFF
--- a/.changeset/video-frame-images-first-class.md
+++ b/.changeset/video-frame-images-first-class.md
@@ -1,0 +1,13 @@
+---
+"@ai-sdk/provider": patch
+"ai": patch
+"@ai-sdk/gateway": patch
+"@ai-sdk/klingai": patch
+"@ai-sdk/bytedance": patch
+"@ai-sdk/alibaba": patch
+"@ai-sdk/google": patch
+"@ai-sdk/google-vertex": patch
+"@ai-sdk/xai": patch
+---
+
+feat (video): add first-class `frameImages` and `inputReferences` call options for video generation

--- a/content/docs/03-ai-sdk-core/38-video-generation.mdx
+++ b/content/docs/03-ai-sdk-core/38-video-generation.mdx
@@ -171,6 +171,46 @@ const { video } = await generateVideo({
 });
 ```
 
+### First and Last Frame
+
+Some video models support first-last-frame generation, where you provide the
+starting and/or ending frames of the video. Use the `frameImages` option to pass
+role-tagged images in a provider-agnostic way:
+
+```tsx highlight={"5-16"}
+const { video } = await generateVideo({
+  model: __VIDEO_MODEL__,
+  prompt: 'The cat walks across the scene and transforms into a dog by the end',
+  frameImages: [
+    {
+      image: 'https://example.com/first-frame.png',
+      frameType: 'first_frame',
+    },
+    {
+      image: 'https://example.com/last-frame.png',
+      frameType: 'last_frame',
+    },
+  ],
+});
+```
+
+### Reference Images
+
+Some video models support reference-to-video generation, where you provide one or
+more reference images that the model incorporates into the generated video. Use the `inputReferences` option to pass
+these images in a provider-agnostic way:
+
+```tsx highlight={"5-8"}
+const { video } = await generateVideo({
+  model: __VIDEO_MODEL__,
+  prompt: 'The two characters meet in a bustling market',
+  inputReferences: [
+    'https://example.com/character-1.png',
+    'https://example.com/character-2.png',
+  ],
+});
+```
+
 ### Providing a Seed
 
 You can provide a seed to the `experimental_generateVideo` function to control the output of the video generation process.

--- a/content/docs/07-reference/01-ai-sdk-core/13-generate-video.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/13-generate-video.mdx
@@ -111,6 +111,18 @@ console.log(videos);
       description: 'Seed for the video generation.',
     },
     {
+      name: 'frameImages',
+      type: 'Array<{ image: DataContent; frameType: "first_frame" | "last_frame" }>',
+      isOptional: true,
+      description: 'Role-tagged image inputs for first-last-frame generation.',
+    },
+    {
+      name: 'inputReferences',
+      type: 'Array<DataContent>',
+      isOptional: true,
+      description: 'Reference image inputs for reference-to-video generation.',
+    },
+    {
       name: 'generateAudio',
       type: 'boolean',
       isOptional: true,

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -984,6 +984,37 @@ const { video } = await generateVideo({
 });
 ```
 
+You can also pass the starting frame via the top-level `frameImages` option using the `first_frame` role. This is provider-agnostic and accepts file data (e.g. a `Buffer`) or a `{ type: 'url', url }` object:
+
+```ts
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+
+const { video } = await generateVideo({
+  model: xai.video('grok-imagine-video'),
+  prompt: 'The cat slowly turns its head and blinks',
+  frameImages: [
+    {
+      image: fs.readFileSync('./start-frame.png'),
+      frameType: 'first_frame',
+    },
+  ],
+  duration: 5,
+  providerOptions: {
+    xai: {
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies XaiVideoModelOptions,
+  },
+});
+```
+
+<Note>
+  xAI does not support first-last-frame interpolation. A `last_frame` entry in
+  `frameImages` is ignored with a warning — use the `extend-video` mode to
+  continue from a video's last frame instead.
+</Note>
+
 ### Video Editing
 
 Edit an existing video using a text prompt by providing a source video URL via provider options:
@@ -1133,9 +1164,38 @@ const { video } = await generateVideo({
 
 Use `<IMAGE_1>`, `<IMAGE_2>`, etc. in your prompt to reference specific images. Up to 7 reference images are supported per request.
 
+Alternatively, use the provider-agnostic top-level `inputReferences` option. Providing it automatically selects reference-to-video mode, and it accepts file data (e.g. a `Buffer`) or `{ type: 'url', url }` objects:
+
+```ts
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+
+const { video } = await generateVideo({
+  model: xai.video('grok-imagine-video'),
+  prompt:
+    'The comic cat and the comic dog are having a playful chase ' +
+    'through a sunlit park. Cinematic slow-motion, warm afternoon light.',
+  inputReferences: [
+    fs.readFileSync('./comic-cat.png'),
+    fs.readFileSync('./comic-dog.png'),
+  ],
+  duration: 8,
+  aspectRatio: '16:9',
+  providerOptions: {
+    xai: {
+      pollTimeoutMs: 600000,
+    } satisfies XaiVideoModelOptions,
+  },
+});
+```
+
 <Note>
   Reference-to-video supports `duration`, `aspectRatio`, and `resolution`. Use
-  `mode` to select the operation — each mode is mutually exclusive.
+  `mode` to select the operation — each mode is mutually exclusive. When both
+  are provided, `frameImages` takes precedence over `inputReferences`, and
+  `inputReferences` takes precedence over the legacy `referenceImageUrls`
+  provider option. Reference-to-video requires the `grok-imagine-video` model.
 </Note>
 
 ### Video Provider Options

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1230,6 +1230,53 @@ const { video } = await generateVideo({
 });
 ```
 
+#### First and Last Frame
+
+Veo supports first-last-frame generation via the top-level `frameImages` option:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: vertex.video('veo-3.1-generate-001'),
+  prompt:
+    'A hand reaches in and places a glass of milk next to the plate of cookies',
+  frameImages: [
+    {
+      image: 'gs://cloud-samples-data/generative-ai/image/cookies.png',
+      frameType: 'first_frame',
+    },
+    {
+      image: 'gs://cloud-samples-data/generative-ai/image/cookies-milk.png',
+      frameType: 'last_frame',
+    },
+  ],
+  duration: 8,
+});
+```
+
+#### Reference Images
+
+Veo 3.1 supports reference-to-video generation via the top-level `inputReferences` option:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: vertex.video('veo-3.1-generate-001'),
+  prompt:
+    'The video opens with a medium shot of a woman in a high-fashion flamingo dress walking through a lagoon',
+  inputReferences: [
+    'gs://bucket/dress.png',
+    'gs://bucket/glasses.png',
+    'gs://bucket/woman.png',
+  ],
+  duration: 8,
+});
+```
+
 #### Provider Options
 
 Further configuration can be done using Google Vertex provider options. You can validate the provider options using the `GoogleVertexVideoModelOptions` type.

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -376,6 +376,30 @@ const { video } = await generateVideo({
 });
 ```
 
+You can also pass the first frame using the top-level `frameImages` option:
+
+```ts
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.6-i2v'),
+  prompt: 'Camera slowly pans across the landscape',
+  frameImages: [
+    {
+      image: 'https://example.com/landscape.jpg',
+      frameType: 'first_frame',
+    },
+  ],
+  duration: 5,
+  providerOptions: {
+    alibaba: {
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies AlibabaVideoModelOptions,
+  },
+});
+```
+
 ### Reference-to-Video
 
 Generate videos using reference images and/or videos for character consistency. Use character identifiers
@@ -390,9 +414,9 @@ const { video } = await generateVideo({
   prompt: 'character1 walks through a beautiful garden and waves at the camera',
   resolution: '1280x720',
   duration: 5,
+  inputReferences: ['https://example.com/character-reference.jpg'],
   providerOptions: {
     alibaba: {
-      referenceUrls: ['https://example.com/character-reference.jpg'],
       pollTimeoutMs: 600000, // 10 minutes
     } satisfies AlibabaVideoModelOptions,
   },
@@ -430,6 +454,7 @@ The following provider options are available via `providerOptions.alibaba`:
 - **referenceUrls** _string[]_
 
   Array of reference image/video URLs for reference-to-video mode. Supports 0-5 images and 0-3 videos, max 5 total.
+  Prefer the top-level `inputReferences` option when passing reference images.
 
 - **pollIntervalMs** _number_
 

--- a/content/providers/01-ai-sdk-providers/85-klingai.mdx
+++ b/content/providers/01-ai-sdk-providers/85-klingai.mdx
@@ -76,7 +76,7 @@ You can use the following optional settings to customize the Kling AI provider i
 You can create Kling AI video models using the `.video()` factory method.
 For more on video generation with the AI SDK see [generateVideo()](/docs/reference/ai-sdk-core/generate-video).
 
-This provider currently supports three video generation modes: text-to-video, image-to-video, and motion control.
+This provider currently supports four video generation modes: text-to-video, image-to-video, reference-to-video (multi-image), and motion control.
 
 <Note>
   Not all options are supported by every model version and mode combination. See
@@ -174,6 +174,31 @@ const { videos } = await generateVideo({
 ```
 
 Multi-shot also works with image-to-video by combining a start frame image with per-shot prompts.
+
+### Reference-to-Video (Multi-Image)
+
+Generate a video that combines reference images using the top-level `inputReferences` option.
+
+```ts
+import { klingai, type KlingAIVideoModelOptions } from '@ai-sdk/klingai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: klingai.video('kling-v1.6-i2v'),
+  prompt: 'The two characters meet and walk together through a sunny park',
+  inputReferences: [
+    'https://example.com/character-1.png',
+    'https://example.com/character-2.png',
+  ],
+  aspectRatio: '16:9',
+  duration: 5,
+  providerOptions: {
+    klingai: {
+      mode: 'std',
+    } satisfies KlingAIVideoModelOptions,
+  },
+});
+```
 
 ### Motion Control
 

--- a/examples/ai-functions/src/generate-video/alibaba/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/i2v-frame-images.ts
@@ -1,4 +1,4 @@
-import { type AlibabaVideoModelOptions, alibaba } from '@ai-sdk/alibaba';
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -6,17 +6,20 @@ import { withSpinner } from '../../lib/spinner';
 
 run(async () => {
   const { video } = await withSpinner(
-    'Generating reference-to-video with wan2.6-r2v-flash...',
+    'Generating image-to-video with wan2.6-i2v...',
     () =>
       generateVideo({
-        model: alibaba.video('wan2.6-r2v-flash'),
+        model: alibaba.video('wan2.6-i2v'),
         prompt:
-          'character1 walks through a beautiful garden and waves at the camera',
-        resolution: '1280x720',
-        duration: 3,
-        inputReferences: [
-          'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          'The character slowly turns its head and blinks in a playful cartoon style',
+        frameImages: [
+          {
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+            frameType: 'first_frame',
+          },
         ],
+        duration: 5,
         providerOptions: {
           alibaba: {
             pollTimeoutMs: 600000, // 10 minutes

--- a/examples/ai-functions/src/generate-video/bytedance/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/i2v-frame-images.ts
@@ -1,0 +1,37 @@
+import { byteDance } from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating first-and-last frame video with seedance-1-5-pro...',
+    () =>
+      generateVideo({
+        model: byteDance.video('seedance-1-5-pro-251215'),
+        prompt: 'Create a 360-degree orbiting camera shot based on this photo',
+        frameImages: [
+          {
+            image:
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seepro_first_frame.jpeg',
+            frameType: 'first_frame',
+          },
+          {
+            image:
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seepro_last_frame.jpeg',
+            frameType: 'last_frame',
+          },
+        ],
+        duration: 5,
+        providerOptions: {
+          bytedance: {
+            watermark: false,
+            pollTimeoutMs: 600000,
+          },
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/bytedance/r2v-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/r2v-reference-images.ts
@@ -1,0 +1,30 @@
+import { byteDance } from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with seedance-1-0-lite...',
+    () =>
+      generateVideo({
+        model: byteDance.video('seedance-1-0-lite-i2v-250428'),
+        prompt:
+          'The two characters walk together through a vibrant city street at night',
+        inputReferences: [
+          'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seepro_first_frame.jpeg',
+          'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seepro_last_frame.jpeg',
+        ],
+        duration: 5,
+        providerOptions: {
+          bytedance: {
+            watermark: false,
+            pollTimeoutMs: 600000,
+          },
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/gateway/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/gateway/i2v-frame-images.ts
@@ -1,0 +1,37 @@
+import { experimental_generateVideo as generateVideo, gateway } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating first-last-frame video via AI Gateway...',
+    () =>
+      generateVideo({
+        model: gateway.videoModel('klingai/kling-v2.6-i2v'),
+        prompt:
+          'The cat walks across the scene and transforms into a dog by the end, in a playful and cartoonish style.',
+        frameImages: [
+          {
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+            frameType: 'first_frame',
+          },
+          {
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+            frameType: 'last_frame',
+          },
+        ],
+        duration: 5,
+        providerOptions: {
+          klingai: {
+            mode: 'pro',
+            pollTimeoutMs: 600000, // 10 minutes
+          },
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/gateway/r2v-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/gateway/r2v-reference-images.ts
@@ -1,0 +1,29 @@
+import { experimental_generateVideo as generateVideo, gateway } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video via AI Gateway...',
+    () =>
+      generateVideo({
+        model: gateway.videoModel('bytedance/seedance-v1.0-lite-i2v'),
+        prompt:
+          'The two characters walk together through a vibrant city street at night',
+        inputReferences: [
+          'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seepro_first_frame.jpeg',
+          'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/seepro_last_frame.jpeg',
+        ],
+        duration: 5,
+        providerOptions: {
+          bytedance: {
+            watermark: false,
+            pollTimeoutMs: 600000,
+          },
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/google/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/google/i2v-frame-images.ts
@@ -1,0 +1,37 @@
+import { google, type GoogleVideoModelOptions } from '@ai-sdk/google';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating first-and-last frame video with Veo...',
+    () =>
+      generateVideo({
+        model: google.video('veo-3.1-generate-preview'),
+        prompt:
+          'The cat walks across the scene and transforms into a dog by the end, in a playful and cartoonish style.',
+        frameImages: [
+          {
+            image: fs.readFileSync('data/comic-cat.png'),
+            frameType: 'first_frame',
+          },
+          {
+            image: fs.readFileSync('data/comic-dog.png'),
+            frameType: 'last_frame',
+          },
+        ],
+        aspectRatio: '16:9',
+        duration: 8,
+        providerOptions: {
+          google: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies GoogleVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/google/r2v-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/google/r2v-reference-images.ts
@@ -1,0 +1,31 @@
+import { google, type GoogleVideoModelOptions } from '@ai-sdk/google';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with Veo...',
+    () =>
+      generateVideo({
+        model: google.video('veo-3.1-generate-preview'),
+        prompt:
+          'The two characters meet and walk together through a sunny park',
+        inputReferences: [
+          fs.readFileSync('data/comic-cat.png'),
+          fs.readFileSync('data/comic-dog.png'),
+        ],
+        aspectRatio: '16:9',
+        duration: 8,
+        providerOptions: {
+          google: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies GoogleVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/klingai/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/klingai/i2v-frame-images.ts
@@ -1,0 +1,38 @@
+import { klingai } from '@ai-sdk/klingai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating KlingAI image-to-video with first and last frames...',
+    () =>
+      generateVideo({
+        model: klingai.video('kling-v2.6-i2v'),
+        prompt:
+          'The cat walks across the scene and transforms into a dog by the end, in a playful and cartoonish style.',
+        frameImages: [
+          {
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+            frameType: 'first_frame',
+          },
+          {
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+            frameType: 'last_frame',
+          },
+        ],
+        duration: 5,
+        providerOptions: {
+          klingai: {
+            mode: 'pro',
+            pollTimeoutMs: 600000, // 10 minutes
+          },
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/klingai/r2v-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/klingai/r2v-reference-images.ts
@@ -1,30 +1,31 @@
-import { type AlibabaVideoModelOptions, alibaba } from '@ai-sdk/alibaba';
+import { klingai } from '@ai-sdk/klingai';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
 import { withSpinner } from '../../lib/spinner';
 
 run(async () => {
-  const { video } = await withSpinner(
-    'Generating reference-to-video with wan2.6-r2v...',
+  const { videos } = await withSpinner(
+    'Generating KlingAI reference-to-video from multiple images...',
     () =>
       generateVideo({
-        model: alibaba.video('wan2.6-r2v'),
-        prompt: 'character1 and character2 have a conversation in a cozy cafe',
-        resolution: '1920x1080',
-        duration: 4,
+        model: klingai.video('kling-v1.6-i2v'),
+        prompt:
+          'The two characters meet and walk together through a sunny park',
         inputReferences: [
           'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
           'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
         ],
+        aspectRatio: '16:9',
+        duration: 5,
         providerOptions: {
-          alibaba: {
-            shotType: 'single',
+          klingai: {
+            mode: 'std',
             pollTimeoutMs: 600000, // 10 minutes
-          } satisfies AlibabaVideoModelOptions,
+          },
         },
       }),
   );
 
-  await presentVideos([video]);
+  await presentVideos(videos);
 });

--- a/examples/ai-functions/src/generate-video/vertex/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/vertex/i2v-frame-images.ts
@@ -1,0 +1,42 @@
+import {
+  vertex,
+  type GoogleVertexVideoModelOptions,
+} from '@ai-sdk/google-vertex';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// Note: Requires GOOGLE_VERTEX_LOCATION to be set to a specific region (e.g., us-central1)
+// Veo models are not available in the 'global' region
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating first-and-last frame video with Vertex Veo...',
+    () =>
+      generateVideo({
+        model: vertex.video('veo-3.1-generate-001'),
+        prompt:
+          'The cat walks across the scene and transforms into a dog by the end, in a playful and cartoonish style.',
+        frameImages: [
+          {
+            image: fs.readFileSync('data/comic-cat.png'),
+            frameType: 'first_frame',
+          },
+          {
+            image: fs.readFileSync('data/comic-dog.png'),
+            frameType: 'last_frame',
+          },
+        ],
+        aspectRatio: '16:9',
+        duration: 8,
+        providerOptions: {
+          vertex: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies GoogleVertexVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/vertex/r2v-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/vertex/r2v-reference-images.ts
@@ -1,0 +1,36 @@
+import {
+  vertex,
+  type GoogleVertexVideoModelOptions,
+} from '@ai-sdk/google-vertex';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// Note: Requires GOOGLE_VERTEX_LOCATION to be set to a specific region (e.g., us-central1)
+// Veo models are not available in the 'global' region
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with Vertex Veo...',
+    () =>
+      generateVideo({
+        model: vertex.video('veo-3.1-generate-001'),
+        prompt:
+          'The two characters meet and walk together through a sunny park',
+        inputReferences: [
+          fs.readFileSync('data/comic-cat.png'),
+          fs.readFileSync('data/comic-dog.png'),
+        ],
+        aspectRatio: '16:9',
+        duration: 8,
+        providerOptions: {
+          vertex: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies GoogleVertexVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/xai/i2v-frame-images.ts
+++ b/examples/ai-functions/src/generate-video/xai/i2v-frame-images.ts
@@ -1,0 +1,34 @@
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating xAI image-to-video from a first frame...',
+    () =>
+      generateVideo({
+        model: xai.video('grok-imagine-video'),
+        prompt:
+          'The comic cat stretches, yawns, and pads off across a sunlit room. ' +
+          'Cinematic, warm afternoon light.',
+        frameImages: [
+          {
+            image: fs.readFileSync('data/comic-cat.png'),
+            frameType: 'first_frame',
+          },
+        ],
+        duration: 8,
+        aspectRatio: '16:9',
+        providerOptions: {
+          xai: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies XaiVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/xai/r2v-reference-images.ts
+++ b/examples/ai-functions/src/generate-video/xai/r2v-reference-images.ts
@@ -1,0 +1,33 @@
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating xAI reference-to-video with grok-imagine-video...',
+    () =>
+      generateVideo({
+        model: xai.video('grok-imagine-video'),
+        prompt:
+          '<IMAGE_1> and <IMAGE_2> ' +
+          'are having a playful chase through a sunlit park. ' +
+          'Cinematic slow-motion, warm afternoon light.',
+        inputReferences: [
+          fs.readFileSync('data/comic-cat.png'),
+          fs.readFileSync('data/comic-dog.png'),
+        ],
+        duration: 8,
+        aspectRatio: '16:9',
+        providerOptions: {
+          xai: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies XaiVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/packages/ai/src/generate-video/generate-video.test.ts
+++ b/packages/ai/src/generate-video/generate-video.test.ts
@@ -114,6 +114,8 @@ describe('experimental_generateVideo', () => {
       n: 1,
       prompt,
       image: undefined,
+      frameImages: undefined,
+      inputReferences: undefined,
       aspectRatio: '16:9',
       resolution: '1920x1080',
       duration: 5,
@@ -979,6 +981,287 @@ describe('experimental_generateVideo', () => {
       if (capturedArgs.image?.type === 'file') {
         expect(capturedArgs.image.mediaType).toBe('image/jpeg');
       }
+    });
+  });
+
+  describe('frameImages', () => {
+    it('should normalize and pass frameImages through to the model', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: 'a clip',
+        frameImages: [
+          {
+            image: 'https://example.com/first.png',
+            frameType: 'first_frame',
+          },
+          {
+            image: 'https://example.com/last.png',
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      expect(capturedArgs.frameImages).toStrictEqual([
+        {
+          image: { type: 'url', url: 'https://example.com/first.png' },
+          frameType: 'first_frame',
+        },
+        {
+          image: { type: 'url', url: 'https://example.com/last.png' },
+          frameType: 'last_frame',
+        },
+      ]);
+    });
+
+    it('should copy a first_frame entry into the image field when no image is provided', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: 'a clip',
+        frameImages: [
+          {
+            image: 'https://example.com/first.png',
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      expect(capturedArgs.image).toStrictEqual({
+        type: 'url',
+        url: 'https://example.com/first.png',
+      });
+      expect(capturedArgs.frameImages).toStrictEqual([
+        {
+          image: { type: 'url', url: 'https://example.com/first.png' },
+          frameType: 'first_frame',
+        },
+      ]);
+    });
+
+    it('should prefer the first_frame over prompt.image and warn when both are provided', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      const result = await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: {
+          text: 'a clip',
+          image: 'https://example.com/prompt-image.png',
+        },
+        frameImages: [
+          {
+            image: 'https://example.com/frame-first.png',
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      expect(capturedArgs.image).toStrictEqual({
+        type: 'url',
+        url: 'https://example.com/frame-first.png',
+      });
+      expect(capturedArgs.frameImages).toStrictEqual([
+        {
+          image: { type: 'url', url: 'https://example.com/frame-first.png' },
+          frameType: 'first_frame',
+        },
+      ]);
+      expect(result.warnings).toContainEqual({
+        type: 'other',
+        message:
+          'prompt.image was ignored because a first_frame frameImage was provided; ' +
+          'the first_frame frameImage takes precedence as the start image.',
+      });
+    });
+
+    it('should pass only last_frame in frameImages without setting image', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: 'a clip',
+        frameImages: [
+          {
+            image: 'https://example.com/last.png',
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      expect(capturedArgs.image).toBeUndefined();
+      expect(capturedArgs.frameImages).toStrictEqual([
+        {
+          image: { type: 'url', url: 'https://example.com/last.png' },
+          frameType: 'last_frame',
+        },
+      ]);
+    });
+
+    it('should keep the prompt image when frameImages only has a last_frame and prompt image is provided', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: {
+          text: 'a clip',
+          image: 'https://example.com/prompt-image.png',
+        },
+        frameImages: [
+          {
+            image: 'https://example.com/last.png',
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      expect(capturedArgs.image).toStrictEqual({
+        type: 'url',
+        url: 'https://example.com/prompt-image.png',
+      });
+      expect(capturedArgs.frameImages).toStrictEqual([
+        {
+          image: { type: 'url', url: 'https://example.com/last.png' },
+          frameType: 'last_frame',
+        },
+      ]);
+    });
+  });
+
+  describe('inputReferences', () => {
+    it('should normalize and pass inputReferences through to the model', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: 'a clip',
+        inputReferences: [
+          'https://example.com/ref-1.png',
+          'https://example.com/ref-2.png',
+        ],
+      });
+
+      expect(capturedArgs.inputReferences).toStrictEqual([
+        { type: 'url', url: 'https://example.com/ref-1.png' },
+        { type: 'url', url: 'https://example.com/ref-2.png' },
+      ]);
+    });
+
+    it('should pass inputReferences as undefined when not provided', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: 'a clip',
+      });
+
+      expect(capturedArgs.inputReferences).toBeUndefined();
+    });
+
+    it('should ignore inputReferences when frameImages is provided', async () => {
+      let capturedArgs!: Parameters<Experimental_VideoModelV3['doGenerate']>[0];
+
+      const result = await experimental_generateVideo({
+        model: new MockVideoModelV3({
+          doGenerate: async args => {
+            capturedArgs = args;
+            return createMockResponse({
+              videos: [
+                { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+              ],
+            });
+          },
+        }),
+        prompt: 'a clip',
+        frameImages: [
+          {
+            image: 'https://example.com/first.png',
+            frameType: 'first_frame',
+          },
+        ],
+        inputReferences: [
+          'https://example.com/ref-1.png',
+          'https://example.com/ref-2.png',
+        ],
+      });
+
+      expect(capturedArgs.frameImages).toStrictEqual([
+        {
+          image: { type: 'url', url: 'https://example.com/first.png' },
+          frameType: 'first_frame',
+        },
+      ]);
+      expect(capturedArgs.inputReferences).toBeUndefined();
+      expect(result.warnings).toContainEqual({
+        type: 'other',
+        message:
+          'inputReferences were ignored because frameImages were provided; ' +
+          'frameImages and inputReferences cannot be combined.',
+      });
     });
   });
 });

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -2,6 +2,8 @@ import type {
   Experimental_VideoModelV3,
   Experimental_VideoModelV3CallOptions,
   Experimental_VideoModelV3File,
+  Experimental_VideoModelV3FrameImage,
+  Experimental_VideoModelV3FrameType,
   SharedV3ProviderMetadata,
 } from '@ai-sdk/provider';
 import {
@@ -30,6 +32,7 @@ import { prepareRetries } from '../util/prepare-retries';
 import { VERSION } from '../version';
 import type { GenerateVideoResult } from './generate-video-result';
 import { splitDataUrl } from '../prompt/split-data-url';
+import { convertDataContentToUint8Array } from '../prompt/data-content';
 
 export type GenerateVideoPrompt =
   | string
@@ -49,6 +52,8 @@ export type GenerateVideoPrompt =
  * @param duration - Duration of the video in seconds.
  * @param fps - Frames per second for the video.
  * @param seed - Seed for the video generation.
+ * @param frameImages - Role-tagged image inputs for image-to-video and first-last-frame generation.
+ * @param inputReferences - Reference image inputs for reference-to-video generation.
  * @param generateAudio - Whether the model should generate audio alongside the video.
  * @param providerOptions - Additional provider-specific options that are passed through to the provider
  * as body parameters.
@@ -70,6 +75,8 @@ export async function experimental_generateVideo({
   duration,
   fps,
   seed,
+  frameImages,
+  inputReferences,
   generateAudio,
   providerOptions,
   maxRetries: maxRetriesArg,
@@ -121,6 +128,26 @@ export async function experimental_generateVideo({
    * Seed for the video generation.
    */
   seed?: number;
+
+  /**
+   * Role-tagged image inputs for image-to-video and first-last-frame generation.
+   */
+  frameImages?: Array<{
+    /**
+     * The image for this frame.
+     */
+    image: DataContent;
+
+    /**
+     * Which frame this image represents.
+     */
+    frameType: Experimental_VideoModelV3FrameType;
+  }>;
+
+  /**
+   * Reference image inputs for reference-to-video generation.
+   */
+  inputReferences?: Array<DataContent>;
 
   /**
    * Whether the model should generate audio alongside the video.
@@ -176,6 +203,55 @@ export async function experimental_generateVideo({
 
   const { prompt, image } = normalizePrompt(promptArg);
 
+  const normalizedFrameImages:
+    | Array<Experimental_VideoModelV3FrameImage>
+    | undefined = frameImages?.map(frame => ({
+    image: normalizeImageData(frame.image),
+    frameType: frame.frameType,
+  }));
+
+  const normalizedInputReferences:
+    | Array<Experimental_VideoModelV3File>
+    | undefined = inputReferences?.map(reference =>
+    normalizeImageData(reference),
+  );
+
+  const effectiveInputReferences =
+    normalizedFrameImages != null && normalizedFrameImages.length > 0
+      ? undefined
+      : normalizedInputReferences;
+
+  const warnings: Array<Warning> = [];
+
+  if (
+    normalizedFrameImages != null &&
+    normalizedFrameImages.length > 0 &&
+    normalizedInputReferences != null &&
+    normalizedInputReferences.length > 0
+  ) {
+    warnings.push({
+      type: 'other',
+      message:
+        'inputReferences were ignored because frameImages were provided; ' +
+        'frameImages and inputReferences cannot be combined.',
+    });
+  }
+
+  const firstFrameImage = normalizedFrameImages?.find(
+    frame => frame.frameType === 'first_frame',
+  )?.image;
+
+  if (image != null && firstFrameImage != null) {
+    warnings.push({
+      type: 'other',
+      message:
+        'prompt.image was ignored because a first_frame frameImage was provided; ' +
+        'the first_frame frameImage takes precedence as the start image.',
+    });
+  }
+
+  const resolvedImage = firstFrameImage ?? image;
+
   const maxVideosPerCallWithDefault =
     maxVideosPerCall ?? (await invokeModelMaxVideosPerCall(model)) ?? 1;
 
@@ -187,29 +263,31 @@ export async function experimental_generateVideo({
   });
 
   const results = await Promise.all(
-    callVideoCounts.map(async callVideoCount =>
-      retry(() =>
-        model.doGenerate({
-          prompt,
-          n: callVideoCount,
-          aspectRatio,
-          resolution,
-          duration,
-          fps,
-          seed,
-          generateAudio,
-          image,
-          providerOptions: providerOptions ?? {},
-          headers: headersWithUserAgent,
-          abortSignal,
-        } satisfies Experimental_VideoModelV3CallOptions),
-      ),
+    callVideoCounts.map(
+      async callVideoCount =>
+        await retry(() =>
+          model.doGenerate({
+            prompt,
+            n: callVideoCount,
+            aspectRatio,
+            resolution,
+            duration,
+            fps,
+            seed,
+            image: resolvedImage,
+            frameImages: normalizedFrameImages,
+            inputReferences: effectiveInputReferences,
+            generateAudio,
+            providerOptions: providerOptions ?? {},
+            headers: headersWithUserAgent,
+            abortSignal,
+          } satisfies Experimental_VideoModelV3CallOptions),
+        ),
     ),
   );
 
   // collect result videos, warnings, and response metadata
   const videos: Array<GeneratedFile> = [];
-  const warnings: Array<Warning> = [];
   const responses: Array<VideoModelResponseMetadata> = [];
   const providerMetadata: SharedV3ProviderMetadata = {};
 
@@ -345,59 +423,59 @@ function normalizePrompt(promptArg: GenerateVideoPrompt): {
     };
   }
 
-  let image: Experimental_VideoModelV3File | undefined;
-
-  if (promptArg.image != null) {
-    const dataContent = promptArg.image;
-
-    if (typeof dataContent === 'string') {
-      if (
-        dataContent.startsWith('http://') ||
-        dataContent.startsWith('https://')
-      ) {
-        image = {
-          type: 'url',
-          url: dataContent,
-        };
-      } else if (dataContent.startsWith('data:')) {
-        const { mediaType, base64Content } = splitDataUrl(dataContent);
-        image = {
-          type: 'file',
-          mediaType: mediaType ?? 'image/png',
-          data: convertBase64ToUint8Array(base64Content ?? ''),
-        };
-      } else {
-        const bytes = convertBase64ToUint8Array(dataContent);
-        const mediaType =
-          detectMediaType({
-            data: bytes,
-            signatures: imageMediaTypeSignatures,
-          }) ?? 'image/png';
-
-        image = {
-          type: 'file',
-          mediaType,
-          data: bytes,
-        };
-      }
-    } else if (dataContent instanceof Uint8Array) {
-      const mediaType =
-        detectMediaType({
-          data: dataContent,
-          signatures: imageMediaTypeSignatures,
-        }) ?? 'image/png';
-
-      image = {
-        type: 'file',
-        mediaType,
-        data: dataContent,
-      };
-    }
-  }
-
   return {
     prompt: promptArg.text,
-    image,
+    image:
+      promptArg.image != null ? normalizeImageData(promptArg.image) : undefined,
+  };
+}
+
+/**
+ * Normalizes a {@link DataContent} image into a {@link Experimental_VideoModelV3File}.
+ * Accepts a URL string, a data URL, a base64 string, or binary image data.
+ */
+function normalizeImageData(
+  dataContent: DataContent,
+): Experimental_VideoModelV3File {
+  if (typeof dataContent === 'string') {
+    if (
+      dataContent.startsWith('http://') ||
+      dataContent.startsWith('https://')
+    ) {
+      return {
+        type: 'url',
+        url: dataContent,
+      };
+    }
+
+    if (dataContent.startsWith('data:')) {
+      const { mediaType, base64Content } = splitDataUrl(dataContent);
+      return {
+        type: 'file',
+        mediaType: mediaType ?? 'image/png',
+        data: convertBase64ToUint8Array(base64Content ?? ''),
+      };
+    }
+
+    const bytes = convertBase64ToUint8Array(dataContent);
+    return {
+      type: 'file',
+      mediaType:
+        detectMediaType({
+          data: bytes,
+          signatures: imageMediaTypeSignatures,
+        }) ?? 'image/png',
+      data: bytes,
+    };
+  }
+
+  const bytes = convertDataContentToUint8Array(dataContent);
+  return {
+    type: 'file',
+    mediaType:
+      detectMediaType({ data: bytes, signatures: imageMediaTypeSignatures }) ??
+      'image/png',
+    data: bytes,
   };
 }
 

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -47,6 +47,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -313,6 +315,109 @@ describe('AlibabaVideoModel', () => {
       });
     });
 
+    it('should use frameImages first_frame as img_url', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: {
+              type: 'url',
+              url: 'https://example.com/first-frame.png',
+            },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          prompt,
+          img_url: 'https://example.com/first-frame.png',
+        },
+      });
+    });
+
+    it('should prefer frameImages first_frame over the legacy image option', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'url',
+          url: 'https://example.com/legacy-image.png',
+        },
+        frameImages: [
+          {
+            image: {
+              type: 'url',
+              url: 'https://example.com/first-frame.png',
+            },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          img_url: 'https://example.com/first-frame.png',
+        },
+      });
+    });
+
+    it('should send img_url as base64 from frameImages first_frame file data', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v-flash' });
+      const imageData = new Uint8Array([137, 80, 78, 71]);
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: {
+              type: 'file',
+              data: imageData,
+              mediaType: 'image/png',
+            },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          img_url: 'iVBORw==',
+        },
+      });
+    });
+
+    it('should warn when frameImages last_frame is provided', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: {
+              type: 'url',
+              url: 'https://example.com/last-frame.png',
+            },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'frameImages',
+        }),
+      );
+    });
+
     it('should map the top-level generateAudio option', async () => {
       const model = createModel({ modelId: 'wan2.6-i2v-flash' });
 
@@ -410,6 +515,97 @@ describe('AlibabaVideoModel', () => {
 
       const body = await server.calls[0].requestBodyJson;
       expect(body.input).not.toHaveProperty('reference_urls');
+    });
+
+    it('should send reference_urls from inputReferences for R2V model', async () => {
+      const model = createModel({ modelId: 'wan2.6-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character-1.png' },
+          { type: 'url', url: 'https://example.com/character-2.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.6-r2v',
+        input: {
+          prompt,
+          reference_urls: [
+            'https://example.com/character-1.png',
+            'https://example.com/character-2.png',
+          ],
+        },
+      });
+    });
+
+    it('should prefer inputReferences over providerOptions.alibaba.referenceUrls', async () => {
+      const model = createModel({ modelId: 'wan2.6-r2v-flash' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/new-ref.png' },
+        ],
+        providerOptions: {
+          alibaba: {
+            referenceUrls: ['https://example.com/legacy-ref.png'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          reference_urls: ['https://example.com/new-ref.png'],
+        },
+      });
+    });
+
+    it('should warn and skip non-URL inputReferences for R2V model', async () => {
+      const model = createModel({ modelId: 'wan2.6-r2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: new Uint8Array([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.input).not.toHaveProperty('reference_urls');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'inputReferences',
+        }),
+      );
+    });
+
+    it('should warn when inputReferences are provided for non-R2V model', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [{ type: 'url', url: 'https://example.com/ref.png' }],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.input).not.toHaveProperty('reference_urls');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'inputReferences',
+        }),
+      );
     });
   });
 

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -1,6 +1,7 @@
 import {
   AISDKError,
   type Experimental_VideoModelV3,
+  type Experimental_VideoModelV3File,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
@@ -133,6 +134,60 @@ function detectMode(modelId: string): 't2v' | 'i2v' | 'r2v' {
   return 't2v';
 }
 
+function fileToImageString(file: Experimental_VideoModelV3File): string {
+  if (file.type === 'url') {
+    return file.url;
+  }
+  return typeof file.data === 'string'
+    ? file.data
+    : convertUint8ArrayToBase64(file.data);
+}
+
+function getFirstFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'first_frame')
+    ?.image;
+}
+
+function resolveStartImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return getFirstFrameImage(options) ?? options.image;
+}
+
+function resolveReferenceUrls(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+  alibabaOptions: AlibabaVideoModelOptions | undefined,
+  warnings: SharedV3Warning[],
+): string[] | undefined {
+  if (options.frameImages != null && options.frameImages.length > 0) {
+    return undefined;
+  }
+
+  if (options.inputReferences != null && options.inputReferences.length > 0) {
+    const urls: string[] = [];
+
+    for (const reference of options.inputReferences) {
+      if (reference.type === 'url') {
+        urls.push(reference.url);
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'inputReferences',
+          details:
+            'Alibaba reference-to-video requires URL references. ' +
+            'Non-URL reference was skipped.',
+        });
+      }
+    }
+
+    return urls.length > 0 ? urls : undefined;
+  }
+
+  return alibabaOptions?.referenceUrls ?? undefined;
+}
+
 export class AlibabaVideoModel implements Experimental_VideoModelV3 {
   readonly specificationVersion = 'v3';
   readonly maxVideosPerCall = 1;
@@ -174,22 +229,49 @@ export class AlibabaVideoModel implements Experimental_VideoModelV3 {
       input.audio_url = alibabaOptions.audioUrl;
     }
 
+    const startImage = resolveStartImage(options);
+    const referenceUrls = resolveReferenceUrls(
+      options,
+      alibabaOptions,
+      warnings,
+    );
+
     // Handle image input for I2V mode
-    if (mode === 'i2v' && options.image != null) {
-      if (options.image.type === 'url') {
-        input.img_url = options.image.url;
-      } else {
-        const base64Data =
-          typeof options.image.data === 'string'
-            ? options.image.data
-            : convertUint8ArrayToBase64(options.image.data);
-        input.img_url = base64Data;
-      }
+    if (mode === 'i2v' && startImage != null) {
+      input.img_url = fileToImageString(startImage);
     }
 
     // Handle reference URLs for R2V mode
-    if (mode === 'r2v' && alibabaOptions?.referenceUrls != null) {
-      input.reference_urls = alibabaOptions.referenceUrls;
+    if (mode === 'r2v' && referenceUrls != null && referenceUrls.length > 0) {
+      input.reference_urls = referenceUrls;
+    }
+
+    const lastFrame = options.frameImages?.find(
+      frame => frame.frameType === 'last_frame',
+    )?.image;
+
+    if (lastFrame != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'frameImages',
+        details:
+          'This model does not support last_frame. ' +
+          'The last frame image was ignored.',
+      });
+    }
+
+    if (
+      options.inputReferences != null &&
+      options.inputReferences.length > 0 &&
+      mode !== 'r2v'
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'Alibaba only supports inputReferences (reference-to-video) on ' +
+          'reference-to-video models. The reference images were ignored.',
+      });
     }
 
     // Build parameters object

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -9,6 +9,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -655,6 +657,238 @@ describe('ByteDanceVideoModel', () => {
           role: 'last_frame',
         },
       ]);
+    });
+
+    it('should add last frame image from frameImages last_frame with role', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-5-pro-251215',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'url',
+          url: 'https://example.com/first-frame.png',
+        },
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/last-frame.png' },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/first-frame.png' },
+          role: 'first_frame',
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/last-frame.png' },
+          role: 'last_frame',
+        },
+      ]);
+    });
+
+    it('should prefer frameImages last_frame over providerOptions.bytedance.lastFrameImage', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-5-pro-251215',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'url',
+          url: 'https://example.com/first-frame.png',
+        },
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/new-last.png' },
+            frameType: 'last_frame',
+          },
+        ],
+        providerOptions: {
+          bytedance: {
+            lastFrameImage: 'https://example.com/legacy-last.png',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toContainEqual({
+        type: 'image_url',
+        image_url: { url: 'https://example.com/new-last.png' },
+        role: 'last_frame',
+      });
+    });
+
+    it('should use frameImages first_frame as the starting image', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-5-pro-251215',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/first-frame.png' },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/first-frame.png' },
+        },
+      ]);
+    });
+
+    it('should prefer frameImages first_frame over the legacy image option', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-5-pro-251215',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'url',
+          url: 'https://example.com/legacy-image.png',
+        },
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/first-frame.png' },
+            frameType: 'first_frame',
+          },
+          {
+            image: { type: 'url', url: 'https://example.com/last-frame.png' },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/first-frame.png' },
+          role: 'first_frame',
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/last-frame.png' },
+          role: 'last_frame',
+        },
+      ]);
+    });
+
+    it('should send only last_frame when only last_frame is provided without a legacy image', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-5-pro-251215',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: undefined,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/last-frame.png' },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/last-frame.png' },
+          role: 'last_frame',
+        },
+      ]);
+    });
+
+    it('should add reference images from inputReferences with role', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-0-lite-i2v-250428',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/ref1.png' },
+          { type: 'url', url: 'https://example.com/ref2.png' },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/ref1.png' },
+          role: 'reference_image',
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/ref2.png' },
+          role: 'reference_image',
+        },
+      ]);
+    });
+
+    it('should prefer inputReferences over providerOptions.bytedance.referenceImages', async () => {
+      const model = createBasicModel({
+        modelId: 'seedance-1-0-lite-i2v-250428',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/new-ref.png' },
+        ],
+        providerOptions: {
+          bytedance: {
+            referenceImages: ['https://example.com/legacy-ref.png'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toContainEqual({
+        type: 'image_url',
+        image_url: { url: 'https://example.com/new-ref.png' },
+        role: 'reference_image',
+      });
+      expect(requestBody.content).not.toContainEqual({
+        type: 'image_url',
+        image_url: { url: 'https://example.com/legacy-ref.png' },
+        role: 'reference_image',
+      });
     });
 
     it('should add reference images with role', async () => {

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -1,6 +1,7 @@
 import {
   AISDKError,
   type Experimental_VideoModelV3,
+  type Experimental_VideoModelV3File,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
@@ -121,6 +122,51 @@ interface ByteDanceVideoModelConfig extends ByteDanceConfig {
   };
 }
 
+function getFirstFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'first_frame')
+    ?.image;
+}
+
+function resolveStartImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return getFirstFrameImage(options) ?? options.image;
+}
+
+function resolveReferenceImages(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+  byteDanceOptions: ByteDanceVideoProviderOptions | undefined,
+): string[] {
+  if (options.frameImages != null && options.frameImages.length > 0) {
+    return [];
+  }
+
+  const inputReferences = options.inputReferences;
+
+  if (inputReferences != null && inputReferences.length > 0) {
+    return inputReferences.map(image => convertImageModelFileToDataUri(image));
+  }
+
+  return byteDanceOptions?.referenceImages ?? [];
+}
+
+function resolveLastFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+  byteDanceOptions: ByteDanceVideoProviderOptions | undefined,
+): string | undefined {
+  const lastFrame = options.frameImages?.find(
+    frame => frame.frameType === 'last_frame',
+  )?.image;
+
+  if (lastFrame != null) {
+    return convertImageModelFileToDataUri(lastFrame);
+  }
+
+  return byteDanceOptions?.lastFrameImage ?? undefined;
+}
+
 export class ByteDanceVideoModel implements Experimental_VideoModelV3 {
   readonly specificationVersion = 'v3';
   readonly maxVideosPerCall = 1;
@@ -175,37 +221,37 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV3 {
       });
     }
 
-    if (options.image != null) {
+    const startImage = resolveStartImage(options);
+    const lastFrameImageUrl = resolveLastFrameImage(options, byteDanceOptions);
+    const referenceImageUrls = resolveReferenceImages(
+      options,
+      byteDanceOptions,
+    );
+
+    if (startImage != null) {
       content.push({
         type: 'image_url',
-        image_url: { url: convertImageModelFileToDataUri(options.image) },
-        ...(byteDanceOptions?.lastFrameImage != null
-          ? { role: 'first_frame' }
-          : {}),
+        image_url: { url: convertImageModelFileToDataUri(startImage) },
+        ...(lastFrameImageUrl != null ? { role: 'first_frame' } : {}),
       });
     }
 
     // Add last frame image if provided
-    if (byteDanceOptions?.lastFrameImage != null) {
+    if (lastFrameImageUrl != null) {
       content.push({
         type: 'image_url',
-        image_url: { url: byteDanceOptions.lastFrameImage },
+        image_url: { url: lastFrameImageUrl },
         role: 'last_frame',
       });
     }
 
     // Add reference images if provided
-    if (
-      byteDanceOptions?.referenceImages != null &&
-      byteDanceOptions.referenceImages.length > 0
-    ) {
-      for (const imageUrl of byteDanceOptions.referenceImages) {
-        content.push({
-          type: 'image_url',
-          image_url: { url: imageUrl },
-          role: 'reference_image',
-        });
-      }
+    for (const imageUrl of referenceImageUrls) {
+      content.push({
+        type: 'image_url',
+        image_url: { url: imageUrl },
+        role: 'reference_image',
+      });
     }
 
     // Add reference videos if provided

--- a/packages/fal/src/fal-video-model.test.ts
+++ b/packages/fal/src/fal-video-model.test.ts
@@ -9,6 +9,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -105,6 +105,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt: 'A beautiful sunset over mountains',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -132,6 +134,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: '16:9',
         resolution: '1920x1080',
@@ -165,6 +169,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -199,6 +205,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 2,
         aspectRatio: undefined,
         resolution: undefined,
@@ -225,6 +233,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -257,6 +267,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -284,6 +296,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -311,6 +325,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -332,6 +348,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -358,6 +376,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -389,6 +409,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -419,6 +441,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -440,6 +464,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -461,6 +487,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -482,6 +510,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -515,6 +545,8 @@ describe('GatewayVideoModel', () => {
       }).doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -539,6 +571,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -569,6 +603,8 @@ describe('GatewayVideoModel', () => {
         createTestModel().doGenerate({
           prompt: 'Test prompt',
           image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
           n: 1,
           aspectRatio: undefined,
           resolution: undefined,
@@ -597,6 +633,8 @@ describe('GatewayVideoModel', () => {
         createTestModel().doGenerate({
           prompt: 'Test prompt',
           image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
           n: 1,
           aspectRatio: undefined,
           resolution: undefined,
@@ -627,6 +665,8 @@ describe('GatewayVideoModel', () => {
         createTestModel().doGenerate({
           prompt: 'Test prompt',
           image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
           n: 1,
           aspectRatio: undefined,
           resolution: undefined,
@@ -657,6 +697,8 @@ describe('GatewayVideoModel', () => {
         createTestModel().doGenerate({
           prompt: 'Test prompt',
           image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
           n: 1,
           aspectRatio: undefined,
           resolution: undefined,
@@ -679,6 +721,8 @@ describe('GatewayVideoModel', () => {
         createTestModel().doGenerate({
           prompt: 'Test prompt',
           image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
           n: 1,
           aspectRatio: undefined,
           resolution: undefined,
@@ -707,6 +751,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -726,6 +772,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -766,6 +814,8 @@ describe('GatewayVideoModel', () => {
       await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -799,6 +849,8 @@ describe('GatewayVideoModel', () => {
       await model.doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -841,6 +893,8 @@ describe('GatewayVideoModel', () => {
       const result = await createTestModel().doGenerate({
         prompt: 'Test prompt',
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         n: 1,
         aspectRatio: undefined,
         resolution: undefined,
@@ -885,6 +939,8 @@ describe('GatewayVideoModel', () => {
             data: binaryData,
           },
           n: 1,
+          frameImages: undefined,
+          inputReferences: undefined,
           aspectRatio: undefined,
           resolution: undefined,
           duration: undefined,
@@ -913,6 +969,8 @@ describe('GatewayVideoModel', () => {
             data: 'already-base64-encoded',
           },
           n: 1,
+          frameImages: undefined,
+          inputReferences: undefined,
           aspectRatio: undefined,
           resolution: undefined,
           duration: undefined,
@@ -940,6 +998,8 @@ describe('GatewayVideoModel', () => {
             url: 'https://example.com/image.png',
           },
           n: 1,
+          frameImages: undefined,
+          inputReferences: undefined,
           aspectRatio: undefined,
           resolution: undefined,
           duration: undefined,
@@ -970,6 +1030,8 @@ describe('GatewayVideoModel', () => {
             providerOptions: { fal: { enhanceImage: true } },
           },
           n: 1,
+          frameImages: undefined,
+          inputReferences: undefined,
           aspectRatio: undefined,
           resolution: undefined,
           duration: undefined,
@@ -986,6 +1048,131 @@ describe('GatewayVideoModel', () => {
           data: 'SGVsbG8=',
           providerOptions: { fal: { enhanceImage: true } },
         });
+      });
+    });
+
+    describe('frameImages and inputReferences encoding', () => {
+      it('should encode frameImages with Uint8Array data to base64', async () => {
+        prepareJsonResponse();
+
+        const binaryData = new Uint8Array([72, 101, 108, 108, 111]);
+
+        await createTestModel().doGenerate({
+          prompt: 'Animate between frames',
+          image: undefined,
+          frameImages: [
+            {
+              frameType: 'first_frame',
+              image: {
+                type: 'file',
+                mediaType: 'image/png',
+                data: binaryData,
+              },
+            },
+            {
+              frameType: 'last_frame',
+              image: {
+                type: 'url',
+                url: 'https://example.com/last-frame.png',
+              },
+            },
+          ],
+          inputReferences: undefined,
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          generateAudio: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.frameImages).toEqual([
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              mediaType: 'image/png',
+              data: 'SGVsbG8=',
+            },
+          },
+          {
+            frameType: 'last_frame',
+            image: {
+              type: 'url',
+              url: 'https://example.com/last-frame.png',
+            },
+          },
+        ]);
+      });
+
+      it('should encode inputReferences with Uint8Array data to base64', async () => {
+        prepareJsonResponse();
+
+        const binaryData = new Uint8Array([72, 101, 108, 108, 111]);
+
+        await createTestModel().doGenerate({
+          prompt: 'Generate from references',
+          image: undefined,
+          frameImages: undefined,
+          inputReferences: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: binaryData,
+            },
+            {
+              type: 'url',
+              url: 'https://example.com/reference.png',
+            },
+          ],
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          generateAudio: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.inputReferences).toEqual([
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: 'SGVsbG8=',
+          },
+          {
+            type: 'url',
+            url: 'https://example.com/reference.png',
+          },
+        ]);
+      });
+
+      it('should omit frameImages and inputReferences when not provided', async () => {
+        prepareJsonResponse();
+
+        await createTestModel().doGenerate({
+          prompt: 'Text to video',
+          image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          generateAudio: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody).not.toHaveProperty('frameImages');
+        expect(requestBody).not.toHaveProperty('inputReferences');
       });
     });
   });

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -48,6 +48,8 @@ export class GatewayVideoModel implements Experimental_VideoModelV3 {
     seed,
     generateAudio,
     image,
+    frameImages,
+    inputReferences,
     providerOptions,
     headers,
     abortSignal,
@@ -83,6 +85,17 @@ export class GatewayVideoModel implements Experimental_VideoModelV3 {
           ...(generateAudio !== undefined && { generateAudio }),
           ...(providerOptions && { providerOptions }),
           ...(image && { image: maybeEncodeVideoFile(image) }),
+          ...(frameImages && {
+            frameImages: frameImages.map(frame => ({
+              ...frame,
+              image: maybeEncodeVideoFile(frame.image),
+            })),
+          }),
+          ...(inputReferences && {
+            inputReferences: inputReferences.map(reference =>
+              maybeEncodeVideoFile(reference),
+            ),
+          }),
         },
         successfulResponseHandler: async ({
           response,

--- a/packages/google-vertex/src/google-vertex-video-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-video-model.test.ts
@@ -11,6 +11,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -481,6 +483,254 @@ describe('GoogleVertexVideoModel', () => {
         type: 'unsupported',
         feature: 'URL-based image input',
       });
+    });
+  });
+
+  describe('frameImages', () => {
+    it('should use frameImages first_frame as image', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: 'first-frame-data',
+              mediaType: 'image/png',
+            },
+          },
+        ],
+      });
+
+      expect(capturedBody).toMatchObject({
+        instances: [
+          {
+            image: {
+              bytesBase64Encoded: 'first-frame-data',
+              mimeType: 'image/png',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should prefer frameImages first_frame over the legacy image option', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'file',
+          data: 'legacy-image-data',
+          mediaType: 'image/png',
+        },
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: 'first-frame-data',
+              mediaType: 'image/png',
+            },
+          },
+        ],
+      });
+
+      expect(capturedBody).toMatchObject({
+        instances: [
+          {
+            image: {
+              bytesBase64Encoded: 'first-frame-data',
+              mimeType: 'image/png',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should send lastFrame from frameImages last_frame', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: 'first-frame-data',
+              mediaType: 'image/png',
+            },
+          },
+          {
+            frameType: 'last_frame',
+            image: {
+              type: 'file',
+              data: 'last-frame-data',
+              mediaType: 'image/jpeg',
+            },
+          },
+        ],
+      });
+
+      expect(capturedBody).toMatchObject({
+        instances: [
+          {
+            lastFrame: {
+              bytesBase64Encoded: 'last-frame-data',
+              mimeType: 'image/jpeg',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should accept GCS URIs in frameImages', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'url',
+              url: 'gs://bucket/first-frame.png',
+            },
+          },
+        ],
+      });
+
+      expect(capturedBody).toMatchObject({
+        instances: [
+          {
+            image: {
+              gcsUri: 'gs://bucket/first-frame.png',
+              mimeType: 'image/png',
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe('inputReferences', () => {
+    it('should send referenceImages from inputReferences', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: 'reference-1',
+            mediaType: 'image/png',
+          },
+          {
+            type: 'file',
+            data: 'reference-2',
+            mediaType: 'image/jpeg',
+          },
+        ],
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ referenceImages: unknown }>;
+      };
+      expect(body.instances[0].referenceImages).toStrictEqual([
+        {
+          image: {
+            bytesBase64Encoded: 'reference-1',
+            mimeType: 'image/png',
+          },
+          referenceType: 'asset',
+        },
+        {
+          image: {
+            bytesBase64Encoded: 'reference-2',
+            mimeType: 'image/jpeg',
+          },
+          referenceType: 'asset',
+        },
+      ]);
+    });
+
+    it('should prefer inputReferences over providerOptions.vertex.referenceImages', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: 'reference-from-input',
+            mediaType: 'image/png',
+          },
+        ],
+        providerOptions: {
+          vertex: {
+            pollIntervalMs: 10,
+            referenceImages: [{ bytesBase64Encoded: 'provider-reference' }],
+          },
+        },
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ referenceImages: unknown }>;
+      };
+      expect(body.instances[0].referenceImages).toStrictEqual([
+        {
+          image: {
+            bytesBase64Encoded: 'reference-from-input',
+            mimeType: 'image/png',
+          },
+          referenceType: 'asset',
+        },
+      ]);
     });
   });
 

--- a/packages/google-vertex/src/google-vertex-video-model.ts
+++ b/packages/google-vertex/src/google-vertex-video-model.ts
@@ -1,6 +1,7 @@
 import {
   AISDKError,
   type Experimental_VideoModelV3,
+  type Experimental_VideoModelV3File,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
@@ -53,6 +54,78 @@ interface GoogleVertexVideoModelConfig {
   };
 }
 
+function getFirstFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'first_frame')
+    ?.image;
+}
+
+function resolveStartImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return getFirstFrameImage(options) ?? options.image;
+}
+
+function getLastFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'last_frame')
+    ?.image;
+}
+
+function getInputReferences(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Array<Experimental_VideoModelV3File> | undefined {
+  if (options.frameImages != null && options.frameImages.length > 0) {
+    return undefined;
+  }
+
+  return options.inputReferences != null && options.inputReferences.length > 0
+    ? options.inputReferences
+    : undefined;
+}
+
+function convertFileToVertexImage(
+  file: Experimental_VideoModelV3File,
+  warnings: SharedV3Warning[],
+): Record<string, unknown> | undefined {
+  if (file.type === 'url') {
+    if (file.url.startsWith('gs://')) {
+      return {
+        gcsUri: file.url,
+        mimeType: 'image/png',
+      };
+    }
+
+    warnings.push({
+      type: 'unsupported',
+      feature: 'URL-based image input',
+      details:
+        'Vertex AI video models require base64-encoded images or GCS URIs. URL will be ignored.',
+    });
+    return undefined;
+  }
+
+  const base64Data =
+    typeof file.data === 'string'
+      ? file.data
+      : convertUint8ArrayToBase64(file.data);
+
+  return {
+    bytesBase64Encoded: base64Data,
+    mimeType: file.mediaType || 'image/png',
+  };
+}
+
+function convertInputReferenceImage(
+  file: Experimental_VideoModelV3File,
+  warnings: SharedV3Warning[],
+): Record<string, unknown> | undefined {
+  const image = convertFileToVertexImage(file, warnings);
+  return image != null ? { image, referenceType: 'asset' } : undefined;
+}
+
 export class GoogleVertexVideoModel implements Experimental_VideoModelV3 {
   readonly specificationVersion = 'v3';
 
@@ -89,28 +162,29 @@ export class GoogleVertexVideoModel implements Experimental_VideoModelV3 {
       instance.prompt = options.prompt;
     }
 
-    if (options.image != null) {
-      if (options.image.type === 'url') {
-        warnings.push({
-          type: 'unsupported',
-          feature: 'URL-based image input',
-          details:
-            'Vertex AI video models require base64-encoded images or GCS URIs. URL will be ignored.',
-        });
-      } else {
-        const base64Data =
-          typeof options.image.data === 'string'
-            ? options.image.data
-            : convertUint8ArrayToBase64(options.image.data);
-
-        instance.image = {
-          bytesBase64Encoded: base64Data,
-          mimeType: options.image.mediaType,
-        };
+    const startImage = resolveStartImage(options);
+    if (startImage != null) {
+      const image = convertFileToVertexImage(startImage, warnings);
+      if (image != null) {
+        instance.image = image;
       }
     }
 
-    if (vertexOptions?.referenceImages != null) {
+    const lastFrameImage = getLastFrameImage(options);
+    if (lastFrameImage != null) {
+      const lastFrame = convertFileToVertexImage(lastFrameImage, warnings);
+      if (lastFrame != null) {
+        instance.lastFrame = lastFrame;
+      }
+    }
+
+    const inputReferences = getInputReferences(options);
+    if (inputReferences != null) {
+      instance.referenceImages = inputReferences.flatMap(reference => {
+        const converted = convertInputReferenceImage(reference, warnings);
+        return converted != null ? [converted] : [];
+      });
+    } else if (vertexOptions?.referenceImages != null) {
       instance.referenceImages = vertexOptions.referenceImages;
     }
 

--- a/packages/google/src/google-generative-ai-video-model.test.ts
+++ b/packages/google/src/google-generative-ai-video-model.test.ts
@@ -11,6 +11,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -455,6 +457,222 @@ describe('GoogleGenerativeAIVideoModel', () => {
         type: 'unsupported',
         feature: 'URL-based image input',
       });
+    });
+  });
+
+  describe('frameImages', () => {
+    it('should use frameImages first_frame as image', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: 'first-frame-data',
+              mediaType: 'image/png',
+            },
+          },
+        ],
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ image: unknown }>;
+      };
+      expect(body.instances[0].image).toStrictEqual({
+        inlineData: {
+          mimeType: 'image/png',
+          data: 'first-frame-data',
+        },
+      });
+    });
+
+    it('should prefer frameImages first_frame over the legacy image option', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'file',
+          data: 'legacy-image-data',
+          mediaType: 'image/png',
+        },
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: 'first-frame-data',
+              mediaType: 'image/png',
+            },
+          },
+        ],
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ image: unknown }>;
+      };
+      expect(body.instances[0].image).toStrictEqual({
+        inlineData: {
+          mimeType: 'image/png',
+          data: 'first-frame-data',
+        },
+      });
+    });
+
+    it('should send lastFrame from frameImages last_frame', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: 'first-frame-data',
+              mediaType: 'image/png',
+            },
+          },
+          {
+            frameType: 'last_frame',
+            image: {
+              type: 'file',
+              data: 'last-frame-data',
+              mediaType: 'image/jpeg',
+            },
+          },
+        ],
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ image: unknown; lastFrame: unknown }>;
+      };
+      expect(body.instances[0].lastFrame).toStrictEqual({
+        inlineData: {
+          mimeType: 'image/jpeg',
+          data: 'last-frame-data',
+        },
+      });
+    });
+  });
+
+  describe('inputReferences', () => {
+    it('should send referenceImages from inputReferences', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: 'reference-1',
+            mediaType: 'image/png',
+          },
+          {
+            type: 'file',
+            data: 'reference-2',
+            mediaType: 'image/jpeg',
+          },
+        ],
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ referenceImages: unknown }>;
+      };
+      expect(body.instances[0].referenceImages).toStrictEqual([
+        {
+          image: {
+            inlineData: {
+              mimeType: 'image/png',
+              data: 'reference-1',
+            },
+          },
+          referenceType: 'asset',
+        },
+        {
+          image: {
+            inlineData: {
+              mimeType: 'image/jpeg',
+              data: 'reference-2',
+            },
+          },
+          referenceType: 'asset',
+        },
+      ]);
+    });
+
+    it('should prefer inputReferences over providerOptions.google.referenceImages', async () => {
+      let capturedBody: unknown;
+      const model = createMockModel({
+        onRequest: (url, body) => {
+          if (url.includes(':predictLongRunning')) {
+            capturedBody = body;
+          }
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: 'reference-from-input',
+            mediaType: 'image/png',
+          },
+        ],
+        providerOptions: {
+          google: {
+            pollIntervalMs: 10,
+            referenceImages: [{ bytesBase64Encoded: 'provider-reference' }],
+          },
+        },
+      });
+
+      const body = capturedBody as {
+        instances: Array<{ referenceImages: unknown }>;
+      };
+      expect(body.instances[0].referenceImages).toStrictEqual([
+        {
+          image: {
+            inlineData: {
+              mimeType: 'image/png',
+              data: 'reference-from-input',
+            },
+          },
+          referenceType: 'asset',
+        },
+      ]);
     });
   });
 

--- a/packages/google/src/google-generative-ai-video-model.ts
+++ b/packages/google/src/google-generative-ai-video-model.ts
@@ -1,6 +1,7 @@
 import {
   AISDKError,
   type Experimental_VideoModelV3,
+  type Experimental_VideoModelV3File,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
@@ -51,6 +52,103 @@ interface GoogleGenerativeAIVideoModelConfig {
   };
 }
 
+function getFirstFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'first_frame')
+    ?.image;
+}
+
+function resolveStartImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return getFirstFrameImage(options) ?? options.image;
+}
+
+function getLastFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'last_frame')
+    ?.image;
+}
+
+function getInputReferences(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Array<Experimental_VideoModelV3File> | undefined {
+  if (options.frameImages != null && options.frameImages.length > 0) {
+    return undefined;
+  }
+
+  return options.inputReferences != null && options.inputReferences.length > 0
+    ? options.inputReferences
+    : undefined;
+}
+
+function convertFileToGoogleImage(
+  file: Experimental_VideoModelV3File,
+  warnings: SharedV3Warning[],
+): Record<string, unknown> | undefined {
+  if (file.type === 'url') {
+    if (file.url.startsWith('gs://')) {
+      return {
+        gcsUri: file.url,
+        mimeType: 'image/png',
+      };
+    }
+
+    warnings.push({
+      type: 'unsupported',
+      feature: 'URL-based image input',
+      details:
+        'Google Generative AI video models require base64-encoded images or GCS URIs. URL will be ignored.',
+    });
+    return undefined;
+  }
+
+  const base64Data =
+    typeof file.data === 'string'
+      ? file.data
+      : convertUint8ArrayToBase64(file.data);
+
+  // The Gemini Developer API (generativelanguage.googleapis.com) requires
+  // inline image bytes wrapped as `inlineData`.
+  return {
+    inlineData: {
+      mimeType: file.mediaType || 'image/png',
+      data: base64Data,
+    },
+  };
+}
+
+function convertProviderReferenceImage(
+  refImg: NonNullable<GoogleVideoModelOptions['referenceImages']>[number],
+): Record<string, unknown> {
+  if (refImg.bytesBase64Encoded) {
+    return {
+      inlineData: {
+        mimeType: 'image/png',
+        data: refImg.bytesBase64Encoded,
+      },
+    };
+  }
+
+  if (refImg.gcsUri) {
+    return {
+      gcsUri: refImg.gcsUri,
+    };
+  }
+
+  return refImg;
+}
+
+function convertInputReferenceImage(
+  file: Experimental_VideoModelV3File,
+  warnings: SharedV3Warning[],
+): Record<string, unknown> | undefined {
+  const image = convertFileToGoogleImage(file, warnings);
+  return image != null ? { image, referenceType: 'asset' } : undefined;
+}
+
 export class GoogleGenerativeAIVideoModel implements Experimental_VideoModelV3 {
   readonly specificationVersion = 'v3';
 
@@ -87,46 +185,32 @@ export class GoogleGenerativeAIVideoModel implements Experimental_VideoModelV3 {
       instance.prompt = options.prompt;
     }
 
-    // Handle image-to-video: convert image to base64
-    if (options.image != null) {
-      if (options.image.type === 'url') {
-        warnings.push({
-          type: 'unsupported',
-          feature: 'URL-based image input',
-          details:
-            'Google Generative AI video models require base64-encoded images. URL will be ignored.',
-        });
-      } else {
-        const base64Data =
-          typeof options.image.data === 'string'
-            ? options.image.data
-            : convertUint8ArrayToBase64(options.image.data);
-
-        instance.image = {
-          inlineData: {
-            mimeType: options.image.mediaType || 'image/png',
-            data: base64Data,
-          },
-        };
+    const startImage = resolveStartImage(options);
+    if (startImage != null) {
+      const image = convertFileToGoogleImage(startImage, warnings);
+      if (image != null) {
+        instance.image = image;
       }
     }
 
-    if (googleOptions?.referenceImages != null) {
-      instance.referenceImages = googleOptions.referenceImages.map(refImg => {
-        if (refImg.bytesBase64Encoded) {
-          return {
-            inlineData: {
-              mimeType: 'image/png',
-              data: refImg.bytesBase64Encoded,
-            },
-          };
-        } else if (refImg.gcsUri) {
-          return {
-            gcsUri: refImg.gcsUri,
-          };
-        }
-        return refImg;
+    const lastFrameImage = getLastFrameImage(options);
+    if (lastFrameImage != null) {
+      const lastFrame = convertFileToGoogleImage(lastFrameImage, warnings);
+      if (lastFrame != null) {
+        instance.lastFrame = lastFrame;
+      }
+    }
+
+    const inputReferences = getInputReferences(options);
+    if (inputReferences != null) {
+      instance.referenceImages = inputReferences.flatMap(reference => {
+        const converted = convertInputReferenceImage(reference, warnings);
+        return converted != null ? [converted] : [];
       });
+    } else if (googleOptions?.referenceImages != null) {
+      instance.referenceImages = googleOptions.referenceImages.map(refImg =>
+        convertProviderReferenceImage(refImg),
+      );
     }
 
     const parameters: Record<string, unknown> = {

--- a/packages/klingai/src/klingai-video-model.test.ts
+++ b/packages/klingai/src/klingai-video-model.test.ts
@@ -58,6 +58,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -79,6 +81,8 @@ const t2vDefaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -103,6 +107,8 @@ const i2vDefaultOptions = {
     type: 'url' as const,
     url: 'https://example.com/start-frame.png',
   },
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -169,6 +175,19 @@ describe('KlingAIVideoModel', () => {
       },
     },
     [`${TEST_BASE_URL}/v1/videos/image2video/task-abc-123`]: {
+      response: {
+        type: 'json-value',
+        body: successfulTaskResponse,
+      },
+    },
+    // Multi-image (reference-to-video) endpoints
+    [`${TEST_BASE_URL}/v1/videos/multi-image2video`]: {
+      response: {
+        type: 'json-value',
+        body: createTaskResponse,
+      },
+    },
+    [`${TEST_BASE_URL}/v1/videos/multi-image2video/task-abc-123`]: {
       response: {
         type: 'json-value',
         body: successfulTaskResponse,
@@ -976,6 +995,132 @@ describe('KlingAIVideoModel', () => {
       });
     });
 
+    it('should send image_tail from frameImages last_frame (URL)', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/end-frame.png' },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image_tail: 'https://example.com/end-frame.png',
+      });
+    });
+
+    it('should send image_tail as base64 from frameImages last_frame (file)', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        frameImages: [
+          {
+            image: {
+              type: 'file',
+              data: new Uint8Array([137, 80, 78, 71]),
+              mediaType: 'image/png',
+            },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({ image_tail: 'iVBORw==' });
+    });
+
+    it('should prefer frameImages last_frame over providerOptions.klingai.imageTail', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/new-end.png' },
+            frameType: 'last_frame',
+          },
+        ],
+        providerOptions: {
+          klingai: {
+            ...i2vProviderOptions.klingai,
+            imageTail: 'https://example.com/legacy-end.png',
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image_tail: 'https://example.com/new-end.png',
+      });
+    });
+
+    it('should use frameImages first_frame as the start image (URL)', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/start-frame.png' },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: 'https://example.com/start-frame.png',
+      });
+    });
+
+    it('should prefer frameImages first_frame over the legacy image option', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: { type: 'url', url: 'https://example.com/legacy-start.png' },
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/new-start.png' },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: 'https://example.com/new-start.png',
+      });
+    });
+
+    it('should send only image_tail when only last_frame is provided without a legacy image', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/end-frame.png' },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image_tail: 'https://example.com/end-frame.png',
+      });
+      expect(body.image).toBeUndefined();
+    });
+
     it('should send prompt with image', async () => {
       const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
 
@@ -1192,6 +1337,191 @@ describe('KlingAIVideoModel', () => {
       const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
 
       const result = await model.doGenerate({ ...i2vDefaultOptions });
+
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://p1.a.kwimgs.com/output/video-001.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+  });
+
+  describe('doGenerate - reference-to-video (multi-image)', () => {
+    const referenceImages = [
+      { type: 'url' as const, url: 'https://example.com/ref-1.png' },
+      { type: 'url' as const, url: 'https://example.com/ref-2.png' },
+    ];
+
+    it('should POST to /v1/videos/multi-image2video when inputReferences are provided', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/v1/videos/multi-image2video`,
+      );
+    });
+
+    it('should GET from /v1/videos/multi-image2video/{id} for polling', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+      });
+
+      expect(server.calls[1].requestUrl).toBe(
+        `${TEST_BASE_URL}/v1/videos/multi-image2video/task-abc-123`,
+      );
+    });
+
+    it('should map inputReferences to image_list', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model_name: 'kling-v2-6',
+        image_list: [
+          { image: 'https://example.com/ref-1.png' },
+          { image: 'https://example.com/ref-2.png' },
+        ],
+      });
+    });
+
+    it('should encode file-based reference images as base64 in image_list', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: [
+          {
+            type: 'file',
+            data: new Uint8Array([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image_list: [{ image: 'iVBORw==' }],
+      });
+    });
+
+    it('should map aspectRatio and duration for reference-to-video', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+        aspectRatio: '16:9',
+        duration: 10,
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        aspect_ratio: '16:9',
+        duration: '10',
+      });
+    });
+
+    it('should not warn about aspectRatio for reference-to-video', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      const result = await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+        aspectRatio: '16:9',
+      });
+
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ feature: 'aspectRatio' }),
+      );
+    });
+
+    it('should send negative_prompt, cfg_scale and mode for reference-to-video', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+        providerOptions: {
+          klingai: {
+            ...i2vProviderOptions.klingai,
+            mode: 'pro',
+            negativePrompt: 'blurry',
+            cfgScale: 0.5,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        mode: 'pro',
+        negative_prompt: 'blurry',
+        cfg_scale: 0.5,
+      });
+    });
+
+    it('should warn when a start image is provided alongside inputReferences', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      const result = await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: { type: 'url', url: 'https://example.com/start-frame.png' },
+        inputReferences: referenceImages,
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'frameImages',
+        }),
+      );
+    });
+
+    it('should warn when inputReferences are provided for text-to-video', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-t2v' });
+
+      const result = await model.doGenerate({
+        ...t2vDefaultOptions,
+        inputReferences: referenceImages,
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/v1/videos/text2video`,
+      );
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'inputReferences',
+        }),
+      );
+    });
+
+    it('should return videos from successful reference-to-video generation', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      const result = await model.doGenerate({
+        ...i2vDefaultOptions,
+        image: undefined,
+        inputReferences: referenceImages,
+      });
 
       expect(result.videos[0]).toStrictEqual({
         type: 'url',

--- a/packages/klingai/src/klingai-video-model.ts
+++ b/packages/klingai/src/klingai-video-model.ts
@@ -1,6 +1,7 @@
 import {
   AISDKError,
   type Experimental_VideoModelV3,
+  type Experimental_VideoModelV3File,
   NoSuchModelError,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
@@ -22,7 +23,56 @@ import { z } from 'zod/v4';
 import { klingaiFailedResponseHandler } from './klingai-error';
 import type { KlingAIVideoModelId } from './klingai-video-settings';
 
-type KlingAIVideoMode = 't2v' | 'i2v' | 'motion-control';
+type KlingAIVideoMode = 't2v' | 'i2v' | 'mi2v' | 'motion-control';
+
+function fileToImageString(file: Experimental_VideoModelV3File): string {
+  if (file.type === 'url') {
+    return file.url;
+  }
+  return typeof file.data === 'string'
+    ? file.data
+    : convertUint8ArrayToBase64(file.data);
+}
+
+function getReferenceImages(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Array<Experimental_VideoModelV3File> | undefined {
+  if (options.frameImages != null && options.frameImages.length > 0) {
+    return undefined;
+  }
+
+  return options.inputReferences != null && options.inputReferences.length > 0
+    ? options.inputReferences
+    : undefined;
+}
+
+function getFirstFrameImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'first_frame')
+    ?.image;
+}
+
+function resolveStartImage(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+): Experimental_VideoModelV3File | undefined {
+  return getFirstFrameImage(options) ?? options.image;
+}
+
+function resolveImageTail(
+  options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+  klingaiOptions: KlingAIVideoModelOptions | undefined,
+): string | undefined {
+  const lastFrame = options.frameImages?.find(
+    frame => frame.frameType === 'last_frame',
+  )?.image;
+
+  if (lastFrame != null) {
+    return fileToImageString(lastFrame);
+  }
+
+  return klingaiOptions?.imageTail ?? undefined;
+}
 
 /**
  * Detects the video generation mode from the model ID suffix.
@@ -40,6 +90,7 @@ function detectMode(modelId: string): KlingAIVideoMode {
 const modeEndpointMap: Record<KlingAIVideoMode, string> = {
   t2v: '/v1/videos/text2video',
   i2v: '/v1/videos/image2video',
+  mi2v: '/v1/videos/multi-image2video',
   'motion-control': '/v1/videos/motion-control',
 };
 
@@ -54,7 +105,12 @@ const modeEndpointMap: Record<KlingAIVideoMode, string> = {
  * - 'kling-v3.0-t2v' → 'kling-v3'
  */
 function getApiModelName(modelId: string, mode: KlingAIVideoMode): string {
-  const suffix = mode === 'motion-control' ? '-motion-control' : `-${mode}`;
+  const suffix =
+    mode === 'motion-control'
+      ? '-motion-control'
+      : mode === 'mi2v'
+        ? '-i2v'
+        : `-${mode}`;
   const baseName = modelId.slice(0, -suffix.length);
   return baseName.replace(/\.0$/, '').replace(/\./g, '-');
 }
@@ -398,14 +454,35 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       schema: klingaiVideoModelOptionsSchema,
     })) as KlingAIVideoModelOptions | undefined;
 
+    const referenceImages = getReferenceImages(options);
+    const effectiveMode: KlingAIVideoMode =
+      mode === 'i2v' && referenceImages != null ? 'mi2v' : mode;
+
     let body: Record<string, unknown>;
 
-    if (mode === 'motion-control') {
+    if (effectiveMode === 'motion-control') {
       body = this.buildMotionControlBody(options, klingaiOptions, warnings);
-    } else if (mode === 't2v') {
+    } else if (effectiveMode === 't2v') {
       body = this.buildT2VBody(options, klingaiOptions, warnings);
+    } else if (effectiveMode === 'mi2v') {
+      body = this.buildMultiImageBody(
+        options,
+        klingaiOptions,
+        referenceImages!,
+        warnings,
+      );
     } else {
       body = this.buildI2VBody(options, klingaiOptions, warnings);
+    }
+
+    if (referenceImages != null && effectiveMode !== 'mi2v') {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'KlingAI only supports inputReferences (reference-to-video) on ' +
+          'image-to-video models. The reference images were ignored.',
+      });
     }
 
     // Warn about universally unsupported standard options
@@ -444,7 +521,7 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       });
     }
 
-    const endpointPath = modeEndpointMap[mode];
+    const endpointPath = modeEndpointMap[effectiveMode];
 
     // Step 1: Create the task
     const { value: createResponse, responseHeaders: createHeaders } =
@@ -649,7 +726,7 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
     }
 
     // Image is not supported for T2V
-    if (options.image != null) {
+    if (resolveStartImage(options) != null) {
       warnings.push({
         type: 'unsupported',
         feature: 'image',
@@ -677,21 +754,16 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       body.prompt = options.prompt;
     }
 
-    // Map standard SDK image to KlingAI's image field (first/start frame)
-    if (options.image != null) {
-      if (options.image.type === 'url') {
-        body.image = options.image.url;
-      } else {
-        body.image =
-          typeof options.image.data === 'string'
-            ? options.image.data
-            : convertUint8ArrayToBase64(options.image.data);
-      }
+    const startImage = resolveStartImage(options);
+    if (startImage != null) {
+      body.image = fileToImageString(startImage);
     }
 
-    // End frame image via provider options
-    if (klingaiOptions?.imageTail != null) {
-      body.image_tail = klingaiOptions.imageTail;
+    // End frame image: prefer top-level frameImages (last_frame), fall back to
+    // providerOptions.klingai.imageTail.
+    const imageTail = resolveImageTail(options, klingaiOptions);
+    if (imageTail != null) {
+      body.image_tail = imageTail;
     }
 
     if (klingaiOptions?.negativePrompt != null) {
@@ -776,6 +848,72 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
     return body;
   }
 
+  private buildMultiImageBody(
+    options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+    klingaiOptions: KlingAIVideoModelOptions | undefined,
+    referenceImages: Array<Experimental_VideoModelV3File>,
+    warnings: SharedV3Warning[],
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      model_name: getApiModelName(this.modelId, 'mi2v'),
+      image_list: referenceImages.map(image => ({
+        image: fileToImageString(image),
+      })),
+    };
+
+    if (options.prompt != null) {
+      body.prompt = options.prompt;
+    }
+
+    if (klingaiOptions?.negativePrompt != null) {
+      body.negative_prompt = klingaiOptions.negativePrompt;
+    }
+
+    if (klingaiOptions?.cfgScale != null) {
+      body.cfg_scale = klingaiOptions.cfgScale;
+    }
+
+    if (klingaiOptions?.mode != null) {
+      body.mode = klingaiOptions.mode;
+    }
+
+    if (options.aspectRatio != null) {
+      body.aspect_ratio = options.aspectRatio;
+    }
+
+    if (options.duration != null) {
+      body.duration = String(options.duration);
+    }
+
+    if (klingaiOptions?.watermarkEnabled != null) {
+      body.watermark_info = { enabled: klingaiOptions.watermarkEnabled };
+    }
+
+    if (resolveStartImage(options) != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'frameImages',
+        details:
+          'KlingAI reference-to-video does not support a separate start frame. ' +
+          'Provide all guidance images via inputReferences instead.',
+      });
+    }
+
+    if (resolveImageTail(options, klingaiOptions) != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'frameImages',
+        details:
+          'KlingAI reference-to-video does not support a last frame (image_tail). ' +
+          'Provide all guidance images via inputReferences instead.',
+      });
+    }
+
+    this.addPassthroughOptions(body, klingaiOptions);
+
+    return body;
+  }
+
   private buildMotionControlBody(
     options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
     klingaiOptions: KlingAIVideoModelOptions | undefined,
@@ -805,16 +943,9 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       body.prompt = options.prompt;
     }
 
-    // Map standard SDK image option to KlingAI's image_url
-    if (options.image != null) {
-      if (options.image.type === 'url') {
-        body.image_url = options.image.url;
-      } else {
-        body.image_url =
-          typeof options.image.data === 'string'
-            ? options.image.data
-            : convertUint8ArrayToBase64(options.image.data);
-      }
+    const startImage = resolveStartImage(options);
+    if (startImage != null) {
+      body.image_url = fileToImageString(startImage);
     }
 
     if (klingaiOptions.keepOriginalSound != null) {

--- a/packages/prodia/src/prodia-video-model.test.ts
+++ b/packages/prodia/src/prodia-video-model.test.ts
@@ -118,6 +118,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -142,6 +144,8 @@ describe('ProdiaVideoModel', () => {
         seed: 42,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -167,6 +171,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {
           prodia: {
             resolution: '720p',
@@ -196,6 +202,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -218,6 +226,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -239,6 +249,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -265,6 +277,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
         headers: {
           'Custom-Request-Header': 'request-value',
@@ -291,6 +305,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -316,6 +332,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -348,6 +366,8 @@ describe('ProdiaVideoModel', () => {
         seed: undefined,
         generateAudio: undefined,
         image: undefined,
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -381,6 +401,8 @@ describe('ProdiaVideoModel', () => {
           seed: undefined,
           generateAudio: undefined,
           image: undefined,
+          frameImages: undefined,
+          inputReferences: undefined,
           providerOptions: {},
         }),
       ).rejects.toMatchObject({
@@ -411,6 +433,8 @@ describe('ProdiaVideoModel', () => {
           mediaType: 'image/png',
           data: new Uint8Array([1, 2, 3, 4]),
         },
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -438,6 +462,8 @@ describe('ProdiaVideoModel', () => {
           type: 'url',
           url: 'https://cdn.example.com/input.png',
         },
+        frameImages: undefined,
+        inputReferences: undefined,
         providerOptions: {},
       });
 
@@ -475,6 +501,8 @@ describe('ProdiaVideoModel', () => {
             type: 'url',
             url: 'http://169.254.169.254/latest/meta-data/',
           },
+          frameImages: undefined,
+          inputReferences: undefined,
           providerOptions: {},
         }),
       ).rejects.toThrow();

--- a/packages/provider/src/video-model/v3/index.ts
+++ b/packages/provider/src/video-model/v3/index.ts
@@ -4,3 +4,7 @@ export type {
 } from './video-model-v3';
 export type { VideoModelV3CallOptions as Experimental_VideoModelV3CallOptions } from './video-model-v3-call-options';
 export type { VideoModelV3File as Experimental_VideoModelV3File } from './video-model-v3-file';
+export type {
+  VideoModelV3FrameImage as Experimental_VideoModelV3FrameImage,
+  VideoModelV3FrameType as Experimental_VideoModelV3FrameType,
+} from './video-model-v3-frame-image';

--- a/packages/provider/src/video-model/v3/video-model-v3-call-options.ts
+++ b/packages/provider/src/video-model/v3/video-model-v3-call-options.ts
@@ -1,5 +1,6 @@
 import type { SharedV3ProviderOptions } from '../../shared';
 import type { VideoModelV3File } from './video-model-v3-file';
+import type { VideoModelV3FrameImage } from './video-model-v3-frame-image';
 
 export type VideoModelV3CallOptions = {
   /**
@@ -53,6 +54,18 @@ export type VideoModelV3CallOptions = {
    * The image serves as the starting frame that the model will animate.
    */
   image: VideoModelV3File | undefined;
+
+  /**
+   * Role-tagged image inputs for first-last-frame generation.
+   * Each entry declares whether it is the `first_frame` or the
+   * `last_frame` of the generated video.
+   */
+  frameImages: Array<VideoModelV3FrameImage> | undefined;
+
+  /**
+   * Reference image inputs for reference-to-video generation.
+   */
+  inputReferences: Array<VideoModelV3File> | undefined;
 
   /**
    * Whether the model should generate audio alongside the video.

--- a/packages/provider/src/video-model/v3/video-model-v3-frame-image.ts
+++ b/packages/provider/src/video-model/v3/video-model-v3-frame-image.ts
@@ -1,0 +1,24 @@
+import type { VideoModelV3File } from './video-model-v3-file';
+
+/**
+ * The role a frame image plays in video generation.
+ *
+ * - `first_frame`: the starting frame the model animates from
+ * - `last_frame`: the ending frame the model animates towards
+ */
+export type VideoModelV3FrameType = 'first_frame' | 'last_frame';
+
+/**
+ * A role-tagged image input for image-to-video and first-last-frame generation.
+ */
+export type VideoModelV3FrameImage = {
+  /**
+   * The image file used for this frame.
+   */
+  image: VideoModelV3File;
+
+  /**
+   * Which frame this image represents.
+   */
+  frameType: VideoModelV3FrameType;
+};

--- a/packages/replicate/src/replicate-video-model.test.ts
+++ b/packages/replicate/src/replicate-video-model.test.ts
@@ -11,6 +11,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -26,6 +26,8 @@ const defaultOptions = {
   prompt,
   n: 1,
   image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
   aspectRatio: undefined,
   resolution: undefined,
   duration: undefined,
@@ -855,6 +857,225 @@ describe('XaiVideoModel', () => {
           },
         }),
       ).rejects.toThrow(InvalidArgumentError);
+    });
+  });
+
+  describe('frameImages', () => {
+    it('should map a first_frame URL image to the image field', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/first.png' },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/generations`,
+      );
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: { url: 'https://example.com/first.png' },
+      });
+    });
+
+    it('should map a first_frame file image to a data URI image field', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: {
+              type: 'file',
+              data: new Uint8Array([137, 80, 78, 71]),
+              mediaType: 'image/png',
+            },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: { url: 'data:image/png;base64,iVBORw==' },
+      });
+    });
+
+    it('should prefer the first_frame image over the image-to-video image input', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        image: { type: 'url', url: 'https://example.com/image-input.png' },
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/first.png' },
+            frameType: 'first_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: { url: 'https://example.com/first.png' },
+      });
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should warn and ignore a last_frame image', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/first.png' },
+            frameType: 'first_frame',
+          },
+          {
+            image: { type: 'url', url: 'https://example.com/last.png' },
+            frameType: 'last_frame',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: { url: 'https://example.com/first.png' },
+      });
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'frameImages',
+        }),
+      );
+    });
+  });
+
+  describe('inputReferences', () => {
+    it('should map URL inputReferences to reference_images and select R2V', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/ref1.jpg' },
+          { type: 'url', url: 'https://example.com/ref2.jpg' },
+        ],
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/generations`,
+      );
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_images: [
+          { url: 'https://example.com/ref1.jpg' },
+          { url: 'https://example.com/ref2.jpg' },
+        ],
+      });
+    });
+
+    it('should map file inputReferences to data URI reference_images', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: new Uint8Array([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_images: [{ url: 'data:image/png;base64,iVBORw==' }],
+      });
+    });
+
+    it('should prefer inputReferences over the legacy referenceImageUrls option', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/first-class.jpg' },
+        ],
+        providerOptions: {
+          xai: {
+            referenceImageUrls: ['https://example.com/legacy.jpg'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_images: [{ url: 'https://example.com/first-class.jpg' }],
+      });
+    });
+
+    it('should ignore and warn about inputReferences when frameImages are present', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: { type: 'url', url: 'https://example.com/first.png' },
+            frameType: 'first_frame',
+          },
+        ],
+        inputReferences: [{ type: 'url', url: 'https://example.com/ref1.jpg' }],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        image: { url: 'https://example.com/first.png' },
+      });
+      expect(body).not.toHaveProperty('reference_images');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'inputReferences',
+        }),
+      );
+    });
+
+    it('should ignore and warn about inputReferences in edit-video mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [{ type: 'url', url: 'https://example.com/ref1.jpg' }],
+        providerOptions: {
+          xai: {
+            mode: 'edit-video',
+            videoUrl: 'https://example.com/source-video.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(`${TEST_BASE_URL}/videos/edits`);
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('reference_images');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'inputReferences',
+        }),
+      );
     });
   });
 

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -1,6 +1,7 @@
 import {
   AISDKError,
   type Experimental_VideoModelV3,
+  type Experimental_VideoModelV3File,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
@@ -37,21 +38,87 @@ const RESOLUTION_MAP: Record<string, string> = {
   '640x480': '480p',
 };
 
-function resolveVideoMode(
-  options: XaiParsedVideoModelOptions | undefined,
-): XaiParsedVideoModelOptions['mode'] | undefined {
-  if (options?.mode != null) {
-    return options.mode;
+type XaiVideoDoGenerateOptions = Parameters<
+  Experimental_VideoModelV3['doGenerate']
+>[0];
+
+function getFirstFrameImage(
+  options: XaiVideoDoGenerateOptions,
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'first_frame')
+    ?.image;
+}
+
+function getLastFrameImage(
+  options: XaiVideoDoGenerateOptions,
+): Experimental_VideoModelV3File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'last_frame')
+    ?.image;
+}
+
+function resolveStartImage(
+  options: XaiVideoDoGenerateOptions,
+): Experimental_VideoModelV3File | undefined {
+  return getFirstFrameImage(options) ?? options.image;
+}
+
+function fileToXaiImageUrl(file: Experimental_VideoModelV3File): string {
+  if (file.type === 'url') {
+    return file.url;
   }
 
-  if (options?.videoUrl != null) {
-    return 'edit-video';
+  const base64Data =
+    typeof file.data === 'string'
+      ? file.data
+      : convertUint8ArrayToBase64(file.data);
+  return `data:${file.mediaType ?? 'image/png'};base64,${base64Data}`;
+}
+
+// Resolves the reference images for R2V generation. First-class
+// `inputReferences` win over the legacy `referenceImageUrls` provider option.
+function resolveReferenceImages(
+  options: XaiVideoDoGenerateOptions,
+  xaiOptions: XaiParsedVideoModelOptions | undefined,
+): Array<{ url: string }> | undefined {
+  if (options.inputReferences != null && options.inputReferences.length > 0) {
+    return options.inputReferences.map(reference => ({
+      url: fileToXaiImageUrl(reference),
+    }));
   }
 
   if (
-    options?.referenceImageUrls != null &&
-    options.referenceImageUrls.length > 0
+    xaiOptions?.referenceImageUrls != null &&
+    xaiOptions.referenceImageUrls.length > 0
   ) {
+    return xaiOptions.referenceImageUrls.map(url => ({ url }));
+  }
+
+  return undefined;
+}
+
+function resolveVideoMode(
+  options: XaiVideoDoGenerateOptions,
+  xaiOptions: XaiParsedVideoModelOptions | undefined,
+): XaiParsedVideoModelOptions['mode'] | undefined {
+  if (xaiOptions?.mode != null) {
+    return xaiOptions.mode;
+  }
+
+  if (xaiOptions?.videoUrl != null) {
+    return 'edit-video';
+  }
+
+  // frameImages (first/last frame) take precedence over reference images, so
+  // only auto-select reference-to-video when no frame images are provided.
+  const hasFrameImages =
+    options.frameImages != null && options.frameImages.length > 0;
+  const hasInputReferences =
+    options.inputReferences != null && options.inputReferences.length > 0;
+  const hasLegacyReferenceUrls =
+    xaiOptions?.referenceImageUrls != null &&
+    xaiOptions.referenceImageUrls.length > 0;
+
+  if (!hasFrameImages && (hasInputReferences || hasLegacyReferenceUrls)) {
     return 'reference-to-video';
   }
 
@@ -83,7 +150,7 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
       schema: xaiVideoModelOptionsSchema,
     })) as XaiParsedVideoModelOptions | undefined;
 
-    const effectiveMode = resolveVideoMode(xaiOptions);
+    const effectiveMode = resolveVideoMode(options, xaiOptions);
 
     const isEdit = effectiveMode === 'edit-video';
     const isExtension = effectiveMode === 'extend-video';
@@ -207,26 +274,47 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
       body.video = { url: xaiOptions!.videoUrl };
     }
 
-    // Convert SDK image input to the nested xAI request image object
-    if (options.image != null) {
-      if (options.image.type === 'url') {
-        body.image = { url: options.image.url };
-      } else {
-        const base64Data =
-          typeof options.image.data === 'string'
-            ? options.image.data
-            : convertUint8ArrayToBase64(options.image.data);
-        body.image = {
-          url: `data:${options.image.mediaType};base64,${base64Data}`,
-        };
-      }
+    // Convert the start image (first_frame or image-to-video input) to the
+    // nested xAI request image object.
+    const startImage = resolveStartImage(options);
+    if (startImage != null) {
+      body.image = { url: fileToXaiImageUrl(startImage) };
+    }
+
+    // xAI has no first-last-frame interpolation; warn and ignore last_frame.
+    if (getLastFrameImage(options) != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'frameImages',
+        details:
+          'xAI video models do not support last_frame. Use ' +
+          'providerOptions.xai.mode "extend-video" to continue from a ' +
+          "video's last frame. The last frame image was ignored.",
+      });
     }
 
     // Reference images for R2V (reference-to-video) generation
     if (hasReferenceImages) {
-      body.reference_images = xaiOptions!.referenceImageUrls!.map(url => ({
-        url,
-      }));
+      const referenceImages = resolveReferenceImages(options, xaiOptions);
+      if (referenceImages != null) {
+        body.reference_images = referenceImages;
+      }
+    }
+
+    // Warn when reference images were provided but cannot be used in the
+    // resolved mode (e.g. alongside frameImages, or in edit/extend modes).
+    if (
+      options.inputReferences != null &&
+      options.inputReferences.length > 0 &&
+      !hasReferenceImages
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'xAI only supports inputReferences for reference-to-video ' +
+          'generation. The reference images were ignored.',
+      });
     }
 
     if (xaiOptions != null) {


### PR DESCRIPTION
Backport of #16219 to `release-v6.0`.

## Summary

Promotes two image inputs to first-class top-level options on `experimental_generateVideo`, instead of requiring provider-specific passthrough:

- **`frameImages`** — role-tagged images (`first_frame` / `last_frame`) for image-to-video and first-last-frame generation.
- **`inputReferences`** — reference images for reference-to-video (r2v) generation.

Both are normalized once in core and passed through to providers, with warnings when they conflict (e.g. `frameImages` + `inputReferences` supplied together, or a `first_frame` overriding `prompt.image`).

## Backport notes

`release-v6.0` is on the **VideoModelV3** spec, whereas the original PR targeted **VideoModelV4** on `main`. Adaptations:

- Added `frameImages` / `inputReferences` to the v3 call-options type and a new `video-model-v3-frame-image.ts` (frame-image / frame-type definitions). All v4-only files from the PR were dropped (`v4` call-options, `v4` frame-image, `as-video-model-v4.test.ts`).
- `generate-video.ts` keeps the v3 `satisfies Experimental_VideoModelV3CallOptions` shape; all `VideoModelV4*` types swapped to their `V3` equivalents.
- Adapted `normalizeImageData` to v6.0's `detectMediaType({ signatures: imageMediaTypeSignatures })` API (the PR used main-only `{ topLevelType: 'image' }`).
- The 7 provider implementations (google, google-vertex, alibaba, bytedance, klingai, xai, gateway) keep `specificationVersion = 'v3'` with `VideoModelV4` → `VideoModelV3` renames throughout.
- `google-generative-ai-video-model.ts` keeps v6.0's class name `GoogleGenerativeAIVideoModel` (renamed to `GoogleVideoModel` on main).
- `google-vertex-video-model.ts` keeps v6.0's `vertexOptions` variable name (renamed to `googleVertexOptions` on main).
- Fixed the back-ported vertex examples + docs to use the v6.0 provider name `vertex` (the PR used the main-only `googleVertex`).