### PR TITLE
fix: tool name parsing when early chunk contains tool name as empty s…

### DIFF
--- a/.changeset/gold-rockets-sin.md
+++ b/.changeset/gold-rockets-sin.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai-compatible": patch
+---
+
+Fixed an issue in streaming chat completions where tool-call deltas with an empty function.name string were forwarded prematurely, causing tool-calls to be emitted with missing names and incomplete arguments. The provider now buffers these deltas until a non-empty name is received.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2420,6 +2420,125 @@ describe('doStream', () => {
     `);
   });
 
+  it('should stream tool deltas when function.name arrives as empty string in early chunk', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-empty-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}\n\n`,
+        // First tool_calls delta carries id, (empty) arguments and empty name
+        `data: {"id":"chatcmpl-empty-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_test","type":"function","function":{"name": "", "arguments":""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // function.name arrives in the next chunk together with the start of the arguments
+        `data: {"id":"chatcmpl-empty-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_test","type":"function","function":{"name":"test-tool","arguments":"{\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-empty-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"value"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-empty-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\"hi\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-empty-name","object":"chat.completion.chunk","created":1729171479,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":10,"total_tokens":28}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-empty-name",
+          "modelId": "grok-3",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "call_test",
+          "toolName": "test-tool",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"",
+          "id": "call_test",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "value",
+          "id": "call_test",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "":"hi"}",
+          "id": "call_test",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "call_test",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"value":"hi"}",
+          "toolCallId": "call_test",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 10,
+              "total": 10,
+            },
+            "raw": {
+              "completion_tokens": 10,
+              "prompt_tokens": 18,
+              "total_tokens": 28,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
   it('should error when streamed tool call never receives a function.name', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -507,7 +507,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
       }
 
       const name = toolCallDelta.function?.name;
-      if (name != null) {
+      if (name != null && name.length > 0) {
         const forwardDelta: OpenAICompatibleStreamingToolCallDelta = {
           index,
           id: pending.id,


### PR DESCRIPTION
## Background

Some OpenAI-compatible providers stream tool-call deltas where the first `function.name` value is an empty string ("") rather than undefined. The previous check only verified `name != null`, so an empty name was treated as valid and forwarded to the tool-call tracker prematurely. This caused the tracker to emit a tool-call with an empty name and lose the buffered arguments that arrived before the real name was streamed.

## Summary

Updated the tool-call delta handling in `OpenAICompatibleChatLanguageModel.doStream` to also require `name.length > 0` before forwarding a buffered tool-call delta. Added a regression test that streams a tool-call delta with `function.name: ""` followed by the delta containing the real name; the test fails without the fix because the tracker receives an empty name and incomplete arguments.

## Manual Verification

Command-a model running on VLLM returns the problematic format of stream. After the implementation of the fix, the tool name gets parsed correctly

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) - minor fix, not needed
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)