### PR TITLE
chore: build only packages in ci:release

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "turbo test --concurrency 16 --filter=!@example/*",
     "test:ci": "turbo test --concurrency 16 --filter=!@example/* --filter=!ai --filter=!@ai-sdk/codemod --only",
     "test:update": "turbo test:update --concurrency 16 --filter=!@example/*",
-    "ci:release": "turbo clean && turbo build && changeset publish",
+    "ci:release": "turbo clean && npm run build:packages && changeset publish",
     "ci:version": "changeset version && node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile",
     "clean-examples": "node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile",
     "check": "ultracite check",


### PR DESCRIPTION
Use `npm run build:packages` instead of `turbo build` in the `ci:release` script. We don't need to build all examples for the release.

### Future work

We should only build the packages that will actually be published as part of the release, instead of building all packages.