### PR TITLE
chore: build only packages in ci:release

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "turbo test --concurrency 16 --filter=!@example/*",
     "test:ci": "turbo test --concurrency 16 --filter=!@example/* --filter=!ai --filter=!@ai-sdk/codemod --only",
     "test:update": "turbo test:update --concurrency 16 --filter=!@example/*",
-    "ci:release": "turbo clean && turbo build && changeset publish --tag ai-v5",
+    "ci:release": "turbo clean && npm run build:packages && changeset publish --tag ai-v5",
     "ci:version": "changeset version && node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile",
     "clean-examples": "node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile"
   },


### PR DESCRIPTION
Use `npm run build:packages` instead of `turbo build` in the `ci:release` script. We don't need to build all examples for the release.