### PR TITLE
docs(openai): update token usage docs

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1863,13 +1863,13 @@ They support additional settings and response metadata:
 - You can use `providerOptions` to set
   - the `reasoningEffort` option (or alternatively the `reasoningEffort` model setting), which determines the amount of reasoning the model performs.
 
-- You can use response `providerMetadata` to access the number of reasoning tokens that the model generated.
+- You can use the response `usage` to access the number of reasoning tokens that the model generated via `usage.outputTokenDetails.reasoningTokens`.
 
 ```ts highlight="4,7-11,17"
 import { openai, type OpenAILanguageModelChatOptions } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { text, usage } = await generateText({
   model: openai.chat('gpt-5'),
   prompt: 'Invent a new holiday and describe its traditions.',
   providerOptions: {
@@ -1880,10 +1880,7 @@ const { text, usage, providerMetadata } = await generateText({
 });
 
 console.log(text);
-console.log('Usage:', {
-  ...usage,
-  reasoningTokens: providerMetadata?.openai?.reasoningTokens,
-});
+console.log('Reasoning tokens:', usage.outputTokenDetails.reasoningTokens);
 ```
 
 <Note>
@@ -2215,7 +2212,7 @@ including `gpt-4o` and `gpt-4o-mini`.
 
 - Prompt caching is automatically enabled for these models, when the prompt is 1024 tokens or longer. It does
   not need to be explicitly enabled.
-- You can use response `providerMetadata` to access the number of prompt tokens that were a cache hit.
+- You can use the response `usage` to access the number of prompt tokens that were a cache hit via `usage.inputTokenDetails.cacheReadTokens`.
 - Note that caching behavior is dependent on load on OpenAI's infrastructure. Prompt prefixes generally remain in the
   cache following 5-10 minutes of inactivity before they are evicted, but during off-peak periods they may persist for up
   to an hour.
@@ -2224,15 +2221,12 @@ including `gpt-4o` and `gpt-4o-mini`.
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { text, usage } = await generateText({
   model: openai.chat('gpt-4o-mini'),
   prompt: `A 1024-token or longer prompt...`,
 });
 
-console.log(`usage:`, {
-  ...usage,
-  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
-});
+console.log('Cached tokens:', usage.inputTokenDetails.cacheReadTokens);
 ```
 
 To improve cache hit rates, you can manually control caching using the `promptCacheKey` option:
@@ -2241,7 +2235,7 @@ To improve cache hit rates, you can manually control caching using the `promptCa
 import { openai, type OpenAILanguageModelChatOptions } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { text, usage } = await generateText({
   model: openai.chat('gpt-5'),
   prompt: `A 1024-token or longer prompt...`,
   providerOptions: {
@@ -2251,10 +2245,7 @@ const { text, usage, providerMetadata } = await generateText({
   },
 });
 
-console.log(`usage:`, {
-  ...usage,
-  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
-});
+console.log('Cached tokens:', usage.inputTokenDetails.cacheReadTokens);
 ```
 
 For GPT-5.1 models, you can enable extended prompt caching that keeps cached prefixes active for up to 24 hours:
@@ -2263,7 +2254,7 @@ For GPT-5.1 models, you can enable extended prompt caching that keeps cached pre
 import { openai, type OpenAILanguageModelChatOptions } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { text, usage } = await generateText({
   model: openai.chat('gpt-5.1'),
   prompt: `A 1024-token or longer prompt...`,
   providerOptions: {
@@ -2274,10 +2265,7 @@ const { text, usage, providerMetadata } = await generateText({
   },
 });
 
-console.log(`usage:`, {
-  ...usage,
-  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
-});
+console.log('Cached tokens:', usage.inputTokenDetails.cacheReadTokens);
 ```
 
 #### Audio Input

--- a/examples/ai-functions/src/generate-text/openai/basic.ts
+++ b/examples/ai-functions/src/generate-text/openai/basic.ts
@@ -5,16 +5,13 @@ import { print } from '../../lib/print';
 
 run(async () => {
   const result = await generateText({
-    model: openai('gpt-5.5'),
-    prompt:
-      'Invent a new holiday and describe its traditions. Consider the ramifications of your answer before responding.',
+    model: openai('gpt-5-nano'),
+    prompt: 'Invent a new holiday and describe its traditions.',
     maxRetries: 0,
-    reasoning: 'medium',
   });
 
   print('Content:', result.content);
   print('Usage:', result.usage);
   print('Finish reason:', result.finishReason);
   print('Raw finish reason:', result.rawFinishReason);
-  print('Provider metadata:', result.finalStep.providerMetadata);
 });

--- a/examples/ai-functions/src/generate-text/openai/basic.ts
+++ b/examples/ai-functions/src/generate-text/openai/basic.ts
@@ -5,13 +5,16 @@ import { print } from '../../lib/print';
 
 run(async () => {
   const result = await generateText({
-    model: openai('gpt-5-nano'),
-    prompt: 'Invent a new holiday and describe its traditions.',
+    model: openai('gpt-5.5'),
+    prompt:
+      'Invent a new holiday and describe its traditions. Consider the ramifications of your answer before responding.',
     maxRetries: 0,
+    reasoning: 'medium',
   });
 
   print('Content:', result.content);
   print('Usage:', result.usage);
   print('Finish reason:', result.finishReason);
   print('Raw finish reason:', result.rawFinishReason);
+  print('Provider metadata:', result.finalStep.providerMetadata);
 });


### PR DESCRIPTION
## Background

Cached token and reasoning token usage is available under `usage.inputTokenDetails` and `usage.inputTokenDetails.cacheReadTokens` respectively, instead of in `providerMetadata`, but the docs for the `openai` provider were not updated.

## Summary

Updated docs to use the new properties

## Manual Verification

Checked that these properties exist when using the `openai` provider

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixed https://github.com/vercel/ai/issues/8426, which was due to incorrect docs