### PR TITLE
fix(perplexity): make delta.role optional and content nullish in perplexityChunkSchema

### DIFF
--- a/.changeset/blue-starfishes-jump.md
+++ b/.changeset/blue-starfishes-jump.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/perplexity": patch
+---
+
+fix perplexityChunkSchema to allow optional role and nullish content in streaming chunks

--- a/packages/perplexity/src/perplexity-language-model.test.ts
+++ b/packages/perplexity/src/perplexity-language-model.test.ts
@@ -789,23 +789,9 @@ describe('doStream', () => {
           "type": "raw",
         },
         {
-          "error": [AI_TypeValidationError: Type validation failed: Value: {"id":"ppl-456","object":"chat.completion.chunk","created":1234567890,"model":"sonar","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}.
-      Error message: [
-        {
-          "code": "invalid_value",
-          "values": [
-            "assistant"
-          ],
-          "path": [
-            "choices",
-            0,
-            "delta",
-            "role"
-          ],
-          "message": "Invalid input: expected \\"assistant\\""
-        }
-      ]],
-          "type": "error",
+          "delta": " world",
+          "id": "0",
+          "type": "text-delta",
         },
         {
           "rawValue": {
@@ -831,51 +817,21 @@ describe('doStream', () => {
           "type": "raw",
         },
         {
-          "error": [AI_TypeValidationError: Type validation failed: Value: {"id":"ppl-789","object":"chat.completion.chunk","created":1234567890,"model":"sonar","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"citation_tokens":2,"num_search_queries":1}}.
-      Error message: [
-        {
-          "code": "invalid_value",
-          "values": [
-            "assistant"
-          ],
-          "path": [
-            "choices",
-            0,
-            "delta",
-            "role"
-          ],
-          "message": "Invalid input: expected \\"assistant\\""
-        },
-        {
-          "expected": "string",
-          "code": "invalid_type",
-          "path": [
-            "choices",
-            0,
-            "delta",
-            "content"
-          ],
-          "message": "Invalid input: expected string, received undefined"
-        }
-      ]],
-          "type": "error",
-        },
-        {
           "id": "0",
           "type": "text-end",
         },
         {
           "finishReason": {
-            "raw": undefined,
-            "unified": "other",
+            "raw": "stop",
+            "unified": "stop",
           },
           "providerMetadata": {
             "perplexity": {
               "cost": null,
               "images": null,
               "usage": {
-                "citationTokens": null,
-                "numSearchQueries": null,
+                "citationTokens": 2,
+                "numSearchQueries": 1,
               },
             },
           },
@@ -884,15 +840,21 @@ describe('doStream', () => {
             "inputTokens": {
               "cacheRead": undefined,
               "cacheWrite": undefined,
-              "noCache": undefined,
-              "total": undefined,
+              "noCache": 10,
+              "total": 10,
             },
             "outputTokens": {
-              "reasoning": undefined,
-              "text": undefined,
-              "total": undefined,
+              "reasoning": 0,
+              "text": 5,
+              "total": 5,
             },
-            "raw": undefined,
+            "raw": {
+              "citation_tokens": 2,
+              "completion_tokens": 5,
+              "num_search_queries": 1,
+              "prompt_tokens": 10,
+              "total_tokens": 15,
+            },
           },
         },
       ]

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -477,8 +477,8 @@ const perplexityChunkSchema = z.object({
   choices: z.array(
     z.object({
       delta: z.object({
-        role: z.literal('assistant'),
-        content: z.string(),
+        role: z.literal('assistant').optional(),
+        content: z.string().nullish(),
       }),
       finish_reason: z.string().nullish(),
     }),


### PR DESCRIPTION
## Background

`@ai-sdk/perplexity` validates every SSE chunk against `perplexityChunkSchema`, which required both `delta.role: z.literal('assistant')` and `delta.content: z.string()` on every chunk.

Perplexity's streaming API (e.g. `sonar-pro`) only emits `delta.role` on the **first** chunk. Subsequent content-delta chunks omit `role` entirely, causing Zod validation to throw:
``` 
[{"path":["choices",0,"delta","role"],"message":"Invalid input: expected "assistant""}]
```
This surfaces as `Type validation failed` stream errors in production for any app using `streamText` with Perplexity models.

Fixes #16530

## Summary

- Made `delta.role` optional (`z.literal('assistant').optional()`)
- Made `delta.content` nullish (`z.string().nullish()`)
- Updated snapshot to reflect correct behavior — chunks that previously threw `type: "error"` now correctly produce `type: "text-delta"`
- Follows the same pattern as `@ai-sdk/openai-compatible`

## Testing

- 32/32 tests passing (both node and edge configs)
- 1 snapshot updated to reflect fixed behavior

## Checklist

- All commits are signed
- Tests have been added / updated
- A patch changeset has been added
- I have reviewed this pull request

## Related Issues

Fixes #16530