### PR TITLE
docs: document xai responses api default in v7 migration guide and provider docs

### DIFF
--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -1883,6 +1883,25 @@ The old names still work as deprecated aliases, but you should migrate to the ne
 
 The main entry point the `google` constant, remains unchanged, so if that's all you use from the provider, no changes are required.
 
+## xAI Provider
+
+### Default Model Now Uses the Responses API
+
+In AI SDK 7, `xai(modelId)` (and `xai.languageModel(modelId)`) uses the xAI Responses API by default instead of the Chat Completions API. To keep using the Chat Completions API, use `xai.chat(modelId)`.
+
+```tsx filename="AI SDK 6"
+// used the Chat Completions API
+const model = xai('grok-4.3');
+```
+
+```tsx filename="AI SDK 7"
+// now uses the Responses API
+const model = xai('grok-4.3');
+
+// use the Chat Completions API explicitly
+const chatModel = xai.chat('grok-4.3');
+```
+
 # Migration Skill
 
 Use the command below to add the migration skill and guide your agent

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -1887,7 +1887,7 @@ The main entry point the `google` constant, remains unchanged, so if that's all 
 
 ### Default Model Now Uses the Responses API
 
-In AI SDK 7, `xai(modelId)` (and `xai.languageModel(modelId)`) uses the xAI Responses API by default instead of the Chat Completions API. To keep using the Chat Completions API, use `xai.chat(modelId)`.
+In AI SDK 7, `xai(modelId)` (and `xai.languageModel(modelId)`) uses the xAI Responses API by default instead of the Chat Completions API. Both APIs were already available in AI SDK 6 via `xai.chat(modelId)` and `xai.responses(modelId)`; AI SDK 7 only changes which one `xai(modelId)` uses by default. To keep using the Chat Completions API, use `xai.chat(modelId)`.
 
 ```tsx filename="AI SDK 6"
 // used the Chat Completions API

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -79,7 +79,12 @@ first argument is the model id, e.g. `grok-4.20-non-reasoning`.
 const model = xai('grok-4.20-non-reasoning');
 ```
 
-By default, `xai(modelId)` uses the Responses API. To use the [Chat Completions API](https://docs.x.ai/docs/api-reference#chat-completions) (legacy), use `xai.chat(modelId)`.
+<Note>
+  Since AI SDK 7, `xai(modelId)` uses the xAI Responses API by default. To use
+  the [Chat Completions
+  API](https://docs.x.ai/docs/api-reference#chat-completions) (legacy), use
+  `xai.chat(modelId)`.
+</Note>
 
 ### Example
 
@@ -165,7 +170,7 @@ calling pattern.
 
 ## Responses API (Agentic Tools)
 
-The xAI Responses API is the default when using `xai(modelId)`. You can also use `xai.responses(modelId)` explicitly. This enables the model to autonomously orchestrate tool calls and research on xAI's servers.
+The xAI Responses API is the default when using `xai(modelId)` (since AI SDK 7). You can also use `xai.responses(modelId)` explicitly. This enables the model to autonomously orchestrate tool calls and research on xAI's servers.
 
 ```ts
 const model = xai.responses('grok-4.20-non-reasoning');


### PR DESCRIPTION
## background

in v7, `xai(modelId)` defaults to the xai responses api (flipped from chat completions in #13340). this wasn't called out in the v7 migration guide or the xai provider docs, so anyone upgrading from v6 hits a silent behavior change

## summary

- add an `## xAI Provider` section to the v7 migration guide documenting that in ai sdk 7, `xai(modelId)` uses the responses api by default (use `xai.chat(modelId)` for legacy chat completions)
- note in the xai provider docs that the responses api is the default since ai sdk 7