### PR TITLE
fix(react): use the latest transport in `useChat` instead of a stale one

### DIFF
--- a/.changeset/pink-crews-beg.md
+++ b/.changeset/pink-crews-beg.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/react": patch
+---
+
+fix(react): use the latest transport in useChat instead of a stale one

--- a/examples/ai-e2e-next/app/api/chat/stale-transport-demo/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/stale-transport-demo/route.ts
@@ -1,0 +1,27 @@
+import { createUIMessageStreamResponse, simulateReadableStream } from 'ai';
+
+// Echoes the `subagent` value received so the stale-transport fix (#7819) can be verified
+export async function POST(req: Request) {
+  const body = await req.json();
+  const subagent = JSON.stringify(body?.subagent ?? null);
+
+  return createUIMessageStreamResponse({
+    stream: simulateReadableStream({
+      initialDelayInMs: 0,
+      chunkDelayInMs: 0,
+      chunks: [
+        { type: 'start' },
+        { type: 'start-step' },
+        { type: 'text-start', id: '0' },
+        {
+          type: 'text-delta',
+          id: '0',
+          delta: `Server received subagent = ${subagent}`,
+        },
+        { type: 'text-end', id: '0' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ],
+    }),
+  });
+}

--- a/examples/ai-e2e-next/app/chat/stale-transport-demo/page.tsx
+++ b/examples/ai-e2e-next/app/chat/stale-transport-demo/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useState } from 'react';
+
+export default function Page() {
+  const [subagent, setSubagent] = useState('todos-agent');
+
+  const { messages, sendMessage, status } = useChat({
+    // A new transport is created with the current `subagent` on each render
+    transport: new DefaultChatTransport({
+      api: '/api/chat/stale-transport-demo',
+      body: { subagent },
+    }),
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-lg py-12 mx-auto gap-4">
+      <h4 className="text-xl font-bold">
+        useChat stale transport demo (#7819)
+      </h4>
+
+      <div className="flex items-center gap-2">
+        <span>Current subagent state:</span>
+        <strong data-testid="subagent">{subagent}</strong>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="px-3 py-1 border rounded"
+          onClick={() => setSubagent('todos-agent')}
+        >
+          set todos-agent
+        </button>
+        <button
+          className="px-3 py-1 border rounded"
+          onClick={() => setSubagent('research-agent')}
+        >
+          set research-agent
+        </button>
+      </div>
+
+      <button
+        className="px-3 py-1 text-white bg-black rounded disabled:opacity-50"
+        disabled={status !== 'ready'}
+        onClick={() => sendMessage({ text: 'what did the server receive?' })}
+      >
+        Send message
+      </button>
+
+      <div className="flex flex-col gap-2">
+        {messages.map(message => (
+          <div key={message.id} className="whitespace-pre-wrap">
+            {message.role === 'user' ? 'User: ' : 'AI: '}
+            {message.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -62,69 +62,60 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   resume = false,
   ...options
 }: UseChatOptions<UI_MESSAGE> = {}): UseChatHelpers<UI_MESSAGE> {
-  // Create a single ref for all callbacks to avoid stale closures
-  const callbacksRef = useRef(
-    !('chat' in options)
-      ? {
-          onToolCall: options.onToolCall,
-          onData: options.onData,
-          onFinish: options.onFinish,
-          onError: options.onError,
-          sendAutomaticallyWhen: options.sendAutomaticallyWhen,
-        }
-      : {},
-  );
+  // the Chat instance is created once and not recreated when options change,
+  // so it would normally keep the callbacks/transport from the first render forever
 
-  // Update callbacks ref on each render to keep them current
+  // keep latest values in a ref that is refreshed on every render,
+  // and hand `Chat` stable wrappers that read from it to avoid stale closures
+  const latestRef = useRef<
+    Partial<
+      Pick<
+        ChatInit<UI_MESSAGE>,
+        | 'onToolCall'
+        | 'onData'
+        | 'onFinish'
+        | 'onError'
+        | 'sendAutomaticallyWhen'
+        | 'transport'
+      >
+    >
+  >({});
+
   if (!('chat' in options)) {
-    callbacksRef.current = {
+    latestRef.current = {
       onToolCall: options.onToolCall,
       onData: options.onData,
       onFinish: options.onFinish,
       onError: options.onError,
       sendAutomaticallyWhen: options.sendAutomaticallyWhen,
+      transport: options.transport,
     };
   }
 
-  // keep ref to the latest transport
-  const transportRef = useRef(
-    !('chat' in options) ? options.transport : undefined,
-  );
-  // update transport ref on each render to keep it current
-  if (!('chat' in options)) {
-    transportRef.current = options.transport;
-  }
+  // resolve the latest transport and fallback to a lazily created default transport
+  let defaultTransport: ChatTransport<UI_MESSAGE> | undefined;
+  const getTransport = () =>
+    latestRef.current.transport ??
+    (defaultTransport ??= new DefaultChatTransport<UI_MESSAGE>());
 
-  // stable proxy transport that forwards to the latest transport in the ref
-  // falls back to a lazily-created default transport when none is provided
-  const transportProxyRef = useRef<ChatTransport<UI_MESSAGE>>(undefined);
-  if (transportProxyRef.current == null) {
-    let defaultTransport: ChatTransport<UI_MESSAGE> | undefined;
-    const getTransport = () =>
-      transportRef.current ??
-      (defaultTransport ??= new DefaultChatTransport<UI_MESSAGE>());
-
-    transportProxyRef.current = {
+  // give `Chat` stable wrappers that always read the latest values from `latestRef`
+  const chatOptions: typeof options = {
+    ...options,
+    transport: {
       sendMessages: sendOptions => getTransport().sendMessages(sendOptions),
       reconnectToStream: reconnectOptions =>
         getTransport().reconnectToStream(reconnectOptions),
-    };
-  }
-
-  // Ensure the Chat instance has the latest callbacks and transport
-  const optionsWithCallbacks: typeof options = {
-    ...options,
-    transport: transportProxyRef.current,
-    onToolCall: arg => callbacksRef.current.onToolCall?.(arg),
-    onData: arg => callbacksRef.current.onData?.(arg),
-    onFinish: arg => callbacksRef.current.onFinish?.(arg),
-    onError: arg => callbacksRef.current.onError?.(arg),
+    },
+    onToolCall: arg => latestRef.current.onToolCall?.(arg),
+    onData: arg => latestRef.current.onData?.(arg),
+    onFinish: arg => latestRef.current.onFinish?.(arg),
+    onError: arg => latestRef.current.onError?.(arg),
     sendAutomaticallyWhen: arg =>
-      callbacksRef.current.sendAutomaticallyWhen?.(arg) ?? false,
+      latestRef.current.sendAutomaticallyWhen?.(arg) ?? false,
   };
 
   const chatRef = useRef<Chat<UI_MESSAGE>>(
-    'chat' in options ? options.chat : new Chat(optionsWithCallbacks),
+    'chat' in options ? options.chat : new Chat(chatOptions),
   );
 
   const shouldRecreateChat =
@@ -134,8 +125,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
-    chatRef.current =
-      'chat' in options ? options.chat : new Chat(optionsWithCallbacks);
+    chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
   }
 
   const subscribeToMessages = useCallback(

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,4 +1,11 @@
-import type { AbstractChat, ChatInit, CreateUIMessage, UIMessage } from 'ai';
+import {
+  type AbstractChat,
+  type ChatInit,
+  type ChatTransport,
+  type CreateUIMessage,
+  type UIMessage,
+  DefaultChatTransport,
+} from 'ai';
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import { Chat } from './chat.react';
 
@@ -79,9 +86,35 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     };
   }
 
-  // Ensure the Chat instance has the latest callbacks
+  // keep ref to the latest transport
+  const transportRef = useRef(
+    !('chat' in options) ? options.transport : undefined,
+  );
+  // update transport ref on each render to keep it current
+  if (!('chat' in options)) {
+    transportRef.current = options.transport;
+  }
+
+  // stable proxy transport that forwards to the latest transport in the ref
+  // falls back to a lazily-created default transport when none is provided
+  const transportProxyRef = useRef<ChatTransport<UI_MESSAGE>>(undefined);
+  if (transportProxyRef.current == null) {
+    let defaultTransport: ChatTransport<UI_MESSAGE> | undefined;
+    const getTransport = () =>
+      transportRef.current ??
+      (defaultTransport ??= new DefaultChatTransport<UI_MESSAGE>());
+
+    transportProxyRef.current = {
+      sendMessages: sendOptions => getTransport().sendMessages(sendOptions),
+      reconnectToStream: reconnectOptions =>
+        getTransport().reconnectToStream(reconnectOptions),
+    };
+  }
+
+  // Ensure the Chat instance has the latest callbacks and transport
   const optionsWithCallbacks: typeof options = {
     ...options,
+    transport: transportProxyRef.current,
     onToolCall: arg => callbacksRef.current.onToolCall?.(arg),
     onData: arg => callbacksRef.current.onData?.(arg),
     onFinish: arg => callbacksRef.current.onFinish?.(arg),

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -5,7 +5,13 @@ import {
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
 import { mockId } from '@ai-sdk/provider-utils/test';
-import { fireEvent, screen, waitFor, render } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+  render,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   DefaultChatTransport,
@@ -884,6 +890,56 @@ describe('use-chat', () => {
 
       expect(onToolCallA).toHaveBeenCalledTimes(0);
       expect(onToolCallB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stale transport', () => {
+    afterEach(cleanup);
+
+    it('should use the latest transport body after a state change (no stale closure)', async () => {
+      const Test = () => {
+        const [subagent, setSubagent] = React.useState('todos-agent');
+        const { sendMessage } = useChat({
+          transport: new DefaultChatTransport({
+            body: { subagent },
+          }),
+        });
+
+        return (
+          <div>
+            <button
+              data-testid="change-subagent"
+              onClick={() => setSubagent('research-agent')}
+            />
+            <button
+              data-testid="do-send"
+              onClick={() => {
+                sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+          </div>
+        );
+      };
+
+      render(<Test />);
+
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('change-subagent'));
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await vi.waitUntil(() => server.calls.length > 0, { timeout: 2000 });
+
+      expect((await server.calls[0].requestBodyJson).subagent).toBe(
+        'research-agent',
+      );
     });
   });
 


### PR DESCRIPTION
## Background

`useChat()` creates its `Chat` instance once and stores it in a `useRef()`, so as a result, a `transport` passed to `useChat()` was captured and then frozen at its value in the first render. If react state later changes, the `transport` becomes stale.

A very similar problem was addressed in https://github.com/vercel/ai/pull/8985 but with callbacks.

## Summary

Rather than passing the transport directly to `Chat`, this passes a proxy object that always reads the latest transport (or falls back to a default one).

This uses the same solution as in https://github.com/vercel/ai/pull/8985 for callbacks. 

## Manual Verification

Added a route to the ai-e2e-next example at `/chat/stale-transport-demo`. It reproduces the bug without the changes made, and then is fixed with these changes.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/7819

Closes https://github.com/vercel/ai/pull/12330
Closes https://github.com/vercel/ai/pull/13464
Closes https://github.com/vercel/ai/pull/15380
Closes https://github.com/vercel/ai/pull/16326


