### PR TITLE
feat(provider/google-vertex): add interactions() for Gemini Interactions API

### DIFF
--- a/.changeset/google-vertex-interactions.md
+++ b/.changeset/google-vertex-interactions.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/google': patch
+---
+
+Add `vertex.interactions()` for the Gemini Interactions API on Vertex AI. Targets the location-scoped `.../locations/{region}/interactions` resource using the existing Vertex OAuth credentials, enabling multimodal-output models such as `gemini-omni-flash-preview` (video output) through Vertex. The `GoogleInteractionsLanguageModel` is now exported from `@ai-sdk/google/internal` for provider reuse.

--- a/examples/ai-functions/src/generate-text/google-vertex/interactions-video-output-modify-stateless.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex/interactions-video-output-modify-stateless.ts
@@ -1,0 +1,83 @@
+import { type GoogleLanguageModelInteractionsOptions } from '@ai-sdk/google';
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
+import { generateText, type ModelMessage } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+const vertex = createGoogleVertex({ location: 'global' });
+const model = vertex.interactions('gemini-omni-flash-preview');
+
+run(async () => {
+  // Stateless modify: Vertex does not support `previousInteractionId` for this
+  // model, so pass `store: false` and re-send the full conversation history
+  // every turn (including the assistant video from turn 1).
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'A marble rolling fast on a chain reaction style track, continuous smooth shot.',
+    },
+  ];
+
+  console.log('--- Turn 1: generate ---');
+  const turn1 = await withSpinner('Generating video...', () =>
+    generateText({
+      model,
+      messages,
+      providerOptions: {
+        google: {
+          store: false,
+        } satisfies GoogleLanguageModelInteractionsOptions,
+      },
+    }),
+  );
+
+  console.log('Turn 1 text:', turn1.text);
+  console.log(
+    'Turn 1 interaction id:',
+    turn1.finalStep.providerMetadata?.google?.interactionId,
+  );
+  console.log('Turn 1 files:', turn1.files.length);
+
+  const turn1Videos = turn1.files.filter(file =>
+    file.mediaType.startsWith('video/'),
+  );
+  if (turn1Videos.length > 0) {
+    await presentVideos(turn1Videos);
+  }
+
+  messages.push(...turn1.response.messages);
+  messages.push({
+    role: 'user',
+    content: 'Make the marble blue.',
+  });
+
+  console.log();
+  console.log('--- Turn 2: modify (make the marble blue) ---');
+  const turn2 = await withSpinner('Modifying video...', () =>
+    generateText({
+      model,
+      messages,
+      providerOptions: {
+        google: {
+          store: false,
+        } satisfies GoogleLanguageModelInteractionsOptions,
+      },
+    }),
+  );
+
+  console.log('Turn 2 text:', turn2.text);
+  console.log(
+    'Turn 2 interaction id:',
+    turn2.finalStep.providerMetadata?.google?.interactionId,
+  );
+  console.log('Turn 2 files:', turn2.files.length);
+
+  const turn2Videos = turn2.files.filter(file =>
+    file.mediaType.startsWith('video/'),
+  );
+  if (turn2Videos.length > 0) {
+    await presentVideos(turn2Videos);
+  }
+});

--- a/examples/ai-functions/src/generate-text/google-vertex/interactions-video-output.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex/interactions-video-output.ts
@@ -1,0 +1,42 @@
+import { type GoogleLanguageModelInteractionsOptions } from '@ai-sdk/google';
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// `gemini-omni-flash-preview` is served by the Interactions API. On Vertex the
+// model is currently only available in the `global` region, so pin the location
+// explicitly rather than relying on `GOOGLE_VERTEX_LOCATION`. Uses standard
+// Google Cloud credentials (not Express Mode API keys).
+const vertex = createGoogleVertex({ location: 'global' });
+
+run(async () => {
+  const result = await withSpinner('Generating video...', () =>
+    generateText({
+      model: vertex.interactions('gemini-omni-flash-preview'),
+      prompt:
+        'A marble rolling fast on a chain reaction style track, continuous smooth shot.',
+      providerOptions: {
+        google: {
+          store: false,
+        } satisfies GoogleLanguageModelInteractionsOptions,
+      },
+    }),
+  );
+
+  console.log(result.text);
+  console.log();
+  console.log(
+    'Interaction id:',
+    result.finalStep.providerMetadata?.google?.interactionId,
+  );
+  console.log('Files:', result.files.length);
+
+  const videos = result.files.filter(file =>
+    file.mediaType.startsWith('video/'),
+  );
+  if (videos.length > 0) {
+    await presentVideos(videos);
+  }
+});

--- a/examples/ai-functions/src/stream-text/google-vertex/interactions-video-output-modify-stateless.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex/interactions-video-output-modify-stateless.ts
@@ -1,0 +1,110 @@
+import { type GoogleLanguageModelInteractionsOptions } from '@ai-sdk/google';
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
+import { streamText, type GeneratedFile, type ModelMessage } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// `gemini-omni-flash-preview` is served by the Interactions API. On Vertex the
+// model is currently only available in the `global` region, so pin the location
+// explicitly rather than relying on `GOOGLE_VERTEX_LOCATION`. Uses standard
+// Google Cloud credentials (not Express Mode API keys).
+const vertex = createGoogleVertex({ location: 'global' });
+const model = vertex.interactions('gemini-omni-flash-preview');
+
+run(async () => {
+  const messages: Array<ModelMessage> = [
+    {
+      role: 'user',
+      content:
+        'A marble rolling fast on a chain reaction style track, continuous smooth shot.',
+    },
+  ];
+
+  console.log('--- Turn 1: generate ---');
+  const turn1Videos: Array<GeneratedFile> = [];
+
+  const turn1 = streamText({
+    model,
+    messages,
+    providerOptions: {
+      google: {
+        store: false,
+      } satisfies GoogleLanguageModelInteractionsOptions,
+    },
+  });
+
+  await withSpinner('Generating video...', async () => {
+    for await (const part of turn1.stream) {
+      switch (part.type) {
+        case 'text-delta': {
+          process.stdout.write(part.text);
+          break;
+        }
+        case 'file': {
+          if (part.file.mediaType.startsWith('video/')) {
+            turn1Videos.push(part.file);
+          }
+          break;
+        }
+      }
+    }
+  });
+
+  console.log();
+  console.log(
+    'Turn 1 interaction id:',
+    (await turn1.providerMetadata)?.google?.interactionId,
+  );
+
+  if (turn1Videos.length > 0) {
+    await presentVideos(turn1Videos);
+  }
+
+  messages.push(...(await turn1.response).messages);
+  messages.push({
+    role: 'user',
+    content: 'Make the marble blue.',
+  });
+
+  console.log();
+  console.log('--- Turn 2: modify (make the marble blue) ---');
+  const turn2Videos: Array<GeneratedFile> = [];
+
+  const turn2 = streamText({
+    model,
+    messages,
+    providerOptions: {
+      google: {
+        store: false,
+      } satisfies GoogleLanguageModelInteractionsOptions,
+    },
+  });
+
+  await withSpinner('Modifying video...', async () => {
+    for await (const part of turn2.stream) {
+      switch (part.type) {
+        case 'text-delta': {
+          process.stdout.write(part.text);
+          break;
+        }
+        case 'file': {
+          if (part.file.mediaType.startsWith('video/')) {
+            turn2Videos.push(part.file);
+          }
+          break;
+        }
+      }
+    }
+  });
+
+  console.log();
+  console.log(
+    'Turn 2 interaction id:',
+    (await turn2.providerMetadata)?.google?.interactionId,
+  );
+
+  if (turn2Videos.length > 0) {
+    await presentVideos(turn2Videos);
+  }
+});

--- a/examples/ai-functions/src/stream-text/google-vertex/interactions-video-output.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex/interactions-video-output.ts
@@ -1,0 +1,54 @@
+import { type GoogleLanguageModelInteractionsOptions } from '@ai-sdk/google';
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
+import { streamText, type GeneratedFile } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// `gemini-omni-flash-preview` is served by the Interactions API. On Vertex the
+// model is currently only available in the `global` region, so pin the location
+// explicitly rather than relying on `GOOGLE_VERTEX_LOCATION`. Uses standard
+// Google Cloud credentials (not Express Mode API keys).
+const vertex = createGoogleVertex({ location: 'global' });
+
+run(async () => {
+  const videos: Array<GeneratedFile> = [];
+
+  await withSpinner('Generating video...', async () => {
+    const result = streamText({
+      model: vertex.interactions('gemini-omni-flash-preview'),
+      prompt:
+        'A marble rolling fast on a chain reaction style track, continuous smooth shot.',
+      providerOptions: {
+        google: {
+          store: false,
+        } satisfies GoogleLanguageModelInteractionsOptions,
+      },
+    });
+
+    for await (const part of result.stream) {
+      switch (part.type) {
+        case 'text-delta': {
+          process.stdout.write(part.text);
+          break;
+        }
+        case 'file': {
+          if (part.file.mediaType.startsWith('video/')) {
+            videos.push(part.file);
+          }
+          break;
+        }
+      }
+    }
+
+    console.log();
+    console.log(
+      'Interaction id:',
+      (await result.finalStep).providerMetadata?.google?.interactionId,
+    );
+  });
+
+  if (videos.length > 0) {
+    await presentVideos(videos);
+  }
+});

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -2,6 +2,7 @@ import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createGoogleVertex } from './google-vertex-provider-base';
 import {
+  GoogleInteractionsLanguageModel,
   GoogleLanguageModel,
   GoogleSpeechModel,
 } from '@ai-sdk/google/internal';
@@ -40,6 +41,7 @@ vi.mock('@ai-sdk/provider-utils', async importOriginal => {
 
 vi.mock('@ai-sdk/google/internal', () => ({
   GoogleLanguageModel: vi.fn(),
+  GoogleInteractionsLanguageModel: vi.fn(),
   GoogleSpeechModel: vi.fn(),
   googleTools: {
     googleSearch: vi.fn(),
@@ -91,6 +93,39 @@ describe('google-vertex-provider-base', () => {
         headers: expect.any(Function),
         generateId: expect.any(Function),
       }),
+    );
+  });
+
+  it('should create an interactions model targeting the location-scoped interactions resource', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+    provider.interactions('gemini-omni-flash-preview');
+
+    expect(GoogleInteractionsLanguageModel).toHaveBeenCalledWith(
+      'gemini-omni-flash-preview',
+      expect.objectContaining({
+        provider: 'google.vertex.interactions',
+        // No `/publishers/google` suffix — the interactions model appends
+        // `/interactions` to reach `.../locations/{region}/interactions`.
+        baseURL:
+          'https://test-location-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/test-location',
+        headers: expect.any(Function),
+        generateId: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should throw for interactions models when an Express Mode API key is set', () => {
+    process.env.GOOGLE_VERTEX_API_KEY = 'test-api-key';
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+
+    expect(() => provider.interactions('gemini-omni-flash-preview')).toThrow(
+      /do not support Express Mode API keys/,
     );
   });
 

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -1,6 +1,10 @@
 import {
+  GoogleInteractionsLanguageModel,
   GoogleLanguageModel,
   GoogleSpeechModel,
+  type GoogleInteractionsAgentName,
+  type GoogleInteractionsModelId,
+  type GoogleInteractionsModelInput,
 } from '@ai-sdk/google/internal';
 import type {
   Experimental_VideoModelV4,
@@ -71,6 +75,19 @@ export interface GoogleVertexProvider extends ProviderV4 {
   (modelId: GoogleVertexModelId): LanguageModelV4;
 
   languageModel: (modelId: GoogleVertexModelId) => LanguageModelV4;
+
+  /**
+   * Creates a language model targeting the Gemini Interactions API
+   * (`.../locations/{region}/interactions`) on Vertex, reusing the Vertex
+   * OAuth credentials. Pass a model id (e.g. `gemini-omni-flash-preview`) or an
+   * `{ agent }` / `{ managedAgent }` reference.
+   */
+  interactions(
+    modelIdOrAgent:
+      | GoogleInteractionsModelId
+      | { agent: GoogleInteractionsAgentName }
+      | { managedAgent: string },
+  ): LanguageModelV4;
 
   /**
    * Creates a model for image generation.
@@ -270,6 +287,31 @@ export function createGoogleVertex(
     });
   };
 
+  const createInteractionsModel = (
+    modelIdOrAgent:
+      | GoogleInteractionsModelId
+      | { agent: GoogleInteractionsAgentName }
+      | { managedAgent: string },
+  ) => {
+    if (apiKey) {
+      throw new Error(
+        'Google Vertex Interactions models do not support Express Mode API keys. Use standard Google Cloud credentials instead.',
+      );
+    }
+
+    return new GoogleInteractionsLanguageModel(
+      modelIdOrAgent as GoogleInteractionsModelInput,
+      {
+        // The Interactions API is a location-scoped resource
+        // (`.../locations/{region}/interactions`), so it uses the
+        // endpoint-style base URL without the `/publishers/google` suffix that
+        // the base-model paths carry.
+        ...createConfig('interactions', { endpoint: true }),
+        generateId: options.generateId ?? generateId,
+      },
+    );
+  };
+
   const createEmbeddingModel = (modelId: GoogleVertexEmbeddingModelId) =>
     new GoogleVertexEmbeddingModel(modelId, createConfig('embedding'));
 
@@ -321,6 +363,7 @@ export function createGoogleVertex(
 
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createChatModel;
+  provider.interactions = createInteractionsModel;
   provider.embeddingModel = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;

--- a/packages/google/src/internal/index.ts
+++ b/packages/google/src/internal/index.ts
@@ -2,3 +2,9 @@ export * from '../google-language-model';
 export * from '../google-speech-model';
 export { googleTools } from '../google-tools';
 export type { GoogleModelId } from '../google-language-model-options';
+export {
+  GoogleInteractionsLanguageModel,
+  type GoogleInteractionsModelInput,
+} from '../interactions/google-interactions-language-model';
+export type { GoogleInteractionsModelId } from '../interactions/google-interactions-language-model-options';
+export type { GoogleInteractionsAgentName } from '../interactions/google-interactions-agent';


### PR DESCRIPTION
## Background

Google's `gemini-omni-flash-preview` is a multimodal-output model (video) served only by the Gemini **Interactions API**. Support for it landed in `@ai-sdk/google` (parse video output, per-modality usage, `google.interactions()`), but the Interactions transport was never wired into `@ai-sdk/google-vertex`. Omni is served on **both** the Gemini Developer API and Vertex AI.

## Summary

Adds `vertex.interactions()` to `@ai-sdk/google-vertex`, reusing the existing `@ai-sdk/google` Interactions model.

## Manual Verification

- **Live endpoint confirmed on Vertex**: `POST https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/{region}/interactions` returns HTTP 200 with a `video/mp4` block, validating the exact path shape this PR builds.
- `@ai-sdk/google-vertex` and `@ai-sdk/google` tests pass

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

