### PR TITLE
fix(ai): preserve tool approval signature when transitioning to appro…

### DIFF
--- a/.changeset/fix-tool-approval-signature.md
+++ b/.changeset/fix-tool-approval-signature.md
@@ -1,0 +1,5 @@
+---\
+'ai': patch\
+---\
+\
+fix(ai): preserve tool approval signature when transitioning to approval-responded

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -2597,6 +2597,56 @@ describe('Chat', () => {
   });
 
   describe('addToolApprovalResponse', () => {
+    describe('approved with signature', () => {
+      let chat: TestChat;
+
+      beforeEach(async () => {
+        chat = new TestChat({
+          id: '123',
+          generateId: mockId({ prefix: 'newid' }),
+          transport: new DefaultChatTransport({
+            api: 'http://localhost:3000/api/chat',
+          }),
+          messages: [
+            {
+              id: 'id-0',
+              role: 'user',
+              parts: [{ text: 'What is the weather in Tokyo?', type: 'text' }],
+            },
+            {
+              id: 'id-1',
+              role: 'assistant',
+              parts: [
+                { type: 'step-start' },
+                {
+                  type: 'tool-weather',
+                  toolCallId: 'call-1',
+                  state: 'approval-requested',
+                  input: { city: 'Tokyo' },
+                  approval: { id: 'approval-1', signature: 'test-signature' },
+                },
+              ],
+            },
+          ],
+        });
+
+        await chat.addToolApprovalResponse({
+          id: 'approval-1',
+          approved: true,
+        });
+      });
+
+      it('should preserve the signature in the approval response', () => {
+        expect(chat.messages[1].parts[1]).toMatchObject({
+          approval: {
+            id: 'approval-1',
+            approved: true,
+            signature: 'test-signature',
+          },
+        });
+      });
+    });
+
     describe('approved', () => {
       let chat: TestChat;
 

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -493,7 +493,14 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           ? {
               ...part,
               state: 'approval-responded',
-              approval: { id, approved, reason },
+              approval: {
+                id,
+                approved,
+                reason,
+                ...(part.approval.signature != null
+                  ? { signature: part.approval.signature }
+                  : {}),
+              },
             }
           : part;
 

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -7757,6 +7757,75 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('automatic tool approval signature preservation', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start' },
+        { type: 'start-step' },
+        {
+          input: {
+            value: 'value',
+          },
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          type: 'tool-input-available',
+        },
+        {
+          approvalId: 'id-1',
+          isAutomatic: true,
+          signature: 'test-signature',
+          toolCallId: 'call-1',
+          type: 'tool-approval-request',
+        },
+        {
+          approvalId: 'id-1',
+          approved: true,
+          type: 'tool-approval-response',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should keep signature through approval response', () => {
+      expect(writeCalls.map(call => call.message.parts[1])).toMatchObject([
+        {}, // tool-input-available
+        {
+          approval: {
+            id: 'id-1',
+            isAutomatic: true,
+            signature: 'test-signature',
+          },
+          state: 'approval-requested',
+        },
+        {
+          approval: {
+            id: 'id-1',
+            approved: true,
+            isAutomatic: true,
+            signature: 'test-signature',
+          },
+          state: 'approval-responded',
+        },
+      ]);
+    });
+  });
+
   describe('automatic tool approval denial (static tool)', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -731,6 +731,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 approved: chunk.approved,
                 ...(chunk.reason != null ? { reason: chunk.reason } : {}),
                 ...(approval.isAutomatic === true ? { isAutomatic: true } : {}),
+                ...(approval.signature != null
+                  ? { signature: approval.signature }
+                  : {}),
               };
               if (chunk.providerExecuted != null) {
                 toolInvocation.providerExecuted = chunk.providerExecuted;


### PR DESCRIPTION
## Background

When `experimental_toolApprovalSecret` is configured, resuming after a tool approval fails with `AI_InvalidToolApprovalSignatureError: missing signature`. 

This happens because the client-side state manager drops `approval.signature` when transitioning from the `approval-requested` state to the `approval-responded` state in two places:
1. In `AbstractChat.addToolApprovalResponse` (manual approval) — rebuilt `approval` as `{ id, approved, reason }` without carrying forward `signature`.
2. In `processUIMessageStream` under the `tool-approval-response` case (streamed/automatic) — rebuilt `toolInvocation.approval` carrying `isAutomatic` but omitting `signature`.

Consequently, `convertToModelMessages` later read `part.approval.signature` as `undefined`, causing the server-side verification check to throw.

## Summary

- **packages/ai/src/ui/chat.ts**:
  - Updated `addToolApprovalResponse` to preserve `part.approval.signature` when mapping and updating message parts.
- **packages/ai/src/ui/process-ui-message-stream.ts**:
  - Updated the `tool-approval-response` case to carry forward the previous `approval.signature` into the updated `toolInvocation.approval` object.
- **packages/ai/src/ui/chat.test.ts**:
  - Added `approved with signature` unit test to verify signature preservation for manual approvals.
- **packages/ai/src/ui/process-ui-message-stream.test.ts**:
  - Added `automatic tool approval signature preservation` unit test to verify signature preservation for streamed/automatic approvals.

## Manual Verification

- Verified the state transitions and signature preservation via the newly added automated unit tests. All tests run successfully:
  ```bash
  ✓ src/ui/chat.test.ts (30 tests) 662ms
  ✓ src/ui/process-ui-message-stream.test.ts (115 tests) 1.59s


## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features)
- [x] I have reviewed this pull request (self-review)

> [!NOTE]
> Please make sure to sign your commits as required by the repository guidelines before merging.

## Related Issues

Fixes #16543
