### PR TITLE
feat(amazon-bedrock): increase limit of embeddings in a request for cohere models

### DIFF
--- a/.changeset/cuddly-foxes-end.md
+++ b/.changeset/cuddly-foxes-end.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+feat(amazon-bedrock): increase limit of embeddings in a request for cohere models

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
@@ -102,6 +102,38 @@ describe('doEmbed', () => {
     },
   );
 
+  it('should expose model-specific max embeddings per call', () => {
+    const cohereModel = new AmazonBedrockEmbeddingModel(
+      'cohere.embed-english-v3',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+      },
+    );
+    const cohereV4UsProfileModel = new AmazonBedrockEmbeddingModel(
+      'us.cohere.embed-v4:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+      },
+    );
+    const novaModel = new AmazonBedrockEmbeddingModel(
+      'amazon.nova-2-multimodal-embeddings-v1:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+      },
+    );
+
+    expect(model.maxEmbeddingsPerCall).toBe(1);
+    expect(cohereModel.maxEmbeddingsPerCall).toBe(96);
+    expect(cohereV4UsProfileModel.maxEmbeddingsPerCall).toBe(96);
+    expect(novaModel.maxEmbeddingsPerCall).toBe(1);
+  });
+
   let callCount = 0;
 
   beforeEach(() => {
@@ -214,6 +246,42 @@ describe('doEmbed', () => {
     expect(body).toEqual({
       input_type: 'search_query',
       texts: [testValues[0]],
+      truncate: undefined,
+      output_dimension: undefined,
+    });
+  });
+
+  it('should send multiple values for Cohere embedding models', async () => {
+    server.urls[cohereV4EmbedUrl].response = {
+      type: 'binary',
+      headers: {
+        'content-type': 'application/json',
+        'x-amzn-bedrock-input-token-count': '12',
+      },
+      body: Buffer.from(
+        JSON.stringify({
+          embeddings: { float: mockEmbeddings },
+        }),
+      ),
+    };
+
+    const cohereV4Model = new AmazonBedrockEmbeddingModel('cohere.embed-v4:0', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: mockConfigHeaders,
+      fetch: fakeFetchWithAuth,
+    });
+
+    const { embeddings, usage } = await cohereV4Model.doEmbed({
+      values: testValues,
+    });
+
+    expect(embeddings).toStrictEqual(mockEmbeddings);
+    expect(usage?.tokens).toBe(12);
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body).toEqual({
+      input_type: 'search_query',
+      texts: testValues,
       truncate: undefined,
       output_dimension: undefined,
     });

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -33,8 +33,11 @@ type DoEmbedResponse = Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>;
 export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
   readonly specificationVersion = 'v4';
   readonly provider = 'amazon-bedrock';
-  readonly maxEmbeddingsPerCall = 1;
   readonly supportsParallelCalls = true;
+
+  get maxEmbeddingsPerCall() {
+    return isCohereEmbeddingModel(this.modelId) ? 96 : 1;
+  }
 
   static [WORKFLOW_SERIALIZE](model: AmazonBedrockEmbeddingModel) {
     return serializeModelOptions({
@@ -95,11 +98,8 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
     // Note: Different embedding model families expect different request/response
     // payloads (e.g. Titan vs Cohere vs Nova). We keep the public interface stable and
     // adapt here based on the modelId.
-    const isNovaModel =
-      this.modelId.startsWith('amazon.nova-') && this.modelId.includes('embed');
-    // Use `includes` so cross-region inference profile ids (e.g.
-    // `us.cohere.embed-v4:0`, `global.cohere.embed-v4:0`) are detected too.
-    const isCohereModel = this.modelId.includes('cohere.embed-');
+    const isNovaModel = isNovaEmbeddingModel(this.modelId);
+    const isCohereModel = isCohereEmbeddingModel(this.modelId);
 
     const args = isNovaModel
       ? {
@@ -119,7 +119,7 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
             // Cohere embedding models on Bedrock require `input_type`.
             // Without it, the service attempts other schema branches and rejects the request.
             input_type: amazonBedrockOptions.inputType ?? 'search_query',
-            texts: [values[0]],
+            texts: values,
             truncate: amazonBedrockOptions.truncate,
             output_dimension: amazonBedrockOptions.outputDimension,
           }
@@ -150,11 +150,11 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
       abortSignal,
     });
 
-    // Extract embedding based on response format
-    let embedding: number[];
+    // Extract embeddings based on response format
+    let embeddings: number[][];
     if ('embedding' in response) {
       // Titan response
-      embedding = response.embedding;
+      embeddings = [response.embedding];
     } else if (Array.isArray(response.embeddings)) {
       const firstEmbedding = response.embeddings[0];
       if (
@@ -163,14 +163,14 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
         'embeddingType' in firstEmbedding
       ) {
         // Nova response
-        embedding = firstEmbedding.embedding;
+        embeddings = [firstEmbedding.embedding];
       } else {
         // Cohere v3 response
-        embedding = firstEmbedding as number[];
+        embeddings = response.embeddings as number[][];
       }
     } else {
       // Cohere v4 response
-      embedding = response.embeddings.float[0];
+      embeddings = response.embeddings.float;
     }
 
     // Extract token count based on response format
@@ -185,11 +185,21 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
           : headerTokenCount;
 
     return {
-      embeddings: [embedding],
+      embeddings,
       usage: { tokens },
       warnings: [],
     };
   }
+}
+
+function isCohereEmbeddingModel(modelId: string) {
+  // Use `includes` so cross-region inference profile ids (e.g.
+  // `us.cohere.embed-v4:0`, `global.cohere.embed-v4:0`) are detected too.
+  return modelId.includes('cohere.embed-');
+}
+
+function isNovaEmbeddingModel(modelId: string) {
+  return modelId.startsWith('amazon.nova-') && modelId.includes('embed');
 }
 
 const AmazonBedrockEmbeddingResponseSchema = z.union([


### PR DESCRIPTION
## Background

the bedrock provider set the limit of `maxEmbeddingsPerCall` as `1`

but for cohere models, this value was actually allowed upto 96. [source ref](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html#model-parameters-embed-v4-request-response)

## Summary

gate the increase of `maxEmbeddingsPerCall` to 96 only for cohere embedding models

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)