### PR TITLE
Review fixes for experimental streaming transcription

### DIFF
--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -71,7 +71,23 @@ for await (const part of result.fullStream) {
 console.log(await result.text);
 ```
 
+To access the final transcript metadata:
+
+```ts
+const text = await result.text; // final transcript text
+const segments = await result.segments; // final segments with timing, if available
+const language = await result.language; // language of the transcript, if available
+const durationInSeconds = await result.durationInSeconds; // duration in seconds, if available
+```
+
 The `audio` stream must contain raw audio chunks. `Uint8Array` chunks are raw bytes; `string` chunks are base64-encoded raw bytes. Always set `inputAudioFormat` to match the chunks you send.
+
+<Note>
+  Streaming transcription requires a provider model instance (e.g.
+  `openai.transcription('gpt-realtime-whisper')`). String model IDs resolve
+  through the global provider (AI Gateway by default), which does not support
+  streaming transcription yet.
+</Note>
 
 OpenAI streaming transcription uses `openai.transcription('gpt-realtime-whisper')`. xAI uses the same `xai.transcription()` model for request/response and streaming transcription; `experimental_streamTranscribe` uses xAI's WebSocket STT transport under the hood.
 

--- a/content/docs/07-reference/01-ai-sdk-core/11-stream-transcribe.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/11-stream-transcribe.mdx
@@ -1,0 +1,149 @@
+---
+title: experimental_streamTranscribe
+description: API Reference for experimental_streamTranscribe.
+---
+
+# `experimental_streamTranscribe()`
+
+<Note type="warning">
+  `experimental_streamTranscribe` is an experimental feature.
+</Note>
+
+Streams a transcript from live raw audio using a transcription model with
+streaming support.
+
+```ts
+import { experimental_streamTranscribe as streamTranscribe } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = streamTranscribe({
+  model: openai.transcription('gpt-realtime-whisper'),
+  audio: audioStream, // ReadableStream<Uint8Array | string>
+  inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === 'transcript-delta') {
+    process.stdout.write(part.delta);
+  }
+}
+
+console.log(await result.text);
+```
+
+## Import
+
+<Snippet
+  text={`import { experimental_streamTranscribe as streamTranscribe } from "ai"`}
+  prompt={false}
+/>
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'model',
+      type: 'TranscriptionModelV4',
+      description:
+        'The transcription model to use. The model must support streaming (`doStream`). String model IDs resolve through the global provider (AI Gateway by default), which does not support streaming transcription yet.',
+    },
+    {
+      name: 'audio',
+      type: 'ReadableStream<Uint8Array | string>',
+      description:
+        'Raw audio chunks to transcribe. `Uint8Array` chunks contain raw audio bytes; `string` chunks contain base64-encoded raw audio bytes.',
+    },
+    {
+      name: 'inputAudioFormat',
+      type: '{ type: string; rate?: number }',
+      description:
+        'The input audio format for the raw audio chunks, e.g. `{ type: "audio/pcm", rate: 24000 }`. Supported types are provider-specific (e.g. `audio/pcm`, `audio/pcmu`, `audio/pcma`).',
+    },
+    {
+      name: 'providerOptions',
+      type: 'Record<string, JSONObject>',
+      isOptional: true,
+      description: 'Additional provider-specific options.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description: 'An optional abort signal to cancel the call.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP/WebSocket headers, if supported by the provider.',
+    },
+    {
+      name: 'includeRawChunks',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'When true, the provider includes raw provider chunks in the stream as `raw` parts.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'fullStream',
+      type: 'AsyncIterableStream<TranscriptionStreamPart>',
+      description:
+        'A stream of transcription parts: `transcript-delta`, `transcript-partial`, `transcript-final`, `raw`, and `error`.',
+    },
+    {
+      name: 'text',
+      type: 'Promise<string>',
+      description: 'The complete transcribed text from the audio input.',
+    },
+    {
+      name: 'segments',
+      type: 'Promise<Array<{ text: string; startSecond: number; endSecond: number }>>',
+      description:
+        'Final transcript segments with timing information, if available.',
+    },
+    {
+      name: 'language',
+      type: 'Promise<string | undefined>',
+      description:
+        'The language of the transcript in ISO-639-1 format, if available.',
+    },
+    {
+      name: 'durationInSeconds',
+      type: 'Promise<number | undefined>',
+      description: 'The duration of the transcript in seconds, if available.',
+    },
+    {
+      name: 'warnings',
+      type: 'Promise<Warning[]>',
+      description:
+        'Warnings for the call, e.g. unsupported settings. Resolves when the provider emits the stream start.',
+    },
+    {
+      name: 'responses',
+      type: 'Promise<Array<TranscriptionModelResponseMetadata>>',
+      description: 'Response metadata (timestamp, model ID, headers).',
+    },
+    {
+      name: 'providerMetadata',
+      type: 'Promise<Record<string, JSONObject>>',
+      description: 'Additional provider-specific metadata.',
+    },
+  ]}
+/>
+
+<Note>
+  The result promises settle as the stream is consumed. If you stop consuming
+  `fullStream` early (e.g. `break` out of the loop), the underlying provider
+  connection is closed and pending result promises reject.
+</Note>

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -59,6 +59,11 @@ AI SDK Core contains the following main functions:
       href: '/docs/reference/ai-sdk-core/transcribe',
     },
     {
+      title: 'experimental_streamTranscribe()',
+      description: 'Stream a transcript from live raw audio.',
+      href: '/docs/reference/ai-sdk-core/stream-transcribe',
+    },
+    {
       title: 'generateSpeech()',
       description: 'Generate speech audio from text.',
       href: '/docs/reference/ai-sdk-core/generate-speech',

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -750,6 +750,14 @@ const result = await transcribe({
 | --------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | `default` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
+<Note>
+  Word timestamps, diarization results, and segments are only returned on the
+  request/response path (`transcribe`). Streaming transcription
+  (`experimental_streamTranscribe`) emits partial and final transcript text with
+  utterance-level timing, but does not surface per-word timestamps, speaker
+  labels, or segments.
+</Note>
+
 ## Image Models
 
 You can create xAI image models using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -2714,7 +2714,7 @@ The following provider options are available:
 | `whisper-1`              | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-4o-mini-transcribe` | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `gpt-4o-transcribe`      | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
-| `gpt-realtime-whisper`   | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> |
+| `gpt-realtime-whisper`   | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 
 ## Speech Models
 

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -80,6 +80,7 @@
     "terminal-image": "^2.0.0",
     "undici": "^8.5.0",
     "valibot": "1.1.0",
+    "ws": "^8.21.0",
     "zod": "3.25.76"
   },
   "scripts": {
@@ -89,6 +90,7 @@
   },
   "devDependencies": {
     "@types/node": "22.19.19",
+    "@types/ws": "^8.5.13",
     "tsx": "4.19.2",
     "typescript": "5.8.3"
   }

--- a/examples/ai-functions/src/stream-transcribe/openai/basic.ts
+++ b/examples/ai-functions/src/stream-transcribe/openai/basic.ts
@@ -1,0 +1,51 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  experimental_streamTranscribe as streamTranscribe,
+  generateSpeech,
+} from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  // generate raw PCM audio (24kHz, 16-bit, mono) to transcribe:
+  const speech = await generateSpeech({
+    model: openai.speech('tts-1'),
+    text: 'Hello from the AI SDK! Streaming transcription is experimental.',
+    outputFormat: 'pcm',
+  });
+
+  // stream the raw audio in chunks, as a microphone would:
+  const bytes = speech.audio.uint8Array;
+  const chunkSize = 16 * 1024;
+  const audio = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.slice(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });
+
+  const result = streamTranscribe({
+    model: openai.transcription('gpt-realtime-whisper'),
+    audio,
+    inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    providerOptions: {
+      openai: {
+        streaming: { delay: 'low' },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'transcript-delta') {
+      process.stdout.write(part.delta);
+    }
+  }
+  console.log();
+
+  console.log('Text:', await result.text);
+  console.log('Language:', await result.language);
+  console.log('Duration:', await result.durationInSeconds);
+  console.log('Warnings:', await result.warnings);
+  console.log('Responses:', await result.responses);
+});

--- a/examples/ai-functions/src/stream-transcribe/xai/basic.ts
+++ b/examples/ai-functions/src/stream-transcribe/xai/basic.ts
@@ -1,0 +1,64 @@
+import { openai } from '@ai-sdk/openai';
+import { createXai, type XaiProviderSettings } from '@ai-sdk/xai';
+import {
+  experimental_streamTranscribe as streamTranscribe,
+  generateSpeech,
+} from 'ai';
+import { WebSocket } from 'ws';
+import { run } from '../../lib/run';
+
+// xAI streaming STT authenticates via WebSocket headers. The native
+// WebSocket in Node.js, browsers, Deno, and Bun cannot send headers,
+// so a header-capable implementation (e.g. the `ws` package) is required.
+const xai = createXai({
+  webSocket: WebSocket as unknown as XaiProviderSettings['webSocket'],
+});
+
+run(async () => {
+  // generate raw PCM audio (24kHz, 16-bit, mono) to transcribe:
+  const speech = await generateSpeech({
+    model: openai.speech('tts-1'),
+    text: 'Hello from the AI SDK! Streaming transcription is experimental.',
+    outputFormat: 'pcm',
+  });
+
+  // stream the raw audio in chunks, as a microphone would:
+  const bytes = speech.audio.uint8Array;
+  const chunkSize = 16 * 1024;
+  const audio = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.slice(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });
+
+  const result = streamTranscribe({
+    model: xai.transcription(),
+    audio,
+    inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    providerOptions: {
+      xai: {
+        keyterm: ['AI SDK'],
+        streaming: {
+          interimResults: true,
+        },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'transcript-partial') {
+      console.log('partial:', part.text);
+    }
+
+    if (part.type === 'transcript-final') {
+      console.log('final:', part.text);
+    }
+  }
+
+  console.log('Text:', await result.text);
+  console.log('Duration:', await result.durationInSeconds);
+  console.log('Warnings:', await result.warnings);
+});

--- a/packages/ai/src/transcribe/index.ts
+++ b/packages/ai/src/transcribe/index.ts
@@ -1,9 +1,8 @@
 import type { TranscriptionResult } from './transcribe-result';
 import { transcribe } from './transcribe';
-import { experimental_streamTranscribe } from './stream-transcribe';
 
 export { transcribe } from './transcribe';
-export { experimental_streamTranscribe } from './stream-transcribe';
+export { streamTranscribe as experimental_streamTranscribe } from './stream-transcribe';
 export type {
   StreamTranscriptionResult,
   TranscriptionStreamPart,

--- a/packages/ai/src/transcribe/stream-transcribe-result.ts
+++ b/packages/ai/src/transcribe/stream-transcribe-result.ts
@@ -1,4 +1,4 @@
-import type { JSONObject } from '@ai-sdk/provider';
+import type { JSONObject, SharedV4ProviderMetadata } from '@ai-sdk/provider';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
 import type { TranscriptionModelResponseMetadata } from '../types/transcription-model-response-metadata';
 import type { Warning } from '../types/warning';
@@ -8,6 +8,7 @@ export type TranscriptionStreamPart =
       type: 'transcript-delta';
       id?: string;
       delta: string;
+      providerMetadata?: SharedV4ProviderMetadata;
     }
   | {
       type: 'transcript-partial';
@@ -16,6 +17,7 @@ export type TranscriptionStreamPart =
       startSecond?: number;
       durationInSeconds?: number;
       channelIndex?: number;
+      providerMetadata?: SharedV4ProviderMetadata;
     }
   | {
       type: 'transcript-final';
@@ -24,6 +26,7 @@ export type TranscriptionStreamPart =
       startSecond?: number;
       endSecond?: number;
       channelIndex?: number;
+      providerMetadata?: SharedV4ProviderMetadata;
     }
   | {
       type: 'raw';
@@ -50,6 +53,16 @@ export interface StreamTranscriptionResult {
       endSecond: number;
     }>
   >;
+
+  /**
+   * The language of the transcript, if available.
+   */
+  readonly language: PromiseLike<string | undefined>;
+
+  /**
+   * The duration of the transcript in seconds, if available.
+   */
+  readonly durationInSeconds: PromiseLike<number | undefined>;
 
   /**
    * Warnings for the call, e.g. unsupported settings.

--- a/packages/ai/src/transcribe/stream-transcribe.test.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.test.ts
@@ -1,7 +1,7 @@
 import {
   UnsupportedFunctionalityError,
+  type Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
   type TranscriptionModelV4,
-  type TranscriptionModelV4StreamPart,
 } from '@ai-sdk/provider';
 import {
   convertArrayToReadableStream,
@@ -18,7 +18,7 @@ import {
 } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockTranscriptionModelV4 } from '../test/mock-transcription-model-v4';
-import { experimental_streamTranscribe } from './stream-transcribe';
+import { streamTranscribe } from './stream-transcribe';
 
 vi.mock('../version', () => {
   return {
@@ -61,7 +61,7 @@ describe('experimental_streamTranscribe', () => {
       NonNullable<TranscriptionModelV4['doStream']>
     >[0];
 
-    const result = experimental_streamTranscribe({
+    const result = streamTranscribe({
       model: new MockTranscriptionModelV4({
         doStream: async args => {
           capturedArgs = args;
@@ -99,7 +99,7 @@ describe('experimental_streamTranscribe', () => {
   });
 
   it('should stream transcript parts and resolve final metadata', async () => {
-    const result = experimental_streamTranscribe({
+    const result = streamTranscribe({
       model: new MockTranscriptionModelV4({
         doStream: async () =>
           createStreamResponse([
@@ -135,6 +135,8 @@ describe('experimental_streamTranscribe', () => {
     await expect(result.segments).resolves.toEqual([
       { text: 'Hello', startSecond: 0, endSecond: 1 },
     ]);
+    await expect(result.language).resolves.toBe('en');
+    await expect(result.durationInSeconds).resolves.toBe(1);
     await expect(result.warnings).resolves.toEqual([
       { type: 'other', message: 'test warning' },
     ]);
@@ -157,7 +159,7 @@ describe('experimental_streamTranscribe', () => {
 
   it('should throw UnsupportedFunctionalityError when doStream is unavailable', () => {
     expect(() =>
-      experimental_streamTranscribe({
+      streamTranscribe({
         model: new MockTranscriptionModelV4(),
         audio,
         inputAudioFormat,
@@ -166,7 +168,7 @@ describe('experimental_streamTranscribe', () => {
   });
 
   it('should reject final promises when no transcript is returned', async () => {
-    const result = experimental_streamTranscribe({
+    const result = streamTranscribe({
       model: new MockTranscriptionModelV4({
         doStream: async () =>
           createStreamResponse([
@@ -193,5 +195,78 @@ describe('experimental_streamTranscribe', () => {
         },
       ],
     });
+  });
+
+  it('should keep already-resolved promises resolved when the stream errors later', async () => {
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () =>
+          createStreamResponse([
+            {
+              type: 'stream-start',
+              warnings: [{ type: 'other', message: 'test warning' }],
+            },
+            { type: 'finish', text: '', segments: [] },
+          ]),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    await expect(
+      convertAsyncIterableToArray(result.fullStream),
+    ).rejects.toMatchObject({
+      name: 'AI_NoTranscriptGeneratedError',
+    });
+
+    // warnings resolved at stream-start and must not flip to rejected:
+    await expect(result.warnings).resolves.toEqual([
+      { type: 'other', message: 'test warning' },
+    ]);
+    await expect(result.text).rejects.toMatchObject({
+      name: 'AI_NoTranscriptGeneratedError',
+    });
+  });
+
+  it('should cancel the model stream when fullStream is cancelled early', async () => {
+    let modelStreamCancelled = false;
+
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () => ({
+          stream: new ReadableStream<TranscriptionModelV4StreamPart>({
+            start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'transcript-delta',
+                id: 'item-1',
+                delta: 'Hel',
+              });
+              controller.enqueue({
+                type: 'transcript-delta',
+                id: 'item-1',
+                delta: 'lo',
+              });
+            },
+            cancel() {
+              modelStreamCancelled = true;
+            },
+          }),
+          response: { timestamp: testDate, modelId: 'test-model-id' },
+        }),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    for await (const part of result.fullStream) {
+      expect(part.type).toBe('transcript-delta');
+      break;
+    }
+
+    await vi.waitFor(() => {
+      expect(modelStreamCancelled).toBe(true);
+    });
+    await expect(result.text).rejects.toThrow();
   });
 });

--- a/packages/ai/src/transcribe/stream-transcribe.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.ts
@@ -1,5 +1,6 @@
 import {
   UnsupportedFunctionalityError,
+  type Experimental_TranscriptionModelV4StreamPart,
   type JSONObject,
 } from '@ai-sdk/provider';
 import {
@@ -38,7 +39,7 @@ type TranscriptSegment = {
  *
  * @returns A result object that contains the streaming transcript and final transcript metadata.
  */
-export function experimental_streamTranscribe({
+export function streamTranscribe({
   model,
   audio,
   inputAudioFormat,
@@ -105,9 +106,17 @@ export function experimental_streamTranscribe({
     throw new Error('Model could not be resolved');
   }
 
-  if (resolvedModel.doStream == null) {
+  const doStream = resolvedModel.doStream?.bind(resolvedModel);
+  if (doStream == null) {
     throw new UnsupportedFunctionalityError({
       functionality: 'streaming transcription',
+      message:
+        `The ${resolvedModel.provider} model "${resolvedModel.modelId}" does not support streaming transcription.` +
+        (typeof model === 'string'
+          ? ' String model IDs resolve through the global provider (AI Gateway by default),' +
+            ' which does not support streaming transcription yet.' +
+            " Pass a provider model instance instead, e.g. openai.transcription('gpt-realtime-whisper')."
+          : ''),
     });
   }
 
@@ -118,6 +127,8 @@ export function experimental_streamTranscribe({
 
   const textPromise = new DelayedPromise<string>();
   const segmentsPromise = new DelayedPromise<Array<TranscriptSegment>>();
+  const languagePromise = new DelayedPromise<string | undefined>();
+  const durationInSecondsPromise = new DelayedPromise<number | undefined>();
   const warningsPromise = new DelayedPromise<Array<Warning>>();
   const responsesPromise = new DelayedPromise<
     Array<TranscriptionModelResponseMetadata>
@@ -126,132 +137,123 @@ export function experimental_streamTranscribe({
     Record<string, JSONObject>
   >();
 
-  const stream = createAsyncIterableStream(
-    new ReadableStream<TranscriptionStreamPart>({
-      async start(controller) {
-        const startedAt = currentDate();
-        let warnings: Array<Warning> | undefined;
-        let response: TranscriptionModelResponseMetadata | undefined;
+  const rejectPendingPromises = (error: unknown) => {
+    for (const promise of [
+      textPromise,
+      segmentsPromise,
+      languagePromise,
+      durationInSecondsPromise,
+      warningsPromise,
+      responsesPromise,
+      providerMetadataPromise,
+    ]) {
+      if (promise.isPending()) {
+        promise.reject(error);
+      }
+    }
+  };
 
-        const rejectPromises = (error: unknown) => {
-          textPromise.reject(error);
-          segmentsPromise.reject(error);
-          warningsPromise.reject(error);
-          responsesPromise.reject(error);
-          providerMetadataPromise.reject(error);
-        };
+  const startedAt = currentDate();
+  let response: TranscriptionModelResponseMetadata | undefined;
+  const currentResponseMetadata = () =>
+    response ?? { timestamp: startedAt, modelId: resolvedModel.modelId };
 
-        try {
-          const result = await resolvedModel.doStream!({
-            audio,
-            inputAudioFormat,
-            providerOptions,
-            abortSignal,
-            headers: headersWithUserAgent,
-            includeRawChunks,
-          });
+  const resolveWarnings = (warnings: Array<Warning>) => {
+    warningsPromise.resolve(warnings);
+    logWarnings({
+      warnings,
+      provider: resolvedModel.provider,
+      model: resolvedModel.modelId,
+    });
+  };
 
+  const transform = new TransformStream<
+    Experimental_TranscriptionModelV4StreamPart,
+    TranscriptionStreamPart
+  >({
+    transform(value, controller) {
+      switch (value.type) {
+        case 'stream-start': {
+          resolveWarnings(value.warnings);
+          break;
+        }
+
+        case 'response-metadata': {
           response = {
-            timestamp: result.response?.timestamp ?? startedAt,
-            modelId: result.response?.modelId ?? resolvedModel.modelId,
-            headers: result.response?.headers,
+            timestamp: value.timestamp ?? currentResponseMetadata().timestamp,
+            modelId: value.modelId ?? currentResponseMetadata().modelId,
+            headers: value.headers ?? response?.headers,
           };
+          break;
+        }
 
-          const reader = result.stream.getReader();
+        case 'transcript-delta':
+        case 'transcript-partial':
+        case 'transcript-final':
+        case 'raw':
+        case 'error': {
+          controller.enqueue(value);
+          break;
+        }
 
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-
-              switch (value.type) {
-                case 'stream-start': {
-                  const streamWarnings = value.warnings;
-                  warnings = streamWarnings;
-                  warningsPromise.resolve(streamWarnings);
-                  logWarnings({
-                    warnings: streamWarnings,
-                    provider: resolvedModel.provider,
-                    model: resolvedModel.modelId,
-                  });
-                  break;
-                }
-
-                case 'response-metadata': {
-                  response = {
-                    timestamp:
-                      value.timestamp ?? response?.timestamp ?? startedAt,
-                    modelId:
-                      value.modelId ??
-                      response?.modelId ??
-                      resolvedModel.modelId,
-                    headers: value.headers ?? response?.headers,
-                  };
-                  break;
-                }
-
-                case 'transcript-delta':
-                case 'transcript-partial':
-                case 'transcript-final':
-                case 'raw':
-                case 'error': {
-                  controller.enqueue(value);
-                  break;
-                }
-
-                case 'finish': {
-                  const responseMetadata = response ?? {
-                    timestamp: startedAt,
-                    modelId: resolvedModel.modelId,
-                  };
-
-                  if (!warningsPromise.isResolved()) {
-                    warnings = [];
-                    warningsPromise.resolve(warnings);
-                    logWarnings({
-                      warnings,
-                      provider: resolvedModel.provider,
-                      model: resolvedModel.modelId,
-                    });
-                  }
-
-                  if (!value.text) {
-                    throw new NoTranscriptGeneratedError({
-                      responses: [responseMetadata],
-                    });
-                  }
-
-                  textPromise.resolve(value.text);
-                  segmentsPromise.resolve(value.segments);
-                  responsesPromise.resolve([responseMetadata]);
-                  providerMetadataPromise.resolve(value.providerMetadata ?? {});
-                  break;
-                }
-              }
-            }
-          } finally {
-            reader.releaseLock();
+        case 'finish': {
+          if (!warningsPromise.isResolved()) {
+            resolveWarnings([]);
           }
 
-          if (textPromise.isPending()) {
+          if (!value.text) {
             throw new NoTranscriptGeneratedError({
-              responses: [
-                response ?? {
-                  timestamp: startedAt,
-                  modelId: resolvedModel.modelId,
-                },
-              ],
+              responses: [currentResponseMetadata()],
             });
           }
 
-          controller.close();
-        } catch (error) {
-          rejectPromises(error);
-          controller.error(error);
+          textPromise.resolve(value.text);
+          segmentsPromise.resolve(value.segments);
+          languagePromise.resolve(value.language);
+          durationInSecondsPromise.resolve(value.durationInSeconds);
+          responsesPromise.resolve([currentResponseMetadata()]);
+          providerMetadataPromise.resolve(value.providerMetadata ?? {});
+          break;
         }
-      },
-    }),
-  );
+      }
+    },
+
+    flush() {
+      if (textPromise.isPending()) {
+        throw new NoTranscriptGeneratedError({
+          responses: [currentResponseMetadata()],
+        });
+      }
+    },
+  });
+
+  // Piping (instead of an eager read loop) preserves consumer backpressure
+  // and propagates cancellation of `fullStream` to the model stream.
+  void (async () => {
+    const result = await doStream({
+      audio,
+      inputAudioFormat,
+      providerOptions,
+      abortSignal,
+      headers: headersWithUserAgent,
+      includeRawChunks,
+    });
+
+    response = {
+      timestamp: result.response?.timestamp ?? startedAt,
+      modelId: result.response?.modelId ?? resolvedModel.modelId,
+      headers: result.response?.headers,
+    };
+
+    await result.stream.pipeTo(transform.writable);
+  })().catch(error => {
+    const reason =
+      error ?? new Error('Transcription stream was cancelled or errored.');
+    rejectPendingPromises(reason);
+    transform.writable.abort(reason).catch(() => {
+      // the writable is already errored when the model stream failed mid-pipe
+    });
+  });
 
   return {
     get text() {
@@ -259,6 +261,12 @@ export function experimental_streamTranscribe({
     },
     get segments() {
       return segmentsPromise.promise;
+    },
+    get language() {
+      return languagePromise.promise;
+    },
+    get durationInSeconds() {
+      return durationInSecondsPromise.promise;
     },
     get warnings() {
       return warningsPromise.promise;
@@ -269,6 +277,6 @@ export function experimental_streamTranscribe({
     get providerMetadata() {
       return providerMetadataPromise.promise;
     },
-    fullStream: stream,
+    fullStream: createAsyncIterableStream(transform.readable),
   };
 }

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -617,4 +617,154 @@ describe('doStream', () => {
       modelId: 'gpt-realtime-whisper',
     });
   });
+
+  it('should accept dated gpt-realtime-whisper snapshot model IDs', async () => {
+    MockWebSocket.instances = [];
+    const model = new OpenAITranscriptionModel(
+      'gpt-realtime-whisper-2026-01-01',
+      {
+        provider: 'test-provider',
+        url: ({ path }) => `https://api.openai.com/v1${path}`,
+        headers: () => ({ Authorization: 'Bearer test-api-key' }),
+        webSocket: MockWebSocket,
+      },
+    );
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await flush();
+
+    expect(JSON.parse(ws.send.mock.calls[0][0]).session.audio.input).toEqual(
+      expect.objectContaining({
+        transcription: expect.objectContaining({
+          model: 'gpt-realtime-whisper-2026-01-01',
+        }),
+      }),
+    );
+
+    ws.message({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item-1',
+      transcript: 'Hello',
+    });
+    await expect(partsPromise).resolves.toBeDefined();
+  });
+
+  it('should warn about unsupported non-streaming provider options', async () => {
+    MockWebSocket.instances = [];
+    const model = new OpenAITranscriptionModel('gpt-realtime-whisper', {
+      provider: 'test-provider',
+      url: ({ path }) => `https://api.openai.com/v1${path}`,
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+      providerOptions: {
+        openai: {
+          prompt: 'context prompt',
+          temperature: 0.5,
+        },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await flush();
+    ws.message({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item-1',
+      transcript: 'Hello',
+    });
+
+    const parts = await partsPromise;
+    expect(parts[0]).toEqual({
+      type: 'stream-start',
+      warnings: [
+        {
+          type: 'unsupported',
+          feature: 'providerOptions.openai.prompt',
+          details: 'OpenAI streaming transcription does not support prompt.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'providerOptions.openai.temperature',
+          details:
+            'OpenAI streaming transcription does not support temperature.',
+        },
+      ],
+    });
+  });
+
+  it('should error the stream with the server message on error events', async () => {
+    MockWebSocket.instances = [];
+    const model = new OpenAITranscriptionModel('gpt-realtime-whisper', {
+      provider: 'test-provider',
+      url: ({ path }) => `https://api.openai.com/v1${path}`,
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await flush();
+
+    const assertion = expect(partsPromise).rejects.toThrow(
+      'invalid session configuration',
+    );
+    ws.message({
+      type: 'error',
+      error: { message: 'invalid session configuration' },
+    });
+    await assertion;
+
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('should close the WebSocket and stop reading audio when the stream is cancelled', async () => {
+    MockWebSocket.instances = [];
+    const model = new OpenAITranscriptionModel('gpt-realtime-whisper', {
+      provider: 'test-provider',
+      url: ({ path }) => `https://api.openai.com/v1${path}`,
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    let audioCancelled = false;
+    const audio = new ReadableStream<Uint8Array>({
+      cancel() {
+        audioCancelled = true;
+      },
+    });
+
+    const result = await model.doStream({
+      audio,
+      inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    });
+
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await flush();
+
+    await result.stream.cancel();
+    await flush();
+
+    expect(ws.close).toHaveBeenCalled();
+    expect(audioCancelled).toBe(true);
+  });
 });

--- a/packages/openai/src/transcription/openai-transcription-model.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.ts
@@ -1,9 +1,9 @@
 import {
   UnsupportedFunctionalityError,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
   type SharedV4Warning,
   type TranscriptionModelV4,
   type TranscriptionModelV4CallOptions,
-  type TranscriptionModelV4StreamOptions,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -14,8 +14,10 @@ import {
   mediaTypeToExtension,
   parseProviderOptions,
   postFormDataToApi,
+  readWebSocketMessageText,
   safeParseJSON,
   serializeModelOptions,
+  toWebSocketUrl,
   WORKFLOW_DESERIALIZE,
   WORKFLOW_SERIALIZE,
 } from '@ai-sdk/provider-utils';
@@ -50,10 +52,20 @@ type OpenAIRealtimeTranscriptionEvent = {
   item_id?: string;
   delta?: string;
   transcript?: string;
-  error?: { message?: string; code?: string };
-  message?: string;
-  code?: string;
+  error?: { message?: string };
 };
+
+/**
+ * Realtime transcription model IDs stream over the realtime WebSocket
+ * and do not support the REST transcription endpoint. Prefix matching
+ * keeps dated snapshots (e.g. `gpt-realtime-whisper-2026-01-01`) working.
+ */
+function isRealtimeTranscriptionModelId(modelId: string): boolean {
+  return (
+    modelId === 'gpt-realtime-whisper' ||
+    modelId.startsWith('gpt-realtime-whisper-')
+  );
+}
 
 interface OpenAITranscriptionModelConfig extends OpenAIConfig {
   _internal?: {
@@ -223,9 +235,9 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
   async doGenerate(
     options: OpenAITranscriptionCallOptions,
   ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
-    if (this.modelId === 'gpt-realtime-whisper') {
+    if (isRealtimeTranscriptionModelId(this.modelId)) {
       throw new UnsupportedFunctionalityError({
-        functionality: 'non-streaming transcription with gpt-realtime-whisper',
+        functionality: `non-streaming transcription with ${this.modelId}`,
       });
     }
 
@@ -287,7 +299,7 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
   ): Promise<
     Awaited<ReturnType<NonNullable<TranscriptionModelV4['doStream']>>>
   > {
-    if (this.modelId !== 'gpt-realtime-whisper') {
+    if (!isRealtimeTranscriptionModelId(this.modelId)) {
       throw new UnsupportedFunctionalityError({
         functionality: `streaming transcription with ${this.modelId}`,
       });
@@ -300,6 +312,25 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
       schema: openAITranscriptionModelOptions,
     });
     const warnings: SharedV4Warning[] = [];
+
+    // options that only apply to the REST transcription endpoint
+    // (checked on the raw options because some have schema defaults):
+    const rawOpenAIOptions = options.providerOptions?.openai ?? {};
+    for (const option of [
+      'include',
+      'prompt',
+      'temperature',
+      'timestampGranularities',
+    ]) {
+      if (rawOpenAIOptions[option as keyof typeof rawOpenAIOptions] != null) {
+        warnings.push({
+          type: 'unsupported',
+          feature: `providerOptions.openai.${option}`,
+          details: `OpenAI streaming transcription does not support ${option}.`,
+        });
+      }
+    }
+
     const headers = combineHeaders(this.config.headers?.(), options.headers);
     const sessionUpdate = buildOpenAIRealtimeTranscriptionSession({
       modelId: this.modelId,
@@ -313,135 +344,184 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
         timestamp: currentDate,
         modelId: this.modelId,
       },
-      stream: new ReadableStream({
-        start: controller => {
-          const WebSocketConstructor = getWebSocketConstructor(
-            this.config.webSocket,
-          );
-          const ws = new WebSocketConstructor(
-            toWebSocketUrl(
-              this.config.url({
-                path: '/realtime?intent=transcription',
-                modelId: this.modelId,
-              }),
-            ),
-            getOpenAIRealtimeProtocols(headers),
-            { headers },
-          );
-          let finished = false;
-
-          const finishWithError = (error: unknown) => {
-            if (finished) return;
-            finished = true;
-            try {
-              ws.close();
-            } catch {}
-            controller.error(error);
-          };
-
-          const finish = (text: string, id?: string) => {
-            if (finished) return;
-            finished = true;
-            if (id != null) {
-              controller.enqueue({ type: 'transcript-final', id, text });
-            }
-            controller.enqueue({
-              type: 'finish',
-              text,
-              segments: [],
-              language: openAIOptions?.language,
-            });
-            controller.close();
-            try {
-              ws.close(1000);
-            } catch {}
-          };
-
-          const abort = () => {
-            finishWithError(
-              options.abortSignal?.reason ?? new Error('Aborted'),
-            );
-          };
-          if (options.abortSignal?.aborted) {
-            abort();
-            return;
-          }
-          options.abortSignal?.addEventListener('abort', abort, { once: true });
-
-          ws.onopen = () => {
-            controller.enqueue({ type: 'stream-start', warnings });
-            ws.send(JSON.stringify(sessionUpdate));
-            void sendOpenAIAudioStream({
-              audio: options.audio,
-              send: audio => {
-                ws.send(
-                  JSON.stringify({
-                    type: 'input_audio_buffer.append',
-                    audio,
-                  }),
-                );
-              },
-              commit: () => {
-                ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-              },
-            }).catch(finishWithError);
-          };
-
-          ws.onmessage = event => {
-            void readWebSocketText(event.data)
-              .then(async text => {
-                const parsed = await safeParseJSON({ text });
-                if (!parsed.success) return;
-                const raw = parsed.value as OpenAIRealtimeTranscriptionEvent;
-
-                if (options.includeRawChunks) {
-                  controller.enqueue({ type: 'raw', rawValue: raw });
-                }
-
-                switch (raw.type) {
-                  case 'conversation.item.input_audio_transcription.delta': {
-                    controller.enqueue({
-                      type: 'transcript-delta',
-                      id: raw.item_id,
-                      delta: raw.delta ?? '',
-                    });
-                    break;
-                  }
-
-                  case 'conversation.item.input_audio_transcription.completed': {
-                    finish(raw.transcript ?? '', raw.item_id);
-                    break;
-                  }
-
-                  case 'error': {
-                    const message =
-                      raw.error?.message ??
-                      raw.message ??
-                      'OpenAI realtime error';
-                    const error = new Error(message);
-                    controller.enqueue({ type: 'error', error });
-                    finishWithError(error);
-                    break;
-                  }
-                }
-              })
-              .catch(finishWithError);
-          };
-
-          ws.onerror = () => {
-            finishWithError(new Error('OpenAI realtime transcription error'));
-          };
-
-          ws.onclose = () => {
-            options.abortSignal?.removeEventListener('abort', abort);
-            if (!finished) {
-              controller.close();
-            }
-          };
-        },
+      stream: createOpenAIRealtimeTranscriptionStream({
+        webSocket: this.config.webSocket,
+        url: toWebSocketUrl(
+          this.config.url({
+            path: '/realtime?intent=transcription',
+            modelId: this.modelId,
+          }),
+        ),
+        headers,
+        sessionUpdate,
+        language: openAIOptions?.language,
+        warnings,
+        audio: options.audio,
+        abortSignal: options.abortSignal,
+        includeRawChunks: options.includeRawChunks,
       }),
     };
   }
+}
+
+function createOpenAIRealtimeTranscriptionStream({
+  webSocket,
+  url,
+  headers,
+  sessionUpdate,
+  language,
+  warnings,
+  audio,
+  abortSignal,
+  includeRawChunks,
+}: {
+  webSocket: OpenAIConfig['webSocket'];
+  url: URL;
+  headers: Record<string, string | undefined>;
+  sessionUpdate: unknown;
+  language: string | undefined;
+  warnings: SharedV4Warning[];
+  audio: ReadableStream<Uint8Array | string>;
+  abortSignal: AbortSignal | undefined;
+  includeRawChunks: boolean | undefined;
+}) {
+  let finished = false;
+  let cleanup: (closeCode?: number) => void = () => {};
+
+  return new ReadableStream({
+    start: controller => {
+      const WebSocketConstructor = getWebSocketConstructor(webSocket);
+      const ws = new WebSocketConstructor(
+        url,
+        getOpenAIRealtimeProtocols(headers),
+        { headers },
+      );
+      let audioReader:
+        | ReadableStreamDefaultReader<Uint8Array | string>
+        | undefined;
+
+      cleanup = (closeCode?: number) => {
+        abortSignal?.removeEventListener('abort', abort);
+        void audioReader?.cancel().catch(() => {});
+        try {
+          ws.close(closeCode);
+        } catch {}
+      };
+
+      const finishWithError = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.error(error);
+      };
+
+      const finish = (text: string, id?: string) => {
+        if (finished) return;
+        finished = true;
+        if (id != null) {
+          controller.enqueue({ type: 'transcript-final', id, text });
+        }
+        controller.enqueue({
+          type: 'finish',
+          text,
+          segments: [],
+          language,
+        });
+        controller.close();
+        cleanup(1000);
+      };
+
+      const abort = () => {
+        finishWithError(abortSignal?.reason ?? new Error('Aborted'));
+      };
+      if (abortSignal?.aborted) {
+        abort();
+        return;
+      }
+      abortSignal?.addEventListener('abort', abort, { once: true });
+
+      const sendAudio = async () => {
+        audioReader = audio.getReader();
+        try {
+          while (true) {
+            const { done, value } = await audioReader.read();
+            if (done || finished) break;
+            ws.send(
+              JSON.stringify({
+                type: 'input_audio_buffer.append',
+                audio: convertToBase64(value),
+              }),
+            );
+          }
+        } finally {
+          audioReader.releaseLock();
+        }
+        if (!finished) {
+          ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
+        }
+      };
+
+      ws.onopen = () => {
+        controller.enqueue({ type: 'stream-start', warnings });
+        ws.send(JSON.stringify(sessionUpdate));
+        void sendAudio().catch(finishWithError);
+      };
+
+      ws.onmessage = event => {
+        void readWebSocketMessageText(event.data)
+          .then(async text => {
+            const parsed = await safeParseJSON({ text });
+            if (!parsed.success) return;
+            const raw = parsed.value as OpenAIRealtimeTranscriptionEvent;
+
+            if (includeRawChunks) {
+              controller.enqueue({ type: 'raw', rawValue: raw });
+            }
+
+            switch (raw.type) {
+              case 'conversation.item.input_audio_transcription.delta': {
+                controller.enqueue({
+                  type: 'transcript-delta',
+                  id: raw.item_id,
+                  delta: raw.delta ?? '',
+                });
+                break;
+              }
+
+              case 'conversation.item.input_audio_transcription.completed': {
+                finish(raw.transcript ?? '', raw.item_id);
+                break;
+              }
+
+              case 'error': {
+                finishWithError(
+                  new Error(raw.error?.message ?? 'OpenAI realtime error'),
+                );
+                break;
+              }
+            }
+          })
+          .catch(finishWithError);
+      };
+
+      ws.onerror = () => {
+        finishWithError(new Error('OpenAI realtime transcription error'));
+      };
+
+      ws.onclose = () => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.close();
+      };
+    },
+
+    cancel: () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    },
+  });
 }
 
 function buildOpenAIRealtimeTranscriptionSession({
@@ -484,28 +564,6 @@ function buildOpenAIRealtimeTranscriptionSession({
   };
 }
 
-async function sendOpenAIAudioStream({
-  audio,
-  send,
-  commit,
-}: {
-  audio: ReadableStream<Uint8Array | string>;
-  send: (audio: string) => void;
-  commit: () => void;
-}) {
-  const reader = audio.getReader();
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      send(convertToBase64(value));
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  commit();
-}
-
 function getOpenAIRealtimeProtocols(
   headers: Record<string, string | undefined>,
 ): string[] {
@@ -517,26 +575,4 @@ function getOpenAIRealtimeProtocols(
   return token == null
     ? ['realtime']
     : ['realtime', `openai-insecure-api-key.${token}`];
-}
-
-function toWebSocketUrl(url: string): string {
-  const wsUrl = new URL(url);
-  if (wsUrl.protocol === 'http:') {
-    wsUrl.protocol = 'ws:';
-  } else if (wsUrl.protocol === 'https:') {
-    wsUrl.protocol = 'wss:';
-  }
-  return wsUrl.toString();
-}
-
-async function readWebSocketText(data: unknown): Promise<string> {
-  if (typeof data === 'string') return data;
-  if (data instanceof ArrayBuffer) return new TextDecoder().decode(data);
-  if (ArrayBuffer.isView(data)) {
-    return new TextDecoder().decode(data);
-  }
-  if (typeof Blob !== 'undefined' && data instanceof Blob) {
-    return data.text();
-  }
-  return String(data);
 }

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -96,6 +96,8 @@ export * from './validate-types';
 export { VERSION } from './version';
 export {
   getWebSocketConstructor,
+  readWebSocketMessageText,
+  toWebSocketUrl,
   type WebSocketConstructor,
   type WebSocketLike,
 } from './websocket';

--- a/packages/provider-utils/src/websocket.ts
+++ b/packages/provider-utils/src/websocket.ts
@@ -28,3 +28,34 @@ export function getWebSocketConstructor(
 
   return WebSocketConstructor;
 }
+
+/**
+ * Converts an http(s) URL to the corresponding ws(s) URL.
+ */
+export function toWebSocketUrl(url: string | URL): URL {
+  const wsUrl = new URL(url);
+  if (wsUrl.protocol === 'http:') {
+    wsUrl.protocol = 'ws:';
+  } else if (wsUrl.protocol === 'https:') {
+    wsUrl.protocol = 'wss:';
+  }
+  return wsUrl;
+}
+
+const textDecoder = new TextDecoder();
+
+/**
+ * Reads WebSocket message data as text, handling string, binary,
+ * and Blob payloads.
+ */
+export async function readWebSocketMessageText(data: unknown): Promise<string> {
+  if (typeof data === 'string') return data;
+  if (data instanceof ArrayBuffer) return textDecoder.decode(data);
+  if (ArrayBuffer.isView(data)) {
+    return textDecoder.decode(data);
+  }
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return data.text();
+  }
+  return String(data);
+}

--- a/packages/provider/src/transcription-model/v4/index.ts
+++ b/packages/provider/src/transcription-model/v4/index.ts
@@ -1,6 +1,6 @@
 export type { TranscriptionModelV4 } from './transcription-model-v4';
 export type { TranscriptionModelV4CallOptions } from './transcription-model-v4-call-options';
 export type { TranscriptionModelV4Result } from './transcription-model-v4-result';
-export type { TranscriptionModelV4StreamOptions } from './transcription-model-v4-stream-options';
-export type { TranscriptionModelV4StreamPart } from './transcription-model-v4-stream-part';
-export type { TranscriptionModelV4StreamResult } from './transcription-model-v4-stream-result';
+export type { TranscriptionModelV4StreamOptions as Experimental_TranscriptionModelV4StreamOptions } from './transcription-model-v4-stream-options';
+export type { TranscriptionModelV4StreamPart as Experimental_TranscriptionModelV4StreamPart } from './transcription-model-v4-stream-part';
+export type { TranscriptionModelV4StreamResult as Experimental_TranscriptionModelV4StreamResult } from './transcription-model-v4-stream-result';

--- a/packages/provider/src/transcription-model/v4/transcription-model-v4.ts
+++ b/packages/provider/src/transcription-model/v4/transcription-model-v4.ts
@@ -35,6 +35,11 @@ export type TranscriptionModelV4 = {
 
   /**
    * Streams a transcript for live audio.
+   *
+   * Experimental: the streaming transcription contract may change in patch
+   * releases while `experimental_streamTranscribe` is experimental. The
+   * stream option/part/result types are exported with `Experimental_`
+   * prefixes for this reason.
    */
   doStream?(
     options: TranscriptionModelV4StreamOptions,

--- a/packages/xai/src/xai-transcription-model-options.ts
+++ b/packages/xai/src/xai-transcription-model-options.ts
@@ -70,24 +70,24 @@ export const xaiTranscriptionModelOptionsSchema = lazySchema(() =>
           /**
            * Emit interim transcript results while speech is being processed.
            */
-          interimResults: z.boolean().nullish(),
+          interimResults: z.boolean().optional(),
 
           /**
            * Silence duration in milliseconds before an utterance-final event.
            */
-          endpointing: z.number().int().min(0).max(5000).nullish(),
+          endpointing: z.number().int().min(0).max(5000).optional(),
 
           /**
            * End-of-turn detection threshold. When set, enables Smart Turn.
            */
-          smartTurn: z.number().min(0).max(1).nullish(),
+          smartTurn: z.number().min(0).max(1).optional(),
 
           /**
            * Maximum silence duration in milliseconds before forcing speech_final.
            */
-          smartTurnTimeout: z.number().int().min(1).max(5000).nullish(),
+          smartTurnTimeout: z.number().int().min(1).max(5000).optional(),
         })
-        .nullish(),
+        .optional(),
     }),
   ),
 );

--- a/packages/xai/src/xai-transcription-model.test.ts
+++ b/packages/xai/src/xai-transcription-model.test.ts
@@ -405,12 +405,6 @@ describe('doStream', () => {
         channelIndex: undefined,
       },
       {
-        type: 'transcript-final',
-        id: undefined,
-        text: 'Hello',
-        channelIndex: undefined,
-      },
-      {
         type: 'finish',
         text: 'Hello',
         segments: [],
@@ -419,5 +413,101 @@ describe('doStream', () => {
       },
     ]);
     expect(result.response).toEqual({ timestamp: testDate, modelId: '' });
+  });
+
+  it('should error the stream with the server message on error events', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    ws.message({ type: 'transcript.created' });
+    await flush();
+
+    const assertion = expect(partsPromise).rejects.toThrow(
+      'invalid sample_rate',
+    );
+    ws.message({ type: 'error', message: 'invalid sample_rate' });
+    await assertion;
+
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('should close the WebSocket and stop reading audio when the stream is cancelled', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    let audioCancelled = false;
+    const audio = new ReadableStream<Uint8Array>({
+      cancel() {
+        audioCancelled = true;
+      },
+    });
+
+    const result = await model.doStream({
+      audio,
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const ws = MockWebSocket.instances[0];
+    ws.message({ type: 'transcript.created' });
+    await flush();
+
+    await result.stream.cancel();
+    await flush();
+
+    expect(ws.close).toHaveBeenCalled();
+    expect(audioCancelled).toBe(true);
+  });
+
+  it('should warn on unrecognized inputAudioFormat types', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/wav' },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    ws.message({ type: 'transcript.created' });
+    await flush();
+    ws.message({ type: 'transcript.done', text: 'Hello' });
+
+    const parts = await partsPromise;
+    expect(parts[0]).toEqual({
+      type: 'stream-start',
+      warnings: [
+        {
+          type: 'other',
+          message: expect.stringContaining(
+            'Unrecognized inputAudioFormat.type "audio/wav"',
+          ),
+        },
+      ],
+    });
   });
 });

--- a/packages/xai/src/xai-transcription-model.ts
+++ b/packages/xai/src/xai-transcription-model.ts
@@ -1,8 +1,8 @@
 import {
   InvalidArgumentError,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
   type SharedV4Warning,
   type TranscriptionModelV4,
-  type TranscriptionModelV4StreamOptions,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -12,8 +12,10 @@ import {
   mediaTypeToExtension,
   parseProviderOptions,
   postFormDataToApi,
+  readWebSocketMessageText,
   safeParseJSON,
   serializeModelOptions,
+  toWebSocketUrl,
   WORKFLOW_DESERIALIZE,
   WORKFLOW_SERIALIZE,
   type FetchFunction,
@@ -202,6 +204,20 @@ export class XaiTranscriptionModel implements TranscriptionModelV4 {
       });
     }
 
+    if (
+      xaiOptions?.audioFormat == null &&
+      !isKnownInputAudioFormat(options.inputAudioFormat.type)
+    ) {
+      warnings.push({
+        type: 'other',
+        message:
+          `Unrecognized inputAudioFormat.type "${options.inputAudioFormat.type}"; ` +
+          `falling back to raw PCM encoding. ` +
+          `Use audio/pcm, audio/pcmu, or audio/pcma, ` +
+          `or set providerOptions.xai.audioFormat explicitly.`,
+      });
+    }
+
     const url = buildXaiStreamingTranscriptionUrl({
       baseURL: this.config.baseURL ?? 'https://api.x.ai/v1',
       inputAudioFormat: options.inputAudioFormat,
@@ -215,143 +231,208 @@ export class XaiTranscriptionModel implements TranscriptionModelV4 {
         timestamp: currentDate,
         modelId: this.modelId,
       },
-      stream: new ReadableStream({
-        start: controller => {
-          const WebSocketConstructor = getWebSocketConstructor(
-            this.config.webSocket,
-          );
-          const ws = new WebSocketConstructor(url, undefined, { headers });
-          const expectedDoneCount =
-            xaiOptions?.multichannel === true ? xaiOptions.channels! : 1;
-          const doneTexts = new Map<number, string>();
-          let doneDuration: number | undefined;
-          let finished = false;
-
-          const finishWithError = (error: unknown) => {
-            if (finished) return;
-            finished = true;
-            try {
-              ws.close();
-            } catch {}
-            controller.error(error);
-          };
-
-          const maybeFinish = () => {
-            if (finished || doneTexts.size < expectedDoneCount) return;
-            finished = true;
-            const text = [...doneTexts.entries()]
-              .sort(([a], [b]) => a - b)
-              .map(([, value]) => value)
-              .join('\n');
-            controller.enqueue({
-              type: 'finish',
-              text,
-              segments: [],
-              language: xaiOptions?.language ?? undefined,
-              durationInSeconds: doneDuration,
-            });
-            controller.close();
-            try {
-              ws.close(1000);
-            } catch {}
-          };
-
-          const abort = () => {
-            finishWithError(
-              options.abortSignal?.reason ?? new Error('Aborted'),
-            );
-          };
-          if (options.abortSignal?.aborted) {
-            abort();
-            return;
-          }
-          options.abortSignal?.addEventListener('abort', abort, { once: true });
-
-          ws.onmessage = event => {
-            void readWebSocketText(event.data)
-              .then(async text => {
-                const parsed = await safeParseJSON({ text });
-                if (!parsed.success) return;
-                const raw = parsed.value as XaiStreamingTranscriptionEvent;
-
-                if (options.includeRawChunks) {
-                  controller.enqueue({ type: 'raw', rawValue: raw });
-                }
-
-                switch (raw.type) {
-                  case 'transcript.created': {
-                    controller.enqueue({ type: 'stream-start', warnings });
-                    void sendXaiAudioStream({
-                      audio: options.audio,
-                      send: chunk => ws.send(chunk),
-                      done: () =>
-                        ws.send(JSON.stringify({ type: 'audio.done' })),
-                    }).catch(finishWithError);
-                    break;
-                  }
-
-                  case 'transcript.partial': {
-                    const id = channelId(raw.channel_index);
-                    const timing = timingFromXaiEvent(raw);
-                    if (raw.is_final) {
-                      controller.enqueue({
-                        type: 'transcript-final',
-                        id,
-                        text: raw.text ?? '',
-                        ...timing,
-                        channelIndex: raw.channel_index,
-                      });
-                    } else {
-                      controller.enqueue({
-                        type: 'transcript-partial',
-                        id,
-                        text: raw.text ?? '',
-                        startSecond: raw.start,
-                        durationInSeconds: raw.duration,
-                        channelIndex: raw.channel_index,
-                      });
-                    }
-                    break;
-                  }
-
-                  case 'transcript.done': {
-                    const channelIndex = raw.channel_index ?? 0;
-                    doneTexts.set(channelIndex, raw.text ?? '');
-                    doneDuration = raw.duration ?? doneDuration;
-                    controller.enqueue({
-                      type: 'transcript-final',
-                      id: channelId(raw.channel_index),
-                      text: raw.text ?? '',
-                      channelIndex: raw.channel_index,
-                    });
-                    maybeFinish();
-                    break;
-                  }
-
-                  case 'error': {
-                    const error = new Error(raw.message ?? 'xAI STT error');
-                    controller.enqueue({ type: 'error', error });
-                    break;
-                  }
-                }
-              })
-              .catch(finishWithError);
-          };
-
-          ws.onerror = () => {
-            finishWithError(new Error('xAI streaming transcription error'));
-          };
-
-          ws.onclose = () => {
-            options.abortSignal?.removeEventListener('abort', abort);
-            if (!finished) {
-              controller.close();
-            }
-          };
-        },
+      stream: createXaiStreamingTranscriptionStream({
+        webSocket: this.config.webSocket,
+        url,
+        headers,
+        warnings,
+        language: xaiOptions?.language ?? undefined,
+        expectedDoneCount:
+          xaiOptions?.multichannel === true ? xaiOptions.channels! : 1,
+        audio: options.audio,
+        abortSignal: options.abortSignal,
+        includeRawChunks: options.includeRawChunks,
       }),
     };
   }
+}
+
+function createXaiStreamingTranscriptionStream({
+  webSocket,
+  url,
+  headers,
+  warnings,
+  language,
+  expectedDoneCount,
+  audio,
+  abortSignal,
+  includeRawChunks,
+}: {
+  webSocket: WebSocketConstructor | undefined;
+  url: URL;
+  headers: Record<string, string | undefined>;
+  warnings: SharedV4Warning[];
+  language: string | undefined;
+  expectedDoneCount: number;
+  audio: ReadableStream<Uint8Array | string>;
+  abortSignal: AbortSignal | undefined;
+  includeRawChunks: boolean | undefined;
+}) {
+  let finished = false;
+  let cleanup: (closeCode?: number) => void = () => {};
+
+  return new ReadableStream({
+    start: controller => {
+      const WebSocketConstructor = getWebSocketConstructor(webSocket);
+      const ws = new WebSocketConstructor(url, undefined, { headers });
+      const doneTexts = new Map<number, string>();
+      let doneDuration: number | undefined;
+      let audioReader:
+        | ReadableStreamDefaultReader<Uint8Array | string>
+        | undefined;
+
+      cleanup = (closeCode?: number) => {
+        abortSignal?.removeEventListener('abort', abort);
+        void audioReader?.cancel().catch(() => {});
+        try {
+          ws.close(closeCode);
+        } catch {}
+      };
+
+      const finishWithError = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.error(error);
+      };
+
+      const maybeFinish = () => {
+        if (finished || doneTexts.size < expectedDoneCount) return;
+        finished = true;
+        const text = [...doneTexts.entries()]
+          .sort(([a], [b]) => a - b)
+          .map(([, value]) => value)
+          .join('\n');
+        controller.enqueue({
+          type: 'finish',
+          text,
+          segments: [],
+          language,
+          durationInSeconds: doneDuration,
+        });
+        controller.close();
+        cleanup(1000);
+      };
+
+      const abort = () => {
+        finishWithError(abortSignal?.reason ?? new Error('Aborted'));
+      };
+      if (abortSignal?.aborted) {
+        abort();
+        return;
+      }
+      abortSignal?.addEventListener('abort', abort, { once: true });
+
+      const sendAudio = async () => {
+        audioReader = audio.getReader();
+        try {
+          while (true) {
+            const { done, value } = await audioReader.read();
+            if (done || finished) break;
+            ws.send(
+              value instanceof Uint8Array
+                ? value
+                : convertBase64ToUint8Array(value),
+            );
+          }
+        } finally {
+          audioReader.releaseLock();
+        }
+        if (!finished) {
+          ws.send(JSON.stringify({ type: 'audio.done' }));
+        }
+      };
+
+      ws.onmessage = event => {
+        void readWebSocketMessageText(event.data)
+          .then(async text => {
+            const parsed = await safeParseJSON({ text });
+            if (!parsed.success) return;
+            const raw = parsed.value as XaiStreamingTranscriptionEvent;
+
+            if (includeRawChunks) {
+              controller.enqueue({ type: 'raw', rawValue: raw });
+            }
+
+            switch (raw.type) {
+              case 'transcript.created': {
+                controller.enqueue({ type: 'stream-start', warnings });
+                void sendAudio().catch(finishWithError);
+                break;
+              }
+
+              case 'transcript.partial': {
+                const id = channelId(raw.channel_index);
+                const timing = timingFromXaiEvent(raw);
+                if (raw.is_final) {
+                  controller.enqueue({
+                    type: 'transcript-final',
+                    id,
+                    text: raw.text ?? '',
+                    ...timing,
+                    channelIndex: raw.channel_index,
+                  });
+                } else {
+                  controller.enqueue({
+                    type: 'transcript-partial',
+                    id,
+                    text: raw.text ?? '',
+                    startSecond: raw.start,
+                    durationInSeconds: raw.duration,
+                    channelIndex: raw.channel_index,
+                  });
+                }
+                break;
+              }
+
+              case 'transcript.done': {
+                const channelIndex = raw.channel_index ?? 0;
+                doneTexts.set(channelIndex, raw.text ?? '');
+                doneDuration = raw.duration ?? doneDuration;
+                maybeFinish();
+                break;
+              }
+
+              case 'error': {
+                // xAI STT errors are terminal: surface the server message
+                // instead of letting the socket close mask it.
+                finishWithError(new Error(raw.message ?? 'xAI STT error'));
+                break;
+              }
+            }
+          })
+          .catch(finishWithError);
+      };
+
+      ws.onerror = () => {
+        finishWithError(
+          new Error(
+            'xAI streaming transcription error.' +
+              (webSocket == null
+                ? ' Note: the native WebSocket implementation in browsers,' +
+                  ' Node.js, Deno, and Bun cannot send the Authorization' +
+                  ' header required by xAI. Pass a header-capable WebSocket' +
+                  " implementation (e.g. the 'ws' package) via" +
+                  ' createXai({ webSocket }).'
+                : ''),
+          ),
+        );
+      };
+
+      ws.onclose = () => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.close();
+      };
+    },
+
+    cancel: () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    },
+  });
 }
 
 function buildXaiStreamingTranscriptionUrl({
@@ -363,12 +444,7 @@ function buildXaiStreamingTranscriptionUrl({
   inputAudioFormat: TranscriptionModelV4StreamOptions['inputAudioFormat'];
   providerOptions: XaiTranscriptionModelOptions | undefined;
 }) {
-  const url = new URL(`${baseURL}/stt`);
-  if (url.protocol === 'http:') {
-    url.protocol = 'ws:';
-  } else if (url.protocol === 'https:') {
-    url.protocol = 'wss:';
-  }
+  const url = toWebSocketUrl(`${baseURL}/stt`);
 
   appendSearchParam(
     url,
@@ -425,6 +501,10 @@ function appendSearchParam(
   }
 }
 
+function isKnownInputAudioFormat(type: string): boolean {
+  return type === 'audio/pcm' || type === 'audio/pcmu' || type === 'audio/pcma';
+}
+
 function encodingFromInputAudioFormat(type: string): 'pcm' | 'mulaw' | 'alaw' {
   switch (type) {
     case 'audio/pcmu':
@@ -434,30 +514,6 @@ function encodingFromInputAudioFormat(type: string): 'pcm' | 'mulaw' | 'alaw' {
     default:
       return 'pcm';
   }
-}
-
-async function sendXaiAudioStream({
-  audio,
-  send,
-  done,
-}: {
-  audio: ReadableStream<Uint8Array | string>;
-  send: (chunk: Uint8Array) => void;
-  done: () => void;
-}) {
-  const reader = audio.getReader();
-  try {
-    while (true) {
-      const { done: streamDone, value } = await reader.read();
-      if (streamDone) break;
-      send(
-        value instanceof Uint8Array ? value : convertBase64ToUint8Array(value),
-      );
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  done();
 }
 
 function channelId(channelIndex: number | undefined): string | undefined {
@@ -471,18 +527,6 @@ function timingFromXaiEvent(event: XaiStreamingTranscriptionEvent) {
       ? { endSecond: event.start + event.duration }
       : {}),
   };
-}
-
-async function readWebSocketText(data: unknown): Promise<string> {
-  if (typeof data === 'string') return data;
-  if (data instanceof ArrayBuffer) return new TextDecoder().decode(data);
-  if (ArrayBuffer.isView(data)) {
-    return new TextDecoder().decode(data);
-  }
-  if (typeof Blob !== 'undefined' && data instanceof Blob) {
-    return data.text();
-  }
-  return String(data);
 }
 
 const xaiTranscriptionResponseSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       valibot:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.8.3)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -464,6 +467,9 @@ importers:
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       tsx:
         specifier: 4.19.2
         version: 4.19.2


### PR DESCRIPTION
## Background

Follow-up to #16338 with fixes for the issues found during review. Targets the PR branch so the changes can be reviewed/merged into the feature PR before it lands on `main`.

## Summary

**Correctness**

- `experimental_streamTranscribe` now pipes the model stream through a `TransformStream` instead of eagerly draining it inside `ReadableStream.start()`. This preserves consumer backpressure (previously every part of a long live session was buffered in memory regardless of consumer pace) and propagates `fullStream` cancellation to the model stream (previously a `for await … break` left the pump running, rejected all result promises with an internal `TypeError`, and never cancelled the provider stream).
- The OpenAI and xAI `doStream` streams define `cancel()` handlers: cancelling closes the WebSocket and stops reading the audio stream. Previously the connection and the audio-sending loop kept running (connection leak, continued audio upload/billing).
- xAI STT `error` events are now terminal and surface the actual server message. Previously the error was only enqueued as a stream part; when the server then closed the socket the caller got an unrelated `AI_NoTranscriptGeneratedError`, and when it didn't, `result.text` hung forever.
- OpenAI no longer enqueues an `error` part immediately before `controller.error()` — erroring a stream resets its queue, so the part was discarded unless a read was pending at that exact moment.
- Result promises that already resolved (e.g. `warnings` at `stream-start`) no longer flip to rejected when the stream fails later; only pending promises are rejected.
- The xAI WebSocket failure message now explains that native WebSocket implementations (browsers, Node.js, Deno, Bun) cannot send the `Authorization` header xAI requires, and points at `createXai({ webSocket })`. Without this, the default path fails with an opaque generic error on every standard runtime.
- Dated `gpt-realtime-whisper-*` snapshot IDs are accepted via prefix match instead of exact-match rejection.
- Warnings are emitted for non-streaming OpenAI options that were silently dropped (`prompt`, `temperature`, `timestampGranularities`, `include`) and for unrecognized `inputAudioFormat.type` values that xAI silently mapped to raw PCM (garbled transcripts with no diagnostic).
- Removed the duplicate `transcript-final` part xAI emitted for the same utterance on `transcript.done` (consumers rendered every utterance twice with no way to dedupe).

**API surface**

- The new provider spec stream types are exported as `Experimental_TranscriptionModelV4Stream*` at the package boundary, matching the `Experimental_VideoModelV4`/`Experimental_RealtimeModelV4` pattern from `contributing/project-philosophies.md` for experimental spec surfaces. (Open question for maintainers: whether `doStream?` on the stable `TranscriptionModelV4` needs further isolation — see review discussion.)
- `streamTranscribe` is declared unprefixed and aliased to `experimental_streamTranscribe` at the export seam per `contributing/naming-conventions.md`.
- `StreamTranscriptionResult` exposes `language` and `durationInSeconds` — both were delivered by the providers in the `finish` part but unreachable through the API (parity with `transcribe()`).
- The `UnsupportedFunctionalityError` for missing `doStream` explains the gateway/string-model limitation.
- `readWebSocketMessageText` and `toWebSocketUrl` moved to `@ai-sdk/provider-utils` (previously duplicated verbatim in both provider packages).
- The new user-facing xAI `streaming` options use `.optional()` instead of `.nullish()` per the provider-options guidance in the repo docs.

**Tests, docs, examples**

- New tests: cancellation propagation (core + both providers), server `error` events, unsupported-option warnings, dated snapshot IDs, promise settlement semantics, unrecognized audio format warning.
- New API reference page for `experimental_streamTranscribe` (+ index entry) — previously the function had no reference docs.
- Capability table corrections: `gpt-realtime-whisper` does not detect language (the code echoes the user's own `language` option); note that xAI streaming does not surface word timestamps/diarization/segments.
- Examples: `examples/ai-functions/src/stream-transcribe/{openai,xai}/basic.ts` (self-contained: synthesize PCM via `generateSpeech`, then stream-transcribe it). Adds `ws` to the example package for the xAI header requirement.

## Not addressed (needs maintainer decision)

- Gateway support for streaming transcription (tracked as future work in #16338).
- Azure: `gpt-realtime-whisper` is in the shared model ID union but Azure has no `webSocket` setting and its `api-key` auth can never reach the WebSocket path.
- Stream part naming (`transcript-partial`/`transcript-final` vs the noun-verb convention) — worth settling before the strings freeze, but a rename touches the whole PR.
- Audio send loops have no `bufferedAmount` flow control; large pre-recorded sources buffer in the socket.

## Verification

- `pnpm --filter ai test:node` (3174 passed)
- `pnpm --filter @ai-sdk/openai test:node` (741 passed)
- `pnpm --filter @ai-sdk/xai test:node` (368 passed)
- `pnpm --filter @ai-sdk/provider-utils test:node` (655 passed)
- `pnpm --filter @ai-sdk/provider --filter @ai-sdk/provider-utils --filter @ai-sdk/openai --filter @ai-sdk/xai --filter ai type-check`
- `pnpm check`