### PR TITLE
Add Anthropic User Profile attribution options

### DIFF
--- a/.changeset/anthropic-user-profile-id.md
+++ b/.changeset/anthropic-user-profile-id.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/anthropic-aws': patch
+'@ai-sdk/google-vertex': patch
+---
+
+Add Anthropic User Profile attribution provider options.

--- a/content/docs/02-foundations/06-provider-options.mdx
+++ b/content/docs/02-foundations/06-provider-options.mdx
@@ -249,6 +249,25 @@ const { text } = await generateText({
 });
 ```
 
+### User Profile Attribution
+
+For Anthropic User Profile attribution, pass a stored profile ID with `userProfileId`:
+
+```ts
+import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: anthropic('claude-sonnet-4-5'),
+  prompt: 'Write a welcome email.',
+  providerOptions: {
+    anthropic: {
+      userProfileId: 'uprof_01HqRxK2mN8vT3wY',
+    } satisfies AnthropicLanguageModelOptions,
+  },
+});
+```
+
 ---
 
 ## Combining Options

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -166,7 +166,7 @@ The following optional provider options are available for Anthropic models:
 
 Anthropic User Profiles let you attribute inference traffic to downstream customers. After creating and storing a profile ID with Anthropic, pass it on each request with `userProfileId`:
 
-```ts highlight="8"
+```ts highlight="9"
 import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -158,6 +158,29 @@ The following optional provider options are available for Anthropic models:
   Optional. Metadata to include with the request. See the [Anthropic API documentation](https://platform.claude.com/docs/en/api/messages/create) for details.
   - `userId` _string_ - An external identifier for the end-user. Should be a UUID, hash, or other opaque identifier. Must not contain PII.
 
+- `userProfileId` _string_
+
+  Optional. Anthropic User Profile ID (`uprof_...`) for end-customer attribution. Sent as the `anthropic-user-profile-id` request header.
+
+### User Profile Attribution
+
+Anthropic User Profiles let you attribute inference traffic to downstream customers. After creating and storing a profile ID with Anthropic, pass it on each request with `userProfileId`:
+
+```ts highlight="8"
+import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5'),
+  prompt: 'Write a welcome email.',
+  providerOptions: {
+    anthropic: {
+      userProfileId: 'uprof_01HqRxK2mN8vT3wY',
+    } satisfies AnthropicLanguageModelOptions,
+  },
+});
+```
+
 ### Structured Outputs and Tool Input Streaming
 
 Tool call streaming is enabled by default. You can opt out by setting the

--- a/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
+++ b/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
@@ -130,6 +130,8 @@ const model = anthropicAws('claude-sonnet-4-6');
 
 Model IDs are identical to the first-party Anthropic API. See the [Anthropic provider docs](/providers/ai-sdk-providers/anthropic#language-models) for the full list of language model options, prompt caching, computer use, web search, code execution, and Agent Skills. All of these work identically here because Claude Platform on AWS uses Anthropic's runtime directly.
 
+Anthropic User Profile attribution also uses the same `providerOptions.anthropic.userProfileId` option as the first-party Anthropic provider. The SDK sends it as the `anthropic-user-profile-id` request header.
+
 ### Example
 
 ```ts

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -243,8 +243,12 @@ Documentation for additional settings based on the selected model can be found w
 
 For Anthropic User Profile attribution on Bedrock Anthropic models, pass the profile ID with `providerOptions.amazonBedrock.userProfileId`. The SDK sends it as the `user_profile_id` body field in `additionalModelRequestFields`.
 
-```ts highlight="8"
-import { type AmazonBedrockLanguageModelChatOptions } from '@ai-sdk/amazon-bedrock';
+```ts highlight="10"
+import {
+  amazonBedrock,
+  type AmazonBedrockLanguageModelChatOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
 
 await generateText({
   model: amazonBedrock('anthropic.claude-3-sonnet-20240229-v1:0'),

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -241,6 +241,22 @@ await generateText({
 
 Documentation for additional settings based on the selected model can be found within the [Amazon Bedrock Inference Parameter Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html).
 
+For Anthropic User Profile attribution on Bedrock Anthropic models, pass the profile ID with `providerOptions.amazonBedrock.userProfileId`. The SDK sends it as the `user_profile_id` body field in `additionalModelRequestFields`.
+
+```ts highlight="8"
+import { type AmazonBedrockLanguageModelChatOptions } from '@ai-sdk/amazon-bedrock';
+
+await generateText({
+  model: amazonBedrock('anthropic.claude-3-sonnet-20240229-v1:0'),
+  prompt: 'Write a welcome email.',
+  providerOptions: {
+    amazonBedrock: {
+      userProfileId: 'uprof_01HqRxK2mN8vT3wY',
+    } satisfies AmazonBedrockLanguageModelChatOptions,
+  },
+});
+```
+
 You can use Amazon Bedrock language models to generate text with the `generateText` function:
 
 ```ts
@@ -1446,6 +1462,10 @@ The following optional provider options are available for Bedrock Anthropic mode
 
   Optional. Metadata to include with the request. See the [Anthropic API documentation](https://platform.claude.com/docs/en/api/messages/create) for details.
   - `userId` _string_ - An external identifier for the end-user.
+
+- `userProfileId` _string_
+
+  Optional. Anthropic User Profile ID (`uprof_...`) for end-customer attribution. Sent as the `user_profile_id` request body field.
 
 ### Cache Control
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1661,6 +1661,10 @@ console.log(text); // text response
 See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details
 on how to integrate reasoning into your chatbot.
 
+#### User Profile Attribution
+
+For Anthropic User Profile attribution, pass the profile ID with `providerOptions.anthropic.userProfileId`. The SDK sends it as the `anthropic-user-profile-id` request header on Vertex Anthropic requests.
+
 #### Cache Control
 
 <Note>

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
@@ -31,13 +31,26 @@ describe('amazonBedrockLanguageModelChatOptions', () => {
     });
   });
 
+  describe('userProfileId', () => {
+    it('accepts a user profile ID', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({
+        userProfileId: 'uprof_123',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.userProfileId).toBe('uprof_123');
+    });
+  });
+
   describe('type inference', () => {
     it('infers AmazonBedrockLanguageModelChatOptions type correctly', () => {
       const options: AmazonBedrockLanguageModelChatOptions = {
         serviceTier: 'priority',
+        userProfileId: 'uprof_123',
       };
 
       expect(options.serviceTier).toBe('priority');
+      expect(options.userProfileId).toBe('uprof_123');
     });
   });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
@@ -132,6 +132,13 @@ export const amazonBedrockLanguageModelChatOptions = z.object({
    */
   anthropicBeta: z.array(z.string()).optional(),
   /**
+   * Anthropic User Profile ID to attribute this request to an end customer.
+   *
+   * Only applies to Anthropic models. Sent as the `user_profile_id` body field
+   * in Bedrock's `additionalModelRequestFields`.
+   */
+  userProfileId: z.string().optional(),
+  /**
    * Service tier for the request.
    * @see https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html
    *

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
@@ -137,7 +137,7 @@ export const amazonBedrockLanguageModelChatOptions = z.object({
    * Only applies to Anthropic models. Sent as the `user_profile_id` body field
    * in Bedrock's `additionalModelRequestFields`.
    */
-  userProfileId: z.string().optional(),
+  userProfileId: z.string().min(1).optional(),
   /**
    * Service tier for the request.
    * @see https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -4077,6 +4077,49 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should warn and ignore userProfileId for non-Anthropic models', async () => {
+    server.urls[novaGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'test response' }],
+          },
+        },
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        stopReason: 'stop',
+      },
+    };
+
+    const novaModel = new AmazonBedrockChatLanguageModel(novaModelId, {
+      baseUrl: () => baseUrl,
+      headers: {},
+      generateId: () => 'test-id',
+    });
+
+    const result = await novaModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        amazonBedrock: {
+          userProfileId: 'uprof_123',
+        },
+      },
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'userProfileId',
+      details:
+        'userProfileId applies only to Anthropic models on Bedrock and will be ignored for this model.',
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(
+      requestBody.additionalModelRequestFields?.user_profile_id,
+    ).toBeUndefined();
+  });
+
   it('should not include anthropic-beta in HTTP headers', async () => {
     server.urls[anthropicGenerateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -4037,6 +4037,46 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should include user_profile_id in additionalModelRequestFields for Anthropic models', async () => {
+    server.urls[anthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'test response' }],
+          },
+        },
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        stopReason: 'stop',
+      },
+    };
+
+    const anthropicModel = new AmazonBedrockChatLanguageModel(
+      anthropicModelId,
+      {
+        baseUrl: () => baseUrl,
+        headers: {},
+        generateId: () => 'test-id',
+      },
+    );
+
+    await anthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        amazonBedrock: {
+          userProfileId: 'uprof_123',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.additionalModelRequestFields).toEqual({
+      user_profile_id: 'uprof_123',
+    });
+  });
+
   it('should not include anthropic-beta in HTTP headers', async () => {
     server.urls[anthropicGenerateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -236,6 +236,22 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       };
     }
 
+    if (amazonBedrockOptions.userProfileId != null) {
+      if (isAnthropicModel) {
+        amazonBedrockOptions.additionalModelRequestFields = {
+          ...amazonBedrockOptions.additionalModelRequestFields,
+          user_profile_id: amazonBedrockOptions.userProfileId,
+        };
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'userProfileId',
+          details:
+            'userProfileId applies only to Anthropic models on Bedrock and will be ignored for this model.',
+        });
+      }
+    }
+
     const thinkingType = amazonBedrockOptions.reasoningConfig?.type;
     const thinkingBudget =
       thinkingType === 'enabled'
@@ -420,6 +436,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       reasoningConfig: _,
       additionalModelRequestFields: __,
       serviceTier: ___,
+      userProfileId: _userProfileId,
       ...filteredAmazonBedrockOptions
     } = providerOptions?.amazonBedrock ?? providerOptions?.bedrock ?? {};
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -278,6 +278,35 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(transformedBody).not.toHaveProperty('model');
   });
 
+  it('should transform user profile ID to the Bedrock body field', () => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      new Set(),
+      'uprof_123',
+    );
+
+    expect(transformedBody).toMatchObject({
+      user_profile_id: 'uprof_123',
+      anthropic_version: 'bedrock-2023-05-31',
+    });
+  });
+
   it('should strip stream parameter from request body', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -262,7 +262,7 @@ export function createAmazonBedrockAnthropic(
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 
-      transformRequestBody: (args, betas) => {
+      transformRequestBody: (args, betas, userProfileId) => {
         const {
           model: _model,
           stream: _stream,
@@ -318,6 +318,7 @@ export function createAmazonBedrockAnthropic(
 
         return {
           ...rest,
+          ...(userProfileId != null ? { user_profile_id: userProfileId } : {}),
           ...(transformedTools != null ? { tools: transformedTools } : {}),
           ...(transformedToolChoice != null
             ? { tool_choice: transformedToolChoice }
@@ -328,6 +329,8 @@ export function createAmazonBedrockAnthropic(
           anthropic_version: 'bedrock-2023-05-31',
         };
       },
+
+      userProfileIdLocation: 'body',
 
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -145,6 +145,15 @@ export const anthropicLanguageModelOptions = z.object({
     .optional(),
 
   /**
+   * Anthropic User Profile ID to attribute this request to an end customer.
+   *
+   * The Anthropic API, Claude Platform on AWS, and Claude on Vertex AI send this
+   * as the `anthropic-user-profile-id` request header. Claude in Amazon Bedrock
+   * sends it as the `user_profile_id` request body field.
+   */
+  userProfileId: z.string().optional(),
+
+  /**
    * MCP servers to be utilized in this request.
    */
   mcpServers: z

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -151,10 +151,10 @@ export const anthropicLanguageModelOptions = z.object({
    * as the `anthropic-user-profile-id` request header. Claude in Amazon Bedrock
    * sends it as the `user_profile_id` request body field.
    *
-   * The required `user-profiles-2026-03-24` beta is added automatically on the
-   * header path.
+   * The `user-profiles-2026-03-24` beta is added automatically on the header
+   * path (required on the Anthropic API and Claude Platform on AWS).
    */
-  userProfileId: z.string().optional(),
+  userProfileId: z.string().min(1).optional(),
 
   /**
    * MCP servers to be utilized in this request.

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -150,6 +150,9 @@ export const anthropicLanguageModelOptions = z.object({
    * The Anthropic API, Claude Platform on AWS, and Claude on Vertex AI send this
    * as the `anthropic-user-profile-id` request header. Claude in Amazon Bedrock
    * sends it as the `user_profile_id` request body field.
+   *
+   * The required `user-profiles-2026-03-24` beta is added automatically on the
+   * header path.
    */
   userProfileId: z.string().optional(),
 

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -8151,9 +8151,66 @@ describe('AnthropicLanguageModel', () => {
       expect(server.calls[0].requestHeaders).toMatchObject({
         'anthropic-user-profile-id': 'uprof_123',
       });
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+        'user-profiles-2026-03-24',
+      );
       expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
         'user_profile_id',
       );
+    });
+
+    it('should not send the user profile header or beta when userProfileIdLocation is body', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'json-value',
+        body: {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-3-haiku-20240307',
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      };
+
+      const transformFn = vi.fn(
+        (
+          body: Record<string, any>,
+          _betas: Set<string>,
+          userProfileId?: string,
+        ) => ({
+          ...body,
+          ...(userProfileId != null ? { user_profile_id: userProfileId } : {}),
+        }),
+      );
+
+      const { AnthropicLanguageModel } =
+        await import('./anthropic-language-model');
+      const model = new AnthropicLanguageModel('claude-3-haiku-20240307', {
+        provider: 'bedrock.anthropic.messages',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: {},
+        transformRequestBody: transformFn,
+        userProfileIdLocation: 'body',
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            userProfileId: 'uprof_123',
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(
+        server.calls[0].requestHeaders['anthropic-user-profile-id'],
+      ).toBeUndefined();
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toBeUndefined();
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        user_profile_id: 'uprof_123',
+      });
     });
 
     it('should support cache control', async () => {

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -8122,6 +8122,40 @@ describe('AnthropicLanguageModel', () => {
       );
     });
 
+    it('should include providerOptions.anthropic.userProfileId in anthropic-user-profile-id header', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'json-value',
+        body: {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          model: 'claude-3-haiku-20240307',
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      };
+
+      const provider = createAnthropic({ apiKey: 'test-api-key' });
+
+      await provider('claude-3-haiku-20240307').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            userProfileId: 'uprof_123',
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        'anthropic-user-profile-id': 'uprof_123',
+      });
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'user_profile_id',
+      );
+    });
+
     it('should support cache control', async () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',
@@ -10269,6 +10303,7 @@ describe('AnthropicLanguageModel', () => {
           ],
         }),
         expect.any(Set),
+        undefined,
       );
 
       // Verify transformed body was sent
@@ -10312,6 +10347,7 @@ describe('AnthropicLanguageModel', () => {
           stream: true,
         }),
         expect.any(Set),
+        undefined,
       );
 
       // Verify transformed body was sent

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -68,8 +68,11 @@ import { sanitizeJsonSchema } from './sanitize-json-schema';
 
 const ANTHROPIC_USER_PROFILE_ID_HEADER = 'anthropic-user-profile-id';
 /**
- * Anthropic requires this beta on inference requests that carry
- * `anthropic-user-profile-id`. Not needed on the Bedrock body path.
+ * Sent alongside `anthropic-user-profile-id` on inference requests. Required
+ * on the Anthropic API and Claude Platform on AWS; also sent on Vertex
+ * Anthropic where it is accepted (matches the AI Gateway's production
+ * behavior). Not sent on the Bedrock body path, which takes the profile as a
+ * `user_profile_id` body field with no beta.
  */
 const ANTHROPIC_USER_PROFILES_BETA = 'user-profiles-2026-03-24';
 
@@ -143,6 +146,12 @@ type AnthropicLanguageModelConfig = {
     betas: Set<string>,
     userProfileId?: string,
   ) => Record<string, any>;
+  /**
+   * Where the provider surface takes the Anthropic user profile ID.
+   * Defaults to `'header'` (`anthropic-user-profile-id` + user-profiles
+   * beta); `'body'` suppresses both and delivers the ID to
+   * `transformRequestBody` instead (Bedrock InvokeModel).
+   */
   userProfileIdLocation?: 'body' | 'header';
   supportedUrls?: () => LanguageModelV4['supportedUrls'];
   generateId?: () => string;

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -67,6 +67,11 @@ import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
 import { sanitizeJsonSchema } from './sanitize-json-schema';
 
 const ANTHROPIC_USER_PROFILE_ID_HEADER = 'anthropic-user-profile-id';
+/**
+ * Anthropic requires this beta on inference requests that carry
+ * `anthropic-user-profile-id`. Not needed on the Bedrock body path.
+ */
+const ANTHROPIC_USER_PROFILES_BETA = 'user-profiles-2026-03-24';
 
 function createCitationSource(
   citation: Citation,
@@ -727,6 +732,13 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
 
     if (anthropicOptions?.fallbacks && anthropicOptions.fallbacks.length > 0) {
       betas.add('server-side-fallback-2026-06-01');
+    }
+
+    if (
+      anthropicOptions?.userProfileId != null &&
+      this.config.userProfileIdLocation !== 'body'
+    ) {
+      betas.add(ANTHROPIC_USER_PROFILES_BETA);
     }
 
     const defaultEagerInputStreaming =

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -66,6 +66,8 @@ import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
 import { sanitizeJsonSchema } from './sanitize-json-schema';
 
+const ANTHROPIC_USER_PROFILE_ID_HEADER = 'anthropic-user-profile-id';
+
 function createCitationSource(
   citation: Citation,
   citationDocuments: Array<{
@@ -134,7 +136,9 @@ type AnthropicLanguageModelConfig = {
   transformRequestBody?: (
     args: Record<string, any>,
     betas: Set<string>,
+    userProfileId?: string,
   ) => Record<string, any>;
+  userProfileIdLocation?: 'body' | 'header';
   supportedUrls?: () => LanguageModelV4['supportedUrls'];
   generateId?: () => string;
 
@@ -776,20 +780,26 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       toolNameMapping,
       providerOptionsName,
       usedCustomProviderKey,
+      userProfileId: anthropicOptions?.userProfileId,
     };
   }
 
   private async getHeaders({
     betas,
     headers,
+    userProfileId,
   }: {
     betas: Set<string>;
     headers: Record<string, string | undefined> | undefined;
+    userProfileId: string | undefined;
   }) {
     return combineHeaders(
       this.config.headers ? await resolve(this.config.headers) : undefined,
       headers,
       betas.size > 0 ? { 'anthropic-beta': Array.from(betas).join(',') } : {},
+      userProfileId != null && this.config.userProfileIdLocation !== 'body'
+        ? { [ANTHROPIC_USER_PROFILE_ID_HEADER]: userProfileId }
+        : {},
     );
   }
 
@@ -823,8 +833,11 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
   private transformRequestBody(
     args: Record<string, any>,
     betas: Set<string>,
+    userProfileId: string | undefined,
   ): Record<string, any> {
-    return this.config.transformRequestBody?.(args, betas) ?? args;
+    return (
+      this.config.transformRequestBody?.(args, betas, userProfileId) ?? args
+    );
   }
 
   private extractCitationDocuments(prompt: LanguageModelV4Prompt): Array<{
@@ -881,6 +894,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       toolNameMapping,
       providerOptionsName,
       usedCustomProviderKey,
+      userProfileId,
     } = await this.getArgs({
       ...options,
       stream: false,
@@ -902,8 +916,12 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       rawValue: rawResponse,
     } = await postJsonToApi({
       url: this.buildRequestUrl(false),
-      headers: await this.getHeaders({ betas, headers: options.headers }),
-      body: this.transformRequestBody(args, betas),
+      headers: await this.getHeaders({
+        betas,
+        headers: options.headers,
+        userProfileId,
+      }),
+      body: this.transformRequestBody(args, betas, userProfileId),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
         anthropicResponseSchema,
@@ -1446,6 +1464,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       toolNameMapping,
       providerOptionsName,
       usedCustomProviderKey,
+      userProfileId,
     } = await this.getArgs({
       ...options,
       stream: true,
@@ -1464,8 +1483,12 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
     const url = this.buildRequestUrl(true);
     const { responseHeaders, value: response } = await postJsonToApi({
       url,
-      headers: await this.getHeaders({ betas, headers: options.headers }),
-      body: this.transformRequestBody(body, betas),
+      headers: await this.getHeaders({
+        betas,
+        headers: options.headers,
+        userProfileId,
+      }),
+      body: this.transformRequestBody(body, betas, userProfileId),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler:
         createEventSourceResponseHandler(anthropicChunkSchema),


### PR DESCRIPTION
## Summary
- Add `providerOptions.anthropic.userProfileId` for Anthropic-compatible providers.
- Send `anthropic-user-profile-id` on direct Anthropic, Claude Platform on AWS, and Vertex Anthropic requests.
- Send Bedrock attribution via `user_profile_id` for native Bedrock Anthropic and Bedrock Converse Anthropic models.
- Document usage and add a patch changeset.

## Tests
- `pnpm --filter @ai-sdk/anthropic test:node src/anthropic-language-model.test.ts`
- `pnpm --filter @ai-sdk/amazon-bedrock test:node src/anthropic/amazon-bedrock-anthropic-provider.test.ts src/amazon-bedrock-chat-language-model-options.test.ts src/amazon-bedrock-chat-language-model.test.ts`
- `pnpm --filter @ai-sdk/anthropic type-check`
- `pnpm --filter @ai-sdk/amazon-bedrock type-check`
- `pnpm --filter @ai-sdk/anthropic-aws type-check`
- `pnpm --filter @ai-sdk/google-vertex type-check`
- Scoped `pnpm exec ultracite check ...`
- `git diff --check`

Local commands warn because Node is v25.9.0; repo engines allow Node 22/24/26.