### PR TITLE
fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching

### DIFF
--- a/.changeset/parallel-tool-results-call-order.md
+++ b/.changeset/parallel-tool-results-call-order.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Serialize parallel tool results in tool-call order when converting generation output to response messages.

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -290,6 +290,64 @@ describe('toResponseMessages', () => {
     `);
   });
 
+  it('should serialize parallel tool results in tool call order', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'text',
+          text: 'Using tools',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          input: {},
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          input: {},
+        },
+        // Simulates parallel execution where toolB resolved before toolA.
+        {
+          type: 'tool-result',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          output: 'B result',
+          input: {},
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          output: 'A result',
+          input: {},
+        },
+      ],
+      tools: {
+        toolA: tool({
+          description: 'Tool A',
+          inputSchema: z.object({}),
+        }),
+        toolB: tool({
+          description: 'Tool B',
+          inputSchema: z.object({}),
+        }),
+      },
+    });
+
+    const toolMessage = result[1];
+    expect(toolMessage?.role).toBe('tool');
+    if (toolMessage?.role !== 'tool') {
+      throw new Error('Expected a tool message');
+    }
+    expect(toolMessage.content.map(part => part.toolCallId)).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+  });
+
   it('should handle undefined text', async () => {
     const result = await toResponseMessages({
       content: [

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -342,10 +342,11 @@ describe('toResponseMessages', () => {
     if (toolMessage?.role !== 'tool') {
       throw new Error('Expected a tool message');
     }
-    expect(toolMessage.content.map(part => part.toolCallId)).toEqual([
-      'call-a',
-      'call-b',
-    ]);
+    expect(
+      toolMessage.content.map(part =>
+        part.type === 'tool-result' ? part.toolCallId : undefined,
+      ),
+    ).toEqual(['call-a', 'call-b']);
   });
 
   it('should handle undefined text', async () => {

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -142,7 +142,25 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
     });
   }
 
-  const toolResultContent: ToolContent = [];
+  const toolCallOrder = new Map<string, number>();
+  for (const part of inputContent) {
+    if (part.type === 'tool-call' && !toolCallOrder.has(part.toolCallId)) {
+      toolCallOrder.set(part.toolCallId, toolCallOrder.size);
+    }
+
+    if (
+      part.type === 'tool-approval-request' &&
+      !toolCallOrder.has(part.toolCall.toolCallId)
+    ) {
+      toolCallOrder.set(part.toolCall.toolCallId, toolCallOrder.size);
+    }
+  }
+
+  const toolResultContent: Array<{
+    part: ToolContent[number];
+    toolCallId: string | undefined;
+    index: number;
+  }> = [];
   for (const part of inputContent) {
     if (
       part.type !== 'tool-approval-response' &&
@@ -154,11 +172,15 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
 
     if (part.type === 'tool-approval-response') {
       toolResultContent.push({
-        type: 'tool-approval-response',
-        approvalId: part.approvalId,
-        approved: part.approved,
-        reason: part.reason,
-        providerExecuted: part.providerExecuted,
+        part: {
+          type: 'tool-approval-response',
+          approvalId: part.approvalId,
+          approved: part.approved,
+          reason: part.reason,
+          providerExecuted: part.providerExecuted,
+        },
+        toolCallId: part.toolCall.toolCallId,
+        index: toolResultContent.length,
       });
 
       // when the tool approval is denied,
@@ -166,13 +188,17 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
       // since there is no corresponding tool result for the tool call
       if (part.approved === false) {
         toolResultContent.push({
-          type: 'tool-result',
-          toolCallId: part.toolCall.toolCallId,
-          toolName: part.toolCall.toolName,
-          output: {
-            type: 'execution-denied' as const,
-            reason: part.reason,
+          part: {
+            type: 'tool-result',
+            toolCallId: part.toolCall.toolCallId,
+            toolName: part.toolCall.toolName,
+            output: {
+              type: 'execution-denied' as const,
+              reason: part.reason,
+            },
           },
+          toolCallId: part.toolCall.toolCallId,
+          index: toolResultContent.length,
         });
       }
       continue;
@@ -191,22 +217,42 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
     });
 
     toolResultContent.push({
-      type: 'tool-result',
+      part: {
+        type: 'tool-result',
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        output,
+        ...(part.providerMetadata != null
+          ? { providerOptions: part.providerMetadata }
+          : {}),
+      },
       toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      output,
-      ...(part.providerMetadata != null
-        ? { providerOptions: part.providerMetadata }
-        : {}),
+      index: toolResultContent.length,
     });
   }
 
   if (toolResultContent.length > 0) {
     responseMessages.push({
       role: 'tool',
-      content: toolResultContent,
+      content: [...toolResultContent]
+        .sort((a, b) => {
+          const orderA = getToolCallOrder(toolCallOrder, a.toolCallId);
+          const orderB = getToolCallOrder(toolCallOrder, b.toolCallId);
+
+          return orderA === orderB ? a.index - b.index : orderA - orderB;
+        })
+        .map(({ part }) => part),
     });
   }
 
   return responseMessages;
+}
+
+function getToolCallOrder(
+  toolCallOrder: Map<string, number>,
+  toolCallId: string | undefined,
+) {
+  return toolCallId == null
+    ? Number.MAX_SAFE_INTEGER
+    : (toolCallOrder.get(toolCallId) ?? Number.MAX_SAFE_INTEGER);
 }


### PR DESCRIPTION
## Background

Parallel tool executions could serialize tool results in completion order instead of tool-call order, producing nondeterministic prompt bytes and breaking provider prompt caching.

## Summary

Updated toResponseMessages to record tool-call order and stably sort emitted tool message parts by the corresponding call order, with unknown IDs kept last.

## Testing

Kept the focused regression test for parallel tool results and adjusted its assertion to type-narrow tool result parts.

## Related Issues

Fixes #16567