### PR TITLE
fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching

### DIFF
--- a/.changeset/calm-tools-sort.md
+++ b/.changeset/calm-tools-sort.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Sort tool results by their tool call order when converting generation output to response messages.

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -290,6 +290,64 @@ describe('toResponseMessages', () => {
     `);
   });
 
+  it('should serialize parallel tool results in tool call order', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'text',
+          text: 'Using tools',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          input: {},
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          input: {},
+        },
+        // Simulates parallel execution where toolB resolved before toolA.
+        {
+          type: 'tool-result',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          output: 'B result',
+          input: {},
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          output: 'A result',
+          input: {},
+        },
+      ],
+      tools: {
+        toolA: tool({
+          description: 'Tool A',
+          inputSchema: z.object({}),
+        }),
+        toolB: tool({
+          description: 'Tool B',
+          inputSchema: z.object({}),
+        }),
+      },
+    });
+
+    const toolMessage = result[1];
+    expect(toolMessage?.role).toBe('tool');
+    if (toolMessage?.role !== 'tool') {
+      throw new Error('Expected a tool message');
+    }
+    expect(toolMessage.content.map(part => part.toolCallId)).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+  });
+
   it('should handle undefined text', async () => {
     const result = await toResponseMessages({
       content: [

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -342,10 +342,11 @@ describe('toResponseMessages', () => {
     if (toolMessage?.role !== 'tool') {
       throw new Error('Expected a tool message');
     }
-    expect(toolMessage.content.map(part => part.toolCallId)).toEqual([
-      'call-a',
-      'call-b',
-    ]);
+    expect(
+      toolMessage.content
+        .filter(part => part.type === 'tool-result')
+        .map(part => part.toolCallId),
+    ).toEqual(['call-a', 'call-b']);
   });
 
   it('should handle undefined text', async () => {

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -19,6 +19,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
   tools: TOOLS | undefined;
 }): Promise<Array<AssistantModelMessage | ToolModelMessage>> {
   const responseMessages: Array<AssistantModelMessage | ToolModelMessage> = [];
+  const toolCallOrder = new Map<string, number>();
 
   const content: AssistantContent = [];
   for (const part of inputContent) {
@@ -79,6 +80,9 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         });
         break;
       case 'tool-call':
+        if (!toolCallOrder.has(part.toolCallId)) {
+          toolCallOrder.set(part.toolCallId, toolCallOrder.size);
+        }
         content.push({
           type: 'tool-call',
           toolCallId: part.toolCallId,
@@ -204,9 +208,49 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
   if (toolResultContent.length > 0) {
     responseMessages.push({
       role: 'tool',
-      content: toolResultContent,
+      content: sortToolResultContentByToolCallOrder({
+        toolResultContent,
+        toolCallOrder,
+      }),
     });
   }
 
   return responseMessages;
+}
+
+function sortToolResultContentByToolCallOrder({
+  toolResultContent,
+  toolCallOrder,
+}: {
+  toolResultContent: ToolContent;
+  toolCallOrder: Map<string, number>;
+}): ToolContent {
+  const sortedToolResults = toolResultContent
+    .filter(part => part.type === 'tool-result')
+    .map((part, index) => ({ part, index }))
+    .sort((a, b) => {
+      const aOrder = toolCallOrder.get(a.part.toolCallId);
+      const bOrder = toolCallOrder.get(b.part.toolCallId);
+
+      if (aOrder == null && bOrder == null) {
+        return a.index - b.index;
+      }
+
+      if (aOrder == null) {
+        return 1;
+      }
+
+      if (bOrder == null) {
+        return -1;
+      }
+
+      return aOrder - bOrder || a.index - b.index;
+    })
+    .map(({ part }) => part);
+
+  let toolResultIndex = 0;
+
+  return toolResultContent.map(part =>
+    part.type === 'tool-result' ? sortedToolResults[toolResultIndex++] : part,
+  );
 }


### PR DESCRIPTION
## Background

Parallel tool results could be serialized in nondeterministic completion order instead of assistant tool-call order, causing equivalent histories to produce byte-different prompts and miss provider prompt caches.

## Summary

Updated toResponseMessages to record assistant tool-call order and stably sort emitted tool-result content by matching toolCallId, with unknown ids kept last.

## Testing

Kept the focused regression test for parallel tool calls resolving out of order and made its assertion type-safe.

## Related Issues

Fixes #16567