### PR TITLE
fix: preserve signed tool approval metadata across approval responses

### DIFF
--- a/.changeset/signed-approval-metadata.md
+++ b/.changeset/signed-approval-metadata.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Preserve signed tool approval metadata when recording approval responses.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -2597,6 +2597,58 @@ describe('Chat', () => {
   });
 
   describe('addToolApprovalResponse', () => {
+    it('should preserve signed approval metadata when recording the response', async () => {
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId({ prefix: 'newid' }),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        messages: [
+          {
+            id: 'id-0',
+            role: 'user',
+            parts: [{ text: 'What is the weather in Tokyo?', type: 'text' }],
+          },
+          {
+            id: 'id-1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-weather',
+                toolCallId: 'call-1',
+                state: 'approval-requested',
+                input: { city: 'Tokyo' },
+                approval: {
+                  id: 'approval-1',
+                  isAutomatic: false,
+                  signature: 'signed-approval-envelope',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      await chat.addToolApprovalResponse({
+        id: 'approval-1',
+        approved: true,
+        reason: 'looks good',
+      });
+
+      expect(chat.messages[1].parts[1]).toMatchObject({
+        state: 'approval-responded',
+        approval: {
+          id: 'approval-1',
+          approved: true,
+          reason: 'looks good',
+          isAutomatic: false,
+          signature: 'signed-approval-envelope',
+        },
+      });
+    });
+
     describe('approved', () => {
       let chat: TestChat;
 

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -493,7 +493,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           ? {
               ...part,
               state: 'approval-responded',
-              approval: { id, approved, reason },
+              approval: { ...part.approval, id, approved, reason },
             }
           : part;
 


### PR DESCRIPTION
## Background

Signed human-in-the-loop tool approvals failed on resume because the UI helper discarded the server-issued approval signature when recording a user decision.

## Summary

Updated addToolApprovalResponse to append approved/reason onto the existing approval envelope instead of replacing it, preserving signature and isAutomatic metadata.

## Testing

Kept the focused regression test in packages/ai/src/ui/chat.test.ts that verifies signed approval metadata survives the approval-requested to approval-responded transition, and added a patch changeset for ai.

## Related Issues

Fixes #16334