### PR TITLE
fix: google.interactions agents dropping File Search tools

### DIFF
--- a/.changeset/google-interactions-agent-tools.md
+++ b/.changeset/google-interactions-agent-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Allow google.interactions agent requests to include supported tools, including file_search.

--- a/packages/google/src/interactions/google-interactions-language-model.test.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.test.ts
@@ -1406,34 +1406,39 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       expect(body.agent_config).toEqual({ type: 'dynamic' });
     });
 
-    it('emits a warning and drops tools when an agent is set', async () => {
+    it('emits file_search tools when an agent is set', async () => {
       const agentModel = provider.interactions({ agent: AGENT_NAME });
       const result = await agentModel.doGenerate({
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'function',
-            name: 'getWeather',
-            description: 'Get the current weather in a location',
-            inputSchema: {
-              type: 'object',
-              properties: { location: { type: 'string' } },
-              required: ['location'],
+            type: 'provider',
+            id: 'google.file_search',
+            name: 'file_search',
+            args: {
+              fileSearchStoreNames: ['fileSearchStores/x'],
             },
           },
         ],
+        providerOptions: { google: { background: true } },
       });
       const body = (await server.calls[0].requestBodyJson) as Record<
         string,
         unknown
       >;
-      expect(body.tools).toBeUndefined();
+      expect(body.tools).toEqual([
+        {
+          type: 'file_search',
+          file_search_store_names: ['fileSearchStores/x'],
+        },
+      ]);
+      expect(body.background).toBe(true);
       const warning = result.warnings.find(
         w =>
           w.type === 'other' &&
           (w as { message?: string }).message?.includes('tools'),
       );
-      expect(warning).toBeDefined();
+      expect(warning).toBeUndefined();
     });
 
     it('emits a warning and drops generation-config fields (temperature, topP, thinkingLevel) when an agent is set', async () => {

--- a/packages/google/src/interactions/google-interactions-language-model.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.ts
@@ -78,7 +78,7 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
 
   /**
    * Optional agent name. When provided, the request body sends `agent:` instead
-   * of `model:` and rejects `tools` / `generation_config` (warned, not thrown).
+   * of `model:` and rejects `generation_config` (warned, not thrown).
    */
   readonly agent: string | undefined;
 
@@ -158,13 +158,7 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
     let toolsForBody: Array<GoogleInteractionsTool> | undefined;
     let toolChoiceForBody: GoogleInteractionsToolChoice | undefined;
 
-    if (hasTools && isAgent) {
-      warnings.push({
-        type: 'other',
-        message:
-          'google.interactions: tools are not supported when an agent is set; tools will be omitted from the request body.',
-      });
-    } else if (hasTools) {
+    if (hasTools) {
       const prepared = prepareGoogleInteractionsTools({
         tools: options.tools,
         toolChoice: options.toolChoice,


### PR DESCRIPTION
## Background

Deep Research agent calls through google.interactions could not be grounded with File Search because agent requests dropped all tools and only returned a warning.

## Summary

Google Interactions now prepares and includes supported tools for agent requests as well as model-id requests, while keeping generation_config omitted for agents.

## Testing

Updated the Google Interactions agent regression test to assert that a file_search tool is serialized on an agent request with background enabled and no tools warning is emitted.

## Related Issues

Fixes #16368