### PR TITLE
fix: Gemini 3 parallel tool calls warn and inject skip validators for unsigned batch members

### DIFF
--- a/.changeset/gemini-parallel-tool-signatures.md
+++ b/.changeset/gemini-parallel-tool-signatures.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Avoid injecting Gemini 3 thought-signature skip validators for unsigned parallel tool calls that follow a signed tool call in the same assistant batch.

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -1828,6 +1828,69 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
     expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
     expect(onWarning.mock.calls[0][0].message).toContain('`search`');
   });
+
+  it('issue #16298 repro: does not warn or inject the skip validator for an unsigned parallel tool call following a signed one', () => {
+    const onWarning = vi.fn();
+
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'check Paris and Tokyo weather' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_paris',
+              toolName: 'get_weather',
+              input: { city: 'Paris' },
+              providerOptions: {
+                vertex: { thoughtSignature: 'parallel-batch-signature' },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_tokyo',
+              toolName: 'get_weather',
+              input: { city: 'Tokyo' },
+            },
+          ],
+        },
+      ],
+      {
+        isGemini3Model: true,
+        providerOptionsNames: ['googleVertex', 'vertex'],
+        onWarning,
+      },
+    );
+
+    const assistant = result.contents.find(content => content.role === 'model');
+
+    expect(assistant?.parts).toEqual([
+      {
+        functionCall: {
+          id: 'tc_paris',
+          name: 'get_weather',
+          args: { city: 'Paris' },
+        },
+        thoughtSignature: 'parallel-batch-signature',
+      },
+      {
+        functionCall: {
+          id: 'tc_tokyo',
+          name: 'get_weather',
+          args: { city: 'Tokyo' },
+        },
+        thoughtSignature: undefined,
+      },
+    ]);
+    expect(assistant?.parts[1]?.thoughtSignature).not.toBe(
+      SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    );
+    expect(onWarning).not.toHaveBeenCalled();
+  });
 });
 
 describe('top-level-only media type resolution', () => {

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -1886,8 +1886,10 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
         thoughtSignature: undefined,
       },
     ]);
-    expect(assistant?.parts[1]?.thoughtSignature).not.toBe(
-      SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+    expect(assistant?.parts[1]).not.toEqual(
+      expect.objectContaining({
+        thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+      }),
     );
     expect(onWarning).not.toHaveBeenCalled();
   });

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -333,6 +333,10 @@ export function convertToGoogleMessages(
 
       case 'assistant': {
         systemMessagesAllowed = false;
+        // Gemini 3 can return one thought signature for a batch of parallel
+        // tool calls, attached to the first functionCall. Subsequent unsigned
+        // calls in the same batch should replay without the skip sentinel.
+        let toolCallBatchHasThoughtSignature = false;
 
         contents.push({
           role: 'model',
@@ -346,6 +350,7 @@ export function convertToGoogleMessages(
 
               switch (part.type) {
                 case 'text': {
+                  toolCallBatchHasThoughtSignature = false;
                   return part.text.length === 0
                     ? undefined
                     : {
@@ -355,6 +360,7 @@ export function convertToGoogleMessages(
                 }
 
                 case 'reasoning': {
+                  toolCallBatchHasThoughtSignature = false;
                   return part.text.length === 0
                     ? undefined
                     : {
@@ -365,6 +371,7 @@ export function convertToGoogleMessages(
                 }
 
                 case 'reasoning-file': {
+                  toolCallBatchHasThoughtSignature = false;
                   switch (part.data.type) {
                     case 'url': {
                       throw new UnsupportedFunctionalityError({
@@ -387,6 +394,7 @@ export function convertToGoogleMessages(
                 }
 
                 case 'file': {
+                  toolCallBatchHasThoughtSignature = false;
                   switch (part.data.type) {
                     case 'url': {
                       throw new UnsupportedFunctionalityError({
@@ -456,10 +464,17 @@ export function convertToGoogleMessages(
                     providerOpts?.serverToolType != null
                       ? String(providerOpts.serverToolType)
                       : undefined;
+                  const hasBatchThoughtSignature =
+                    toolCallBatchHasThoughtSignature;
+                  if (thoughtSignature != null) {
+                    toolCallBatchHasThoughtSignature = true;
+                  }
                   const effectiveThoughtSignature =
                     thoughtSignature ??
                     (isGemini3Model
-                      ? injectSkipSignature(part.toolName)
+                      ? hasBatchThoughtSignature
+                        ? undefined
+                        : injectSkipSignature(part.toolName)
                       : undefined);
 
                   if (serverToolCallId && serverToolType) {
@@ -489,6 +504,7 @@ export function convertToGoogleMessages(
                 }
 
                 case 'tool-result': {
+                  toolCallBatchHasThoughtSignature = false;
                   const serverToolCallId =
                     providerOpts?.serverToolCallId != null
                       ? String(providerOpts.serverToolCallId)


### PR DESCRIPTION
## Background

Gemini 3 can return a single thought signature for a parallel function-call batch, so replaying later unsigned calls in the same batch should not create noisy warnings or inject the skip validator.

## Summary

Updated Google message conversion to track signed assistant tool-call batches and avoid applying the Gemini 3 skip sentinel to later unsigned calls in the same contiguous batch, while preserving sentinel behavior when no real signature is present.

## Testing

Kept the issue #16298 regression coverage for a signed first parallel tool call followed by an unsigned one, and made its sentinel assertion type-safe.

## Related Issues

Fixes #16298