### PR TITLE
fix: handle MCP HTTP SSE rejections

### DIFF
--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -577,6 +577,37 @@ describe('HttpMCPTransport', () => {
     expect(error.message).toContain('GET SSE failed');
   });
 
+  it('should route background inbound SSE rejections to onerror', async () => {
+    const networkError = new TypeError('terminated');
+    const fetchFn = vi.fn(async () => {
+      throw networkError;
+    });
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      fetch: fetchFn,
+    });
+
+    const errors: unknown[] = [];
+    transport.onerror = error => {
+      errors.push(error);
+    };
+
+    await expect(transport.start()).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(errors).toContain(networkError);
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+    expect(errors).toContain(networkError);
+  });
+
   it('should handle inbound SSE messages without explicit event field', async () => {
     const controller = new TestResponseController();
     server.urls['http://localhost:4000/mcp'].response = {

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -186,7 +186,7 @@ export class HttpMCPTransport implements MCPTransport {
     }
     this.abortController = new AbortController();
 
-    void this.openInboundSse();
+    this.openInboundSseSafely();
   }
 
   async close(): Promise<void> {
@@ -260,7 +260,7 @@ export class HttpMCPTransport implements MCPTransport {
           // If inbound SSE was not available earlier (e.g. 405 before init), try again now
           // Do not await to avoid blocking send()
           if (!this.inboundSseConnection) {
-            void this.openInboundSse();
+            this.openInboundSseSafely();
           }
           return;
         }
@@ -357,7 +357,7 @@ export class HttpMCPTransport implements MCPTransport {
             }
           };
 
-          processEvents();
+          processEvents().catch(error => this.onerror?.(error));
           return;
         }
 
@@ -404,8 +404,24 @@ export class HttpMCPTransport implements MCPTransport {
     this.inboundReconnectAttempts += 1;
     setTimeout(async () => {
       if (this.abortController?.signal.aborted) return;
-      await this.openInboundSse(false, this.lastInboundEventId);
+      await this.openInboundSse(false, this.lastInboundEventId).catch(error =>
+        this.handleInboundSseError(error),
+      );
     }, delay);
+  }
+
+  private openInboundSseSafely(): void {
+    this.openInboundSse().catch(error => this.handleInboundSseError(error));
+  }
+
+  private handleInboundSseError(error: unknown): void {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return;
+    }
+    this.onerror?.(error);
+    if (!this.abortController?.signal.aborted) {
+      this.scheduleInboundSseReconnection();
+    }
   }
 
   // Open optional inbound SSE stream; best-effort and resumable
@@ -515,15 +531,9 @@ export class HttpMCPTransport implements MCPTransport {
         close: () => reader.cancel(),
       };
       this.inboundReconnectAttempts = 0;
-      processEvents();
+      processEvents().catch(error => this.handleInboundSseError(error));
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        return;
-      }
-      this.onerror?.(error);
-      if (!this.abortController?.signal.aborted) {
-        this.scheduleInboundSseReconnection();
-      }
+      this.handleInboundSseError(error);
     }
   }
 }


### PR DESCRIPTION
Summary
- route fire-and-forget inbound SSE startup failures through the transport error handler
- attach rejection handlers to SSE reader loops and reconnection attempts so background stream failures do not escape as unhandled rejections
- add regression coverage for rejected inbound SSE opens and retry scheduling

Tests
- pnpm --dir /Users/icezero/Documents/autofix/oss-fixes/vercel-ai --filter @ai-sdk/mcp test -- mcp-http-transport.test.ts

Fixes #16541
