### PR TITLE
fix: omit Gemini image diffusion options

### DIFF
--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -9,12 +9,14 @@ function createBasicModel({
   headers,
   fetch,
   currentDate,
+  modelId = 'stabilityai/stable-diffusion-xl',
 }: {
   headers?: () => Record<string, string>;
   fetch?: FetchFunction;
   currentDate?: () => Date;
+  modelId?: string;
 } = {}) {
-  return new TogetherAIImageModel('stabilityai/stable-diffusion-xl', {
+  return new TogetherAIImageModel(modelId, {
     provider: 'togetherai',
     baseURL: 'https://api.example.com',
     headers: headers ?? (() => ({ 'api-key': 'test-key' })),
@@ -84,6 +86,36 @@ describe('doGenerate', () => {
     expect(requestBody).toStrictEqual({
       model: 'stabilityai/stable-diffusion-xl',
       prompt,
+      response_format: 'base64',
+    });
+  });
+
+  it('should omit diffusion-only options for Gemini image models', async () => {
+    const model = createBasicModel({ modelId: 'google/gemini-3-pro-image' });
+
+    await model.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: '1264x848',
+      seed: 42,
+      providerOptions: {
+        togetherai: {
+          steps: 28,
+          guidance: 3.5,
+          negative_prompt: 'low quality',
+          disable_safety_checker: true,
+        },
+      },
+      aspectRatio: undefined,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'google/gemini-3-pro-image',
+      prompt,
+      width: 1264,
+      height: 848,
       response_format: 'base64',
     });
   });

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -91,6 +91,12 @@ export class TogetherAIImageModel implements ImageModelV4 {
       providerOptions,
       schema: togetheraiImageModelOptionsSchema,
     });
+    const diffusionOptions = this.supportsDiffusionOptions()
+      ? {
+          ...(seed != null ? { seed } : {}),
+          ...(togetheraiOptions ?? {}),
+        }
+      : {};
 
     // Handle image input from files
     let imageUrl: string | undefined;
@@ -114,7 +120,7 @@ export class TogetherAIImageModel implements ImageModelV4 {
       body: {
         model: this.modelId,
         prompt,
-        ...(seed != null ? { seed } : {}),
+        ...diffusionOptions,
         ...(n > 1 ? { n } : {}),
         ...(splitSize && {
           width: parseInt(splitSize[0]),
@@ -122,7 +128,6 @@ export class TogetherAIImageModel implements ImageModelV4 {
         }),
         ...(imageUrl != null ? { image_url: imageUrl } : {}),
         response_format: 'base64',
-        ...(togetheraiOptions ?? {}),
       },
       failedResponseHandler: createJsonErrorResponseHandler({
         errorSchema: togetheraiErrorSchema,
@@ -144,6 +149,10 @@ export class TogetherAIImageModel implements ImageModelV4 {
         headers: responseHeaders,
       },
     };
+  }
+
+  private supportsDiffusionOptions(): boolean {
+    return this.modelId !== 'google/gemini-3-pro-image';
   }
 }
 


### PR DESCRIPTION
Summary
- omit TogetherAI diffusion-only image options for `google/gemini-3-pro-image`
- keep standard request fields such as prompt, size-derived width/height, and response format
- add regression coverage for filtering `seed`, `steps`, `guidance`, `negative_prompt`, and `disable_safety_checker`

Tests
- pnpm --dir /Users/icezero/Documents/autofix/oss-fixes/vercel-ai/packages/togetherai exec vitest --config vitest.node.config.js --run src/togetherai-image-model.test.ts
- pnpm --dir /Users/icezero/Documents/autofix/oss-fixes/vercel-ai/packages/togetherai exec vitest --config vitest.edge.config.js --run src/togetherai-image-model.test.ts

Notes
- The package-level `pnpm --filter @ai-sdk/togetherai test -- togetherai-image-model.test.ts` command is blocked in this checkout by an unrelated local resolution error for `@ai-sdk/openai-compatible` in other TogetherAI test files.

Fixes #15035
