### PR TITLE
reproduction: Reproduces #13438

### DIFF
--- a/reproductions/issue-13438/repro-issue-13438.sh
+++ b/reproductions/issue-13438/repro-issue-13438.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+echo "Reproducing vercel/ai#13438: Provider requires rerankingModel but OpenResponsesProvider inherits optional ProviderV3.rerankingModel"
+echo "Command: pnpm exec tsc -p reproductions/issue-13438/tsconfig.json"
+pnpm exec tsc -p reproductions/issue-13438/tsconfig.json

--- a/reproductions/issue-13438/repro.ts
+++ b/reproductions/issue-13438/repro.ts
@@ -1,0 +1,12 @@
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import type { Provider } from 'ai';
+
+// Expected to type-check if ai.Provider matches @ai-sdk/provider.ProviderV3.
+// Currently fails because ai.Provider requires rerankingModel while OpenResponsesProvider
+// inherits ProviderV3 where rerankingModel is optional.
+const provider: Provider = createOpenResponses({
+  name: 'test',
+  url: 'http://localhost/v1/responses',
+});
+
+console.log(provider);

--- a/reproductions/issue-13438/tsconfig.json
+++ b/reproductions/issue-13438/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "baseUrl": "../..",
+    "paths": {
+      "ai": ["packages/ai/dist/index.d.ts"],
+      "@ai-sdk/open-responses": ["packages/open-responses/dist/index.d.ts"]
+    }
+  },
+  "include": ["repro.ts"]
+}


### PR DESCRIPTION
## Reproduction

Created runnable artifact reproductions/issue-13438/repro-issue-13438.sh with a strict TypeScript assignment of createOpenResponses() to ai.Provider. Ran ./reproductions/issue-13438/repro-issue-13438.sh; tsc failed with TS2322 because OpenResponsesProvider.rerankingModel is optional while ai.Provider requires it.

## Branch

bug-13438-2

## Related Issues

Reproduces #13438