### PR TITLE
reproduction: Reproduces #13304

### DIFF
--- a/packages/react/src/use-chat.issue-13304.test.tsx
+++ b/packages/react/src/use-chat.issue-13304.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ChatTransport, type UIMessageChunk } from 'ai';
+import React, { act, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useChat } from './use-chat';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+describe('issue #13304: useChat id change during streaming', () => {
+  it('aborts the library-created previous Chat stream when id changes', async () => {
+    const abortSignals: AbortSignal[] = [];
+    let streamController: ReadableStreamDefaultController<UIMessageChunk>;
+
+    const transport: ChatTransport = {
+      sendMessages: vi.fn(async ({ abortSignal }) => {
+        abortSignals.push(abortSignal);
+
+        return new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            streamController = controller;
+          },
+        });
+      }),
+      reconnectToStream: vi.fn(),
+    };
+
+    function TestComponent() {
+      const [chatId, setChatId] = useState('chat-a');
+      const { id, sendMessage, status } = useChat({
+        id: chatId,
+        transport,
+      });
+
+      return (
+        <div>
+          <div data-testid="id">{id}</div>
+          <div data-testid="status">{status}</div>
+          <button
+            type="button"
+            data-testid="send"
+            onClick={() =>
+              sendMessage({
+                role: 'user',
+                parts: [{ type: 'text', text: 'hello' }],
+              })
+            }
+          />
+          <button
+            type="button"
+            data-testid="switch-chat"
+            onClick={() => setChatId('chat-b')}
+          />
+        </div>
+      );
+    }
+
+    render(<TestComponent />);
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    await waitFor(() => {
+      expect(transport.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      streamController.enqueue({ type: 'text-start', id: '0' });
+      streamController.enqueue({ type: 'text-delta', id: '0', delta: 'hi' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+    });
+
+    await userEvent.click(screen.getByTestId('switch-chat'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('id')).toHaveTextContent('chat-b');
+    });
+
+    let assertionError: unknown;
+    try {
+      expect(abortSignals[0].aborted).toBe(true);
+    } catch (error) {
+      assertionError = error;
+    } finally {
+      act(() => {
+        streamController.enqueue({ type: 'text-end', id: '0' });
+        streamController.enqueue({ type: 'finish', finishReason: 'stop' });
+        streamController.close();
+      });
+    }
+
+    if (assertionError) {
+      throw assertionError;
+    }
+  });
+});


### PR DESCRIPTION
## Reproduction

Added failing reproduction test packages/react/src/use-chat.issue-13304.test.tsx. Ran `pnpm --dir packages/react exec vitest --config vitest.config.js --run src/use-chat.issue-13304.test.tsx`; it fails because after switching useChat id from chat-a to chat-b during an active stream, the previous transport AbortSignal remains `aborted === false` instead of true.

## Branch

bug-13304-1

## Related Issues

Reproduces #13304