### PR TITLE
fix: Amazon Bedrock Mistral tool-call ID collisions

### DIFF
--- a/.changeset/fuzzy-chairs-grin.md
+++ b/.changeset/fuzzy-chairs-grin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Hash Mistral tool call IDs to the full 9-character alphanumeric space to avoid duplicate normalized Bedrock tool call IDs.

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
@@ -33,32 +33,41 @@ describe('normalizeToolCallId', () => {
     expect(normalizeToolCallId(originalId, false)).toBe(originalId);
   });
 
-  it('should extract first 9 alphanumeric characters for Mistral models', () => {
-    // Bedrock format: tooluse_bpe71yCfRu2b5i-nKGDr5g
-    // After removing non-alphanumeric: toolusebpe71yCfRu2b5inKGDr5g
-    // First 9 chars: toolusebp
-    expect(normalizeToolCallId('tooluse_bpe71yCfRu2b5i-nKGDr5g', true)).toBe(
-      'toolusebp',
+  it('should hash Bedrock tool call IDs to 9 alphanumeric characters for Mistral models', () => {
+    expect(normalizeToolCallId('tooluse_bpe71yCfRu2b5i-nKGDr5g', true)).toMatch(
+      /^[a-zA-Z0-9]{9}$/,
+    );
+  });
+
+  it('should deterministically normalize the same ID', () => {
+    const toolCallId = 'tooluse_bpe71yCfRu2b5i-nKGDr5g';
+
+    expect(normalizeToolCallId(toolCallId, true)).toBe(
+      normalizeToolCallId(toolCallId, true),
     );
   });
 
   it('should handle IDs with various special characters', () => {
-    expect(normalizeToolCallId('tool-use_123ABC456', true)).toBe('tooluse12');
-    expect(normalizeToolCallId('___abc123DEF___', true)).toBe('abc123DEF');
+    expect(normalizeToolCallId('tool-use_123ABC456', true)).toMatch(
+      /^[a-zA-Z0-9]{9}$/,
+    );
+    expect(normalizeToolCallId('___abc123DEF___', true)).toMatch(
+      /^[a-zA-Z0-9]{9}$/,
+    );
   });
 
-  it('should handle IDs that are already alphanumeric', () => {
+  it('should preserve IDs that are already valid Mistral tool call IDs', () => {
     expect(normalizeToolCallId('abcdefghi', true)).toBe('abcdefghi');
     expect(normalizeToolCallId('abc123XYZ', true)).toBe('abc123XYZ');
   });
 
   it('should handle short IDs', () => {
-    expect(normalizeToolCallId('abc', true)).toBe('abc');
-    expect(normalizeToolCallId('12345', true)).toBe('12345');
+    expect(normalizeToolCallId('abc', true)).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(normalizeToolCallId('12345', true)).toMatch(/^[a-zA-Z0-9]{9}$/);
   });
 
   it('should handle IDs with only special characters', () => {
-    expect(normalizeToolCallId('___---___', true)).toBe('');
+    expect(normalizeToolCallId('___---___', true)).toMatch(/^[a-zA-Z0-9]{9}$/);
   });
 
   it('should produce valid Mistral tool call IDs (9 alphanumeric chars)', () => {
@@ -66,8 +75,7 @@ describe('normalizeToolCallId', () => {
       'tooluse_bpe71yCfRu2b5i-nKGDr5g',
       true,
     );
-    // Verify the ID matches Mistral's requirements: ^[a-zA-Z0-9]{1,9}$
-    expect(normalizedId).toMatch(/^[a-zA-Z0-9]{1,9}$/);
+    expect(normalizedId).toMatch(/^[a-zA-Z0-9]{9}$/);
   });
 
   it('should not collide for distinct Bedrock IDs that share the tooluse prefix and first two suffix chars', () => {

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
@@ -69,4 +69,13 @@ describe('normalizeToolCallId', () => {
     // Verify the ID matches Mistral's requirements: ^[a-zA-Z0-9]{1,9}$
     expect(normalizedId).toMatch(/^[a-zA-Z0-9]{1,9}$/);
   });
+
+  it('should not collide for distinct Bedrock IDs that share the tooluse prefix and first two suffix chars', () => {
+    const a = normalizeToolCallId('tooluse_Ac1Xq9ZklmNoPq', true);
+    const b = normalizeToolCallId('tooluse_Ac2Yt7WrstUvWx', true);
+
+    expect(a).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(b).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(a).not.toBe(b);
+  });
 });

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.ts
@@ -16,7 +16,7 @@ export function isMistralModel(modelId: string): boolean {
  * Bedrock generates tool call IDs in formats like `tooluse_bpe71yCfRu2b5i-nKGDr5g`,
  * which are incompatible with Mistral's requirements.
  *
- * This function extracts the first 9 alphanumeric characters from the ID.
+ * This function hashes incompatible IDs into 9 alphanumeric characters.
  *
  * @param toolCallId - The original tool call ID from Bedrock
  * @param isMistral - Whether the model is a Mistral model
@@ -30,7 +30,40 @@ export function normalizeToolCallId(
     return toolCallId;
   }
 
-  // Extract only alphanumeric characters and take first 9
-  const alphanumericChars = toolCallId.replace(/[^a-zA-Z0-9]/g, '');
-  return alphanumericChars.slice(0, 9);
+  if (/^[a-zA-Z0-9]{9}$/.test(toolCallId)) {
+    return toolCallId;
+  }
+
+  return convertToBase62Hash(toolCallId);
+}
+
+const base62Characters =
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const base62Length = BigInt(base62Characters.length);
+const normalizedToolCallIdLength = 9;
+const normalizedToolCallIdSpace =
+  base62Length ** BigInt(normalizedToolCallIdLength);
+const fnvOffsetBasis64 = BigInt('14695981039346656037');
+const fnvPrime64 = BigInt('1099511628211');
+const fnv64BitMask = BigInt('18446744073709551615');
+
+function convertToBase62Hash(value: string): string {
+  // FNV-1a 64-bit hash. It is deterministic across runtimes and gives the
+  // normalized ID access to the full 9-character base62 space.
+  let hash = fnvOffsetBasis64;
+
+  for (let i = 0; i < value.length; i++) {
+    hash ^= BigInt(value.charCodeAt(i));
+    hash = (hash * fnvPrime64) & fnv64BitMask;
+  }
+
+  let base62Value = hash % normalizedToolCallIdSpace;
+  let result = '';
+
+  for (let i = 0; i < normalizedToolCallIdLength; i++) {
+    result = base62Characters[Number(base62Value % base62Length)] + result;
+    base62Value /= base62Length;
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Background

Amazon Bedrock Mistral tool-call IDs must be exactly 9 alphanumeric characters, but the previous normalization truncated Bedrock IDs to the fixed `tooluse` prefix plus only two random characters, causing duplicate IDs and Bedrock validation failures.

## Summary

Replaced first-9-character truncation with deterministic 9-character base62 hashing for incompatible Mistral tool-call IDs while preserving already-valid 9-character IDs.

## Testing

Updated the Amazon Bedrock normalizeToolCallId tests to cover deterministic hashing, exact Mistral ID shape, preservation of valid IDs, and the reported collision case.

## Related Issues

Fixes #16182

Co-authored-by: arpanpal-at <253363140+arpanpal-at@users.noreply.github.com>