### PR TITLE
fix: resubscribe useChat messages for same-id Chat instance replacements

### DIFF
--- a/.changeset/silver-chats-resubscribe.md
+++ b/.changeset/silver-chats-resubscribe.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Fix `useChat` message subscriptions when replacing a `Chat` instance with another instance that has the same id.

--- a/packages/react/src/use-chat.same-id-instance.test.tsx
+++ b/packages/react/src/use-chat.same-id-instance.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import React, { act, useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Chat } from './chat.react';
+import { useChat } from './use-chat';
+
+const message = (id: string, text: string) => ({
+  id,
+  role: 'user' as const,
+  parts: [{ type: 'text' as const, text }],
+});
+
+describe('useChat with externally provided Chat instances', () => {
+  afterEach(cleanup);
+
+  it('resubscribes message updates when the chat instance changes but the id stays the same', () => {
+    const firstChat = new Chat({
+      id: 'same-chat-id',
+      messages: [message('first', 'first chat')],
+    });
+
+    const secondChat = new Chat({
+      id: 'same-chat-id',
+      messages: [message('second', 'second chat')],
+    });
+
+    let replaceWithSecondChat!: () => void;
+    let updateFirstChat!: () => void;
+    let updateSecondChat!: () => void;
+
+    function TestComponent() {
+      const [chat, setChat] = useState(firstChat);
+      const { messages } = useChat({ chat });
+
+      replaceWithSecondChat = () => setChat(secondChat);
+      updateFirstChat = () => {
+        firstChat.messages = [
+          ...firstChat.messages,
+          message('first-update', 'first chat update'),
+        ];
+      };
+      updateSecondChat = () => {
+        secondChat.messages = [
+          ...secondChat.messages,
+          message('second-update', 'second chat update'),
+        ];
+      };
+
+      return (
+        <div data-testid="messages">
+          {messages.map(message => message.parts[0].text).join(',')}
+        </div>
+      );
+    }
+
+    render(<TestComponent />);
+
+    expect(screen.getByTestId('messages')).toHaveTextContent('first chat');
+
+    act(() => {
+      replaceWithSecondChat();
+    });
+
+    expect(screen.getByTestId('messages')).toHaveTextContent('second chat');
+
+    act(() => {
+      updateSecondChat();
+    });
+
+    expect(screen.getByTestId('messages')).toHaveTextContent(
+      'second chat update',
+    );
+
+    act(() => {
+      updateFirstChat();
+    });
+
+    expect(screen.getByTestId('messages')).not.toHaveTextContent(
+      'first chat update',
+    );
+  });
+});

--- a/packages/react/src/use-chat.same-id-instance.test.tsx
+++ b/packages/react/src/use-chat.same-id-instance.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from '@testing-library/react';
-import React, { act, useState } from 'react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Chat } from './chat.react';
 import { useChat } from './use-chat';

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -128,12 +128,12 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
   }
 
+  const chat = chatRef.current;
+
   const subscribeToMessages = useCallback(
     (update: () => void) =>
-      chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    // `chatRef.current.id` is required to trigger re-subscription when the chat ID changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [throttleWaitMs, chatRef.current.id],
+      chat['~registerMessagesCallback'](update, throttleWaitMs),
+    [throttleWaitMs, chat],
   );
 
   const messages = useSyncExternalStore(


### PR DESCRIPTION
## Background

Replacing a useChat-provided Chat object with a new instance that reused the same id left the message subscription attached to the old instance, so updates on the new chat did not re-render.

## Summary

Updated useChat so the message subscription callback captures and depends on the current Chat instance rather than only the chat id, causing React to resubscribe when the instance changes.

## Testing

Kept the focused same-id Chat replacement regression test and adjusted its act import to use the testing-library helper.

## Related Issues

Fixes #15873

Co-authored-by: shaddollxz <56341682+shaddollxz@users.noreply.github.com>