### PR TITLE
fix: overlapping chat resume streams log TypeError on finish

### DIFF
--- a/.changeset/tiny-cats-resume.md
+++ b/.changeset/tiny-cats-resume.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix a race in chat request finalization that logged a TypeError when overlapping resume streams cleared the shared active response.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -86,8 +86,9 @@ describe('Chat', () => {
 
   describe('overlapping resume streams', () => {
     it('should not log a TypeError when one resume clears activeResponse before the other finishes', async () => {
-      const controllers: Array<ReadableStreamDefaultController<UIMessageChunk>> =
-        [];
+      const controllers: Array<
+        ReadableStreamDefaultController<UIMessageChunk>
+      > = [];
 
       const transport: ChatTransport<UIMessage> = {
         async sendMessages() {
@@ -105,12 +106,13 @@ describe('Chat', () => {
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
+      const onFinish = vi.fn();
 
       const chat = new TestChat({
         id: '123',
         generateId: mockId(),
         transport,
-        onFinish: () => {},
+        onFinish,
       });
 
       const firstResume = chat.resumeStream();
@@ -127,6 +129,10 @@ describe('Chat', () => {
       await firstResume;
 
       expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.any(TypeError));
+      expect(onFinish.mock.calls.map(([event]) => event.message.id)).toEqual([
+        'id-1',
+        'id-0',
+      ]);
     });
   });
 

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -12,6 +12,7 @@ import {
   type ChatState,
   type ChatStatus,
 } from './chat';
+import type { ChatTransport } from './chat-transport';
 import { DefaultChatTransport } from './default-chat-transport';
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from './last-assistant-message-is-complete-with-approval-responses';
 import { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
@@ -81,6 +82,52 @@ describe('Chat', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe('overlapping resume streams', () => {
+    it('should not log a TypeError when one resume clears activeResponse before the other finishes', async () => {
+      const controllers: Array<ReadableStreamDefaultController<UIMessageChunk>> =
+        [];
+
+      const transport: ChatTransport<UIMessage> = {
+        async sendMessages() {
+          throw new Error('sendMessages should not be called');
+        },
+        async reconnectToStream() {
+          return new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controllers.push(controller);
+            },
+          });
+        },
+      };
+
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport,
+        onFinish: () => {},
+      });
+
+      const firstResume = chat.resumeStream();
+      const secondResume = chat.resumeStream();
+
+      await vi.waitFor(() => {
+        expect(controllers).toHaveLength(2);
+      });
+
+      controllers[1].close();
+      await secondResume;
+
+      controllers[0].close();
+      await firstResume;
+
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.any(TypeError));
+    });
   });
 
   describe('send a simple message', () => {

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -650,21 +650,26 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     let isAbort = false;
     let isDisconnect = false;
     let isError = false;
+    let activeResponse: ActiveResponse<UI_MESSAGE> | undefined;
 
     try {
-      const activeResponse = {
+      activeResponse = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
           messageId: this.generateId(),
         }),
         abortController: new AbortController(),
       } as ActiveResponse<UI_MESSAGE>;
+      const activeResponseForRequest = activeResponse;
 
-      activeResponse.abortController.signal.addEventListener('abort', () => {
-        isAbort = true;
-      });
+      activeResponseForRequest.abortController.signal.addEventListener(
+        'abort',
+        () => {
+          isAbort = true;
+        },
+      );
 
-      this.activeResponse = activeResponse;
+      this.activeResponse = activeResponseForRequest;
 
       let stream: ReadableStream<UIMessageChunk>;
 
@@ -674,7 +679,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         stream = await this.transport.sendMessages({
           chatId: this.id,
           messages: this.state.messages,
-          abortSignal: activeResponse.abortController.signal,
+          abortSignal: activeResponseForRequest.abortController.signal,
           metadata,
           headers,
           body,
@@ -692,21 +697,22 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         // serialize the job execution to avoid race conditions:
         this.jobExecutor.run(() =>
           job({
-            state: activeResponse.state,
+            state: activeResponseForRequest.state,
             write: () => {
               // streaming is set on first write (before it should be "submitted")
               this.setStatus({ status: 'streaming' });
 
               const replaceLastMessage =
-                activeResponse.state.message.id === this.lastMessage?.id;
+                activeResponseForRequest.state.message.id ===
+                this.lastMessage?.id;
 
               if (replaceLastMessage) {
                 this.state.replaceMessage(
                   this.state.messages.length - 1,
-                  activeResponse.state.message,
+                  activeResponseForRequest.state.message,
                 );
               } else {
-                this.state.pushMessage(activeResponse.state.message);
+                this.state.pushMessage(activeResponseForRequest.state.message);
               }
             },
           }),
@@ -756,19 +762,23 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.setStatus({ status: 'error', error: err as Error });
     } finally {
       try {
-        this.onFinish?.({
-          message: this.activeResponse!.state.message,
-          messages: this.state.messages,
-          isAbort,
-          isDisconnect,
-          isError,
-          finishReason: this.activeResponse?.state.finishReason,
-        });
+        if (activeResponse != null) {
+          this.onFinish?.({
+            message: activeResponse.state.message,
+            messages: this.state.messages,
+            isAbort,
+            isDisconnect,
+            isError,
+            finishReason: activeResponse.state.finishReason,
+          });
+        }
       } catch (err) {
         console.error(err);
       }
 
-      this.activeResponse = undefined;
+      if (this.activeResponse === activeResponse) {
+        this.activeResponse = undefined;
+      }
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true


### PR DESCRIPTION
## Background

Overlapping useChat resume streams could race on the shared activeResponse and log a swallowed TypeError during request finalization.

## Summary

AbstractChat.makeRequest now finalizes using the per-request active response and only clears the shared activeResponse when the completing request still owns it.

## Testing

Enhanced the overlapping resume-stream regression test to verify no TypeError is logged and each onFinish receives its own message.

## Related Issues

Fixes #15870

Co-authored-by: aabarry-ship-it <217388238+aabarry-ship-it@users.noreply.github.com>