### PR TITLE
reproduction: Reproduces #12876

### DIFF
--- a/reproductions/issue-12876.mjs
+++ b/reproductions/issue-12876.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { generateText, Output } from '../packages/ai/dist/index.js';
+import { anthropic } from '../packages/anthropic/dist/index.js';
+import { z } from '../packages/anthropic/node_modules/zod/index.js';
+
+const modelId = process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001';
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('Missing ANTHROPIC_API_KEY. Set it to run the live Anthropic reproduction.');
+  process.exit(2);
+}
+
+const schema = z.object({
+  cars: z.discriminatedUnion('brand', [
+    z.object({ brand: z.literal('BMW') }),
+    z.object({ brand: z.literal('Mercedes') }),
+  ]),
+});
+
+try {
+  const result = await generateText({
+    model: anthropic(modelId),
+    output: Output.object({ schema }),
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Return a JSON object choosing either BMW or Mercedes as the most used car brand worldwide.',
+      },
+    ],
+    maxOutputTokens: 200,
+  });
+
+  console.log('generateText succeeded unexpectedly. Structured output:', result.output);
+  process.exit(0);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error('generateText failed with message:');
+  console.error(message);
+
+  if (error && typeof error === 'object') {
+    console.error('error name:', error.name);
+    if ('statusCode' in error) console.error('statusCode:', error.statusCode);
+    if ('responseBody' in error) console.error('responseBody:', error.responseBody);
+    if ('cause' in error && error.cause) console.error('cause:', error.cause);
+  }
+
+  if (message.includes("Schema type 'oneOf' is not supported")) {
+    console.error('Reproduced issue #12876: Anthropic rejected the oneOf generated for a Zod discriminated union.');
+    process.exit(1);
+  }
+
+  console.error('Did not observe the exact reported oneOf error.');
+  process.exit(3);
+}

--- a/reproductions/issue-12876.sh
+++ b/reproductions/issue-12876.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+# Reproduction for vercel/ai issue #12876 using the reported AI SDK package versions
+# plus a valid peer Zod v4 version that emits oneOf for discriminated unions.
+# Requires a live Anthropic key because the reported failure is returned by Anthropic.
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "Missing ANTHROPIC_API_KEY. Set it to run the live Anthropic reproduction." >&2
+  exit 2
+fi
+
+REPRO_DIR="${TMPDIR:-/tmp}/vercel-ai-issue-12876"
+rm -rf "$REPRO_DIR"
+mkdir -p "$REPRO_DIR"
+cd "$REPRO_DIR" || exit 2
+
+npm init -y >/dev/null
+npm install --silent ai@6.0.39 @ai-sdk/anthropic@3.0.47 zod@4.4.3
+
+cat > repro.mjs <<'JS'
+import { generateText, Output } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+import { z } from 'zod';
+
+const modelId = process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001';
+
+const schema = z.object({
+  cars: z.discriminatedUnion('brand', [
+    z.object({ brand: z.literal('BMW') }),
+    z.object({ brand: z.literal('Mercedes') }),
+  ]),
+});
+
+const responseFormat = await Output.object({ schema }).responseFormat;
+console.log('Generated response format schema:');
+console.log(JSON.stringify(responseFormat.schema, null, 2));
+
+try {
+  const { output } = await generateText({
+    model: anthropic(modelId),
+    output: Output.object({ schema }),
+    messages: [
+      { role: 'user', content: 'What is the most used car brand worldwide?' },
+    ],
+    maxOutputTokens: 200,
+  });
+
+  console.log('Unexpected success:', output);
+  process.exit(0);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error('Observed error message:');
+  console.error(message);
+  if (error && typeof error === 'object') {
+    if ('name' in error) console.error('name:', error.name);
+    if ('statusCode' in error) console.error('statusCode:', error.statusCode);
+    if ('responseBody' in error) console.error('responseBody:', error.responseBody);
+  }
+
+  if (message.includes("output_format.schema: Schema type 'oneOf' is not supported")) {
+    console.error('Reproduced issue #12876.');
+    process.exit(1);
+  }
+
+  console.error('The live call failed, but not with the reported oneOf error.');
+  process.exit(3);
+}
+JS
+
+node repro.mjs


### PR DESCRIPTION
## Reproduction

Reproduced with live Anthropic by running ./reproductions/issue-12876.sh. The script installs ai@6.0.39, @ai-sdk/anthropic@3.0.47, and zod@4.4.3, shows the discriminated union schema emits oneOf, then fails with the reported 400 error: "output_format.schema: Schema type 'oneOf' is not supported". Reproduction artifact left at reproductions/issue-12876.sh.

## Branch

bug-12876-1

## Related Issues

Reproduces #12876