### PR TITLE
fix: generated audio file format detection failures throwing non-SDK errors

### DIFF
--- a/.changeset/tidy-audio-format-error.md
+++ b/.changeset/tidy-audio-format-error.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Throw an `InvalidResponseDataError` when generated speech audio format cannot be determined from the provider media type.

--- a/packages/ai/src/generate-speech/generated-audio-file.test.ts
+++ b/packages/ai/src/generate-speech/generated-audio-file.test.ts
@@ -1,0 +1,24 @@
+import {
+  AISDKError,
+  InvalidResponseDataError,
+} from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { DefaultGeneratedAudioFile } from './generated-audio-file';
+
+describe('DefaultGeneratedAudioFile', () => {
+  it('throws an AI SDK error when the audio format cannot be determined', () => {
+    let error: unknown;
+
+    try {
+      new DefaultGeneratedAudioFile({
+        data: new Uint8Array([1, 2, 3]),
+        mediaType: 'audio/',
+      });
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(AISDKError.isInstance(error)).toBe(true);
+    expect(InvalidResponseDataError.isInstance(error)).toBe(true);
+  });
+});

--- a/packages/ai/src/generate-speech/generated-audio-file.test.ts
+++ b/packages/ai/src/generate-speech/generated-audio-file.test.ts
@@ -1,7 +1,4 @@
-import {
-  AISDKError,
-  InvalidResponseDataError,
-} from '@ai-sdk/provider';
+import { AISDKError, InvalidResponseDataError } from '@ai-sdk/provider';
 import { describe, expect, it } from 'vitest';
 import { DefaultGeneratedAudioFile } from './generated-audio-file';
 
@@ -20,5 +17,9 @@ describe('DefaultGeneratedAudioFile', () => {
 
     expect(AISDKError.isInstance(error)).toBe(true);
     expect(InvalidResponseDataError.isInstance(error)).toBe(true);
+    expect(error).toMatchObject({
+      data: 'audio/',
+      message: 'Could not determine audio format from media type: audio/',
+    });
   });
 });

--- a/packages/ai/src/generate-speech/generated-audio-file.ts
+++ b/packages/ai/src/generate-speech/generated-audio-file.ts
@@ -1,3 +1,4 @@
+import { InvalidResponseDataError } from '@ai-sdk/provider';
 import {
   DefaultGeneratedFile,
   type GeneratedFile,
@@ -41,10 +42,10 @@ export class DefaultGeneratedAudioFile
     }
 
     if (!format) {
-      // TODO this should be an AI SDK error
-      throw new Error(
-        'Audio format must be provided or determinable from media type',
-      );
+      throw new InvalidResponseDataError({
+        data: mediaType,
+        message: `Could not determine audio format from media type: ${mediaType}`,
+      });
     }
 
     this.format = format;


### PR DESCRIPTION
## Background

Malformed generated speech media types such as "audio/" could make DefaultGeneratedAudioFile throw a plain Error, preventing callers from recognizing it with AISDKError.isInstance.

## Summary

DefaultGeneratedAudioFile now throws InvalidResponseDataError with the provider media type when it cannot derive an audio format.

## Testing

Updated the generated audio file regression test to assert the error is both an AISDKError and InvalidResponseDataError and includes the expected data and message.

## Related Issues

Fixes #15814

Co-authored-by: Abuhaithem <107338221+Abuhaithem@users.noreply.github.com>