### PR TITLE
feat(examples): xAI combined voice (TTS + STT) demo

### DIFF
--- a/examples/xai-tts-demo/server.mjs
+++ b/examples/xai-tts-demo/server.mjs
@@ -3,7 +3,10 @@
 // browser.
 import { createServer } from 'node:http';
 import { xai } from '@ai-sdk/xai';
-import { generateSpeech, transcribe } from 'ai';
+import {
+  experimental_generateSpeech as generateSpeech,
+  experimental_transcribe as transcribe,
+} from 'ai';
 
 const PORT = Number(process.env.PORT) || 5051;
 const VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'];


### PR DESCRIPTION
## Summary

Adds a minimal, self-contained browser demo for **xAI text-to-speech and speech-to-text** via `@ai-sdk/xai`, so others can try out the new xAI voice models end-to-end.

- Single Node HTTP server (`examples/xai-tts-demo/server.mjs`) — no framework, no build step beyond building the workspace packages.
- **TTS**: pick voice, language, codec, sample rate, speed, streaming-latency/normalization options and play the result in the browser.
- **STT**: record from the mic and transcribe, with optional language, keyterm, formatting, and diarization.
- API key stays on the server (read from `XAI_API_KEY`); never sent to the browser.

## How to run

```bash
cp examples/xai-tts-demo/.env.example examples/xai-tts-demo/.env   # add XAI_API_KEY
pnpm --filter @example/xai-tts-demo start
```

Then open http://localhost:5051.

## Notes

- Draft — for others to try the demo, not intended to merge.
- No secrets committed: only `.env.example` is tracked; `.env` is gitignored.

## Test plan

- [ ] `pnpm --filter @example/xai-tts-demo start` boots the server
- [ ] TTS generates and plays audio for each voice/codec
- [ ] STT records and returns a transcript

Made with [Cursor](https://cursor.com)