### PR TITLE
fix: prevent Chat resume-stream onFinish errors when requests overlap

### DIFF
--- a/.changeset/fresh-tigers-continue.md
+++ b/.changeset/fresh-tigers-continue.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix chat `onFinish` handling when overlapping requests clear the active response before a resume stream finishes.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1471,6 +1471,81 @@ describe('Chat', () => {
     expect(chat.status).toBe('error');
   });
 
+  it('should not throw to console when an overlapped request clears activeResponse before resume-stream finishes', async () => {
+    let resumeController!: ReadableStreamDefaultController<UIMessageChunk>;
+    const resumeStream = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        resumeController = controller;
+        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: 'start-step' });
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'resumed',
+        });
+      },
+    });
+
+    const submitStream = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: 'start-step' });
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'submitted',
+        });
+        controller.enqueue({ type: 'text-end', id: 'text-1' });
+        controller.enqueue({ type: 'finish-step' });
+        controller.enqueue({ type: 'finish', finishReason: 'stop' });
+        controller.close();
+      },
+    });
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const chat = new TestChat({
+      id: '123',
+      generateId: mockId(),
+      transport: {
+        sendMessages: async () => submitStream,
+        reconnectToStream: async () => resumeStream,
+      },
+      onFinish: () => {},
+    });
+
+    let resumeSettled = false;
+    const resumePromise = chat.resumeStream().finally(() => {
+      resumeSettled = true;
+    });
+
+    while ((chat.messages[0]?.parts[1] as any)?.text !== 'resumed') {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(resumeSettled).toBe(false);
+
+    await chat.sendMessage({ text: 'Hello, world!' });
+
+    expect((chat as any).activeResponse).toBeUndefined();
+
+    resumeController.enqueue({ type: 'text-end', id: 'text-1' });
+    resumeController.enqueue({ type: 'finish-step' });
+    resumeController.enqueue({ type: 'finish', finishReason: 'stop' });
+    resumeController.close();
+    await resumePromise;
+
+    try {
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   describe('sendAutomaticallyWhen', () => {
     it('should delay tool output submission until the stream is finished', async () => {
       const controller1 = new TestResponseController();

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -650,9 +650,10 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     let isAbort = false;
     let isDisconnect = false;
     let isError = false;
+    let activeResponse: ActiveResponse<UI_MESSAGE> | undefined;
 
     try {
-      const activeResponse = {
+      const response = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
           messageId: this.generateId(),
@@ -660,11 +661,13 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         abortController: new AbortController(),
       } as ActiveResponse<UI_MESSAGE>;
 
-      activeResponse.abortController.signal.addEventListener('abort', () => {
+      activeResponse = response;
+
+      response.abortController.signal.addEventListener('abort', () => {
         isAbort = true;
       });
 
-      this.activeResponse = activeResponse;
+      this.activeResponse = response;
 
       let stream: ReadableStream<UIMessageChunk>;
 
@@ -674,7 +677,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         stream = await this.transport.sendMessages({
           chatId: this.id,
           messages: this.state.messages,
-          abortSignal: activeResponse.abortController.signal,
+          abortSignal: response.abortController.signal,
           metadata,
           headers,
           body,
@@ -692,21 +695,21 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         // serialize the job execution to avoid race conditions:
         this.jobExecutor.run(() =>
           job({
-            state: activeResponse.state,
+            state: response.state,
             write: () => {
               // streaming is set on first write (before it should be "submitted")
               this.setStatus({ status: 'streaming' });
 
               const replaceLastMessage =
-                activeResponse.state.message.id === this.lastMessage?.id;
+                response.state.message.id === this.lastMessage?.id;
 
               if (replaceLastMessage) {
                 this.state.replaceMessage(
                   this.state.messages.length - 1,
-                  activeResponse.state.message,
+                  response.state.message,
                 );
               } else {
-                this.state.pushMessage(activeResponse.state.message);
+                this.state.pushMessage(response.state.message);
               }
             },
           }),
@@ -756,19 +759,23 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.setStatus({ status: 'error', error: err as Error });
     } finally {
       try {
-        this.onFinish?.({
-          message: this.activeResponse!.state.message,
-          messages: this.state.messages,
-          isAbort,
-          isDisconnect,
-          isError,
-          finishReason: this.activeResponse?.state.finishReason,
-        });
+        if (activeResponse) {
+          this.onFinish?.({
+            message: activeResponse.state.message,
+            messages: this.state.messages,
+            isAbort,
+            isDisconnect,
+            isError,
+            finishReason: activeResponse.state.finishReason,
+          });
+        }
       } catch (err) {
         console.error(err);
       }
 
-      this.activeResponse = undefined;
+      if (this.activeResponse === activeResponse) {
+        this.activeResponse = undefined;
+      }
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true


### PR DESCRIPTION
## Background

Overlapping chat requests could clear the shared active response before a resume-stream request reached its finally block, causing onFinish handling to log a TypeError in development.

## Summary

Chat.makeRequest now keeps a request-local active response for finish handling and only clears the shared activeResponse when it still belongs to the finishing request.

## Testing

Kept the focused regression test covering an overlapped resumeStream and sendMessage request where activeResponse is cleared before the resume stream finishes.

## Related Issues

Fixes #15668

Co-authored-by: alexanderjacobsen <22945509+alexanderjacobsen@users.noreply.github.com>