### PR TITLE
fix: honor Anthropic disableParallelToolUse override in jsonTool structured output mode

### DIFF
--- a/.changeset/calm-tools-sort.md
+++ b/.changeset/calm-tools-sort.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Sort tool results by their tool call order when converting generation output to response messages.

--- a/.changeset/fuzzy-steaks-matter.md
+++ b/.changeset/fuzzy-steaks-matter.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `extractJsonMiddleware` preserving leading whitespace in the final streamed text suffix when no markdown fence prefix was stripped.

--- a/.changeset/khaki-dingos-trade.md
+++ b/.changeset/khaki-dingos-trade.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+Respect `disableParallelToolUse: false` when using Anthropic `jsonTool` structured output mode.

--- a/.changeset/quick-swans-pull.md
+++ b/.changeset/quick-swans-pull.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/anthropic": patch
+"@ai-sdk/gateway": patch
+"@ai-sdk/google": patch
+"@ai-sdk/provider-utils": patch
+---
+
+Prevent prototype pollution when synchronously parsing provider JSON inputs and expose `secureJsonParse` from provider-utils.

--- a/.changeset/quiet-starfishes-provide.md
+++ b/.changeset/quiet-starfishes-provide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Normalize a bare `https://api.anthropic.com` base URL to include `/v1`.

--- a/.changeset/twenty-windows-count.md
+++ b/.changeset/twenty-windows-count.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Fix Google embedding batch size to respect the Gemini API limit of 100 requests per batch.

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -290,6 +290,65 @@ describe('toResponseMessages', () => {
     `);
   });
 
+  it('should serialize parallel tool results in tool call order', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'text',
+          text: 'Using tools',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          input: {},
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          input: {},
+        },
+        // Simulates parallel execution where toolB resolved before toolA.
+        {
+          type: 'tool-result',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          output: 'B result',
+          input: {},
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          output: 'A result',
+          input: {},
+        },
+      ],
+      tools: {
+        toolA: tool({
+          description: 'Tool A',
+          inputSchema: z.object({}),
+        }),
+        toolB: tool({
+          description: 'Tool B',
+          inputSchema: z.object({}),
+        }),
+      },
+    });
+
+    const toolMessage = result[1];
+    expect(toolMessage?.role).toBe('tool');
+    if (toolMessage?.role !== 'tool') {
+      throw new Error('Expected a tool message');
+    }
+    expect(
+      toolMessage.content
+        .filter(part => part.type === 'tool-result')
+        .map(part => part.toolCallId),
+    ).toEqual(['call-a', 'call-b']);
+  });
+
   it('should handle undefined text', async () => {
     const result = await toResponseMessages({
       content: [

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -19,6 +19,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
   tools: TOOLS | undefined;
 }): Promise<Array<AssistantModelMessage | ToolModelMessage>> {
   const responseMessages: Array<AssistantModelMessage | ToolModelMessage> = [];
+  const toolCallOrder = new Map<string, number>();
 
   const content: AssistantContent = [];
   for (const part of inputContent) {
@@ -79,6 +80,9 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         });
         break;
       case 'tool-call':
+        if (!toolCallOrder.has(part.toolCallId)) {
+          toolCallOrder.set(part.toolCallId, toolCallOrder.size);
+        }
         content.push({
           type: 'tool-call',
           toolCallId: part.toolCallId,
@@ -204,9 +208,49 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
   if (toolResultContent.length > 0) {
     responseMessages.push({
       role: 'tool',
-      content: toolResultContent,
+      content: sortToolResultContentByToolCallOrder({
+        toolResultContent,
+        toolCallOrder,
+      }),
     });
   }
 
   return responseMessages;
+}
+
+function sortToolResultContentByToolCallOrder({
+  toolResultContent,
+  toolCallOrder,
+}: {
+  toolResultContent: ToolContent;
+  toolCallOrder: Map<string, number>;
+}): ToolContent {
+  const sortedToolResults = toolResultContent
+    .filter(part => part.type === 'tool-result')
+    .map((part, index) => ({ part, index }))
+    .sort((a, b) => {
+      const aOrder = toolCallOrder.get(a.part.toolCallId);
+      const bOrder = toolCallOrder.get(b.part.toolCallId);
+
+      if (aOrder == null && bOrder == null) {
+        return a.index - b.index;
+      }
+
+      if (aOrder == null) {
+        return 1;
+      }
+
+      if (bOrder == null) {
+        return -1;
+      }
+
+      return aOrder - bOrder || a.index - b.index;
+    })
+    .map(({ part }) => part);
+
+  let toolResultIndex = 0;
+
+  return toolResultContent.map(part =>
+    part.type === 'tool-result' ? sortedToolResults[toolResultIndex++] : part,
+  );
 }

--- a/packages/ai/src/middleware/extract-json-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.test.ts
@@ -1,4 +1,7 @@
-import type { LanguageModelV4Usage } from '@ai-sdk/provider';
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,
@@ -345,6 +348,39 @@ describe('extractJsonMiddleware', () => {
       });
 
       expect(await result.text).toBe('{"value": "test"}');
+    });
+
+    it('should preserve leading space in final streamed suffix without fences', async () => {
+      const middleware = extractJsonMiddleware();
+
+      const wrapped = await middleware.wrapStream!({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 't' },
+            { type: 'text-delta', id: 't', delta: 'there' },
+            { type: 'text-delta', id: 't', delta: ' altogether?' },
+            { type: 'text-end', id: 't' },
+          ]),
+        }),
+      } as any);
+
+      const reader = wrapped.stream.getReader();
+      const chunks: LanguageModelV4StreamPart[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        chunks.push(value);
+      }
+
+      const text = chunks
+        .filter(chunk => chunk.type === 'text-delta')
+        .map(chunk => chunk.delta)
+        .join('');
+
+      expect(text).toBe('there altogether?');
     });
 
     it('should handle fence split across multiple deltas', async () => {

--- a/packages/ai/src/middleware/extract-json-middleware.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.ts
@@ -15,6 +15,10 @@ function defaultTransform(text: string): string {
     .trim();
 }
 
+function stripMarkdownCodeFenceSuffix(text: string): string {
+  return text.replace(/\n?```\s*$/, '').trimEnd();
+}
+
 /**
  * Middleware that extracts JSON from text content by stripping
  * markdown code fences and other formatting.
@@ -169,10 +173,15 @@ export function extractJsonMiddleware(options?: {
                     remaining = transform(remaining);
                   } else if (block.prefixStripped) {
                     // strip suffix since prefix already handled
-                    remaining = remaining.replace(/\n?```\s*$/, '').trimEnd();
-                  } else {
-                    // Apply full transform (handles both prefix and suffix)
+                    remaining = stripMarkdownCodeFenceSuffix(remaining);
+                  } else if (block.phase === 'prefix') {
+                    // No text has streamed yet, so the full transform is safe.
                     remaining = transform(remaining);
+                  } else {
+                    // Only strip the suffix. Since earlier text may already have
+                    // streamed, trimming the remaining suffix would remove valid
+                    // leading whitespace at the stream boundary.
+                    remaining = stripMarkdownCodeFenceSuffix(remaining);
                   }
 
                   if (remaining.length > 0) {

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -757,6 +757,55 @@ describe('AnthropicLanguageModel', () => {
           }
         `);
       });
+
+      it('should respect disableParallelToolUse false with jsonTool structured output and real tools', async () => {
+        prepareJsonFixtureResponse('anthropic-json-tool.1');
+
+        await provider('claude-sonnet-4-5').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'searchDocs',
+              description: 'Search docs',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+          ],
+          providerOptions: {
+            anthropic: {
+              structuredOutputMode: 'jsonTool',
+              disableParallelToolUse: false,
+            } satisfies AnthropicLanguageModelOptions,
+          },
+          responseFormat: {
+            type: 'json',
+            schema: {
+              type: 'object',
+              properties: {
+                items: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['items'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          tool_choice: {
+            type: 'any',
+            disable_parallel_tool_use: false,
+          },
+        });
+      });
     });
 
     describe('json schema response format with other tool response (unsupported model)', () => {

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -799,10 +799,62 @@ describe('AnthropicLanguageModel', () => {
           },
         });
 
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
+        expect(
+          await server.calls[server.calls.length - 1].requestBodyJson,
+        ).toMatchObject({
           tool_choice: {
             type: 'any',
             disable_parallel_tool_use: false,
+          },
+        });
+      });
+
+      it('should default disableParallelToolUse to true with jsonTool structured output and real tools', async () => {
+        prepareJsonFixtureResponse('anthropic-json-tool.1');
+
+        await provider('claude-sonnet-4-5').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'searchDocs',
+              description: 'Search docs',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+          ],
+          providerOptions: {
+            anthropic: {
+              structuredOutputMode: 'jsonTool',
+            } satisfies AnthropicLanguageModelOptions,
+          },
+          responseFormat: {
+            type: 'json',
+            schema: {
+              type: 'object',
+              properties: {
+                items: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['items'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        });
+
+        expect(
+          await server.calls[server.calls.length - 1].requestBodyJson,
+        ).toMatchObject({
+          tool_choice: {
+            type: 'any',
+            disable_parallel_tool_use: true,
           },
         });
       });

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -28,6 +28,7 @@ import {
   postJsonToApi,
   resolve,
   resolveProviderReference,
+  secureJsonParse,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -738,7 +739,8 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
         ? {
             tools: [...(tools ?? []), jsonResponseTool],
             toolChoice: { type: 'required' },
-            disableParallelToolUse: true,
+            disableParallelToolUse:
+              anthropicOptions?.disableParallelToolUse ?? true,
             cacheControlValidator,
             supportsStructuredOutput: false,
             supportsStrictTools,
@@ -2126,7 +2128,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                         contentBlock.input === '' ? '{}' : contentBlock.input;
                       if (contentBlock.providerToolName === 'code_execution') {
                         try {
-                          const parsed = JSON.parse(finalInput);
+                          const parsed = secureJsonParse(finalInput);
                           if (
                             parsed != null &&
                             typeof parsed === 'object' &&

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -83,6 +83,41 @@ describe('createAnthropic', () => {
       expect(requestUrl).toBe('https://proxy.anthropic.example/v1/messages');
     });
 
+    it('normalizes a bare Anthropic API URL from ANTHROPIC_BASE_URL', async () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com/';
+
+      const fetchMock = createFetchMock();
+      const provider = createAnthropic({
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-3-haiku-20240307').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://api.anthropic.com/v1/messages');
+    });
+
+    it('normalizes a bare Anthropic API URL from the baseURL option', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropic({
+        apiKey: 'test-api-key',
+        baseURL: 'https://api.anthropic.com/',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-3-haiku-20240307').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://api.anthropic.com/v1/messages');
+    });
+
     it('prefers the baseURL option over ANTHROPIC_BASE_URL', async () => {
       process.env.ANTHROPIC_BASE_URL = 'https://env.anthropic.example/v1';
 

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -21,6 +21,17 @@ import { anthropicTools } from './anthropic-tools';
 import { AnthropicSkills } from './skills/anthropic-skills';
 import { VERSION } from './version';
 
+const ANTHROPIC_API_URL = 'https://api.anthropic.com';
+const ANTHROPIC_API_VERSIONED_URL = `${ANTHROPIC_API_URL}/v1`;
+
+function normalizeBaseURL(baseURL: string | undefined): string | undefined {
+  const baseURLWithoutTrailingSlash = withoutTrailingSlash(baseURL);
+
+  return baseURLWithoutTrailingSlash === ANTHROPIC_API_URL
+    ? ANTHROPIC_API_VERSIONED_URL
+    : baseURLWithoutTrailingSlash;
+}
+
 export interface AnthropicProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
@@ -102,12 +113,12 @@ export function createAnthropic(
   options: AnthropicProviderSettings = {},
 ): AnthropicProvider {
   const baseURL =
-    withoutTrailingSlash(
+    normalizeBaseURL(
       loadOptionalSetting({
         settingValue: options.baseURL,
         environmentVariableName: 'ANTHROPIC_BASE_URL',
       }),
-    ) ?? 'https://api.anthropic.com/v1';
+    ) ?? ANTHROPIC_API_VERSIONED_URL;
 
   const providerName = options.name ?? 'anthropic.messages';
 

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -9,11 +9,12 @@ import {
   convertBase64ToUint8Array,
   convertToBase64,
   getTopLevelMediaType,
+  isNonNullable,
   parseProviderOptions,
   resolveFullMediaType,
   resolveProviderReference,
+  secureJsonParse,
   validateTypes,
-  isNonNullable,
   type ToolNameMapping,
 } from '@ai-sdk/provider-utils';
 import {
@@ -48,7 +49,7 @@ function convertBytesDataToString(data: Uint8Array | string): string {
 function extractErrorValue(value: unknown): { errorCode?: string } {
   try {
     if (typeof value === 'string') {
-      return JSON.parse(value);
+      return secureJsonParse(value);
     } else if (typeof value === 'object' && value !== null) {
       return value as { errorCode?: string };
     }
@@ -844,7 +845,7 @@ export async function convertToAnthropicPrompt({
                     let errorInfo: { type?: string; errorCode?: string } = {};
                     try {
                       if (typeof output.value === 'string') {
-                        errorInfo = JSON.parse(output.value);
+                        errorInfo = secureJsonParse(output.value);
                       } else if (
                         typeof output.value === 'object' &&
                         output.value !== null

--- a/packages/gateway/src/errors/extract-api-call-response.ts
+++ b/packages/gateway/src/errors/extract-api-call-response.ts
@@ -1,4 +1,5 @@
 import type { APICallError } from '@ai-sdk/provider';
+import { secureJsonParse } from '@ai-sdk/provider-utils';
 
 export function extractApiCallResponse(error: APICallError): unknown {
   if (error.data !== undefined) {
@@ -6,7 +7,7 @@ export function extractApiCallResponse(error: APICallError): unknown {
   }
   if (error.responseBody != null) {
     try {
-      return JSON.parse(error.responseBody);
+      return secureJsonParse(error.responseBody);
     } catch {
       return error.responseBody;
     }

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -10,6 +10,7 @@ import {
   isFullMediaType,
   resolveFullMediaType,
   resolveProviderReference,
+  secureJsonParse,
 } from '@ai-sdk/provider-utils';
 import type {
   GoogleContent,
@@ -468,7 +469,7 @@ export function convertToGoogleMessages(
                         toolType: serverToolType,
                         args:
                           typeof part.input === 'string'
-                            ? JSON.parse(part.input)
+                            ? secureJsonParse(part.input)
                             : part.input,
                         id: serverToolCallId,
                       },

--- a/packages/google/src/google-embedding-model.test.ts
+++ b/packages/google/src/google-embedding-model.test.ts
@@ -263,11 +263,15 @@ describe('GoogleEmbeddingModel', () => {
       headers: () => ({}),
     });
 
-    const tooManyValues = Array(2049).fill('test');
+    const tooManyValues = Array(101).fill('test');
 
     await expect(model.doEmbed({ values: tooManyValues })).rejects.toThrow(
-      'Too many values for a single embedding call. The google.generative-ai model "gemini-embedding-001" can only embed up to 2048 values per call, but 2049 values were provided.',
+      'Too many values for a single embedding call. The google.generative-ai model "gemini-embedding-001" can only embed up to 100 values per call, but 101 values were provided.',
     );
+  });
+
+  it('should expose the Google batch embedding API limit', () => {
+    expect(model.maxEmbeddingsPerCall).toBe(100);
   });
 
   it('should use the batch embeddings endpoint', async () => {

--- a/packages/google/src/google-embedding-model.ts
+++ b/packages/google/src/google-embedding-model.ts
@@ -31,7 +31,7 @@ type GoogleEmbeddingConfig = {
 export class GoogleEmbeddingModel implements EmbeddingModelV4 {
   readonly specificationVersion = 'v4';
   readonly modelId: GoogleEmbeddingModelId;
-  readonly maxEmbeddingsPerCall = 2048;
+  readonly maxEmbeddingsPerCall = 100;
   readonly supportsParallelCalls = true;
 
   private readonly config: GoogleEmbeddingConfig;

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -858,6 +858,37 @@ describe('convertToGoogleInteractionsInput', () => {
       expect(fnCall?.arguments).toEqual({ location: 'Boston' });
     });
 
+    it('rejects prototype-polluting stringified tool-call input', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hi' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_abc',
+              toolName: 'getWeather',
+              input: '{"__proto__":{"polluted":true}}',
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+      const steps = result.input as Array<{
+        type: string;
+        arguments?: Record<string, unknown>;
+      }>;
+      const fnCall = steps.find(step => step.type === 'function_call');
+
+      expect(fnCall?.arguments).toEqual({
+        value: '{"__proto__":{"polluted":true}}',
+      });
+    });
+
     it('round-trips a function_call signature via providerMetadata.google.signature', () => {
       const prompt: LanguageModelV4Prompt = [
         {

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -10,6 +10,7 @@ import {
   isFullMediaType,
   resolveFullMediaType,
   resolveProviderReference,
+  secureJsonParse,
 } from '@ai-sdk/provider-utils';
 import type {
   GoogleInteractionsContent,
@@ -376,7 +377,7 @@ function compactPromptForPreviousInteraction({
 
 function safeParseToolArgs(input: string): Record<string, unknown> {
   try {
-    const parsed = JSON.parse(input);
+    const parsed = secureJsonParse(input);
     if (
       parsed != null &&
       typeof parsed === 'object' &&

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -84,6 +84,7 @@ export {
   type ValidationResult,
 } from './schema';
 export { serializeModelOptions } from './serialize-model-options';
+export { secureJsonParse } from './secure-json-parse';
 export {
   StreamingToolCallTracker,
   type StreamingToolCallDelta,


### PR DESCRIPTION
## Background

Anthropic jsonTool structured output mode always serialized disable_parallel_tool_use as true, so users could not opt back into parallel real-tool calls with disableParallelToolUse: false.

## Summary

The Anthropic jsonTool path now passes anthropicOptions.disableParallelToolUse when explicitly provided and still defaults to true when omitted.

## Testing

Added regression coverage for jsonTool structured output with a real tool, asserting disable_parallel_tool_use is false when explicitly requested and remains true by default.

## Related Issues

Fixes #15652

Co-authored-by: tim-inkeep <132074086+tim-inkeep@users.noreply.github.com>