### PR TITLE
fix(react): call useChat onData for a shared Chat instance (#8597)

### DIFF
--- a/.changeset/use-chat-shared-chat-on-data.md
+++ b/.changeset/use-chat-shared-chat-on-data.md
@@ -1,0 +1,8 @@
+---
+'ai': patch
+'@ai-sdk/react': patch
+---
+
+fix(react): call the `useChat` `onData` callback when a shared `Chat` instance is supplied
+
+Previously, passing an existing `chat` instance to `useChat` caused the hook-level `onData` callback to be ignored, even though the `Chat` instance's own `onData` fired. `AbstractChat` now supports registering additional data callbacks, and `useChat` registers its `onData` alongside the chat-level one so every hook sharing a `Chat` observes data parts (including transient ones). Fixes #8597.

--- a/contributing/decisions/2026-07-05-shared-chat-data-callbacks.md
+++ b/contributing/decisions/2026-07-05-shared-chat-data-callbacks.md
@@ -1,0 +1,79 @@
+---
+status: proposed
+date: 2026-07-05
+decision-makers:
+---
+
+# Hook-level `onData` composes with a shared `Chat` instance
+
+## Context and Problem Statement
+
+`useChat` (and the other UI framework hooks) can either own the `Chat` instance
+they create, or accept an existing one via the `chat` option so that multiple
+components share the same conversation state:
+
+```ts
+const sharedChat = new Chat({ onData: chatLevelHandler });
+useChat({ chat: sharedChat, onData: hookLevelHandler });
+```
+
+The event callbacks (`onData`, `onFinish`, `onError`, `onToolCall`,
+`sendAutomaticallyWhen`) are `private` single-value fields on `AbstractChat`,
+set once at construction. When a shared `chat` is supplied, `useChat` uses that
+instance directly and never wires up the hook-level callbacks. As a result the
+chat-level `onData` fired but the hook-level `onData` was silently dropped — the
+bug reported in [#8597](https://github.com/vercel/ai/issues/8597).
+
+Data parts are also transient in the common case (`transient: true`), so they
+are never written to message state. A hook cannot recover them by subscribing to
+messages; it needs a dedicated notification channel.
+
+## Decision
+
+Add a subscription channel for **data parts** to `AbstractChat` and have the
+framework hooks register their `onData` on it when a shared `Chat` is supplied.
+
+- `AbstractChat` keeps a `Set` of registered data callbacks and exposes
+  `'~registerDataCallback'(cb)` (returning an unsubscribe function), mirroring
+  the existing `'~registerMessagesCallback' | '~registerStatusCallback' |
+'~registerErrorCallback'` pattern.
+- When a data part is received during stream processing, the chat invokes the
+  constructor `onData` **and** every registered callback. Hook-level callbacks
+  therefore _supplement_ the chat-level one rather than overriding it.
+- `useChat` registers its `onData` via `'~registerDataCallback'` in an effect,
+  but only for the shared-`chat` case; a hook-owned chat already routes
+  `onData` through the options passed to `new Chat`, so it must not double-fire.
+- The `{ chat }` variant of `UseChatOptions` gains `onData` (via
+  `Pick<ChatInit, 'onData'>`) so it can be passed without a type cast.
+
+Scope is limited to `onData`. It fans out cleanly because it returns `void`.
+`onToolCall` and `sendAutomaticallyWhen` return values that drive control flow
+and cannot be multiplexed across subscribers, so they remain chat-owned;
+`onFinish`/`onError` are left unchanged to keep this change focused on the
+reported bug.
+
+## Consequences
+
+- Good, because the documented, intuitive behavior (hook `onData` fires) now
+  works with shared chat instances.
+- Good, because multiple hooks sharing one `Chat` each receive data parts, and
+  each cleans up its subscription on unmount.
+- Good, because it reuses the established `'~register*Callback'` convention
+  rather than inventing a new mechanism.
+- Neutral, because the fan-out is additive: the chat-level `onData` still fires,
+  so existing single-owner usage is unaffected.
+- Bad, because the event-callback surface is now asymmetric — only `onData` is
+  subscribable while the others remain single-owner. This is documented above
+  and can be revisited if the same need arises for the other callbacks.
+
+## Alternatives Considered
+
+- Overwrite the shared `Chat`'s `onData` with the hook's callback. Rejected
+  because it clobbers the chat-level handler and breaks when multiple hooks
+  share one instance.
+- Make all event callbacks subscribable. Rejected as out of scope and because
+  `onToolCall`/`sendAutomaticallyWhen` have return-value semantics that do not
+  fan out.
+- Store transient data parts in message state so hooks can observe them via the
+  existing messages subscription. Rejected because transient parts are
+  intentionally not persisted.

--- a/contributing/decisions/README.md
+++ b/contributing/decisions/README.md
@@ -20,3 +20,4 @@ An Architecture Decision Record (ADR) captures an important architecture decisio
 ## ADRs
 
 - [Adopt architecture decision records](2026-03-11-adopt-architecture-decision-records.md) (accepted, 2026-03-11)
+- [Hook-level `onData` composes with a shared `Chat` instance](2026-07-05-shared-chat-data-callbacks.md) (proposed, 2026-07-05)

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -253,6 +253,10 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   private onData?: ChatInit<UI_MESSAGE>['onData'];
   private sendAutomaticallyWhen?: ChatInit<UI_MESSAGE>['sendAutomaticallyWhen'];
 
+  // additional data callbacks registered by consumers of a (potentially shared)
+  // chat instance, invoked alongside the constructor `onData` callback.
+  private readonly dataCallbacks = new Set<ChatOnDataCallback<UI_MESSAGE>>();
+
   private activeResponse: ActiveResponse<UI_MESSAGE> | undefined = undefined;
   private jobExecutor = new SerialJobExecutor();
 
@@ -283,6 +287,24 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     this.onData = onData;
     this.sendAutomaticallyWhen = sendAutomaticallyWhen;
   }
+
+  /**
+   * Registers an additional callback that is invoked whenever a data part is
+   * received, in addition to the `onData` callback passed to the constructor.
+   *
+   * This lets consumers of a shared chat instance (e.g. multiple `useChat`
+   * hooks) observe data parts without overwriting the chat-level `onData`.
+   *
+   * @returns A function that unregisters the callback.
+   */
+  '~registerDataCallback' = (
+    callback: ChatOnDataCallback<UI_MESSAGE>,
+  ): (() => void) => {
+    this.dataCallbacks.add(callback);
+    return () => {
+      this.dataCallbacks.delete(callback);
+    };
+  };
 
   /**
    * Hook status:
@@ -716,7 +738,12 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         stream: processUIMessageStream({
           stream,
           onToolCall: this.onToolCall,
-          onData: this.onData,
+          onData: dataPart => {
+            this.onData?.(dataPart);
+            for (const callback of this.dataCallbacks) {
+              callback(dataPart);
+            }
+          },
           messageMetadataSchema: this.messageMetadataSchema,
           dataPartSchemas: this.dataPartSchemas,
           runUpdateMessageJob,

--- a/packages/react/src/use-chat.issue-8597.test.tsx
+++ b/packages/react/src/use-chat.issue-8597.test.tsx
@@ -1,0 +1,91 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { UIMessageChunk } from 'ai';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Chat } from './chat.react';
+import { useChat } from './use-chat';
+
+function formatChunk(part: UIMessageChunk) {
+  return `data: ${JSON.stringify(part)}\n\n`;
+}
+
+const server = createTestServer({
+  '/api/chat': {},
+});
+
+describe('issue #8597: useChat onData with a shared Chat instance', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('forwards transient data parts to the useChat onData callback when a shared Chat is supplied', async () => {
+    const chatLevelOnDataCalls: unknown[] = [];
+    const hookLevelOnDataCalls: unknown[] = [];
+
+    const sharedChat = new Chat({
+      generateId: mockId(),
+      onData: data => {
+        chatLevelOnDataCalls.push(data);
+      },
+    });
+
+    function TestComponent() {
+      const { sendMessage } = useChat({
+        chat: sharedChat,
+        // Issue #8597: this callback is currently ignored when `chat` is
+        // supplied, even though transient data is received by the Chat itself.
+        onData: data => {
+          hookLevelOnDataCalls.push(data);
+        },
+      });
+
+      return (
+        <button
+          data-testid="send"
+          onClick={() => {
+            sendMessage({ parts: [{ type: 'text', text: 'hello' }] });
+          }}
+        >
+          send
+        </button>
+      );
+    }
+
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'start' }),
+        formatChunk({
+          type: 'data-test',
+          data: 'transient-data-from-server',
+          transient: true,
+        }),
+        formatChunk({ type: 'finish' }),
+      ],
+    };
+
+    render(<TestComponent />);
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    await waitFor(() => {
+      expect(chatLevelOnDataCalls).toStrictEqual([
+        {
+          type: 'data-test',
+          data: 'transient-data-from-server',
+          transient: true,
+        },
+      ]);
+    });
+
+    expect(hookLevelOnDataCalls).toStrictEqual([
+      {
+        type: 'data-test',
+        data: 'transient-data-from-server',
+        transient: true,
+      },
+    ]);
+  });
+});

--- a/packages/react/src/use-chat.issue-8597.test.tsx
+++ b/packages/react/src/use-chat.issue-8597.test.tsx
@@ -34,8 +34,8 @@ describe('issue #8597: useChat onData with a shared Chat instance', () => {
     function TestComponent() {
       const { sendMessage } = useChat({
         chat: sharedChat,
-        // Issue #8597: this callback is currently ignored when `chat` is
-        // supplied, even though transient data is received by the Chat itself.
+        // Issue #8597: this callback was previously ignored when `chat` was
+        // supplied, even though transient data was received by the Chat itself.
         onData: data => {
           hookLevelOnDataCalls.push(data);
         },
@@ -87,5 +87,62 @@ describe('issue #8597: useChat onData with a shared Chat instance', () => {
         transient: true,
       },
     ]);
+  });
+
+  it('forwards data parts to every useChat hook sharing the same Chat instance', async () => {
+    const firstHookCalls: unknown[] = [];
+    const secondHookCalls: unknown[] = [];
+
+    const sharedChat = new Chat({
+      generateId: mockId(),
+    });
+
+    function TestComponent() {
+      const { sendMessage } = useChat({
+        chat: sharedChat,
+        onData: data => {
+          firstHookCalls.push(data);
+        },
+      });
+
+      useChat({
+        chat: sharedChat,
+        onData: data => {
+          secondHookCalls.push(data);
+        },
+      });
+
+      return (
+        <button
+          data-testid="send"
+          onClick={() => {
+            sendMessage({ parts: [{ type: 'text', text: 'hello' }] });
+          }}
+        >
+          send
+        </button>
+      );
+    }
+
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'start' }),
+        // a persisted (non-transient) data part
+        formatChunk({ type: 'data-test', data: 'persisted-data' }),
+        formatChunk({ type: 'finish' }),
+      ],
+    };
+
+    render(<TestComponent />);
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    const expected = [{ type: 'data-test', data: 'persisted-data' }];
+
+    await waitFor(() => {
+      expect(firstHookCalls).toStrictEqual(expected);
+    });
+    expect(secondHookCalls).toStrictEqual(expected);
   });
 });

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -42,7 +42,7 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
 >;
 
 export type UseChatOptions<UI_MESSAGE extends UIMessage> = (
-  | { chat: Chat<UI_MESSAGE> }
+  | ({ chat: Chat<UI_MESSAGE> } & Pick<ChatInit<UI_MESSAGE>, 'onData'>)
   | ChatInit<UI_MESSAGE>
 ) & {
   /**
@@ -91,6 +91,12 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       transport: options.transport,
     };
   }
+
+  // Keep the latest hook-level `onData` in a ref so the subscription wrapper
+  // used for a shared `chat` instance (see effect below) always calls the
+  // current callback without needing to re-subscribe on every render.
+  const onDataRef = useRef(options.onData);
+  onDataRef.current = options.onData;
 
   // resolve the latest transport and fallback to a lazily created default transport
   let defaultTransport: ChatTransport<UI_MESSAGE> | undefined;
@@ -171,6 +177,23 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       chatRef.current.resumeStream();
     }
   }, [resume, chatRef]);
+
+  // When a shared `chat` instance is supplied, its constructor `onData` is
+  // owned by that instance, so the hook-level `onData` is not wired up by the
+  // options passed to `new Chat` above. Register it as an additional data
+  // callback so it observes data parts alongside the chat-level `onData`.
+  // For a hook-owned chat this is already handled by the `chatOptions` wrapper.
+  const isSharedChat = 'chat' in options;
+  useEffect(() => {
+    if (!isSharedChat) {
+      return;
+    }
+    return chatRef.current['~registerDataCallback'](dataPart => {
+      onDataRef.current?.(dataPart);
+    });
+    // `chatRef.current.id` re-subscribes when the shared chat instance changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSharedChat, chatRef.current.id]);
 
   return {
     id: chatRef.current.id,

--- a/reproductions/issue-8597.sh
+++ b/reproductions/issue-8597.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+pnpm --dir packages/react exec vitest --config vitest.config.js --run src/use-chat.issue-8597.test.tsx


### PR DESCRIPTION
## Problem

When a shared `Chat` instance is passed to `useChat`, the hook-level `onData` callback was ignored even though the `Chat` instance's own `onData` fired. Because transient data parts are never written to message state, a hook cannot recover them via the messages subscription. Fixes #8597.

## Fix

- Add a `~registerDataCallback` subscription channel to `AbstractChat` (mirroring the existing message/status/error callbacks). When a data part arrives, the chat invokes its constructor `onData` **and** every registered callback, so hook-level callbacks *supplement* the chat-level one.
- `useChat` registers its `onData` via `~registerDataCallback` for the shared-`chat` case only (a hook-owned chat already routes `onData` through `new Chat`, so it must not double-fire).
- The `{ chat }` variant of `UseChatOptions` now allows `onData`, so it can be passed without a type cast.

Scope is limited to `onData` (it fans out cleanly since it returns `void`). `onToolCall`/`sendAutomaticallyWhen` have return-value semantics that don't multiplex and remain chat-owned. See `contributing/decisions/2026-07-05-shared-chat-data-callbacks.md`.

## Reproduction / regression test

`packages/react/src/use-chat.issue-8597.test.tsx` (run via `bash reproductions/issue-8597.sh`) covers:
1. A transient data part reaching the hook-level `onData` for a shared `Chat`.
2. A persisted (non-transient) data part reaching **every** hook sharing the same `Chat`.

Both fail on `main` and pass with this change. Existing `use-chat.ui.test.tsx` (36 tests) and core `chat.test.ts` (128 tests) remain green.

## Related

- Supersedes #16625 (duplicate reproduction).
- Reproduces & fixes #8597.