### PR TITLE
reproduction: Reproduces #8597

### DIFF
--- a/packages/react/src/use-chat.issue-8597.test.tsx
+++ b/packages/react/src/use-chat.issue-8597.test.tsx
@@ -1,0 +1,97 @@
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChatTransport, UIMessage, UIMessageChunk } from 'ai';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { Chat } from './chat.react';
+import { useChat } from './use-chat';
+
+function streamFromChunks(chunks: UIMessageChunk[]) {
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('issue #8597', () => {
+  it('calls useChat onData when a shared Chat receives a transient data part', async () => {
+    const chatOnDataCalls: unknown[] = [];
+    const useChatOnDataCalls: unknown[] = [];
+
+    const transport: ChatTransport<UIMessage> = {
+      sendMessages: async () =>
+        streamFromChunks([
+          { type: 'start', messageId: 'assistant-0' },
+          { type: 'start-step' },
+          {
+            type: 'data-test',
+            data: 'transient payload',
+            transient: true,
+          },
+          { type: 'finish-step' },
+          { type: 'finish' },
+        ]),
+      reconnectToStream: async () => null,
+    };
+
+    const sharedChat = new Chat({
+      id: 'shared-chat',
+      generateId: mockId(),
+      transport,
+      onData: data => {
+        chatOnDataCalls.push(data);
+      },
+    });
+
+    function TestComponent() {
+      const { sendMessage, status } = useChat({
+        chat: sharedChat,
+        // Reproduction for issue #8597: this hook-level callback is expected to
+        // observe transient data parts even when a shared Chat instance is used.
+        onData: data => {
+          useChatOnDataCalls.push(data);
+        },
+      } as Parameters<typeof useChat>[0]);
+
+      return (
+        <>
+          <div data-testid="status">{status}</div>
+          <button
+            data-testid="send"
+            onClick={() => {
+              sendMessage({ text: 'hello' });
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<TestComponent />);
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('ready');
+      expect(chatOnDataCalls).toStrictEqual([
+        {
+          type: 'data-test',
+          data: 'transient payload',
+          transient: true,
+        },
+      ]);
+    });
+
+    expect(useChatOnDataCalls).toStrictEqual([
+      {
+        type: 'data-test',
+        data: 'transient payload',
+        transient: true,
+      },
+    ]);
+  });
+});

--- a/reproductions/issue-8597.sh
+++ b/reproductions/issue-8597.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+pnpm --dir packages/react exec vitest --config vitest.config.js --run src/use-chat.issue-8597.test.tsx


### PR DESCRIPTION
## Reproduction

Created failing reproduction artifacts packages/react/src/use-chat.issue-8597.test.tsx and reproductions/issue-8597.sh. Running `bash reproductions/issue-8597.sh` shows the shared Chat-level onData receives the transient data part, but the useChat-level onData remains [], reproducing issue #8597.

## Branch

bug-8597-3

## Related Issues

Reproduces #8597