### PR TITLE
reproduction: Reproduces #12709

### DIFF
--- a/packages/ai/reproductions/issue-12709-approval-requested-tool-call.ts
+++ b/packages/ai/reproductions/issue-12709-approval-requested-tool-call.ts
@@ -1,0 +1,86 @@
+import { convertToModelMessages } from '../src/ui/convert-to-model-messages';
+
+async function main() {
+  const uiMessages = [
+    {
+      role: 'user' as const,
+      parts: [{ type: 'text' as const, text: 'Book lunch.' }],
+    },
+    {
+      role: 'assistant' as const,
+      parts: [
+        {
+          type: 'text' as const,
+          text: 'I need approval before scheduling lunch.',
+          state: 'done' as const,
+        },
+        {
+          type: 'tool-scheduleLunch',
+          state: 'approval-requested' as const,
+          toolCallId: 'call_issue_12709',
+          input: { time: '12:00' },
+        },
+      ],
+    },
+    {
+      role: 'user' as const,
+      parts: [
+        {
+          type: 'text' as const,
+          text: 'Actually, make it 12:30 instead.',
+        },
+      ],
+    },
+  ];
+
+  const modelMessages = await convertToModelMessages(uiMessages, {
+    // This is what DirectChatTransport uses when converting UI messages for
+    // another model request. approval-requested is also incomplete and should
+    // be stripped here, just like input-streaming/input-available.
+    ignoreIncompleteToolCalls: true,
+  });
+
+  console.log(JSON.stringify(modelMessages, null, 2));
+
+  const leakedToolCall = modelMessages.some(
+    message =>
+      message.role === 'assistant' &&
+      Array.isArray(message.content) &&
+      message.content.some(
+        part =>
+          part.type === 'tool-call' &&
+          part.toolCallId === 'call_issue_12709',
+      ),
+  );
+
+  const matchingToolResult = modelMessages.some(
+    message =>
+      message.role === 'tool' &&
+      Array.isArray(message.content) &&
+      message.content.some(
+        part =>
+          part.type === 'tool-result' &&
+          part.toolCallId === 'call_issue_12709',
+      ),
+  );
+
+  if (leakedToolCall && !matchingToolResult) {
+    throw new Error(
+      [
+        'Reproduced issue #12709:',
+        'convertToModelMessages(..., { ignoreIncompleteToolCalls: true })',
+        'kept an approval-requested tool call without a matching tool result.',
+        'Submitting this history as the next request causes tool-result/function-call pairing errors.',
+      ].join(' '),
+    );
+  }
+
+  console.log(
+    'Could not reproduce: approval-requested tool call was filtered or paired with a result.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/repro-12709-live.ts
+++ b/repro-12709-live.ts
@@ -1,0 +1,49 @@
+import { convertToModelMessages } from './packages/ai/src/ui/convert-to-model-messages.ts';
+import { generateText, jsonSchema, tool } from './packages/ai/src/index.ts';
+import { openai } from './packages/openai/src/index.ts';
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required');
+  const uiMessages = [
+    { role: 'user' as const, parts: [{ type: 'text' as const, text: 'Book lunch.' }] },
+    { role: 'assistant' as const, parts: [
+      { type: 'text' as const, text: 'I need approval.', state: 'done' as const },
+      { type: 'tool-scheduleLunch', state: 'approval-requested' as const, toolCallId: 'call_123', input: { time: 'noon' } },
+    ]},
+    { role: 'user' as const, parts: [{ type: 'text' as const, text: 'Make it 12:30 instead.' }] },
+  ];
+  const messages = await convertToModelMessages(uiMessages, { ignoreIncompleteToolCalls: true });
+  console.log('Model messages sent to provider:');
+  console.log(JSON.stringify(messages, null, 2));
+  try {
+    const result = await generateText({
+      model: openai.chat('gpt-4o-mini'),
+      messages,
+      tools: {
+        scheduleLunch: tool({
+          description: 'Schedule lunch.',
+          inputSchema: jsonSchema({
+            type: 'object',
+            properties: { time: { type: 'string' } },
+            required: ['time'],
+            additionalProperties: false,
+          }),
+        }),
+      },
+    });
+    console.log('Unexpected success:', result.text);
+    process.exit(1);
+  } catch (error) {
+    const anyError = error as any;
+    console.error('Provider call failed as observed:');
+    console.error(anyError?.message ?? error);
+    if (anyError?.cause) console.error('cause:', anyError.cause?.message ?? anyError.cause);
+    const haystack = `${anyError?.message ?? ''}\n${anyError?.cause?.message ?? ''}`;
+    if (haystack.includes('No tool output found for function call') || haystack.includes('tool') || haystack.includes('function_call')) {
+      process.exit(0);
+    }
+    process.exit(2);
+  }
+}
+
+main().catch(error => { console.error(error); process.exit(1); });


### PR DESCRIPTION
## Reproduction

Created packages/ai/reproductions/issue-12709-approval-requested-tool-call.ts. Running `pnpm exec tsx packages/ai/reproductions/issue-12709-approval-requested-tool-call.ts` showed `convertToModelMessages(..., { ignoreIncompleteToolCalls: true })` keeps an `approval-requested` tool-call without a matching tool result and the script fails with the reproduction error.

## Branch

bug-12709-1

## Related Issues

Reproduces #12709