### PR TITLE
docs: expand Open Responses quickstart

### DIFF
--- a/content/providers/01-ai-sdk-providers/06-open-responses.mdx
+++ b/content/providers/01-ai-sdk-providers/06-open-responses.mdx
@@ -7,6 +7,12 @@ description: Learn how to use the Open Responses provider for the AI SDK.
 
 The [Open Responses](https://www.openresponses.org/) provider contains language model support for Open Responses compatible APIs.
 
+Use this provider when you want to call an Open Responses compatible endpoint
+through the AI SDK instead of sending raw HTTP requests yourself. It works with
+the AI SDK Core functions, including [`generateText`](/docs/reference/ai-sdk-core/generate-text),
+[`streamText`](/docs/reference/ai-sdk-core/stream-text), tools, and structured
+outputs.
+
 ## Setup
 
 The Open Responses provider is available in the `@ai-sdk/open-responses` module. You can install it with
@@ -76,7 +82,7 @@ You can use Open Responses models with the `generateText` and `streamText` funct
 and they support structured data generation with [`Output`](/docs/reference/ai-sdk-core/output)
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
-### Example
+### Generate Text
 
 ```ts
 import { createOpenResponses } from '@ai-sdk/open-responses';
@@ -92,6 +98,57 @@ const { text } = await generateText({
   prompt: 'Invent a new holiday and describe its traditions.',
 });
 ```
+
+### Stream Text
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { streamText } from 'ai';
+
+const openResponses = createOpenResponses({
+  name: 'aProvider',
+  url: 'http://localhost:1234/v1/responses',
+});
+
+const result = streamText({
+  model: openResponses('mistralai/ministral-3-14b-reasoning'),
+  prompt: 'Write a short haiku about reliable APIs.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+## Provider Options
+
+Provider options are keyed by the `name` that you pass to
+`createOpenResponses`. For example, when the provider name is `lmstudio`, pass
+Open Responses-specific options under `providerOptions.lmstudio`:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { generateText } from 'ai';
+
+const lmstudio = createOpenResponses({
+  name: 'lmstudio',
+  url: 'http://localhost:1234/v1/responses',
+});
+
+const { text } = await generateText({
+  model: lmstudio('zai-org/glm-4.7-flash'),
+  prompt: 'Explain why response formats matter.',
+  providerOptions: {
+    lmstudio: {
+      reasoningSummary: 'detailed',
+    },
+  },
+});
+```
+
+- **reasoningSummary** _'auto' | 'concise' | 'detailed' | null_
+
+  Controls reasoning summary output from models that support reasoning summaries.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Explain when to use @ai-sdk/open-responses instead of raw HTTP calls.
- Split the language model examples into generateText and streamText quickstarts.
- Document how providerOptions are keyed by the configured provider name and show reasoningSummary.

Fixes #15931.

## Verification

- ./node_modules/.bin/oxfmt --check content/providers/01-ai-sdk-providers/06-open-responses.mdx
- ./node_modules/.bin/oxlint content/providers/01-ai-sdk-providers/06-open-responses.mdx
