### PR TITLE
docs: clarify Deep Agents sandbox requirements

### DIFF
--- a/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
+++ b/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
@@ -162,6 +162,13 @@ const sandbox = createVercelSandbox({
 });
 ```
 
+The sandbox is required even when your agent primarily uses skills. The adapter
+starts a Deep Agents bridge inside the sandbox and communicates with it over the
+exposed port. Use [`activeTools`](/docs/ai-sdk-harnesses/tools#active-tools) or
+[`inactiveTools`](/docs/ai-sdk-harnesses/tools#inactive-tools) to restrict which
+built-in tools can run, and use `permissionMode` when you want built-in tool
+calls to require approval before execution.
+
 ## Skills
 
 Skills passed to the session are materialized as native Deep Agents skill folders

--- a/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
+++ b/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
@@ -164,8 +164,8 @@ const sandbox = createVercelSandbox({
 
 The sandbox is required even when your agent primarily uses skills. The adapter
 starts a Deep Agents bridge inside the sandbox and communicates with it over the
-exposed port. Use [`activeTools`](/docs/ai-sdk-harnesses/tools#active-tools) or
-[`inactiveTools`](/docs/ai-sdk-harnesses/tools#inactive-tools) to restrict which
+exposed port. Use [`activeTools`](/docs/ai-sdk-harnesses/tools#tool-filtering) or
+[`inactiveTools`](/docs/ai-sdk-harnesses/tools#tool-filtering) to restrict which
 built-in tools can run, and use `permissionMode` when you want built-in tool
 calls to require approval before execution.
 


### PR DESCRIPTION
## Summary

- Clarify that the Deep Agents harness requires a network sandbox even when the agent primarily uses skills.
- Explain that the adapter starts a bridge inside the sandbox and communicates over an exposed port.
- Point readers to activeTools/inactiveTools and permissionMode for restricting built-in execution.

Addresses #15860.

## Verification

- ./node_modules/.bin/oxfmt --check content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
- ./node_modules/.bin/oxlint content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
