### PR TITLE
docs: fix human-in-the-loop example link

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -348,6 +348,6 @@ const result = streamText({
 
 ## Full Example
 
-To see this code in action, check out the [`next-openai` example](https://github.com/vercel/ai/tree/main/examples/next-openai) in the AI SDK repository. Navigate to the `/test-tool-approval` page and associated route handler.
+To see this code in action, check out the [`ai-e2e-next` tool approval page](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next/app/chat/tool-approval) and its [route handler](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next/app/api/chat/tool-approval) in the AI SDK repository.
 
 For more details on tool execution approval, see the [Tool Execution Approval](/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval) and [Chatbot Tool Usage](/docs/ai-sdk-ui/chatbot-tool-usage#tool-execution-approval) documentation.


### PR DESCRIPTION
## Summary

- Replace the stale examples/next-openai link in the human-in-the-loop cookbook.
- Point readers to the existing ai-e2e-next tool approval page and API route.

Fixes #14705.

## Verification

- ./node_modules/.bin/oxfmt --check content/cookbook/01-next/75-human-in-the-loop.mdx
- ./node_modules/.bin/oxlint content/cookbook/01-next/75-human-in-the-loop.mdx
