### PR TITLE
docs: update Braintrust stream response helper

### DIFF
--- a/content/providers/03-observability/braintrust.mdx
+++ b/content/providers/03-observability/braintrust.mdx
@@ -67,7 +67,7 @@ export async function POST(req: Request) {
     prompt,
   });
 
-  return result.toDataStreamResponse();
+  return result.toUIMessageStreamResponse();
 }
 ```
 


### PR DESCRIPTION
## Summary

- Update the Braintrust streaming route example to use the current streamText response helper.
- Replace the stale toDataStreamResponse call with toUIMessageStreamResponse.

## Verification

- ./node_modules/.bin/oxfmt --check content/providers/03-observability/braintrust.mdx
- ./node_modules/.bin/oxlint content/providers/03-observability/braintrust.mdx
