### PR TITLE
docs: update MCP completion response helper

### DIFF
--- a/content/cookbook/01-next/73-mcp-tools.mdx
+++ b/content/cookbook/01-next/73-mcp-tools.mdx
@@ -18,7 +18,11 @@ If you prefer to use the official transports (optional), install the official Ty
 
 ```ts filename="app/api/completion/route.ts"
 import { createMCPClient } from '@ai-sdk/mcp';
-import { streamText } from 'ai';
+import {
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+} from 'ai';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
 // Optional: Official transports if you prefer them
@@ -103,7 +107,9 @@ export async function POST(req: Request) {
       },
     });
 
-    return response.toDataStreamResponse();
+    return createUIMessageStreamResponse({
+      stream: toUIMessageStream({ stream: response.stream }),
+    });
   } catch (error) {
     return new Response('Internal Server Error', { status: 500 });
   }


### PR DESCRIPTION
## Summary

- Update the MCP tools cookbook completion route to avoid the stale toDataStreamResponse helper.
- Use createUIMessageStreamResponse and toUIMessageStream, matching the current useCompletion docs pattern.

## Verification

- ./node_modules/.bin/oxfmt --check content/cookbook/01-next/73-mcp-tools.mdx
- ./node_modules/.bin/oxlint content/cookbook/01-next/73-mcp-tools.mdx
