### PR TITLE
feat(alibaba): support wan2.7 text-to-video and reference-to-video models

### DIFF
--- a/.changeset/hot-pandas-repeat.md
+++ b/.changeset/hot-pandas-repeat.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/alibaba': patch
+'@ai-sdk/gateway': patch
+---
+
+feat(alibaba): support wan2.7 reference-to-video models with the new `input.media` protocol

--- a/.changeset/hot-pandas-repeat.md
+++ b/.changeset/hot-pandas-repeat.md
@@ -3,4 +3,4 @@
 '@ai-sdk/gateway': patch
 ---
 
-feat(alibaba): support wan2.7 reference-to-video models with the new `input.media` protocol
+feat(alibaba): support wan2.7 text-to-video and reference-to-video models with the new protocol (`input.media`, `resolution` + `ratio`)

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -402,8 +402,10 @@ const { video } = await generateVideo({
 
 ### Reference-to-Video
 
-Generate videos using reference images and/or videos for character consistency. Use character identifiers
-(`character1`, `character2`, etc.) in your prompt to reference them:
+Generate videos using reference images and/or videos for character consistency.
+
+For `wan2.6` models, use character identifiers (`character1`, `character2`, etc.)
+in your prompt to reference them. References must be public URLs:
 
 ```ts
 import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
@@ -418,6 +420,59 @@ const { video } = await generateVideo({
   providerOptions: {
     alibaba: {
       pollTimeoutMs: 600000, // 10 minutes
+    } satisfies AlibabaVideoModelOptions,
+  },
+});
+```
+
+For `wan2.7` models, use `Image 1`, `Image 2`, `Video 1`, etc. in your prompt
+(images and videos are counted separately, in reference order). Image references
+can be public URLs or inline file data; video references must be public URLs:
+
+```ts
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { readFile } from 'node:fs/promises';
+
+const imageBytes = await readFile('./character.png');
+
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.7-r2v'),
+  prompt: 'Image 1 walks through the scene shown in Image 2.',
+  resolution: '1920x1080',
+  duration: 5,
+  inputReferences: [
+    { data: imageBytes, mediaType: 'image/png' }, // sent as base64 data URI
+    'https://example.com/background.png',
+  ],
+  providerOptions: {
+    alibaba: {
+      ratio: '16:9',
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies AlibabaVideoModelOptions,
+  },
+});
+```
+
+For full control over the `wan2.7` media array (e.g. voice references or explicit
+media types), use the `media` provider option, which overrides the automatic
+mapping from `inputReferences` and `frameImages`:
+
+```ts
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.7-r2v'),
+  prompt: 'Video 1 walks into the room. Image 1 looks up and says hello.',
+  providerOptions: {
+    alibaba: {
+      media: [
+        {
+          type: 'reference_video',
+          url: 'https://example.com/character.mp4',
+          referenceVoice: 'https://example.com/voice.mp3',
+        },
+        { type: 'reference_image', url: 'https://example.com/scene.png' },
+        { type: 'first_frame', url: 'https://example.com/opening-frame.png' },
+      ],
     } satisfies AlibabaVideoModelOptions,
   },
 });
@@ -453,8 +508,19 @@ The following provider options are available via `providerOptions.alibaba`:
 
 - **referenceUrls** _string[]_
 
-  Array of reference image/video URLs for reference-to-video mode. Supports 0-5 images and 0-3 videos, max 5 total.
+  Array of reference image/video URLs for reference-to-video mode (`wan2.6` models). Supports 0-5 images and 0-3 videos, max 5 total.
   Prefer the top-level `inputReferences` option when passing reference images.
+
+- **media** _Array&lt;\{ type, url, referenceVoice? \}&gt;_
+
+  Explicit media array for reference-to-video mode (`wan2.7` models). Each item has a `type`
+  (`'reference_image'`, `'reference_video'`, or `'first_frame'`), a `url` (public URL, or a
+  `data:{mime};base64,{data}` URI for images), and an optional `referenceVoice` audio URL.
+  Overrides the automatic mapping from `inputReferences` and `frameImages`.
+
+- **ratio** `'16:9'` | `'9:16'` | `'1:1'` | `'4:3'` | `'3:4'`
+
+  Aspect ratio for reference-to-video mode (`wan2.7` models).
 
 - **pollIntervalMs** _number_
 
@@ -488,10 +554,12 @@ The following provider options are available via `providerOptions.alibaba`:
 
 #### Reference-to-Video
 
-| Model              | Audio    | Resolution  | Duration |
-| ------------------ | -------- | ----------- | -------- |
-| `wan2.6-r2v-flash` | Optional | 720P, 1080P | 2-10s    |
-| `wan2.6-r2v`       | Yes      | 720P, 1080P | 2-10s    |
+| Model                   | Audio    | Resolution  | Duration                      |
+| ----------------------- | -------- | ----------- | ----------------------------- |
+| `wan2.6-r2v-flash`      | Optional | 720P, 1080P | 2-10s                         |
+| `wan2.6-r2v`            | Yes      | 720P, 1080P | 2-10s                         |
+| `wan2.7-r2v`            | Yes      | 720P, 1080P | 2-10s (with video ref), 2-15s |
+| `wan2.7-r2v-2026-06-12` | Yes      | 720P, 1080P | 2-10s (with video ref), 2-15s |
 
 <Note>
   The tables above list models available in the Singapore International region.

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -353,6 +353,21 @@ const { video } = await generateVideo({
 });
 ```
 
+`wan2.7` models additionally support the `aspectRatio` option (mapped to the
+API's `ratio` parameter) and always generate audio. Multi-shot structure is
+described directly in the prompt instead of the `shotType` option:
+
+```ts
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.7-t2v'),
+  prompt:
+    'A serene mountain lake at sunset. The camera pans across the water, then cuts to a close-up of ripples catching the light.',
+  resolution: '1920x1080',
+  aspectRatio: '16:9',
+  duration: 5,
+});
+```
+
 ### Image-to-Video
 
 Generate videos from a first-frame image and optional text prompt:
@@ -442,7 +457,7 @@ const { video } = await generateVideo({
   resolution: '1920x1080',
   duration: 5,
   inputReferences: [
-    { data: imageBytes, mediaType: 'image/png' }, // sent as base64 data URI
+    imageBytes, // inline image data, sent as base64 data URI
     'https://example.com/background.png',
   ],
   providerOptions: {
@@ -504,7 +519,7 @@ The following provider options are available via `providerOptions.alibaba`:
 
 - **audio** _boolean_
 
-  Whether to generate audio (for I2V and R2V models that support it).
+  Whether to generate audio (for `wan2.6` I2V and R2V models; `wan2.7` models always generate audio).
 
 - **referenceUrls** _string[]_
 
@@ -520,7 +535,8 @@ The following provider options are available via `providerOptions.alibaba`:
 
 - **ratio** `'16:9'` | `'9:16'` | `'1:1'` | `'4:3'` | `'3:4'`
 
-  Aspect ratio for reference-to-video mode (`wan2.7` models).
+  Aspect ratio (`wan2.7` text-to-video and reference-to-video models).
+  The top-level `aspectRatio` option is mapped to this parameter automatically.
 
 - **pollIntervalMs** _number_
 
@@ -540,10 +556,12 @@ The following provider options are available via `providerOptions.alibaba`:
 
 #### Text-to-Video
 
-| Model                | Audio | Resolution        | Duration |
-| -------------------- | ----- | ----------------- | -------- |
-| `wan2.6-t2v`         | Yes   | 720P, 1080P       | 2-15s    |
-| `wan2.5-t2v-preview` | Yes   | 480P, 720P, 1080P | 5s, 10s  |
+| Model                   | Audio | Resolution        | Duration |
+| ----------------------- | ----- | ----------------- | -------- |
+| `wan2.6-t2v`            | Yes   | 720P, 1080P       | 2-15s    |
+| `wan2.5-t2v-preview`    | Yes   | 480P, 720P, 1080P | 5s, 10s  |
+| `wan2.7-t2v`            | Yes   | 720P, 1080P       | 2-15s    |
+| `wan2.7-t2v-2026-06-12` | Yes   | 720P, 1080P       | 2-15s    |
 
 #### Image-to-Video (First Frame)
 

--- a/examples/ai-functions/src/generate-video/alibaba/wan2.7-r2v-reference-voice.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan2.7-r2v-reference-voice.ts
@@ -1,0 +1,44 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with voice references (wan2.7-r2v)...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.7-r2v'),
+        prompt:
+          'Image 1 and Video 1 stand side by side and introduce themselves to the camera',
+        resolution: '1920x1080',
+        duration: 6,
+        providerOptions: {
+          alibaba: {
+            // referenceVoice sets a character's voice from an audio clip
+            // (wav/mp3, 1-10 seconds, public URL). It does not determine
+            // the spoken content, which comes from the prompt.
+            media: [
+              {
+                type: 'reference_image',
+                url: 'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260408/sjuytr/wan-r2v-object-girl.jpg',
+                referenceVoice:
+                  'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260408/gbqewz/wan-r2v-girl-voice.mp3',
+              },
+              {
+                type: 'reference_video',
+                url: 'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260129/qigswt/wan-r2v-role2.mp4',
+                referenceVoice:
+                  'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260408/isllrq/wan-r2v-boy-voice.mp3',
+              },
+            ],
+            ratio: '16:9',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan2.7-r2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan2.7-r2v.ts
@@ -1,0 +1,30 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with wan2.7-r2v...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.7-r2v'),
+        prompt: 'Image 1 and Image 2 have a conversation in a cozy cafe',
+        resolution: '1920x1080',
+        duration: 4,
+        inputReferences: [
+          'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+        ],
+        providerOptions: {
+          alibaba: {
+            ratio: '16:9',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan2.7-t2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan2.7-t2v.ts
@@ -1,0 +1,29 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating text-to-video with wan2.7-t2v...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.7-t2v'),
+        prompt:
+          'A serene mountain lake at sunset. The camera slowly pans across ' +
+          'the water, then cuts to a close-up of gentle ripples catching ' +
+          'the golden light.',
+        resolution: '1920x1080',
+        aspectRatio: '16:9',
+        duration: 5,
+        providerOptions: {
+          alibaba: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/packages/alibaba/src/alibaba-video-model-options.ts
+++ b/packages/alibaba/src/alibaba-video-model-options.ts
@@ -15,11 +15,28 @@ export type AlibabaVideoModelOptions = {
   /** Enable audio generation (for I2V/R2V models). */
   audio?: boolean | null;
   /**
-   * Reference URLs for reference-to-video mode.
+   * Reference URLs for reference-to-video mode (wan2.6 models).
    * Array of URLs to images (0-5) and/or videos (0-3), max 5 total.
    * Use character identifiers (character1, character2) in prompts to reference them.
    */
   referenceUrls?: string[] | null;
+  /**
+   * Explicit media array for reference-to-video mode (wan2.7 models).
+   * Overrides the automatic mapping from `inputReferences` and `frameImages`.
+   * Use `Image 1`, `Video 1`, etc. in prompts to reference media items
+   * (images and videos are counted separately, in array order).
+   */
+  media?: Array<{
+    type: 'reference_image' | 'reference_video' | 'first_frame';
+    /** Public URL, or a `data:{mime};base64,{data}` URI for images. */
+    url: string;
+    /** URL to an audio file used as voice reference for this media item. */
+    referenceVoice?: string | null;
+  }> | null;
+  /**
+   * Aspect ratio for reference-to-video mode (wan2.7 models).
+   */
+  ratio?: '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | null;
   /** Polling interval in milliseconds. Defaults to 5000 (5 seconds). */
   pollIntervalMs?: number | null;
   /** Maximum wait time in milliseconds for video generation. Defaults to 600000 (10 minutes). */
@@ -37,6 +54,16 @@ export const alibabaVideoModelOptionsSchema = lazySchema(() =>
       watermark: z.boolean().nullish(),
       audio: z.boolean().nullish(),
       referenceUrls: z.array(z.string()).nullish(),
+      media: z
+        .array(
+          z.object({
+            type: z.enum(['reference_image', 'reference_video', 'first_frame']),
+            url: z.string(),
+            referenceVoice: z.string().nullish(),
+          }),
+        )
+        .nullish(),
+      ratio: z.enum(['16:9', '9:16', '1:1', '4:3', '3:4']).nullish(),
       pollIntervalMs: z.number().positive().nullish(),
       pollTimeoutMs: z.number().positive().nullish(),
     }),

--- a/packages/alibaba/src/alibaba-video-model-options.ts
+++ b/packages/alibaba/src/alibaba-video-model-options.ts
@@ -8,11 +8,17 @@ export type AlibabaVideoModelOptions = {
   audioUrl?: string | null;
   /** Enable prompt extension/rewriting for better generation. Defaults to true. */
   promptExtend?: boolean | null;
-  /** Shot type: 'single' for single-shot or 'multi' for multi-shot narrative. */
+  /**
+   * Shot type: 'single' for single-shot or 'multi' for multi-shot narrative
+   * (wan2.6 and earlier; wan2.7 models describe shot structure in the prompt).
+   */
   shotType?: 'single' | 'multi' | null;
   /** Whether to add watermark to generated video. Defaults to false. */
   watermark?: boolean | null;
-  /** Enable audio generation (for I2V/R2V models). */
+  /**
+   * Enable audio generation (for wan2.6 I2V/R2V models;
+   * wan2.7 models always generate audio).
+   */
   audio?: boolean | null;
   /**
    * Reference URLs for reference-to-video mode (wan2.6 models).
@@ -34,7 +40,7 @@ export type AlibabaVideoModelOptions = {
     referenceVoice?: string | null;
   }> | null;
   /**
-   * Aspect ratio for reference-to-video mode (wan2.7 models).
+   * Aspect ratio (wan2.7 text-to-video and reference-to-video models).
    */
   ratio?: '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | null;
   /** Polling interval in milliseconds. Defaults to 5000 (5 seconds). */

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -609,6 +609,271 @@ describe('AlibabaVideoModel', () => {
     });
   });
 
+  describe('doGenerate - reference-to-video (wan2.7 media protocol)', () => {
+    it('should send input.media with reference_image for URL image refs', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character-1.png' },
+          { type: 'url', url: 'https://example.com/character-2.jpg' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.7-r2v',
+        input: {
+          prompt,
+          media: [
+            {
+              type: 'reference_image',
+              url: 'https://example.com/character-1.png',
+            },
+            {
+              type: 'reference_image',
+              url: 'https://example.com/character-2.jpg',
+            },
+          ],
+        },
+      });
+      expect(body.input).not.toHaveProperty('reference_urls');
+    });
+
+    it('should send reference_video for video URL refs', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.mp4' },
+          { type: 'url', url: 'https://example.com/scene.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          media: [
+            {
+              type: 'reference_video',
+              url: 'https://example.com/character.mp4',
+            },
+            { type: 'reference_image', url: 'https://example.com/scene.png' },
+          ],
+        },
+      });
+    });
+
+    it('should send file image refs as base64 data URIs', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+      const imageData = new Uint8Array([137, 80, 78, 71]); // PNG magic bytes
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'file', data: imageData, mediaType: 'image/png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          media: [
+            {
+              type: 'reference_image',
+              url: 'data:image/png;base64,iVBORw==',
+            },
+          ],
+        },
+      });
+    });
+
+    it('should warn and skip non-URL video refs', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 0, 0, 24]),
+            mediaType: 'video/mp4',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.input).not.toHaveProperty('media');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'inputReferences',
+        }),
+      );
+    });
+
+    it('should include frameImages first_frame in media', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        frameImages: [
+          {
+            image: {
+              type: 'url',
+              url: 'https://example.com/opening-frame.png',
+            },
+            frameType: 'first_frame',
+          },
+        ],
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          media: [
+            {
+              type: 'reference_image',
+              url: 'https://example.com/character.png',
+            },
+            {
+              type: 'first_frame',
+              url: 'https://example.com/opening-frame.png',
+            },
+          ],
+        },
+      });
+    });
+
+    it('should send resolution tier and ratio instead of size', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1920x1080',
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: {
+          resolution: '1080P',
+          ratio: '16:9',
+        },
+      });
+      expect(body.parameters).not.toHaveProperty('size');
+    });
+
+    it('should map aspectRatio to ratio without warning', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '9:16',
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { ratio: '9:16' },
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ feature: 'aspectRatio' }),
+      );
+    });
+
+    it('should prefer providerOptions ratio over aspectRatio', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '9:16',
+        providerOptions: {
+          alibaba: {
+            ratio: '16:9',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { ratio: '16:9' },
+      });
+    });
+
+    it('should use providerOptions.alibaba.media as override with reference_voice', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v-2026-06-12' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/ignored.png' },
+        ],
+        providerOptions: {
+          alibaba: {
+            media: [
+              {
+                type: 'reference_video',
+                url: 'https://example.com/character.mp4',
+                referenceVoice: 'https://example.com/voice.mp3',
+              },
+              {
+                type: 'first_frame',
+                url: 'https://example.com/opening-frame.png',
+              },
+            ],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.7-r2v-2026-06-12',
+        input: {
+          media: [
+            {
+              type: 'reference_video',
+              url: 'https://example.com/character.mp4',
+              reference_voice: 'https://example.com/voice.mp3',
+            },
+            {
+              type: 'first_frame',
+              url: 'https://example.com/opening-frame.png',
+            },
+          ],
+        },
+      });
+    });
+
+    it('should keep the legacy reference_urls protocol for wan2.6 models', async () => {
+      const model = createModel({ modelId: 'wan2.6-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.input).toHaveProperty('reference_urls');
+      expect(body.input).not.toHaveProperty('media');
+    });
+  });
+
   describe('headers', () => {
     it('should send X-DashScope-Async header on task creation', async () => {
       const model = createModel();

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -771,6 +771,48 @@ describe('AlibabaVideoModel', () => {
       expect(body.parameters).not.toHaveProperty('size');
     });
 
+    it('should warn and skip unsupported resolutions', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '832x480',
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.parameters).not.toHaveProperty('resolution');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'resolution',
+        }),
+      );
+    });
+
+    it('should warn and skip the audio option', async () => {
+      const model = createModel({ modelId: 'wan2.7-r2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        generateAudio: true,
+        inputReferences: [
+          { type: 'url', url: 'https://example.com/character.png' },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.parameters).not.toHaveProperty('audio');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'generateAudio',
+        }),
+      );
+    });
+
     it('should map aspectRatio to ratio without warning', async () => {
       const model = createModel({ modelId: 'wan2.7-r2v' });
 
@@ -871,6 +913,123 @@ describe('AlibabaVideoModel', () => {
       const body = await server.calls[0].requestBodyJson;
       expect(body.input).toHaveProperty('reference_urls');
       expect(body.input).not.toHaveProperty('media');
+    });
+  });
+
+  describe('doGenerate - text-to-video (wan2.7)', () => {
+    it('should send resolution tier and ratio instead of size', async () => {
+      const model = createModel({ modelId: 'wan2.7-t2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1920x1080',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.7-t2v',
+        input: { prompt },
+        parameters: {
+          resolution: '1080P',
+          ratio: '16:9',
+        },
+      });
+      expect(body.parameters).not.toHaveProperty('size');
+    });
+
+    it('should map aspectRatio to ratio without warning', async () => {
+      const model = createModel({ modelId: 'wan2.7-t2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '9:16',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { ratio: '9:16' },
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ feature: 'aspectRatio' }),
+      );
+    });
+
+    it('should warn and skip the shotType option', async () => {
+      const model = createModel({ modelId: 'wan2.7-t2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            shotType: 'multi',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.parameters).not.toHaveProperty('shot_type');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'shotType',
+        }),
+      );
+    });
+
+    it('should warn and skip the audio option', async () => {
+      const model = createModel({ modelId: 'wan2.7-t2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        generateAudio: true,
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.parameters).not.toHaveProperty('audio');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'generateAudio',
+        }),
+      );
+    });
+
+    it('should still send audio_url', async () => {
+      const model = createModel({ modelId: 'wan2.7-t2v-2026-06-12' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            audioUrl: 'https://example.com/soundtrack.mp3',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.7-t2v-2026-06-12',
+        input: {
+          audio_url: 'https://example.com/soundtrack.mp3',
+        },
+      });
+    });
+
+    it('should keep the legacy size parameter for wan2.6-t2v', async () => {
+      const model = createModel({ modelId: 'wan2.6-t2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1920x1080',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.parameters).toMatchObject({ size: '1920*1080' });
+      expect(body.parameters).not.toHaveProperty('ratio');
     });
   });
 

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -92,6 +92,44 @@ function detectMode(modelId: string): 't2v' | 'i2v' | 'r2v' {
   return 't2v';
 }
 
+// wan2.7 models use the new reference-to-video protocol (input.media)
+// instead of the legacy wan2.6 protocol (input.reference_urls).
+function usesMediaProtocol(modelId: string): boolean {
+  return modelId.startsWith('wan2.7');
+}
+
+// Maps SDK "WIDTHxHEIGHT" resolutions to Alibaba resolution tiers.
+const resolutionTierMap: Record<string, string> = {
+  '1280x720': '720P',
+  '720x1280': '720P',
+  '960x960': '720P',
+  '1088x832': '720P',
+  '832x1088': '720P',
+  '1920x1080': '1080P',
+  '1080x1920': '1080P',
+  '1440x1440': '1080P',
+  '1632x1248': '1080P',
+  '1248x1632': '1080P',
+  '832x480': '480P',
+  '480x832': '480P',
+  '624x624': '480P',
+};
+
+const supportedRatios = new Set(['16:9', '9:16', '1:1', '4:3', '3:4']);
+
+function deriveRatioFromResolution(
+  resolution: `${number}x${number}`,
+): string | undefined {
+  const [width, height] = resolution.split('x').map(Number);
+  let a = width;
+  let b = height;
+  while (b !== 0) {
+    [a, b] = [b, a % b];
+  }
+  const ratio = `${width / a}:${height / a}`;
+  return supportedRatios.has(ratio) ? ratio : undefined;
+}
+
 function fileToImageString(file: Experimental_VideoModelV4File): string {
   if (file.type === 'url') {
     return file.url;
@@ -112,6 +150,73 @@ function resolveStartImage(
   options: Parameters<Experimental_VideoModelV4['doGenerate']>[0],
 ): Experimental_VideoModelV4File | undefined {
   return getFirstFrameImage(options) ?? options.image;
+}
+
+function fileToDataUri(file: {
+  data: string | Uint8Array;
+  mediaType: string;
+}): string {
+  const base64 =
+    typeof file.data === 'string'
+      ? file.data
+      : convertUint8ArrayToBase64(file.data);
+  return `data:${file.mediaType};base64,${base64}`;
+}
+
+function isVideoUrl(url: string): boolean {
+  return /\.(mp4|mov)([?#]|$)/i.test(url);
+}
+
+// Builds the wan2.7 input.media array from inputReferences and frameImages.
+function resolveMedia(
+  options: Parameters<Experimental_VideoModelV4['doGenerate']>[0],
+  alibabaOptions: AlibabaVideoModelOptions | undefined,
+  warnings: SharedV4Warning[],
+): Array<Record<string, unknown>> | undefined {
+  if (alibabaOptions?.media != null && alibabaOptions.media.length > 0) {
+    return alibabaOptions.media.map(item => ({
+      type: item.type,
+      url: item.url,
+      ...(item.referenceVoice != null
+        ? { reference_voice: item.referenceVoice }
+        : {}),
+    }));
+  }
+
+  const media: Array<Record<string, unknown>> = [];
+
+  for (const reference of options.inputReferences ?? []) {
+    if (reference.type === 'url') {
+      media.push({
+        type: isVideoUrl(reference.url) ? 'reference_video' : 'reference_image',
+        url: reference.url,
+      });
+    } else if (reference.mediaType.startsWith('image/')) {
+      media.push({
+        type: 'reference_image',
+        url: fileToDataUri(reference),
+      });
+    } else {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'Alibaba reference-to-video requires URL references for videos. ' +
+          'Non-URL video reference was skipped.',
+      });
+    }
+  }
+
+  const firstFrame = getFirstFrameImage(options);
+  if (firstFrame != null) {
+    media.push({
+      type: 'first_frame',
+      url:
+        firstFrame.type === 'url' ? firstFrame.url : fileToDataUri(firstFrame),
+    });
+  }
+
+  return media.length > 0 ? media : undefined;
 }
 
 function resolveReferenceUrls(
@@ -188,20 +293,32 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
     }
 
     const startImage = resolveStartImage(options);
-    const referenceUrls = resolveReferenceUrls(
-      options,
-      alibabaOptions,
-      warnings,
-    );
+    const mediaProtocol = mode === 'r2v' && usesMediaProtocol(this.modelId);
 
     // Handle image input for I2V mode
     if (mode === 'i2v' && startImage != null) {
       input.img_url = fileToImageString(startImage);
     }
 
-    // Handle reference URLs for R2V mode
-    if (mode === 'r2v' && referenceUrls != null && referenceUrls.length > 0) {
-      input.reference_urls = referenceUrls;
+    // Handle references for R2V mode
+    if (mode === 'r2v') {
+      if (mediaProtocol) {
+        // wan2.7: new protocol with input.media
+        const media = resolveMedia(options, alibabaOptions, warnings);
+        if (media != null) {
+          input.media = media;
+        }
+      } else {
+        // wan2.6: legacy protocol with input.reference_urls
+        const referenceUrls = resolveReferenceUrls(
+          options,
+          alibabaOptions,
+          warnings,
+        );
+        if (referenceUrls != null && referenceUrls.length > 0) {
+          input.reference_urls = referenceUrls;
+        }
+      }
     }
 
     const lastFrame = options.frameImages?.find(
@@ -245,29 +362,27 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
 
     // Resolution / Size mapping
     if (options.resolution != null) {
-      if (mode === 'i2v') {
-        // I2V uses "720P" / "1080P" format
-        const resolutionMap: Record<string, string> = {
-          '1280x720': '720P',
-          '720x1280': '720P',
-          '960x960': '720P',
-          '1088x832': '720P',
-          '832x1088': '720P',
-          '1920x1080': '1080P',
-          '1080x1920': '1080P',
-          '1440x1440': '1080P',
-          '1632x1248': '1080P',
-          '1248x1632': '1080P',
-          '832x480': '480P',
-          '480x832': '480P',
-          '624x624': '480P',
-        };
+      if (mode === 'i2v' || mediaProtocol) {
+        // I2V and wan2.7 R2V use "720P" / "1080P" format
         parameters.resolution =
-          resolutionMap[options.resolution] || options.resolution;
+          resolutionTierMap[options.resolution] || options.resolution;
       } else {
-        // T2V and R2V use "WIDTH*HEIGHT" format for the size parameter
+        // T2V and wan2.6 R2V use "WIDTH*HEIGHT" format for the size parameter
         // Convert "WIDTHxHEIGHT" (SDK standard) to "WIDTH*HEIGHT" (Alibaba API)
         parameters.size = options.resolution.replace('x', '*');
+      }
+    }
+
+    // wan2.7 R2V supports an explicit aspect ratio parameter
+    if (mediaProtocol) {
+      const ratio =
+        alibabaOptions?.ratio ??
+        options.aspectRatio ??
+        (options.resolution != null
+          ? deriveRatioFromResolution(options.resolution)
+          : undefined);
+      if (ratio != null) {
+        parameters.ratio = ratio;
       }
     }
 
@@ -287,7 +402,7 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
     }
 
     // Warn about unsupported standard options
-    if (options.aspectRatio) {
+    if (options.aspectRatio && !mediaProtocol) {
       warnings.push({
         type: 'unsupported',
         feature: 'aspectRatio',

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -92,9 +92,10 @@ function detectMode(modelId: string): 't2v' | 'i2v' | 'r2v' {
   return 't2v';
 }
 
-// wan2.7 models use the new reference-to-video protocol (input.media)
-// instead of the legacy wan2.6 protocol (input.reference_urls).
-function usesMediaProtocol(modelId: string): boolean {
+// wan2.7 models use a different protocol than earlier wan models:
+// resolution tiers + ratio instead of size, input.media instead of
+// input.reference_urls (R2V), and no shot_type or audio parameters.
+function isWan27Model(modelId: string): boolean {
   return modelId.startsWith('wan2.7');
 }
 
@@ -293,7 +294,9 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
     }
 
     const startImage = resolveStartImage(options);
-    const mediaProtocol = mode === 'r2v' && usesMediaProtocol(this.modelId);
+    const wan27 = isWan27Model(this.modelId);
+    // wan2.7 T2V and R2V take an explicit aspect ratio (I2V follows the input image)
+    const supportsRatio = wan27 && mode !== 'i2v';
 
     // Handle image input for I2V mode
     if (mode === 'i2v' && startImage != null) {
@@ -302,8 +305,8 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
 
     // Handle references for R2V mode
     if (mode === 'r2v') {
-      if (mediaProtocol) {
-        // wan2.7: new protocol with input.media
+      if (wan27) {
+        // wan2.7: input.media
         const media = resolveMedia(options, alibabaOptions, warnings);
         if (media != null) {
           input.media = media;
@@ -362,19 +365,30 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
 
     // Resolution / Size mapping
     if (options.resolution != null) {
-      if (mode === 'i2v' || mediaProtocol) {
-        // I2V and wan2.7 R2V use "720P" / "1080P" format
-        parameters.resolution =
+      if (mode === 'i2v' || wan27) {
+        // I2V and wan2.7 models use "720P" / "1080P" format
+        const resolutionTier =
           resolutionTierMap[options.resolution] || options.resolution;
+        if (wan27 && resolutionTier !== '720P' && resolutionTier !== '1080P') {
+          warnings.push({
+            type: 'unsupported',
+            feature: 'resolution',
+            details:
+              'wan2.7 models only support 720P and 1080P ' +
+              `resolutions. The resolution "${options.resolution}" was ignored.`,
+          });
+        } else {
+          parameters.resolution = resolutionTier;
+        }
       } else {
-        // T2V and wan2.6 R2V use "WIDTH*HEIGHT" format for the size parameter
+        // wan2.6 T2V and R2V use "WIDTH*HEIGHT" format for the size parameter
         // Convert "WIDTHxHEIGHT" (SDK standard) to "WIDTH*HEIGHT" (Alibaba API)
         parameters.size = options.resolution.replace('x', '*');
       }
     }
 
-    // wan2.7 R2V supports an explicit aspect ratio parameter
-    if (mediaProtocol) {
+    // wan2.7 T2V and R2V support an explicit aspect ratio parameter
+    if (supportsRatio) {
       const ratio =
         alibabaOptions?.ratio ??
         options.aspectRatio ??
@@ -391,18 +405,40 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
       parameters.prompt_extend = alibabaOptions.promptExtend;
     }
     if (alibabaOptions?.shotType != null) {
-      parameters.shot_type = alibabaOptions.shotType;
+      if (wan27) {
+        // wan2.7 removed shot_type; shot structure is described in the prompt
+        warnings.push({
+          type: 'unsupported',
+          feature: 'shotType',
+          details:
+            'wan2.7 models do not support the shotType option. ' +
+            'Describe the shot structure in the prompt instead.',
+        });
+      } else {
+        parameters.shot_type = alibabaOptions.shotType;
+      }
     }
     if (alibabaOptions?.watermark != null) {
       parameters.watermark = alibabaOptions.watermark;
     }
     const audio = options.generateAudio ?? alibabaOptions?.audio;
     if (audio != null) {
-      parameters.audio = audio;
+      if (wan27) {
+        // wan2.7 does not have an audio parameter (audio is always generated)
+        warnings.push({
+          type: 'unsupported',
+          feature: 'generateAudio',
+          details:
+            'wan2.7 models always generate audio. ' +
+            'The audio option was ignored.',
+        });
+      } else {
+        parameters.audio = audio;
+      }
     }
 
     // Warn about unsupported standard options
-    if (options.aspectRatio && !mediaProtocol) {
+    if (options.aspectRatio && !supportsRatio) {
       warnings.push({
         type: 'unsupported',
         feature: 'aspectRatio',

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -6,6 +6,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
+  convertImageModelFileToDataUri,
   convertUint8ArrayToBase64,
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
@@ -161,17 +162,6 @@ function resolveStartImage(
   return getFirstFrameImage(options) ?? options.image;
 }
 
-function fileToDataUri(file: {
-  data: string | Uint8Array;
-  mediaType: string;
-}): string {
-  const base64 =
-    typeof file.data === 'string'
-      ? file.data
-      : convertUint8ArrayToBase64(file.data);
-  return `data:${file.mediaType};base64,${base64}`;
-}
-
 function isVideoUrl(url: string): boolean {
   return /\.(mp4|mov)([?#]|$)/i.test(url);
 }
@@ -203,7 +193,7 @@ function resolveMedia(
     } else if (reference.mediaType.startsWith('image/')) {
       media.push({
         type: 'reference_image',
-        url: fileToDataUri(reference),
+        url: convertImageModelFileToDataUri(reference),
       });
     } else {
       warnings.push({
@@ -220,8 +210,7 @@ function resolveMedia(
   if (firstFrame != null) {
     media.push({
       type: 'first_frame',
-      url:
-        firstFrame.type === 'url' ? firstFrame.url : fileToDataUri(firstFrame),
+      url: convertImageModelFileToDataUri(firstFrame),
     });
   }
 

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -122,6 +122,14 @@ function deriveRatioFromResolution(
   resolution: `${number}x${number}`,
 ): string | undefined {
   const [width, height] = resolution.split('x').map(Number);
+  if (
+    !Number.isInteger(width) ||
+    !Number.isInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return undefined;
+  }
   let a = width;
   let b = height;
   while (b !== 0) {

--- a/packages/alibaba/src/alibaba-video-settings.ts
+++ b/packages/alibaba/src/alibaba-video-settings.ts
@@ -9,4 +9,6 @@ export type AlibabaVideoModelId =
   // Reference-to-Video
   | 'wan2.6-r2v'
   | 'wan2.6-r2v-flash'
+  | 'wan2.7-r2v'
+  | 'wan2.7-r2v-2026-06-12'
   | (string & {});

--- a/packages/alibaba/src/alibaba-video-settings.ts
+++ b/packages/alibaba/src/alibaba-video-settings.ts
@@ -3,6 +3,8 @@ export type AlibabaVideoModelId =
   // Text-to-Video
   | 'wan2.6-t2v'
   | 'wan2.5-t2v-preview'
+  | 'wan2.7-t2v'
+  | 'wan2.7-t2v-2026-06-12'
   // Image-to-Video (first frame)
   | 'wan2.6-i2v'
   | 'wan2.6-i2v-flash'

--- a/packages/gateway/src/gateway-video-model-settings.ts
+++ b/packages/gateway/src/gateway-video-model-settings.ts
@@ -5,6 +5,7 @@ export type GatewayVideoModelId =
   | 'alibaba/wan-v2.6-r2v'
   | 'alibaba/wan-v2.6-r2v-flash'
   | 'alibaba/wan-v2.6-t2v'
+  | 'alibaba/wan-v2.7-r2v'
   | 'bytedance/seedance-2.0'
   | 'bytedance/seedance-2.0-fast'
   | 'bytedance/seedance-v1.0-pro'

--- a/packages/gateway/src/gateway-video-model-settings.ts
+++ b/packages/gateway/src/gateway-video-model-settings.ts
@@ -6,6 +6,7 @@ export type GatewayVideoModelId =
   | 'alibaba/wan-v2.6-r2v-flash'
   | 'alibaba/wan-v2.6-t2v'
   | 'alibaba/wan-v2.7-r2v'
+  | 'alibaba/wan-v2.7-t2v'
   | 'bytedance/seedance-2.0'
   | 'bytedance/seedance-2.0-fast'
   | 'bytedance/seedance-v1.0-pro'


### PR DESCRIPTION
## Background

Alibaba wan2.7 video model family (`wan2.7-t2v`, `wan2.7-r2v`, plus `-2026-06-12` dated snapshots) are served on the same endpoint as wan2.6 but use a changed request protocol.

## Summary

- **`@ai-sdk/alibaba`**: `isWan27Model` predicate gates the protocol split in `AlibabaVideoModel`.
- **Model IDs**: added `wan2.7-t2v`, `wan2.7-t2v-2026-06-12`, `wan2.7-r2v`, `wan2.7-r2v-2026-06-12`.
- **`@ai-sdk/gateway`**: added `alibaba/wan-v2.7-t2v` and `alibaba/wan-v2.7-r2v` video model IDs.
- **Examples**: `wan2.7-t2v`, `wan2.7-r2v`, and `wan2.7-r2v-reference-voice` (voice references via the `media` provider option) under `examples/ai-functions/src/generate-video/alibaba/`.

## Manual Verification

- Verified the request mapping field-by-field against Alibaba's official wan2.7 API references (media item shape and `reference_voice`, resolution/ratio enums and defaults, duration ranges, base64-for-images/URL-only-for-videos constraints, removed `shot_type`/`audio` parameters, prompt reference conventions).
- Ran the new examples

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

- **wan2.7 i2v** support
- Once `feat/video-reference-inputs` lands (adds `mediaType` to URL references), prefer the explicit `mediaType` over the current `.mp4`/`.mov` extension sniffing when classifying URL references in `resolveMedia`.
- Backport to `release-v6.0`
