### PR TITLE
fix(azure): use custom base urls if provided

### DIFF
--- a/.changeset/angry-terms-smoke.md
+++ b/.changeset/angry-terms-smoke.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/azure": patch
+---
+
+fix(azure): use custom base urls if provided

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -98,7 +98,9 @@ You can use the following optional settings to customize the OpenAI provider ins
   Either this or `resourceName` can be used.
   When a baseURL is provided, the resourceName is ignored.
 
-  With a baseURL, the resolved URL is `{baseURL}/v1{path}`.
+  With an Azure OpenAI baseURL, the resolved URL is `{baseURL}/v1{path}`.
+  With a non-Azure custom gateway baseURL, the resolved URL is `{baseURL}{path}`;
+  the SDK does not append `/v1` or an `api-version` query parameter in this mode.
 
 - **headers** _Record&lt;string,string&gt;_
 

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -95,6 +95,7 @@ const server = createTestServer({
   'https://test-resource.openai.azure.com/openai/v1/responses': {},
   'https://test-resource.openai.azure.com/openai/v1/audio/transcriptions': {},
   'https://test-resource.openai.azure.com/openai/v1/audio/speech': {},
+  'https://our-gateway.example.com/azure/chat/completions': {},
   'https://test-resource.openai.azure.com/openai/deployments/whisper-1/audio/transcriptions':
     {},
 });
@@ -374,6 +375,41 @@ describe('chat', () => {
       });
       expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
         `"https://test-resource.openai.azure.com/openai/v1/chat/completions?api-version=v1"`,
+      );
+    });
+
+    it('should use custom gateway baseURL as-is', async () => {
+      server.urls[
+        'https://our-gateway.example.com/azure/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-repro-13956',
+          object: 'chat.completion',
+          created: 0,
+          model: 'test-deployment',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        },
+      };
+
+      const provider = createAzure({
+        baseURL: 'https://our-gateway.example.com/azure',
+        apiKey: 'test-api-key',
+      });
+
+      await provider.chat('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
+        `"https://our-gateway.example.com/azure/chat/completions"`,
       );
     });
   });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -21,6 +21,7 @@ import {
   loadApiKey,
   loadSetting,
   normalizeHeaders,
+  withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
@@ -113,7 +114,8 @@ export interface AzureOpenAIProviderSettings {
    * Use a different URL prefix for API calls, e.g. to use proxy servers. Either this or `resourceName` can be used.
    * When a baseURL is provided, the resourceName is ignored.
    *
-   * With a baseURL, the resolved URL is `{baseURL}/v1{path}`.
+   * With an Azure OpenAI baseURL, the resolved URL is `{baseURL}/v1{path}`.
+   * With a non-Azure custom gateway baseURL, the resolved URL is `{baseURL}{path}`.
    */
   baseURL?: string;
 
@@ -151,6 +153,12 @@ export interface AzureOpenAIProviderSettings {
    * `{baseURL}/v1{path}?api-version={apiVersion}`.
    */
   useDeploymentBasedUrls?: boolean;
+}
+
+function isAzureOpenAIBaseURL(baseURL: string | undefined) {
+  return (
+    baseURL == null || new URL(baseURL).hostname.endsWith('.openai.azure.com')
+  );
 }
 
 /**
@@ -213,21 +221,29 @@ export function createAzure(
     });
 
   const apiVersion = options.apiVersion ?? 'v1';
+  const useAzureOpenAIEndpoint = isAzureOpenAIBaseURL(options.baseURL);
 
   const url = ({ path, modelId }: { path: string; modelId: string }) => {
-    const baseUrlPrefix =
-      options.baseURL ?? `https://${getResourceName()}.openai.azure.com/openai`;
+    const baseUrlPrefix = withoutTrailingSlash(
+      options.baseURL ?? `https://${getResourceName()}.openai.azure.com/openai`,
+    );
 
     let fullUrl: URL;
     if (options.useDeploymentBasedUrls) {
       // Use deployment-based format for compatibility with certain Azure OpenAI models
       fullUrl = new URL(`${baseUrlPrefix}/deployments/${modelId}${path}`);
+    } else if (!useAzureOpenAIEndpoint) {
+      // Custom gateways can own Azure routing and versioning themselves.
+      fullUrl = new URL(`${baseUrlPrefix}${path}`);
     } else {
       // Use v1 API format - no deployment ID in URL
       fullUrl = new URL(`${baseUrlPrefix}/v1${path}`);
     }
 
-    fullUrl.searchParams.set('api-version', apiVersion);
+    if (useAzureOpenAIEndpoint || options.useDeploymentBasedUrls) {
+      fullUrl.searchParams.set('api-version', apiVersion);
+    }
+
     return fullUrl.toString();
   };
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/13956

createAzure({ baseURL }) always treated `baseURL` as an Azure OpenAI prefix and unconditionally added `/v1`
`?api-version=v1`

which incorrectly changed the URL for users

## Summary

we now distinguish between:

- Azure OpenAI resource URLs &
- Non-Azure custom gateway URLs

## Manual Verification

verified by running the repro in the branch https://github.com/vercel/ai/tree/bug-reproduction/13956-1

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #13956