### PR TITLE
test(harness): wait for bridge replay in resume test

### DIFF
--- a/packages/harness/src/bridge/index.test.ts
+++ b/packages/harness/src/bridge/index.test.ts
@@ -188,7 +188,7 @@ describe('runBridge', () => {
     const b = await connect(handle.port);
     await b.waitFor(f => f.type === 'bridge-hello');
     b.send({ type: 'resume', lastSeenEventId: 0 });
-    await new Promise(r => setTimeout(r, 50));
+    await b.waitFor(f => f.seq === 4);
 
     const replayedSeqs = b.frames
       .filter(f => typeof f.seq === 'number')


### PR DESCRIPTION
## Summary
- fix the Node 26 CI flake in the bridge resume test by waiting for the replayed terminal frame instead of sleeping for 50ms
- keeps the assertion that only the current turn's monotonic seq values are replayed

## Context
The failing CI job was Test (26) in https://github.com/vercel/ai/actions/runs/28617422562/job/84865316153. It failed in `packages/harness/src/bridge/index.test.ts` with `expected [] to deeply equal [3, 4]`, meaning the test sampled the fresh connection before replay frames had arrived.

## Tests
- `npx -y -p node@26 -p pnpm@10.33.4 pnpm --dir packages/harness exec vitest --config vitest.node.config.js --run src/bridge/index.test.ts`
- `npx -y -p pnpm@10.33.4 pnpm --dir packages/harness exec vitest --config vitest.node.config.js --run src/bridge/index.test.ts`
- `npx -y -p pnpm@10.33.4 pnpm check`
- `npx -y -p pnpm@10.33.4 pnpm exec turbo test --filter=@ai-sdk/harness --concurrency 16`
- `npx -y -p pnpm@10.33.4 pnpm type-check:full`