### PR TITLE
feat(gateway): support experimental streaming transcription

### DIFF
--- a/.changeset/gateway-stream-transcribe.md
+++ b/.changeset/gateway-stream-transcribe.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/gateway': patch
+'ai': patch
+---
+
+feat(gateway): support experimental streaming transcription. `GatewayTranscriptionModel` now implements `doStream`, so `experimental_streamTranscribe` works through the AI Gateway (e.g. `gateway.transcription('openai/gpt-realtime-whisper')` or the `'openai/gpt-realtime-whisper'` string model ID). The gateway buffers the audio stream and streams the transcript back over SSE.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -83,10 +83,12 @@ const durationInSeconds = await result.durationInSeconds; // duration in seconds
 The `audio` stream must contain raw audio chunks. `Uint8Array` chunks are raw bytes; `string` chunks are base64-encoded raw bytes. Always set `inputAudioFormat` to match the chunks you send.
 
 <Note>
-  Streaming transcription requires a provider model instance (e.g.
-  `openai.transcription('gpt-realtime-whisper')`). String model IDs resolve
-  through the global provider (AI Gateway by default), which does not support
-  streaming transcription yet.
+  Streaming transcription works with a provider model instance (e.g.
+  `openai.transcription('gpt-realtime-whisper')`) as well as through the AI
+  Gateway (e.g. `gateway.transcription('openai/gpt-realtime-whisper')` or the
+  `'openai/gpt-realtime-whisper'` string model ID). The AI Gateway buffers the
+  audio stream and streams the transcript back, so transcription starts once the
+  audio has been read rather than while it is still being captured.
 </Note>
 
 OpenAI streaming transcription uses `openai.transcription('gpt-realtime-whisper')`. xAI uses the same `xai.transcription()` model for request/response and streaming transcription; `experimental_streamTranscribe` uses xAI's WebSocket STT transport under the hood.

--- a/examples/ai-functions/src/stream-transcribe/gateway/basic.ts
+++ b/examples/ai-functions/src/stream-transcribe/gateway/basic.ts
@@ -1,0 +1,51 @@
+import { gateway } from '@ai-sdk/gateway';
+import {
+  experimental_streamTranscribe as streamTranscribe,
+  generateSpeech,
+} from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  // generate raw PCM audio (24kHz, 16-bit, mono) to transcribe:
+  const speech = await generateSpeech({
+    model: gateway.speech('openai/tts-1'),
+    text: 'Hello from the AI SDK! Streaming transcription through the AI Gateway is experimental.',
+    outputFormat: 'pcm',
+  });
+
+  // stream the raw audio in chunks, as a microphone would:
+  const bytes = speech.audio.uint8Array;
+  const chunkSize = 16 * 1024;
+  const audio = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.slice(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });
+
+  const result = streamTranscribe({
+    model: gateway.transcription('openai/gpt-realtime-whisper'),
+    audio,
+    inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    providerOptions: {
+      openai: {
+        streaming: { delay: 'low' },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'transcript-delta') {
+      process.stdout.write(part.delta);
+    }
+  }
+  console.log();
+
+  console.log('Text:', await result.text);
+  console.log('Language:', await result.language);
+  console.log('Duration:', await result.durationInSeconds);
+  console.log('Warnings:', await result.warnings);
+  console.log('Responses:', await result.responses);
+});

--- a/packages/ai/src/transcribe/stream-transcribe.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.ts
@@ -113,9 +113,9 @@ export function streamTranscribe({
       message:
         `The ${resolvedModel.provider} model "${resolvedModel.modelId}" does not support streaming transcription.` +
         (typeof model === 'string'
-          ? ' String model IDs resolve through the global provider (AI Gateway by default),' +
-            ' which does not support streaming transcription yet.' +
-            " Pass a provider model instance instead, e.g. openai.transcription('gpt-realtime-whisper')."
+          ? ' String model IDs resolve through the global provider (AI Gateway by default).' +
+            " Use a model that supports streaming transcription, e.g. 'openai/gpt-realtime-whisper'" +
+            " or a provider model instance such as openai.transcription('gpt-realtime-whisper')."
           : ''),
     });
   }

--- a/packages/gateway/src/gateway-transcription-model.test.ts
+++ b/packages/gateway/src/gateway-transcription-model.test.ts
@@ -1,4 +1,8 @@
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
 import { describe, expect, it } from 'vitest';
 import {
   GatewayInternalServerError,
@@ -157,6 +161,184 @@ describe('GatewayTranscriptionModel', () => {
       expect(result.language).toBeUndefined();
       expect(result.durationInSeconds).toBeUndefined();
       expect(result.warnings).toStrictEqual([]);
+    });
+  });
+
+  describe('doStream', () => {
+    function prepareStreamResponse({
+      chunks,
+    }: {
+      chunks?: string[];
+    } = {}) {
+      server.urls['https://api.test.com/transcription-model'].response = {
+        type: 'stream-chunks',
+        chunks: chunks ?? [
+          `data: ${JSON.stringify({ type: 'stream-start', warnings: [] })}\n\n`,
+          `data: ${JSON.stringify({ type: 'transcript-delta', delta: 'Hello' })}\n\n`,
+          `data: ${JSON.stringify({ type: 'transcript-delta', delta: ' world' })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'finish',
+            text: 'Hello world',
+            segments: [{ text: 'Hello world', startSecond: 0, endSecond: 1 }],
+            language: 'en',
+            durationInSeconds: 1,
+          })}\n\n`,
+        ],
+      };
+    }
+
+    const inputAudioFormat = { type: 'audio/pcm', rate: 24000 } as const;
+
+    it('should send the streaming model config headers', async () => {
+      prepareStreamResponse();
+
+      await createTestModel().doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+        inputAudioFormat,
+        headers: { 'Custom-Header': 'test-value' },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-token',
+        'custom-header': 'test-value',
+        'ai-transcription-model-specification-version': '4',
+        'ai-model-id': 'openai/gpt-4o-transcribe',
+        'ai-transcription-model-streaming': 'true',
+      });
+    });
+
+    it('should buffer audio chunks into a single base64 payload', async () => {
+      prepareStreamResponse();
+
+      await createTestModel().doStream({
+        audio: convertArrayToReadableStream([
+          new Uint8Array([1, 2]),
+          // string chunks are base64-encoded raw bytes ([3, 4] === 'AwQ=')
+          'AwQ=',
+        ]),
+        inputAudioFormat,
+        providerOptions: { openai: { streaming: { delay: 'low' } } },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        audio: 'AQIDBA==',
+        inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+        providerOptions: { openai: { streaming: { delay: 'low' } } },
+      });
+    });
+
+    it('should stream transcript parts', async () => {
+      prepareStreamResponse();
+
+      const { stream } = await createTestModel().doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+        inputAudioFormat,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+        { type: 'stream-start', warnings: [] },
+        { type: 'transcript-delta', delta: 'Hello' },
+        { type: 'transcript-delta', delta: ' world' },
+        {
+          type: 'finish',
+          text: 'Hello world',
+          segments: [{ text: 'Hello world', startSecond: 0, endSecond: 1 }],
+          language: 'en',
+          durationInSeconds: 1,
+        },
+      ]);
+    });
+
+    it('should coerce response-metadata timestamps to Date', async () => {
+      prepareStreamResponse({
+        chunks: [
+          `data: ${JSON.stringify({
+            type: 'response-metadata',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            modelId: 'openai/gpt-realtime-whisper',
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'finish',
+            text: 'Hello world',
+            segments: [],
+          })}\n\n`,
+        ],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+        inputAudioFormat,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      expect(parts[0]).toStrictEqual({
+        type: 'response-metadata',
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        modelId: 'openai/gpt-realtime-whisper',
+      });
+    });
+
+    it('should drop raw chunks unless includeRawChunks is set', async () => {
+      prepareStreamResponse({
+        chunks: [
+          `data: ${JSON.stringify({ type: 'raw', rawValue: { a: 1 } })}\n\n`,
+          `data: ${JSON.stringify({ type: 'transcript-delta', delta: 'Hi' })}\n\n`,
+          `data: ${JSON.stringify({ type: 'finish', text: 'Hi', segments: [] })}\n\n`,
+        ],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1])]),
+        inputAudioFormat,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+        { type: 'transcript-delta', delta: 'Hi' },
+        { type: 'finish', text: 'Hi', segments: [] },
+      ]);
+    });
+
+    it('should keep raw chunks when includeRawChunks is true', async () => {
+      prepareStreamResponse({
+        chunks: [
+          `data: ${JSON.stringify({ type: 'raw', rawValue: { a: 1 } })}\n\n`,
+          `data: ${JSON.stringify({ type: 'finish', text: 'Hi', segments: [] })}\n\n`,
+        ],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1])]),
+        inputAudioFormat,
+        includeRawChunks: true,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+        { type: 'raw', rawValue: { a: 1 } },
+        { type: 'finish', text: 'Hi', segments: [] },
+      ]);
+    });
+
+    it('should throw GatewayInvalidRequestError on 400', async () => {
+      server.urls['https://api.test.com/transcription-model'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          error: {
+            message: 'Invalid audio format',
+            type: 'invalid_request_error',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doStream({
+          audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+          inputAudioFormat,
+        }),
+      ).rejects.toSatisfy(
+        err =>
+          GatewayInvalidRequestError.isInstance(err) && err.statusCode === 400,
+      );
     });
   });
 

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -1,15 +1,19 @@
 import type {
+  Experimental_TranscriptionModelV4StreamPart,
   SharedV4ProviderMetadata,
   SharedV4Warning,
   TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
+  convertBase64ToUint8Array,
   convertUint8ArrayToBase64,
+  createEventSourceResponseHandler,
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
   resolve,
+  type ParseResult,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
@@ -54,7 +58,7 @@ export class GatewayTranscriptionModel implements TranscriptionModelV4 {
         headers: combineHeaders(
           resolvedHeaders,
           headers ?? {},
-          this.getModelConfigHeaders(),
+          this.getModelConfigHeaders(false),
           await resolve(this.config.o11yHeaders),
         ),
         body: {
@@ -99,16 +103,138 @@ export class GatewayTranscriptionModel implements TranscriptionModelV4 {
     }
   }
 
+  async doStream({
+    audio,
+    inputAudioFormat,
+    providerOptions,
+    headers,
+    abortSignal,
+    includeRawChunks,
+  }: Parameters<NonNullable<TranscriptionModelV4['doStream']>>[0]): Promise<
+    Awaited<ReturnType<NonNullable<TranscriptionModelV4['doStream']>>>
+  > {
+    const resolvedHeaders = this.config.headers
+      ? await resolve(this.config.headers)
+      : undefined;
+
+    try {
+      // The gateway is an HTTP proxy, so the live audio stream is buffered into
+      // a single base64 payload before the request. The transcript is then
+      // streamed back over SSE. This means transcription starts once all audio
+      // has been read, not while it is still being captured.
+      const body = {
+        audio: await collectAudioAsBase64(audio),
+        inputAudioFormat,
+        ...(providerOptions && { providerOptions }),
+      };
+
+      const { value: response, responseHeaders } = await postJsonToApi({
+        url: this.getUrl(),
+        headers: combineHeaders(
+          resolvedHeaders,
+          headers ?? {},
+          this.getModelConfigHeaders(true),
+          await resolve(this.config.o11yHeaders),
+        ),
+        body,
+        successfulResponseHandler: createEventSourceResponseHandler(z.any()),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        ...(abortSignal && { abortSignal }),
+        fetch: this.config.fetch,
+      });
+
+      return {
+        stream: response.pipeThrough(
+          new TransformStream<
+            ParseResult<Experimental_TranscriptionModelV4StreamPart>,
+            Experimental_TranscriptionModelV4StreamPart
+          >({
+            transform(chunk, controller) {
+              if (!chunk.success) {
+                controller.error(chunk.error);
+                return;
+              }
+
+              const part = chunk.value;
+
+              // Only surface raw provider chunks when explicitly requested.
+              if (part.type === 'raw' && !includeRawChunks) {
+                return;
+              }
+
+              // Timestamps are serialized as strings over SSE.
+              if (
+                part.type === 'response-metadata' &&
+                typeof part.timestamp === 'string'
+              ) {
+                part.timestamp = new Date(part.timestamp);
+              }
+
+              controller.enqueue(part);
+            },
+          }),
+        ),
+        request: { body },
+        response: { headers: responseHeaders },
+      };
+    } catch (error) {
+      throw await asGatewayError(
+        error,
+        await parseAuthMethod(resolvedHeaders ?? {}),
+      );
+    }
+  }
+
   private getUrl() {
     return `${this.config.baseURL}/transcription-model`;
   }
 
-  private getModelConfigHeaders() {
+  private getModelConfigHeaders(streaming: boolean) {
     return {
       'ai-transcription-model-specification-version': '4',
       'ai-model-id': this.modelId,
+      'ai-transcription-model-streaming': String(streaming),
     };
   }
+}
+
+/**
+ * Drains a raw-audio stream into a single base64 payload. `Uint8Array` chunks
+ * contain raw bytes; `string` chunks contain base64-encoded raw bytes.
+ */
+async function collectAudioAsBase64(
+  audio: ReadableStream<Uint8Array | string>,
+): Promise<string> {
+  const reader = audio.getReader();
+  const chunks: Array<Uint8Array> = [];
+  let totalLength = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      const bytes =
+        typeof value === 'string' ? convertBase64ToUint8Array(value) : value;
+      chunks.push(bytes);
+      totalLength += bytes.length;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return convertUint8ArrayToBase64(merged);
 }
 
 const providerMetadataEntrySchema = z.object({}).catchall(z.unknown());


### PR DESCRIPTION
## Background

Follow-up to #16338, which added `experimental_streamTranscribe` and left this as **Future Work**:

> Wire AI Gateway to expose a streaming transcription surface backed by these transcription-model streaming capabilities.

Before this change, `GatewayTranscriptionModel` only implemented `doGenerate`, so string model IDs (which resolve through the AI Gateway by default) threw `UnsupportedFunctionalityError`, and the transcription docs carried a Note saying the gateway "does not support streaming transcription yet."

## Summary

- `GatewayTranscriptionModel` now implements `doStream`, mirroring `GatewayLanguageModel.doStream` (`postJsonToApi` → `createEventSourceResponseHandler` SSE).
- `experimental_streamTranscribe` now works through the gateway, e.g. `gateway.transcription('openai/gpt-realtime-whisper')` or the `'openai/gpt-realtime-whisper'` string model ID.
- Added `doStream` unit tests, a gateway `stream-transcribe` example, docs update, and a patch changeset (`@ai-sdk/gateway`, `ai`).

```ts
import { gateway } from '@ai-sdk/gateway';
import { experimental_streamTranscribe as streamTranscribe } from 'ai';

const result = streamTranscribe({
  model: gateway.transcription('openai/gpt-realtime-whisper'),
  audio: audioStream, // ReadableStream<Uint8Array | string>
  inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
  providerOptions: { openai: { streaming: { delay: 'low' } } },
});

for await (const part of result.fullStream) {
  if (part.type === 'transcript-delta') process.stdout.write(part.delta);
}
```

## Decisions made

- **Transport: buffer + SSE proxy.** `doStream` drains the audio `ReadableStream` into a single base64 payload, POSTs it to `/transcription-model` with an `ai-transcription-model-streaming: true` header, and streams `TranscriptionModelV4StreamPart`s back over SSE. This was chosen because it mirrors the existing `GatewayLanguageModel.doStream` pattern exactly, keeping the gateway architecture consistent and the change fully reviewable.
- **Wire format** (SDK → gateway backend): request body `{ audio: <base64>, inputAudioFormat, providerOptions? }`; response is an SSE stream of `TranscriptionModelV4StreamPart`s (`stream-start`, `transcript-delta`/`partial`/`final`, `response-metadata`, `finish`, optional `raw`, `error`). `raw` chunks are dropped unless `includeRawChunks` is set; `response-metadata` timestamps are coerced from strings to `Date`.
- **Docs / error message updated** to reflect that the gateway now supports streaming transcription (removing the stale "not supported yet" wording).

## Caveats / please review

- ⚠️ **Not live.** Unlike OpenAI's genuinely bidirectional WebSocket path, the gateway buffers all audio before transcription starts — so this streams the transcript *out* but not the audio *in*. If a live/duplex or WebSocket transport is preferred, the implementation can be swapped.
- ⚠️ **Backend dependency.** This wires the SDK side only. It cannot be verified end-to-end from this repo — the hosted AI Gateway must actually serve a streaming `/transcription-model` endpoint matching the body/SSE contract above. **Please confirm the intended backend wire protocol (KDA-146) matches what's implemented here** before merge; happy to adjust to the real spec.

## Checklist

- [x] Tests added (`gateway-transcription-model.test.ts` `doStream` block)
- [x] Documentation updated (`content/docs/03-ai-sdk-core/36-transcription.mdx`)
- [x] Example added (`examples/ai-functions/src/stream-transcribe/gateway/basic.ts`)
- [x] Patch changeset added

cc @shaper @kkdawkins