### PR TITLE
fix(xai): fix streaming final text handling coming through output_item.done

### DIFF
--- a/.changeset/polite-rings-look.md
+++ b/.changeset/polite-rings-look.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+fix(xai): fix streaming final text handling coming through output_item.done

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -2298,6 +2298,81 @@ describe('XaiResponsesLanguageModel', () => {
         expect(parts).toMatchSnapshot();
       });
 
+      it('should emit final text from response.output_item.done after streaming', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_issue_13836',
+              object: 'response',
+              model: 'grok-4-1-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: {
+              type: 'message',
+              id: 'msg_issue_13836',
+              role: 'assistant',
+              status: 'in_progress',
+              content: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_text.delta',
+            item_id: 'msg_issue_13836',
+            output_index: 0,
+            content_index: 0,
+            delta: '1. alfa beta gama\n',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: {
+              type: 'message',
+              id: 'msg_issue_13836',
+              role: 'assistant',
+              status: 'completed',
+              content: [
+                {
+                  type: 'output_text',
+                  text: '2. delta epsilon zeta\nEND_OK_9981',
+                  annotations: [],
+                },
+              ],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_issue_13836',
+              object: 'response',
+              model: 'grok-4-1-fast-non-reasoning',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel(
+          'grok-4-1-fast-non-reasoning',
+        ).doStream({
+          prompt: TEST_PROMPT,
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+        const textDeltas = parts.filter(part => part.type === 'text-delta');
+
+        expect(textDeltas.map(d => d.delta)).toEqual([
+          '1. alfa beta gama\n',
+          '2. delta epsilon zeta\nEND_OK_9981',
+        ]);
+      });
+
       it('should not emit duplicate text-delta from response.output_item.done after streaming', async () => {
         prepareStreamChunks([
           JSON.stringify({

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -517,7 +517,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     let usage: LanguageModelV4Usage | undefined = undefined;
     let costInUsdTicks: number | undefined = undefined;
     let isFirstChunk = true;
-    const contentBlocks: Record<string, { type: 'text' }> = {};
+    const contentBlocks: Record<string, { type: 'text'; text: string }> = {};
     const seenToolCalls = new Set<string>();
 
     // Track ongoing function calls by output_index so we can stream
@@ -644,9 +644,11 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
 
             if (event.type === 'response.output_text.delta') {
               const blockId = `text-${event.item_id}`;
+              let block = contentBlocks[blockId];
 
-              if (contentBlocks[blockId] == null) {
-                contentBlocks[blockId] = { type: 'text' };
+              if (block == null) {
+                block = { type: 'text', text: '' };
+                contentBlocks[blockId] = block;
                 controller.enqueue({
                   type: 'text-start',
                   id: blockId,
@@ -658,6 +660,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                 id: blockId,
                 delta: event.delta,
               });
+              block.text += event.delta;
 
               return;
             }
@@ -963,20 +966,28 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                 for (const contentPart of part.content) {
                   if (contentPart.text && contentPart.text.length > 0) {
                     const blockId = `text-${part.id}`;
+                    let block = contentBlocks[blockId];
 
-                    // Only emit text if we haven't already streamed it via output_text.delta events
-                    if (contentBlocks[blockId] == null) {
-                      contentBlocks[blockId] = { type: 'text' };
+                    if (block == null) {
+                      block = { type: 'text', text: '' };
+                      contentBlocks[blockId] = block;
                       controller.enqueue({
                         type: 'text-start',
                         id: blockId,
                       });
+                    }
 
+                    const delta = contentPart.text.startsWith(block.text)
+                      ? contentPart.text.slice(block.text.length)
+                      : contentPart.text;
+
+                    if (delta.length > 0) {
                       controller.enqueue({
                         type: 'text-delta',
                         id: blockId,
-                        delta: contentPart.text,
+                        delta,
                       });
+                      block.text += delta;
                     }
                   }
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/13836

When using the xAI Responses path, the adapter can silently drop final text fragments coming  via the output_item.done in streaming mode if the content block already exists.

## Summary

Every streamed `output_text.delta` appends to `block.text`. Then, when `output_item.done` arrives, it compares the final/done text against what was already emitted

- If `output_item.done` contains the full accumulated text it emits nothing extra.
- If `output_item.done` contains only additional final text, like the repro, it emits that final text.
- If no text was streamed before, it still starts a text block and emits the done text.

## Manual Verification

verified by the diff in https://github.com/vercel/ai/tree/bug-reproduction/13836-1

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #13836 