### PR TITLE
feat(xai): add promptCacheKey provider option to the Responses API

### DIFF
--- a/.changeset/xai-prompt-cache-key.md
+++ b/.changeset/xai-prompt-cache-key.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+feat(xai): add promptCacheKey provider option to the Responses API

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -513,6 +513,10 @@ The following provider options are available:
 
   The ID of the previous response from the model. You can use it to continue a conversation.
 
+- **promptCacheKey** _string_
+
+  A stable cache routing key (for example a conversation ID). Requests with the same key are routed to the same server, maximizing [prompt cache](https://docs.x.ai/developers/advanced-api-usage/prompt-caching) hits across consecutive requests.
+
 <Note>
   The Responses API only supports server-side tools. You cannot mix server-side
   tools with client-side function tools in the same request.

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -35,8 +35,8 @@ export const xaiLanguageModelResponsesOptions = z.object({
    */
   previousResponseId: z.string().optional(),
   /**
-   * A stable cache routing key. Requests with the same key are routed to the
-   * same server, maximizing prompt cache hits across consecutive requests.
+   * Stable cache routing key; requests with the same key are routed to the
+   * same server to maximize prompt cache hits.
    *
    * @see https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
    */

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -35,6 +35,13 @@ export const xaiLanguageModelResponsesOptions = z.object({
    */
   previousResponseId: z.string().optional(),
   /**
+   * A stable cache routing key. Requests with the same key are routed to the
+   * same server, maximizing prompt cache hits across consecutive requests.
+   *
+   * @see https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+   */
+  promptCacheKey: z.string().optional(),
+  /**
    * Specify additional output data to include in the model response.
    * Example values: 'file_search_call.results'.
    */

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -35,8 +35,8 @@ export const xaiLanguageModelResponsesOptions = z.object({
    */
   previousResponseId: z.string().optional(),
   /**
-   * Stable cache routing key; requests with the same key are routed to the
-   * same server to maximize prompt cache hits.
+   * A stable cache routing key. Requests that share the same key are routed
+   * to the same server, which increases prompt cache hits.
    *
    * @see https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
    */

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -777,6 +777,29 @@ describe('XaiResponsesLanguageModel', () => {
           expect(requestBody.previous_response_id).toBe('resp_456');
         });
 
+        it('promptCacheKey', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                promptCacheKey: 'conv-abc-123',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.prompt_cache_key).toBe('conv-abc-123');
+        });
+
         it('include with file_search_call.results', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -228,6 +228,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
       ...(options.previousResponseId != null && {
         previous_response_id: options.previousResponseId,
       }),
+      ...(options.promptCacheKey != null && {
+        prompt_cache_key: options.promptCacheKey,
+      }),
     };
 
     if (xaiTools && xaiTools.length > 0) {


### PR DESCRIPTION
## Background

xAI's Responses API accepts a `prompt_cache_key` field; requests sharing the same key are routed to the same server, increasing prompt cache hits ([xAI docs](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits)). The xAI documentation already shows `providerOptions: { xai: { promptCacheKey } }` in its AI SDK example, but the option does not exist in `@ai-sdk/xai` and is silently dropped.

## Summary

Adds a `promptCacheKey` provider option to the xAI Responses API language model, sent as `prompt_cache_key` in the request body. Mirrors the existing option on `@ai-sdk/openai`.

## Manual Verification

Ran the built package against the live API with a fetch wrapper recording outgoing requests: the option appeared as `prompt_cache_key` in the request body, the API accepted it, and repeated calls with the same key reported cached tokens in `usage.input_tokens_details`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
