### PR TITLE
fix(alibaba): do not derive a ratio from an unsupported resolution for wan2.7 video models

### DIFF
--- a/.changeset/alibaba-wan27-ratio-derivation.md
+++ b/.changeset/alibaba-wan27-ratio-derivation.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/alibaba': patch
+---
+
+fix(alibaba): do not derive a ratio from an unsupported resolution for wan2.7 video models
+
+When an unsupported resolution (e.g. `1024x768`) was passed to a wan2.7 text-to-video or reference-to-video model, the resolution was correctly warned about and ignored, but a `ratio` was still derived from that same ignored resolution and sent to the API. For 4:3/3:4 resolutions this produced a `ratio` (e.g. `4:3`) that wan2.7 models do not support, resulting in a request the API rejects. The ratio is now only derived from a resolution that was actually accepted.

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -1031,6 +1031,28 @@ describe('AlibabaVideoModel', () => {
       expect(body.parameters).toMatchObject({ size: '1920*1080' });
       expect(body.parameters).not.toHaveProperty('ratio');
     });
+
+    it('should not derive a ratio from an unsupported resolution', async () => {
+      const model = createModel({ modelId: 'wan2.7-t2v' });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        // 1024x768 is 4:3 and not a supported 720P/1080P tier. It must be
+        // ignored entirely, without leaking a "4:3" ratio (which wan2.7 does
+        // not support) derived from it.
+        resolution: '1024x768',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.parameters).not.toHaveProperty('resolution');
+      expect(body.parameters).not.toHaveProperty('ratio');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'resolution',
+        }),
+      );
+    });
   });
 
   describe('headers', () => {

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -361,6 +361,7 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
     }
 
     // Resolution / Size mapping
+    let resolutionAccepted = false;
     if (options.resolution != null) {
       if (mode === 'i2v' || wan27) {
         // I2V and wan2.7 models use "720P" / "1080P" format
@@ -376,20 +377,26 @@ export class AlibabaVideoModel implements Experimental_VideoModelV4 {
           });
         } else {
           parameters.resolution = resolutionTier;
+          resolutionAccepted = true;
         }
       } else {
         // wan2.6 T2V and R2V use "WIDTH*HEIGHT" format for the size parameter
         // Convert "WIDTHxHEIGHT" (SDK standard) to "WIDTH*HEIGHT" (Alibaba API)
         parameters.size = options.resolution.replace('x', '*');
+        resolutionAccepted = true;
       }
     }
 
-    // wan2.7 T2V and R2V support an explicit aspect ratio parameter
+    // wan2.7 T2V and R2V support an explicit aspect ratio parameter.
+    // Only derive a ratio from the resolution when that resolution was
+    // accepted: an unsupported resolution is ignored (see the warning above),
+    // so deriving a ratio from it would silently send a ratio the model does
+    // not support (e.g. "4:3" from "1024x768").
     if (supportsRatio) {
       const ratio =
         alibabaOptions?.ratio ??
         options.aspectRatio ??
-        (options.resolution != null
+        (resolutionAccepted && options.resolution != null
           ? deriveRatioFromResolution(options.resolution)
           : undefined);
       if (ratio != null) {


### PR DESCRIPTION
## Background

wan2.7 video models (`wan2.7-t2v`, `wan2.7-r2v`, and dated snapshots) map the SDK `resolution` to a resolution tier (`720P`/`1080P`) plus a separate `ratio` parameter. When neither `providerOptions.alibaba.ratio` nor `aspectRatio` is set, the `ratio` is derived from the `resolution`.

That derivation ran even for a resolution that was rejected as unsupported. An unsupported resolution is warned about and dropped, but a `ratio` derived from that same dropped resolution was still sent. For a 4:3 resolution such as `1024x768` this produced `ratio: "4:3"`, which wan2.7 does not support (per the official API reference the valid values are `16:9`, `9:16`, `1:1`), silently making the request invalid.

## Summary

- Track whether the resolution was accepted (`resolutionAccepted`).
- Only derive a `ratio` from the resolution when it was accepted (a supported `720P`/`1080P` tier). Explicit `ratio`/`aspectRatio` handling is unchanged.

Accepted tier resolutions only ever derive `16:9`, `9:16`, or `1:1`, so behavior for all valid inputs is identical; the change only stops the invalid `ratio` from being emitted for rejected resolutions.

## Manual Verification

Probed the outgoing request body against a mock server for `wan2.7-t2v`:

| Input | Before | After |
| --- | --- | --- |
| `1920x1080` | `resolution: 1080P, ratio: 16:9` | unchanged |
| `720x1280` | `resolution: 720P, ratio: 9:16` | unchanged |
| `960x960` | `resolution: 720P, ratio: 1:1` | unchanged |
| `1024x768` (unsupported 4:3) | `ratio: 4:3` (+ resolution warning) | no `ratio`, no `resolution` (+ resolution warning) |

Ran `pnpm --filter @ai-sdk/alibaba test` (node + edge, 132 tests) and lint/format/build — all green.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16663
