### PR TITLE
reproduction: Reproduces #13218

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-13218-xai-provider-tool-result.ts
+++ b/examples/ai-functions/src/reproduction/issue-13218-xai-provider-tool-result.ts
@@ -1,0 +1,188 @@
+import 'dotenv/config';
+
+import { xai } from '@ai-sdk/xai';
+import {
+  APICallError,
+  LoadAPIKeyError,
+  streamText,
+  type TextStreamPart,
+} from 'ai';
+
+const ISSUE_DESCRIPTION =
+  'vercel/ai#13218: xAI Responses provider-executed web_search streams a tool-call but no tool-result.';
+
+type ToolEvents = {
+  toolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    providerExecuted?: boolean;
+  }>;
+  toolResults: Array<{
+    toolCallId: string;
+    toolName: string;
+    providerExecuted?: boolean;
+    output: unknown;
+  }>;
+  inputEvents: string[];
+};
+
+function isAccessBlocker(error: unknown) {
+  if (LoadAPIKeyError.isInstance(error)) {
+    return true;
+  }
+
+  if (APICallError.isInstance(error)) {
+    return (
+      error.statusCode === 401 ||
+      error.statusCode === 402 ||
+      error.statusCode === 403 ||
+      error.statusCode === 429
+    );
+  }
+
+  return false;
+}
+
+function describeError(error: unknown) {
+  if (APICallError.isInstance(error)) {
+    return JSON.stringify(
+      {
+        name: error.name,
+        message: error.message,
+        statusCode: error.statusCode,
+        responseBody: error.responseBody,
+      },
+      null,
+      2,
+    );
+  }
+
+  if (error instanceof Error) {
+    return JSON.stringify(
+      {
+        name: error.name,
+        message: error.message,
+      },
+      null,
+      2,
+    );
+  }
+
+  return JSON.stringify(error, null, 2);
+}
+
+async function main() {
+  console.log(ISSUE_DESCRIPTION);
+  console.log(
+    'Running a real xAI Responses API stream with xai.tools.webSearch() and asserting every provider-executed tool-call has a matching provider-executed tool-result.',
+  );
+
+  const result = streamText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    tools: {
+      webSearch: xai.tools.webSearch(),
+    },
+    toolChoice: 'required',
+    maxOutputTokens: 512,
+    prompt:
+      'Use the web_search tool to search the web for the latest public Vercel AI SDK release information, then summarize it in one sentence.',
+  });
+
+  const events: ToolEvents = {
+    toolCalls: [],
+    toolResults: [],
+    inputEvents: [],
+  };
+
+  for await (const part of result.stream as AsyncIterable<TextStreamPart<any>>) {
+    switch (part.type) {
+      case 'tool-input-start':
+      case 'tool-input-delta':
+      case 'tool-input-end': {
+        events.inputEvents.push(part.type);
+        console.log(`[${part.type}] ${part.toolName} ${part.toolCallId}`);
+        break;
+      }
+
+      case 'tool-call': {
+        events.toolCalls.push({
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          providerExecuted: part.providerExecuted,
+        });
+        console.log(
+          `[tool-call] ${part.toolName} ${part.toolCallId} providerExecuted=${String(
+            part.providerExecuted,
+          )}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        events.toolResults.push({
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          providerExecuted: part.providerExecuted,
+          output: part.output,
+        });
+        console.log(
+          `[tool-result] ${part.toolName} ${part.toolCallId} providerExecuted=${String(
+            part.providerExecuted,
+          )} output=${JSON.stringify(part.output)}`,
+        );
+        break;
+      }
+
+      case 'error': {
+        throw part.error;
+      }
+    }
+  }
+
+  console.log('Observed xAI provider-executed tool events:');
+  console.log(JSON.stringify(events, null, 2));
+
+  const providerExecutedToolCalls = events.toolCalls.filter(
+    toolCall => toolCall.providerExecuted === true,
+  );
+  const providerExecutedToolResults = events.toolResults.filter(
+    toolResult => toolResult.providerExecuted === true,
+  );
+
+  if (providerExecutedToolCalls.length === 0) {
+    throw new Error(
+      'The live xAI response did not make a provider-executed webSearch tool-call, so this run did not exercise issue #13218.',
+    );
+  }
+
+  const missingResults = providerExecutedToolCalls.filter(
+    toolCall =>
+      !providerExecutedToolResults.some(
+        toolResult => toolResult.toolCallId === toolCall.toolCallId,
+      ),
+  );
+
+  if (missingResults.length > 0) {
+    throw new Error(
+      `Reproduced #13218: provider-executed tool-call(s) had no matching provider-executed tool-result: ${JSON.stringify(
+        missingResults,
+      )}`,
+    );
+  }
+
+  console.log(
+    'Could not reproduce #13218: every provider-executed xAI webSearch tool-call had a matching provider-executed tool-result.',
+  );
+}
+
+main().catch(error => {
+  if (isAccessBlocker(error)) {
+    console.error('External provider access blocker while attempting #13218:');
+    console.error(describeError(error));
+    process.exitCode = 2;
+    return;
+  }
+
+  console.error(describeError(error));
+  process.exitCode = 1;
+});

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -2454,6 +2454,85 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      it('should emit a tool-result when a provider-executed web_search tool call is done', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_123',
+              name: 'web_search',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_123',
+              name: 'web_search',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'completed',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'ws_123',
+          toolName: 'web_search',
+          input: '{"query":"test"}',
+          providerExecuted: true,
+        });
+
+        expect(parts).toContainEqual(
+          expect.objectContaining({
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'web_search',
+          }),
+        );
+      });
+
       it('should stream function tool call arguments', async () => {
         prepareStreamChunks([
           JSON.stringify({


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction script examples/ai-functions/src/reproduction/issue-13218-xai-provider-tool-result.ts and failing regression test packages/xai/src/responses/xai-responses-language-model.test.ts. Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-13218-xai-provider-tool-result.ts`; the live xAI Responses webSearch stream emitted providerExecuted tool-call/tool-input chunks but 0 tool-result chunks, failing with the reported missing tool-result. Also ran `pnpm -C packages/xai test:node src/responses/xai-responses-language-model.test.ts -t "should emit a tool-result when a provider-executed web_search tool call is done"`; it failed because the adapter output contained tool-call but no tool-result. Expected issue behavior is a provider-executed tool-result after response.output_item.done; no blocker.

## Branch

bug-13218-4

## Related Issues

Reproduces #13218