### PR TITLE
docs: clarify onToolCall output handling

### DIFF
--- a/.changeset/bright-cameras-serve.md
+++ b/.changeset/bright-cameras-serve.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Clarify that `onToolCall` return values are ignored and tool outputs must be provided with `addToolOutput`.

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -208,8 +208,8 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
    * Optional callback function that is invoked when a tool call is received.
    * Intended for automatic client-side tool execution.
    *
-   * You can optionally return a result for the tool call,
-   * either synchronously or asynchronously.
+   * The callback return value is ignored. To provide a tool result, call
+   * `addToolOutput` with the tool call id and output.
    */
   onToolCall?: ChatOnToolCallCallback<UI_MESSAGE>;
 


### PR DESCRIPTION
## Summary

- Update `onToolCall` JSDoc to match the callback type and implementation.
- Clarify that returned values are ignored.
- Point users to `addToolOutput` for resolving client-executed tool calls.

Fixes #15268.

## Verification

- `./node_modules/.bin/oxfmt --check packages/ai/src/ui/chat.ts .changeset/bright-cameras-serve.md`
- `./node_modules/.bin/oxlint packages/ai/src/ui/chat.ts`