### PR TITLE
docs: include approval tool states in switch example

### DIFF
--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -635,6 +635,16 @@ export default function Chat() {
                     return <pre>{JSON.stringify(part.output, null, 2)}</pre>;
                   case 'output-error':
                     return <div>Error: {part.errorText}</div>;
+                  case 'approval-requested':
+                    return <div>Waiting for approval...</div>;
+                  case 'approval-responded':
+                    return (
+                      <div>
+                        Approval {part.approval.approved ? 'granted' : 'denied'}
+                      </div>
+                    );
+                  case 'output-denied':
+                    return <div>Tool execution was denied.</div>;
                 }
             }
           })}


### PR DESCRIPTION
## Summary

- Add `approval-requested`, `approval-responded`, and `output-denied` to the tool state switch example.
- Keep the streaming tool call example aligned with the approval states documented earlier on the page.

Fixes #12303.

## Verification

- `./node_modules/.bin/oxfmt --check content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx`
- `git diff --check`