### PR TITLE
docs: fix legacy telemetry tool span hierarchy

### DIFF
--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -646,7 +646,7 @@ This is the legacy format. Consider migrating to the `OpenTelemetry` for better 
 
 `generateText` records 3 types of spans:
 
-- `ai.generateText` (span): the full length of the generateText call. It contains 1 or more `ai.generateText.doGenerate` spans.
+- `ai.generateText` (span): the full length of the generateText call. It contains 1 or more `ai.generateText.doGenerate` spans and any `ai.toolCall` spans.
   It contains the [basic LLM span information](#basic-llm-span-information) and the following attributes:
   - `operation.name`: `ai.generateText` and the functionId that was set through `telemetry.functionId`
   - `ai.operationId`: `"ai.generateText"`
@@ -656,7 +656,7 @@ This is the legacy format. Consider migrating to the `OpenTelemetry` for better 
   - `ai.response.finishReason`: the reason why the generation finished
   - `ai.settings.maxOutputTokens`: the maximum number of output tokens that were set
 
-- `ai.generateText.doGenerate` (span): a provider doGenerate call. It can contain `ai.toolCall` spans.
+- `ai.generateText.doGenerate` (span): a provider doGenerate call.
   It contains the [call LLM span information](#call-llm-span-information) and the following attributes:
   - `operation.name`: `ai.generateText.doGenerate` and the functionId that was set through `telemetry.functionId`
   - `ai.operationId`: `"ai.generateText.doGenerate"`
@@ -676,7 +676,7 @@ This is the legacy format. Consider migrating to the `OpenTelemetry` for better 
 
 `streamText` records 3 types of spans and 2 types of events:
 
-- `ai.streamText` (span): the full length of the streamText call. It contains a `ai.streamText.doStream` span.
+- `ai.streamText` (span): the full length of the streamText call. It contains a `ai.streamText.doStream` span and any `ai.toolCall` spans.
   It contains the [basic LLM span information](#basic-llm-span-information) and the following attributes:
   - `operation.name`: `ai.streamText` and the functionId that was set through `telemetry.functionId`
   - `ai.operationId`: `"ai.streamText"`
@@ -687,7 +687,7 @@ This is the legacy format. Consider migrating to the `OpenTelemetry` for better 
   - `ai.settings.maxOutputTokens`: the maximum number of output tokens that were set
 
 - `ai.streamText.doStream` (span): a provider doStream call.
-  This span contains an `ai.stream.firstChunk` event and `ai.toolCall` spans.
+  This span contains an `ai.stream.firstChunk` event.
   It contains the [call LLM span information](#call-llm-span-information) and the following attributes:
   - `operation.name`: `ai.streamText.doStream` and the functionId that was set through `telemetry.functionId`
   - `ai.operationId`: `"ai.streamText.doStream"`


### PR DESCRIPTION
## Summary

- Clarify that legacy `ai.toolCall` spans are children of the top-level `ai.generateText` / `ai.streamText` spans.
- Remove the implication that provider `doGenerate` / `doStream` spans contain tool call spans.

Fixes #10037.

## Verification

- `./node_modules/.bin/oxfmt --check content/docs/03-ai-sdk-core/60-telemetry.mdx`
- `git diff --check`