### PR TITLE
docs: clarify originalMessages for merged UI streams

### DIFF
--- a/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
@@ -47,7 +47,12 @@ const stream = createUIMessageStream({
       prompt: 'Write a haiku about AI',
     });
 
-    writer.merge(toUIMessageStream({ stream: result.stream }));
+    writer.merge(
+      toUIMessageStream({
+        stream: result.stream,
+        originalMessages: existingMessages,
+      }),
+    );
   },
   onError: error => `Custom error: ${error.message}`,
   originalMessages: existingMessages,
@@ -56,6 +61,12 @@ const stream = createUIMessageStream({
   },
 });
 ```
+
+<Note>
+  When you merge a `streamText` result that can continue existing tool calls,
+  including tool approval flows, pass the same `originalMessages` to both
+  `createUIMessageStream` and `toUIMessageStream`.
+</Note>
 
 ## API Signature
 


### PR DESCRIPTION
## Summary

- Pass `originalMessages` through the `createUIMessageStream` reference example when merging a `toUIMessageStream` result.
- Add a note for tool approval flows that continue existing tool calls.

Fixes #12622.

## Verification

- `./node_modules/.bin/oxfmt --check content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx`
- `git diff --check`