### PR TITLE
docs: clarify toUIMessageStream onError frequency

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -4005,7 +4005,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: '(error: unknown) => string',
               isOptional: true,
               description:
-                'Process an error, e.g. to log it. Returns error message to include in the data stream. Defaults to () => "An error occurred."',
+                'Process an error and return the error message to include in the data stream. This callback may be invoked more than once for the same upstream error, so side effects such as logging, metrics, or persistence should be idempotent or deduplicated externally. Defaults to () => "An error occurred."',
             },
             {
               name: 'consumeSseStream',


### PR DESCRIPTION
## Summary

- Clarify that `toUIMessageStream` `onError` may run more than once for the same upstream error.
- Recommend idempotent or externally deduplicated side effects for logging, metrics, and persistence.

Fixes #14726.

## Verification

- `./node_modules/.bin/oxfmt --check content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx`
- `git diff --check`