### PR TITLE
docs: clarify Google Vertex image configuration

### DIFF
--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -963,10 +963,18 @@ You can create image models using the `.image()` factory method. The Google Vert
 #### Imagen Models
 
 [Imagen models](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images) generate images using the Imagen on Vertex AI API.
+Configure the provider with a Google Cloud project and location, or set the
+corresponding `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` environment
+variables for the default provider instance.
 
 ```ts
-import { googleVertex } from '@ai-sdk/google-vertex';
+import { createGoogleVertex } from '@ai-sdk/google-vertex';
 import { generateImage } from 'ai';
+
+const googleVertex = createGoogleVertex({
+  project: 'my-project',
+  location: 'us-central1',
+});
 
 const { image } = await generateImage({
   model: googleVertex.image('imagen-4.0-generate-001'),


### PR DESCRIPTION
## Summary

- Clarify that Imagen examples need a Google Cloud project and location.
- Show `createGoogleVertex` configuration in the image generation example.
- Mention the default provider can use `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION`.

Fixes #7587.

## Verification

- `./node_modules/.bin/oxfmt --check content/providers/01-ai-sdk-providers/16-google-vertex.mdx`
- `git diff --check`