### PR TITLE
docs: clarify finish chunk message id handling

### DIFF
--- a/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
@@ -445,6 +445,8 @@ data: {"type":"finish-step"}
 ### Finish Message Part
 
 A part indicating the completion of a message.
+The message ID is established by the preceding [message start part](#message-start-part);
+the finish part does not include a `messageId`.
 
 Format: Server-Sent Event with JSON object
 


### PR DESCRIPTION
## Summary

- Clarify that UI message IDs are established by the start chunk.
- Note that the finish message part does not include a `messageId`.

Refs #8095.

## Verification

- `./node_modules/.bin/oxfmt --check content/docs/04-ai-sdk-ui/50-stream-protocol.mdx`
- `git diff --check`