### PR TITLE
docs: add ToolLoopAgent testing example

### DIFF
--- a/content/docs/03-ai-sdk-core/55-testing.mdx
+++ b/content/docs/03-ai-sdk-core/55-testing.mdx
@@ -179,6 +179,41 @@ const result = streamText({
 });
 ```
 
+### ToolLoopAgent
+
+```ts
+import { ToolLoopAgent } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+
+const agent = new ToolLoopAgent({
+  model: new MockLanguageModelV4({
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: 'Hello from the test agent!' }],
+      finishReason: { unified: 'stop', raw: undefined },
+      usage: {
+        inputTokens: {
+          total: 10,
+          noCache: 10,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: 20,
+          text: 20,
+          reasoning: undefined,
+        },
+      },
+      warnings: [],
+    }),
+  }),
+  instructions: 'You are a test agent.',
+});
+
+const result = await agent.generate({
+  prompt: 'Say hello.',
+});
+```
+
 ### Simulate UI Message Stream Responses
 
 You can also simulate [UI Message Stream](/docs/ai-sdk-ui/stream-protocol#ui-message-stream) responses for testing,


### PR DESCRIPTION
## Summary

- Add a `ToolLoopAgent` example to the AI SDK Core testing guide.
- Show how to construct an agent with `MockLanguageModelV4` and call `agent.generate` in tests.

Fixes #12616.

## Verification

- `./node_modules/.bin/oxfmt --check content/docs/03-ai-sdk-core/55-testing.mdx`
- `git diff --check`