### PR TITLE
fix(anthropic): forward thinking { type: 'disabled' } to the API

### DIFF
--- a/.changeset/anthropic-thinking-disabled.md
+++ b/.changeset/anthropic-thinking-disabled.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): forward `thinking: { type: 'disabled' }` to the API instead of stripping it
+
+Previously, setting `providerOptions.anthropic.thinking = { type: 'disabled' }` (or top-level `reasoning: 'none'`) was accepted by the schema but silently dropped from the outgoing request. For models that default thinking on (e.g. Sonnet 5), this left thinking enabled and could consume a small `max_tokens` budget entirely. The `disabled` value is now sent to the Anthropic Messages API.

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -221,6 +221,51 @@ describe('AnthropicLanguageModel', () => {
       });
     });
 
+    describe('reasoning (thinking disabled)', () => {
+      it('should forward thinking { type: "disabled" } to the API instead of stripping it', async () => {
+        prepareJsonFixtureResponse('anthropic-text');
+
+        const result = await provider('claude-sonnet-5').doGenerate({
+          prompt: TEST_PROMPT,
+          maxOutputTokens: 100,
+          providerOptions: {
+            anthropic: {
+              thinking: { type: 'disabled' },
+            } satisfies AnthropicLanguageModelOptions,
+          },
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.thinking).toEqual({ type: 'disabled' });
+        // disabled thinking must not reserve a thinking budget in max_tokens
+        expect(requestBody.max_tokens).toBe(100);
+        expect(result.warnings).toEqual([]);
+      });
+
+      it('should not strip temperature / topP / topK when thinking is disabled', async () => {
+        prepareJsonFixtureResponse('anthropic-text');
+
+        const result = await provider('claude-sonnet-4-5').doGenerate({
+          prompt: TEST_PROMPT,
+          maxOutputTokens: 100,
+          temperature: 0.5,
+          topK: 0.1,
+          providerOptions: {
+            anthropic: {
+              thinking: { type: 'disabled' },
+            } satisfies AnthropicLanguageModelOptions,
+          },
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.thinking).toEqual({ type: 'disabled' });
+        // unlike enabled thinking, disabled thinking keeps sampling params
+        expect(requestBody.temperature).toBe(0.5);
+        expect(requestBody.top_k).toBe(0.1);
+        expect(result.warnings).toEqual([]);
+      });
+    });
+
     describe('top-level reasoning (newer models with adaptive thinking)', () => {
       it('should not set thinking config when reasoning is "provider-default"', async () => {
         prepareJsonFixtureResponse('anthropic-text');
@@ -245,7 +290,7 @@ describe('AnthropicLanguageModel', () => {
         });
 
         const requestBody = await server.calls[0].requestBodyJson;
-        expect(requestBody.thinking).toBeUndefined();
+        expect(requestBody.thinking).toEqual({ type: 'disabled' });
         expect(requestBody.output_config).toBeUndefined();
         expect(result.warnings).toEqual([]);
       });
@@ -396,7 +441,7 @@ describe('AnthropicLanguageModel', () => {
         });
 
         const requestBody = await server.calls[0].requestBodyJson;
-        expect(requestBody.thinking).toBeUndefined();
+        expect(requestBody.thinking).toEqual({ type: 'disabled' });
         expect(result.warnings).toEqual([]);
       });
 
@@ -536,7 +581,7 @@ describe('AnthropicLanguageModel', () => {
         });
 
         const requestBody = await server.calls[0].requestBodyJson;
-        expect(requestBody.thinking).toBeUndefined();
+        expect(requestBody.thinking).toEqual({ type: 'disabled' });
         expect(requestBody.output_config).toBeUndefined();
       });
 

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -422,6 +422,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
     const thinkingType = anthropicOptions?.thinking?.type;
     const isThinking =
       thinkingType === 'enabled' || thinkingType === 'adaptive';
+    // `disabled` must still be forwarded to the API: some models (e.g. Sonnet 5)
+    // default thinking on, so omitting it would leave thinking enabled and
+    // consume the max_tokens budget.
+    const sendThinking = isThinking || thinkingType === 'disabled';
     let thinkingBudget =
       thinkingType === 'enabled'
         ? anthropicOptions?.thinking?.budgetTokens
@@ -445,7 +449,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       stop_sequences: stopSequences,
 
       // provider specific settings:
-      ...(isThinking && {
+      ...(sendThinking && {
         thinking: {
           type: thinkingType,
           ...(thinkingBudget != null && { budget_tokens: thinkingBudget }),


### PR DESCRIPTION
## Background

Setting `providerOptions.anthropic.thinking = { type: 'disabled' }` (or top-level `reasoning: 'none'`) was accepted by the provider-options schema but silently dropped from the outgoing request. The request builder only emitted the `thinking` field when the type was `enabled` or `adaptive`:

```ts
const isThinking = thinkingType === 'enabled' || thinkingType === 'adaptive';
// ...
...(isThinking && { thinking: { type: thinkingType, ... } }),
```

The Anthropic Messages API accepts `thinking: { type: 'disabled' }` as an explicit value. Because it was stripped, models that default thinking on (e.g. Sonnet 5) kept thinking enabled even when the caller explicitly disabled it — and with a small `max_tokens` budget, that budget could be consumed entirely by thinking.

## Summary

- Forward `thinking: { type: 'disabled' }` to the Anthropic API instead of omitting it (new `sendThinking` flag that additionally covers the `disabled` type).
- Keep the "thinking enabled" handling (default budget warning, `max_tokens` budget adjustment, temperature/topP/topK stripping) gated on `isThinking`, so disabling thinking does **not** strip sampling params or reserve budget.
- This also fixes the top-level `reasoning: 'none'` path, which resolves to `{ type: 'disabled' }` and was affected by the same silent drop.

## Manual Verification

Captured the outgoing request body via the test server.

Before — `thinking` absent for `claude-sonnet-5` with `thinking: { type: 'disabled' }`:

```json
{ "model": "claude-sonnet-5", "max_tokens": 100, "messages": [ ... ] }
```

After:

```json
{ "model": "claude-sonnet-5", "max_tokens": 100, "thinking": { "type": "disabled" }, "messages": [ ... ] }
```

`max_tokens` stays at the requested value (no thinking budget reserved), and sampling params are preserved on models that support them.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16686
