### PR TITLE
fix(sandbox): pass env into just-bash commands

### DIFF
--- a/.changeset/fuzzy-mails-brush.md
+++ b/.changeset/fuzzy-mails-brush.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/sandbox-just-bash': patch
+---
+
+Pass per-command env values through to just-bash commands.

--- a/packages/sandbox-just-bash/src/just-bash-sandbox-session.test.ts
+++ b/packages/sandbox-just-bash/src/just-bash-sandbox-session.test.ts
@@ -53,6 +53,41 @@ describe('JustBashSandboxSession', () => {
       expect(result.stdout.trim()).toBe('/tmp/cwd-test');
     });
 
+    it('honours env variables', async () => {
+      const result = await sandbox.run({
+        command: 'printf "%s" "$WORK_DIR"',
+        env: { WORK_DIR: '/home/user/repro-dir' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('/home/user/repro-dir');
+    });
+
+    it('uses env variables when creating directories', async () => {
+      const mkdir = await sandbox.run({
+        command: 'mkdir -p "$WORK_DIR"',
+        env: { WORK_DIR: '/home/user/repro-dir' },
+      });
+
+      expect(mkdir.exitCode).toBe(0);
+
+      const cd = await sandbox.run({
+        command: 'cd /home/user/repro-dir && pwd',
+      });
+
+      expect(cd.exitCode).toBe(0);
+      expect(cd.stdout.trim()).toBe('/home/user/repro-dir');
+    });
+
+    it('shell-quotes env values', async () => {
+      const result = await sandbox.run({
+        command: 'printf "%s" "$PAYLOAD"',
+        env: { PAYLOAD: "one two ' three" },
+      });
+
+      expect(result.stdout).toBe("one two ' three");
+    });
+
     it('throws when abortSignal is already aborted', async () => {
       const ac = new AbortController();
       ac.abort();

--- a/packages/sandbox-just-bash/src/just-bash-sandbox-session.ts
+++ b/packages/sandbox-just-bash/src/just-bash-sandbox-session.ts
@@ -48,9 +48,8 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
 
     const finished = await this.sandbox.runCommand({
       cmd: 'bash',
-      args: ['-c', command],
+      args: ['-c', withEnvironment(command, env)],
       ...(workingDirectory !== undefined ? { cwd: workingDirectory } : {}),
-      ...(env !== undefined ? { env } : {}),
       ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
     });
 
@@ -81,10 +80,9 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
 
     const live = await this.sandbox.runCommand({
       cmd: 'bash',
-      args: ['-c', command],
+      args: ['-c', withEnvironment(command, env)],
       detached: true,
       ...(workingDirectory !== undefined ? { cwd: workingDirectory } : {}),
-      ...(env !== undefined ? { env } : {}),
       ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
     });
 
@@ -190,6 +188,27 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
       abortSignal,
     });
   }
+}
+
+function withEnvironment(
+  command: string,
+  env: Record<string, string> | undefined,
+): string {
+  if (env == null || Object.keys(env).length === 0) return command;
+
+  const exports: string[] = [];
+  for (const key of Object.keys(env)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    exports.push(`export ${key}=${shellQuote(env[key])}`);
+  }
+
+  if (exports.length === 0) return command;
+
+  return `${exports.join('\n')}\n${command}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.split("'").join("'\\''")}'`;
 }
 
 function createSandboxProcess(


### PR DESCRIPTION
## Background

`HarnessAgent.createSession()` can fail with `createJustBashSandbox()` because the harness asks the sandbox to create a work directory via an env-backed command:

```ts
session.run({ command: 'mkdir -p "$WORK_DIR"', env: { WORK_DIR: workDir } })
```

The just-bash session was executing the command without exporting `RunCommandParams.env`, so `$WORK_DIR` expanded as empty. That made directory creation look successful while leaving the expected work directory missing, and the first later `cd` into that path failed.

Root cause: `runCommand` accepted an `env` field at the sandbox/session boundary, but the just-bash command wrapper only launched the command text and did not pass those variables into the bash invocation.

## Summary

- Export `RunCommandParams.env` into just-bash commands before running the command body.
- Preserve shell quoting for env values instead of interpolating them unsafely.
- Add regression coverage for the harness-shaped `$WORK_DIR` directory creation case and for shell-quoted env values.

## Contributor Credit

Thanks to @ZyroEolu-sk for the minimal reproduction in #16690. @lgrammel, tagging you for review since you already had context on the issue/PR thread.

## End-to-End Verification

The focused verification exercises the same contract the harness depends on: a just-bash command can receive `env`, expand it inside bash, and create/use the requested path.

## Test Plan

- `npx pnpm@10.33.4 install --filter @ai-sdk/sandbox-just-bash... --frozen-lockfile`
- `npx pnpm@10.33.4 --filter @ai-sdk/provider build`
- `npx pnpm@10.33.4 --filter @ai-sdk/provider-utils build`
- `npx pnpm@10.33.4 --dir packages/sandbox-just-bash test -- just-bash-sandbox-session.test.ts`
- `git diff --check`
- `npx pnpm@10.33.4 --dir packages/sandbox-just-bash type-check`

Local note: this runner had Node v20.19.2 while the repo requests Node >=22, so pnpm emitted engine warnings. The focused test and type-check still passed locally. The currently visible automated checks are not reporting a failing test; this is waiting on review.

## Risk / reviewer notes

Small behavior fix in the just-bash provider. The only intended behavior change is that per-command env values supplied through the public sandbox API are available to the command. Values are shell-quoted before export to avoid changing command parsing for spaces/special characters.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16690.
