### PR TITLE
reproduction: Reproduces #16695

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-16695-sandbox-vercel-resume-credentials.ts
+++ b/examples/ai-functions/src/reproduction/issue-16695-sandbox-vercel-resume-credentials.ts
@@ -1,0 +1,41 @@
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+async function main() {
+  const sandbox = createVercelSandbox({
+    token: process.env.VERCEL_TOKEN ?? 'issue-16695-repro-token',
+    teamId: process.env.VERCEL_TEAM_ID ?? 'team_issue_16695',
+    projectId: process.env.VERCEL_PROJECT_ID ?? 'prj_issue_16695',
+  });
+
+  try {
+    await sandbox.resumeSession!({
+      sessionId: 'issue-16695',
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('Could not get credentials from OIDC context')) {
+      console.error(
+        [
+          'Reproduced issue #16695.',
+          'resumeSession was configured with token/teamId/projectId, but @vercel/sandbox still attempted OIDC credential lookup.',
+          '',
+          message,
+        ].join('\n'),
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  throw new Error(
+    'Expected resumeSession to fail by attempting OIDC credential lookup, but it completed successfully.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/sandbox-vercel/src/vercel-sandbox.test.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox.test.ts
@@ -2,10 +2,18 @@ import type { Sandbox } from '@vercel/sandbox';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVercelSandbox } from './vercel-sandbox';
 
-const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+const { createMock, getMock, getOrCreateMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  getMock: vi.fn(),
+  getOrCreateMock: vi.fn(),
+}));
 
 vi.mock('@vercel/sandbox', () => ({
-  Sandbox: { create: createMock },
+  Sandbox: {
+    create: createMock,
+    get: getMock,
+    getOrCreate: getOrCreateMock,
+  },
 }));
 
 type MockSpies = {
@@ -222,6 +230,13 @@ describe('createVercelSandbox (wrap existing)', () => {
 describe('createVercelSandbox (create from scratch)', () => {
   beforeEach(() => {
     createMock.mockReset();
+    getMock.mockReset();
+    getOrCreateMock.mockReset();
+    (
+      globalThis as {
+        [key: symbol]: Map<string, string> | undefined;
+      }
+    )[Symbol.for('ai-sdk.harness.vercel-template-snapshots')]?.clear();
   });
 
   it('applies a 30 minute default timeout when none is provided', async () => {
@@ -243,6 +258,64 @@ describe('createVercelSandbox (create from scratch)', () => {
     await createVercelSandbox({ timeout: 60_000 }).createSession();
 
     expect(createMock.mock.calls[0][0]).toMatchObject({ timeout: 60_000 });
+  });
+
+  it('forwards access-token credentials when resuming a named session', async () => {
+    const { sandbox } = makeMockSandbox();
+    getMock.mockResolvedValueOnce(sandbox);
+    const abortController = new AbortController();
+
+    const provider = createVercelSandbox({
+      token: 'vercel-token',
+      teamId: 'team_123',
+      projectId: 'prj_123',
+    });
+
+    await provider.resumeSession!({
+      sessionId: 'session-123',
+      abortSignal: abortController.signal,
+    });
+
+    expect(getMock).toHaveBeenCalledWith({
+      name: 'ai-sdk-harness-session-session-123',
+      token: 'vercel-token',
+      teamId: 'team_123',
+      projectId: 'prj_123',
+      signal: abortController.signal,
+    });
+  });
+
+  it('forwards access-token credentials when polling for a template snapshot', async () => {
+    const { sandbox: template } = makeMockSandbox({
+      stop: vi.fn(async () => ({})),
+    });
+    const { sandbox: refreshedTemplate } = makeMockSandbox();
+    const { sandbox: fork } = makeMockSandbox();
+    Object.assign(template, { currentSnapshotId: undefined });
+    Object.assign(refreshedTemplate, { currentSnapshotId: 'snap_123' });
+    getOrCreateMock.mockResolvedValueOnce(template);
+    getMock.mockResolvedValueOnce(refreshedTemplate);
+    createMock.mockResolvedValueOnce(fork);
+    const abortController = new AbortController();
+
+    await createVercelSandbox({
+      token: 'vercel-token',
+      teamId: 'team_123',
+      projectId: 'prj_123',
+    }).createSession({
+      identity: 'issue-16695-template',
+      abortSignal: abortController.signal,
+      onFirstCreate: async () => {},
+    });
+
+    expect(getMock).toHaveBeenCalledWith({
+      name: 'ai-sdk-harness-issue-16695-template',
+      resume: false,
+      token: 'vercel-token',
+      teamId: 'team_123',
+      projectId: 'prj_123',
+      signal: abortController.signal,
+    });
   });
 
   it('destroy stops and deletes owned sandboxes', async () => {


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Reproduced with artifact examples/ai-functions/src/reproduction/issue-16695-sandbox-vercel-resume-credentials.ts: running `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-16695-sandbox-vercel-resume-credentials.ts` exited 1 with the reported OIDC error despite token/teamId/projectId being configured; expected resumeSession to use those explicit credentials. Added failing regression coverage in packages/sandbox-vercel/src/vercel-sandbox.test.ts; running `pnpm -C packages/sandbox-vercel exec vitest --config vitest.node.config.js --run src/vercel-sandbox.test.ts -t "forwards access-token credentials"` failed because Sandbox.get received only name/signal or name/resume/signal, missing token/teamId/projectId for both resume and snapshot polling.

## Branch

bug-16695-1

## Related Issues

Reproduces #16695