### PR TITLE
reproduction: Reproduces #12687

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12687.ts
+++ b/examples/ai-functions/src/reproduction/issue-12687.ts
@@ -1,0 +1,107 @@
+import { createAzure } from '@ai-sdk/azure';
+import { generateText, type ModelMessage } from 'ai';
+
+async function main() {
+  let requestBody: any;
+
+  const azure = createAzure({
+    resourceName: 'issue-12687-reproduction',
+    apiKey: 'test-api-key',
+    fetch: async (_url, init) => {
+      requestBody = JSON.parse(init?.body as string);
+
+      return new Response(
+        JSON.stringify({
+          id: 'resp_issue_12687',
+          created_at: 1,
+          model: 'gpt-5-mini',
+          output: [
+            {
+              type: 'message',
+              id: 'msg_issue_12687',
+              role: 'assistant',
+              content: [
+                {
+                  type: 'output_text',
+                  text: 'ok',
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    },
+  });
+
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Initial question' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'reasoning',
+          text: 'Prior encrypted reasoning summary',
+          providerOptions: {
+            azure: {
+              itemId: 'rs_issue_12687',
+              reasoningEncryptedContent: 'encrypted_reasoning_issue_12687',
+            },
+          },
+        },
+        { type: 'text', text: 'Prior answer' },
+      ],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Follow up' }],
+    },
+  ];
+
+  await generateText({
+    model: azure.responses('gpt-5-mini'),
+    messages,
+    providerOptions: {
+      azure: {
+        store: false,
+        forceReasoning: true,
+      },
+    },
+  });
+
+  const reasoningItem = requestBody?.input?.find(
+    (item: any) => item.type === 'reasoning',
+  );
+
+  console.log(JSON.stringify({ store: requestBody?.store, reasoningItem }));
+
+  if (reasoningItem == null) {
+    throw new Error('No reasoning item was sent in the Azure request payload.');
+  }
+
+  if ('id' in reasoningItem) {
+    throw new Error(
+      `Reproduced issue #12687: store:false request reasoning item still includes id ${JSON.stringify(reasoningItem.id)}.`,
+    );
+  }
+
+  console.log(
+    'Could not reproduce issue #12687: reasoning item id was omitted.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/openai/src/responses/issue-12687-reasoning-store-false.test.ts
+++ b/packages/openai/src/responses/issue-12687-reasoning-store-false.test.ts
@@ -1,0 +1,50 @@
+import type { ToolNameMapping } from '../../../provider-utils/src/create-tool-name-mapping';
+import { describe, expect, it } from 'vitest';
+import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-input';
+
+const testToolNameMapping: ToolNameMapping = {
+  toProviderToolName: (customToolName: string) => customToolName,
+  toCustomToolName: (providerToolName: string) => providerToolName,
+};
+
+describe('issue #12687', () => {
+  it('omits reasoning item ids for Azure when store is false', async () => {
+    const result = await convertToOpenAIResponsesInput({
+      toolNameMapping: testToolNameMapping,
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'Prior encrypted reasoning summary',
+              providerOptions: {
+                azure: {
+                  itemId: 'rs_issue_12687',
+                  reasoningEncryptedContent:
+                    'encrypted_reasoning_issue_12687',
+                },
+              },
+            },
+          ],
+        },
+      ],
+      systemMessageMode: 'system',
+      providerOptionsName: 'azure',
+      store: false,
+    });
+
+    expect(result.input).toEqual([
+      {
+        type: 'reasoning',
+        encrypted_content: 'encrypted_reasoning_issue_12687',
+        summary: [
+          {
+            type: 'summary_text',
+            text: 'Prior encrypted reasoning summary',
+          },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction script examples/ai-functions/src/reproduction/issue-12687.ts and failing provider test packages/openai/src/responses/issue-12687-reasoning-store-false.test.ts. Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12687.ts`; observed store:false Azure request payload contains reasoningItem.id `rs_issue_12687` and exits with the reproduction error. Expected behavior is that reasoning item ids are omitted when store:false. Also ran `pnpm -C packages/openai exec vitest --config vitest.node.config.js --run src/responses/issue-12687-reasoning-store-false.test.ts`, which fails because the actual converted reasoning item includes `id`. No blocker.

## Branch

bug-12687-1

## Related Issues

Reproduces #12687