### PR TITLE
reproduction: Reproduces #12099

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12099-last-assistant-message-complete-with-tool-calls.ts
+++ b/examples/ai-functions/src/reproduction/issue-12099-last-assistant-message-complete-with-tool-calls.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import {
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type UIMessage,
+} from 'ai';
+
+async function main() {
+  const messages: UIMessage[] = [
+    {
+      id: 'user-2',
+      role: 'user',
+      parts: [{ type: 'text', text: 'get from docs aws templates' }],
+    },
+    {
+      id: 'assistant-2',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'Searching...' },
+        { type: 'step-start' },
+        {
+          type: 'tool-Docs',
+          toolCallId: 'call-1',
+          state: 'output-available',
+          input: { query: 'some query' },
+          output: {
+            success: true,
+            queryResult: 'huge data result ...',
+          },
+        },
+        { type: 'text', text: 'Prompt is too long' },
+      ],
+    },
+  ];
+
+  const actual = lastAssistantMessageIsCompleteWithToolCalls({ messages });
+  console.log(
+    `lastAssistantMessageIsCompleteWithToolCalls returned: ${actual}`,
+  );
+
+  assert.equal(
+    actual,
+    false,
+    'expected no automatic chat resume after a backend tool output is followed by an error text response',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.test.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.test.ts
@@ -2,6 +2,39 @@ import { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-me
 import { describe, it, expect } from 'vitest';
 
 describe('lastAssistantMessageIsCompleteWithToolCalls', () => {
+  it('should return false when a backend tool output is followed by an error text response', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [
+          {
+            id: 'user-2',
+            role: 'user',
+            parts: [{ type: 'text', text: 'get from docs aws templates' }],
+          },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            parts: [
+              { type: 'reasoning', text: 'Searching...' },
+              { type: 'step-start' },
+              {
+                type: 'tool-Docs',
+                toolCallId: 'call-1',
+                state: 'output-available',
+                input: { query: 'some query' },
+                output: {
+                  success: true,
+                  queryResult: 'huge data result ...',
+                },
+              },
+              { type: 'text', text: 'Prompt is too long' },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it('should return false if the last step of a multi-step sequence only has text', () => {
     expect(
       lastAssistantMessageIsCompleteWithToolCalls({


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction artifacts at examples/ai-functions/src/reproduction/issue-12099-last-assistant-message-complete-with-tool-calls.ts and packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.test.ts. Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12099-last-assistant-message-complete-with-tool-calls.ts`, which printed `lastAssistantMessageIsCompleteWithToolCalls returned: true` and failed the assertion expecting false; also ran `pnpm -C packages/ai exec vitest --config vitest.node.config.js --run src/ui/last-assistant-message-is-complete-with-tool-calls.test.ts`, which failed the added test with received true/expected false. Expected issue behavior is false to avoid unexpected chat resume after backend tool error text. No blocker.

## Branch

bug-12099-1

## Related Issues

Reproduces #12099