### PR TITLE
reproduction: Reproduces #11943

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts
+++ b/examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+
+import { convertUserContent } from '../../../../packages/langchain/src/utils';
+
+async function main() {
+  const imageUrl = 'https://example.com/image.jpg';
+
+  const message = convertUserContent([
+    { type: 'text', text: 'What is in this image?' },
+    { type: 'image', image: imageUrl },
+  ]);
+
+  const expectedLangChainContent = [
+    { type: 'text', text: 'What is in this image?' },
+    { type: 'image', url: imageUrl },
+  ];
+
+  console.log(
+    'convertUserContent output:',
+    JSON.stringify(message.content, null, 2),
+  );
+
+  assert.deepEqual(
+    message.content,
+    expectedLangChainContent,
+    'Expected LangChain canonical image ContentBlock, but convertUserContent emitted a provider-specific image_url block.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction artifact examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts and ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11943-langchain-image-content-block.ts`; it failed with an assertion because convertUserContent output `{ type: "image_url", image_url: { url: "https://example.com/image.jpg" } }` instead of the expected LangChain canonical `{ type: "image", url: "https://example.com/image.jpg" }`. No blocker.

## Branch

bug-11943-1

## Related Issues

Reproduces #11943