### PR TITLE
reproduction: Reproduces #11874

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11874-node-tar-vulnerability.ts
+++ b/examples/ai-functions/src/reproduction/issue-11874-node-tar-vulnerability.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type AuditAdvisory = {
+  module_name?: string;
+  title?: string;
+  vulnerable_versions?: string;
+  patched_versions?: string;
+  findings?: Array<{
+    version?: string;
+    paths?: string[];
+  }>;
+};
+
+function runPnpmAudit(repoRoot: string) {
+  try {
+    return execFileSync('pnpm', ['audit', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const maybeExecError = error as { stdout?: Buffer | string };
+    if (maybeExecError.stdout != null) {
+      return maybeExecError.stdout.toString();
+    }
+
+    throw error;
+  }
+}
+
+async function main() {
+  const repoRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../..',
+  );
+  const lockfile = readFileSync(resolve(repoRoot, 'pnpm-lock.yaml'), 'utf8');
+
+  const langgraphCliBlockStart = lockfile.indexOf(
+    "  '@langchain/langgraph-cli@1.2.1(",
+  );
+  if (langgraphCliBlockStart === -1) {
+    throw new Error(
+      'Could not find @langchain/langgraph-cli@1.2.1 snapshot in pnpm-lock.yaml.',
+    );
+  }
+
+  const langgraphCliBlockEnd = lockfile.indexOf(
+    '\n\n  ',
+    langgraphCliBlockStart + 1,
+  );
+  const langgraphCliBlock = lockfile.slice(
+    langgraphCliBlockStart,
+    langgraphCliBlockEnd === -1 ? undefined : langgraphCliBlockEnd,
+  );
+  const langgraphCliTarVersion =
+    langgraphCliBlock.match(/\n      tar: ([^\s]+)/)?.[1];
+
+  if (langgraphCliTarVersion == null) {
+    throw new Error(
+      '@langchain/langgraph-cli is present, but this lockfile snapshot does not show a tar dependency.',
+    );
+  }
+
+  const auditOutput = runPnpmAudit(repoRoot);
+  const audit = JSON.parse(auditOutput) as {
+    advisories?: Record<string, AuditAdvisory>;
+  };
+
+  const tarAdvisories = Object.entries(audit.advisories ?? {}).filter(
+    ([, advisory]) => advisory.module_name === 'tar',
+  );
+
+  if (tarAdvisories.length > 0) {
+    console.error('Reproduced issue #11874: npm audit reports vulnerable tar.');
+    console.error(
+      `@langchain/langgraph-cli@1.2.1 depends on tar@${langgraphCliTarVersion} in pnpm-lock.yaml.`,
+    );
+
+    for (const [id, advisory] of tarAdvisories) {
+      console.error(
+        JSON.stringify(
+          {
+            advisoryId: id,
+            title: advisory.title,
+            vulnerableVersions: advisory.vulnerable_versions,
+            patchedVersions: advisory.patched_versions,
+            findings: advisory.findings,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+
+    process.exit(1);
+  }
+
+  console.log(
+    `Could not reproduce issue #11874: @langchain/langgraph-cli depends on tar@${langgraphCliTarVersion}, but pnpm audit did not report a tar advisory.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction artifact examples/ai-functions/src/reproduction/issue-11874-node-tar-vulnerability.ts and ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11874-node-tar-vulnerability.ts`; it failed as intended, showing @langchain/langgraph-cli@1.2.1 depends on tar@7.5.15 in pnpm-lock.yaml and pnpm audit reports tar advisory 1120782 vulnerable <=7.5.15, matching the expected issue behavior that a vulnerable node-tar dependency is present. No blocker.

## Branch

bug-11874-1

## Related Issues

Reproduces #11874