### PR TITLE
reproduction: Reproduces #11865

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11865-use-chat-visibility-resume.ts
+++ b/examples/ai-functions/src/reproduction/issue-11865-use-chat-visibility-resume.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+async function main() {
+  const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+  const args = [
+    '-C',
+    'packages/react',
+    'exec',
+    'vitest',
+    '--config',
+    'vitest.config.js',
+    '--run',
+    'src/use-chat.ui.test.tsx',
+    '-t',
+    'should automatically reconnect when tab becomes visible after a dropped stream',
+  ];
+
+  console.log(`Running: pnpm ${args.join(' ')}`);
+
+  const result = spawnSync('pnpm', args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2099,6 +2099,144 @@ describe('use-chat', () => {
     });
   });
 
+  describe('resume stream when returning to a visible tab', () => {
+    let submitController!: TestResponseController;
+
+    setupTestComponent(
+      () => {
+        const { messages, sendMessage, status } = useChat({
+          id: '123',
+          generateId: mockId(),
+          resume: true,
+        });
+
+        return (
+          <div>
+            {messages.map((m, idx) => (
+              <div data-testid={`message-${idx}`} key={m.id}>
+                {m.role === 'user' ? 'User: ' : 'AI: '}
+                {m.parts
+                  .map(part => (part.type === 'text' ? part.text : ''))
+                  .join('')}
+              </div>
+            ))}
+
+            <div data-testid="status">{status}</div>
+            <button
+              type="button"
+              data-testid="do-send"
+              onClick={() =>
+                sendMessage({ parts: [{ type: 'text', text: 'hello' }] })
+              }
+            />
+          </div>
+        );
+      },
+      {
+        init: TestComponent => {
+          submitController = new TestResponseController();
+          server.urls['/api/chat/123/stream'].response = {
+            type: 'empty',
+            status: 204,
+          };
+          server.urls['/api/chat'].response = {
+            type: 'controlled-stream',
+            controller: submitController,
+          };
+
+          return <TestComponent />;
+        },
+      },
+    );
+
+    it('should automatically reconnect when tab becomes visible after a dropped stream', async () => {
+      await waitFor(() => {
+        expect(
+          server.calls.filter(call => call.requestMethod === 'GET'),
+        ).toHaveLength(1);
+      });
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+      });
+
+      await submitController.write(
+        formatChunk({ type: 'text-start', id: '0' }),
+      );
+      await submitController.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+        expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+      });
+
+      await submitController.error(new TypeError('network connection lost'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('error');
+      });
+
+      const resumeController = new TestResponseController();
+      server.urls['/api/chat/123/stream'].response = {
+        type: 'controlled-stream',
+        controller: resumeController,
+      };
+
+      const originalVisibilityState = document.visibilityState;
+
+      try {
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: () => 'hidden',
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: () => 'visible',
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        await waitFor(() => {
+          expect(
+            server.calls.filter(call => call.requestMethod === 'GET'),
+          ).toHaveLength(2);
+        });
+
+        await resumeController.write(
+          formatChunk({ type: 'text-start', id: '0' }),
+        );
+        await resumeController.write(
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        );
+        await resumeController.write(
+          formatChunk({ type: 'text-delta', id: '0', delta: ', world.' }),
+        );
+        await resumeController.write(
+          formatChunk({ type: 'text-end', id: '0' }),
+        );
+        await resumeController.close();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('message-1')).toHaveTextContent(
+            'AI: Hello, world.',
+          );
+          expect(screen.getByTestId('status')).toHaveTextContent('ready');
+        });
+      } finally {
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: () => originalVisibilityState,
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      }
+    });
+  });
+
   describe('resume with no active stream should not flash submitted status', () => {
     setupTestComponent(
       () => {


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created a failing reproduction test at packages/react/src/use-chat.ui.test.tsx and runnable script at examples/ai-functions/src/reproduction/issue-11865-use-chat-visibility-resume.ts. Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11865-use-chat-visibility-resume.ts`; observed the focused test fail after dispatching hidden/visible `visibilitychange` because only the mount-time GET resume call occurred (`expected length 2 but got 1`), leaving the chat in error with partial output. Expected behavior is an automatic reconnect/resume GET when the tab becomes visible again. Blocker: none.

## Branch

bug-11865-1

## Related Issues

Reproduces #11865