### PR TITLE
reproduction: Could not reproduce #11855

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11855.ts
+++ b/examples/ai-functions/src/reproduction/issue-11855.ts
@@ -1,0 +1,118 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { APICallError, generateText, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  console.log(
+    'Issue 11855: sending an Anthropic follow-up conversation that contains a client tool call, a provider-executed code_execution tool call with an error result in the assistant message, and the client tool result in the next tool message.',
+  );
+
+  let requestBody: any;
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      requestBody = JSON.parse(String(init?.body));
+      return fetch(input, init);
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model: anthropic('claude-sonnet-4-5'),
+      maxOutputTokens: 32,
+      tools: {
+        web_scraper: tool({
+          inputSchema: z.object({
+            url: z.string(),
+          }),
+          execute: async () => 'not used by this reproduction',
+        }),
+        code_execution: anthropic.tools.codeExecution_20250825(),
+      },
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Prepare the brief.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'I will inspect the website and run code.',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'toolu_issue11855_web_scraper',
+              toolName: 'web_scraper',
+              input: { url: 'https://example.com' },
+              providerOptions: {
+                anthropic: {
+                  caller: { type: 'direct' },
+                },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'srvtoolu_issue11855_code_execution',
+              toolName: 'code_execution',
+              input: {
+                type: 'programmatic-tool-call',
+                code: 'print("hello")',
+              },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'srvtoolu_issue11855_code_execution',
+              toolName: 'code_execution',
+              output: {
+                type: 'error-json',
+                value: JSON.stringify({
+                  type: 'code_execution_tool_result_error',
+                  errorCode: 'unavailable',
+                }),
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'toolu_issue11855_web_scraper',
+              toolName: 'web_scraper',
+              output: {
+                type: 'text',
+                value: 'Example Domain page contents.',
+              },
+            },
+          ],
+        },
+      ] as any,
+    });
+
+    console.log('Anthropic request completed.');
+    console.log(
+      'Converted assistant content order:',
+      requestBody.messages[1].content.map((part: { type: string }) => part.type),
+    );
+    console.log('Result text:', result.text);
+  } catch (error) {
+    console.error('Anthropic request failed.');
+    console.error(error);
+
+    if (APICallError.isInstance(error)) {
+      console.error('Status code:', error.statusCode);
+      console.error('Response body:', error.responseBody);
+      console.error('Request body:', error.requestBodyValues);
+    }
+
+    process.exitCode = 1;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-11855-follow-up.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-11855-follow-up.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_01B7iXdj8CDnjU3aBLD4sHoU",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "I need more information to prepare a brief for you. Could you please provide:\n\n1. **What kind of brief** do you need? (project brief"
+    }
+  ],
+  "stop_reason": "max_tokens",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 2497,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 32,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -4484,6 +4484,176 @@ describe('AnthropicLanguageModel', () => {
           }
         `);
       });
+
+      it('should place client tool_use after provider-executed code execution error result on follow-up turns', async () => {
+        prepareJsonFixtureResponse('anthropic-issue-11855-follow-up');
+
+        const result = await provider('claude-sonnet-4-5').doGenerate({
+          maxOutputTokens: 32,
+          prompt: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Prepare the brief.' }],
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'text',
+                  text: 'I will inspect the website and run code.',
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolu_issue11855_web_scraper',
+                  toolName: 'web_scraper',
+                  input: { url: 'https://example.com' },
+                  providerOptions: {
+                    anthropic: {
+                      caller: { type: 'direct' },
+                    },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'srvtoolu_issue11855_code_execution',
+                  toolName: 'code_execution',
+                  input: {
+                    type: 'programmatic-tool-call',
+                    code: 'print("hello")',
+                  },
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'srvtoolu_issue11855_code_execution',
+                  toolName: 'code_execution',
+                  output: {
+                    type: 'error-json',
+                    value: JSON.stringify({
+                      type: 'code_execution_tool_result_error',
+                      errorCode: 'unavailable',
+                    }),
+                  },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'toolu_issue11855_web_scraper',
+                  toolName: 'web_scraper',
+                  output: {
+                    type: 'text',
+                    value: 'Example Domain page contents.',
+                  },
+                },
+              ],
+            },
+          ],
+          tools: [
+            {
+              type: 'function',
+              name: 'web_scraper',
+              description: undefined,
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  url: { type: 'string' },
+                },
+                required: ['url'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+            {
+              type: 'provider',
+              id: 'anthropic.code_execution_20250825',
+              name: 'code_execution',
+              args: {},
+            },
+          ],
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+
+        expect(requestBody).toMatchObject({
+          max_tokens: 32,
+          model: 'claude-sonnet-4-5',
+          tools: [
+            {
+              name: 'web_scraper',
+              input_schema: {
+                type: 'object',
+                properties: {
+                  url: { type: 'string' },
+                },
+                required: ['url'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+            {
+              name: 'code_execution',
+              type: 'code_execution_20250825',
+            },
+          ],
+        });
+
+        expect(requestBody.messages[1].content).toEqual([
+          {
+            text: 'I will inspect the website and run code.',
+            type: 'text',
+          },
+          {
+            id: 'srvtoolu_issue11855_code_execution',
+            input: {
+              code: 'print("hello")',
+            },
+            name: 'code_execution',
+            type: 'server_tool_use',
+          },
+          {
+            content: {
+              error_code: 'unavailable',
+              type: 'code_execution_tool_result_error',
+            },
+            tool_use_id: 'srvtoolu_issue11855_code_execution',
+            type: 'code_execution_tool_result',
+          },
+          {
+            caller: {
+              type: 'direct',
+            },
+            id: 'toolu_issue11855_web_scraper',
+            input: {
+              url: 'https://example.com',
+            },
+            name: 'web_scraper',
+            type: 'tool_use',
+          },
+        ]);
+
+        expect(requestBody.messages[2].content).toEqual([
+          {
+            content: 'Example Domain page contents.',
+            tool_use_id: 'toolu_issue11855_web_scraper',
+            type: 'tool_result',
+          },
+        ]);
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "I need more information to prepare a brief for you. Could you please provide:
+
+          1. **What kind of brief** do you need? (project brief",
+              "type": "text",
+            },
+          ]
+        `);
+      });
     });
 
     describe('agent skills', () => {


### PR DESCRIPTION
## Bug Reproduction

**Bug could not be reproduced.**

Created reproduction script examples/ai-functions/src/reproduction/issue-11855.ts and ran live provider command `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11855.ts`; Anthropic completed successfully, with converted assistant content ordered `[text, server_tool_use, code_execution_tool_result, tool_use]` and no reported `tool_use ids were found without tool_result blocks immediately after` API error. Recorded live response fixture at packages/anthropic/src/__fixtures__/anthropic-issue-11855-follow-up.json and added provider unit test at packages/anthropic/src/anthropic-language-model.test.ts; verified with `pnpm -C packages/anthropic exec vitest --config vitest.node.config.js --run src/anthropic-language-model.test.ts -t "should place client tool_use after provider-executed code execution error result on follow-up turns"`. Expected issue behavior was an Anthropic API request failure; observed behavior worked. No blocker.

## Branch

bug-11855-1

## Related Issues

Could not reproduce #11855