### PR TITLE
feat(provider/gateway): add getModelMetrics()

### DIFF
--- a/.changeset/gateway-model-metrics.md
+++ b/.changeset/gateway-model-metrics.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': minor
+---
+
+Add `getModelMetrics()` to the gateway provider for fetching per model and provider performance metrics (time to first token, throughput, uptime) alongside declared pricing from the public `/v1/models/metrics` endpoint.

--- a/packages/gateway/src/gateway-model-metrics.test.ts
+++ b/packages/gateway/src/gateway-model-metrics.test.ts
@@ -152,9 +152,9 @@ describe('GatewayModelMetrics', () => {
                 },
               },
               uptime: {
-                last_15m: 1,
-                last_1h: 0.999,
-                last_1d: 0.997,
+                last_15m: 100,
+                last_1h: 99.9,
+                last_1d: 99.7,
                 meta: {
                   source: 'observed',
                   window: 'hourly',
@@ -207,9 +207,9 @@ describe('GatewayModelMetrics', () => {
           },
         },
         uptime: {
-          last15m: 1,
-          last1h: 0.999,
-          last1d: 0.997,
+          last15m: 100,
+          last1h: 99.9,
+          last1d: 99.7,
           meta: {
             source: 'observed',
             window: 'hourly',
@@ -262,6 +262,35 @@ describe('GatewayModelMetrics', () => {
       });
     });
 
+    it('should normalize omitted metric groups to null (forward compatibility)', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          object: 'list',
+          data: [
+            {
+              id: 'openai/gpt-5.2',
+              name: 'GPT-5.2',
+              provider: null,
+              type: 'language',
+              pricing: {
+                meta: { source: 'declared' },
+              },
+              // No latency_last_1h / throughput_last_1h / uptime keys at all
+            },
+          ],
+          meta: responseMeta,
+        },
+      };
+
+      const metrics = createModelMetrics();
+      const result = await metrics.getModelMetrics();
+
+      expect(result.data[0].latency).toBeNull();
+      expect(result.data[0].throughput).toBeNull();
+      expect(result.data[0].uptime).toBeNull();
+    });
+
     it('should handle uptime windows without data yet', async () => {
       server.urls['https://api.example.com/*'].response = {
         type: 'json-value',
@@ -282,8 +311,8 @@ describe('GatewayModelMetrics', () => {
               throughput_last_1h: null,
               uptime: {
                 last_15m: null,
-                last_1h: 0.98,
-                last_1d: 0.999,
+                last_1h: 98,
+                last_1d: 99.9,
                 meta: { source: 'observed', window: 'hourly' },
               },
             },
@@ -297,8 +326,8 @@ describe('GatewayModelMetrics', () => {
 
       expect(result.data[0].uptime).toEqual({
         last15m: null,
-        last1h: 0.98,
-        last1d: 0.999,
+        last1h: 98,
+        last1d: 99.9,
         meta: { source: 'observed', window: 'hourly' },
       });
     });

--- a/packages/gateway/src/gateway-model-metrics.test.ts
+++ b/packages/gateway/src/gateway-model-metrics.test.ts
@@ -1,0 +1,467 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { GatewayModelMetrics } from './gateway-model-metrics';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  GatewayAuthenticationError,
+  GatewayInternalServerError,
+  GatewayRateLimitError,
+  GatewayResponseError,
+} from './errors';
+
+function createModelMetrics({
+  headers,
+  fetch,
+}: {
+  headers?: () => Record<string, string>;
+  fetch?: FetchFunction;
+} = {}) {
+  return new GatewayModelMetrics({
+    baseURL: 'https://api.example.com',
+    headers,
+    fetch,
+  });
+}
+
+const responseMeta = {
+  generated_at: '2026-07-05T00:00:00.000Z',
+  source_windows: {
+    latency: '1h',
+    throughput: '1h',
+    uptime: ['15m', '1h', '1d'],
+  },
+  provenance_note:
+    'Latency and throughput are observed from live gateway traffic.',
+};
+
+const expectedResponseMeta = {
+  generatedAt: '2026-07-05T00:00:00.000Z',
+  sourceWindows: {
+    latency: '1h',
+    throughput: '1h',
+    uptime: ['15m', '1h', '1d'],
+  },
+  provenanceNote:
+    'Latency and throughput are observed from live gateway traffic.',
+};
+
+describe('GatewayModelMetrics', () => {
+  const server = createTestServer({
+    'https://api.example.com/*': {
+      response: {
+        type: 'json-value',
+        body: {
+          object: 'list',
+          data: [],
+          meta: responseMeta,
+        },
+      },
+    },
+  });
+
+  describe('getModelMetrics', () => {
+    it('should fetch from the correct endpoint', async () => {
+      const metrics = createModelMetrics();
+
+      await metrics.getModelMetrics();
+
+      expect(server.calls[0].requestMethod).toBe('GET');
+      const url = new URL(server.calls[0].requestUrl);
+      expect(url.pathname).toBe('/v1/models/metrics');
+      expect(url.search).toBe('');
+    });
+
+    it('should serialize all optional query params', async () => {
+      const metrics = createModelMetrics();
+
+      await metrics.getModelMetrics({
+        type: 'language',
+        tags: ['tools', 'reasoning'],
+        maxInputPrice: 0.000005,
+        sort: 'ttft',
+        limit: 100,
+      });
+
+      const url = new URL(server.calls[0].requestUrl);
+      expect(url.searchParams.get('type')).toBe('language');
+      expect(url.searchParams.getAll('tag')).toEqual(['tools', 'reasoning']);
+      expect(url.searchParams.get('max_input_price')).toBe('0.000005');
+      expect(url.searchParams.get('sort')).toBe('ttft');
+      expect(url.searchParams.get('limit')).toBe('100');
+    });
+
+    it('should not include optional params when not provided', async () => {
+      const metrics = createModelMetrics();
+
+      await metrics.getModelMetrics({});
+
+      const url = new URL(server.calls[0].requestUrl);
+      expect(url.searchParams.has('type')).toBe(false);
+      expect(url.searchParams.has('tag')).toBe(false);
+      expect(url.searchParams.has('max_input_price')).toBe(false);
+      expect(url.searchParams.has('sort')).toBe(false);
+      expect(url.searchParams.has('limit')).toBe(false);
+    });
+
+    it('should not include tag params when tags array is empty', async () => {
+      const metrics = createModelMetrics();
+
+      await metrics.getModelMetrics({ tags: [] });
+
+      const url = new URL(server.calls[0].requestUrl);
+      expect(url.searchParams.has('tag')).toBe(false);
+    });
+
+    it('should transform snake_case response fields to camelCase', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          object: 'list',
+          data: [
+            {
+              id: 'anthropic/claude-sonnet-4.5',
+              name: 'Claude Sonnet 4.5',
+              provider: 'anthropic',
+              type: 'language',
+              tags: ['tools', 'reasoning'],
+              pricing: {
+                input: '0.000003',
+                output: '0.000015',
+                meta: { source: 'declared' },
+              },
+              latency_last_1h: {
+                p50: 350,
+                p95: 900,
+                meta: {
+                  source: 'observed',
+                  window: '1h',
+                  measured_at: '2026-07-05T00:00:00.000Z',
+                  sample_size: 1250,
+                  region: 'global',
+                },
+              },
+              throughput_last_1h: {
+                p50: 85.5,
+                p95: 120.2,
+                meta: {
+                  source: 'observed',
+                  window: '1h',
+                  measured_at: '2026-07-05T00:00:00.000Z',
+                  sample_size: 1250,
+                  region: 'global',
+                },
+              },
+              uptime: {
+                last_15m: 1,
+                last_1h: 0.999,
+                last_1d: 0.997,
+                meta: {
+                  source: 'observed',
+                  window: 'hourly',
+                  measured_at: '2026-07-05T00:00:00.000Z',
+                  sample_size: null,
+                },
+              },
+            },
+          ],
+          meta: responseMeta,
+        },
+      };
+
+      const metrics = createModelMetrics();
+      const result = await metrics.getModelMetrics();
+
+      expect(result.object).toBe('list');
+      expect(result.meta).toEqual(expectedResponseMeta);
+      expect(result.data[0]).toEqual({
+        id: 'anthropic/claude-sonnet-4.5',
+        name: 'Claude Sonnet 4.5',
+        provider: 'anthropic',
+        type: 'language',
+        tags: ['tools', 'reasoning'],
+        pricing: {
+          input: '0.000003',
+          output: '0.000015',
+          meta: { source: 'declared' },
+        },
+        latency: {
+          p50: 350,
+          p95: 900,
+          meta: {
+            source: 'observed',
+            window: '1h',
+            measuredAt: '2026-07-05T00:00:00.000Z',
+            sampleSize: 1250,
+            region: 'global',
+          },
+        },
+        throughput: {
+          p50: 85.5,
+          p95: 120.2,
+          meta: {
+            source: 'observed',
+            window: '1h',
+            measuredAt: '2026-07-05T00:00:00.000Z',
+            sampleSize: 1250,
+            region: 'global',
+          },
+        },
+        uptime: {
+          last15m: 1,
+          last1h: 0.999,
+          last1d: 0.997,
+          meta: {
+            source: 'observed',
+            window: 'hourly',
+            measuredAt: '2026-07-05T00:00:00.000Z',
+            sampleSize: null,
+          },
+        },
+      });
+      expect('latency_last_1h' in result.data[0]).toBe(false);
+      expect('throughput_last_1h' in result.data[0]).toBe(false);
+    });
+
+    it('should handle catalog-only rows without observed metrics', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          object: 'list',
+          data: [
+            {
+              id: 'openai/gpt-5.2',
+              name: 'GPT-5.2',
+              provider: null,
+              type: 'language',
+              pricing: {
+                meta: { source: 'declared' },
+              },
+              latency_last_1h: null,
+              throughput_last_1h: null,
+              uptime: null,
+            },
+          ],
+          meta: responseMeta,
+        },
+      };
+
+      const metrics = createModelMetrics();
+      const result = await metrics.getModelMetrics();
+
+      expect(result.data[0]).toEqual({
+        id: 'openai/gpt-5.2',
+        name: 'GPT-5.2',
+        provider: null,
+        type: 'language',
+        pricing: {
+          meta: { source: 'declared' },
+        },
+        latency: null,
+        throughput: null,
+        uptime: null,
+      });
+    });
+
+    it('should handle uptime windows without data yet', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          object: 'list',
+          data: [
+            {
+              id: 'openai/gpt-5.2',
+              name: 'GPT-5.2',
+              provider: 'openai',
+              type: 'language',
+              pricing: {
+                input: '0.00000125',
+                output: '0.00001',
+                meta: { source: 'declared' },
+              },
+              latency_last_1h: null,
+              throughput_last_1h: null,
+              uptime: {
+                last_15m: null,
+                last_1h: 0.98,
+                last_1d: 0.999,
+                meta: { source: 'observed', window: 'hourly' },
+              },
+            },
+          ],
+          meta: responseMeta,
+        },
+      };
+
+      const metrics = createModelMetrics();
+      const result = await metrics.getModelMetrics();
+
+      expect(result.data[0].uptime).toEqual({
+        last15m: null,
+        last1h: 0.98,
+        last1d: 0.999,
+        meta: { source: 'observed', window: 'hourly' },
+      });
+    });
+
+    it('should handle empty data', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          object: 'list',
+          data: [],
+          meta: responseMeta,
+        },
+      };
+
+      const metrics = createModelMetrics();
+      const result = await metrics.getModelMetrics();
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.generatedAt).toBe('2026-07-05T00:00:00.000Z');
+    });
+
+    it('should work without headers since the endpoint is public', async () => {
+      const metrics = createModelMetrics();
+
+      const result = await metrics.getModelMetrics();
+
+      expect(result.data).toEqual([]);
+      expect(server.calls[0].requestHeaders).not.toHaveProperty(
+        'authorization',
+      );
+    });
+
+    it('should pass headers correctly', async () => {
+      const metrics = createModelMetrics({
+        headers: () => ({
+          Authorization: 'Bearer custom-token',
+          'Custom-Header': 'custom-value',
+        }),
+      });
+
+      await metrics.getModelMetrics();
+
+      expect(server.calls[0].requestHeaders).toEqual({
+        authorization: 'Bearer custom-token',
+        'custom-header': 'custom-value',
+      });
+    });
+
+    it('should handle 401 authentication errors', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          error: {
+            message: 'Unauthorized',
+            type: 'authentication_error',
+          },
+        }),
+      };
+
+      const metrics = createModelMetrics();
+
+      try {
+        await metrics.getModelMetrics();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+        const authError = error as GatewayAuthenticationError;
+        expect(authError.statusCode).toBe(401);
+      }
+    });
+
+    it('should handle 429 rate limit errors', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 429,
+        body: JSON.stringify({
+          error: {
+            message: 'Rate limit exceeded',
+            type: 'rate_limit_exceeded',
+          },
+        }),
+      };
+
+      const metrics = createModelMetrics();
+
+      await expect(metrics.getModelMetrics()).rejects.toThrow(
+        GatewayRateLimitError,
+      );
+    });
+
+    it('should handle 500 internal server errors', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'Internal server error',
+            type: 'internal_server_error',
+          },
+        }),
+      };
+
+      const metrics = createModelMetrics();
+
+      await expect(metrics.getModelMetrics()).rejects.toThrow(
+        GatewayInternalServerError,
+      );
+    });
+
+    it('should handle malformed JSON error responses', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 500,
+        body: '{ invalid json',
+      };
+
+      const metrics = createModelMetrics();
+
+      try {
+        await metrics.getModelMetrics();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayResponseError.isInstance(error)).toBe(true);
+        const responseError = error as GatewayResponseError;
+        expect(responseError.statusCode).toBe(500);
+      }
+    });
+
+    it('should use custom fetch function when provided', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            object: 'list',
+            data: [
+              {
+                id: 'anthropic/claude-sonnet-4.5',
+                name: 'Claude Sonnet 4.5',
+                provider: 'anthropic',
+                type: 'language',
+                pricing: { meta: { source: 'declared' } },
+                latency_last_1h: null,
+                throughput_last_1h: null,
+                uptime: null,
+              },
+            ],
+            meta: responseMeta,
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+      const metrics = createModelMetrics({
+        fetch: mockFetch,
+      });
+
+      const result = await metrics.getModelMetrics();
+
+      expect(mockFetch).toHaveBeenCalled();
+      expect(result.data[0].id).toBe('anthropic/claude-sonnet-4.5');
+    });
+  });
+});

--- a/packages/gateway/src/gateway-model-metrics.ts
+++ b/packages/gateway/src/gateway-model-metrics.ts
@@ -1,0 +1,244 @@
+import {
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  getFromApi,
+  lazySchema,
+  resolve,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { asGatewayError } from './errors';
+import type { GatewayConfig } from './gateway-config';
+
+export interface GatewayModelMetricsOptions {
+  /** Filter to a specific model type (e.g. 'language'). */
+  type?: string;
+  /** Filter to models that have all of these capability tags. */
+  tags?: string[];
+  /** Only include models with an input price at or below this value (USD per token). */
+  maxInputPrice?: number;
+  /** Sort order for the returned rows. */
+  sort?: 'cost' | 'ttft' | 'tps' | 'reliability';
+  /** Maximum number of rows to return (up to 500). */
+  limit?: number;
+}
+
+export interface GatewayModelMetricMeta {
+  /**
+   * Where the value comes from: declared by the provider, observed from
+   * live gateway traffic, or verified by active probes.
+   */
+  source: 'declared' | 'observed' | 'verified';
+  /** Observation window the value was computed over (e.g. '1h'). */
+  window?: string;
+  /** ISO 8601 timestamp of when the value was measured. */
+  measuredAt?: string;
+  /** Number of samples behind the value. */
+  sampleSize?: number | null;
+  /** Region the value was measured from. */
+  region?: string;
+}
+
+export interface GatewayModelMetricsRow {
+  /** The model id in 'creator/model-slug' format. */
+  id: string;
+  /** The display name of the model. */
+  name: string;
+  /**
+   * The provider this row was measured for. `null` for catalog-only rows
+   * that have no observed metrics.
+   */
+  provider: string | null;
+  /** Model type (e.g. 'language'). */
+  type: string | null;
+  /** Capability tags of the model (e.g. 'tools', 'reasoning'). */
+  tags?: string[];
+
+  /**
+   * Declared pricing as decimal strings in USD per token. The `input` and
+   * `output` fields are omitted when the model is not token-priced.
+   */
+  pricing: {
+    /** Cost per input token in USD. */
+    input?: string;
+    /** Cost per output token in USD. */
+    output?: string;
+    meta: GatewayModelMetricMeta;
+  };
+  /** Time to first token (TTFT) in milliseconds over the last hour. */
+  latency: {
+    p50: number;
+    p95: number;
+    meta: GatewayModelMetricMeta;
+  } | null;
+  /** Output throughput in tokens per second over the last hour. */
+  throughput: {
+    p50: number;
+    p95: number;
+    meta: GatewayModelMetricMeta;
+  } | null;
+  /** Success rate over trailing windows. */
+  uptime: {
+    last15m: number | null;
+    last1h: number | null;
+    last1d: number | null;
+    meta: GatewayModelMetricMeta;
+  } | null;
+}
+
+export interface GatewayModelMetricsResponseMeta {
+  /** ISO 8601 timestamp of when the response was generated. */
+  generatedAt: string;
+  /** Observation windows the metrics were computed over. */
+  sourceWindows: {
+    latency: string;
+    throughput: string;
+    uptime: string[];
+  };
+  /** Human-readable note about where the metric values come from. */
+  provenanceNote: string;
+}
+
+export interface GatewayModelMetricsResponse {
+  object: 'list';
+  data: GatewayModelMetricsRow[];
+  meta: GatewayModelMetricsResponseMeta;
+}
+
+export class GatewayModelMetrics {
+  constructor(private readonly config: GatewayConfig) {}
+
+  async getModelMetrics(
+    options: GatewayModelMetricsOptions = {},
+  ): Promise<GatewayModelMetricsResponse> {
+    try {
+      const baseUrl = new URL(this.config.baseURL);
+
+      const searchParams = new URLSearchParams();
+
+      if (options.type) {
+        searchParams.set('type', options.type);
+      }
+      if (options.tags) {
+        for (const tag of options.tags) {
+          searchParams.append('tag', tag);
+        }
+      }
+      if (options.maxInputPrice != null) {
+        searchParams.set('max_input_price', String(options.maxInputPrice));
+      }
+      if (options.sort) {
+        searchParams.set('sort', options.sort);
+      }
+      if (options.limit != null) {
+        searchParams.set('limit', String(options.limit));
+      }
+
+      const query = searchParams.toString();
+
+      const { value } = await getFromApi({
+        url: `${baseUrl.origin}/v1/models/metrics${query ? `?${query}` : ''}`,
+        headers: this.config.headers
+          ? await resolve(this.config.headers)
+          : undefined,
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayModelMetricsResponseSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        fetch: this.config.fetch,
+      });
+
+      return value;
+    } catch (error) {
+      throw await asGatewayError(error);
+    }
+  }
+}
+
+const gatewayModelMetricMetaSchema = z
+  .object({
+    source: z.enum(['declared', 'observed', 'verified']),
+    window: z.string().optional(),
+    measured_at: z.string().optional(),
+    sample_size: z.number().nullable().optional(),
+    region: z.string().optional(),
+  })
+  .transform(({ measured_at, sample_size, ...rest }) => ({
+    ...rest,
+    ...(measured_at !== undefined ? { measuredAt: measured_at } : {}),
+    ...(sample_size !== undefined ? { sampleSize: sample_size } : {}),
+  }));
+
+const gatewayModelMetricsResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      object: z.literal('list'),
+      data: z.array(
+        z
+          .object({
+            id: z.string(),
+            name: z.string(),
+            provider: z.string().nullable(),
+            type: z.string().nullable(),
+            tags: z.array(z.string()).optional(),
+            pricing: z.object({
+              input: z.string().optional(),
+              output: z.string().optional(),
+              meta: gatewayModelMetricMetaSchema,
+            }),
+            latency_last_1h: z
+              .object({
+                p50: z.number(),
+                p95: z.number(),
+                meta: gatewayModelMetricMetaSchema,
+              })
+              .nullable(),
+            throughput_last_1h: z
+              .object({
+                p50: z.number(),
+                p95: z.number(),
+                meta: gatewayModelMetricMetaSchema,
+              })
+              .nullable(),
+            uptime: z
+              .object({
+                last_15m: z.number().nullable(),
+                last_1h: z.number().nullable(),
+                last_1d: z.number().nullable(),
+                meta: gatewayModelMetricMetaSchema,
+              })
+              .transform(({ last_15m, last_1h, last_1d, meta }) => ({
+                last15m: last_15m,
+                last1h: last_1h,
+                last1d: last_1d,
+                meta,
+              }))
+              .nullable(),
+          })
+          .transform(({ latency_last_1h, throughput_last_1h, ...rest }) => ({
+            ...rest,
+            latency: latency_last_1h,
+            throughput: throughput_last_1h,
+          })),
+      ),
+      meta: z
+        .object({
+          generated_at: z.string(),
+          source_windows: z.object({
+            latency: z.string(),
+            throughput: z.string(),
+            uptime: z.array(z.string()),
+          }),
+          provenance_note: z.string(),
+        })
+        .transform(({ generated_at, source_windows, provenance_note }) => ({
+          generatedAt: generated_at,
+          sourceWindows: source_windows,
+          provenanceNote: provenance_note,
+        })),
+    }),
+  ),
+);

--- a/packages/gateway/src/gateway-model-metrics.ts
+++ b/packages/gateway/src/gateway-model-metrics.ts
@@ -77,7 +77,7 @@ export interface GatewayModelMetricsRow {
     p95: number;
     meta: GatewayModelMetricMeta;
   } | null;
-  /** Success rate over trailing windows. */
+  /** Uptime success percentages (0-100) over trailing windows. */
   uptime: {
     last15m: number | null;
     last1h: number | null;
@@ -189,20 +189,23 @@ const gatewayModelMetricsResponseSchema = lazySchema(() =>
               output: z.string().optional(),
               meta: gatewayModelMetricMetaSchema,
             }),
+            // Metric groups are nullish (not just nullable) for forward
+            // compatibility: if the gateway ever omits a group key instead
+            // of sending null, older SDK versions keep parsing.
             latency_last_1h: z
               .object({
                 p50: z.number(),
                 p95: z.number(),
                 meta: gatewayModelMetricMetaSchema,
               })
-              .nullable(),
+              .nullish(),
             throughput_last_1h: z
               .object({
                 p50: z.number(),
                 p95: z.number(),
                 meta: gatewayModelMetricMetaSchema,
               })
-              .nullable(),
+              .nullish(),
             uptime: z
               .object({
                 last_15m: z.number().nullable(),
@@ -216,13 +219,16 @@ const gatewayModelMetricsResponseSchema = lazySchema(() =>
                 last1d: last_1d,
                 meta,
               }))
-              .nullable(),
+              .nullish(),
           })
-          .transform(({ latency_last_1h, throughput_last_1h, ...rest }) => ({
-            ...rest,
-            latency: latency_last_1h,
-            throughput: throughput_last_1h,
-          })),
+          .transform(
+            ({ latency_last_1h, throughput_last_1h, uptime, ...rest }) => ({
+              ...rest,
+              latency: latency_last_1h ?? null,
+              throughput: throughput_last_1h ?? null,
+              uptime: uptime ?? null,
+            }),
+          ),
       ),
       meta: z
         .object({

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -7,6 +7,7 @@ import {
 import { GatewayFetchMetadata } from './gateway-fetch-metadata';
 import { GatewaySpendReport } from './gateway-spend-report';
 import { GatewayGenerationInfoFetcher } from './gateway-generation-info';
+import { GatewayModelMetrics } from './gateway-model-metrics';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { GatewayEmbeddingModel } from './gateway-embedding-model';
 import { GatewayImageModel } from './gateway-image-model';
@@ -54,6 +55,35 @@ vi.mock('./gateway-generation-info', () => ({
     };
   }),
 }));
+
+const mockGetModelMetrics = vi.fn();
+vi.mock('./gateway-model-metrics', () => ({
+  GatewayModelMetrics: vi.fn(function (config: any) {
+    return {
+      getModelMetrics: async (params: any) => {
+        if (config.headers && typeof config.headers === 'function') {
+          await config.headers();
+        }
+        return mockGetModelMetrics(params);
+      },
+    };
+  }),
+}));
+
+const emptyModelMetricsResponse = {
+  object: 'list',
+  data: [],
+  meta: {
+    generatedAt: '2026-07-05T00:00:00.000Z',
+    sourceWindows: {
+      latency: '1h',
+      throughput: '1h',
+      uptime: ['15m', '1h', '1d'],
+    },
+    provenanceNote:
+      'Latency and throughput are observed from live gateway traffic.',
+  },
+};
 
 // Mock the gateway fetch metadata to prevent actual network calls
 // We'll create a more flexible mock that can simulate auth failures
@@ -254,6 +284,7 @@ describe('GatewayProvider', () => {
     mockGetCredits.mockReturnValue({ balance: '100.00', total_used: '50.00' });
     mockGetSpendReport.mockReturnValue({ results: [] });
     mockGetGenerationInfo.mockReturnValue({ id: 'gen_test' });
+    mockGetModelMetrics.mockReturnValue(emptyModelMetricsResponse);
     if ('AI_GATEWAY_API_KEY' in process.env) {
       Reflect.deleteProperty(process.env, 'AI_GATEWAY_API_KEY');
     }
@@ -1714,6 +1745,141 @@ describe('GatewayProvider', () => {
 
       expect(generationInfo).toBeDefined();
       expect(getVercelOidcToken).toHaveBeenCalled();
+    });
+  });
+
+  describe('getModelMetrics method', () => {
+    it('should fetch model metrics successfully', async () => {
+      const mockResults = {
+        ...emptyModelMetricsResponse,
+        data: [
+          {
+            id: 'anthropic/claude-sonnet-4.5',
+            name: 'Claude Sonnet 4.5',
+            provider: 'anthropic',
+            type: 'language',
+            pricing: { meta: { source: 'declared' } },
+            latency: null,
+            throughput: null,
+            uptime: null,
+          },
+        ],
+      };
+      mockGetModelMetrics.mockReturnValue(mockResults);
+
+      const provider = createGateway({
+        apiKey: 'test-key',
+      });
+
+      const metrics = await provider.getModelMetrics();
+
+      expect(metrics).toEqual(mockResults);
+      expect(GatewayModelMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://ai-gateway.vercel.sh/v4/ai',
+          headers: expect.any(Function),
+          fetch: undefined,
+        }),
+      );
+    });
+
+    it('should pass options through to GatewayModelMetrics', async () => {
+      const provider = createGateway({
+        apiKey: 'test-key',
+      });
+
+      await provider.getModelMetrics({
+        type: 'language',
+        tags: ['tools', 'reasoning'],
+        maxInputPrice: 0.000005,
+        sort: 'ttft',
+        limit: 100,
+      });
+
+      expect(mockGetModelMetrics).toHaveBeenCalledWith({
+        type: 'language',
+        tags: ['tools', 'reasoning'],
+        maxInputPrice: 0.000005,
+        sort: 'ttft',
+        limit: 100,
+      });
+    });
+
+    it('should work with custom baseURL', async () => {
+      const customBaseURL = 'https://custom-gateway.example.com/v4/ai';
+      const provider = createGateway({
+        apiKey: 'test-key',
+        baseURL: customBaseURL,
+      });
+
+      await provider.getModelMetrics();
+
+      expect(GatewayModelMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: customBaseURL,
+        }),
+      );
+    });
+
+    it('should work with custom fetch function', async () => {
+      const customFetch = vi.fn();
+      const provider = createGateway({
+        apiKey: 'test-key',
+        fetch: customFetch,
+      });
+
+      await provider.getModelMetrics();
+
+      expect(GatewayModelMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetch: customFetch,
+        }),
+      );
+    });
+
+    it('should handle errors from the model metrics endpoint', async () => {
+      const testError = new Error('Metrics service unavailable');
+      mockGetModelMetrics.mockRejectedValue(testError);
+
+      const provider = createGateway({
+        apiKey: 'test-key',
+      });
+
+      await expect(provider.getModelMetrics()).rejects.toThrow(
+        'Metrics service unavailable',
+      );
+    });
+
+    it('should work without credentials since the endpoint is public', async () => {
+      vi.mocked(getVercelOidcToken).mockRejectedValue(
+        new Error('OIDC token not available'),
+      );
+
+      const provider = createGateway();
+
+      const metrics = await provider.getModelMetrics();
+
+      expect(metrics).toEqual(emptyModelMetricsResponse);
+    });
+
+    it('should work with OIDC authentication in model metrics', async () => {
+      vi.mocked(getVercelOidcToken).mockResolvedValue('oidc-token');
+
+      const provider = createGateway();
+
+      const metrics = await provider.getModelMetrics();
+
+      expect(metrics).toBeDefined();
+      expect(getVercelOidcToken).toHaveBeenCalled();
+    });
+
+    it('should be available on the provider interface', () => {
+      const provider = createGateway({ apiKey: 'test-key' });
+      expect(typeof provider.getModelMetrics).toBe('function');
+    });
+
+    it('should be available on the default gateway export', () => {
+      expect(typeof gateway.getModelMetrics).toBe('function');
     });
   });
 

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -25,6 +25,11 @@ import {
   type GatewaySpendReportResponse,
 } from './gateway-spend-report';
 import {
+  GatewayModelMetrics,
+  type GatewayModelMetricsOptions,
+  type GatewayModelMetricsResponse,
+} from './gateway-model-metrics';
+import {
   GatewayGenerationInfoFetcher,
   type GatewayGenerationInfoParams,
   type GatewayGenerationInfo,
@@ -99,6 +104,15 @@ export interface GatewayProvider extends ProviderV4 {
   getGenerationInfo(
     params: GatewayGenerationInfoParams,
   ): Promise<GatewayGenerationInfo>;
+
+  /**
+   * Returns per model and provider performance metrics (time to first token,
+   * throughput, uptime) alongside declared pricing. This is a public endpoint:
+   * no authentication is required, but credentials are attached when available.
+   */
+  getModelMetrics(
+    options?: GatewayModelMetricsOptions,
+  ): Promise<GatewayModelMetricsResponse>;
 
   /**
    * Creates a model for generating text embeddings.
@@ -275,6 +289,26 @@ export function createGateway(
     }
   };
 
+  // Headers for public endpoints such as the model metrics endpoint:
+  // credentials are attached when available (harmless), but their absence
+  // does not prevent the request.
+  const getMetricsHeaders = async () => {
+    try {
+      return createAuthHeaders(await getGatewayAuthToken(options));
+    } catch {
+      return withUserAgentSuffix(
+        {
+          'ai-gateway-protocol-version': AI_GATEWAY_PROTOCOL_VERSION,
+          ...(options.teamIdOrSlug != null
+            ? { [VERCEL_AI_GATEWAY_TEAM_HEADER]: options.teamIdOrSlug }
+            : {}),
+          ...options.headers,
+        },
+        `ai-sdk/gateway/${VERSION}`,
+      );
+    }
+  };
+
   const getRealtimeAuthToken = async () => {
     try {
       return await getGatewayAuthToken(options);
@@ -442,6 +476,21 @@ export function createGateway(
       });
   };
 
+  const getModelMetrics = async (params?: GatewayModelMetricsOptions) => {
+    return new GatewayModelMetrics({
+      baseURL,
+      headers: getMetricsHeaders,
+      fetch: options.fetch,
+    })
+      .getModelMetrics(params)
+      .catch(async (error: unknown) => {
+        throw await asGatewayError(
+          error,
+          await parseAuthMethod(await getMetricsHeaders()),
+        );
+      });
+  };
+
   const provider = function (modelId: GatewayModelId) {
     if (new.target) {
       throw new Error(
@@ -457,6 +506,7 @@ export function createGateway(
   provider.getCredits = getCredits;
   provider.getSpendReport = getSpendReport;
   provider.getGenerationInfo = getGenerationInfo;
+  provider.getModelMetrics = getModelMetrics;
   provider.imageModel = (modelId: GatewayImageModelId) => {
     return new GatewayImageModel(modelId, {
       provider: 'gateway',

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -26,6 +26,13 @@ export type {
   GatewayGenerationInfoParams,
   GatewayGenerationInfo,
 } from './gateway-generation-info';
+export type {
+  GatewayModelMetricsOptions,
+  GatewayModelMetricMeta,
+  GatewayModelMetricsRow,
+  GatewayModelMetricsResponse,
+  GatewayModelMetricsResponseMeta,
+} from './gateway-model-metrics';
 export type { GatewayLanguageModelEntry as GatewayModelEntry } from './gateway-model-entry';
 export {
   createGateway,


### PR DESCRIPTION
## Summary

Adds `gateway.getModelMetrics()` to `@ai-sdk/gateway` — first-class access to the AI Gateway's fleet-wide model performance API (`GET /v1/models/metrics`): one row per model × provider with observed last-hour TTFT/throughput percentiles, 15m/1h/1d uptime, and declared pricing, each group carrying a provenance envelope (`source: 'declared' | 'observed' | 'verified'`, window, `measuredAt`, `sampleSize`, region).

This enables runtime, data-driven model/provider selection from application code:

```ts
import { gateway } from '@ai-sdk/gateway';

const { data } = await gateway.getModelMetrics({
  tags: ['tool-use'],
  maxInputPrice: 0.000005,
  sort: 'ttft',
});
// data[0] → fastest healthy model×provider under the price cap, with the
// latency/throughput/uptime numbers (and their provenance) to justify it
```

Options: `type`, `tags` (AND-matched), `maxInputPrice`, `sort` (`'cost' | 'ttft' | 'tps' | 'reliability'`), `limit`. Wire snake_case is transformed to camelCase per package convention; new exported types: `GatewayModelMetricsOptions`, `GatewayModelMetricMeta`, `GatewayModelMetricsRow`, `GatewayModelMetricsResponse`, `GatewayModelMetricsResponseMeta`.

Implementation mirrors the existing non-inference endpoint pattern (`getCredits` / `getSpendReport`): URL derived as `new URL(baseURL).origin + '/v1/models/metrics'`; auth headers attached when credentials resolve but the call degrades to unauthenticated (the endpoint is public).

## ⚠️ Dependency — do not merge yet

The gateway endpoint ships in vercel/ai-gateway#2497 (currently in review, flag-gated). Before undrafting, re-verify the zod schema against the deployed endpoint's response. Keeping this as a visible draft so SDK review can happen in parallel.

## Testing

- `turbo test --filter=@ai-sdk/gateway`: 20 files, 493 passed (node) / 488 passed + 5 pre-existing skips (edge), including 14 new endpoint tests (success, query serialization, catalog-only rows with `provider: null`, null uptime windows, error paths, custom fetch) and 9 new provider-surface tests
- `turbo type-check --filter=@ai-sdk/gateway`: clean (tsc --build + tsup DTS)
- `ultracite check` on touched files: clean
- Changeset included (minor, `@ai-sdk/gateway`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
