### PR TITLE
reproduction: Reproduces #11701

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11701-openai-output-array-schema.ts
+++ b/examples/ai-functions/src/reproduction/issue-11701-openai-output-array-schema.ts
@@ -1,0 +1,48 @@
+import { openai } from '@ai-sdk/openai';
+import { APICallError, generateText, Output } from 'ai';
+import { z } from 'zod/v4';
+
+async function main() {
+  console.log(
+    'Reproducing issue #11701 with generateText({ output }) and a top-level array schema.',
+  );
+  console.log(
+    'This uses the OpenAI provider path (not AI Gateway) because live AI Gateway checks are skipped by policy.',
+  );
+
+  try {
+    const result = await generateText({
+      model: openai('gpt-4o-mini'),
+      maxRetries: 0,
+      prompt: 'Return 3 random words',
+      output: Output.object({
+        schema: z.array(
+          z.object({
+            word: z.string(),
+            category: z.string(),
+          }),
+        ),
+      }),
+    });
+
+    console.log('Unexpected success:', JSON.stringify(result.output));
+  } catch (error) {
+    if (APICallError.isInstance(error)) {
+      console.error('Provider APICallError:', error.message);
+      console.error('Status code:', error.statusCode);
+      console.error('Response body:', error.responseBody);
+      console.error(
+        'Request body:',
+        JSON.stringify(error.requestBodyValues, null, 2),
+      );
+      throw error;
+    }
+
+    console.error(error);
+    throw error;
+  }
+}
+
+main().catch(() => {
+  process.exitCode = 1;
+});

--- a/packages/openai/src/responses/__fixtures__/issue-11701-output-array-schema.1.json
+++ b/packages/openai/src/responses/__fixtures__/issue-11701-output-array-schema.1.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Invalid schema for response_format 'response': schema must be a JSON Schema of 'type: \"object\"', got 'type: \"array\"'.",
+    "type": "invalid_request_error",
+    "param": "text.format.schema",
+    "code": "invalid_json_schema"
+  }
+}

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1910,6 +1910,39 @@ describe('OpenAIResponsesLanguageModel', () => {
           'You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.',
         );
       });
+
+      it('issue #11701: should support generateText output schemas whose root is an array', async () => {
+        prepareJsonFixtureResponse('issue-11701-output-array-schema.1');
+
+        await expect(
+          createModel('gpt-4o-mini').doGenerate({
+            prompt: [
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'Return 3 random words' }],
+              },
+            ],
+            responseFormat: {
+              type: 'json',
+              schema: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    word: { type: 'string' },
+                    category: { type: 'string' },
+                  },
+                  required: ['word', 'category'],
+                  additionalProperties: false,
+                },
+              },
+            },
+          }),
+        ).resolves.toMatchObject({
+          content: expect.any(Array),
+        });
+      });
     });
 
     describe('reasoning', () => {


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Reproduced with live OpenAI provider using artifact examples/ai-functions/src/reproduction/issue-11701-openai-output-array-schema.ts; ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11701-openai-output-array-schema.ts` and observed APICallError 400 invalid_json_schema because the response_format schema root was an array, while the expected issue behavior is that generateText({ output }) returns the 3 word objects. Recorded fixture: packages/openai/src/responses/__fixtures__/issue-11701-output-array-schema.1.json. Added failing provider test: packages/openai/src/responses/openai-responses-language-model.test.ts; `pnpm -C packages/openai test:node src/responses/openai-responses-language-model.test.ts -t 'issue #11701'` fails with the same recorded error. AI Gateway live-service portion was not attempted by policy.

## Branch

bug-11701-1

## Related Issues

Reproduces #11701