### PR TITLE
reproduction: Reproduces #11686

### DIFF
--- a/examples/ai-functions/src/reproduction/reproduce-11686.ts
+++ b/examples/ai-functions/src/reproduction/reproduce-11686.ts
@@ -1,0 +1,35 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+async function main() {
+  const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+  const args = [
+    '-C',
+    'packages/react',
+    'exec',
+    'vitest',
+    '--config',
+    'vitest.config.js',
+    '--run',
+    'src/use-chat.stale-closures.test.tsx',
+  ];
+
+  console.log(`Running: pnpm ${args.join(' ')}`);
+
+  const result = spawnSync('pnpm', args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error != null) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/react/src/use-chat.stale-closures.test.tsx
+++ b/packages/react/src/use-chat.stale-closures.test.tsx
@@ -1,0 +1,123 @@
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  createTestServer,
+} from '@ai-sdk/test-server/with-vitest';
+import { mockId } from '@ai-sdk/provider-utils/test';
+import type { UIMessageChunk } from 'ai';
+import React, { useMemo, useRef, useState } from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useChat } from './use-chat';
+
+function formatChunk(part: UIMessageChunk) {
+  return `data: ${JSON.stringify(part)}\n\n`;
+}
+
+const server = createTestServer({
+  '/api/chat': {},
+});
+
+describe('useChat memoized callback closures', () => {
+  const onDataCounters: Array<{
+    closureCounter: number;
+    refCounter: number;
+  }> = [];
+  const onFinishCounters: Array<{
+    closureCounter: number;
+    refCounter: number;
+  }> = [];
+
+  function TestComponent() {
+    const [counter, setCounter] = useState(0);
+    const counterRef = useRef(counter);
+    counterRef.current = counter;
+
+    const chatOptions = useMemo(
+      () => ({
+        generateId: mockId(),
+        onData: () => {
+          onDataCounters.push({
+            closureCounter: counter,
+            refCounter: counterRef.current,
+          });
+        },
+        onFinish: () => {
+          onFinishCounters.push({
+            closureCounter: counter,
+            refCounter: counterRef.current,
+          });
+        },
+      }),
+      [],
+    );
+
+    const { sendMessage } = useChat(chatOptions);
+
+    return (
+      <div>
+        <div data-testid="counter">{counter}</div>
+        <button
+          data-testid="increment"
+          onClick={() => setCounter(current => current + 1)}
+        />
+        <button
+          data-testid="send"
+          onClick={() =>
+            sendMessage({ parts: [{ type: 'text', text: 'Hello' }] })
+          }
+        />
+      </div>
+    );
+  }
+
+  beforeEach(() => {
+    onDataCounters.length = 0;
+    onFinishCounters.length = 0;
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <TestComponent />
+      </SWRConfig>,
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('passes current React state to onData and onFinish when options are memoized', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'data-test', data: 'example-data' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hi' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'finish', finishReason: 'stop' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('increment'));
+    await userEvent.click(screen.getByTestId('increment'));
+    await userEvent.click(screen.getByTestId('increment'));
+
+    expect(screen.getByTestId('counter')).toHaveTextContent('3');
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    await waitFor(() => {
+      expect(onFinishCounters).toHaveLength(1);
+    });
+
+    expect({ onDataCounters, onFinishCounters }).toStrictEqual({
+      onDataCounters: [{ closureCounter: 3, refCounter: 3 }],
+      onFinishCounters: [{ closureCounter: 3, refCounter: 3 }],
+    });
+  });
+});


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction artifacts at packages/react/src/use-chat.stale-closures.test.tsx and examples/ai-functions/src/reproduction/reproduce-11686.ts. Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/reproduce-11686.ts`; the focused Vitest test failed because both onData and onFinish observed closureCounter 0 while refCounter was 3, whereas the expected issue behavior is for callbacks to see current counter 3. No blocker.

## Branch

bug-11686-1

## Related Issues

Reproduces #11686