### PR TITLE
reproduction: Reproduces #11679

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11679-openai-diarize-transcribe.ts
+++ b/examples/ai-functions/src/reproduction/issue-11679-openai-diarize-transcribe.ts
@@ -1,0 +1,54 @@
+import 'dotenv/config';
+
+import { openai } from '@ai-sdk/openai';
+import { APICallError, transcribe } from 'ai';
+import { readFile } from 'node:fs/promises';
+
+async function main() {
+  try {
+    await transcribe({
+      model: openai.transcription('gpt-4o-transcribe-diarize'),
+      audio: await readFile('data/galileo.mp3'),
+      providerOptions: {
+        openai: {
+          // These snake_case options are the options requested in #11679.
+          // They are intentionally cast because the current OpenAI provider
+          // option schema does not expose them.
+          chunking_strategy: 'auto',
+          response_format: 'json',
+        } as any,
+      },
+    });
+
+    throw new Error(
+      'Issue #11679 was not reproduced: diarized transcription unexpectedly succeeded.',
+    );
+  } catch (error) {
+    if (!APICallError.isInstance(error)) {
+      throw error;
+    }
+
+    console.error('OpenAI transcription API call failed.');
+    console.error('Status code:', error.statusCode);
+    console.error('Request body values:', error.requestBodyValues);
+    console.error('Response body:', error.responseBody);
+
+    const responseBody = String(error.responseBody ?? '');
+    if (
+      error.statusCode === 400 &&
+      responseBody.includes("response_format 'verbose_json' is not compatible")
+    ) {
+      throw new Error(
+        'Reproduced issue #11679: providerOptions.openai.response_format was set to "json", but the API received/validated "verbose_json".',
+        { cause: error },
+      );
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/transcription/__fixtures__/openai-diarize-verbose-json-error.json
+++ b/packages/openai/src/transcription/__fixtures__/openai-diarize-verbose-json-error.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "response_format 'verbose_json' is not compatible with model 'gpt-4o-transcribe-diarize-api-ev3'. Use 'json' or 'text' instead.",
+    "type": "invalid_request_error",
+    "param": "response_format",
+    "code": "unsupported_value"
+  }
+}

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -7,7 +7,7 @@ import {
   convertReadableStreamToArray,
 } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
-import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
+import { APICallError, UnsupportedFunctionalityError } from '@ai-sdk/provider';
 import { createOpenAI } from '../openai-provider';
 import { OpenAITranscriptionModel } from './openai-transcription-model';
 import { describe, it, expect, vi } from 'vitest';
@@ -71,6 +71,17 @@ function prepareJsonFixtureResponse(
         `src/transcription/__fixtures__/${filename}.json`,
         'utf8',
       ),
+    ),
+  };
+}
+
+function prepareJsonErrorFixtureResponse(filename: string, status = 400) {
+  server.urls['https://api.openai.com/v1/audio/transcriptions'].response = {
+    type: 'error',
+    status,
+    body: fs.readFileSync(
+      `src/transcription/__fixtures__/${filename}.json`,
+      'utf8',
     ),
   };
 }
@@ -265,6 +276,41 @@ describe('doGenerate', () => {
         "response_format": "json",
         "temperature": "0",
         "timestamp_granularities[]": "word",
+      }
+    `);
+  });
+
+  it('should pass diarization chunking_strategy and response_format provider options', async () => {
+    prepareJsonErrorFixtureResponse('openai-diarize-verbose-json-error');
+
+    const model = provider.transcription('gpt-4o-transcribe-diarize');
+    await expect(
+      model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/mpeg',
+        providerOptions: {
+          openai: {
+            chunking_strategy: 'auto',
+            response_format: 'json',
+          } as any,
+        },
+      }),
+    ).rejects.toSatisfy(error => {
+      expect(APICallError.isInstance(error)).toBe(true);
+      expect(String((error as APICallError).responseBody)).toContain(
+        "response_format 'verbose_json' is not compatible",
+      );
+      return true;
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!.file).toBeInstanceOf(File);
+    const { file: _, ...rest } = body!;
+    expect(rest).toMatchInlineSnapshot(`
+      {
+        "chunking_strategy": "auto",
+        "model": "gpt-4o-transcribe-diarize",
+        "response_format": "json",
       }
     `);
   });


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Reproduced with live OpenAI call via `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11679-openai-diarize-transcribe.ts` using artifact `examples/ai-functions/src/reproduction/issue-11679-openai-diarize-transcribe.ts`: despite providerOptions requesting `chunking_strategy: auto` and `response_format: json`, the request body sent `response_format: verbose_json`, omitted `chunking_strategy`, and OpenAI returned 400 `response_format 'verbose_json' is not compatible...`; expected those provider options to reach the API. Recorded fixture `packages/openai/src/transcription/__fixtures__/openai-diarize-verbose-json-error.json` and added provider unit test in `packages/openai/src/transcription/openai-transcription-model.test.ts`; `pnpm -C packages/openai test:node src/transcription/openai-transcription-model.test.ts` fails on the new test showing the request body mismatch. Blocker: none.

## Branch

bug-11679-1

## Related Issues

Reproduces #11679