### PR TITLE
reproduction: Could not reproduce #11674

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11674.ts
+++ b/examples/ai-functions/src/reproduction/issue-11674.ts
@@ -1,0 +1,72 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText, tool } from 'ai';
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+async function main() {
+  let executed = false;
+  const rawChunks: string[] = [];
+  const streamChunks: unknown[] = [];
+
+  const result = streamText({
+    model: anthropic('claude-haiku-4-5'),
+    include: { rawChunks: true },
+    tools: {
+      sayHello: tool({
+        description: 'Say hello',
+        inputSchema: z.object({}),
+        execute: async ({}) => {
+          executed = true;
+          console.log('Executing sayHello tool');
+          return 'Hello!';
+        },
+      }),
+    },
+    toolChoice: {
+      type: 'tool',
+      toolName: 'sayHello',
+    },
+    prompt: 'Say hello!',
+  });
+
+  for await (const chunk of result.fullStream) {
+    streamChunks.push(chunk);
+    console.log(JSON.stringify(chunk));
+    if (chunk.type === 'raw') {
+      rawChunks.push(JSON.stringify(chunk.rawValue));
+    }
+  }
+
+  fs.mkdirSync('output', { recursive: true });
+  fs.writeFileSync(
+    path.join('output', 'issue-11674.1.chunks.txt'),
+    rawChunks.join('\n'),
+  );
+
+  const finish = streamChunks.find(
+    chunk =>
+      typeof chunk === 'object' &&
+      chunk != null &&
+      'type' in chunk &&
+      chunk.type === 'finish',
+  );
+  const toolCalls = streamChunks.filter(
+    chunk =>
+      typeof chunk === 'object' &&
+      chunk != null &&
+      'type' in chunk &&
+      chunk.type === 'tool-call',
+  );
+
+  if (!executed || toolCalls.length === 0) {
+    throw new Error(
+      `Issue #11674 reproduced: forced empty-schema tool was not executed. toolCalls=${toolCalls.length}; finish=${JSON.stringify(finish)}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt
@@ -1,0 +1,7 @@
+{"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_01XjqkS9ukKo8oda3vP8AsVZ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":666,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard","inference_geo":"not_available"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01ShZKk3kJGrMg3LqcfyHLBA","name":"sayHello","input":{},"caller":{"type":"direct"}}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_stop","index":0}
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":666,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":16}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -9370,6 +9370,78 @@ describe('AnthropicLanguageModel', () => {
             ]
           `);
       });
+
+      it('should support forced tools with empty parameters in streaming', async () => {
+        prepareChunksFixtureResponse(
+          'anthropic-issue-11674-empty-schema-forced-tool-call.1',
+        );
+
+        const result = await provider('claude-haiku-4-5').doStream({
+          tools: [
+            {
+              type: 'function',
+              name: 'sayHello',
+              description: 'Say hello',
+              inputSchema: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+          ],
+          toolChoice: { type: 'tool', toolName: 'sayHello' },
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Say hello!' }] },
+          ],
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          tool_choice: { type: 'tool', name: 'sayHello' },
+          tools: [
+            {
+              name: 'sayHello',
+              input_schema: {
+                type: 'object',
+                properties: {},
+                required: [],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+          ],
+        });
+
+        const chunks = await convertReadableStreamToArray(result.stream);
+        const toolCall = chunks.find(
+          (chunk): chunk is LanguageModelV4StreamPart & { type: 'tool-call' } =>
+            chunk.type === 'tool-call',
+        );
+        const finish = chunks.find(chunk => chunk.type === 'finish');
+
+        expect(toolCall).toMatchObject({
+          type: 'tool-call',
+          toolCallId: 'toolu_01ShZKk3kJGrMg3LqcfyHLBA',
+          toolName: 'sayHello',
+          input: '{}',
+          providerMetadata: {
+            anthropic: {
+              caller: {
+                type: 'direct',
+                toolId: undefined,
+              },
+            },
+          },
+        });
+        expect(finish).toMatchObject({
+          type: 'finish',
+          finishReason: {
+            raw: 'tool_use',
+            unified: 'tool-calls',
+          },
+        });
+      });
     });
 
     describe('programmatic tool calling', () => {


### PR DESCRIPTION
## Bug Reproduction

**Bug could not be reproduced.**

Could not reproduce issue #11674. Created live reproduction script at examples/ai-functions/src/reproduction/issue-11674.ts and ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11674.ts`; observed Anthropic streaming returned a `tool-call`, executed `sayHello`, and finished with `finishReason: "tool-calls"`, whereas the expected issue behavior was no content/no tool execution despite `tool-calls`. Recorded live chunks in packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt and added provider unit coverage in packages/anthropic/src/anthropic-language-model.test.ts; ran `pnpm -C packages/anthropic test:node -- -t "should support forced tools with empty parameters in streaming"`, which passed. No blocker encountered.

## Branch

bug-11674-1

## Related Issues

Could not reproduce #11674