### PR TITLE
fix(langchain): avoid call stack overflow when base64-encoding large binary content

### DIFF
--- a/.changeset/langchain-base64-large-binary.md
+++ b/.changeset/langchain-base64-large-binary.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+Fix `convertUserContent` throwing `RangeError: Maximum call stack size exceeded` on large binary image and file inputs. The base64 encoding used `btoa(String.fromCharCode(...bytes))`, which passes one argument per byte and overflows the argument limit for real-sized images and documents. It now uses `convertUint8ArrayToBase64` from `@ai-sdk/provider-utils`, which the rest of the SDK already relies on. The encoded output is unchanged for inputs that did not previously overflow.

--- a/.changeset/langchain-base64-large-binary.md
+++ b/.changeset/langchain-base64-large-binary.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+Fix `convertUserContent` throwing `RangeError: Maximum call stack size exceeded` on large binary image and file inputs. The base64 encoding used `btoa(String.fromCharCode(...bytes))`, which passes one argument per byte and overflows the argument limit for real-sized images and documents. It now uses `convertUint8ArrayToBase64` from `@ai-sdk/provider-utils` (moved to dependencies since it is now a runtime import). The encoded output is unchanged for inputs that did not previously overflow.

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -36,10 +36,10 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/provider-utils": "workspace:*",
     "ai": "workspace:*"
   },
   "devDependencies": {
-    "@ai-sdk/provider-utils": "workspace:*",
     "@langchain/core": "^1.1.46",
     "@langchain/langgraph": "^1.3.0",
     "@types/node": "22.19.19",

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -265,6 +265,60 @@ describe('convertUserContent', () => {
     ]);
   });
 
+  it('should convert large binary image data without exceeding the call stack', () => {
+    // Real images are far larger than the argument limit of
+    // String.fromCharCode(...bytes), which threw "Maximum call stack size
+    // exceeded" for binary of this size.
+    const largeImage = new Uint8Array(300_000);
+    for (let i = 0; i < largeImage.length; i++) {
+      largeImage[i] = i % 256;
+    }
+
+    const content: UserContent = [
+      { type: 'image', image: largeImage, mediaType: 'image/png' },
+    ];
+
+    const result = convertUserContent(content);
+
+    const block = (
+      result.content as unknown as Array<{
+        type: string;
+        image_url: { url: string };
+      }>
+    )[0];
+    expect(block.type).toBe('image_url');
+
+    const base64 = block.image_url.url.split(',')[1];
+    const decoded = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+    expect(decoded).toEqual(largeImage);
+  });
+
+  it('should convert large binary file data without exceeding the call stack', () => {
+    const largeFile = new Uint8Array(300_000);
+    for (let i = 0; i < largeFile.length; i++) {
+      largeFile[i] = i % 256;
+    }
+
+    const content: UserContent = [
+      {
+        type: 'file',
+        data: largeFile,
+        mediaType: 'application/pdf',
+        filename: 'large.pdf',
+      },
+    ];
+
+    const result = convertUserContent(content);
+
+    const block = (
+      result.content as unknown as Array<{ type: string; data: string }>
+    )[0];
+    expect(block.type).toBe('file');
+
+    const decoded = Uint8Array.from(atob(block.data), c => c.charCodeAt(0));
+    expect(decoded).toEqual(largeFile);
+  });
+
   it('should include image parts with URL using OpenAI image_url format', () => {
     const content: UserContent = [
       { type: 'text', text: 'What is in this image?' },

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -395,6 +395,61 @@ describe('convertUserContent', () => {
       },
     ]);
   });
+
+  it('should convert large binary image data without exceeding the call stack', () => {
+    // Real images are far larger than the argument limit of
+    // String.fromCharCode(...bytes), which threw "Maximum call stack size
+    // exceeded" for binary of this size.
+    const largeImage = new Uint8Array(300_000);
+    for (let i = 0; i < largeImage.length; i++) {
+      largeImage[i] = i % 256;
+    }
+
+    const content: UserContent = [
+      { type: 'image', image: largeImage, mediaType: 'image/png' },
+    ];
+
+    const result = convertUserContent(content);
+
+    const block = (
+      result.content as unknown as Array<{
+        type: string;
+        data: string;
+        mimeType: string;
+      }>
+    )[0];
+    expect(block.type).toBe('image');
+    expect(block.mimeType).toBe('image/png');
+
+    const decoded = Uint8Array.from(atob(block.data), c => c.charCodeAt(0));
+    expect(decoded).toEqual(largeImage);
+  });
+
+  it('should convert large binary file data without exceeding the call stack', () => {
+    const largeFile = new Uint8Array(300_000);
+    for (let i = 0; i < largeFile.length; i++) {
+      largeFile[i] = i % 256;
+    }
+
+    const content: UserContent = [
+      {
+        type: 'file',
+        data: largeFile,
+        mediaType: 'application/pdf',
+        filename: 'large.pdf',
+      },
+    ];
+
+    const result = convertUserContent(content);
+
+    const block = (
+      result.content as unknown as Array<{ type: string; data: string }>
+    )[0];
+    expect(block.type).toBe('file');
+
+    const decoded = Uint8Array.from(atob(block.data), c => c.charCodeAt(0));
+    expect(decoded).toEqual(largeFile);
+  });
 });
 
 describe('isToolResultPart', () => {

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -17,6 +17,7 @@ import type {
   ProviderMetadata,
   JSONValue,
 } from 'ai';
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
 import type {
   LangGraphEventState,
@@ -216,7 +217,7 @@ export function convertUserContent(content: UserContent): HumanMessage {
         /**
          * Convert to base64 data URL
          */
-        const base64 = btoa(String.fromCharCode(...bytes));
+        const base64 = convertUint8ArrayToBase64(bytes);
         const mimeType = imagePart.mediaType || 'image/png';
         contentBlocks.push({
           type: 'image_url',
@@ -317,7 +318,7 @@ export function convertUserContent(content: UserContent): HumanMessage {
             filePart.data instanceof ArrayBuffer
               ? new Uint8Array(filePart.data)
               : filePart.data;
-          const base64 = btoa(String.fromCharCode(...bytes));
+          const base64 = convertUint8ArrayToBase64(bytes);
           contentBlocks.push({
             type: 'image_url',
             image_url: { url: `data:${filePart.mediaType};base64,${base64}` },
@@ -379,7 +380,7 @@ export function convertUserContent(content: UserContent): HumanMessage {
             filePart.data instanceof ArrayBuffer
               ? new Uint8Array(filePart.data)
               : filePart.data;
-          const base64 = btoa(String.fromCharCode(...bytes));
+          const base64 = convertUint8ArrayToBase64(bytes);
           contentBlocks.push({
             type: 'file',
             data: base64,

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -17,6 +17,7 @@ import type {
   ProviderMetadata,
   JSONValue,
 } from 'ai';
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
 import type {
   LangGraphEventState,
@@ -249,7 +250,7 @@ function convertImageToContentBlock(
   const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
   return {
     type: 'image',
-    data: btoa(String.fromCharCode(...bytes)),
+    data: convertUint8ArrayToBase64(bytes),
     mimeType: mediaType,
   };
 }
@@ -396,7 +397,7 @@ export function convertUserContent(content: UserContent): HumanMessage {
             filePart.data instanceof ArrayBuffer
               ? new Uint8Array(filePart.data)
               : filePart.data;
-          const base64 = btoa(String.fromCharCode(...bytes));
+          const base64 = convertUint8ArrayToBase64(bytes);
           contentBlocks.push({
             type: 'file',
             data: base64,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3303,13 +3303,13 @@ importers:
 
   packages/langchain:
     dependencies:
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
       ai:
         specifier: workspace:*
         version: link:../ai
     devDependencies:
-      '@ai-sdk/provider-utils':
-        specifier: workspace:*
-        version: link:../provider-utils
       '@langchain/core':
         specifier: ^1.1.46
         version: 1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.40.0(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)


### PR DESCRIPTION
### What

`convertUserContent` in `@ai-sdk/langchain` base64-encodes inline binary image and file data with:

```ts
btoa(String.fromCharCode(...bytes))
```

Spreading a `Uint8Array` into `String.fromCharCode` passes one argument per byte, so once `bytes` is larger than the engine's argument limit it throws `RangeError: Maximum call stack size exceeded`. Real images and PDFs clear that limit easily, so sending inline binary content to a LangChain model through the adapter crashes instead of encoding it. The same expression appears three times in `convertUserContent`: the `image` branch, and both the image-file and non-image-file branches.

### Fix

Use `convertUint8ArrayToBase64` from `@ai-sdk/provider-utils`, which builds the string with a loop instead of a spread. The SDK already avoids this footgun in the two other places that encode large buffers: `convertUint8ArrayToBase64` itself, and `encodeRealtimeAudio` in `packages/ai/src/realtime/audio-utils.ts`, which chunks the array specifically to stay under the argument limit. For any input that did not already overflow, the output is byte-identical, so existing behaviour and the existing image assertions are unchanged.

### Test

Added two regression tests that push 300 KB of binary through the `image` and `file` paths of `convertUserContent` and check that the base64 round-trips back to the original bytes.

Reverting only the `utils.ts` change and rerunning the suite fails exactly where expected:

```
× should convert large binary image data without exceeding the call stack
    RangeError: Maximum call stack size exceeded  (utils.ts:219)
× should convert large binary file data without exceeding the call stack
    RangeError: Maximum call stack size exceeded  (utils.ts:382)
```

With the change, `packages/langchain/src/utils.test.ts` passes (128 tests). Existing cases such as `[1, 2, 3]` -> `AQID` are unaffected since the encoding output is identical.
