### PR TITLE
reproduction: Reproduces #11216

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11216-amazon-bedrock-tool-result.ts
+++ b/examples/ai-functions/src/reproduction/issue-11216-amazon-bedrock-tool-result.ts
@@ -1,0 +1,72 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { convertToAmazonBedrockChatMessages } from '../../../../packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts';
+
+function assertBedrockToolResultImmediatelyFollowsToolUse(
+  messages: Array<{ role: string; content: Array<Record<string, unknown>> }>,
+) {
+  const assistantToolUseIndex = messages.findIndex(
+    message =>
+      message.role === 'assistant' &&
+      message.content.some(part => 'toolUse' in part),
+  );
+
+  if (assistantToolUseIndex === -1) {
+    throw new Error('Expected the converted Bedrock payload to contain toolUse.');
+  }
+
+  const nextMessage = messages[assistantToolUseIndex + 1];
+
+  if (
+    nextMessage?.role !== 'user' ||
+    !nextMessage.content.some(part => 'toolResult' in part)
+  ) {
+    throw new Error(
+      [
+        'Reproduced issue #11216: the Amazon Bedrock payload contains a toolUse',
+        'but the immediately following message is not a user message containing',
+        'the matching toolResult. Bedrock rejects this shape with:',
+        '`tool_use` ids were found without `tool_result` blocks immediately after.',
+      ].join(' '),
+    );
+  }
+}
+
+async function main() {
+  const prompt: LanguageModelV4Prompt = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'User prompt here' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+          toolName: 'toolCall',
+          input: { query: 'toolCallInput' },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+          toolName: 'toolCall',
+          output: { type: 'json', value: { success: true } },
+        },
+      ],
+    },
+    {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'assistant response' }],
+    },
+  ];
+
+  const converted = await convertToAmazonBedrockChatMessages(prompt);
+
+  console.log(JSON.stringify(converted, null, 2));
+  assertBedrockToolResultImmediatelyFollowsToolUse(converted.messages);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1361,6 +1361,73 @@ describe('assistant messages', () => {
       system: [],
     });
   });
+
+  it('should place assistant tool results immediately after assistant tool use', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'User prompt here' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+            toolName: 'toolCall',
+            input: { query: 'toolCallInput' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+            toolName: 'toolCall',
+            output: { type: 'json', value: { success: true } },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'assistant response' }],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'User prompt here' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+                name: 'toolCall',
+                input: { query: 'toolCallInput' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+                content: [{ text: JSON.stringify({ success: true }) }],
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ text: 'assistant response' }],
+        },
+      ],
+      system: [],
+    });
+  });
 });
 
 describe('tool messages', () => {


### PR DESCRIPTION
## Bug Reproduction

**Bug was reproduced.**

Created reproduction script examples/ai-functions/src/reproduction/issue-11216-amazon-bedrock-tool-result.ts and failing provider test packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts. Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11216-amazon-bedrock-tool-result.ts`: observed the Bedrock payload drops the assistant `tool-result`, leaving `toolUse` without an immediate following user `toolResult`; expected a user `toolResult` message immediately after the assistant `toolUse`. Also ran `pnpm -C packages/amazon-bedrock exec vitest --config vitest.node.config.js --run src/convert-to-amazon-bedrock-chat-messages.test.ts -t "should place assistant tool results immediately after assistant tool use"`, which fails with the same missing immediate `toolResult`; no blocker.

## Branch

bug-11216-1

## Related Issues

Reproduces #11216