### PR TITLE
chore: bump @ai-sdk/anthropic-aws to v2.0.0

### DIFF
--- a/.changeset/anthropic-aws-major-v2.md
+++ b/.changeset/anthropic-aws-major-v2.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic-aws': major
+---
+
+Release `@ai-sdk/anthropic-aws` as `2.0.0`. The provider was initially published as `1.0.0` because its `major` changeset was applied to the package's starting `0.0.1` version (`0.0.1` → `1.0.0`) rather than to the `1.0.0` intended for its first stable release. This major bump corrects the version to `2.0.0` to reflect the intended v2 line.


### PR DESCRIPTION
## Summary

Adds a `major` changeset for `@ai-sdk/anthropic-aws` to release it as `2.0.0`.

## Why

When the provider was first added in #15230, it was intended to launch as `1.0.0`. Instead it published as `1.0.0-canary.0` (and later `1.0.x`), because changesets applies the bump to the package's **current `package.json` version**, not to the `initialVersions` entry in `.changeset/pre.json`.

The package shipped its `package.json` at `0.0.1`, so the `major` changeset computed `semverInc("0.0.1", "major")` → `1.0.0` rather than the intended `2.0.0`-worthy first stable. The `1.0.0` recorded in `pre.json`'s `initialVersions` is bookkeeping state and is never used to compute the released version.

This changeset corrects the version line by bumping the current version to `2.0.0`.

## Changes

- Add `.changeset/anthropic-aws-major-v2.md` (`major` bump for `@ai-sdk/anthropic-aws`)

No production code changes.