### PR TITLE
feat(anthropic-aws): add Claude Platform on AWS provider (v5)

### DIFF
--- a/.changeset/anthropic-aws-v5.md
+++ b/.changeset/anthropic-aws-v5.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic-aws': minor
+---
+
+feat(anthropic-aws): add Claude Platform on AWS provider to the v5 release line
+
+Backports the `@ai-sdk/anthropic-aws` provider to AI SDK v5, adapted to the V2 provider specification (`LanguageModelV2` / `ProviderV2`). The provider wraps the Anthropic Messages API hosted on AWS, authenticated with AWS SigV4 or an AWS-provisioned API key.

--- a/packages/anthropic-aws/CHANGELOG.md
+++ b/packages/anthropic-aws/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ai-sdk/anthropic-aws

--- a/packages/anthropic-aws/README.md
+++ b/packages/anthropic-aws/README.md
@@ -1,0 +1,46 @@
+# AI SDK - Claude Platform on AWS Provider
+
+The **[Claude Platform on AWS provider](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic-aws)** for the [AI SDK](https://ai-sdk.dev/docs)
+gives you access to the Anthropic Messages API hosted in AWS at
+`aws-external-anthropic.{region}.api.aws`, authenticated with AWS SigV4 or an
+AWS-provisioned API key.
+
+Same wire format and feature set as `@ai-sdk/anthropic` — model IDs, streaming,
+prompt caching, tool use, computer use, and `anthropic-beta` headers all match
+the first-party Claude API.
+
+## Setup
+
+```bash
+npm install @ai-sdk/anthropic-aws
+```
+
+## Provider Instance
+
+```ts
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+
+// SigV4 — picks up AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
+const anthropicAws = createAnthropicAws({
+  region: 'us-west-2',
+  workspaceId: 'wrkspc_…',
+});
+```
+
+## Example
+
+```ts
+import { createAnthropicAws } from '@ai-sdk/anthropic-aws';
+import { generateText } from 'ai';
+
+const anthropicAws = createAnthropicAws();
+
+const { text } = await generateText({
+  model: anthropicAws('claude-sonnet-4-6'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+## Documentation
+
+Please check out the **[Claude Platform on AWS provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic-aws)** for more information.

--- a/packages/anthropic-aws/package.json
+++ b/packages/anthropic-aws/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@ai-sdk/anthropic-aws",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*",
+    "aws4fetch": "^1.0.20"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "20.17.24",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/anthropic-aws"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/anthropic-aws/src/anthropic-aws-fetch.test.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-fetch.test.ts
@@ -1,0 +1,706 @@
+import {
+  createSigV4FetchFunction,
+  createApiKeyFetchFunction,
+} from './anthropic-aws-fetch';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+// Mock the version module
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+// Mock provider-utils to control runtime environment detection
+vi.mock('@ai-sdk/provider-utils', async () => {
+  const actual = await vi.importActual('@ai-sdk/provider-utils');
+  return {
+    ...actual,
+    getRuntimeEnvironmentUserAgent: vi.fn(() => 'runtime/testenv'),
+  };
+});
+
+// Mock AwsV4Signer so that no real crypto calls are made.
+vi.mock('aws4fetch', () => {
+  class MockAwsV4Signer {
+    options: Record<string, unknown>;
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+    }
+    async sign() {
+      // Return a fake Headers instance with predetermined signing headers.
+      const headers = new Headers();
+      headers.set('x-amz-date', '20240315T000000Z');
+      headers.set('authorization', 'AWS4-HMAC-SHA256 Credential=test');
+      if (this.options.sessionToken) {
+        headers.set(
+          'x-amz-security-token',
+          this.options.sessionToken as string,
+        );
+      }
+      return { headers };
+    }
+  }
+  return { AwsV4Signer: MockAwsV4Signer };
+});
+
+const createFetchFunction = (dummyFetch: typeof fetch) =>
+  createSigV4FetchFunction(
+    () => ({
+      region: 'us-west-2',
+      accessKeyId: 'test-access-key',
+      secretAccessKey: 'test-secret',
+    }),
+    dummyFetch,
+  );
+
+describe('createSigV4FetchFunction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should bypass signing for non-POST requests', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const response = await fetchFn('http://example.com', { method: 'GET' });
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'GET',
+      headers: {
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should bypass signing if POST request has no body', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const response = await fetchFn('http://example.com', { method: 'POST' });
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      headers: {
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should handle a POST request with a string body and merge signed headers including user-agent', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+
+    // Provide settings (including a sessionToken) so that the signer includes that header.
+    const fetchFn = createSigV4FetchFunction(
+      () => ({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret',
+        sessionToken: 'test-session-token',
+      }),
+      dummyFetch,
+    );
+
+    const inputUrl = 'http://example.com';
+    const init: RequestInit = {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'Custom-Header': 'value',
+      },
+    };
+
+    await fetchFn(inputUrl, init);
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    // `combinedHeaders` should merge the original headers with the signing
+    // headers added by the AwsV4Signer mock.
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers['content-type']).toEqual('application/json');
+    expect(headers['custom-header']).toEqual('value');
+    expect(headers['empty-header']).toBeUndefined();
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+    expect(headers['x-amz-security-token']).toEqual('test-session-token');
+    expect(headers['user-agent']).toEqual(
+      'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+    );
+    // Body is left unmodified for a string body.
+    expect(calledInit.body).toEqual('{"test": "data"}');
+  });
+
+  it('shold handle a POST request with a Request object', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const request = new Request(inputUrl, {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: { 'X-From-Request': 'from-request' },
+    });
+    const init: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Custom-Header': 'value',
+      },
+    };
+    await fetchFn(request, init);
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledRequest = dummyFetch.mock.calls[0][0] as Request;
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(calledRequest.url).toEqual('http://example.com/');
+    expect(calledInit.body).toEqual('{"test": "data"}');
+    expect(headers['content-type']).toEqual('application/json');
+    expect(headers['custom-header']).toEqual('value');
+    expect(headers['x-from-request']).toEqual('from-request');
+  });
+
+  it('should sign when input is a POST Request with body and no init', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const request = new Request('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-From-Request': 'from-request',
+      },
+    });
+
+    await fetchFn(request);
+
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+
+    expect(calledInit.body).toEqual('{"test": "data"}');
+    expect(headers['content-type']).toEqual('application/json');
+    expect(headers['x-from-request']).toEqual('from-request');
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+    expect(headers['user-agent']).toEqual(
+      'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+    );
+  });
+
+  it('should handle non-string body by stringifying it', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const jsonBody = { field: 'value' };
+
+    await fetchFn(inputUrl, {
+      method: 'POST',
+      body: jsonBody as unknown as BodyInit,
+      headers: {},
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    // The body should be stringified.
+    expect(calledInit.body).toEqual(JSON.stringify(jsonBody));
+  });
+
+  it('should handle Uint8Array body', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const uint8Body = new TextEncoder().encode('binaryTest');
+
+    await fetchFn(inputUrl, {
+      method: 'POST',
+      body: uint8Body,
+      headers: {},
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    // The Uint8Array body should have been decoded to a string.
+    expect(calledInit.body).toEqual('binaryTest');
+  });
+
+  it('should handle ArrayBuffer body', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const inputUrl = 'http://example.com';
+    const text = 'bufferTest';
+    const buffer = new TextEncoder().encode(text).buffer;
+
+    await fetchFn(inputUrl, {
+      method: 'POST',
+      body: buffer,
+      headers: {},
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    expect(calledInit.body).toEqual(text);
+  });
+
+  it('should extract headers from a Headers instance', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const h = new Headers();
+    h.set('A', 'value-a');
+    h.set('B', 'value-b');
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: h,
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers['a'] || headers['A']).toEqual('value-a');
+    expect(headers['b'] || headers['B']).toEqual('value-b');
+  });
+
+  it('should handle headers provided as an array', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const headersArray: [string, string][] = [
+      ['Array-Header', 'array-value'],
+      ['Another-Header', 'another-value'],
+    ];
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: headersArray,
+    });
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers['array-header'] || headers['Array-Header']).toEqual(
+      'array-value',
+    );
+    expect(headers['another-header'] || headers['Another-Header']).toEqual(
+      'another-value',
+    );
+    // Also check that the signing headers are included.
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+  });
+
+  it('should call original fetch if init is undefined', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const fetchFn = createFetchFunction(dummyFetch);
+
+    const response = await fetchFn('http://example.com');
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: {
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should correctly handle async credential providers', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+
+    // Create a function that returns a Promise of credentials
+    const asyncCredentialsProvider = () =>
+      Promise.resolve({
+        region: 'us-east-1',
+        accessKeyId: 'async-access-key',
+        secretAccessKey: 'async-secret-key',
+        sessionToken: 'async-session-token',
+      });
+
+    const fetchFn = createSigV4FetchFunction(
+      asyncCredentialsProvider,
+      dummyFetch,
+    );
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "async"}',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    // Verify the request was properly signed
+    expect(dummyFetch).toHaveBeenCalled();
+    const calledInit = dummyFetch.mock.calls[0][1] as RequestInit;
+    const headers = calledInit.headers as Record<string, string>;
+
+    // Check that the signing headers were added
+    expect(headers['x-amz-date']).toEqual('20240315T000000Z');
+    expect(headers['authorization']).toEqual(
+      'AWS4-HMAC-SHA256 Credential=test',
+    );
+    expect(headers['x-amz-security-token']).toEqual('async-session-token');
+    expect(headers['content-type']).toEqual('application/json');
+  });
+
+  it('should handle async credential providers that reject', async () => {
+    const dummyFetch = vi.fn();
+    const errorMessage = 'Failed to get credentials';
+
+    // Create a function that returns a rejected Promise
+    const failingCredentialsProvider = () =>
+      Promise.reject(new Error(errorMessage));
+
+    const fetchFn = createSigV4FetchFunction(
+      failingCredentialsProvider,
+      dummyFetch,
+    );
+
+    // The fetch call should propagate the rejection
+    await expect(
+      fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      }),
+    ).rejects.toThrow(errorMessage);
+
+    // The underlying fetch should not be called
+    expect(dummyFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('createApiKeyFetchFunction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should add x-api-key header with user-agent', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-123';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const response = await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'test-api-key-123',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+    expect(response).toBe(dummyResponse);
+  });
+
+  it('should merge x-api-key header with existing headers', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-456';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'Custom-Header': 'custom-value',
+        'X-Request-ID': 'req-123',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'custom-header': 'custom-value',
+        'x-request-id': 'req-123',
+        'x-api-key': 'test-api-key-456',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work with Headers instance', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-789';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('X-Custom', 'value');
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers,
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-custom': 'value',
+        'x-api-key': 'test-api-key-789',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work with headers as array', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-array';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const headersArray: [string, string][] = [
+      ['Content-Type', 'application/json'],
+      ['X-Array-Header', 'array-value'],
+    ];
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: headersArray,
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-array-header': 'array-value',
+        'x-api-key': 'test-api-key-array',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work with GET requests', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-get';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        'x-api-key': 'test-api-key-get',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work when no headers are provided', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-no-headers';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'x-api-key': 'test-api-key-no-headers',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should work when init is undefined', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-undefined';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com');
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: {
+        'x-api-key': 'test-api-key-undefined',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should override existing x-api-key header', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-override';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': 'old-token',
+      },
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'test-api-key-override',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should use default fetch when no custom fetch provided', async () => {
+    const originalFetch = globalThis.fetch;
+    const mockGlobalFetch = vi.fn().mockResolvedValue(new Response('OK'));
+    globalThis.fetch = mockGlobalFetch;
+
+    try {
+      const apiKey = 'test-api-key-default';
+      const fetchFn = createApiKeyFetchFunction(apiKey);
+
+      await fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      });
+
+      expect(mockGlobalFetch).toHaveBeenCalledWith('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+        headers: {
+          'x-api-key': 'test-api-key-default',
+          'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should resolve default fetch lazily when no custom fetch provided', async () => {
+    const originalFetch = globalThis.fetch;
+    const initialFetch = vi.fn().mockResolvedValue(new Response('Initial'));
+    const patchedFetch = vi.fn().mockResolvedValue(new Response('Patched'));
+
+    globalThis.fetch = initialFetch;
+    const fetchFn = createApiKeyFetchFunction('test-api-key-lazy');
+    globalThis.fetch = patchedFetch;
+
+    try {
+      await fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      });
+
+      expect(initialFetch).not.toHaveBeenCalled();
+      expect(patchedFetch).toHaveBeenCalledWith('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+        headers: {
+          'x-api-key': 'test-api-key-lazy',
+          'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should handle empty string API key', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = '';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+      headers: {
+        'x-api-key': '',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+    });
+  });
+
+  it('should preserve request body and other properties', async () => {
+    const dummyResponse = new Response('OK', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    const apiKey = 'test-api-key-preserve';
+
+    const fetchFn = createApiKeyFetchFunction(apiKey, dummyFetch);
+
+    const requestBody = JSON.stringify({ data: 'test' });
+    await fetchFn('http://example.com', {
+      method: 'PUT',
+      body: requestBody,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+    });
+
+    expect(dummyFetch).toHaveBeenCalledWith('http://example.com', {
+      method: 'PUT',
+      body: requestBody,
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': 'test-api-key-preserve',
+        'user-agent': 'ai-sdk/anthropic-aws/0.0.0-test runtime/testenv',
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+    });
+  });
+});

--- a/packages/anthropic-aws/src/anthropic-aws-fetch.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-fetch.ts
@@ -1,0 +1,141 @@
+import {
+  combineHeaders,
+  normalizeHeaders,
+  withUserAgentSuffix,
+  getRuntimeEnvironmentUserAgent,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { AwsV4Signer } from 'aws4fetch';
+import { VERSION } from './version';
+
+export interface AnthropicAwsCredentials {
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+/**
+ * Creates a fetch function that applies AWS Signature Version 4 signing for
+ * Claude Platform on AWS.
+ *
+ * @param getCredentials - Function that returns the AWS credentials to use when signing.
+ * @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+ * @returns A FetchFunction that signs requests before passing them to the underlying fetch.
+ */
+export function createSigV4FetchFunction(
+  getCredentials: () =>
+    | AnthropicAwsCredentials
+    | PromiseLike<AnthropicAwsCredentials>,
+  fetch?: FetchFunction,
+): FetchFunction {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const effectiveFetch = fetch ?? globalThis.fetch;
+    const request = input instanceof Request ? input : undefined;
+    const originalHeaders = combineHeaders(
+      normalizeHeaders(request?.headers),
+      normalizeHeaders(init?.headers),
+    );
+    const headersWithUserAgent = withUserAgentSuffix(
+      originalHeaders,
+      `ai-sdk/anthropic-aws/${VERSION}`,
+      getRuntimeEnvironmentUserAgent(),
+    );
+
+    let effectiveBody: BodyInit | undefined = init?.body ?? undefined;
+    if (effectiveBody === undefined && request && request.body !== null) {
+      try {
+        effectiveBody = await request.clone().text();
+      } catch {}
+    }
+
+    const effectiveMethod = init?.method ?? request?.method;
+
+    if (effectiveMethod?.toUpperCase() !== 'POST' || !effectiveBody) {
+      return effectiveFetch(input, {
+        ...init,
+        headers: headersWithUserAgent as HeadersInit,
+      });
+    }
+
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+
+    const body = prepareBodyString(effectiveBody);
+    const credentials = await getCredentials();
+    const signer = new AwsV4Signer({
+      url,
+      method: 'POST',
+      headers: Object.entries(headersWithUserAgent),
+      body,
+      region: credentials.region,
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
+      service: 'aws-external-anthropic',
+    });
+
+    const signingResult = await signer.sign();
+    const signedHeaders = normalizeHeaders(signingResult.headers);
+    const combinedHeaders = combineHeaders(headersWithUserAgent, signedHeaders);
+
+    return effectiveFetch(input, {
+      ...init,
+      body,
+      headers: combinedHeaders as HeadersInit,
+    });
+  };
+}
+
+function prepareBodyString(body: BodyInit | undefined): string {
+  if (typeof body === 'string') {
+    return body;
+  } else if (body instanceof Uint8Array) {
+    return new TextDecoder().decode(body);
+  } else if (body instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(body));
+  } else {
+    return JSON.stringify(body);
+  }
+}
+
+/**
+ * Creates a fetch function that applies x-api-key header authentication.
+ *
+ * @param apiKey - The API key to use for x-api-key header authentication.
+ * @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+ * @returns A FetchFunction that adds the x-api-key header to requests.
+ */
+export function createApiKeyFetchFunction(
+  apiKey: string,
+  fetch?: FetchFunction,
+): FetchFunction {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const effectiveFetch = fetch ?? globalThis.fetch;
+    const originalHeaders = normalizeHeaders(init?.headers);
+    const headersWithUserAgent = withUserAgentSuffix(
+      originalHeaders,
+      `ai-sdk/anthropic-aws/${VERSION}`,
+      getRuntimeEnvironmentUserAgent(),
+    );
+
+    const finalHeaders = combineHeaders(headersWithUserAgent, {
+      'x-api-key': apiKey,
+    });
+
+    return effectiveFetch(input, {
+      ...init,
+      headers: finalHeaders as HeadersInit,
+    });
+  };
+}

--- a/packages/anthropic-aws/src/anthropic-aws-provider.test.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-provider.test.ts
@@ -1,0 +1,569 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAnthropicAws } from './anthropic-aws-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+vi.mock('aws4fetch', () => {
+  class MockAwsV4Signer {
+    options: Record<string, unknown>;
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+    }
+    async sign() {
+      const headers = new Headers();
+      headers.set('x-amz-date', '20240315T000000Z');
+      headers.set('authorization', 'AWS4-HMAC-SHA256 Credential=test');
+      return { headers };
+    }
+  }
+  return { AwsV4Signer: MockAwsV4Signer };
+});
+
+const TEST_PROMPT: LanguageModelV2Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+const createSuccessfulResponse = () =>
+  new Response(
+    JSON.stringify({
+      type: 'message',
+      id: 'msg_123',
+      model: 'claude-sonnet-4-6',
+      content: [{ type: 'text', text: 'Hi' }],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+
+const createFetchMock = () =>
+  vi.fn().mockResolvedValue(createSuccessfulResponse());
+
+const stubDefaultEnv = () => {
+  vi.stubEnv('AWS_REGION', 'us-west-2');
+  vi.stubEnv('ANTHROPIC_AWS_WORKSPACE_ID', 'wrkspc_default');
+  vi.stubEnv('ANTHROPIC_AWS_API_KEY', undefined);
+  vi.stubEnv('AWS_ACCESS_KEY_ID', undefined);
+  vi.stubEnv('AWS_SECRET_ACCESS_KEY', undefined);
+  vi.stubEnv('AWS_SESSION_TOKEN', undefined);
+};
+
+describe('createAnthropicAws', () => {
+  describe('baseURL configuration', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      stubDefaultEnv();
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('uses the default Claude Platform on AWS base URL with region templating', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-east-1',
+        workspaceId: 'wrkspc_test',
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe(
+        'https://aws-external-anthropic.us-east-1.api.aws/v1/messages',
+      );
+    });
+
+    it('reads AWS_REGION from the environment when region option is omitted', async () => {
+      vi.stubEnv('AWS_REGION', 'eu-west-1');
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        workspaceId: 'wrkspc_test',
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe(
+        'https://aws-external-anthropic.eu-west-1.api.aws/v1/messages',
+      );
+    });
+
+    it('prefers the baseURL option over the default template', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        apiKey: 'test-api-key',
+        baseURL: 'https://proxy.example.com/v1/',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://proxy.example.com/v1/messages');
+    });
+  });
+});
+
+describe('anthropicAws provider - authentication', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('apiKey option', () => {
+    it('sends x-api-key header when apiKey is provided', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        apiKey: 'sk-aws-platform-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [, requestOptions] = fetchMock.mock.calls[0]!;
+      expect(requestOptions.headers['x-api-key']).toBe('sk-aws-platform-key');
+      expect(requestOptions.headers.authorization).toBeUndefined();
+    });
+
+    it('reads apiKey from ANTHROPIC_AWS_API_KEY when option is omitted', async () => {
+      vi.stubEnv('ANTHROPIC_AWS_API_KEY', 'sk-from-env');
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [, requestOptions] = fetchMock.mock.calls[0]!;
+      expect(requestOptions.headers['x-api-key']).toBe('sk-from-env');
+    });
+  });
+
+  describe('SigV4 path', () => {
+    it('signs requests with SigV4 when apiKey is not provided', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        accessKeyId: 'akid',
+        secretAccessKey: 'secret',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      const [, requestOptions] = fetchMock.mock.calls[0]!;
+      expect(requestOptions.headers.authorization).toBe(
+        'AWS4-HMAC-SHA256 Credential=test',
+      );
+      expect(requestOptions.headers['x-amz-date']).toBe('20240315T000000Z');
+      expect(requestOptions.headers['x-api-key']).toBeUndefined();
+    });
+
+    it('honors a credentialProvider for dynamic SigV4 credentials', async () => {
+      const fetchMock = createFetchMock();
+      const credentialProvider = vi.fn().mockResolvedValue({
+        accessKeyId: 'dynamic-akid',
+        secretAccessKey: 'dynamic-secret',
+        sessionToken: 'dynamic-session',
+      });
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        credentialProvider,
+        fetch: fetchMock,
+      });
+
+      await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+      expect(credentialProvider).toHaveBeenCalled();
+    });
+
+    it('throws a guided error when SigV4 credentials are missing', async () => {
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+      });
+
+      await expect(
+        provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toThrow(/AWS SigV4 authentication requires AWS credentials/);
+    });
+
+    it('wraps credentialProvider rejections with a guided message', async () => {
+      const provider = createAnthropicAws({
+        region: 'us-west-2',
+        workspaceId: 'wrkspc_test',
+        credentialProvider: async () => {
+          throw new Error('STS denied');
+        },
+      });
+
+      await expect(
+        provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toThrow(/AWS credential provider failed: STS denied/);
+    });
+  });
+});
+
+describe('anthropicAws provider - workspaceId', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('sends the anthropic-version header on every request', async () => {
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-version']).toBe('2023-06-01');
+  });
+
+  it('sends the anthropic-workspace-id header on every request', async () => {
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_unique',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_unique',
+    );
+  });
+
+  it('reads workspaceId from ANTHROPIC_AWS_WORKSPACE_ID when option is omitted', async () => {
+    vi.stubEnv('ANTHROPIC_AWS_WORKSPACE_ID', 'wrkspc_from_env');
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_from_env',
+    );
+  });
+
+  it('throws when workspaceId is not resolvable at request time', async () => {
+    vi.stubEnv('ANTHROPIC_AWS_WORKSPACE_ID', undefined);
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT }),
+    ).rejects.toThrow(/workspace/i);
+  });
+});
+
+describe('anthropicAws provider - region', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when region is not resolvable at model creation time', () => {
+    vi.stubEnv('AWS_REGION', undefined);
+    const provider = createAnthropicAws({
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+    expect(() => provider('claude-sonnet-4-6')).toThrow(/region/i);
+  });
+});
+
+describe('anthropicAws provider - headers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('merges custom headers with the workspace-id header', async () => {
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+      headers: { 'x-custom': 'value' },
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_test',
+    );
+    expect(requestOptions.headers['x-custom']).toBe('value');
+  });
+});
+
+describe('anthropicAws provider - supportedUrls', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should support image/* URLs', async () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-sonnet-4-6');
+    const supportedUrls = await model.supportedUrls;
+
+    expect(supportedUrls['image/*']).toBeDefined();
+    expect(
+      supportedUrls['image/*']![0]!.test('https://example.com/image.png'),
+    ).toBe(true);
+  });
+
+  it('should support application/pdf URLs', async () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-sonnet-4-6');
+    const supportedUrls = await model.supportedUrls;
+
+    expect(supportedUrls['application/pdf']).toBeDefined();
+    expect(
+      supportedUrls['application/pdf']![0]!.test(
+        'https://arxiv.org/pdf/2401.00001',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('anthropicAws provider - model identity', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('sets the provider name to anthropic-aws.messages on the model', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-sonnet-4-6');
+    expect(model.provider).toBe('anthropic-aws.messages');
+  });
+
+  it('throws NoSuchModelError when textEmbeddingModel is invoked', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    expect(() => provider.textEmbeddingModel('any-model-id')).toThrow(
+      /no such textEmbeddingModel/i,
+    );
+  });
+
+  it('throws NoSuchModelError when imageModel is invoked', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    expect(() => provider.imageModel('any-model-id')).toThrow(
+      /no such imageModel/i,
+    );
+  });
+
+  it('throws if the provider function is called with new', () => {
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+    });
+
+    expect(
+      () =>
+        new (provider as unknown as new (m: string) => unknown)(
+          'claude-sonnet-4-6',
+        ),
+    ).toThrow(/cannot be called with the new keyword/);
+  });
+});
+
+describe('anthropicAws provider - auth precedence', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers the API-key path when both apiKey and AWS SigV4 creds are present', async () => {
+    vi.stubEnv('AWS_ACCESS_KEY_ID', 'should-be-ignored');
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'should-be-ignored');
+    const fetchMock = createFetchMock();
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'sk-aws-platform-key',
+      fetch: fetchMock,
+    });
+
+    await provider('claude-sonnet-4-6').doGenerate({ prompt: TEST_PROMPT });
+
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['x-api-key']).toBe('sk-aws-platform-key');
+    expect(requestOptions.headers.authorization).toBeUndefined();
+    expect(requestOptions.headers['x-amz-date']).toBeUndefined();
+  });
+});
+
+describe('anthropicAws provider - streaming', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubDefaultEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('forwards doStream through the SigV4 / api-key fetch wrapper and yields stream events', async () => {
+    const sseBody = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-6","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}',
+      '',
+      'event: content_block_stop',
+      'data: {"type":"content_block_stop","index":0}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}',
+      '',
+      'event: message_stop',
+      'data: {"type":"message_stop"}',
+      '',
+    ].join('\n');
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+    const provider = createAnthropicAws({
+      region: 'us-west-2',
+      workspaceId: 'wrkspc_test',
+      apiKey: 'test-api-key',
+      fetch: fetchMock,
+    });
+
+    const { stream } = await provider('claude-sonnet-4-6').doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const reader = stream.getReader();
+    const parts: unknown[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parts.push(value);
+    }
+
+    expect(parts.length).toBeGreaterThan(0);
+    expect(
+      parts.some(
+        p =>
+          typeof p === 'object' &&
+          p !== null &&
+          'type' in p &&
+          (p as { type: string }).type === 'text-delta',
+      ),
+    ).toBe(true);
+
+    // confirm the same workspace + version headers we tested for doGenerate
+    // also fire for streaming requests
+    const [, requestOptions] = fetchMock.mock.calls[0]!;
+    expect(requestOptions.headers['anthropic-version']).toBe('2023-06-01');
+    expect(requestOptions.headers['anthropic-workspace-id']).toBe(
+      'wrkspc_test',
+    );
+    expect(requestOptions.headers['x-api-key']).toBe('test-api-key');
+  });
+});

--- a/packages/anthropic-aws/src/anthropic-aws-provider.ts
+++ b/packages/anthropic-aws/src/anthropic-aws-provider.ts
@@ -1,0 +1,261 @@
+import {
+  NoSuchModelError,
+  type LanguageModelV2,
+  type ProviderV2,
+} from '@ai-sdk/provider';
+import {
+  loadOptionalSetting,
+  loadSetting,
+  withoutTrailingSlash,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import {
+  AnthropicMessagesLanguageModel,
+  anthropicTools,
+  type AnthropicMessagesModelId,
+} from '@ai-sdk/anthropic/internal';
+import {
+  createApiKeyFetchFunction,
+  createSigV4FetchFunction,
+  type AnthropicAwsCredentials,
+} from './anthropic-aws-fetch';
+
+export interface AnthropicAwsProvider extends ProviderV2 {
+  /**
+   * Creates a model for text generation.
+   */
+  (modelId: AnthropicMessagesModelId): LanguageModelV2;
+
+  /**
+   * Creates a model for text generation.
+   */
+  languageModel(modelId: AnthropicMessagesModelId): LanguageModelV2;
+
+  /**
+   * Anthropic on AWS does not provide text embedding models.
+   */
+  textEmbeddingModel(modelId: string): never;
+
+  tools: typeof anthropicTools;
+}
+
+export interface AnthropicAwsProviderSettings {
+  /**
+   * The AWS region to use for Claude Platform on AWS. Defaults to the value of the
+   * `AWS_REGION` environment variable. Required — no fallback default.
+   */
+  region?: string;
+
+  /**
+   * The Anthropic workspace ID for this AWS account. Sent on every request via the
+   * `anthropic-workspace-id` header. Defaults to the value of the
+   * `ANTHROPIC_AWS_WORKSPACE_ID` environment variable.
+   */
+  workspaceId?: string;
+
+  /**
+   * API key for authenticating requests via the `x-api-key` header.
+   * When provided, this will be used instead of AWS SigV4 authentication.
+   * Defaults to the value of the `ANTHROPIC_AWS_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * The AWS access key ID to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_ACCESS_KEY_ID` environment variable.
+   */
+  accessKeyId?: string;
+
+  /**
+   * The AWS secret access key to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SECRET_ACCESS_KEY` environment variable.
+   */
+  secretAccessKey?: string;
+
+  /**
+   * The AWS session token to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SESSION_TOKEN` environment variable.
+   */
+  sessionToken?: string;
+
+  /**
+   * Base URL for the Claude Platform on AWS API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string | undefined>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+
+  /**
+   * The AWS credential provider to use to get dynamic credentials similar to the
+   * AWS SDK. Setting a provider here will cause its credential values to be used
+   * instead of the `accessKeyId`, `secretAccessKey`, and `sessionToken` settings.
+   */
+  credentialProvider?: () => PromiseLike<
+    Omit<AnthropicAwsCredentials, 'region'>
+  >;
+
+  generateId?: () => string;
+}
+
+/**
+ * Create a Claude Platform on AWS provider instance.
+ * This provider uses the Anthropic Messages API hosted in AWS, authenticated
+ * with AWS SigV4 or an AWS-provisioned API key.
+ */
+export function createAnthropicAws(
+  options: AnthropicAwsProviderSettings = {},
+): AnthropicAwsProvider {
+  const apiKey = loadOptionalSetting({
+    settingValue: options.apiKey,
+    environmentVariableName: 'ANTHROPIC_AWS_API_KEY',
+  });
+
+  const fetchFunction = apiKey
+    ? createApiKeyFetchFunction(apiKey, options.fetch)
+    : createSigV4FetchFunction(async () => {
+        const region = loadSetting({
+          settingValue: options.region,
+          settingName: 'region',
+          environmentVariableName: 'AWS_REGION',
+          description: 'AWS region',
+        });
+
+        if (options.credentialProvider) {
+          try {
+            return {
+              ...(await options.credentialProvider()),
+              region,
+            };
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            throw new Error(
+              `AWS credential provider failed: ${errorMessage}. ` +
+                'Please ensure your credential provider returns valid AWS credentials ' +
+                'with accessKeyId and secretAccessKey properties.',
+            );
+          }
+        }
+
+        try {
+          return {
+            region,
+            accessKeyId: loadSetting({
+              settingValue: options.accessKeyId,
+              settingName: 'accessKeyId',
+              environmentVariableName: 'AWS_ACCESS_KEY_ID',
+              description: 'AWS access key ID',
+            }),
+            secretAccessKey: loadSetting({
+              settingValue: options.secretAccessKey,
+              settingName: 'secretAccessKey',
+              environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
+              description: 'AWS secret access key',
+            }),
+            sessionToken: loadOptionalSetting({
+              settingValue: options.sessionToken,
+              environmentVariableName: 'AWS_SESSION_TOKEN',
+            }),
+          };
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          if (
+            errorMessage.includes('AWS_ACCESS_KEY_ID') ||
+            errorMessage.includes('accessKeyId')
+          ) {
+            throw new Error(
+              'AWS SigV4 authentication requires AWS credentials. Please provide either:\n' +
+                '1. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables\n' +
+                '2. Provide accessKeyId and secretAccessKey in options\n' +
+                '3. Use a credentialProvider function\n' +
+                '4. Use API key authentication with ANTHROPIC_AWS_API_KEY or apiKey option\n' +
+                `Original error: ${errorMessage}`,
+            );
+          }
+          if (
+            errorMessage.includes('AWS_SECRET_ACCESS_KEY') ||
+            errorMessage.includes('secretAccessKey')
+          ) {
+            throw new Error(
+              'AWS SigV4 authentication requires both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. ' +
+                'Please ensure both credentials are provided.\n' +
+                `Original error: ${errorMessage}`,
+            );
+          }
+          throw error;
+        }
+      }, options.fetch);
+
+  const getBaseURL = (): string =>
+    withoutTrailingSlash(options.baseURL) ??
+    `https://aws-external-anthropic.${loadSetting({
+      settingValue: options.region,
+      settingName: 'region',
+      environmentVariableName: 'AWS_REGION',
+      description: 'AWS region',
+    })}.api.aws/v1`;
+
+  const getHeaders = (): Record<string, string | undefined> => ({
+    'anthropic-version': '2023-06-01',
+    'anthropic-workspace-id': loadSetting({
+      settingValue: options.workspaceId,
+      settingName: 'workspaceId',
+      environmentVariableName: 'ANTHROPIC_AWS_WORKSPACE_ID',
+      description: 'Anthropic AWS workspace ID',
+    }),
+    ...options.headers,
+  });
+
+  const createChatModel = (modelId: AnthropicMessagesModelId) =>
+    new AnthropicMessagesLanguageModel(modelId, {
+      provider: 'anthropic-aws.messages',
+      baseURL: getBaseURL(),
+      headers: getHeaders,
+      fetch: fetchFunction,
+      generateId: options.generateId,
+      supportedUrls: () => ({
+        'image/*': [/^https?:\/\/.*$/],
+        'application/pdf': [/^https?:\/\/.*$/],
+      }),
+    });
+
+  const provider = function (modelId: AnthropicMessagesModelId) {
+    if (new.target) {
+      throw new Error(
+        'The Anthropic AWS model function cannot be called with the new keyword.',
+      );
+    }
+    return createChatModel(modelId);
+  };
+
+  provider.specificationVersion = 'v2' as const;
+  provider.languageModel = createChatModel;
+  provider.chat = createChatModel;
+  provider.messages = createChatModel;
+
+  provider.textEmbeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });
+  };
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  provider.tools = anthropicTools;
+
+  return provider;
+}
+
+/**
+ * Default Claude Platform on AWS provider instance.
+ */
+export const anthropicAws = createAnthropicAws();

--- a/packages/anthropic-aws/src/index.ts
+++ b/packages/anthropic-aws/src/index.ts
@@ -1,0 +1,7 @@
+export { anthropicAws, createAnthropicAws } from './anthropic-aws-provider';
+export type {
+  AnthropicAwsProvider,
+  AnthropicAwsProviderSettings,
+} from './anthropic-aws-provider';
+export type { AnthropicAwsCredentials } from './anthropic-aws-fetch';
+export { VERSION } from './version';

--- a/packages/anthropic-aws/src/version.ts
+++ b/packages/anthropic-aws/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/anthropic-aws/tsconfig.build.json
+++ b/packages/anthropic-aws/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/anthropic-aws/tsconfig.json
+++ b/packages/anthropic-aws/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../anthropic"
+    },
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/anthropic-aws/tsup.config.ts
+++ b/packages/anthropic-aws/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/anthropic-aws/turbo.json
+++ b/packages/anthropic-aws/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/anthropic-aws/vitest.edge.config.js
+++ b/packages/anthropic-aws/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/anthropic-aws/vitest.node.config.js
+++ b/packages/anthropic-aws/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,40 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/anthropic-aws:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../anthropic
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/assemblyai:
     dependencies:
       '@ai-sdk/provider':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "packages/anthropic"
     },
     {
+      "path": "packages/anthropic-aws"
+    },
+    {
       "path": "packages/assemblyai"
     },
     {


### PR DESCRIPTION
## Summary

Backports the `@ai-sdk/anthropic-aws` provider to the **AI SDK v5** release line (`release-v5.0`), so it can be published starting at **`0.1.0`**.

The provider wraps the Anthropic Messages API hosted on AWS ("Claude Platform on AWS"), authenticated with AWS SigV4 or an AWS-provisioned API key.

## Version spec adaptation

`release-v5.0` uses the **V2** provider spec (`@ai-sdk/provider@2.x`), so the port targets those types rather than the V3/V4 types used on `release-v6.0`/`main`:

- `ProviderV3` → `ProviderV2`, `LanguageModelV3` → `LanguageModelV2`
- `provider.specificationVersion = 'v3'` → `'v2'`
- V2 has no `embeddingModel` method — replaced with `textEmbeddingModel` throwing `NoSuchModelError({ modelType: 'textEmbeddingModel' })` (V2 shape), matching `@ai-sdk/anthropic`'s own v5 provider
- Test prompt type `LanguageModelV3Prompt` → `LanguageModelV2Prompt`

The SigV4 / API-key fetch layer (`anthropic-aws-fetch.ts`) is spec-independent and ports unchanged; all its `@ai-sdk/provider-utils` imports exist on the v5 line, and `aws4fetch` is already in the v5 lockfile.

## Versioning

- `package.json` starts at `0.0.0`
- A **`minor`** changeset takes it to **`0.1.0`** on the next release (`semverInc('0.0.0', 'minor')` = `0.1.0`)

## Verification

- `pnpm build` — ESM + CJS + DTS all succeed
- `pnpm type-check` — passes
- `pnpm test` — 48/48 pass (node + edge)
- `pnpm check` — 0 warnings, 0 errors

## Notes

- Docs copying (`prepack`/`postpack`) was dropped from `package.json` since the `07-anthropic-aws.mdx` content file does not exist on the v5 line.
- Added `packages/anthropic-aws` to the root `tsconfig.json` references.
- `pnpm-lock.yaml` change is limited to the new package entry.