### PR TITLE
fix(ai): resolve functional body in prepareSendMessagesRequest before serialization

### DIFF
--- a/.changeset/honest-pets-study.md
+++ b/.changeset/honest-pets-study.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix DefaultChatTransport to execute functional body returned from prepareSendMessagesRequest before serialization

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -23,13 +23,13 @@ export type PrepareSendMessagesRequest<UI_MESSAGE extends UIMessage> = (
   },
 ) =>
   | {
-      body: object;
+      body: Resolvable<object>;
       headers?: HeadersInit;
       credentials?: RequestCredentials;
       api?: string;
     }
   | PromiseLike<{
-      body: object;
+      body: Resolvable<object>;
       headers?: HeadersInit;
       credentials?: RequestCredentials;
       api?: string;
@@ -172,9 +172,14 @@ export abstract class HttpChatTransport<
       preparedRequest?.headers !== undefined
         ? normalizeHeaders(preparedRequest.headers)
         : baseHeaders;
-    const body =
+    const resolvedPreparedBody =
       preparedRequest?.body !== undefined
-        ? preparedRequest.body
+        ? await resolve(preparedRequest.body)
+        : undefined;
+
+    const body =
+      resolvedPreparedBody !== undefined
+        ? resolvedPreparedBody
         : {
             ...resolvedBody,
             ...options.body,


### PR DESCRIPTION
## Background

DefaultChatTransport (via HttpChatTransport) fails to serialize the request body when prepareSendMessagesRequest returns body as a function. The function is passed directly to JSON.stringify without being called, producing an empty or missing request body on the server.
This affects React 19 users who use a functional body to defer ref access outside the render cycle — the documented "Dynamic Configuration" pattern silently sends nothing to the server.

Fixes #11253

## Summary

Updated PrepareSendMessagesRequest return type to allow body: Resolvable<object> (supports plain object, Promise, or function returning either)
Added await resolve(preparedRequest.body) before serialization, consistent with how this.body, this.headers, and this.credentials are already resolved in the same method

## Checklist

 All commits are signed
 A patch changeset has been added
 I have reviewed this pull request

## Related Issues
Fixes #11253