### PR TITLE
[release-v5.0] fix(deepseek): exclude internal.d.ts from typecheck

### DIFF
--- a/packages/deepseek/tsconfig.json
+++ b/packages/deepseek/tsconfig.json
@@ -9,7 +9,8 @@
     "dist",
     "build",
     "node_modules",
-    "tsup.config.ts"
+    "tsup.config.ts",
+    "internal.d.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
## Background

Deepseek provider was different from other providers, leading to errors:

````
❯ pnpm type-check
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.

> ai-repo@ type-check /Users/larsgrammel/repositories/ai
> tsc --build

error TS5055: Cannot write file '/Users/larsgrammel/repositories/ai/packages/deepseek/dist/internal/index.d.ts' because it would overwrite input file.

Found 1 error.

 ELIFECYCLE  Command failed with exit code 2.
````

## Summary

Align with other providers.

## Related Issues

Backport of #16670 