### PR TITLE
feat(mcp): surface tool annotation hints on tool metadata

### DIFF
--- a/.changeset/mcp-tool-annotations.md
+++ b/.changeset/mcp-tool-annotations.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Surface MCP tool annotation hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) on the tool's `metadata.annotations`. These propagate to `toolCall.toolMetadata`, enabling approval-gating via `toolApproval` (e.g. requiring confirmation for destructive tools). Adds `isMCPToolCall` and `getMCPToolAnnotations` helpers to detect MCP tool calls and read their typed hints without casting. Closes #6732.

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -625,6 +625,43 @@ try {
 }
 ```
 
+## Tool Annotations
+
+MCP servers can attach [behavioral hints](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool) to a tool via its `annotations`. The client surfaces these hints on each tool's `metadata.annotations`, which propagates to the tool call's `toolMetadata`. This lets you gate execution — for example, requiring approval for any tool that reports itself as destructive.
+
+The following hints are surfaced: `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. Per the MCP spec, treat these as untrusted hints rather than guarantees.
+
+A single `toolApproval` function decides for every tool call, so use `isMCPToolCall` to scope the MCP branch and read the typed hints with `getMCPToolAnnotations`. Non-MCP tools are handled separately and are never affected by the MCP logic.
+
+```typescript
+import {
+  createMCPClient,
+  getMCPToolAnnotations,
+  isMCPToolCall,
+} from '@ai-sdk/mcp';
+import { generateText } from 'ai';
+
+const client = await createMCPClient({ transport });
+
+const response = await generateText({
+  model: __MODEL__,
+  tools: await client.tools(),
+  toolApproval: ({ toolCall }) => {
+    if (isMCPToolCall(toolCall)) {
+      const annotations = getMCPToolAnnotations(toolCall);
+      // Read-only MCP tools run automatically; anything else needs approval.
+      return annotations?.readOnlyHint === true ? 'approved' : 'user-approval';
+    }
+
+    // Your own policy for non-MCP tools.
+    return 'approved';
+  },
+  messages: [{ role: 'user', content: 'Query the data' }],
+});
+```
+
+Both helpers accept either a discovered tool (reading `metadata`) or a tool call (reading `toolMetadata`). `getMCPToolAnnotations` returns `undefined` both when the source is not an MCP tool and when it is an MCP tool whose server sent no hints — call `isMCPToolCall` first if you need to distinguish those cases.
+
 ## Error Handling
 
 The client throws `MCPClientError` for:

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -22,6 +22,8 @@
     "client:tool-meta": "tsx src/tool-meta/client.ts",
     "server:provider-metadata": "tsx src/provider-metadata/server.ts",
     "client:provider-metadata": "tsx src/provider-metadata/client.ts",
+    "server:tool-annotations": "tsx src/tool-annotations/server.ts",
+    "client:tool-annotations": "tsx src/tool-annotations/client.ts",
     "server:server-instructions": "tsx src/server-instructions/server.ts",
     "client:server-instructions": "tsx src/server-instructions/client.ts",
     "stdio:build": "tsc src/stdio/server.ts --outDir src/stdio/dist --target es2023 --module nodenext",

--- a/examples/mcp/src/tool-annotations/client.ts
+++ b/examples/mcp/src/tool-annotations/client.ts
@@ -1,0 +1,84 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  createMCPClient,
+  getMCPToolAnnotations,
+  isMCPToolCall,
+  type MCPClient,
+} from '@ai-sdk/mcp';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { generateText, isStepCount } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(
+    new URL('http://localhost:8086/mcp'),
+  );
+
+  const mcpClient: MCPClient = await createMCPClient({
+    transport,
+    clientName: 'tool-annotations-example-client',
+  });
+
+  try {
+    const tools = await mcpClient.tools();
+
+    const result = await generateText({
+      model: openai('gpt-4o-mini'),
+      tools,
+      // A single approval function decides for every tool call. Use
+      // `isMCPToolCall` to scope the MCP-specific branch, then read the typed
+      // behavioral hints with `getMCPToolAnnotations`. Non-MCP tools are handled
+      // in the else branch and are never touched by the MCP logic.
+      toolApproval: ({ toolCall }) => {
+        if (isMCPToolCall(toolCall)) {
+          const annotations = getMCPToolAnnotations(toolCall);
+
+          // Read-only MCP tools run automatically.
+          if (annotations?.readOnlyHint === true) {
+            return 'approved';
+          }
+
+          // Destructive MCP tools would prompt a human via 'user-approval' in a
+          // real app. We auto-deny so the example runs non-interactively.
+          if (annotations?.destructiveHint === true) {
+            return {
+              type: 'denied',
+              reason: 'destructive tool blocked by policy',
+            };
+          }
+
+          // MCP tool the server gave no hints for: default conservatively.
+          return 'user-approval';
+        }
+
+        // Non-MCP tools: your own policy goes here. This example has none, so we
+        // let them run.
+        return 'approved';
+      },
+      prompt:
+        'Read the status of order order_123, then cancel order order_123.',
+      stopWhen: isStepCount(5),
+    });
+
+    for (const step of result.steps) {
+      for (const part of step.content) {
+        if (part.type === 'tool-approval-response') {
+          const annotations = getMCPToolAnnotations(part.toolCall);
+          console.log(
+            `Tool "${part.toolCall.toolName}" ` +
+              `(readOnlyHint=${annotations?.readOnlyHint ?? '(none)'}, ` +
+              `destructiveHint=${annotations?.destructiveHint ?? '(none)'}) ` +
+              `was automatically ${part.approved ? 'approved' : 'denied'}` +
+              (part.reason != null ? ` — ${part.reason}` : ''),
+          );
+        }
+      }
+    }
+
+    console.log(`\nFINAL ANSWER: ${result.text}`);
+  } finally {
+    await mcpClient.close();
+  }
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/tool-annotations/server.ts
+++ b/examples/mcp/src/tool-annotations/server.ts
@@ -1,0 +1,93 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { z } from 'zod';
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+  const server = new McpServer({
+    name: 'tool-annotations-example-server',
+    version: '1.0.0',
+  });
+
+  // A read-only tool: safe to auto-approve.
+  server.registerTool(
+    'read-order',
+    {
+      title: 'Read Order',
+      description: 'Read the status of a customer order.',
+      inputSchema: {
+        orderId: z.string().describe('The order ID to read.'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ orderId }) => ({
+      content: [
+        {
+          type: 'text',
+          text: `Order ${orderId} is packed and ready to ship.`,
+        },
+      ],
+    }),
+  );
+
+  // A destructive tool: the client should gate this behind approval.
+  server.registerTool(
+    'cancel-order',
+    {
+      title: 'Cancel Order',
+      description: 'Cancel a customer order. This cannot be undone.',
+      inputSchema: {
+        orderId: z.string().describe('The order ID to cancel.'),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ orderId }) => ({
+      content: [
+        {
+          type: 'text',
+          text: `Order ${orderId} has been cancelled.`,
+        },
+      ],
+    }),
+  );
+
+  try {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+    res.on('close', () => {
+      transport.close();
+      server.close();
+    });
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error',
+        },
+        id: null,
+      });
+    }
+  }
+});
+
+app.listen(8086, () => {
+  console.log('Tool annotations example MCP server listening on port 8086');
+  console.log('Connect via Streamable HTTP at: http://localhost:8086/mcp');
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -22,6 +22,7 @@ export {
   type MCPAppResourceCSP,
   type MCPAppResourceMeta,
 } from './tool/mcp-apps';
+export { getMCPToolAnnotations, isMCPToolCall } from './tool/tool-annotations';
 export { ElicitationRequestSchema, ElicitResultSchema } from './tool/types';
 export type {
   CallToolResult,

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -2777,6 +2777,144 @@ describe('MCPClient', () => {
         toolName: 'typed-titled-tool',
       });
     });
+
+    it('should surface all behavioral annotation hints on metadata.annotations', async () => {
+      const mockTransport = new MockMCPTransport({
+        overrideTools: [
+          {
+            name: 'hinted-tool',
+            description: 'A tool with behavioral hints',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+            annotations: {
+              readOnlyHint: true,
+              destructiveHint: false,
+              idempotentHint: true,
+              openWorldHint: false,
+            },
+          },
+        ],
+      });
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      const tools = await client.tools();
+      expect(tools['hinted-tool'].metadata).toMatchObject({
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      });
+    });
+
+    it('should only include defined hints and omit undefined ones', async () => {
+      const mockTransport = new MockMCPTransport({
+        overrideTools: [
+          {
+            name: 'partial-hint-tool',
+            description: 'A tool with a single hint',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+            annotations: {
+              readOnlyHint: true,
+            },
+          },
+        ],
+      });
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      const tools = await client.tools();
+      expect(tools['partial-hint-tool'].metadata).toMatchObject({
+        annotations: { readOnlyHint: true },
+      });
+      expect(
+        (tools['partial-hint-tool'].metadata as { annotations: object })
+          .annotations,
+      ).toEqual({ readOnlyHint: true });
+    });
+
+    it('should not set metadata.annotations when no hints are present', async () => {
+      const mockTransport = new MockMCPTransport({
+        overrideTools: [
+          {
+            name: 'title-only-tool',
+            description: 'A tool with only an annotation title',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+            annotations: {
+              title: 'Annotation Title',
+            },
+          },
+        ],
+      });
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      const tools = await client.tools();
+      expect(tools['title-only-tool'].title).toBe('Annotation Title');
+      expect(tools['title-only-tool'].metadata).toEqual({
+        clientName: 'ai-sdk-mcp-client',
+        title: 'Annotation Title',
+        toolName: 'title-only-tool',
+      });
+    });
+
+    it('should surface annotation hints on typed tools with schemas', async () => {
+      const mockTransport = new MockMCPTransport({
+        overrideTools: [
+          {
+            name: 'typed-hinted-tool',
+            description: 'A typed tool with hints',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                input: { type: 'string' },
+              },
+            },
+            annotations: {
+              readOnlyHint: false,
+              destructiveHint: true,
+            },
+          },
+        ],
+      });
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      const tools = await client.tools({
+        schemas: {
+          'typed-hinted-tool': {
+            inputSchema: z.object({
+              input: z.string(),
+            }),
+          },
+        },
+      });
+
+      expect(tools['typed-hinted-tool'].metadata).toMatchObject({
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+        },
+      });
+    });
   });
 
   describe('protocol version negotiation', () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -53,6 +53,7 @@ import {
   type ListResourcesResult,
   type ListPromptsResult,
   type ListToolsResult,
+  type MCPTool,
   type McpToolSet,
   type Notification,
   type PaginatedRequest,
@@ -90,6 +91,35 @@ function getErrorStatusCode(error: unknown): number | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Extracts the behavioral hints from an MCP tool's `annotations`, returning
+ * only the keys that are defined. Returns `undefined` when no hint is present
+ * so callers can omit `metadata.annotations` entirely rather than emitting `{}`.
+ */
+function pickAnnotationHints(
+  annotations: MCPTool['annotations'],
+): McpProviderMetadata['annotations'] | undefined {
+  if (annotations == null) {
+    return undefined;
+  }
+
+  const hints: NonNullable<McpProviderMetadata['annotations']> = {};
+  if (annotations.readOnlyHint != null) {
+    hints.readOnlyHint = annotations.readOnlyHint;
+  }
+  if (annotations.destructiveHint != null) {
+    hints.destructiveHint = annotations.destructiveHint;
+  }
+  if (annotations.idempotentHint != null) {
+    hints.idempotentHint = annotations.idempotentHint;
+  }
+  if (annotations.openWorldHint != null) {
+    hints.openWorldHint = annotations.openWorldHint;
+  }
+
+  return Object.keys(hints).length > 0 ? hints : undefined;
 }
 
 function getStringErrorCode(error: unknown): string | undefined {
@@ -833,10 +863,12 @@ class DefaultMCPClient implements MCPClient {
       const outputSchema =
         schemas !== 'automatic' ? schemas[name]?.outputSchema : undefined;
       const appMeta = getMCPAppToolMeta({ _meta });
+      const annotationHints = pickAnnotationHints(annotations);
       const metadata = {
         clientName: this.clientInfo.name,
         toolName: name,
         ...(resolvedTitle != null ? { title: resolvedTitle } : {}),
+        ...(annotationHints != null ? { annotations: annotationHints } : {}),
         ...(appMeta?.resourceUri != null
           ? {
               app: {

--- a/packages/mcp/src/tool/tool-annotations.test.ts
+++ b/packages/mcp/src/tool/tool-annotations.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { getMCPToolAnnotations, isMCPToolCall } from './tool-annotations';
+
+const mcpMetadata = {
+  clientName: 'ai-sdk-mcp-client',
+  toolName: 'cancel-order',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
+};
+
+describe('isMCPToolCall', () => {
+  it('returns true for a tool call with MCP toolMetadata', () => {
+    expect(isMCPToolCall({ toolMetadata: mcpMetadata })).toBe(true);
+  });
+
+  it('returns true for a discovered tool with MCP metadata', () => {
+    expect(isMCPToolCall({ metadata: mcpMetadata })).toBe(true);
+  });
+
+  it('returns false when metadata lacks the MCP marker', () => {
+    expect(isMCPToolCall({ toolMetadata: { foo: 'bar' } })).toBe(false);
+  });
+
+  it('returns false when only clientName is present (no toolName)', () => {
+    expect(isMCPToolCall({ toolMetadata: { clientName: 'x' } })).toBe(false);
+  });
+
+  it('returns false for undefined / null / missing metadata', () => {
+    expect(isMCPToolCall(undefined)).toBe(false);
+    expect(isMCPToolCall(null)).toBe(false);
+    expect(isMCPToolCall({})).toBe(false);
+    expect(isMCPToolCall({ toolMetadata: undefined })).toBe(false);
+  });
+});
+
+describe('getMCPToolAnnotations', () => {
+  it('returns the hints for an MCP tool call that carries them', () => {
+    expect(getMCPToolAnnotations({ toolMetadata: mcpMetadata })).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
+  });
+
+  it('reads from a discovered tool metadata as well', () => {
+    expect(getMCPToolAnnotations({ metadata: mcpMetadata })).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
+  });
+
+  it('returns undefined for an MCP tool with no annotations', () => {
+    expect(
+      getMCPToolAnnotations({
+        toolMetadata: {
+          clientName: 'ai-sdk-mcp-client',
+          toolName: 'read-order',
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a non-MCP tool call', () => {
+    expect(
+      getMCPToolAnnotations({ toolMetadata: { foo: 'bar' } }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for missing metadata', () => {
+    expect(getMCPToolAnnotations(undefined)).toBeUndefined();
+    expect(getMCPToolAnnotations({})).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/tool/tool-annotations.ts
+++ b/packages/mcp/src/tool/tool-annotations.ts
@@ -1,0 +1,75 @@
+import type { McpProviderMetadata } from './types';
+
+type MetadataSource =
+  | { metadata?: unknown }
+  | { toolMetadata?: unknown }
+  | null
+  | undefined;
+
+/**
+ * Reads the raw metadata object from a discovered tool (`metadata`) or a tool
+ * call (`toolMetadata`), returning `undefined` when neither is a usable object.
+ */
+function getRawMcpMetadata(
+  source: MetadataSource,
+): Record<string, unknown> | undefined {
+  if (source == null || typeof source !== 'object') {
+    return undefined;
+  }
+
+  const meta =
+    (source as { metadata?: unknown }).metadata ??
+    (source as { toolMetadata?: unknown }).toolMetadata;
+
+  return meta != null && typeof meta === 'object'
+    ? (meta as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Determines whether a tool or tool call originated from an MCP server.
+ *
+ * The MCP client stamps `clientName` and `toolName` into the tool's `metadata`,
+ * which is surfaced on a tool call as `toolMetadata`. This checks for that
+ * marker, so it can be used inside a generic `toolApproval` function to scope
+ * MCP-specific logic and leave non-MCP tools untouched.
+ *
+ * @example
+ * ```ts
+ * toolApproval: ({ toolCall }) => {
+ *   if (isMCPToolCall(toolCall)) {
+ *     const annotations = getMCPToolAnnotations(toolCall);
+ *     return annotations?.readOnlyHint === true ? 'approved' : 'user-approval';
+ *   }
+ *   // ...your own policy for non-MCP tools
+ * }
+ * ```
+ */
+export function isMCPToolCall(source: MetadataSource): boolean {
+  const meta = getRawMcpMetadata(source);
+  return meta != null && 'clientName' in meta && 'toolName' in meta;
+}
+
+/**
+ * Reads the MCP behavioral annotation hints from a tool or tool call.
+ *
+ * Returns the typed hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`,
+ * `openWorldHint`) when the source is an MCP tool that carries them, otherwise
+ * `undefined`.
+ *
+ * Note that `undefined` covers two distinct cases: the source is not an MCP
+ * tool, or it is an MCP tool whose server sent no behavioral hints. Use
+ * {@link isMCPToolCall} first if you need to tell these apart.
+ *
+ * Per the MCP spec these hints are untrusted signals rather than guarantees.
+ */
+export function getMCPToolAnnotations(
+  source: MetadataSource,
+): McpProviderMetadata['annotations'] | undefined {
+  if (!isMCPToolCall(source)) {
+    return undefined;
+  }
+
+  const meta = getRawMcpMetadata(source);
+  return (meta as McpProviderMetadata | undefined)?.annotations;
+}

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -15,6 +15,21 @@ export type McpProviderMetadata = {
   title?: string;
   toolName?: string;
   app?: JSONObject;
+  /**
+   * Behavioral hints from the MCP tool's `annotations`.
+   *
+   * Per the MCP spec these are untrusted hints (not guarantees) and are
+   * surfaced here so consumers can read them from `toolCall.toolMetadata`
+   * (e.g. to gate approval on `destructiveHint` / `!readOnlyHint`).
+   *
+   * @see https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
+   */
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
 };
 
 /** MCP tool metadata - keys should follow MCP _meta key format specification */
@@ -168,6 +183,10 @@ const ToolSchema = z
       z
         .object({
           title: z.optional(z.string()),
+          readOnlyHint: z.optional(z.boolean()),
+          destructiveHint: z.optional(z.boolean()),
+          idempotentHint: z.optional(z.boolean()),
+          openWorldHint: z.optional(z.boolean()),
         })
         .loose(),
     ),


### PR DESCRIPTION
## Summary

Surfaces MCP tool [annotation hints](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool) (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) through the AI SDK's MCP client so consumers can gate tool execution on them (e.g. requiring approval for destructive tools).

Closes #6732.

Today the MCP client reads `annotations.title` but drops every behavioral hint, so an agent loop or UI has no typed way to know a tool is read-only vs. destructive. This threads the hints through to the tool call, where they can drive `toolApproval`.

## Prior art & why the last attempt was closed

A previous PR (#10463) implemented this by adding an `annotations` field — shaped like MCP's — onto the core `Tool` type in `@ai-sdk/provider-utils`, and was closed on design grounds. Two objections were raised:

- **@lgrammel:** *"I am not sure how much we should tie MCP to our more abstract tools. This PR bleeds the MCP spec into our tool spec."* He suggested that `readOnlyHint` has universal value but the others are "more MCP specific," and that the hints should live on a generic **`metadata` or `hints` property** rather than as first-class fields on the core tool type. He also noted tests and documentation would be needed.
- **@nicoalbanese:** *"feel strongly that this would be best implemented in some kind of generic tool metadata."*

This PR is designed around that feedback.

## How this PR accounts for those considerations

1. **No coupling of the core `Tool` type to MCP.** `@ai-sdk/provider-utils`, `@ai-sdk/provider`, and `ai` are **unchanged**. All production changes are confined to `@ai-sdk/mcp`. The MCP spec never touches the abstract tool spec — directly addressing the "bleeds MCP into our tool spec" objection.

2. **Rides the existing generic metadata container** — exactly the "generic tool metadata" both maintainers pointed at. The core `Tool` type already exposes `metadata?: JSONObject`, documented as propagating onto the tool call's `toolMetadata`. The MCP client already builds a metadata object here; this change adds the hints to it under a namespaced `annotations` key:

   ```ts
   metadata.annotations = { readOnlyHint, destructiveHint, idempotentHint, openWorldHint }
   ```

   MCP's vocabulary is typed only inside `@ai-sdk/mcp` (`McpProviderMetadata.annotations`), never in the core packages.

3. **Namespaced, not flattened.** The hints go under a nested `annotations` sub-object rather than onto the metadata root, so they can't collide with sibling metadata keys (`clientName`, `toolName`, `title`, `app`) and stay self-evidently MCP-sourced.

4. **All four hints, but only as generic metadata.** @lgrammel's hesitation about `destructive`/`idempotent`/`openWorld` was about putting them on the *core type*. Since they now live purely in MCP-local metadata, there's no cost to passing all four, and it avoids a follow-up PR for the ones consumers actually need (`destructiveHint` is the field the original issue author wanted for confirmation-gating).

5. **Cast-free consumer ergonomics + correct scoping.** Because `metadata` is a generic `JSONObject`, reading it back would otherwise require an unchecked cast, and a naive `toolApproval` would accidentally gate non-MCP tools too. Two small helpers solve both:
   - `isMCPToolCall(source)` — detects MCP tools/tool calls (via the `clientName`/`toolName` marker) so you can scope MCP logic and leave other tools untouched.
   - `getMCPToolAnnotations(source)` — returns the typed hints without casting. Both accept a discovered tool (`metadata`) or a tool call (`toolMetadata`).

6. **Tests, docs, and an example** — addressing the "tests and documentation would be good to have" note.

## Usage

```ts
import { getMCPToolAnnotations, isMCPToolCall } from '@ai-sdk/mcp';

await generateText({
  model,
  tools: await client.tools(),
  toolApproval: ({ toolCall }) => {
    if (isMCPToolCall(toolCall)) {
      const a = getMCPToolAnnotations(toolCall);
      if (a?.readOnlyHint === true) return 'approved';
      if (a?.destructiveHint === true) return 'user-approval';
      return 'user-approval';
    }
    // your own policy for non-MCP tools
    return 'approved';
  },
  prompt: '…',
});
```

## Changes

- `packages/mcp/src/tool/types.ts` — type the four hints in `ToolSchema.annotations` (still `.loose()`); add typed `annotations` to `McpProviderMetadata`.
- `packages/mcp/src/tool/mcp-client.ts` — copy defined hints into `metadata.annotations` (omitted entirely when no hints are present).
- `packages/mcp/src/tool/tool-annotations.ts` — new `isMCPToolCall` / `getMCPToolAnnotations` helpers, exported from the package.
- Tests: helper unit tests + MCP client tests covering all-hints, partial hints, unhinted MCP tools, and title-only annotations.
- Docs: `content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx`.
- Example: `examples/mcp/src/tool-annotations/` (read-only + destructive tools, approval gated on the hints).
- Patch changeset for `@ai-sdk/mcp`.

## Verification

- `@ai-sdk/mcp` full test suite passes (helper + client tests).
- Package and example type-check clean; lint/format clean.
- The example was run end-to-end: a read-only tool auto-approves and executes; a destructive tool is gated purely on its `destructiveHint`.
