### PR TITLE
[release-v5.0] chore: align gitignore with main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 .DS_Store
 .cache
+.claude
 .env
 .envrc
 .next
+.pnpm-store
 .turbo
+.well-known
+.workflow-vitest
 dist
 dist-ssr
 dist-bundle-check
@@ -16,3 +20,4 @@ tsconfig.vitest-temp.json
 *.log
 *.local
 *.tsbuildinfo
+packages/ai/docs


### PR DESCRIPTION
## Background

Differences in the `.gitigore` led to ultracite failures in the software factory.

## Summary

align gitignore with main branch