### PR TITLE
[v6.0] fix: extractJsonMiddleware removes valid leading space from final streamed suffix

### DIFF
--- a/.changeset/fuzzy-steaks-matter.md
+++ b/.changeset/fuzzy-steaks-matter.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `extractJsonMiddleware` preserving leading whitespace in the final streamed text suffix when no markdown fence prefix was stripped.

--- a/packages/ai/src/middleware/extract-json-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.test.ts
@@ -1,11 +1,7 @@
-<<<<<<< HEAD
-import type { LanguageModelV3Usage } from '@ai-sdk/provider';
-=======
 import type {
-  LanguageModelV4StreamPart,
-  LanguageModelV4Usage,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
 } from '@ai-sdk/provider';
->>>>>>> a193137a1 (fix: extractJsonMiddleware removes valid leading space from final streamed suffix (#16576))
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,
@@ -370,7 +366,7 @@ describe('extractJsonMiddleware', () => {
       } as any);
 
       const reader = wrapped.stream.getReader();
-      const chunks: LanguageModelV4StreamPart[] = [];
+      const chunks: LanguageModelV3StreamPart[] = [];
       while (true) {
         const { done, value } = await reader.read();
         if (done) {

--- a/packages/ai/src/middleware/extract-json-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.test.ts
@@ -1,4 +1,11 @@
+<<<<<<< HEAD
 import type { LanguageModelV3Usage } from '@ai-sdk/provider';
+=======
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+>>>>>>> a193137a1 (fix: extractJsonMiddleware removes valid leading space from final streamed suffix (#16576))
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,
@@ -345,6 +352,39 @@ describe('extractJsonMiddleware', () => {
       });
 
       expect(await result.text).toBe('{"value": "test"}');
+    });
+
+    it('should preserve leading space in final streamed suffix without fences', async () => {
+      const middleware = extractJsonMiddleware();
+
+      const wrapped = await middleware.wrapStream!({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 't' },
+            { type: 'text-delta', id: 't', delta: 'there' },
+            { type: 'text-delta', id: 't', delta: ' altogether?' },
+            { type: 'text-end', id: 't' },
+          ]),
+        }),
+      } as any);
+
+      const reader = wrapped.stream.getReader();
+      const chunks: LanguageModelV4StreamPart[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        chunks.push(value);
+      }
+
+      const text = chunks
+        .filter(chunk => chunk.type === 'text-delta')
+        .map(chunk => chunk.delta)
+        .join('');
+
+      expect(text).toBe('there altogether?');
     });
 
     it('should handle fence split across multiple deltas', async () => {

--- a/packages/ai/src/middleware/extract-json-middleware.ts
+++ b/packages/ai/src/middleware/extract-json-middleware.ts
@@ -15,6 +15,10 @@ function defaultTransform(text: string): string {
     .trim();
 }
 
+function stripMarkdownCodeFenceSuffix(text: string): string {
+  return text.replace(/\n?```\s*$/, '').trimEnd();
+}
+
 /**
  * Middleware that extracts JSON from text content by stripping
  * markdown code fences and other formatting.
@@ -169,10 +173,15 @@ export function extractJsonMiddleware(options?: {
                     remaining = transform(remaining);
                   } else if (block.prefixStripped) {
                     // strip suffix since prefix already handled
-                    remaining = remaining.replace(/\n?```\s*$/, '').trimEnd();
-                  } else {
-                    // Apply full transform (handles both prefix and suffix)
+                    remaining = stripMarkdownCodeFenceSuffix(remaining);
+                  } else if (block.phase === 'prefix') {
+                    // No text has streamed yet, so the full transform is safe.
                     remaining = transform(remaining);
+                  } else {
+                    // Only strip the suffix. Since earlier text may already have
+                    // streamed, trimming the remaining suffix would remove valid
+                    // leading whitespace at the stream boundary.
+                    remaining = stripMarkdownCodeFenceSuffix(remaining);
                   }
 
                   if (remaining.length > 0) {


### PR DESCRIPTION
## Background

extractJsonMiddleware could join words by trimming a valid leading space from the buffered final streamed suffix when no markdown fence prefix was stripped.

## Summary

Stream finalization now strips only a trailing markdown code-fence suffix after content has already streamed, avoiding trimStart on the buffered suffix while preserving full transforms when no text has streamed.

## Testing

Kept and adjusted the regression test covering streamed chunks `there` + ` altogether?` so the final text remains `there altogether?`.

## Related Issues

Fixes #15921

Backport of #16576