### PR TITLE
[v6.0] fix: Raw `JSON.parse` used in production provider code (prototype pollution risk)

### DIFF
--- a/.changeset/quick-swans-pull.md
+++ b/.changeset/quick-swans-pull.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/anthropic": patch
+"@ai-sdk/gateway": patch
+"@ai-sdk/google": patch
+"@ai-sdk/provider-utils": patch
+---
+
+Prevent prototype pollution when synchronously parsing provider JSON inputs and expose `secureJsonParse` from provider-utils.

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -24,6 +24,14 @@ import {
   parseProviderOptions,
   postJsonToApi,
   resolve,
+<<<<<<< HEAD:packages/anthropic/src/anthropic-messages-language-model.ts
+=======
+  resolveProviderReference,
+  secureJsonParse,
+  serializeModelOptions,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+>>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/anthropic/src/anthropic-language-model.ts
   type FetchFunction,
   type InferSchema,
   type ParseResult,
@@ -2078,7 +2086,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                         contentBlock.input === '' ? '{}' : contentBlock.input;
                       if (contentBlock.providerToolName === 'code_execution') {
                         try {
-                          const parsed = JSON.parse(finalInput);
+                          const parsed = secureJsonParse(finalInput);
                           if (
                             parsed != null &&
                             typeof parsed === 'object' &&

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -24,14 +24,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
   resolve,
-<<<<<<< HEAD:packages/anthropic/src/anthropic-messages-language-model.ts
-=======
-  resolveProviderReference,
   secureJsonParse,
-  serializeModelOptions,
-  WORKFLOW_SERIALIZE,
-  WORKFLOW_DESERIALIZE,
->>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/anthropic/src/anthropic-language-model.ts
   type FetchFunction,
   type InferSchema,
   type ParseResult,

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -9,10 +9,18 @@ import {
 import {
   convertBase64ToUint8Array,
   convertToBase64,
+<<<<<<< HEAD:packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
   parseProviderOptions,
   safeParseJSON,
-  validateTypes,
+=======
+  getTopLevelMediaType,
   isNonNullable,
+  parseProviderOptions,
+  resolveFullMediaType,
+  resolveProviderReference,
+  secureJsonParse,
+>>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/anthropic/src/convert-to-anthropic-prompt.ts
+  validateTypes,
   type ToolNameMapping,
 } from '@ai-sdk/provider-utils';
 import {
@@ -74,6 +82,7 @@ function getUrlString(data: LanguageModelV3DataContent): string {
  * Extract error information from a provider tool error result value.
  * Handles both stringified JSON and plain object forms.
  */
+<<<<<<< HEAD:packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
 async function extractErrorValue(
   value: unknown,
 ): Promise<{ errorCode?: string }> {
@@ -86,6 +95,14 @@ async function extractErrorValue(
       result.value !== null
     ) {
       return result.value as { errorCode?: string };
+=======
+function extractErrorValue(value: unknown): { errorCode?: string } {
+  try {
+    if (typeof value === 'string') {
+      return secureJsonParse(value);
+    } else if (typeof value === 'object' && value !== null) {
+      return value as { errorCode?: string };
+>>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/anthropic/src/convert-to-anthropic-prompt.ts
     }
 
     return {
@@ -767,7 +784,7 @@ export async function convertToAnthropicMessagesPrompt({
                     let errorInfo: { type?: string; errorCode?: string } = {};
                     try {
                       if (typeof output.value === 'string') {
-                        errorInfo = JSON.parse(output.value);
+                        errorInfo = secureJsonParse(output.value);
                       } else if (
                         typeof output.value === 'object' &&
                         output.value !== null

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -9,17 +9,10 @@ import {
 import {
   convertBase64ToUint8Array,
   convertToBase64,
-<<<<<<< HEAD:packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
   parseProviderOptions,
   safeParseJSON,
-=======
-  getTopLevelMediaType,
   isNonNullable,
-  parseProviderOptions,
-  resolveFullMediaType,
-  resolveProviderReference,
   secureJsonParse,
->>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/anthropic/src/convert-to-anthropic-prompt.ts
   validateTypes,
   type ToolNameMapping,
 } from '@ai-sdk/provider-utils';
@@ -82,7 +75,6 @@ function getUrlString(data: LanguageModelV3DataContent): string {
  * Extract error information from a provider tool error result value.
  * Handles both stringified JSON and plain object forms.
  */
-<<<<<<< HEAD:packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
 async function extractErrorValue(
   value: unknown,
 ): Promise<{ errorCode?: string }> {
@@ -95,14 +87,6 @@ async function extractErrorValue(
       result.value !== null
     ) {
       return result.value as { errorCode?: string };
-=======
-function extractErrorValue(value: unknown): { errorCode?: string } {
-  try {
-    if (typeof value === 'string') {
-      return secureJsonParse(value);
-    } else if (typeof value === 'object' && value !== null) {
-      return value as { errorCode?: string };
->>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/anthropic/src/convert-to-anthropic-prompt.ts
     }
 
     return {

--- a/packages/gateway/src/errors/extract-api-call-response.ts
+++ b/packages/gateway/src/errors/extract-api-call-response.ts
@@ -1,4 +1,5 @@
 import type { APICallError } from '@ai-sdk/provider';
+import { secureJsonParse } from '@ai-sdk/provider-utils';
 
 export function extractApiCallResponse(error: APICallError): unknown {
   if (error.data !== undefined) {
@@ -6,7 +7,7 @@ export function extractApiCallResponse(error: APICallError): unknown {
   }
   if (error.responseBody != null) {
     try {
-      return JSON.parse(error.responseBody);
+      return secureJsonParse(error.responseBody);
     } catch {
       return error.responseBody;
     }

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -3,7 +3,18 @@ import {
   type LanguageModelV3Prompt,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
+<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.ts
 import { convertToBase64 } from '@ai-sdk/provider-utils';
+=======
+import {
+  convertToBase64,
+  getTopLevelMediaType,
+  isFullMediaType,
+  resolveFullMediaType,
+  resolveProviderReference,
+  secureJsonParse,
+} from '@ai-sdk/provider-utils';
+>>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/google/src/convert-to-google-messages.ts
 import type {
   GoogleGenerativeAIContent,
   GoogleGenerativeAIContentPart,
@@ -385,7 +396,7 @@ export function convertToGoogleGenerativeAIMessages(
                         toolType: serverToolType,
                         args:
                           typeof part.input === 'string'
-                            ? JSON.parse(part.input)
+                            ? secureJsonParse(part.input)
                             : part.input,
                         id: serverToolCallId,
                       },

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -3,18 +3,7 @@ import {
   type LanguageModelV3Prompt,
   type SharedV3Warning,
 } from '@ai-sdk/provider';
-<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.ts
-import { convertToBase64 } from '@ai-sdk/provider-utils';
-=======
-import {
-  convertToBase64,
-  getTopLevelMediaType,
-  isFullMediaType,
-  resolveFullMediaType,
-  resolveProviderReference,
-  secureJsonParse,
-} from '@ai-sdk/provider-utils';
->>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579)):packages/google/src/convert-to-google-messages.ts
+import { convertToBase64, secureJsonParse } from '@ai-sdk/provider-utils';
 import type {
   GoogleGenerativeAIContent,
   GoogleGenerativeAIContentPart,

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -631,7 +631,7 @@ describe('convertToGoogleInteractionsInput', () => {
     });
 
     it('rejects prototype-polluting stringified tool-call input', () => {
-      const prompt: LanguageModelV4Prompt = [
+      const prompt: LanguageModelV3Prompt = [
         {
           role: 'user',
           content: [{ type: 'text', text: 'Hi' }],

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -630,6 +630,37 @@ describe('convertToGoogleInteractionsInput', () => {
       expect(fnCall?.arguments).toEqual({ location: 'Boston' });
     });
 
+    it('rejects prototype-polluting stringified tool-call input', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hi' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_abc',
+              toolName: 'getWeather',
+              input: '{"__proto__":{"polluted":true}}',
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+      const steps = result.input as Array<{
+        type: string;
+        arguments?: Record<string, unknown>;
+      }>;
+      const fnCall = steps.find(step => step.type === 'function_call');
+
+      expect(fnCall?.arguments).toEqual({
+        value: '{"__proto__":{"polluted":true}}',
+      });
+    });
+
     it('round-trips a function_call signature via providerMetadata.google.signature', () => {
       const prompt: LanguageModelV3Prompt = [
         {

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -4,18 +4,7 @@ import type {
   LanguageModelV3ToolResultOutput,
   SharedV3Warning,
 } from '@ai-sdk/provider';
-<<<<<<< HEAD
-import { convertToBase64 } from '@ai-sdk/provider-utils';
-=======
-import {
-  convertToBase64,
-  getTopLevelMediaType,
-  isFullMediaType,
-  resolveFullMediaType,
-  resolveProviderReference,
-  secureJsonParse,
-} from '@ai-sdk/provider-utils';
->>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579))
+import { convertToBase64, secureJsonParse } from '@ai-sdk/provider-utils';
 import type {
   GoogleInteractionsContent,
   GoogleInteractionsContentBlock,

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -4,7 +4,18 @@ import type {
   LanguageModelV3ToolResultOutput,
   SharedV3Warning,
 } from '@ai-sdk/provider';
+<<<<<<< HEAD
 import { convertToBase64 } from '@ai-sdk/provider-utils';
+=======
+import {
+  convertToBase64,
+  getTopLevelMediaType,
+  isFullMediaType,
+  resolveFullMediaType,
+  resolveProviderReference,
+  secureJsonParse,
+} from '@ai-sdk/provider-utils';
+>>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579))
 import type {
   GoogleInteractionsContent,
   GoogleInteractionsContentBlock,
@@ -372,7 +383,7 @@ function compactPromptForPreviousInteraction({
 
 function safeParseToolArgs(input: string): Record<string, unknown> {
   try {
-    const parsed = JSON.parse(input);
+    const parsed = secureJsonParse(input);
     if (
       parsed != null &&
       typeof parsed === 'object' &&

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -59,16 +59,7 @@ export {
   type Schema,
   type ValidationResult,
 } from './schema';
-<<<<<<< HEAD
-=======
-export { serializeModelOptions } from './serialize-model-options';
 export { secureJsonParse } from './secure-json-parse';
-export {
-  StreamingToolCallTracker,
-  type StreamingToolCallDelta,
-  type StreamingToolCallTrackerOptions,
-} from './streaming-tool-call-tracker';
->>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579))
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
 export { validateDownloadUrl } from './validate-download-url';

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -59,6 +59,16 @@ export {
   type Schema,
   type ValidationResult,
 } from './schema';
+<<<<<<< HEAD
+=======
+export { serializeModelOptions } from './serialize-model-options';
+export { secureJsonParse } from './secure-json-parse';
+export {
+  StreamingToolCallTracker,
+  type StreamingToolCallDelta,
+  type StreamingToolCallTrackerOptions,
+} from './streaming-tool-call-tracker';
+>>>>>>> c6f5e624a (fix: Raw `JSON.parse` used in production provider code (prototype pollution risk) (#16579))
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
 export { validateDownloadUrl } from './validate-download-url';


### PR DESCRIPTION
## Background

Provider code was synchronously parsing LLM/tool/error JSON with raw JSON.parse, bypassing the SDK's prototype-pollution protections.

## Summary

Exported secureJsonParse from @ai-sdk/provider-utils and replaced the six reported production JSON.parse call sites in Google, Anthropic, and Gateway code with secureJsonParse while preserving existing try/catch fallback behavior.

## Testing

Kept the reproduction regression test that verifies prototype-polluting Google Interactions tool-call input is rejected/falls back instead of being parsed as arguments.

## Related Issues

Fixes #15812

Backport of #16579