### PR TITLE
[v5.0] fix: normalize bare Anthropic API base URL to avoid missing /v1 path

### DIFF
--- a/.changeset/quiet-starfishes-provide.md
+++ b/.changeset/quiet-starfishes-provide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Normalize a bare `https://api.anthropic.com` base URL to include `/v1`.

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -83,6 +83,41 @@ describe('createAnthropic', () => {
       expect(requestUrl).toBe('https://proxy.anthropic.example/v1/messages');
     });
 
+    it('normalizes a bare Anthropic API URL from ANTHROPIC_BASE_URL', async () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com/';
+
+      const fetchMock = createFetchMock();
+      const provider = createAnthropic({
+        apiKey: 'test-api-key',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-3-haiku-20240307').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://api.anthropic.com/v1/messages');
+    });
+
+    it('normalizes a bare Anthropic API URL from the baseURL option', async () => {
+      const fetchMock = createFetchMock();
+      const provider = createAnthropic({
+        apiKey: 'test-api-key',
+        baseURL: 'https://api.anthropic.com/',
+        fetch: fetchMock,
+      });
+
+      await provider('claude-3-haiku-20240307').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl] = fetchMock.mock.calls[0]!;
+      expect(requestUrl).toBe('https://api.anthropic.com/v1/messages');
+    });
+
     it('prefers the baseURL option over ANTHROPIC_BASE_URL', async () => {
       process.env.ANTHROPIC_BASE_URL = 'https://env.anthropic.example/v1';
 

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -16,7 +16,22 @@ import { AnthropicMessagesLanguageModel } from './anthropic-messages-language-mo
 import type { AnthropicMessagesModelId } from './anthropic-messages-options';
 import { anthropicTools } from './anthropic-tools';
 
+<<<<<<< HEAD
 export interface AnthropicProvider extends ProviderV2 {
+=======
+const ANTHROPIC_API_URL = 'https://api.anthropic.com';
+const ANTHROPIC_API_VERSIONED_URL = `${ANTHROPIC_API_URL}/v1`;
+
+function normalizeBaseURL(baseURL: string | undefined): string | undefined {
+  const baseURLWithoutTrailingSlash = withoutTrailingSlash(baseURL);
+
+  return baseURLWithoutTrailingSlash === ANTHROPIC_API_URL
+    ? ANTHROPIC_API_VERSIONED_URL
+    : baseURLWithoutTrailingSlash;
+}
+
+export interface AnthropicProvider extends ProviderV4 {
+>>>>>>> 679c52a01 (fix: normalize bare Anthropic API base URL to avoid missing /v1 path (#16584))
   /**
 Creates a model for text generation.
 */
@@ -77,12 +92,12 @@ export function createAnthropic(
   options: AnthropicProviderSettings = {},
 ): AnthropicProvider {
   const baseURL =
-    withoutTrailingSlash(
+    normalizeBaseURL(
       loadOptionalSetting({
         settingValue: options.baseURL,
         environmentVariableName: 'ANTHROPIC_BASE_URL',
       }),
-    ) ?? 'https://api.anthropic.com/v1';
+    ) ?? ANTHROPIC_API_VERSIONED_URL;
 
   const providerName = options.name ?? 'anthropic.messages';
 

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -16,9 +16,6 @@ import { AnthropicMessagesLanguageModel } from './anthropic-messages-language-mo
 import type { AnthropicMessagesModelId } from './anthropic-messages-options';
 import { anthropicTools } from './anthropic-tools';
 
-<<<<<<< HEAD
-export interface AnthropicProvider extends ProviderV2 {
-=======
 const ANTHROPIC_API_URL = 'https://api.anthropic.com';
 const ANTHROPIC_API_VERSIONED_URL = `${ANTHROPIC_API_URL}/v1`;
 
@@ -30,8 +27,7 @@ function normalizeBaseURL(baseURL: string | undefined): string | undefined {
     : baseURLWithoutTrailingSlash;
 }
 
-export interface AnthropicProvider extends ProviderV4 {
->>>>>>> 679c52a01 (fix: normalize bare Anthropic API base URL to avoid missing /v1 path (#16584))
+export interface AnthropicProvider extends ProviderV2 {
   /**
 Creates a model for text generation.
 */


### PR DESCRIPTION
## Background

Claude Code/Cursor can inject ANTHROPIC_BASE_URL=https://api.anthropic.com, which made @ai-sdk/anthropic call https://api.anthropic.com/messages instead of the versioned Anthropic API path.

## Summary

Added Anthropic provider base URL normalization so the bare official API host resolves to https://api.anthropic.com/v1 while preserving existing versioned and custom base URLs.

## Testing

Added regression coverage for bare https://api.anthropic.com values from both ANTHROPIC_BASE_URL and the baseURL option.

## Related Issues

Fixes #15542

Backport of #16584