### PR TITLE
[v5.0] fix: emit completed results for xAI provider-executed streaming tools

### DIFF
--- a/.changeset/quiet-tools-smile.md
+++ b/.changeset/quiet-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Emit provider-executed tool results for completed xAI Responses API streaming tool calls.

--- a/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
+++ b/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
@@ -11434,6 +11434,12 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream w
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "fc_98a8d4aa-fc8b-fd93-e673-d5a8f1c9cee8_0",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "id": "text-msg_98a8d4aa-fc8b-fd93-e673-d5a8f1c9cee8",
     "type": "text-start",
   },
@@ -12862,6 +12868,12 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_24148162",
+    "toolName": "x_search",
+    "type": "tool-result",
+  },
+  {
     "id": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
     "toolName": "web_search",
     "type": "tool-input-start",
@@ -12946,6 +12958,30 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_09546004",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_45339693",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_63718660",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "id": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
     "toolName": "view_x_video",
     "type": "tool-input-start",
@@ -12965,6 +13001,12 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
     "toolName": "view_x_video",
     "type": "tool-call",
+  },
+  {
+    "result": {},
+    "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
+    "toolName": "view_x_video",
+    "type": "tool-result",
   },
   {
     "id": "text-msg_b7b464ea-cc85-d44a-0f2f-1f7320e703c3",

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1870,7 +1870,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider',
+              type: 'provider-defined',
               id: 'xai.web_search',
               name: 'web_search',
               args: {},

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1818,6 +1818,83 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      it('should emit a tool result when provider-executed tool calls finish', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_123',
+              name: 'web_search',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_123',
+              name: 'web_search',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'completed',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'ws_123',
+          toolName: 'web_search',
+          input: '{"query":"test"}',
+          providerExecuted: true,
+        });
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_123',
+          toolName: 'web_search',
+          result: {},
+        });
+      });
+
       it('should stream function tool call arguments', async () => {
         prepareStreamChunks([
           JSON.stringify({

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -762,6 +762,15 @@ export class XaiResponsesLanguageModel implements LanguageModelV2 {
                   });
                 }
 
+                if (event.type === 'response.output_item.done') {
+                  controller.enqueue({
+                    type: 'tool-result',
+                    toolCallId: part.id,
+                    toolName,
+                    result: {},
+                  });
+                }
+
                 return;
               }
 


### PR DESCRIPTION
## Background

xAI Responses provider-executed tools emitted tool-call parts but no matching tool-result on completion, leaving UI tool status stuck in an in-progress/input-available state.

## Summary

Updated xAI Responses streaming to enqueue a final tool-result when provider-executed tool output items complete.

## Testing

Added a streaming regression test for completed web_search_call tool results and updated xAI Responses stream snapshots for provider-executed tool-result parts.

## Related Issues

Fixes #13218

Backport of #16673

Co-authored-by: pepegc <26247616+pepegc@users.noreply.github.com>