### PR TITLE
[v5.0] fix: embedMany over-batches @ai-sdk/google embedding models

### DIFF
--- a/.changeset/twenty-windows-count.md
+++ b/.changeset/twenty-windows-count.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Fix Google embedding batch size to respect the Gemini API limit of 100 requests per batch.

--- a/packages/google/src/google-generative-ai-embedding-model.test.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.test.ts
@@ -169,11 +169,15 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       headers: () => ({}),
     });
 
-    const tooManyValues = Array(2049).fill('test');
+    const tooManyValues = Array(101).fill('test');
 
     await expect(model.doEmbed({ values: tooManyValues })).rejects.toThrow(
-      'Too many values for a single embedding call. The google.generative-ai model "gemini-embedding-001" can only embed up to 2048 values per call, but 2049 values were provided.',
+      'Too many values for a single embedding call. The google.generative-ai model "gemini-embedding-001" can only embed up to 100 values per call, but 101 values were provided.',
     );
+  });
+
+  it('should expose the Google batch embedding API limit', () => {
+    expect(model.maxEmbeddingsPerCall).toBe(100);
   });
 
   it('should use the batch embeddings endpoint', async () => {

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -26,17 +26,10 @@ type GoogleGenerativeAIEmbeddingConfig = {
   fetch?: FetchFunction;
 };
 
-<<<<<<< HEAD:packages/google/src/google-generative-ai-embedding-model.ts
 export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV2<string> {
   readonly specificationVersion = 'v2';
   readonly modelId: GoogleGenerativeAIEmbeddingModelId;
-  readonly maxEmbeddingsPerCall = 2048;
-=======
-export class GoogleEmbeddingModel implements EmbeddingModelV4 {
-  readonly specificationVersion = 'v4';
-  readonly modelId: GoogleEmbeddingModelId;
   readonly maxEmbeddingsPerCall = 100;
->>>>>>> bd8d172c7 (fix: embedMany over-batches @ai-sdk/google embedding models (#16575)):packages/google/src/google-embedding-model.ts
   readonly supportsParallelCalls = true;
 
   private readonly config: GoogleGenerativeAIEmbeddingConfig;

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -26,10 +26,17 @@ type GoogleGenerativeAIEmbeddingConfig = {
   fetch?: FetchFunction;
 };
 
+<<<<<<< HEAD:packages/google/src/google-generative-ai-embedding-model.ts
 export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV2<string> {
   readonly specificationVersion = 'v2';
   readonly modelId: GoogleGenerativeAIEmbeddingModelId;
   readonly maxEmbeddingsPerCall = 2048;
+=======
+export class GoogleEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: GoogleEmbeddingModelId;
+  readonly maxEmbeddingsPerCall = 100;
+>>>>>>> bd8d172c7 (fix: embedMany over-batches @ai-sdk/google embedding models (#16575)):packages/google/src/google-embedding-model.ts
   readonly supportsParallelCalls = true;
 
   private readonly config: GoogleGenerativeAIEmbeddingConfig;


### PR DESCRIPTION
## Background

Google Gemini batch embedding requests are capped at 100 items, but @ai-sdk/google advertised 2048, causing embedMany to send oversized batches and receive 400 errors for inputs over 100 values.

## Summary

Changed GoogleEmbeddingModel.maxEmbeddingsPerCall from 2048 to 100 so embedMany chunks Google embedding requests within the API limit.

## Testing

Updated Google embedding model regression coverage to assert the 100-item batch limit and the TooManyEmbeddingValuesForCallError behavior at 101 values.

## Related Issues

Fixes #16101

Backport of #16575