### PR TITLE
[v5.0] fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching

### DIFF
--- a/.changeset/calm-tools-sort.md
+++ b/.changeset/calm-tools-sort.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Sort tool results by their tool call order when converting generation output to response messages.

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -256,12 +256,8 @@ describe('toResponseMessages', () => {
     `);
   });
 
-<<<<<<< HEAD
-  it('should handle undefined text', () => {
+  it('should serialize parallel tool results in tool call order', () => {
     const result = toResponseMessages({
-=======
-  it('should serialize parallel tool results in tool call order', async () => {
-    const result = await toResponseMessages({
       content: [
         {
           type: 'text',
@@ -319,9 +315,8 @@ describe('toResponseMessages', () => {
     ).toEqual(['call-a', 'call-b']);
   });
 
-  it('should handle undefined text', async () => {
-    const result = await toResponseMessages({
->>>>>>> ecfeb6f7b (fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching (#16578))
+  it('should handle undefined text', () => {
+    const result = toResponseMessages({
       content: [
         {
           type: 'reasoning',

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -256,8 +256,72 @@ describe('toResponseMessages', () => {
     `);
   });
 
+<<<<<<< HEAD
   it('should handle undefined text', () => {
     const result = toResponseMessages({
+=======
+  it('should serialize parallel tool results in tool call order', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'text',
+          text: 'Using tools',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          input: {},
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          input: {},
+        },
+        // Simulates parallel execution where toolB resolved before toolA.
+        {
+          type: 'tool-result',
+          toolCallId: 'call-b',
+          toolName: 'toolB',
+          output: 'B result',
+          input: {},
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-a',
+          toolName: 'toolA',
+          output: 'A result',
+          input: {},
+        },
+      ],
+      tools: {
+        toolA: tool({
+          description: 'Tool A',
+          inputSchema: z.object({}),
+        }),
+        toolB: tool({
+          description: 'Tool B',
+          inputSchema: z.object({}),
+        }),
+      },
+    });
+
+    const toolMessage = result[1];
+    expect(toolMessage?.role).toBe('tool');
+    if (toolMessage?.role !== 'tool') {
+      throw new Error('Expected a tool message');
+    }
+    expect(
+      toolMessage.content
+        .filter(part => part.type === 'tool-result')
+        .map(part => part.toolCallId),
+    ).toEqual(['call-a', 'call-b']);
+  });
+
+  it('should handle undefined text', async () => {
+    const result = await toResponseMessages({
+>>>>>>> ecfeb6f7b (fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching (#16578))
       content: [
         {
           type: 'reasoning',

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -21,7 +21,6 @@ export function toResponseMessages<TOOLS extends ToolSet>({
   const responseMessages: Array<AssistantModelMessage | ToolModelMessage> = [];
   const toolCallOrder = new Map<string, number>();
 
-<<<<<<< HEAD
   const content: AssistantContent = inputContent
     .filter(part => part.type !== 'source')
     .filter(
@@ -52,6 +51,9 @@ export function toResponseMessages<TOOLS extends ToolSet>({
             providerOptions: part.providerMetadata,
           };
         case 'tool-call':
+          if (!toolCallOrder.has(part.toolCallId)) {
+            toolCallOrder.set(part.toolCallId, toolCallOrder.size);
+          }
           return {
             type: 'tool-call',
             toolCallId: part.toolCallId,
@@ -85,96 +87,6 @@ export function toResponseMessages<TOOLS extends ToolSet>({
             }),
             providerOptions: part.providerMetadata,
           };
-=======
-  const content: AssistantContent = [];
-  for (const part of inputContent) {
-    // Skip sources - they are response-only content that no provider expects back
-    if (part.type === 'source') {
-      continue;
-    }
-
-    // Skip non-provider-executed tool results/errors (they go in the tool message)
-    if (
-      (part.type === 'tool-result' || part.type === 'tool-error') &&
-      !part.providerExecuted
-    ) {
-      continue;
-    }
-
-    // Skip empty text
-    if (part.type === 'text' && part.text.length === 0) {
-      continue;
-    }
-
-    switch (part.type) {
-      case 'text':
-        content.push({
-          type: 'text',
-          text: part.text,
-          providerOptions: part.providerMetadata,
-        });
-        break;
-      case 'custom':
-        content.push({
-          type: 'custom',
-          kind: part.kind,
-          providerOptions: part.providerMetadata,
-        });
-        break;
-      case 'reasoning':
-        content.push({
-          type: 'reasoning',
-          text: part.text,
-          providerOptions: part.providerMetadata,
-        });
-        break;
-      case 'file':
-        content.push({
-          type: 'file',
-          data: part.file.base64,
-          mediaType: part.file.mediaType,
-          providerOptions: part.providerMetadata,
-        });
-        break;
-      case 'reasoning-file':
-        content.push({
-          type: 'reasoning-file',
-          data: part.file.base64,
-          mediaType: part.file.mediaType,
-          providerOptions: part.providerMetadata,
-        });
-        break;
-      case 'tool-call':
-        if (!toolCallOrder.has(part.toolCallId)) {
-          toolCallOrder.set(part.toolCallId, toolCallOrder.size);
-        }
-        content.push({
-          type: 'tool-call',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          input:
-            part.invalid && typeof part.input !== 'object' ? {} : part.input,
-          providerExecuted: part.providerExecuted,
-          providerOptions: part.providerMetadata,
-        });
-        break;
-      case 'tool-result': {
-        const output = await createToolModelOutput({
-          toolCallId: part.toolCallId,
-          input: part.input,
-          tool: tools?.[part.toolName],
-          output: part.output,
-          errorMode: 'none',
-        });
-        content.push({
-          type: 'tool-result',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          output,
-          providerOptions: part.providerMetadata,
-        });
-        break;
->>>>>>> ecfeb6f7b (fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching (#16578))
       }
     });
 

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -19,7 +19,9 @@ export function toResponseMessages<TOOLS extends ToolSet>({
   tools: TOOLS | undefined;
 }): Array<AssistantModelMessage | ToolModelMessage> {
   const responseMessages: Array<AssistantModelMessage | ToolModelMessage> = [];
+  const toolCallOrder = new Map<string, number>();
 
+<<<<<<< HEAD
   const content: AssistantContent = inputContent
     .filter(part => part.type !== 'source')
     .filter(
@@ -83,6 +85,96 @@ export function toResponseMessages<TOOLS extends ToolSet>({
             }),
             providerOptions: part.providerMetadata,
           };
+=======
+  const content: AssistantContent = [];
+  for (const part of inputContent) {
+    // Skip sources - they are response-only content that no provider expects back
+    if (part.type === 'source') {
+      continue;
+    }
+
+    // Skip non-provider-executed tool results/errors (they go in the tool message)
+    if (
+      (part.type === 'tool-result' || part.type === 'tool-error') &&
+      !part.providerExecuted
+    ) {
+      continue;
+    }
+
+    // Skip empty text
+    if (part.type === 'text' && part.text.length === 0) {
+      continue;
+    }
+
+    switch (part.type) {
+      case 'text':
+        content.push({
+          type: 'text',
+          text: part.text,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+      case 'custom':
+        content.push({
+          type: 'custom',
+          kind: part.kind,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+      case 'reasoning':
+        content.push({
+          type: 'reasoning',
+          text: part.text,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+      case 'file':
+        content.push({
+          type: 'file',
+          data: part.file.base64,
+          mediaType: part.file.mediaType,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+      case 'reasoning-file':
+        content.push({
+          type: 'reasoning-file',
+          data: part.file.base64,
+          mediaType: part.file.mediaType,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+      case 'tool-call':
+        if (!toolCallOrder.has(part.toolCallId)) {
+          toolCallOrder.set(part.toolCallId, toolCallOrder.size);
+        }
+        content.push({
+          type: 'tool-call',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input:
+            part.invalid && typeof part.input !== 'object' ? {} : part.input,
+          providerExecuted: part.providerExecuted,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+      case 'tool-result': {
+        const output = await createToolModelOutput({
+          toolCallId: part.toolCallId,
+          input: part.input,
+          tool: tools?.[part.toolName],
+          output: part.output,
+          errorMode: 'none',
+        });
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          output,
+          providerOptions: part.providerMetadata,
+        });
+        break;
+>>>>>>> ecfeb6f7b (fix: Parallel tool results are serialized in completion order, silently breaking provider prompt caching (#16578))
       }
     });
 
@@ -116,9 +208,49 @@ export function toResponseMessages<TOOLS extends ToolSet>({
   if (toolResultContent.length > 0) {
     responseMessages.push({
       role: 'tool',
-      content: toolResultContent,
+      content: sortToolResultContentByToolCallOrder({
+        toolResultContent,
+        toolCallOrder,
+      }),
     });
   }
 
   return responseMessages;
+}
+
+function sortToolResultContentByToolCallOrder({
+  toolResultContent,
+  toolCallOrder,
+}: {
+  toolResultContent: ToolContent;
+  toolCallOrder: Map<string, number>;
+}): ToolContent {
+  const sortedToolResults = toolResultContent
+    .filter(part => part.type === 'tool-result')
+    .map((part, index) => ({ part, index }))
+    .sort((a, b) => {
+      const aOrder = toolCallOrder.get(a.part.toolCallId);
+      const bOrder = toolCallOrder.get(b.part.toolCallId);
+
+      if (aOrder == null && bOrder == null) {
+        return a.index - b.index;
+      }
+
+      if (aOrder == null) {
+        return 1;
+      }
+
+      if (bOrder == null) {
+        return -1;
+      }
+
+      return aOrder - bOrder || a.index - b.index;
+    })
+    .map(({ part }) => part);
+
+  let toolResultIndex = 0;
+
+  return toolResultContent.map(part =>
+    part.type === 'tool-result' ? sortedToolResults[toolResultIndex++] : part,
+  );
 }


### PR DESCRIPTION
## Background

Parallel tool results could be serialized in nondeterministic completion order instead of assistant tool-call order, causing equivalent histories to produce byte-different prompts and miss provider prompt caches.

## Summary

Updated toResponseMessages to record assistant tool-call order and stably sort emitted tool-result content by matching toolCallId, with unknown ids kept last.

## Testing

Kept the focused regression test for parallel tool calls resolving out of order and made its assertion type-safe.

## Related Issues

Fixes #16567

Backport of #16578