### PR TITLE
reproduction: @ai-sdk/alibaba: wan2.7 video models send an unsupported ratio

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-16663-alibaba-wan27-unsupported-resolution-ratio-live.ts
+++ b/examples/ai-functions/src/reproduction/issue-16663-alibaba-wan27-unsupported-resolution-ratio-live.ts
@@ -1,0 +1,108 @@
+import { createAlibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+type CapturedFetch = {
+  url: string;
+  method: string;
+  requestBody?: unknown;
+  response?: {
+    status: number;
+    body?: unknown;
+  };
+};
+
+async function parseJsonOrText(text: string): Promise<unknown> {
+  if (text.length === 0) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+async function main() {
+  const calls: CapturedFetch[] = [];
+
+  const model = createAlibaba({
+    fetch: async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method =
+        init?.method ?? (input instanceof Request ? input.method : 'GET');
+      const requestText =
+        typeof init?.body === 'string'
+          ? init.body
+          : init?.body == null
+            ? undefined
+            : String(init.body);
+
+      const call: CapturedFetch = {
+        url,
+        method,
+        requestBody:
+          requestText == null ? undefined : await parseJsonOrText(requestText),
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      const responseText = await response.clone().text();
+      call.response = {
+        status: response.status,
+        body: await parseJsonOrText(responseText),
+      };
+      return response;
+    },
+  }).video('wan2.7-t2v');
+
+  try {
+    const result = await generateVideo({
+      model,
+      prompt: 'A serene mountain lake at sunset',
+      resolution: '1024x768',
+      providerOptions: {
+        alibaba: {
+          pollIntervalMs: 250,
+          pollTimeoutMs: 1500,
+        },
+      },
+    });
+
+    console.log(
+      JSON.stringify(
+        {
+          outcome: 'resolved',
+          warnings: result.warnings,
+          calls,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.log(
+      JSON.stringify(
+        {
+          outcome: 'rejected',
+          error:
+            error instanceof Error
+              ? {
+                  name: error.name,
+                  message: error.message,
+                  cause: error.cause,
+                }
+              : error,
+          calls,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/alibaba/src/__fixtures__/issue-16663-wan27-unsupported-resolution-ratio-live.json
+++ b/packages/alibaba/src/__fixtures__/issue-16663-wan27-unsupported-resolution-ratio-live.json
@@ -1,0 +1,85 @@
+{
+  "source": "live Alibaba DashScope call via examples/ai-functions/src/reproduction/issue-16663-alibaba-wan27-unsupported-resolution-ratio-live.ts",
+  "model": "wan2.7-t2v",
+  "prompt": "A serene mountain lake at sunset",
+  "resolution": "1024x768",
+  "observedAt": "2026-07-07T01:01:50+08:00",
+  "outcome": "rejected",
+  "error": {
+    "name": "ALIBABA_VIDEO_GENERATION_TIMEOUT",
+    "message": "Video generation timed out after 1500ms"
+  },
+  "calls": [
+    {
+      "url": "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/video-generation/video-synthesis",
+      "method": "POST",
+      "requestBody": {
+        "model": "wan2.7-t2v",
+        "input": {
+          "prompt": "A serene mountain lake at sunset"
+        },
+        "parameters": {
+          "ratio": "4:3"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "request_id": "1bc646c3-2eb6-9217-98dd-fd9316823335",
+          "output": {
+            "task_id": "09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+            "task_status": "PENDING"
+          }
+        }
+      }
+    },
+    {
+      "url": "https://dashscope-intl.aliyuncs.com/api/v1/tasks/09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+      "method": "GET",
+      "response": {
+        "status": 200,
+        "body": {
+          "request_id": "6bd1b453-e0ee-9029-98b0-bd0701914a39",
+          "output": {
+            "task_id": "09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+            "task_status": "RUNNING",
+            "submit_time": "2026-07-07 01:01:50.411",
+            "scheduled_time": "2026-07-07 01:01:50.446"
+          }
+        }
+      }
+    },
+    {
+      "url": "https://dashscope-intl.aliyuncs.com/api/v1/tasks/09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+      "method": "GET",
+      "response": {
+        "status": 200,
+        "body": {
+          "request_id": "4a726420-e9b8-98e6-a7b9-4aa31d9a6040",
+          "output": {
+            "task_id": "09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+            "task_status": "RUNNING",
+            "submit_time": "2026-07-07 01:01:50.411",
+            "scheduled_time": "2026-07-07 01:01:50.446"
+          }
+        }
+      }
+    },
+    {
+      "url": "https://dashscope-intl.aliyuncs.com/api/v1/tasks/09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+      "method": "GET",
+      "response": {
+        "status": 200,
+        "body": {
+          "request_id": "10caa0fc-095b-9f58-8f05-e6b7ae591f84",
+          "output": {
+            "task_id": "09523ea5-bbe6-4e10-9d18-ae482b5ac69b",
+            "task_status": "RUNNING",
+            "submit_time": "2026-07-07 01:01:50.411",
+            "scheduled_time": "2026-07-07 01:01:50.446"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
 import { AlibabaVideoModel } from './alibaba-video-model';
@@ -7,6 +8,40 @@ const prompt = 'A serene mountain lake at sunset with gentle ripples';
 const TEST_BASE_URL = 'https://dashscope-intl.aliyuncs.com';
 const CREATE_URL = `${TEST_BASE_URL}/api/v1/services/aigc/video-generation/video-synthesis`;
 const TASK_URL = `${TEST_BASE_URL}/api/v1/tasks/task-abc-123`;
+
+const issue16663Fixture = JSON.parse(
+  fs.readFileSync(
+    'src/__fixtures__/issue-16663-wan27-unsupported-resolution-ratio-live.json',
+    'utf8',
+  ),
+) as {
+  calls: [
+    {
+      response: {
+        body: {
+          request_id: string;
+          output: { task_id: string; task_status: string };
+        };
+      };
+    },
+    {
+      response: {
+        body: {
+          request_id: string;
+          output: {
+            task_id: string;
+            task_status: string;
+            submit_time: string;
+            scheduled_time: string;
+          };
+        };
+      };
+    },
+  ];
+};
+
+const issue16663CreateTaskResponse = issue16663Fixture.calls[0].response.body;
+const ISSUE_16663_TASK_URL = `${TEST_BASE_URL}/api/v1/tasks/${issue16663CreateTaskResponse.output.task_id}`;
 
 const createTaskResponse = {
   output: {
@@ -82,6 +117,12 @@ describe('AlibabaVideoModel', () => {
     },
     [TASK_URL]: {
       response: { type: 'json-value', body: succeededTaskResponse },
+    },
+    [ISSUE_16663_TASK_URL]: {
+      response: {
+        type: 'json-value',
+        body: issue16663Fixture.calls[1].response.body,
+      },
     },
   });
 
@@ -935,6 +976,37 @@ describe('AlibabaVideoModel', () => {
         },
       });
       expect(body.parameters).not.toHaveProperty('size');
+    });
+
+    it('should not derive ratio from an unsupported resolution', async () => {
+      const originalCreateResponse = server.urls[CREATE_URL].response;
+      server.urls[CREATE_URL].response = {
+        type: 'json-value',
+        body: issue16663CreateTaskResponse,
+      };
+
+      try {
+        const model = createModel({ modelId: 'wan2.7-t2v' });
+
+        await model
+          .doGenerate({
+            ...defaultOptions,
+            resolution: '1024x768',
+            providerOptions: {
+              alibaba: {
+                pollIntervalMs: 10,
+                pollTimeoutMs: 25,
+              },
+            },
+          })
+          .catch(() => undefined);
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).not.toHaveProperty('resolution');
+        expect(body.parameters).not.toHaveProperty('ratio');
+      } finally {
+        server.urls[CREATE_URL].response = originalCreateResponse;
+      }
     });
 
     it('should map aspectRatio to ratio without warning', async () => {


### PR DESCRIPTION
## Bug

@ai-sdk/alibaba: wan2.7 video models send an unsupported `ratio` derived from an ignored resolution

## Reproduction

Classified as provider-specific. Created live reproduction script at examples/ai-functions/src/reproduction/issue-16663-alibaba-wan27-unsupported-resolution-ratio-live.ts and ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-16663-alibaba-wan27-unsupported-resolution-ratio-live.ts`: live DashScope POST body contained `parameters: { "ratio": "4:3" }` for unsupported `resolution: "1024x768"` while omitting `resolution`, then polling timed out after a 200 PENDING create response; expected unsupported resolution to be fully ignored with no derived ratio. Recorded fixture at packages/alibaba/src/__fixtures__/issue-16663-wan27-unsupported-resolution-ratio-live.json and added failing provider unit test in packages/alibaba/src/alibaba-video-model.test.ts. Direct test command `pnpm -C packages/alibaba exec vitest --config vitest.node.config.js --run src/alibaba-video-model.test.ts -t "should not derive ratio from an unsupported resolution"` fails with `expected { ratio: '4:3' } to not have property "ratio"`. Checks `pnpm check`, `pnpm type-check`, `pnpm konsistent:check`, `pnpm -C packages/alibaba type-check`, and `pnpm -C examples/ai-functions type-check` passed. No blocker.

## Related Issues

Reproduces #16663