### PR TITLE
[v6.0] docs(content): harmonize SAP AI Core provider documentation

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -82,7 +82,7 @@ The open-source community has created the following providers:
 - [Browser AI Provider](/providers/community-providers/browser-ai) (`browser-ai`)
 - [Gemini CLI Provider](/providers/community-providers/gemini-cli) (`ai-sdk-provider-gemini-cli`)
 - [A2A Provider](/providers/community-providers/a2a) (`a2a-ai-provider`)
-- [SAP-AI Provider](/providers/community-providers/sap-ai) (`@mymediset/sap-ai-provider`)
+- [SAP AI Core Provider](/providers/community-providers/sap-ai) (`@jerome-benoit/sap-ai-provider`)
 - [AI/ML API Provider](/providers/community-providers/aimlapi) (`@ai-ml.api/aimlapi-vercel-ai`)
 - [MCP Sampling Provider](/providers/community-providers/mcp-sampling) (`@mcpc-tech/mcp-sampling-ai-provider`)
 - [ACP Provider](/providers/community-providers/acp) (`@mcpc-tech/acp-ai-provider`)

--- a/content/providers/03-community-providers/39-sap-ai.mdx
+++ b/content/providers/03-community-providers/39-sap-ai.mdx
@@ -5,18 +5,18 @@ description: Learn how to use the SAP AI Core provider for the AI SDK.
 
 # SAP AI Core Provider
 
-The AI SDK supports [SAP AI Core](https://help.sap.com/docs/ai-core) through two community providers:
+[jerome-benoit/sap-ai-provider](https://github.com/jerome-benoit/sap-ai-provider) is a community provider for SAP AI Core built on the official **@sap-ai-sdk/orchestration** and **@sap-ai-sdk/foundation-models** packages.
 
-- [jerome-benoit/sap-ai-provider](https://github.com/jerome-benoit/sap-ai-provider) - Language Model V3 for AI SDK 5.x & 6.x (recommended)
-- [jerome-benoit/sap-ai-provider-v2](https://github.com/jerome-benoit/sap-ai-provider-v2) - Language Model V2 for AI SDK 5.x
+Two npm packages are published from this repository:
 
-Both providers are built on the official **@sap-ai-sdk/orchestration** and **@sap-ai-sdk/foundation-models** packages, providing language model and embedding support through the familiar AI SDK interface.
+- `@jerome-benoit/sap-ai-provider` - Language Model V3 for AI SDK 5.x & 6.x (recommended)
+- `@jerome-benoit/sap-ai-provider-v2` - Language Model V2 for AI SDK 5.x
 
 ## Features
 
 Both providers offer:
 
-- **Dual API Support**: Choose between Orchestration API (with data masking, content filtering, document grounding, translation) or Foundation Models API (direct model access)
+- **Dual API Support**: Choose between Orchestration API (with data masking, content filtering, document grounding, translation) or Foundation Models API (`logprobs`, `seed`, `dataSources`)
 - **Tool calling** and **multi-modal input** (images)
 - **Streaming support** for real-time text generation
 - **Text embeddings** for RAG and semantic search
@@ -88,9 +88,13 @@ You can use the following optional settings to customize the SAP AI provider ins
 
   Specific deployment ID. If not provided, the SDK resolves deployment automatically.
 
-- **api** _string_
+- **api** _'orchestration' | 'foundation-models'_
 
-  API to use: `'orchestration'` (default) or `'foundation-models'`. Orchestration API supports data masking, content filtering, document grounding, and translation.
+  API to use. Defaults to `'orchestration'`. Can be overridden per model or per call via `providerOptions`.
+
+- **name** _string_
+
+  Provider name used as key in `providerOptions`. Defaults to `'sap-ai'`.
 
 - **defaultSettings** _object_
 
@@ -101,7 +105,7 @@ You can use the following optional settings to customize the SAP AI provider ins
 You can create models that call the SAP AI Core API using the provider instance. The first argument is the model id. Model naming follows SAP AI Core conventions with vendor prefixes:
 
 ```ts
-const model = sapai('gpt-4o');
+const model = sapai('gpt-4.1');
 const claudeModel = sapai('anthropic--claude-3.5-sonnet');
 const geminiModel = sapai('gemini-2.0-flash');
 ```
@@ -116,5 +120,5 @@ const geminiModel = sapai('gemini-2.0-flash');
 You can create models that call the SAP AI Core embeddings API using the `.embeddingModel()` factory method:
 
 ```ts
-const model = sapai.embeddingModel('text-embedding-ada-002');
+const model = sapai.embeddingModel('text-embedding-3-small');
 ```


### PR DESCRIPTION
Backport of #12922 to `release-v6.0` (clean cherry-pick). Corrects the SAP AI Core community provider package name and description; the docs explicitly target AI SDK 5.x/6.x.

Part of the v6.0 backport tracking issue #16767.