### PR TITLE
[v6.0] docs: enhance 'tool.toModelOutput' description in jsdoc and docs website

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -139,7 +139,7 @@ export const weatherTool = tool({
               isOptional: true,
               type: '({toolCallId: string; input: INPUT; output: OUTPUT}) => ToolResultOutput | PromiseLike<ToolResultOutput>',
               description:
-                'Optional conversion function that maps the tool result to an output that can be used by the language model. If not provided, the tool result will be sent as a JSON object.',
+                'Optional conversion function that maps the tool result to an output that can be used by the language model. If not provided, the tool result will be sent as a JSON object. This function is invoked on the server by "convertToModelMessages", so ensure that you pass the same "tools" (ToolSet) to both "convertToModelMessages" and "streamText" (or other generation APIs).',
             },
             {
               name: 'onInputStart',

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -198,6 +198,8 @@ export type Tool<
      * Optional conversion function that maps the tool result to an output that can be used by the language model.
      *
      * If not provided, the tool result will be sent as a JSON object.
+     *
+     * This function is invoked on the server by `convertToModelMessages`, so ensure that you pass the same "tools" (ToolSet) to both "convertToModelMessages" and "streamText" (or other generation APIs).
      */
     toModelOutput?: (options: {
       /**


### PR DESCRIPTION
Backport of #13481 to `release-v6.0` (clean cherry-pick). Clarifies that `toModelOutput` is invoked by `convertToModelMessages`; the API is identical in v6. Jsdoc/docs only — no runtime changes.

Part of the v6.0 backport tracking issue #16767.