### PR TITLE
[v6.0] docs: fix http link to https in deployment guide

### DIFF
--- a/content/docs/06-advanced/10-vercel-deployment-guide.mdx
+++ b/content/docs/06-advanced/10-vercel-deployment-guide.mdx
@@ -40,7 +40,7 @@ You can create a GitHub repository from within your terminal, or on [github.com]
 
 To create your GitHub repository:
 
-1. Navigate to [github.com](http://github.com/)
+1. Navigate to [github.com](https://github.com/)
 2. In the top right corner, click the "plus" icon and select "New repository"
 3. Pick a name for your repository (this can be anything)
 4. Click "Create repository"


### PR DESCRIPTION
Backport of #16510 to `release-v6.0` (clean cherry-pick). Trivial http→https link fix.

Part of the v6.0 backport tracking issue #16767.