### PR TITLE
[v6.0] docs: add example to prepareCall jsdoc

### DIFF
--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -151,6 +151,16 @@ export type ToolLoopAgentSettings<
    * Prepare the parameters for the generateText or streamText call.
    *
    * You can use this to have templates based on call options.
+   *
+   * The design requires you to pass call parameters as follows to
+   * allow for the removal of parameters from the original settings
+   * by setting them to `undefined`:
+   *
+   * ```
+   *   prepareCall: ({ options, ...rest }) => ({
+   *     ...rest,
+   *   }),
+   * ```
    */
   prepareCall?: (
     options: Omit<


### PR DESCRIPTION
Manual backport of #15098 to `release-v6.0`. The surrounding `ToolLoopAgentSettings` type diverged between v6 and main, so the jsdoc example was applied by hand to v6's `prepareCall` declaration. Jsdoc only — no runtime changes.

Part of the v6.0 backport tracking issue #16767.