### PR TITLE
[v6.0] fix(ui): export isDynamicToolUIPart from ai package

### DIFF
--- a/.changeset/export-isDynamicToolUIPart.md
+++ b/.changeset/export-isDynamicToolUIPart.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ui): export `isDynamicToolUIPart` from `ai` package

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -37,6 +37,7 @@ export {
   getToolName,
   getToolOrDynamicToolName,
   isDataUIPart,
+  isDynamicToolUIPart,
   isFileUIPart,
   isReasoningUIPart,
   isStaticToolUIPart,


### PR DESCRIPTION
Backport of #13961 to `release-v6.0` (clean cherry-pick). v6 defines `isDynamicToolUIPart` but omits it from the `ui/index.ts` export list.

Part of the v6.0 backport tracking issue #16767.