### PR TITLE
[v6.0] fix(ai): return validated elements from array output parseCompleteOutput

### DIFF
--- a/.changeset/green-ravens-enjoy.md
+++ b/.changeset/green-ravens-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Return validated elements from generateText array output

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -352,6 +352,36 @@ describe('Output.array', () => {
         });
       }
     });
+
+    it('should return schema-validated values (with transforms applied)', async () => {
+      const arrayWithTransform = array({
+        element: z
+          .object({ content: z.string() })
+          .transform(val => ({ ...val, extra: true })),
+      });
+
+      const result = await arrayWithTransform.parseCompleteOutput(
+        { text: `{ "elements": [{ "content": "hello" }] }` },
+        context,
+      );
+
+      expect(result).toStrictEqual([{ content: 'hello', extra: true }]);
+    });
+
+    it('should return validated values for multiple elements', async () => {
+      const result = await array1.parseCompleteOutput(
+        {
+          text: `{ "elements": [{ "content": "a" }, { "content": "b" }, { "content": "c" }] }`,
+        },
+        context,
+      );
+
+      expect(result).toStrictEqual([
+        { content: 'a' },
+        { content: 'b' },
+        { content: 'c' },
+      ]);
+    });
   });
 
   describe('array.parsePartialOutput', () => {

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -278,6 +278,7 @@ export const array = <ELEMENT>({
         });
       }
 
+      const validatedElements: Array<ELEMENT> = [];
       for (const element of outerValue.elements) {
         const validationResult = await safeValidateTypes({
           value: element,
@@ -294,9 +295,11 @@ export const array = <ELEMENT>({
             finishReason: context.finishReason,
           });
         }
+
+        validatedElements.push(validationResult.value);
       }
 
-      return outerValue.elements as Array<ELEMENT>;
+      return validatedElements;
     },
 
     async parsePartialOutput({ text }: { text: string }) {


### PR DESCRIPTION
Backport of #15734 to `release-v6.0` (clean cherry-pick). Array output previously returned the unvalidated elements, silently dropping schema transforms/coercions/defaults.

Part of the v6.0 backport tracking issue #16767.