### PR TITLE
[v6.0] fix(gateway): accept deprecated warnings in image, speech, transcription, and video responses

### DIFF
--- a/.changeset/quick-eagles-explain.md
+++ b/.changeset/quick-eagles-explain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): accept deprecated warnings in image, speech, transcription, and video responses

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -73,6 +73,7 @@ describe('GatewayImageModel', () => {
       warnings?: Array<
         | { type: 'unsupported'; feature: string; details?: string }
         | { type: 'compatibility'; feature: string; details?: string }
+        | { type: 'deprecated'; setting: string; message: string }
         | { type: 'other'; message: string }
       >;
       providerMetadata?: Record<string, unknown>;
@@ -286,6 +287,34 @@ describe('GatewayImageModel', () => {
     it('should return warnings when provided', async () => {
       const mockWarnings = [
         { type: 'other' as const, message: 'Setting not supported' },
+      ];
+
+      prepareJsonResponse({
+        images: ['base64-1'],
+        warnings: mockWarnings,
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toEqual(mockWarnings);
+    });
+
+    it('should return deprecated warnings correctly', async () => {
+      const mockWarnings = [
+        {
+          type: 'deprecated' as const,
+          setting: 'size',
+          message: 'Use `aspectRatio` instead.',
+        },
       ];
 
       prepareJsonResponse({

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -308,7 +308,7 @@ describe('GatewayImageModel', () => {
       expect(result.warnings).toEqual(mockWarnings);
     });
 
-    it('should return deprecated warnings correctly', async () => {
+    it('should map deprecated warnings to other warnings', async () => {
       const mockWarnings = [
         {
           type: 'deprecated' as const,
@@ -333,7 +333,9 @@ describe('GatewayImageModel', () => {
         providerOptions: {},
       });
 
-      expect(result.warnings).toEqual(mockWarnings);
+      expect(result.warnings).toEqual([
+        { type: 'other', message: 'Use `aspectRatio` instead.' },
+      ]);
     });
 
     it('should return unsupported warnings correctly', async () => {

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -13,6 +13,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { mapGatewayWarnings } from './map-gateway-warnings';
 import type { GatewayConfig } from './gateway-config';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
@@ -87,7 +88,7 @@ export class GatewayImageModel implements ImageModelV3 {
 
       return {
         images: responseBody.images, // Always base64 strings from server
-        warnings: responseBody.warnings ?? [],
+        warnings: mapGatewayWarnings(responseBody.warnings),
         providerMetadata:
           responseBody.providerMetadata as ImageModelV3ProviderMetadata,
         response: {

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -148,6 +148,11 @@ const gatewayImageWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/gateway-speech-model.ts
+++ b/packages/gateway/src/gateway-speech-model.ts
@@ -1,8 +1,4 @@
-import type {
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
-  SpeechModelV3,
-} from '@ai-sdk/provider';
+import type { SharedV3ProviderMetadata, SpeechModelV3 } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonErrorResponseHandler,
@@ -12,6 +8,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { mapGatewayWarnings } from './map-gateway-warnings';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';
@@ -80,7 +77,7 @@ export class GatewaySpeechModel implements SpeechModelV3 {
 
       return {
         audio: responseBody.audio,
-        warnings: (responseBody.warnings ?? []) as Array<SharedV3Warning>,
+        warnings: mapGatewayWarnings(responseBody.warnings),
         providerMetadata:
           responseBody.providerMetadata as SharedV3ProviderMetadata,
         response: {

--- a/packages/gateway/src/gateway-speech-model.ts
+++ b/packages/gateway/src/gateway-speech-model.ts
@@ -124,6 +124,11 @@ const gatewaySpeechWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -1,6 +1,5 @@
 import type {
   SharedV3ProviderMetadata,
-  SharedV3Warning,
   TranscriptionModelV3,
 } from '@ai-sdk/provider';
 import {
@@ -13,6 +12,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { mapGatewayWarnings } from './map-gateway-warnings';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';
@@ -79,7 +79,7 @@ export class GatewayTranscriptionModel implements TranscriptionModelV3 {
         segments: responseBody.segments ?? [],
         language: responseBody.language ?? undefined,
         durationInSeconds: responseBody.durationInSeconds ?? undefined,
-        warnings: (responseBody.warnings ?? []) as Array<SharedV3Warning>,
+        warnings: mapGatewayWarnings(responseBody.warnings),
         providerMetadata:
           responseBody.providerMetadata as SharedV3ProviderMetadata,
         response: {

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -123,6 +123,11 @@ const gatewayTranscriptionWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -17,6 +17,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { mapGatewayWarnings } from './map-gateway-warnings';
 import type { GatewayConfig } from './gateway-config';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
@@ -183,7 +184,7 @@ export class GatewayVideoModel implements Experimental_VideoModelV3 {
 
       return {
         videos: responseBody.videos,
-        warnings: responseBody.warnings ?? [],
+        warnings: mapGatewayWarnings(responseBody.warnings),
         providerMetadata:
           responseBody.providerMetadata as SharedV3ProviderMetadata,
         response: {

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -250,6 +250,11 @@ const gatewayVideoWarningSchema = z.discriminatedUnion('type', [
     details: z.string().optional(),
   }),
   z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
     type: z.literal('other'),
     message: z.string(),
   }),

--- a/packages/gateway/src/map-gateway-warnings.ts
+++ b/packages/gateway/src/map-gateway-warnings.ts
@@ -1,0 +1,21 @@
+import type { SharedV3Warning } from '@ai-sdk/provider';
+
+type GatewayResponseWarning =
+  | SharedV3Warning
+  | { type: 'deprecated'; setting: string; message: string };
+
+/**
+ * Maps warnings from gateway responses to `SharedV3Warning`.
+ *
+ * The gateway backend can emit `deprecated` warnings, which the v3
+ * specification cannot represent — they are mapped to `other` warnings.
+ */
+export function mapGatewayWarnings(
+  warnings: Array<GatewayResponseWarning> | undefined,
+): Array<SharedV3Warning> {
+  return (warnings ?? []).map(warning =>
+    warning.type === 'deprecated'
+      ? { type: 'other', message: warning.message }
+      : warning,
+  );
+}


### PR DESCRIPTION
Backport of #16030 to `release-v6.0` (clean cherry-pick). v6 gateway warning schemas lack the `deprecated` variant, so the shared gateway backend emitting deprecated warnings would fail response parsing.

Part of the v6.0 backport tracking issue #16767.