### PR TITLE
[v6.0] fix(ai): omit empty assistant message for data-only blocks in convertToModelMessages

### DIFF
--- a/.changeset/fix-convert-to-model-messages-empty-assistant.md
+++ b/.changeset/fix-convert-to-model-messages-empty-assistant.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix: `convertToModelMessages` no longer emits an empty assistant message when a block contains only unknown data parts (e.g. a data part before `step-start` with no `convertDataPart` provided)

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1,7 +1,40 @@
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import type { ModelMessage } from '@ai-sdk/provider-utils';
 import { describe, expect, it } from 'vitest';
+import type { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
+import { consumeStream } from '../util/consume-stream';
 import { convertToModelMessages } from './convert-to-model-messages';
+import {
+  createStreamingUIMessageState,
+  processUIMessageStream,
+} from './process-ui-message-stream';
 import type { UIMessage } from './ui-messages';
+
+async function recordAssistantMessageFromChunks<
+  UI_MESSAGE extends UIMessage = UIMessage,
+>(chunks: UIMessageChunk[]): Promise<UI_MESSAGE> {
+  const state = createStreamingUIMessageState<UI_MESSAGE>({
+    messageId: 'msg-123',
+    lastMessage: undefined,
+  });
+
+  await consumeStream({
+    stream: processUIMessageStream<UI_MESSAGE>({
+      stream: convertArrayToReadableStream(chunks),
+      runUpdateMessageJob: async job => {
+        await job({
+          state,
+          write: () => {},
+        });
+      },
+      onError: error => {
+        throw error;
+      },
+    }),
+  });
+
+  return state.message;
+}
 
 describe('convertToModelMessages', () => {
   describe('system message', () => {
@@ -2657,6 +2690,78 @@ describe('convertToModelMessages', () => {
               "content": [
                 {
                   "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ]
+        `);
+      });
+
+      it('should not emit empty assistant message for persistent data written before model stream starts', async () => {
+        type WeatherUIMessage = UIMessage<
+          unknown,
+          {
+            weather: {
+              city: string;
+              status: 'loading' | 'success';
+              weather?: string;
+            };
+          }
+        >;
+
+        const recordedMessage =
+          await recordAssistantMessageFromChunks<WeatherUIMessage>([
+            { type: 'start', messageId: 'msg-123' },
+            {
+              type: 'data-weather',
+              id: 'weather-1',
+              data: { city: 'San Francisco', status: 'loading' },
+            },
+            { type: 'start-step' },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'It is sunny.' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish-step' },
+            { type: 'finish' },
+          ]);
+
+        expect(recordedMessage).toMatchInlineSnapshot(`
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [
+              {
+                "data": {
+                  "city": "San Francisco",
+                  "status": "loading",
+                },
+                "id": "weather-1",
+                "type": "data-weather",
+              },
+              {
+                "type": "step-start",
+              },
+              {
+                "providerMetadata": undefined,
+                "state": "done",
+                "text": "It is sunny.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          }
+        `);
+
+        const result = await convertToModelMessages([recordedMessage]);
+
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "It is sunny.",
                   "type": "text",
                 },
               ],

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -246,10 +246,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
               }
             }
 
-            modelMessages.push({
-              role: 'assistant',
-              content,
-            });
+            if (content.length > 0) {
+              modelMessages.push({
+                role: 'assistant',
+                content,
+              });
+            }
 
             // check if there are tool invocations with results in the block
             // Include non-provider-executed tools, OR provider-executed tools with approval responses


### PR DESCRIPTION
Backport of #15040 to `release-v6.0` (clean cherry-pick). Data-only blocks previously produced empty assistant messages.

Part of the v6.0 backport tracking issue #16767.