### PR TITLE
[v6.0] fix: Google provider marks Gemini external HTTPS file URLs as unsupported

### DIFF
--- a/.changeset/green-gemini-files.md
+++ b/.changeset/green-gemini-files.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Pass documented Gemini external HTTPS file URLs through without downloading them.

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -275,12 +275,12 @@ describe('google-provider', () => {
   });
 
   it('should support documented external HTTPS URLs for Gemini models that accept external URLs', () => {
-    const provider = createGoogle({
+    const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
     });
     provider('gemini-3.5-flash');
 
-    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
     const supportedUrlsFunction = call[1].supportedUrls;
 
     expect(supportedUrlsFunction).toBeDefined();
@@ -340,12 +340,12 @@ describe('google-provider', () => {
   });
 
   it('should not support external HTTPS URLs for Gemini 2.0 models', () => {
-    const provider = createGoogle({
+    const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
     });
     provider('gemini-2.0-flash');
 
-    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
     const supportedUrlsFunction = call[1].supportedUrls;
 
     expect(supportedUrlsFunction).toBeDefined();

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -1,4 +1,5 @@
 import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
+import { isUrlSupported } from '@ai-sdk/provider-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createGoogleGenerativeAI } from './google-provider';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
@@ -271,6 +272,93 @@ describe('google-provider', () => {
         ],
       }
     `);
+  });
+
+  it('should support documented external HTTPS URLs for Gemini models that accept external URLs', () => {
+    const provider = createGoogle({
+      apiKey: 'test-api-key',
+    });
+    provider('gemini-3.5-flash');
+
+    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+
+    expect(supportedUrlsFunction).toBeDefined();
+
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+
+    const supportedExternalUrlMediaTypes = [
+      'text/html',
+      'text/css',
+      'text/plain',
+      'text/xml',
+      'text/csv',
+      'text/rtf',
+      'text/javascript',
+      'application/json',
+      'application/pdf',
+      'image/bmp',
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'video/mp4',
+      'video/mpeg',
+      'video/quicktime',
+      'video/avi',
+      'video/x-flv',
+      'video/mpg',
+      'video/webm',
+      'video/wmv',
+      'video/3gpp',
+    ];
+
+    for (const mediaType of supportedExternalUrlMediaTypes) {
+      expect(
+        isUrlSupported({
+          url: 'https://example.com/file',
+          mediaType,
+          supportedUrls,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      isUrlSupported({
+        url: 'http://example.com/file.txt',
+        mediaType: 'text/plain',
+        supportedUrls,
+      }),
+    ).toBe(false);
+
+    expect(
+      isUrlSupported({
+        url: 'https://example.com/file.md',
+        mediaType: 'text/markdown',
+        supportedUrls,
+      }),
+    ).toBe(false);
+  });
+
+  it('should not support external HTTPS URLs for Gemini 2.0 models', () => {
+    const provider = createGoogle({
+      apiKey: 'test-api-key',
+    });
+    provider('gemini-2.0-flash');
+
+    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+
+    expect(supportedUrlsFunction).toBeDefined();
+
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+
+    expect(
+      isUrlSupported({
+        url: 'https://example.com/file.txt',
+        mediaType: 'text/plain',
+        supportedUrls,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -141,6 +141,37 @@ export interface GoogleGenerativeAIProviderSettings {
   name?: string;
 }
 
+const supportedExternalUrlMediaTypes = [
+  'text/html',
+  'text/css',
+  'text/plain',
+  'text/xml',
+  'text/csv',
+  'text/rtf',
+  'text/javascript',
+  'application/json',
+  'application/pdf',
+  'image/bmp',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'video/mp4',
+  'video/mpeg',
+  'video/quicktime',
+  'video/avi',
+  'video/x-flv',
+  'video/mpg',
+  'video/webm',
+  'video/wmv',
+  'video/3gpp',
+];
+
+const externalHttpsUrlPattern = /^https:\/\/.*$/;
+
+function supportsExternalFileUrls(modelId: string) {
+  return /(^|\/)gemini-/.test(modelId) && !/(^|\/)gemini-2\.0/.test(modelId);
+}
+
 /**
  * Create a Google Generative AI provider instance.
  */
@@ -183,6 +214,14 @@ export function createGoogleGenerativeAI(
           ),
           new RegExp(`^https://youtu\\.be/[\\w-]+(?:\\?[\\w=&.-]*)?$`),
         ],
+        ...(supportsExternalFileUrls(modelId)
+          ? Object.fromEntries(
+              supportedExternalUrlMediaTypes.map(mediaType => [
+                mediaType,
+                [externalHttpsUrlPattern],
+              ]),
+            )
+          : {}),
       }),
       fetch: options.fetch,
     });


### PR DESCRIPTION
Backport of #16757 to `release-v6.0` (clean cherry-pick). v6's `supportedUrls` only covers generativelanguage/youtube, so external HTTPS file URLs are downloaded instead of passed as `fileUri`. Additive change.

Part of the v6.0 backport tracking issue #16767.