### PR TITLE
[v6.0] fix(react): preserve chat when id is undefined

### DIFF
--- a/.changeset/use-chat-nullish-id.md
+++ b/.changeset/use-chat-nullish-id.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/react": patch
+---
+
+Treat nullish `useChat` IDs the same as omitted IDs so the chat instance is not recreated on every render.

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -101,7 +101,9 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
 
   const shouldRecreateChat =
     ('chat' in options && options.chat !== chatRef.current) ||
-    ('id' in options && chatRef.current.id !== options.id);
+    ('id' in options &&
+      options.id != null &&
+      chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
     chatRef.current =

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2398,6 +2398,82 @@ describe('id changes', () => {
   });
 });
 
+describe('undefined id', () => {
+  setupTestComponent(
+    () => {
+      const [renderCount, setRenderCount] = React.useState(0);
+      const {
+        messages,
+        setMessages,
+        id: idKey,
+      } = useChat({
+        id: undefined,
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          <div data-testid="id">{idKey}</div>
+          <div data-testid="render-count">{renderCount}</div>
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+          <button
+            data-testid="set-message"
+            onClick={() => {
+              setMessages([
+                {
+                  id: 'message-0',
+                  role: 'user',
+                  parts: [{ text: 'hi', type: 'text' }],
+                },
+              ]);
+            }}
+          />
+          <button
+            data-testid="rerender"
+            onClick={() => {
+              setRenderCount(count => count + 1);
+            }}
+          />
+        </div>
+      );
+    },
+    {
+      init: TestComponent => <TestComponent />,
+    },
+  );
+
+  it('should not recreate chat when id is explicitly undefined', async () => {
+    const initialId = screen.getByTestId('id').textContent;
+
+    await userEvent.click(screen.getByTestId('set-message'));
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toStrictEqual([
+        {
+          id: 'message-0',
+          role: 'user',
+          parts: [{ text: 'hi', type: 'text' }],
+        },
+      ]);
+    });
+
+    await userEvent.click(screen.getByTestId('rerender'));
+
+    expect(screen.getByTestId('id').textContent).toBe(initialId);
+    expect(
+      JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+    ).toStrictEqual([
+      {
+        id: 'message-0',
+        role: 'user',
+        parts: [{ text: 'hi', type: 'text' }],
+      },
+    ]);
+  });
+});
+
 describe('chat instance changes', () => {
   setupTestComponent(
     () => {


### PR DESCRIPTION
Backport of #16484 to `release-v6.0`. Passing an explicitly-undefined `id` to `useChat` recreated the internal `Chat` instance on every render (because the `id` key exists in options while the generated chat ID never equals `undefined`), wiping messages and stream state; the fix changes the recreate guard to only apply when the provided `id` is non-nullish. The `use-chat.ts` guard change and the changeset applied cleanly; the regression test from the original commit conflicted only because `main`'s test file wraps everything in an outer `describe('use-chat')` block that does not exist on v6, so the new `describe('undefined id')` block was re-indented to match v6's flat test file structure with no semantic changes. Part of the v6.0 backport tracking issue #16767.