### PR TITLE
[v6.0] fix(provider/xai): extract reasoning text from content in responses doGenerate

### DIFF
--- a/.changeset/six-schools-enjoy.md
+++ b/.changeset/six-schools-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix reasoning text extraction from content in responses doGenerate

--- a/examples/ai-functions/src/generate-text/xai/responses-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-reasoning.ts
@@ -1,0 +1,26 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai.responses('grok-3-mini-latest'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+  });
+
+  for (const part of result.content) {
+    switch (part.type) {
+      case 'reasoning': {
+        console.log('--- reasoning ---');
+        console.log(part.text);
+        break;
+      }
+      case 'text': {
+        console.log('--- text ---');
+        console.log(part.text);
+        break;
+      }
+    }
+    console.log();
+  }
+});

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -225,6 +225,9 @@ const outputItemSchema = z.discriminatedUnion('type', [
     type: z.literal('reasoning'),
     id: z.string(),
     summary: z.array(reasoningSummaryPartSchema),
+    content: z
+      .array(z.object({ type: z.string(), text: z.string() }))
+      .nullish(),
     status: z.string(),
     encrypted_content: z.string().nullish(),
   }),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -407,6 +407,68 @@ describe('XaiResponsesLanguageModel', () => {
           ]
         `);
       });
+
+      it('should extract reasoning from content when summary is empty', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-3-mini',
+          output: [
+            {
+              type: 'reasoning',
+              id: 'rs_456',
+              status: 'completed',
+              summary: [],
+              content: [
+                {
+                  type: 'reasoning_text',
+                  text: 'Let me think step by step.',
+                },
+              ],
+            },
+            {
+              type: 'message',
+              id: 'msg_123',
+              status: 'completed',
+              role: 'assistant',
+              content: [
+                {
+                  type: 'output_text',
+                  text: 'The answer is 444.',
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 15,
+          },
+        });
+
+        const result = await createModel('grok-3-mini').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "providerMetadata": {
+                "xai": {
+                  "itemId": "rs_456",
+                },
+              },
+              "text": "Let me think step by step.",
+              "type": "reasoning",
+            },
+            {
+              "text": "The answer is 444.",
+              "type": "text",
+            },
+          ]
+        `);
+      });
     });
 
     describe('settings and options', () => {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -367,11 +367,14 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
         }
 
         case 'reasoning': {
-          const summaryTexts = part.summary
-            .map(s => s.text)
-            .filter(text => text && text.length > 0);
+          const texts =
+            part.summary.length > 0
+              ? part.summary.map(s => s.text)
+              : (part.content ?? []).map(c => c.text);
 
-          const reasoningText = summaryTexts.join('');
+          const reasoningText = texts
+            .filter(text => text && text.length > 0)
+            .join('');
 
           // condition changed here since encrypted content can now come with empty reasoning text
           if (reasoningText || part.encrypted_content) {


### PR DESCRIPTION
Backport of #13372 to the release-v6.0 branch. xAI's non-streaming responses API returns reasoning text in the `content` field on reasoning output items (as `reasoning_text` parts), not only in `summary`, so reasoning was silently dropped in `generateText`. This ports the fix: the reasoning output item schema gains the `content` field, and doGenerate falls back to reading reasoning text from `content` when `summary` is empty. During conflict resolution, v6's existing condition (`reasoningText || part.encrypted_content` with the `hasMetadata` providerMetadata spread, which supports encrypted content with empty reasoning text) was kept intact instead of main's older `if (reasoningText)` structure, and both v6's existing encrypted-content test and the new content-fallback regression test were retained. Part of the v6.0 backport tracking issue #16767.