### PR TITLE
[v6.0] fix: include object type in default tool schema

### DIFF
--- a/.changeset/gold-baboons-explode.md
+++ b/.changeset/gold-baboons-explode.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+Ensure the default empty tool input schema includes `type: "object"` for OpenAI-compatible providers that require object schemas.

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -3,6 +3,18 @@ import * as z4 from 'zod/v4';
 import { safeParseJSON } from './parse-json';
 import { asSchema, zodSchema, type StandardSchema } from './schema';
 
+describe('asSchema', () => {
+  it('should create an object schema when no schema is provided', async () => {
+    const schema = asSchema(undefined);
+
+    expect(await schema.jsonSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+});
+
 describe('zodSchema', () => {
   describe('zod/v4', () => {
     describe('json schema conversion', () => {

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -136,7 +136,11 @@ export function asSchema<OBJECT>(
   schema: FlexibleSchema<OBJECT> | undefined,
 ): Schema<OBJECT> {
   return schema == null
-    ? jsonSchema({ properties: {}, additionalProperties: false })
+    ? jsonSchema({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      })
     : isSchema(schema)
       ? schema
       : '~standard' in schema


### PR DESCRIPTION
Backport of #15249 to `release-v6.0`. When a tool defines no input schema, `asSchema(undefined)` now produces a default schema with an explicit `type: "object"`, so strict OpenAI-compatible providers (e.g. DeepSeek) no longer reject tool definitions with empty parameter schemas. The only conflict was in `packages/provider-utils/src/schema.test.ts`, where the new `asSchema` regression test block was inserted at the top of the file adjacent to unrelated surrounding test changes on main; the test was ported verbatim (including `await schema.jsonSchema`, which is valid in v6 since `jsonSchema` may be a `PromiseLike`). The changeset from the original commit is kept. Part of the v6.0 backport tracking issue #16767.