### PR TITLE
[v6.0] fix: prevent streaming tool calls from finalizing on parsable partial JSON

### DIFF
--- a/.changeset/fix-streaming-tool-call-early-finalization.md
+++ b/.changeset/fix-streaming-tool-call-early-finalization.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/alibaba': patch
+---
+
+fix(security): prevent streaming tool calls from finalizing on parsable partial JSON
+
+Streaming tool call arguments were finalized using `isParsableJson()` as a heuristic for completion. If partial accumulated JSON happened to be valid JSON before all chunks arrived, the tool call would be executed with incomplete arguments. Tool call finalization now only occurs in `flush()` after the stream is fully consumed.

--- a/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
+++ b/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
@@ -2967,6 +2967,11 @@ exports[`doStream > tool call > should stream tool call 1`] = `
     "type": "tool-input-delta",
   },
   {
+    "delta": "",
+    "id": "call_eee11723464a4b9eb8cee71d",
+    "type": "tool-input-delta",
+  },
+  {
     "id": "call_eee11723464a4b9eb8cee71d",
     "type": "tool-input-end",
   },

--- a/packages/alibaba/src/alibaba-chat-language-model.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.ts
@@ -19,7 +19,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   type ParseResult,
@@ -426,23 +425,6 @@ export class AlibabaLanguageModel implements LanguageModelV3 {
                     });
                   }
 
-                  // Check if already complete (some providers send full tool call at once)
-                  if (isParsableJson(toolCall.function.arguments)) {
-                    controller.enqueue({
-                      type: 'tool-input-end',
-                      id: toolCall.id,
-                    });
-
-                    controller.enqueue({
-                      type: 'tool-call',
-                      toolCallId: toolCall.id,
-                      toolName: toolCall.function.name,
-                      input: toolCall.function.arguments,
-                    });
-
-                    toolCall.hasFinished = true;
-                  }
-
                   continue;
                 }
 
@@ -463,23 +445,6 @@ export class AlibabaLanguageModel implements LanguageModelV3 {
                     id: toolCall.id,
                     delta: toolCallDelta.function.arguments,
                   });
-                }
-
-                // Check if tool call is now complete
-                if (isParsableJson(toolCall.function.arguments)) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id,
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-
-                  toolCall.hasFinished = true;
                 }
               }
             }
@@ -503,6 +468,25 @@ export class AlibabaLanguageModel implements LanguageModelV3 {
 
             if (activeText) {
               controller.enqueue({ type: 'text-end', id: '0' });
+            }
+
+            // Finalize any unfinished tool calls on stream end to
+            // prevent premature execution from parsable partial JSON.
+            for (const toolCall of toolCalls) {
+              if (!toolCall.hasFinished) {
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id,
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                });
+                toolCall.hasFinished = true;
+              }
             }
 
             controller.enqueue({

--- a/packages/cerebras/src/cerebras-chat-language-model.test.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model.test.ts
@@ -223,7 +223,7 @@ describe('doStream', () => {
       `);
     });
 
-    it('preserves the first streamed tool call and drops the repeated one', async () => {
+    it('drops the spurious tool calls from a mixed structured-output stream', async () => {
       const fetch = createStreamFixtureFetchMock(
         'cererebras-structured-output-tools.1',
       );
@@ -237,17 +237,12 @@ describe('doStream', () => {
       });
       const chunks = await convertStreamToArray(stream);
 
-      expect(chunks.filter(chunk => chunk.type === 'tool-call'))
-        .toMatchInlineSnapshot(`
-        [
-          {
-            "input": "{}",
-            "toolCallId": "bbd2b9d98",
-            "toolName": "nonUsefulTool",
-            "type": "tool-call",
-          },
-        ]
-      `);
+      // Tool calls finalize during flush (after the structured-output text has
+      // streamed), so the json-mode filter drops them all — matching the
+      // doGenerate behavior of treating the mixed response as the final answer.
+      expect(
+        chunks.filter(chunk => chunk.type === 'tool-call'),
+      ).toMatchInlineSnapshot(`[]`);
     });
   });
 });

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -15,7 +15,6 @@ import {
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   type FetchFunction,
@@ -431,23 +430,6 @@ export class DeepSeekChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -471,26 +453,6 @@ export class DeepSeekChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
           },

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -1256,6 +1256,11 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -15,7 +15,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   type FetchFunction,
@@ -468,23 +467,6 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -508,26 +490,6 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
           },
@@ -539,6 +501,25 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
 
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
+            }
+
+            // Finalize any unfinished tool calls on stream end to
+            // prevent premature execution from parsable partial JSON.
+            for (const toolCall of toolCalls) {
+              if (!toolCall.hasFinished) {
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id ?? generateId(),
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                });
+                toolCall.hasFinished = true;
+              }
             }
 
             controller.enqueue({

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2617,6 +2617,11 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -18,7 +18,6 @@ import {
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   type FetchFunction,
@@ -601,32 +600,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                        ...(toolCall.thoughtSignature
-                          ? {
-                              providerMetadata: {
-                                [providerOptionsName]: {
-                                  thoughtSignature: toolCall.thoughtSignature,
-                                },
-                              },
-                            }
-                          : {}),
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -650,35 +623,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                    ...(toolCall.thoughtSignature
-                      ? {
-                          providerMetadata: {
-                            [providerOptionsName]: {
-                              thoughtSignature: toolCall.thoughtSignature,
-                            },
-                          },
-                        }
-                      : {}),
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
           },

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2765,6 +2765,15 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "0",
+          "type": "text-end",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },
@@ -2773,10 +2782,6 @@ describe('doStream', () => {
           "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-call",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
         },
         {
           "finishReason": {
@@ -2808,6 +2813,82 @@ describe('doStream', () => {
         },
       ]
     `);
+  });
+
+  it('should not finalize tool call early when partial JSON is coincidentally parsable', async () => {
+    // Regression test: if streamed tool call arguments form valid JSON before
+    // all chunks have arrived, the tool call must NOT be finalized early.
+    // For example, {"query": "test"} is valid JSON but the full args are
+    // {"query": "test", "limit": 10}. Finalizing early would lose "limit".
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // initial chunk with tool call start
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_early123","type":"function",` +
+          `"function":{"name":"search","arguments":""}}]},"finish_reason":null}]}\n\n`,
+        // This chunk produces valid JSON: {"query": "test"}
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"test\\"}"}}]},"finish_reason":null}]}\n\n`,
+        // More data arrives - the full args include "limit"
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":""}}]},"finish_reason":null}]}\n\n`,
+        // Even more data: adding the comma and limit field
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":", \\"limit\\": 10}"}}]},"finish_reason":null}]}\n\n`,
+        // finish
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              limit: { type: 'number' },
+            },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    // Find the tool-call event
+    const toolCallEvent = result.find(
+      (e: { type: string }) => e.type === 'tool-call',
+    );
+
+    // The tool call must contain the COMPLETE arguments, not just the
+    // partial JSON that happened to be parsable mid-stream.
+    expect(toolCallEvent).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call_early123',
+      toolName: 'search',
+      input: '{"query": "test"}, "limit": 10}',
+    });
+
+    // Verify there is exactly one tool-call event (no premature duplicate)
+    const toolCallEvents = result.filter(
+      (e: { type: string }) => e.type === 'tool-call',
+    );
+    expect(toolCallEvents).toHaveLength(1);
   });
 
   it('should stream tool call with missing type field (Azure AI Foundry / Mistral)', async () => {

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -15,7 +15,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   type FetchFunction,
@@ -605,23 +604,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -645,26 +627,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
 
@@ -685,6 +647,26 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
           flush(controller) {
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: '0' });
+            }
+
+            // Finalize any unfinished tool calls. Tool calls are only
+            // finalized here (on stream end) to prevent premature
+            // execution when partial JSON is coincidentally parsable.
+            for (const toolCall of toolCalls) {
+              if (!toolCall.hasFinished) {
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id ?? generateId(),
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                });
+                toolCall.hasFinished = true;
+              }
             }
 
             controller.enqueue({


### PR DESCRIPTION
Backport of #13137 (security fix, VULN-6861) to `release-v6.0`. Streaming tool call arguments in the `openai`, `openai-compatible`, `groq`, `deepseek`, and `alibaba` providers were finalized as soon as the accumulated argument text happened to be parsable JSON, which could execute tool calls with incomplete arguments and silently drop trailing parameters; finalization now happens exclusively in the stream `flush()` handler after all chunks have arrived. The only conflict was in the import block of `packages/deepseek/src/chat/deepseek-chat-language-model.ts`: v6 already imports `type InferSchema`, so the resolution simply removes the now-unused `isParsableJson` import without duplicating the `InferSchema` import from main's import style; all inline early-finalization blocks were removed exactly as in the original commit, and v6's existing `flush()` loop over unfinished tool calls provides the finalization. The regression test, snapshot updates, and changeset from the original commit are kept. Part of the v6.0 backport tracking issue #16767.