### PR TITLE
[v6.0] fix(ai): include tool input on tool result for provider executed dynamic tools

### DIFF
--- a/.changeset/heavy-tables-fetch.md
+++ b/.changeset/heavy-tables-fetch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): include tool input on tool result for provider executed dynamic tools

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -171,10 +171,8 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   // keep track of outstanding tool results for stream closing:
   const outstandingToolResults = new Set<string>();
 
-  // keep track of tool inputs for provider-side tool results
-  const toolInputs = new Map<string, unknown>();
-
   // keep track of parsed tool calls so provider-emitted approval requests can reference them
+  // keep track of tool inputs for provider-side tool results
   const toolCallsByToolCallId = new Map<string, TypedToolCall<TOOLS>>();
 
   let canClose = false;
@@ -349,8 +347,6 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
               break;
             }
 
-            toolInputs.set(toolCall.toolCallId, toolCall.input);
-
             // Only execute tools that are not provider-executed:
             if (tool.execute != null && toolCall.providerExecuted !== true) {
               const toolExecutionId = generateId(); // use our own id to guarantee uniqueness
@@ -405,7 +401,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
               type: 'tool-error',
               toolCallId: chunk.toolCallId,
               toolName,
-              input: toolInputs.get(chunk.toolCallId),
+              input: toolCall?.input,
               providerExecuted: true,
               error: chunk.result,
               dynamic: chunk.dynamic,
@@ -421,7 +417,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
               type: 'tool-result',
               toolCallId: chunk.toolCallId,
               toolName,
-              input: toolInputs.get(chunk.toolCallId),
+              input: toolCall?.input,
               output: chunk.result,
               providerExecuted: true,
               dynamic: chunk.dynamic,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -18811,7 +18811,9 @@ describe('streamText', () => {
               },
               {
                 "dynamic": true,
-                "input": undefined,
+                "input": {
+                  "city": "San Francisco",
+                },
                 "output": {
                   "status": "success",
                   "text": "The weather in San Francisco is 72°F",
@@ -18968,7 +18970,9 @@ describe('streamText', () => {
             },
             {
               "dynamic": true,
-              "input": undefined,
+              "input": {
+                "city": "San Francisco",
+              },
               "output": {
                 "status": "success",
                 "text": "The weather in San Francisco is 72°F",


### PR DESCRIPTION
Backport of #13605 to `release-v6.0`. For provider-executed dynamic tools, the tool result and tool error stream parts had `input: undefined` because v6 broke out of the tool-call handling before recording the input for tools that are not in the tool set. This ports the fix by unifying the bookkeeping on the existing `toolCallsByToolCallId` map and removing the separate `toolInputs` map. During conflict resolution the tool-result branch was adapted to v6's structure (if/else with `toolResultsStreamController` for the error case and the `toolMetadata` spread fields), using `toolCall?.input` from the already-looked-up map entry instead of main's inline `toolCallsByToolCallId.get(...)?.input`. Part of the v6.0 backport tracking issue #16767.