### PR TITLE
[v6.0] fix(ai): tag step/chunk timeout aborts with TimeoutError reason

### DIFF
--- a/.changeset/timeout-abort-reason.md
+++ b/.changeset/timeout-abort-reason.md
@@ -1,0 +1,7 @@
+---
+"ai": patch
+---
+
+fix(ai): tag step/chunk timeout aborts with `TimeoutError` reason
+
+When `timeout: { stepMs }` or `timeout: { chunkMs }` fires, the abort reason is now a `TimeoutError` `DOMException`, matching what `AbortSignal.timeout()` produces natively. Consumers can distinguish a framework timeout from a user-initiated cancel via `signal.reason.name === 'TimeoutError'`.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -8,6 +8,7 @@ import {
   type LanguageModelV3Usage,
 } from '@ai-sdk/provider';
 import {
+  DelayedPromise,
   dynamicTool,
   jsonSchema,
   tool,
@@ -4125,6 +4126,38 @@ describe('generateText', () => {
       });
 
       expect(receivedAbortSignal).toBeDefined();
+    });
+
+    it('should abort when step timeout expires', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const delayedPromise = new DelayedPromise<void>();
+
+      const generatePromise = generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            await delayedPromise.promise;
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { stepMs: 50 },
+        maxRetries: 0,
+      });
+
+      // Advance time past the step timeout — fires stepAbortController.abort(...)
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Allow doGenerate to complete so the test cleans up
+      delayedPromise.resolve(undefined);
+
+      await generatePromise.catch(() => {});
+
+      expect(receivedAbortSignal?.aborted).toBe(true);
+      expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
     });
   });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -52,6 +52,7 @@ import { asArray } from '../util/as-array';
 import type { DownloadFunction } from '../util/download/download-function';
 import { mergeObjects } from '../util/merge-objects';
 import { prepareRetries } from '../util/prepare-retries';
+import { setAbortTimeout } from '../util/set-abort-timeout';
 import { VERSION } from '../version';
 import type {
   OnFinishEvent,
@@ -684,10 +685,11 @@ export async function generateText<
 
         do {
           // Set up step timeout if configured
-          const stepTimeoutId =
-            stepTimeoutMs != null
-              ? setTimeout(() => stepAbortController!.abort(), stepTimeoutMs)
-              : undefined;
+          const stepTimeoutId = setAbortTimeout({
+            abortController: stepAbortController,
+            label: 'Step',
+            timeoutMs: stepTimeoutMs,
+          });
 
           try {
             const stepInputMessages = [...initialMessages, ...responseMessages];

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -13078,6 +13078,7 @@ describe('streamText', () => {
 
       // The abort signal should have been triggered due to chunk timeout
       expect(receivedAbortSignal?.aborted).toBe(true);
+      expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
     });
 
     it('should support chunkMs alongside totalMs and stepMs', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -82,6 +82,7 @@ import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
 import { now as originalNow } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
+import { setAbortTimeout } from '../util/set-abort-timeout';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { validateApprovedToolApprovals } from './validate-tool-approvals';
 import type {
@@ -1567,25 +1568,25 @@ class DefaultStreamTextResult<
           const includeRawChunks = self.includeRawChunks;
 
           // Set up step timeout if configured
-          const stepTimeoutId =
-            stepTimeoutMs != null
-              ? setTimeout(() => stepAbortController!.abort(), stepTimeoutMs)
-              : undefined;
+          const stepTimeoutId = setAbortTimeout({
+            abortController: stepAbortController,
+            label: 'Step',
+            timeoutMs: stepTimeoutMs,
+          });
 
           // Set up chunk timeout tracking (will be reset on each chunk)
           let chunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
             undefined;
 
           function resetChunkTimeout() {
-            if (chunkTimeoutMs != null) {
-              if (chunkTimeoutId != null) {
-                clearTimeout(chunkTimeoutId);
-              }
-              chunkTimeoutId = setTimeout(
-                () => chunkAbortController!.abort(),
-                chunkTimeoutMs,
-              );
+            if (chunkTimeoutId != null) {
+              clearTimeout(chunkTimeoutId);
             }
+            chunkTimeoutId = setAbortTimeout({
+              abortController: chunkAbortController,
+              label: 'Chunk',
+              timeoutMs: chunkTimeoutMs,
+            });
           }
 
           function clearChunkTimeout() {

--- a/packages/ai/src/util/set-abort-timeout.test.ts
+++ b/packages/ai/src/util/set-abort-timeout.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setAbortTimeout } from './set-abort-timeout';
+
+describe('setAbortTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not abort the controller before the timeout elapses', () => {
+    const abortController = new AbortController();
+
+    setAbortTimeout({ abortController, label: 'Step', timeoutMs: 100 });
+    vi.advanceTimersByTime(99);
+
+    expect(abortController.signal.aborted).toBe(false);
+  });
+
+  it('should abort the controller when the timeout elapses', () => {
+    const abortController = new AbortController();
+
+    setAbortTimeout({ abortController, label: 'Step', timeoutMs: 100 });
+    vi.advanceTimersByTime(100);
+
+    expect(abortController.signal.aborted).toBe(true);
+  });
+
+  it('should abort with a TimeoutError DOMException', () => {
+    const abortController = new AbortController();
+
+    setAbortTimeout({ abortController, label: 'Step', timeoutMs: 100 });
+    vi.advanceTimersByTime(100);
+
+    expect(abortController.signal.reason).toBeInstanceOf(DOMException);
+    expect((abortController.signal.reason as DOMException).name).toBe(
+      'TimeoutError',
+    );
+  });
+
+  it('should include the label and duration in the abort reason message', () => {
+    const abortController = new AbortController();
+
+    setAbortTimeout({ abortController, label: 'Chunk', timeoutMs: 250 });
+    vi.advanceTimersByTime(250);
+
+    expect((abortController.signal.reason as DOMException).message).toBe(
+      'Chunk timeout of 250ms exceeded',
+    );
+  });
+
+  it('should return a timeout id that can be cleared to cancel the abort', () => {
+    const abortController = new AbortController();
+
+    const id = setAbortTimeout({
+      abortController,
+      label: 'Step',
+      timeoutMs: 100,
+    });
+    clearTimeout(id);
+    vi.advanceTimersByTime(100);
+
+    expect(abortController.signal.aborted).toBe(false);
+  });
+
+  it('should return undefined when abortController is undefined', () => {
+    const id = setAbortTimeout({
+      abortController: undefined,
+      label: 'Step',
+      timeoutMs: 100,
+    });
+
+    expect(id).toBeUndefined();
+  });
+
+  it('should return undefined when timeoutMs is undefined', () => {
+    const abortController = new AbortController();
+
+    const id = setAbortTimeout({
+      abortController,
+      label: 'Step',
+      timeoutMs: undefined,
+    });
+    vi.advanceTimersByTime(1000);
+
+    expect(id).toBeUndefined();
+    expect(abortController.signal.aborted).toBe(false);
+  });
+});

--- a/packages/ai/src/util/set-abort-timeout.ts
+++ b/packages/ai/src/util/set-abort-timeout.ts
@@ -1,0 +1,37 @@
+/**
+ * Schedules a timeout that aborts the given controller with a `TimeoutError`
+ * `DOMException`, matching the reason produced by `AbortSignal.timeout(ms)`.
+ *
+ * @param abortController - The controller to abort when the timeout elapses.
+ * If undefined, no timeout is scheduled.
+ * @param label - Human-readable label included in the error message
+ * (e.g. "Step", "Chunk").
+ * @param timeoutMs - Duration in milliseconds before the controller is aborted.
+ * If undefined, no timeout is scheduled.
+ * @returns The timeout id (suitable for passing to `clearTimeout`), or
+ * `undefined` if no timeout was scheduled.
+ */
+export function setAbortTimeout({
+  abortController,
+  label,
+  timeoutMs,
+}: {
+  abortController: AbortController | undefined;
+  label: string;
+  timeoutMs: number | undefined;
+}): ReturnType<typeof setTimeout> | undefined {
+  if (abortController == null || timeoutMs == null) {
+    return undefined;
+  }
+
+  return setTimeout(
+    () =>
+      abortController.abort(
+        new DOMException(
+          `${label} timeout of ${timeoutMs}ms exceeded`,
+          'TimeoutError',
+        ),
+      ),
+    timeoutMs,
+  );
+}


### PR DESCRIPTION
Manual backport of #14943 to `release-v6.0` (the surrounding stream-text/generate-text code diverged, so the hunks were applied by hand; the new `setAbortTimeout` util and its tests came over verbatim). Step/chunk timeouts now abort with a `TimeoutError` `DOMException` — matching `AbortSignal.timeout(ms)` — instead of an undefined reason. Tests adapted to v6 (`MockLanguageModelV3`); 551 tests across the three touched test files pass locally.

Part of the v6.0 backport tracking issue #16767.