### PR TITLE
[v6.0] fix(openai): throw on early stream error events

### DIFF
--- a/.changeset/openai-early-stream-errors.md
+++ b/.changeset/openai-early-stream-errors.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): throw retryable errors for OpenAI stream failures before output starts

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2963,12 +2963,56 @@ describe('doStream', () => {
     `);
   });
 
-  it('should handle error stream parts', async () => {
+  it('should throw an api error when the first stream chunk is an error', async () => {
     server.urls['https://api.openai.com/v1/chat/completions'].response = {
       type: 'stream-chunks',
       chunks: [
         `data: {"error":{"message": "The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our ` +
           `help center at help.openai.com if you keep seeing this error.","type":"server_error","param":null,"code":null}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    await expect(
+      model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      }),
+    ).rejects.toMatchObject({
+      message:
+        'The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error.',
+      statusCode: 500,
+      isRetryable: true,
+    });
+  });
+
+  it('should preserve numeric status codes from early stream errors', async () => {
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"error":{"message":"bad request","type":"provider_error","param":null,"code":400}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    await expect(
+      model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      }),
+    ).rejects.toMatchObject({
+      message: 'bad request',
+      statusCode: 400,
+      isRetryable: false,
+    });
+  });
+
+  it('should forward error stream parts after output has started', async () => {
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-error-after-output","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}\n\n`,
+        `data: {"error":{"message":"stream failed after output","type":"server_error","param":null,"code":null}}\n\n`,
         'data: [DONE]\n\n',
       ],
     };
@@ -2985,13 +3029,32 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": "chatcmpl-error-after-output",
+          "modelId": "gpt-3.5-turbo-0613",
+          "timestamp": 2023-12-15T16:17:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Hello",
+          "id": "0",
+          "type": "text-delta",
+        },
+        {
           "error": {
             "code": null,
-            "message": "The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error.",
+            "message": "stream failed after output",
             "param": null,
             "type": "server_error",
           },
           "type": "error",
+        },
+        {
+          "id": "0",
+          "type": "text-end",
         },
         {
           "finishReason": {

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -23,6 +23,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { openaiFailedResponseHandler } from '../openai-error';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
+import { throwIfOpenAIStreamErrorBeforeOutput } from '../openai-stream-error';
 import {
   convertOpenAIChatUsage,
   type OpenAIChatUsage,
@@ -414,11 +415,13 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       },
     };
 
+    const url = this.config.url({
+      path: '/chat/completions',
+      modelId: this.modelId,
+    });
+
     const { responseHeaders, value: response } = await postJsonToApi({
-      url: this.config.url({
-        path: '/chat/completions',
-        modelId: this.modelId,
-      }),
+      url,
       headers: combineHeaders(this.config.headers(), options.headers),
       body,
       failedResponseHandler: openaiFailedResponseHandler,
@@ -427,6 +430,15 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       ),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
+    });
+
+    const checkedResponse = await throwIfOpenAIStreamErrorBeforeOutput({
+      stream: response,
+      getError: chunk => ('error' in chunk ? chunk.error : undefined),
+      isOutputChunk: isOpenAIChatOutputChunk,
+      url,
+      requestBodyValues: body,
+      responseHeaders,
     });
 
     const toolCalls: Array<{
@@ -449,8 +461,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
 
     const providerMetadata: SharedV3ProviderMetadata = { openai: {} };
 
-    return {
-      stream: response.pipeThrough(
+    const result = {
+      stream: checkedResponse.pipeThrough(
         new TransformStream<
           ParseResult<OpenAIChatChunk>,
           LanguageModelV3StreamPart
@@ -699,5 +711,23 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       request: { body },
       response: { headers: responseHeaders },
     };
+
+    return result;
   }
+}
+
+function isOpenAIChatOutputChunk(chunk: OpenAIChatChunk): boolean {
+  if ('error' in chunk) {
+    return false;
+  }
+
+  return chunk.choices.some(choice => {
+    const delta = choice.delta;
+
+    return (
+      (delta?.content != null && delta.content.length > 0) ||
+      (delta?.tool_calls != null && delta.tool_calls.length > 0) ||
+      (delta?.annotations != null && delta.annotations.length > 0)
+    );
+  });
 }

--- a/packages/openai/src/completion/openai-completion-language-model.test.ts
+++ b/packages/openai/src/completion/openai-completion-language-model.test.ts
@@ -536,12 +536,35 @@ describe('doStream', () => {
     `);
   });
 
-  it('should handle error stream parts', async () => {
+  it('should throw an api error when the first stream chunk is an error', async () => {
     server.urls['https://api.openai.com/v1/completions'].response = {
       type: 'stream-chunks',
       chunks: [
         `data: {"error":{"message": "The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our ` +
           `help center at help.openai.com if you keep seeing this error.","type":"server_error","param":null,"code":null}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    await expect(
+      model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      }),
+    ).rejects.toMatchObject({
+      message:
+        'The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error.',
+      statusCode: 500,
+      isRetryable: true,
+    });
+  });
+
+  it('should forward error stream parts after output has started', async () => {
+    server.urls['https://api.openai.com/v1/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"cmpl-error-after-output","object":"text_completion","created":1711363440,"choices":[{"text":"Hello","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}\n\n`,
+        `data: {"error":{"message":"stream failed after output","type":"server_error","param":null,"code":null}}\n\n`,
         'data: [DONE]\n\n',
       ],
     };
@@ -558,13 +581,32 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": "cmpl-error-after-output",
+          "modelId": "gpt-3.5-turbo-instruct",
+          "timestamp": 2024-03-25T10:44:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Hello",
+          "id": "0",
+          "type": "text-delta",
+        },
+        {
           "error": {
             "code": null,
-            "message": "The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error.",
+            "message": "stream failed after output",
             "param": null,
             "type": "server_error",
           },
           "type": "error",
+        },
+        {
+          "id": "0",
+          "type": "text-end",
         },
         {
           "finishReason": {

--- a/packages/openai/src/completion/openai-completion-language-model.ts
+++ b/packages/openai/src/completion/openai-completion-language-model.ts
@@ -18,6 +18,7 @@ import {
   type ParseResult,
 } from '@ai-sdk/provider-utils';
 import { openaiFailedResponseHandler } from '../openai-error';
+import { throwIfOpenAIStreamErrorBeforeOutput } from '../openai-stream-error';
 import {
   convertOpenAICompletionUsage,
   type OpenAICompletionUsage,
@@ -224,11 +225,13 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
       },
     };
 
+    const url = this.config.url({
+      path: '/completions',
+      modelId: this.modelId,
+    });
+
     const { responseHeaders, value: response } = await postJsonToApi({
-      url: this.config.url({
-        path: '/completions',
-        modelId: this.modelId,
-      }),
+      url,
       headers: combineHeaders(this.config.headers(), options.headers),
       body,
       failedResponseHandler: openaiFailedResponseHandler,
@@ -239,6 +242,15 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
       fetch: this.config.fetch,
     });
 
+    const checkedResponse = await throwIfOpenAIStreamErrorBeforeOutput({
+      stream: response,
+      getError: chunk => ('error' in chunk ? chunk.error : undefined),
+      isOutputChunk: isOpenAICompletionOutputChunk,
+      url,
+      requestBodyValues: body,
+      responseHeaders,
+    });
+
     let finishReason: LanguageModelV3FinishReason = {
       unified: 'other',
       raw: undefined,
@@ -247,8 +259,8 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
     let usage: OpenAICompletionUsage | undefined = undefined;
     let isFirstChunk = true;
 
-    return {
-      stream: response.pipeThrough(
+    const result = {
+      stream: checkedResponse.pipeThrough(
         new TransformStream<
           ParseResult<OpenAICompletionChunk>,
           LanguageModelV3StreamPart
@@ -332,5 +344,13 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
       request: { body },
       response: { headers: responseHeaders },
     };
+
+    return result;
   }
+}
+
+function isOpenAICompletionOutputChunk(chunk: OpenAICompletionChunk): boolean {
+  return (
+    !('error' in chunk) && chunk.choices.some(choice => choice.text.length > 0)
+  );
 }

--- a/packages/openai/src/openai-stream-error.ts
+++ b/packages/openai/src/openai-stream-error.ts
@@ -1,0 +1,181 @@
+import { APICallError } from '@ai-sdk/provider';
+import type { ParseResult } from '@ai-sdk/provider-utils';
+
+type StreamError = {
+  message: string;
+  code?: string | number | null;
+  type?: string | null;
+  frame: unknown;
+};
+
+export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
+  stream,
+  getError,
+  isOutputChunk,
+  url,
+  requestBodyValues,
+  responseHeaders,
+}: {
+  stream: ReadableStream<ParseResult<T>>;
+  getError: (chunk: T) => unknown | undefined;
+  isOutputChunk: (chunk: T) => boolean;
+  url: string;
+  requestBodyValues: unknown;
+  responseHeaders?: Record<string, string>;
+}): Promise<ReadableStream<ParseResult<T>>> {
+  const [streamForEarlyError, streamForConsumer] = stream.tee();
+  const reader = streamForEarlyError.getReader();
+
+  try {
+    while (true) {
+      const result = await reader.read();
+
+      if (result.done) {
+        return streamForConsumer;
+      }
+
+      const chunk = result.value;
+
+      if (!chunk.success) {
+        return streamForConsumer;
+      }
+
+      const errorFrame = getError(chunk.value);
+
+      if (errorFrame != null) {
+        streamForConsumer.cancel().catch(() => {});
+        throw createOpenAIStreamError({
+          frame: errorFrame,
+          url,
+          requestBodyValues,
+          responseHeaders,
+        });
+      }
+
+      if (isOutputChunk(chunk.value)) {
+        return streamForConsumer;
+      }
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+function createOpenAIStreamError({
+  frame,
+  url,
+  requestBodyValues,
+  responseHeaders,
+}: {
+  frame: unknown;
+  url: string;
+  requestBodyValues: unknown;
+  responseHeaders?: Record<string, string>;
+}): APICallError {
+  const streamError = parseStreamError(frame);
+  return new APICallError({
+    message:
+      streamError?.message ??
+      'OpenAI stream failed before any output was generated',
+    url,
+    requestBodyValues,
+    statusCode: streamError == null ? 500 : getStatusCode(streamError),
+    responseHeaders,
+    responseBody: JSON.stringify(frame),
+    data: frame,
+  });
+}
+
+function parseStreamError(frame: unknown): StreamError | undefined {
+  const value = asRecord(frame);
+
+  if (value == null) {
+    return undefined;
+  }
+
+  if (value.type === 'response.failed') {
+    const response = asRecord(value.response);
+    const responseError = asRecord(response?.error);
+
+    return typeof responseError?.message === 'string'
+      ? {
+          message: responseError.message,
+          code: getStringOrNumber(responseError.code),
+          type: 'response.failed',
+          frame,
+        }
+      : undefined;
+  }
+
+  const error = asRecord(value.error) ?? value;
+
+  return typeof error.message === 'string' &&
+    (asRecord(value.error) != null ||
+      typeof error.type === 'string' ||
+      'code' in error ||
+      'param' in error)
+    ? {
+        message: error.message,
+        code: getStringOrNumber(error.code),
+        type: typeof error.type === 'string' ? error.type : undefined,
+        frame,
+      }
+    : undefined;
+}
+
+function getStatusCode(error: StreamError): number {
+  if (typeof error.code === 'number' && isHttpErrorStatusCode(error.code)) {
+    return error.code;
+  }
+
+  if (typeof error.code === 'string' && /^\d{3}$/.test(error.code)) {
+    const numericCode = Number(error.code);
+    if (isHttpErrorStatusCode(numericCode)) {
+      return numericCode;
+    }
+  }
+
+  const discriminator = [error.code, error.type]
+    .filter(value => typeof value === 'string' || typeof value === 'number')
+    .join(' ')
+    .toLowerCase();
+
+  if (
+    ['insufficient_quota', 'rate_limit'].some(term =>
+      discriminator.includes(term),
+    )
+  ) {
+    return 429;
+  }
+  if (discriminator.includes('authentication')) return 401;
+  if (discriminator.includes('permission')) return 403;
+  if (discriminator.includes('not_found')) return 404;
+  if (
+    ['invalid', 'bad_request', 'context_length'].some(term =>
+      discriminator.includes(term),
+    )
+  ) {
+    return 400;
+  }
+  if (discriminator.includes('overload')) return 503;
+  if (discriminator.includes('timeout')) return 504;
+
+  return 500;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value != null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function getStringOrNumber(value: unknown): string | number | undefined {
+  return typeof value === 'string' || typeof value === 'number'
+    ? value
+    : undefined;
+}
+
+function isHttpErrorStatusCode(value: number): boolean {
+  return Number.isInteger(value) && value >= 400 && value <= 599;
+}

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -472,6 +472,30 @@ export type OpenAIResponsesReasoning = {
   }>;
 };
 
+// Captured from the Responses API when OpenAI returned an early
+// insufficient_quota stream error after HTTP 200. This shape differs from the
+// currently documented ResponseErrorEvent below.
+const openaiResponsesNestedErrorChunkSchema = z.object({
+  type: z.literal('error'),
+  sequence_number: z.number(),
+  error: z.object({
+    type: z.string(),
+    code: z.string(),
+    message: z.string(),
+    param: z.string().nullish(),
+  }),
+});
+
+// Current OpenAI OpenAPI docs define ResponseErrorEvent with top-level
+// code/message/param fields.
+const openaiResponsesErrorChunkSchema = z.object({
+  type: z.literal('error'),
+  sequence_number: z.number(),
+  code: z.string().nullish(),
+  message: z.string(),
+  param: z.string().nullish(),
+});
+
 export const openaiResponsesChunkSchema = lazySchema(() =>
   zodSchema(
     z.union([
@@ -520,6 +544,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
       }),
       z.object({
         type: z.literal('response.failed'),
+        sequence_number: z.number(),
         response: z.object({
           error: z
             .object({
@@ -1034,16 +1059,8 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
         output_index: z.number(),
         diff: z.string(),
       }),
-      z.object({
-        type: z.literal('error'),
-        sequence_number: z.number(),
-        error: z.object({
-          type: z.string(),
-          code: z.string(),
-          message: z.string(),
-          param: z.string().nullish(),
-        }),
-      }),
+      openaiResponsesNestedErrorChunkSchema,
+      openaiResponsesErrorChunkSchema,
       z
         .object({ type: z.string() })
         .loose()

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1767,7 +1767,7 @@ describe('OpenAIResponsesLanguageModel', () => {
       it('should throw an error', async () => {
         prepareJsonFixtureResponse('openai-error.1');
 
-        expect(
+        await expect(
           createModel('gpt-4o').doGenerate({
             prompt: TEST_PROMPT,
           }),
@@ -7474,77 +7474,72 @@ describe('OpenAIResponsesLanguageModel', () => {
     });
 
     describe('errors', () => {
-      it('should stream error parts', async () => {
+      it('should throw an api error when the stream errors before output starts', async () => {
         prepareChunksFixtureResponse('openai-error.1');
 
-        const { stream } = await createModel('gpt-4o-mini').doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
+        await expect(
+          createModel('gpt-4o-mini').doStream({
+            prompt: TEST_PROMPT,
+            includeRawChunks: false,
+          }),
+        ).rejects.toMatchObject({
+          message:
+            'You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.',
+          statusCode: 429,
+          isRetryable: true,
         });
-
-        expect(await convertReadableStreamToArray(stream))
-          .toMatchInlineSnapshot(`
-            [
-              {
-                "type": "stream-start",
-                "warnings": [],
-              },
-              {
-                "id": "resp_05500b38c2cd9bfc00691c7c9d222481a3b595421266dab424",
-                "modelId": "gpt-5-nano-2025-08-07",
-                "timestamp": 2025-11-18T14:03:09.000Z,
-                "type": "response-metadata",
-              },
-              {
-                "error": {
-                  "error": {
-                    "code": "insufficient_quota",
-                    "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
-                    "param": null,
-                    "type": "insufficient_quota",
-                  },
-                  "sequence_number": 2,
-                  "type": "error",
-                },
-                "type": "error",
-              },
-              {
-                "finishReason": {
-                  "raw": "error",
-                  "unified": "error",
-                },
-                "providerMetadata": {
-                  "openai": {
-                    "responseId": "resp_05500b38c2cd9bfc00691c7c9d222481a3b595421266dab424",
-                  },
-                },
-                "type": "finish",
-                "usage": {
-                  "inputTokens": {
-                    "cacheRead": undefined,
-                    "cacheWrite": undefined,
-                    "noCache": undefined,
-                    "total": undefined,
-                  },
-                  "outputTokens": {
-                    "reasoning": undefined,
-                    "text": undefined,
-                    "total": undefined,
-                  },
-                  "raw": undefined,
-                },
-              },
-            ]
-          `);
       });
 
-      it('should expose raw finish reason from response.failed incomplete details', async () => {
+      it('should throw an api error for documented top-level error events before output starts', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_error_top_level","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
+            `data:{"type":"error","sequence_number":1,"code":"rate_limit_exceeded","message":"Rate limit reached","param":null}\n\n`,
+          ],
+        };
+
+        await expect(
+          createModel('gpt-4o-mini').doStream({
+            prompt: TEST_PROMPT,
+            includeRawChunks: true,
+          }),
+        ).rejects.toMatchObject({
+          message: 'Rate limit reached',
+          statusCode: 429,
+          isRetryable: true,
+        });
+      });
+
+      it('should throw an api error when response.failed arrives before output starts', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_failed_before_output","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
+            `data:{"type":"response.failed","sequence_number":1,"response":{"error":{"code":"server_error","message":"response failed"},"incomplete_details":null,"usage":null,"service_tier":null}}\n\n`,
+          ],
+        };
+
+        await expect(
+          createModel('gpt-4o-mini').doStream({
+            prompt: TEST_PROMPT,
+            includeRawChunks: false,
+          }),
+        ).rejects.toMatchObject({
+          message: 'response failed',
+          statusCode: 500,
+          isRetryable: true,
+        });
+      });
+
+      it('should expose raw finish reason from late response.failed incomplete details', async () => {
         server.urls['https://api.openai.com/v1/responses'].response = {
           type: 'stream-chunks',
           chunks: [
             `data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_failed_with_reason","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
-            `data:{"type":"error","sequence_number":1,"error":{"type":"server_error","code":"server_error","message":"response failed","param":null}}\n\n`,
-            `data:{"type":"response.failed","sequence_number":2,"response":{"error":{"code":"server_error","message":"response failed"},"incomplete_details":{"reason":"max_output_tokens"},"usage":null,"service_tier":null}}\n\n`,
+            `data:{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"msg_failed_with_reason","type":"message"}}\n\n`,
+            `data:{"type":"error","sequence_number":2,"error":{"type":"server_error","code":"server_error","message":"response failed","param":null}}\n\n`,
+            `data:{"type":"response.failed","sequence_number":3,"response":{"error":{"code":"server_error","message":"response failed"},"incomplete_details":{"reason":"max_output_tokens"},"usage":null,"service_tier":null}}\n\n`,
           ],
         };
 
@@ -7568,6 +7563,15 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "response-metadata",
             },
             {
+              "id": "msg_failed_with_reason",
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_failed_with_reason",
+                },
+              },
+              "type": "text-start",
+            },
+            {
               "error": {
                 "error": {
                   "code": "server_error",
@@ -7575,7 +7579,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                   "param": null,
                   "type": "server_error",
                 },
-                "sequence_number": 1,
+                "sequence_number": 2,
                 "type": "error",
               },
               "type": "error",

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -28,6 +28,7 @@ import {
 import type { OpenAIConfig } from '../openai-config';
 import { openaiFailedResponseHandler } from '../openai-error';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
+import { throwIfOpenAIStreamErrorBeforeOutput } from '../openai-stream-error';
 import type { applyPatchInputSchema } from '../tool/apply-patch';
 import type {
   codeInterpreterInputSchema,
@@ -1057,6 +1058,19 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       fetch: this.config.fetch,
     });
 
+    const checkedResponse = await throwIfOpenAIStreamErrorBeforeOutput({
+      stream: response,
+      getError: chunk =>
+        isErrorChunk(chunk) ||
+        (isResponseFailedChunk(chunk) && chunk.response.error != null)
+          ? chunk
+          : undefined,
+      isOutputChunk: isResponseOutputChunk,
+      url,
+      requestBodyValues: body,
+      responseHeaders,
+    });
+
     const self = this;
 
     const approvalRequestIdToDummyToolCallIdFromPrompt =
@@ -1117,9 +1131,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     let serviceTier: string | undefined;
     const hostedToolSearchCallIds: string[] = [];
+    let encounteredStreamError = false;
 
-    return {
-      stream: response.pipeThrough(
+    const result = {
+      stream: checkedResponse.pipeThrough(
         new TransformStream<
           ParseResult<OpenAIResponsesChunk>,
           LanguageModelV3StreamPart
@@ -2046,6 +2061,22 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 raw: incompleteReason ?? 'error',
               };
               usage = value.response.usage ?? undefined;
+
+              if (!encounteredStreamError && value.response.error != null) {
+                encounteredStreamError = true;
+                controller.enqueue({
+                  type: 'error',
+                  error: {
+                    type: 'response.failed',
+                    sequence_number: value.sequence_number,
+                    response: {
+                      error: value.response.error,
+                      incomplete_details: value.response.incomplete_details,
+                      service_tier: value.response.service_tier,
+                    },
+                  },
+                });
+              }
             } else if (isResponseAnnotationAddedChunk(value)) {
               ongoingAnnotations.push(value.annotation);
               if (value.annotation.type === 'url_citation') {
@@ -2115,6 +2146,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 });
               }
             } else if (isErrorChunk(value)) {
+              encounteredStreamError = true;
+              finishReason = { unified: 'error', raw: 'error' };
               controller.enqueue({ type: 'error', error: value });
             }
           },
@@ -2140,6 +2173,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       request: { body },
       response: { headers: responseHeaders },
     };
+
+    return result;
   }
 }
 
@@ -2291,6 +2326,15 @@ function isErrorChunk(
   chunk: OpenAIResponsesChunk,
 ): chunk is OpenAIResponsesChunk & { type: 'error' } {
   return chunk.type === 'error';
+}
+
+function isResponseOutputChunk(chunk: OpenAIResponsesChunk): boolean {
+  return !(
+    chunk.type === 'response.created' ||
+    chunk.type === 'response.failed' ||
+    chunk.type === 'error' ||
+    chunk.type === 'unknown_chunk'
+  );
 }
 
 function mapWebSearchOutput(


### PR DESCRIPTION
Backport of #15922 to the release-v6.0 branch. OpenAI can return HTTP 200 for streaming requests and then emit an error frame before any model output (e.g. `insufficient_quota`); previously these surfaced as stream `error` parts, so retry/fallback logic never saw a failed `doStream()` call. This ports the fix to the Responses, Chat Completions, and legacy Completions models: pre-output stream errors are converted into a retryable `APICallError` (preserving numeric HTTP status codes and mapping well-known error codes like `insufficient_quota` to 429), while errors after real output has started continue to be forwarded as stream error parts. During conflict resolution, the changes were adapted to v6's `LanguageModelV3` types, v6's `this.config.headers()` call (main uses `headers?.()`), and v6's chat tool-call tracking (a `toolCalls` array instead of main's `StreamingToolCallTracker`); the new `openai-stream-error.ts` helper, schema additions, and all regression tests apply unchanged. Part of the v6.0 backport tracking issue #16767.