### PR TITLE
[v6.0] fix(react): use the latest transport in useChat instead of a stale one

### DIFF
--- a/.changeset/pink-crews-beg.md
+++ b/.changeset/pink-crews-beg.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/react": patch
+---
+
+fix(react): use the latest transport in useChat instead of a stale one

--- a/examples/ai-e2e-next/app/api/chat/stale-transport-demo/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/stale-transport-demo/route.ts
@@ -1,0 +1,27 @@
+import { createUIMessageStreamResponse, simulateReadableStream } from 'ai';
+
+// Echoes the `subagent` value received so the stale-transport fix (#7819) can be verified
+export async function POST(req: Request) {
+  const body = await req.json();
+  const subagent = JSON.stringify(body?.subagent ?? null);
+
+  return createUIMessageStreamResponse({
+    stream: simulateReadableStream({
+      initialDelayInMs: 0,
+      chunkDelayInMs: 0,
+      chunks: [
+        { type: 'start' },
+        { type: 'start-step' },
+        { type: 'text-start', id: '0' },
+        {
+          type: 'text-delta',
+          id: '0',
+          delta: `Server received subagent = ${subagent}`,
+        },
+        { type: 'text-end', id: '0' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ],
+    }),
+  });
+}

--- a/examples/ai-e2e-next/app/chat/stale-transport-demo/page.tsx
+++ b/examples/ai-e2e-next/app/chat/stale-transport-demo/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useState } from 'react';
+
+export default function Page() {
+  const [subagent, setSubagent] = useState('todos-agent');
+
+  const { messages, sendMessage, status } = useChat({
+    // A new transport is created with the current `subagent` on each render
+    transport: new DefaultChatTransport({
+      api: '/api/chat/stale-transport-demo',
+      body: { subagent },
+    }),
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-lg py-12 mx-auto gap-4">
+      <h4 className="text-xl font-bold">
+        useChat stale transport demo (#7819)
+      </h4>
+
+      <div className="flex items-center gap-2">
+        <span>Current subagent state:</span>
+        <strong data-testid="subagent">{subagent}</strong>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="px-3 py-1 border rounded"
+          onClick={() => setSubagent('todos-agent')}
+        >
+          set todos-agent
+        </button>
+        <button
+          className="px-3 py-1 border rounded"
+          onClick={() => setSubagent('research-agent')}
+        >
+          set research-agent
+        </button>
+      </div>
+
+      <button
+        className="px-3 py-1 text-white bg-black rounded disabled:opacity-50"
+        disabled={status !== 'ready'}
+        onClick={() => sendMessage({ text: 'what did the server receive?' })}
+      >
+        Send message
+      </button>
+
+      <div className="flex flex-col gap-2">
+        {messages.map(message => (
+          <div key={message.id} className="whitespace-pre-wrap">
+            {message.role === 'user' ? 'User: ' : 'AI: '}
+            {message.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,8 +1,10 @@
 import {
   type AbstractChat,
   type ChatInit,
+  type ChatTransport,
   type CreateUIMessage,
   type UIMessage,
+  DefaultChatTransport,
 } from 'ai';
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import { Chat } from './chat.react';
@@ -60,43 +62,60 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   resume = false,
   ...options
 }: UseChatOptions<UI_MESSAGE> = {}): UseChatHelpers<UI_MESSAGE> {
-  // Create a single ref for all callbacks to avoid stale closures
-  const callbacksRef = useRef(
-    !('chat' in options)
-      ? {
-          onToolCall: options.onToolCall,
-          onData: options.onData,
-          onFinish: options.onFinish,
-          onError: options.onError,
-          sendAutomaticallyWhen: options.sendAutomaticallyWhen,
-        }
-      : {},
-  );
+  // the Chat instance is created once and not recreated when options change,
+  // so it would normally keep the callbacks/transport from the first render forever
 
-  // Update callbacks ref on each render to keep them current
+  // keep latest values in a ref that is refreshed on every render,
+  // and hand `Chat` stable wrappers that read from it to avoid stale closures
+  const latestRef = useRef<
+    Partial<
+      Pick<
+        ChatInit<UI_MESSAGE>,
+        | 'onToolCall'
+        | 'onData'
+        | 'onFinish'
+        | 'onError'
+        | 'sendAutomaticallyWhen'
+        | 'transport'
+      >
+    >
+  >({});
+
   if (!('chat' in options)) {
-    callbacksRef.current = {
+    latestRef.current = {
       onToolCall: options.onToolCall,
       onData: options.onData,
       onFinish: options.onFinish,
       onError: options.onError,
       sendAutomaticallyWhen: options.sendAutomaticallyWhen,
+      transport: options.transport,
     };
   }
 
-  // Ensure the Chat instance has the latest callbacks
-  const optionsWithCallbacks: typeof options = {
+  // resolve the latest transport and fallback to a lazily created default transport
+  let defaultTransport: ChatTransport<UI_MESSAGE> | undefined;
+  const getTransport = () =>
+    latestRef.current.transport ??
+    (defaultTransport ??= new DefaultChatTransport<UI_MESSAGE>());
+
+  // give `Chat` stable wrappers that always read the latest values from `latestRef`
+  const chatOptions: typeof options = {
     ...options,
-    onToolCall: arg => callbacksRef.current.onToolCall?.(arg),
-    onData: arg => callbacksRef.current.onData?.(arg),
-    onFinish: arg => callbacksRef.current.onFinish?.(arg),
-    onError: arg => callbacksRef.current.onError?.(arg),
+    transport: {
+      sendMessages: sendOptions => getTransport().sendMessages(sendOptions),
+      reconnectToStream: reconnectOptions =>
+        getTransport().reconnectToStream(reconnectOptions),
+    },
+    onToolCall: arg => latestRef.current.onToolCall?.(arg),
+    onData: arg => latestRef.current.onData?.(arg),
+    onFinish: arg => latestRef.current.onFinish?.(arg),
+    onError: arg => latestRef.current.onError?.(arg),
     sendAutomaticallyWhen: arg =>
-      callbacksRef.current.sendAutomaticallyWhen?.(arg) ?? false,
+      latestRef.current.sendAutomaticallyWhen?.(arg) ?? false,
   };
 
   const chatRef = useRef<Chat<UI_MESSAGE>>(
-    'chat' in options ? options.chat : new Chat(optionsWithCallbacks),
+    'chat' in options ? options.chat : new Chat(chatOptions),
   );
 
   const shouldRecreateChat =
@@ -104,8 +123,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     ('id' in options && chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
-    chatRef.current =
-      'chat' in options ? options.chat : new Chat(optionsWithCallbacks);
+    chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
   }
 
   const subscribeToMessages = useCallback(

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -5,7 +5,7 @@ import {
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
 import { mockId } from '@ai-sdk/provider-utils/test';
-import { screen, waitFor, render } from '@testing-library/react';
+import { cleanup, screen, waitFor, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   DefaultChatTransport,
@@ -871,6 +871,56 @@ describe('onToolCall', () => {
 
     expect(onToolCallA).toHaveBeenCalledTimes(0);
     expect(onToolCallB).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stale transport', () => {
+  afterEach(cleanup);
+
+  it('should use the latest transport body after a state change (no stale closure)', async () => {
+    const Test = () => {
+      const [subagent, setSubagent] = React.useState('todos-agent');
+      const { sendMessage } = useChat({
+        transport: new DefaultChatTransport({
+          body: { subagent },
+        }),
+      });
+
+      return (
+        <div>
+          <button
+            data-testid="change-subagent"
+            onClick={() => setSubagent('research-agent')}
+          />
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+        </div>
+      );
+    };
+
+    render(<Test />);
+
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('change-subagent'));
+    await userEvent.click(screen.getByTestId('do-send'));
+
+    await vi.waitUntil(() => server.calls.length > 0, { timeout: 2000 });
+
+    expect((await server.calls[0].requestBodyJson).subagent).toBe(
+      'research-agent',
+    );
   });
 });
 


### PR DESCRIPTION
Backport of #16546 to `release-v6.0`. `useChat()` creates its `Chat` instance once in a `useRef`, so a `transport` passed to `useChat()` was frozen at its first-render value and became stale after React state changes; the fix extends the existing latest-values ref pattern (already used for callbacks on v6) to also cover the transport, handing `Chat` a stable proxy transport whose `sendMessages`/`reconnectToStream` always delegate to the latest transport (falling back to a lazily created `DefaultChatTransport`). The `use-chat.ts` rewrite from `callbacksRef` to `latestRef` applied cleanly and matches main exactly, except that v6's `shouldRecreateChat` guard is kept as-is (the nullish-id guard from #16484 is backported independently in its own PR); conflict resolution was limited to the import block (v6 does not import `fireEvent` in the test file) and re-indenting the new `stale transport` test describe block to v6's flat test file structure (main wraps tests in an outer `describe('use-chat')`). Verified the ported regression test fails on v6 without the fix and passes with it. Part of the v6.0 backport tracking issue #16767.