### PR TITLE
fix(provider-utils): do not finalize streaming tool calls on parsable partial JSON

### DIFF
--- a/.changeset/tracker-no-early-finalization.md
+++ b/.changeset/tracker-no-early-finalization.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/alibaba': patch
+---
+
+Fix `StreamingToolCallTracker` finalizing streaming tool calls on parsable partial JSON. Tool calls now only finalize during stream flush, restoring the behavior of #13137: a parsable argument buffer can still be the prefix of a longer argument string, so finalizing early could act on truncated tool inputs.

--- a/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
+++ b/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
@@ -2967,6 +2967,11 @@ exports[`doStream > tool call > should stream tool call 1`] = `
     "type": "tool-input-delta",
   },
   {
+    "delta": "",
+    "id": "call_eee11723464a4b9eb8cee71d",
+    "type": "tool-input-delta",
+  },
+  {
     "id": "call_eee11723464a4b9eb8cee71d",
     "type": "tool-input-end",
   },

--- a/packages/cerebras/src/cerebras-chat-language-model.test.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model.test.ts
@@ -223,7 +223,7 @@ describe('doStream', () => {
       `);
     });
 
-    it('preserves the first streamed tool call and drops the repeated one', async () => {
+    it('drops the spurious tool calls from a mixed structured-output stream', async () => {
       const fetch = createStreamFixtureFetchMock(
         'cererebras-structured-output-tools.1',
       );
@@ -237,17 +237,12 @@ describe('doStream', () => {
       });
       const chunks = await convertStreamToArray(stream);
 
-      expect(chunks.filter(chunk => chunk.type === 'tool-call'))
-        .toMatchInlineSnapshot(`
-        [
-          {
-            "input": "{}",
-            "toolCallId": "bbd2b9d98",
-            "toolName": "nonUsefulTool",
-            "type": "tool-call",
-          },
-        ]
-      `);
+      // Tool calls finalize during flush (after the structured-output text has
+      // streamed), so the json-mode filter drops them all — matching the
+      // doGenerate behavior of treating the mixed response as the final answer.
+      expect(
+        chunks.filter(chunk => chunk.type === 'tool-call'),
+      ).toMatchInlineSnapshot(`[]`);
     });
   });
 });

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -1317,6 +1317,11 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2860,6 +2860,11 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2864,6 +2864,15 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "0",
+          "type": "text-end",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },
@@ -2872,10 +2881,6 @@ describe('doStream', () => {
           "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-call",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
         },
         {
           "finishReason": {
@@ -2907,6 +2912,82 @@ describe('doStream', () => {
         },
       ]
     `);
+  });
+
+  it('should not finalize tool call early when partial JSON is coincidentally parsable', async () => {
+    // Regression test: if streamed tool call arguments form valid JSON before
+    // all chunks have arrived, the tool call must NOT be finalized early.
+    // For example, {"query": "test"} is valid JSON but the full args are
+    // {"query": "test", "limit": 10}. Finalizing early would lose "limit".
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // initial chunk with tool call start
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_early123","type":"function",` +
+          `"function":{"name":"search","arguments":""}}]},"finish_reason":null}]}\n\n`,
+        // This chunk produces valid JSON: {"query": "test"}
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"test\\"}"}}]},"finish_reason":null}]}\n\n`,
+        // More data arrives - the full args include "limit"
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":""}}]},"finish_reason":null}]}\n\n`,
+        // Even more data: adding the comma and limit field
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":", \\"limit\\": 10}"}}]},"finish_reason":null}]}\n\n`,
+        // finish
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              limit: { type: 'number' },
+            },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    // Find the tool-call event
+    const toolCallEvent = result.find(
+      (e: { type: string }) => e.type === 'tool-call',
+    );
+
+    // The tool call must contain the COMPLETE arguments, not just the
+    // partial JSON that happened to be parsable mid-stream.
+    expect(toolCallEvent).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call_early123',
+      toolName: 'search',
+      input: '{"query": "test"}, "limit": 10}',
+    });
+
+    // Verify there is exactly one tool-call event (no premature duplicate)
+    const toolCallEvents = result.filter(
+      (e: { type: string }) => e.type === 'tool-call',
+    );
+    expect(toolCallEvents).toHaveLength(1);
   });
 
   it('should stream tool call with missing type field (Azure AI Foundry / Mistral)', async () => {

--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -47,7 +47,8 @@ describe('StreamingToolCallTracker', () => {
 
       parts.length = 0;
 
-      // Third delta: completes the JSON
+      // Third delta: completes the JSON — must not finalize before flush,
+      // since a parsable buffer can still be the prefix of longer arguments
       tracker.processDelta({
         index: 0,
         function: { arguments: ' Francisco"}' },
@@ -59,6 +60,13 @@ describe('StreamingToolCallTracker', () => {
           id: 'call_1',
           delta: ' Francisco"}',
         },
+      ]);
+
+      parts.length = 0;
+
+      tracker.flush();
+
+      expect(parts).toEqual([
         { type: 'tool-input-end', id: 'call_1' },
         {
           type: 'tool-call',
@@ -90,6 +98,13 @@ describe('StreamingToolCallTracker', () => {
           id: 'call_1',
           delta: '{"city": "London"}',
         },
+      ]);
+
+      parts.length = 0;
+
+      tracker.flush();
+
+      expect(parts).toEqual([
         { type: 'tool-input-end', id: 'call_1' },
         {
           type: 'tool-call',
@@ -98,6 +113,40 @@ describe('StreamingToolCallTracker', () => {
           input: '{"city": "London"}',
         },
       ]);
+    });
+
+    it('should not finalize a tool call when its argument prefix is parsable JSON', () => {
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
+
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search', arguments: '{"query": "test"}' },
+      });
+
+      // the parsable prefix must not emit tool-input-end / tool-call
+      expect(parts.map(part => part.type)).toEqual([
+        'tool-input-start',
+        'tool-input-delta',
+      ]);
+
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: ', "limit": 10}' },
+      });
+
+      tracker.flush();
+
+      expect(parts.at(-1)).toEqual({
+        type: 'tool-call',
+        toolCallId: 'call_1',
+        toolName: 'search',
+        input: '{"query": "test"}, "limit": 10}',
+      });
+
+      expect(parts.filter(part => part.type === 'tool-call')).toHaveLength(1);
     });
 
     it('should handle multiple concurrent tool calls', () => {
@@ -128,13 +177,15 @@ describe('StreamingToolCallTracker', () => {
       const { parts, controller } = createCollector();
       const tracker = new StreamingToolCallTracker(controller);
 
-      // Complete tool call in one chunk
       tracker.processDelta({
         index: 0,
         id: 'call_1',
         type: 'function',
         function: { name: 'fn', arguments: '{}' },
       });
+
+      // Finalize via flush
+      tracker.flush();
 
       parts.length = 0;
 
@@ -324,13 +375,15 @@ describe('StreamingToolCallTracker', () => {
       const { parts, controller } = createCollector();
       const tracker = new StreamingToolCallTracker(controller);
 
-      // Complete tool call in one chunk
       tracker.processDelta({
         index: 0,
         id: 'call_1',
         type: 'function',
         function: { name: 'fn', arguments: '{}' },
       });
+
+      // First flush finalizes the tool call
+      tracker.flush();
 
       parts.length = 0;
 
@@ -364,6 +417,8 @@ describe('StreamingToolCallTracker', () => {
         function: { name: 'fn', arguments: '{}' },
         extra_content: { google: { thought_signature: 'sig123' } },
       } as any);
+
+      tracker.flush();
 
       const toolCallEvent = parts.find(p => p.type === 'tool-call');
       expect(toolCallEvent).toEqual({
@@ -420,6 +475,8 @@ describe('StreamingToolCallTracker', () => {
         type: 'function',
         function: { name: 'fn', arguments: '{}' },
       });
+
+      tracker.flush();
 
       const toolCallEvent = parts.find(p => p.type === 'tool-call');
       expect(toolCallEvent).toEqual({

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -4,7 +4,6 @@ import {
   type SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import { generateId as defaultGenerateId } from './generate-id';
-import { isParsableJson } from './parse-json';
 
 /**
  * Minimal interface for a streaming tool call delta from an OpenAI-compatible API.
@@ -188,11 +187,10 @@ export class StreamingToolCallTracker<
       });
     }
 
-    // Check if tool call is complete
-    // (some providers send the full tool call in one chunk)
-    if (isParsableJson(toolCall.function.arguments)) {
-      this.finishToolCall(toolCall);
-    }
+    // Tool calls must not finalize before the stream ends: a parsable
+    // argument buffer can still be the prefix of a longer argument string,
+    // so acting on it early would use truncated inputs (see #13137).
+    // Finalization happens in flush().
   }
 
   private processExistingToolCall(index: number, toolCallDelta: DELTA): void {
@@ -210,11 +208,6 @@ export class StreamingToolCallTracker<
         id: toolCall.id,
         delta: toolCallDelta.function.arguments,
       });
-    }
-
-    // Check if tool call is complete
-    if (isParsableJson(toolCall.function.arguments)) {
-      this.finishToolCall(toolCall);
     }
   }
 


### PR DESCRIPTION
## Background

#13137 (`fix(security): prevent streaming tool calls from finalizing on parsable partial JSON`) removed the inline `isParsableJson` early finalization from the streaming tool-call handling: a parsable argument buffer can still be the prefix of a longer argument string, so finalizing early can act on truncated tool inputs.

The `StreamingToolCallTracker` refactor (#14565) later reintroduced that inline finalization in both `processNewToolCall` and `processExistingToolCall` (its description notes it "finalizes tool calls both inline (via isParsableJson) and in flush()"), and the openai-package regression test added by #13137 was removed along with the inline code — so nothing caught the regression. #13137 is an ancestor of #14565, so this is a straight behavioral revert of that fix for the openai, openai-compatible, groq, deepseek, and alibaba providers (and everything extending openai-compatible).

Found while backporting #13137 to `release-v6.0` (#16800, tracking issue #16767) — the backported cerebras test surfaced the semantic difference. `release-v6.0` currently has the stricter (correct) behavior; this PR brings `main` back in line.

## Summary

- `StreamingToolCallTracker` no longer finalizes tool calls when the accumulated arguments happen to parse as JSON; finalization only happens during stream `flush()` (which #14565 already implemented as a safety net).
- Restores #13137's regression test (`should not finalize tool call early when partial JSON is coincidentally parsable`) in the openai package, and adds an equivalent tracker-level regression test.
- Updates tracker unit tests to the flush-based semantics.
- Snapshot updates in openai/openai-compatible/groq/alibaba mirror #13137's original diff (an empty `tool-input-delta` that early finalization used to swallow now flows through; `text-end` precedes tool finalization).
- Adapts the cerebras mixed structured-output streaming test: tool calls now finalize after the text has streamed, so the json-mode filter drops the spurious repeated tool call entirely — matching the `doGenerate` treatment of mixed responses (same adaptation as on `release-v6.0`).

## Manual verification

I reproduced the regression end-to-end with a mock OpenAI streaming endpoint. The tool-call arguments are streamed in fragments where an **intermediate** buffer is coincidentally parsable JSON (`{"query": "test"}`) before the rest of the arguments arrive (`, "limit": 10}`). A tracker that finalizes on parsable partial JSON fires the tool call with the truncated prefix and drops everything after it.

<details>
<summary><code>repro-partial-json-tool-call.ts</code></summary>

```ts
import { createOpenAI } from '@ai-sdk/openai';
import { jsonSchema, stepCountIs, streamText, tool } from 'ai';
import { createServer } from 'node:http';

// Mock OpenAI chat completions endpoint. The tool-call arguments are
// streamed in fragments where an INTERMEDIATE buffer is parsable JSON:
//   '{"query": "test"}'  <-- parsable, but only a prefix
//   ', "limit": 10}'     <-- rest of the arguments
// A tracker that finalizes on parsable partial JSON will fire the tool
// call with the truncated arguments and drop the rest.
const argFragments = ['', '{"query": "test"}', '', ', "limit": 10}'];

function sseChunk(delta: object): string {
  return `data: ${JSON.stringify({
    id: 'chatcmpl-early',
    object: 'chat.completion.chunk',
    created: 1733162241,
    model: 'gpt-4',
    choices: [{ index: 0, delta, finish_reason: null }],
  })}\n\n`;
}

let requestCount = 0;
const server = createServer((req, res) => {
  res.writeHead(200, { 'content-type': 'text/event-stream' });
  requestCount++;
  if (requestCount === 1) {
    res.write(
      sseChunk({
        role: 'assistant',
        content: null,
        tool_calls: [
          {
            index: 0,
            id: 'call_early123',
            type: 'function',
            function: { name: 'search', arguments: argFragments[0] },
          },
        ],
      }),
    );
    for (const fragment of argFragments.slice(1)) {
      res.write(
        sseChunk({
          tool_calls: [{ index: 0, function: { arguments: fragment } }],
        }),
      );
    }
    res.write(
      `data: ${JSON.stringify({
        id: 'chatcmpl-early',
        object: 'chat.completion.chunk',
        created: 1733162241,
        model: 'gpt-4',
        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
      })}\n\n`,
    );
  }
  res.write('data: [DONE]\n\n');
  res.end();
});

server.listen(0, async () => {
  const { port } = server.address() as { port: number };
  const openai = createOpenAI({
    apiKey: 'test-key',
    baseURL: `http://localhost:${port}/v1`,
  });

  const result = streamText({
    model: openai.chat('gpt-4'),
    prompt: 'Search for "test" with a limit of 10 results.',
    maxRetries: 0,
    stopWhen: stepCountIs(1),
    tools: {
      search: tool({
        inputSchema: jsonSchema<{ query: string; limit?: number }>({
          type: 'object',
          properties: {
            query: { type: 'string' },
            limit: { type: 'number' },
          },
          required: ['query'],
          additionalProperties: false,
        }),
        execute: async input => {
          console.log('TOOL EXECUTED with input:', JSON.stringify(input));
          return 'ok';
        },
      }),
    },
    onError: () => {},
  });

  for await (const part of result.stream) {
    if (part.type === 'tool-call') {
      console.log('tool-call part input:', JSON.stringify(part.input));
    } else if (part.type === 'tool-error') {
      console.log('tool-error part:', String(part.error).split('\n')[0]);
    } else if (part.type === 'error') {
      console.log('error part:', String(part.error).split('\n')[0]);
    }
  }

  server.close();
});
```

</details>

**On `main` (before this PR)** — the tracker finalizes at the parsable prefix, so the tool executes with truncated arguments and the `limit` field is silently lost:

```
tool-call part input: {"query":"test"}
TOOL EXECUTED with input: {"query":"test"}
```

**On this branch** — the tracker forwards the complete streamed argument string instead of finalizing early; the truncated call never happens (here the full arguments are inconsistent, so it correctly surfaces as a tool-error rather than silently executing a truncated call):

```
tool-call part input: "{\"query\": \"test\"}, \"limit\": 10}"
tool-error part: AI_InvalidToolInputError: Invalid input for tool search: AI_JSONParseError: JSON parsing failed: Text: {"query": "test"}, "limit": 10}.
```

### Automated tests

- `@ai-sdk/provider-utils`: 656/656 (incl. 18 tracker tests with the new regression test)
- `@ai-sdk/openai`: 743/743 (incl. the restored #13137 regression test)
- `@ai-sdk/openai-compatible`: 233/233, `@ai-sdk/groq`: 95/95, `@ai-sdk/deepseek`: 40/40, `@ai-sdk/alibaba`: 131/131, `@ai-sdk/cerebras`: 13/13
- Dependent providers (fireworks, deepinfra, togetherai, baseten, huggingface, moonshotai, vercel, xai, google-vertex): all suites pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
