### PR TITLE
fix(workflow): expose totalUsage and finishReason on stream result

### DIFF
--- a/.changeset/workflow-agent-stream-result-totalusage.md
+++ b/.changeset/workflow-agent-stream-result-totalusage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Expose `totalUsage` and `finishReason` on the `WorkflowAgent.stream()` result, mirroring `GenerateTextResult`/`StreamTextResult` and the existing `onEnd` event payload.

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -499,6 +499,30 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         ]
       `);
     });
+
+    it('should expose finishReason and totalUsage on the stream result', async () => {
+      const agent = new WorkflowAgent({
+        model: mockModel,
+      });
+
+      const { writable } = createMockWritable();
+      const result = await agent.stream({
+        messages: [{ role: 'user' as const, content: 'test' }],
+        writable,
+      });
+
+      expect({
+        finishReason: result.finishReason,
+        inputTokens: result.totalUsage.inputTokens,
+        outputTokens: result.totalUsage.outputTokens,
+      }).toMatchInlineSnapshot(`
+        {
+          "finishReason": "stop",
+          "inputTokens": 3,
+          "outputTokens": 10,
+        }
+      `);
+    });
   });
 
   describe('experimental_onStart', () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1149,6 +1149,16 @@ export interface WorkflowAgentStreamResult<
   toolResults: ToolResult[];
 
   /**
+   * The finish reason from the last step.
+   */
+  finishReason: FinishReason;
+
+  /**
+   * The total token usage across all steps.
+   */
+  totalUsage: LanguageModelUsage;
+
+  /**
    * The generated structured output. It uses the `output` specification.
    * Only available when `output` is specified.
    */
@@ -2062,6 +2072,8 @@ export class WorkflowAgent<
         steps,
         toolCalls: [],
         toolResults: [],
+        finishReason: 'other',
+        totalUsage: aggregateUsage(steps),
         output: undefined as OUTPUT,
       };
     }
@@ -2264,15 +2276,16 @@ export class WorkflowAgent<
             }
 
             const messages = iterMessages as unknown as ModelMessage[];
+            const lastStep = steps[steps.length - 1];
+            const totalUsage = aggregateUsage(steps);
+            const finishReason = lastStep?.finishReason ?? 'other';
 
             if (mergedOnEnd && !wasAborted) {
-              const lastStep = steps[steps.length - 1];
-              const totalUsage = aggregateUsage(steps);
               await mergedOnEnd({
                 steps,
                 messages,
                 text: lastStep?.text ?? '',
-                finishReason: lastStep?.finishReason ?? 'other',
+                finishReason,
                 usage: totalUsage,
                 totalUsage,
                 runtimeContext,
@@ -2283,10 +2296,10 @@ export class WorkflowAgent<
             }
             if (!wasAborted && steps.length > 0) {
               const telemetrySteps = steps.map(normalizeStepForTelemetry);
-              const lastStep = telemetrySteps[telemetrySteps.length - 1];
-              const totalUsage = aggregateUsage(steps);
+              const lastTelemetryStep =
+                telemetrySteps[telemetrySteps.length - 1];
               await telemetryDispatcher.onEnd?.({
-                ...lastStep,
+                ...lastTelemetryStep,
                 steps: telemetrySteps,
                 usage: totalUsage,
                 totalUsage,
@@ -2327,6 +2340,8 @@ export class WorkflowAgent<
               steps,
               toolCalls: allToolCalls,
               toolResults: allToolResults,
+              finishReason,
+              totalUsage,
               output: undefined as OUTPUT,
             };
           }
@@ -2491,15 +2506,17 @@ export class WorkflowAgent<
       }
     }
 
+    const lastStep = steps[steps.length - 1];
+    const totalUsage = aggregateUsage(steps);
+    const finishReason = lastStep?.finishReason ?? 'other';
+
     // Call onEnd callback if provided (always call, even on errors, but not on abort)
     if (mergedOnEnd && !wasAborted) {
-      const lastStep = steps[steps.length - 1];
-      const totalUsage = aggregateUsage(steps);
       await mergedOnEnd({
         steps,
         messages: messages as ModelMessage[],
         text: lastStep?.text ?? '',
-        finishReason: lastStep?.finishReason ?? 'other',
+        finishReason,
         usage: totalUsage,
         totalUsage,
         runtimeContext,
@@ -2509,10 +2526,9 @@ export class WorkflowAgent<
     }
     if (!wasAborted && steps.length > 0) {
       const telemetrySteps = steps.map(normalizeStepForTelemetry);
-      const lastStep = telemetrySteps[telemetrySteps.length - 1];
-      const totalUsage = aggregateUsage(steps);
+      const lastTelemetryStep = telemetrySteps[telemetrySteps.length - 1];
       await telemetryDispatcher.onEnd?.({
-        ...lastStep,
+        ...lastTelemetryStep,
         steps: telemetrySteps,
         usage: totalUsage,
         totalUsage,
@@ -2546,6 +2562,8 @@ export class WorkflowAgent<
       steps,
       toolCalls: lastStepToolCalls,
       toolResults: lastStepToolResults,
+      finishReason,
+      totalUsage,
       output: experimentalOutput,
     };
   }


### PR DESCRIPTION
## Summary

`WorkflowAgentStreamResult` (the awaited return of `agent.stream()`) is missing `totalUsage` and `finishReason`. Both are already computed in the runtime and passed to the `onEnd` callback, so the omission from the result is asymmetric and diverges from `GenerateTextResult`/`StreamTextResult`, which expose them directly.

This adds them to the interface and to all three return sites (early-abort, paused-tools, and the final return), reusing the existing `aggregateUsage(steps)` helper. The `lastStep`/`totalUsage`/`finishReason` locals are hoisted out of the `onEnd` blocks so the callback and the return value share the same computation.

Redo of #14786 against `main` — that PR targeted the stale `workflow-agent-unify-callbacks` branch. Port of [vercel/workflow#1863](https://github.com/vercel/workflow/pull/1863) (merged) to `@ai-sdk/workflow`.

## Test plan

- [x] New regression test in `workflow-agent-compat.test.ts` asserts `result.totalUsage` and `result.finishReason` after a normal stream
- [x] `pnpm --filter @ai-sdk/workflow test` passes (148 tests, node + edge)
- [x] `pnpm type-check:full` passes
- [x] `pnpm check` (lint/format) clean