### PR TITLE
Backport: feat(provider/google-vertex): add interactions() for Gemini Interactions API (#16550)

### DIFF
--- a/.changeset/google-vertex-interactions-v6.md
+++ b/.changeset/google-vertex-interactions-v6.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
+---
+
+Backport `vertex.interactions()` for the Gemini Interactions API on Vertex AI for AI SDK v6.

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -1,7 +1,10 @@
 import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createVertex } from './google-vertex-provider';
-import { GoogleGenerativeAILanguageModel } from '@ai-sdk/google/internal';
+import {
+  GoogleGenerativeAILanguageModel,
+  GoogleInteractionsLanguageModel,
+} from '@ai-sdk/google/internal';
 import { GoogleVertexEmbeddingModel } from './google-vertex-embedding-model';
 import { GoogleVertexImageModel } from './google-vertex-image-model';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
@@ -37,6 +40,7 @@ vi.mock('@ai-sdk/provider-utils', async importOriginal => {
 
 vi.mock('@ai-sdk/google/internal', () => ({
   GoogleGenerativeAILanguageModel: vi.fn(),
+  GoogleInteractionsLanguageModel: vi.fn(),
   googleTools: {
     googleSearch: vi.fn(),
     urlContext: vi.fn(),
@@ -87,6 +91,39 @@ describe('google-vertex-provider', () => {
         headers: expect.any(Function),
         generateId: expect.any(Function),
       }),
+    );
+  });
+
+  it('should create an interactions model targeting the location-scoped interactions resource', () => {
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+    provider.interactions('gemini-omni-flash-preview');
+
+    expect(GoogleInteractionsLanguageModel).toHaveBeenCalledWith(
+      'gemini-omni-flash-preview',
+      expect.objectContaining({
+        provider: 'google.vertex.interactions',
+        // No `/publishers/google` suffix — the interactions model appends
+        // `/interactions` to reach `.../locations/{region}/interactions`.
+        baseURL:
+          'https://test-location-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/test-location',
+        headers: expect.any(Function),
+        generateId: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should throw for interactions models when an Express Mode API key is set', () => {
+    process.env.GOOGLE_VERTEX_API_KEY = 'test-api-key';
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+
+    expect(() => provider.interactions('gemini-omni-flash-preview')).toThrow(
+      /do not support Express Mode API keys/,
     );
   });
 

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -1,4 +1,10 @@
-import { GoogleGenerativeAILanguageModel } from '@ai-sdk/google/internal';
+import {
+  GoogleGenerativeAILanguageModel,
+  GoogleInteractionsLanguageModel,
+  type GoogleInteractionsAgentName,
+  type GoogleInteractionsModelId,
+  type GoogleInteractionsModelInput,
+} from '@ai-sdk/google/internal';
 import type {
   Experimental_VideoModelV3,
   ImageModelV3,
@@ -57,6 +63,19 @@ export interface GoogleVertexProvider extends ProviderV3 {
   (modelId: GoogleVertexModelId): LanguageModelV3;
 
   languageModel: (modelId: GoogleVertexModelId) => LanguageModelV3;
+
+  /**
+   * Creates a language model targeting the Gemini Interactions API
+   * (`.../locations/{region}/interactions`) on Vertex, reusing the Vertex
+   * OAuth credentials. Pass a model id (e.g. `gemini-omni-flash-preview`) or an
+   * `{ agent }` / `{ managedAgent }` reference.
+   */
+  interactions(
+    modelIdOrAgent:
+      | GoogleInteractionsModelId
+      | { agent: GoogleInteractionsAgentName }
+      | { managedAgent: string },
+  ): LanguageModelV3;
 
   /**
    * Creates a model for image generation.
@@ -171,7 +190,7 @@ export function createVertex(
       description: 'Google Vertex location',
     });
 
-  const loadBaseURL = () => {
+  const loadBaseURL = ({ endpoint = false }: { endpoint?: boolean } = {}) => {
     if (apiKey) {
       return withoutTrailingSlash(options.baseURL) ?? EXPRESS_MODE_BASE_URL;
     }
@@ -191,11 +210,16 @@ export function createVertex(
 
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${getHost()}/v1beta1/projects/${project}/locations/${region}/publishers/google`
+      `https://${getHost()}/v1beta1/projects/${project}/locations/${region}${
+        endpoint ? '' : '/publishers/google'
+      }`
     );
   };
 
-  const createConfig = (name: string): GoogleVertexConfig => {
+  const createConfig = (
+    name: string,
+    { endpoint = false }: { endpoint?: boolean } = {},
+  ): GoogleVertexConfig => {
     const getHeaders = async () => {
       const originalHeaders = await resolve(options.headers ?? {});
       return withUserAgentSuffix(
@@ -210,7 +234,7 @@ export function createVertex(
       fetch: apiKey
         ? createExpressModeFetch(apiKey, options.fetch)
         : options.fetch,
-      baseURL: loadBaseURL(),
+      baseURL: loadBaseURL({ endpoint }),
     };
   };
 
@@ -227,6 +251,31 @@ export function createVertex(
         ],
       }),
     });
+  };
+
+  const createInteractionsModel = (
+    modelIdOrAgent:
+      | GoogleInteractionsModelId
+      | { agent: GoogleInteractionsAgentName }
+      | { managedAgent: string },
+  ) => {
+    if (apiKey) {
+      throw new Error(
+        'Google Vertex Interactions models do not support Express Mode API keys. Use standard Google Cloud credentials instead.',
+      );
+    }
+
+    return new GoogleInteractionsLanguageModel(
+      modelIdOrAgent as GoogleInteractionsModelInput,
+      {
+        // The Interactions API is a location-scoped resource
+        // (`.../locations/{region}/interactions`), so it uses the
+        // endpoint-style base URL without the `/publishers/google` suffix that
+        // the base-model paths carry.
+        ...createConfig('interactions', { endpoint: true }),
+        generateId: options.generateId ?? generateId,
+      },
+    );
   };
 
   const createEmbeddingModel = (modelId: GoogleVertexEmbeddingModelId) =>
@@ -277,6 +326,7 @@ export function createVertex(
 
   provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
+  provider.interactions = createInteractionsModel;
   provider.embeddingModel = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;

--- a/packages/google/src/internal/index.ts
+++ b/packages/google/src/internal/index.ts
@@ -1,3 +1,9 @@
 export * from '../google-generative-ai-language-model';
 export { googleTools } from '../google-tools';
 export type { GoogleGenerativeAIModelId } from '../google-generative-ai-options';
+export {
+  GoogleInteractionsLanguageModel,
+  type GoogleInteractionsModelInput,
+} from '../interactions/google-interactions-language-model';
+export type { GoogleInteractionsModelId } from '../interactions/google-interactions-language-model-options';
+export type { GoogleInteractionsAgentName } from '../interactions/google-interactions-agent';


### PR DESCRIPTION
Backport of

- vercel/ai#16550 — feat(provider/google-vertex): add interactions() for Gemini Interactions API

## Summary

Backports `vertex.interactions()` from #16550 to `release-v6.0`, wiring the Gemini Interactions API into `@ai-sdk/google-vertex`