### PR TITLE
[v6.0] fix: Mistral presencePenalty and frequencyPenalty are incorrectly reported as unsupported

### DIFF
--- a/.changeset/brave-peaches-help.md
+++ b/.changeset/brave-peaches-help.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Forward Mistral presence and frequency penalties without unsupported warnings.

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -175,6 +175,33 @@ describe('doGenerate', () => {
     );
   });
 
+  it('should forward presencePenalty and frequencyPenalty without unsupported warnings', async () => {
+    prepareJsonFixtureResponse('mistral-text');
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      presencePenalty: 0.1,
+      frequencyPenalty: 0.2,
+    });
+
+    expect(result.warnings).not.toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'presencePenalty',
+      }),
+    );
+    expect(result.warnings).not.toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'frequencyPenalty',
+      }),
+    );
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      presence_penalty: 0.1,
+      frequency_penalty: 0.2,
+    });
+  });
+
   it('should pass headers', async () => {
     prepareJsonFixtureResponse('mistral-text');
 

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -92,48 +92,6 @@ export class MistralChatLanguageModel implements LanguageModelV3 {
       warnings.push({ type: 'unsupported', feature: 'topK' });
     }
 
-<<<<<<< HEAD
-    if (frequencyPenalty != null) {
-      warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
-    }
-
-    if (presencePenalty != null) {
-      warnings.push({ type: 'unsupported', feature: 'presencePenalty' });
-=======
-    const supportsReasoningEffort =
-      this.modelId === 'mistral-small-latest' ||
-      this.modelId === 'mistral-small-2603' ||
-      this.modelId === 'mistral-medium-3' ||
-      this.modelId === 'mistral-medium-3.5';
-
-    let resolvedReasoningEffort: string | undefined;
-    if (supportsReasoningEffort) {
-      resolvedReasoningEffort =
-        options.reasoningEffort ??
-        (isCustomReasoning(reasoning)
-          ? reasoning === 'none'
-            ? 'none'
-            : mapReasoningToProviderEffort({
-                reasoning,
-                effortMap: {
-                  minimal: 'high',
-                  low: 'high',
-                  medium: 'high',
-                  high: 'high',
-                  xhigh: 'high',
-                },
-                warnings,
-              })
-          : undefined);
-    } else if (isCustomReasoning(reasoning)) {
-      warnings.push({
-        type: 'unsupported',
-        feature: 'reasoning',
-        details: 'This model does not support reasoning configuration.',
-      });
->>>>>>> ec8c408f2 (fix: Mistral presencePenalty and frequencyPenalty are incorrectly reported as unsupported (#16845))
-    }
-
     const structuredOutputs = options.structuredOutputs ?? true;
     const strictJsonSchema = options.strictJsonSchema ?? false;
 

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -92,12 +92,46 @@ export class MistralChatLanguageModel implements LanguageModelV3 {
       warnings.push({ type: 'unsupported', feature: 'topK' });
     }
 
+<<<<<<< HEAD
     if (frequencyPenalty != null) {
       warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
     }
 
     if (presencePenalty != null) {
       warnings.push({ type: 'unsupported', feature: 'presencePenalty' });
+=======
+    const supportsReasoningEffort =
+      this.modelId === 'mistral-small-latest' ||
+      this.modelId === 'mistral-small-2603' ||
+      this.modelId === 'mistral-medium-3' ||
+      this.modelId === 'mistral-medium-3.5';
+
+    let resolvedReasoningEffort: string | undefined;
+    if (supportsReasoningEffort) {
+      resolvedReasoningEffort =
+        options.reasoningEffort ??
+        (isCustomReasoning(reasoning)
+          ? reasoning === 'none'
+            ? 'none'
+            : mapReasoningToProviderEffort({
+                reasoning,
+                effortMap: {
+                  minimal: 'high',
+                  low: 'high',
+                  medium: 'high',
+                  high: 'high',
+                  xhigh: 'high',
+                },
+                warnings,
+              })
+          : undefined);
+    } else if (isCustomReasoning(reasoning)) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'reasoning',
+        details: 'This model does not support reasoning configuration.',
+      });
+>>>>>>> ec8c408f2 (fix: Mistral presencePenalty and frequencyPenalty are incorrectly reported as unsupported (#16845))
     }
 
     const structuredOutputs = options.structuredOutputs ?? true;
@@ -123,6 +157,10 @@ export class MistralChatLanguageModel implements LanguageModelV3 {
       max_tokens: maxOutputTokens,
       temperature,
       top_p: topP,
+      ...(frequencyPenalty != null
+        ? { frequency_penalty: frequencyPenalty }
+        : {}),
+      ...(presencePenalty != null ? { presence_penalty: presencePenalty } : {}),
       stop: stopSequences,
       random_seed: seed,
       reasoning_effort: options.reasoningEffort,


### PR DESCRIPTION
## Background

Mistral supports presence and frequency penalties, but the provider was warning they were unsupported and not forwarding them.

## Summary

The Mistral chat request builder now forwards presencePenalty as presence_penalty and frequencyPenalty as frequency_penalty when provided, without emitting unsupported warnings.

## Testing

Added a Mistral chat model regression test asserting both penalties are sent in the request body and no unsupported warnings are emitted; removed reproduction-only scratch artifacts.

## Related Issues

Fixes #16775

Backport of #16845

Co-authored-by: stof <439401+stof@users.noreply.github.com>