### PR TITLE
feat (provider/amazon-transcribe): add Amazon Transcribe provider

### DIFF
--- a/.changeset/amazon-transcribe-provider.md
+++ b/.changeset/amazon-transcribe-provider.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/amazon-transcribe': major
+---
+
+feat (provider/amazon-transcribe): add Amazon Transcribe provider with batch transcription support
+
+Adds a new `@ai-sdk/amazon-transcribe` provider that implements the AI SDK
+`transcribe` function using the Amazon Transcribe batch transcription API. The
+provider uploads the audio to a configured S3 bucket (`providerOptions.amazonTranscribe.inputBucket`),
+starts a transcription job, polls until completion, and returns the transcript,
+segments, language, and duration. Authentication uses AWS SigV4.

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -47,6 +47,7 @@ The AI SDK comes with a wide range of providers that you can use to interact wit
 - [Deepgram Provider](/providers/ai-sdk-providers/deepgram) (`@ai-sdk/deepgram`)
 - [Gladia Provider](/providers/ai-sdk-providers/gladia) (`@ai-sdk/gladia`)
 - [AssemblyAI Provider](/providers/ai-sdk-providers/assemblyai) (`@ai-sdk/assemblyai`)
+- [Amazon Transcribe Provider](/providers/ai-sdk-providers/amazon-transcribe) (`@ai-sdk/amazon-transcribe`)
 - [Baseten Provider](/providers/ai-sdk-providers/baseten) (`@ai-sdk/baseten`)
 
 You can also use the [OpenAI Compatible provider](/providers/openai-compatible-providers) with OpenAI-compatible APIs:

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -300,6 +300,7 @@ try {
 | [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)               | `default`                |
 | [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)       | `universal-3-5-pro`      |
 | [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)       | `universal-3-pro`        |
+| [Amazon Transcribe](/providers/ai-sdk-providers/amazon-transcribe#transcription-models) | `default`                |
 | [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `whisper`                |
 | [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `wizper`                 |
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |

--- a/content/providers/01-ai-sdk-providers/190-amazon-transcribe.mdx
+++ b/content/providers/01-ai-sdk-providers/190-amazon-transcribe.mdx
@@ -1,0 +1,197 @@
+---
+title: Amazon Transcribe
+description: Learn how to use the Amazon Transcribe provider for the AI SDK.
+---
+
+# Amazon Transcribe Provider
+
+The [Amazon Transcribe](https://aws.amazon.com/transcribe/) provider contains transcription
+model support for the Amazon Transcribe batch transcription API.
+
+<Note>
+  Amazon Transcribe is a separate AWS service from Amazon Bedrock. Batch
+  transcription reads the audio from, and optionally writes the transcript to,
+  Amazon S3. Because the AI SDK `transcribe` function provides raw audio bytes,
+  the provider uploads the audio to a configured S3 bucket before starting the
+  job, then polls the job until it completes.
+</Note>
+
+## Setup
+
+The Amazon Transcribe provider is available in the `@ai-sdk/amazon-transcribe` module. You can install it with
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/amazon-transcribe" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/amazon-transcribe" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/amazon-transcribe" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/amazon-transcribe" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default provider instance `amazonTranscribe` from `@ai-sdk/amazon-transcribe`:
+
+```ts
+import { amazonTranscribe } from '@ai-sdk/amazon-transcribe';
+```
+
+If you need a customized setup, you can import `createAmazonTranscribe` from `@ai-sdk/amazon-transcribe` and create a provider instance with your settings:
+
+```ts
+import { createAmazonTranscribe } from '@ai-sdk/amazon-transcribe';
+
+const amazonTranscribe = createAmazonTranscribe({
+  region: 'us-east-1',
+  // credentials are resolved from the environment by default
+});
+```
+
+You can use the following optional settings to customize the Amazon Transcribe provider instance:
+
+- **region** _string_
+
+  The AWS region to use. Defaults to the `AWS_REGION` environment variable.
+
+- **accessKeyId** _string_
+
+  The AWS access key ID. Defaults to the `AWS_ACCESS_KEY_ID` environment variable.
+
+- **secretAccessKey** _string_
+
+  The AWS secret access key. Defaults to the `AWS_SECRET_ACCESS_KEY` environment variable.
+
+- **sessionToken** _string_
+
+  The AWS session token. Defaults to the `AWS_SESSION_TOKEN` environment variable.
+
+- **credentialProvider** _() => Promise&lt;&#123; accessKeyId, secretAccessKey, sessionToken? &#125;&gt;_
+
+  A function returning dynamic AWS credentials (similar to the AWS SDK). When set,
+  its values are used instead of `accessKeyId`, `secretAccessKey`, and `sessionToken`.
+
+- **baseURL** _string_
+
+  Base URL for the Amazon Transcribe API calls. Defaults to
+  `https://transcribe.{region}.amazonaws.com`.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+
+## Transcription Models
+
+You can create models that call the [Amazon Transcribe StartTranscriptionJob API](https://docs.aws.amazon.com/transcribe/latest/APIReference/API_StartTranscriptionJob.html)
+using the `.transcription()` factory method.
+
+```ts
+const model = amazonTranscribe.transcription();
+```
+
+At minimum you must supply an `inputBucket` via `providerOptions`. This is the S3
+bucket the audio is uploaded to and that Amazon Transcribe reads from. The IAM
+identity used must have permission to `s3:PutObject` to this bucket and
+`transcribe:StartTranscriptionJob` / `transcribe:GetTranscriptionJob`.
+
+```ts highlight="8-11"
+import { transcribe } from 'ai';
+import { amazonTranscribe } from '@ai-sdk/amazon-transcribe';
+import { type AmazonTranscribeTranscriptionModelOptions } from '@ai-sdk/amazon-transcribe';
+import { readFile } from 'fs/promises';
+
+const result = await transcribe({
+  model: amazonTranscribe.transcription(),
+  audio: await readFile('audio.mp3'),
+  providerOptions: {
+    amazonTranscribe: {
+      inputBucket: 'my-audio-bucket',
+      languageCode: 'en-US',
+    } satisfies AmazonTranscribeTranscriptionModelOptions,
+  },
+});
+```
+
+The following provider options are available:
+
+- **inputBucket** _string_ (required)
+
+  Name of the S3 bucket the audio is uploaded to and that Amazon Transcribe reads from.
+
+- **inputKeyPrefix** _string_
+
+  Optional key prefix (folder) for the uploaded audio object.
+
+- **outputBucket** _string_
+
+  Name of the S3 bucket Amazon Transcribe writes the transcript to. When omitted,
+  a service-managed bucket is used and a pre-signed download URL is returned by the API.
+
+- **outputKey** _string_
+
+  The object key for the transcription output within `outputBucket`.
+
+- **transcriptionJobName** _string_
+
+  The name to assign to the transcription job. Must be unique within the AWS account.
+  When omitted, a unique name is generated.
+
+- **languageCode** _string_
+
+  The language code of the audio, e.g. `en-US`. Mutually exclusive with
+  `identifyLanguage` / `identifyMultipleLanguages`. When none of these are set,
+  automatic single-language identification is enabled.
+
+- **identifyLanguage** _boolean_
+
+  Enables automatic identification of the single language spoken in the audio.
+  Defaults to `true` when neither `languageCode` nor `identifyMultipleLanguages`
+  is set; pass `false` to disable it.
+
+- **identifyMultipleLanguages** _boolean_
+
+  Enables automatic identification of multiple languages spoken in the audio.
+
+- **languageOptions** _string[]_
+
+  Restricts automatic language identification to the provided language codes.
+
+- **mediaFormat** _string_
+
+  The format of the input media (`mp3`, `mp4`, `wav`, `flac`, `ogg`, `amr`, `webm`).
+  When omitted, it is inferred from the audio media type.
+
+- **mediaSampleRateHertz** _number_
+
+  Sample rate of the audio in Hertz.
+
+- **settings** _object_
+
+  Additional [`Settings`](https://docs.aws.amazon.com/transcribe/latest/APIReference/API_Settings.html)
+  passed through to `StartTranscriptionJob` (e.g. `ShowSpeakerLabels`, `MaxSpeakerLabels`, `VocabularyName`).
+
+- **pollIntervalMillis** _number_
+
+  Interval in milliseconds between transcription job status polls. Defaults to `3000`.
+
+- **maxPollDurationMillis** _number_
+
+  Maximum time in milliseconds to wait for the job to complete before timing out.
+  Defaults to `600000` (10 minutes).
+
+### Model Capabilities
+
+| Model     | Transcription       | Duration            | Segments            | Language            |
+| --------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `default` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@ai-sdk/alibaba": "workspace:*",
     "@ai-sdk/amazon-bedrock": "workspace:*",
+    "@ai-sdk/amazon-transcribe": "workspace:*",
     "@ai-sdk/anthropic": "workspace:*",
     "@ai-sdk/anthropic-aws": "workspace:*",
     "@ai-sdk/assemblyai": "workspace:*",

--- a/examples/ai-functions/src/transcribe/amazon-transcribe/basic.ts
+++ b/examples/ai-functions/src/transcribe/amazon-transcribe/basic.ts
@@ -1,0 +1,24 @@
+import { amazonTranscribe } from '@ai-sdk/amazon-transcribe';
+import { transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await transcribe({
+    model: amazonTranscribe.transcription(),
+    audio: await readFile('data/galileo.mp3'),
+    providerOptions: {
+      amazonTranscribe: {
+        // S3 bucket the audio is uploaded to and read from by Amazon Transcribe.
+        inputBucket: process.env.AWS_TRANSCRIBE_INPUT_BUCKET!,
+        languageCode: 'en-US',
+      },
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+  console.log('Segments:', result.segments);
+  console.log('Warnings:', result.warnings);
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../../packages/amazon-bedrock"
     },
     {
+      "path": "../../packages/amazon-transcribe"
+    },
+    {
       "path": "../../packages/anthropic"
     },
     {

--- a/examples/harness-e2e-next/tsconfig.json
+++ b/examples/harness-e2e-next/tsconfig.json
@@ -53,6 +53,12 @@
       "path": "../../packages/harness-codex"
     },
     {
+      "path": "../../packages/harness-deepagents"
+    },
+    {
+      "path": "../../packages/harness-opencode"
+    },
+    {
       "path": "../../packages/harness-pi"
     },
     {

--- a/examples/harness-e2e-tui/tsconfig.json
+++ b/examples/harness-e2e-tui/tsconfig.json
@@ -44,6 +44,12 @@
       "path": "../../packages/harness-codex"
     },
     {
+      "path": "../../packages/harness-deepagents"
+    },
+    {
+      "path": "../../packages/harness-opencode"
+    },
+    {
       "path": "../../packages/harness-pi"
     },
     {

--- a/packages/amazon-transcribe/README.md
+++ b/packages/amazon-transcribe/README.md
@@ -1,0 +1,44 @@
+# AI SDK - Amazon Transcribe Provider
+
+The **[Amazon Transcribe provider](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-transcribe)** for the [AI SDK](https://ai-sdk.dev/docs) contains transcription model support for the [Amazon Transcribe](https://aws.amazon.com/transcribe/) batch transcription API.
+
+> Amazon Transcribe is a separate AWS service from Amazon Bedrock. Batch transcription reads audio from (and optionally writes the transcript to) Amazon S3. Because the AI SDK `transcribe` function provides raw audio bytes, this provider uploads the audio to a configured S3 bucket before starting the job, then polls until it completes.
+
+## Setup
+
+The Amazon Transcribe provider is available in the `@ai-sdk/amazon-transcribe` module. You can install it with
+
+```bash
+npm i @ai-sdk/amazon-transcribe
+```
+
+## Provider Instance
+
+You can import the default provider instance `amazonTranscribe` from `@ai-sdk/amazon-transcribe`:
+
+```ts
+import { amazonTranscribe } from '@ai-sdk/amazon-transcribe';
+```
+
+## Example
+
+```ts
+import { amazonTranscribe } from '@ai-sdk/amazon-transcribe';
+import { transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+
+const { text } = await transcribe({
+  model: amazonTranscribe.transcription(),
+  audio: await readFile('audio.mp3'),
+  providerOptions: {
+    amazonTranscribe: {
+      inputBucket: 'my-audio-bucket',
+      languageCode: 'en-US',
+    },
+  },
+});
+```
+
+## Documentation
+
+Please check out the **[Amazon Transcribe provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-transcribe)** for more information.

--- a/packages/amazon-transcribe/package.json
+++ b/packages/amazon-transcribe/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@ai-sdk/amazon-transcribe",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "tsup --tsconfig tsconfig.build.json",
+    "build:watch": "tsup --tsconfig tsconfig.build.json --watch",
+    "clean": "del-cli dist docs",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/190-amazon-transcribe.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "type-check": "tsc --noEmit",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run",
+    "test:node:watch": "vitest --config vitest.node.config.js --watch"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*",
+    "aws4fetch": "^1.0.20"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.6.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/amazon-transcribe"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/amazon-transcribe/src/__fixtures__/transcript.json
+++ b/packages/amazon-transcribe/src/__fixtures__/transcript.json
@@ -1,0 +1,48 @@
+{
+  "jobName": "test-job",
+  "accountId": "123456789012",
+  "status": "COMPLETED",
+  "results": {
+    "language_code": "en-US",
+    "transcripts": [{ "transcript": "Hello from the AI SDK." }],
+    "audio_segments": [
+      {
+        "id": 0,
+        "transcript": "Hello from the AI SDK.",
+        "start_time": "0.0",
+        "end_time": "1.85",
+        "items": [0, 1, 2, 3, 4, 5]
+      }
+    ],
+    "items": [
+      {
+        "type": "pronunciation",
+        "start_time": "0.0",
+        "end_time": "0.5",
+        "alternatives": [{ "confidence": "0.999", "content": "Hello" }]
+      },
+      {
+        "type": "pronunciation",
+        "start_time": "0.5",
+        "end_time": "0.8",
+        "alternatives": [{ "confidence": "0.999", "content": "from" }]
+      },
+      {
+        "type": "pronunciation",
+        "start_time": "0.8",
+        "end_time": "1.0",
+        "alternatives": [{ "confidence": "0.999", "content": "the" }]
+      },
+      {
+        "type": "pronunciation",
+        "start_time": "1.0",
+        "end_time": "1.85",
+        "alternatives": [{ "confidence": "0.999", "content": "AI SDK" }]
+      },
+      {
+        "type": "punctuation",
+        "alternatives": [{ "confidence": "0.0", "content": "." }]
+      }
+    ]
+  }
+}

--- a/packages/amazon-transcribe/src/amazon-transcribe-config.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-config.ts
@@ -1,0 +1,48 @@
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+
+export type AmazonTranscribeConfig = {
+  provider: string;
+
+  /**
+   * Resolves the AWS region the provider is configured for.
+   */
+  region: () => string;
+
+  /**
+   * Base URL for the Amazon Transcribe API
+   * (e.g. `https://transcribe.us-east-1.amazonaws.com`).
+   */
+  transcribeBaseUrl: () => string;
+
+  /**
+   * Builds the path-style S3 object URL for the given bucket and key
+   * (e.g. `https://s3.us-east-1.amazonaws.com/bucket/key`).
+   */
+  s3ObjectUrl: (options: { bucket: string; key: string }) => string;
+
+  /**
+   * Static headers to include in every request.
+   */
+  headers: () => Record<string, string | undefined>;
+
+  /**
+   * SigV4-signing fetch scoped to the `transcribe` service.
+   */
+  transcribeFetch: FetchFunction;
+
+  /**
+   * SigV4-signing fetch scoped to the `s3` service.
+   */
+  s3Fetch: FetchFunction;
+
+  /**
+   * Unsigned fetch used for downloading service-managed pre-signed transcript URLs.
+   */
+  fetch?: FetchFunction;
+
+  generateId: () => string;
+
+  _internal?: {
+    currentDate?: () => Date;
+  };
+};

--- a/packages/amazon-transcribe/src/amazon-transcribe-error.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-error.ts
@@ -1,0 +1,21 @@
+import { AISDKError } from '@ai-sdk/provider';
+
+const name = 'AI_AmazonTranscribeError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Error thrown when the Amazon Transcribe API returns an error or a
+ * transcription job cannot be completed.
+ */
+export class AmazonTranscribeError extends AISDKError {
+  private readonly [symbol] = true;
+
+  constructor({ message, cause }: { message: string; cause?: unknown }) {
+    super({ name, message, cause });
+  }
+
+  static isInstance(error: unknown): error is AmazonTranscribeError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/amazon-transcribe/src/amazon-transcribe-provider.test.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-provider.test.ts
@@ -1,0 +1,42 @@
+import { NoSuchModelError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { createAmazonTranscribe } from './amazon-transcribe-provider';
+import { AmazonTranscribeTranscriptionModel } from './amazon-transcribe-transcription-model';
+
+const provider = createAmazonTranscribe({
+  region: 'us-east-1',
+  accessKeyId: 'test-access-key-id',
+  secretAccessKey: 'test-secret-access-key',
+});
+
+describe('createAmazonTranscribe', () => {
+  it('creates a transcription model via the factory method', () => {
+    const model = provider.transcription();
+    expect(model).toBeInstanceOf(AmazonTranscribeTranscriptionModel);
+    expect(model.modelId).toBe('default');
+    expect(model.provider).toBe('amazon-transcribe.transcription');
+  });
+
+  it('creates a transcription model when called directly', () => {
+    const model = provider('default');
+    expect(model).toBeInstanceOf(AmazonTranscribeTranscriptionModel);
+  });
+
+  it('passes a custom model id through as the model id', () => {
+    const model = provider.transcriptionModel('my-custom-language-model');
+    expect(model.modelId).toBe('my-custom-language-model');
+  });
+
+  it('throws when constructed with the new keyword', () => {
+    expect(() => {
+      // @ts-expect-error - testing runtime guard
+      new provider('default');
+    }).toThrow();
+  });
+
+  it('throws NoSuchModelError for unsupported model types', () => {
+    expect(() => provider.languageModel('x')).toThrow(NoSuchModelError);
+    expect(() => provider.imageModel('x')).toThrow(NoSuchModelError);
+    expect(() => provider.embeddingModel('x')).toThrow(NoSuchModelError);
+  });
+});

--- a/packages/amazon-transcribe/src/amazon-transcribe-provider.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-provider.ts
@@ -1,0 +1,234 @@
+import {
+  NoSuchModelError,
+  type ProviderV4,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
+import {
+  generateId,
+  loadOptionalSetting,
+  loadSetting,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import type { AmazonTranscribeConfig } from './amazon-transcribe-config';
+import {
+  createAmazonTranscribeSigV4FetchFunction,
+  type AmazonTranscribeCredentials,
+} from './amazon-transcribe-sigv4-fetch';
+import { AmazonTranscribeTranscriptionModel } from './amazon-transcribe-transcription-model';
+import type { AmazonTranscribeTranscriptionModelId } from './amazon-transcribe-transcription-options';
+import { VERSION } from './version';
+
+export interface AmazonTranscribeProviderSettings {
+  /**
+   * The AWS region to use for Amazon Transcribe. Defaults to the value of the
+   * `AWS_REGION` environment variable.
+   */
+  region?: string;
+
+  /**
+   * The AWS access key ID. Defaults to the value of the `AWS_ACCESS_KEY_ID`
+   * environment variable.
+   */
+  accessKeyId?: string;
+
+  /**
+   * The AWS secret access key. Defaults to the value of the
+   * `AWS_SECRET_ACCESS_KEY` environment variable.
+   */
+  secretAccessKey?: string;
+
+  /**
+   * The AWS session token. When `accessKeyId` and `secretAccessKey` are both
+   * passed explicitly, only this field is used. Otherwise it falls back to the
+   * `AWS_SESSION_TOKEN` environment variable.
+   */
+  sessionToken?: string;
+
+  /**
+   * The AWS credential provider to use to get dynamic credentials (similar to
+   * the AWS SDK). When set, its credential values are used instead of the
+   * `accessKeyId`, `secretAccessKey`, and `sessionToken` settings.
+   */
+  credentialProvider?: () => PromiseLike<
+    Omit<AmazonTranscribeCredentials, 'region'>
+  >;
+
+  /**
+   * Base URL for the Amazon Transcribe API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept
+   * requests, or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+
+  // for testing
+  generateId?: () => string;
+}
+
+export interface AmazonTranscribeProvider extends ProviderV4 {
+  (modelId?: AmazonTranscribeTranscriptionModelId): TranscriptionModelV4;
+
+  /**
+   * Creates a model for transcription.
+   */
+  transcription(
+    modelId?: AmazonTranscribeTranscriptionModelId,
+  ): TranscriptionModelV4;
+
+  /**
+   * Creates a model for transcription.
+   */
+  transcriptionModel(
+    modelId?: AmazonTranscribeTranscriptionModelId,
+  ): TranscriptionModelV4;
+}
+
+/**
+ * Create an Amazon Transcribe provider instance.
+ */
+export function createAmazonTranscribe(
+  options: AmazonTranscribeProviderSettings = {},
+): AmazonTranscribeProvider {
+  const getRegion = (): string =>
+    loadSetting({
+      settingValue: options.region,
+      settingName: 'region',
+      environmentVariableName: 'AWS_REGION',
+      description: 'AWS region',
+    });
+
+  const getCredentials = async (): Promise<AmazonTranscribeCredentials> => {
+    const region = getRegion();
+
+    if (options.credentialProvider) {
+      return { ...(await options.credentialProvider()), region };
+    }
+
+    return {
+      region,
+      accessKeyId: loadSetting({
+        settingValue: options.accessKeyId,
+        settingName: 'accessKeyId',
+        environmentVariableName: 'AWS_ACCESS_KEY_ID',
+        description: 'AWS access key ID',
+      }),
+      secretAccessKey: loadSetting({
+        settingValue: options.secretAccessKey,
+        settingName: 'secretAccessKey',
+        environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
+        description: 'AWS secret access key',
+      }),
+      sessionToken:
+        options.accessKeyId != null && options.secretAccessKey != null
+          ? options.sessionToken
+          : loadOptionalSetting({
+              settingValue: options.sessionToken,
+              environmentVariableName: 'AWS_SESSION_TOKEN',
+            }),
+    };
+  };
+
+  const transcribeFetch = createAmazonTranscribeSigV4FetchFunction(
+    getCredentials,
+    'transcribe',
+    options.fetch,
+  );
+  const s3Fetch = createAmazonTranscribeSigV4FetchFunction(
+    getCredentials,
+    's3',
+    options.fetch,
+  );
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      options.headers ?? {},
+      `ai-sdk/amazon-transcribe/${VERSION}`,
+    );
+
+  const getTranscribeBaseUrl = (): string =>
+    withoutTrailingSlash(
+      options.baseURL ?? `https://transcribe.${getRegion()}.amazonaws.com`,
+    ) ?? `https://transcribe.${getRegion()}.amazonaws.com`;
+
+  const config: AmazonTranscribeConfig = {
+    provider: 'amazon-transcribe.transcription',
+    region: getRegion,
+    transcribeBaseUrl: getTranscribeBaseUrl,
+    s3ObjectUrl: ({ bucket, key }) =>
+      `https://s3.${getRegion()}.amazonaws.com/${bucket}/${encodeS3Key(key)}`,
+    headers: getHeaders,
+    transcribeFetch,
+    s3Fetch,
+    fetch: options.fetch,
+    generateId: options.generateId ?? generateId,
+  };
+
+  const createTranscriptionModel = (
+    modelId: AmazonTranscribeTranscriptionModelId = 'default',
+  ) => new AmazonTranscribeTranscriptionModel(modelId, config);
+
+  const provider = function (
+    modelId: AmazonTranscribeTranscriptionModelId = 'default',
+  ) {
+    if (new.target) {
+      throw new Error(
+        'The Amazon Transcribe model function cannot be called with the new keyword.',
+      );
+    }
+
+    return createTranscriptionModel(modelId);
+  };
+
+  provider.specificationVersion = 'v4' as const;
+  provider.transcription = createTranscriptionModel;
+  provider.transcriptionModel = createTranscriptionModel;
+
+  provider.languageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'languageModel',
+      message: 'Amazon Transcribe does not provide language models',
+    });
+  };
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+      message: 'Amazon Transcribe does not provide text embedding models',
+    });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'imageModel',
+      message: 'Amazon Transcribe does not provide image models',
+    });
+  };
+
+  return provider as AmazonTranscribeProvider;
+}
+
+function encodeS3Key(key: string): string {
+  return key
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+}
+
+/**
+ * Default Amazon Transcribe provider instance.
+ */
+export const amazonTranscribe = createAmazonTranscribe();

--- a/packages/amazon-transcribe/src/amazon-transcribe-sigv4-fetch.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-sigv4-fetch.ts
@@ -1,0 +1,89 @@
+import {
+  combineHeaders,
+  getRuntimeEnvironmentUserAgent,
+  normalizeHeaders,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { AwsV4Signer } from 'aws4fetch';
+import { VERSION } from './version';
+
+export interface AmazonTranscribeCredentials {
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+/**
+ * Creates a fetch function that applies AWS Signature Version 4 signing for a
+ * specific AWS service (e.g. `transcribe` or `s3`).
+ *
+ * Unlike a POST-only signer, this signs all HTTP methods (GET/PUT/POST/...) so
+ * it can be used both for the Amazon Transcribe JSON API and for uploading the
+ * audio to / downloading the transcript from Amazon S3.
+ *
+ * @param getCredentials - Function that returns the AWS credentials to use when signing.
+ * @param service - The AWS service name to use for the SigV4 signing scope.
+ * @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+ * @returns A FetchFunction that signs requests before passing them to the underlying fetch.
+ */
+export function createAmazonTranscribeSigV4FetchFunction(
+  getCredentials: () =>
+    | AmazonTranscribeCredentials
+    | PromiseLike<AmazonTranscribeCredentials>,
+  service: string,
+  fetch?: FetchFunction,
+): FetchFunction {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    // avoid caching globalThis.fetch in case it is patched by other libraries
+    const effectiveFetch = fetch ?? globalThis.fetch;
+
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+
+    const method = (init?.method ?? 'GET').toUpperCase();
+
+    const headersWithUserAgent = withUserAgentSuffix(
+      normalizeHeaders(init?.headers),
+      `ai-sdk/amazon-transcribe/${VERSION}`,
+      getRuntimeEnvironmentUserAgent(),
+    );
+
+    // aws4fetch derives x-amz-content-sha256 from the body (string or binary).
+    const body = init?.body ?? undefined;
+
+    const credentials = await getCredentials();
+    const signer = new AwsV4Signer({
+      url,
+      method,
+      headers: Object.entries(headersWithUserAgent),
+      body,
+      region: credentials.region,
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
+      service,
+    });
+
+    const signingResult = await signer.sign();
+    const signedHeaders = normalizeHeaders(signingResult.headers);
+
+    return effectiveFetch(url, {
+      ...init,
+      method,
+      body,
+      headers: combineHeaders(
+        headersWithUserAgent,
+        signedHeaders,
+      ) as HeadersInit,
+    });
+  };
+}

--- a/packages/amazon-transcribe/src/amazon-transcribe-transcription-model-options.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-transcription-model-options.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod/v4';
+
+/**
+ * Provider options for Amazon Transcribe batch transcription.
+ *
+ * Amazon Transcribe reads audio from and (optionally) writes results to Amazon
+ * S3. Because the AI SDK `transcribe()` function provides raw audio bytes, the
+ * provider uploads the audio to the configured `inputBucket` before starting a
+ * transcription job.
+ *
+ * @see https://docs.aws.amazon.com/transcribe/latest/APIReference/API_StartTranscriptionJob.html
+ */
+export const amazonTranscribeTranscriptionModelOptionsSchema = z.object({
+  /**
+   * Name of the S3 bucket the audio is uploaded to and that Amazon Transcribe
+   * reads the audio from. Required.
+   */
+  inputBucket: z.string(),
+
+  /**
+   * Optional key prefix (folder) for the uploaded audio object. The generated
+   * object key is `${inputKeyPrefix}${jobName}.${extension}`.
+   */
+  inputKeyPrefix: z.string().optional(),
+
+  /**
+   * Name of the S3 bucket Amazon Transcribe writes the transcript to. When
+   * omitted, a service-managed bucket is used and a pre-signed download URL is
+   * returned by the API.
+   */
+  outputBucket: z.string().optional(),
+
+  /**
+   * The object key for the transcription output within `outputBucket`.
+   */
+  outputKey: z.string().optional(),
+
+  /**
+   * The name to assign to the transcription job. Must be unique within the AWS
+   * account. When omitted, a unique name is generated.
+   */
+  transcriptionJobName: z.string().optional(),
+
+  /**
+   * The language code of the audio, e.g. `'en-US'`. Mutually exclusive with
+   * `identifyLanguage` / `identifyMultipleLanguages`. When none of these are
+   * set, automatic single-language identification is enabled.
+   */
+  languageCode: z.string().optional(),
+
+  /**
+   * Enables automatic identification of the single language spoken in the audio.
+   * Defaults to `true` when neither `languageCode` nor
+   * `identifyMultipleLanguages` is set; pass `false` to disable it.
+   */
+  identifyLanguage: z.boolean().optional(),
+
+  /**
+   * Enables automatic identification of multiple languages spoken in the audio.
+   */
+  identifyMultipleLanguages: z.boolean().optional(),
+
+  /**
+   * Restricts automatic language identification to the provided language codes.
+   */
+  languageOptions: z.array(z.string()).optional(),
+
+  /**
+   * The format of the input media (e.g. `'mp3'`, `'mp4'`, `'wav'`, `'flac'`,
+   * `'ogg'`, `'amr'`, `'webm'`). When omitted, it is inferred from the audio
+   * media type.
+   */
+  mediaFormat: z.string().optional(),
+
+  /**
+   * Sample rate of the audio in Hertz.
+   */
+  mediaSampleRateHertz: z.number().optional(),
+
+  /**
+   * Additional `Settings` passed through to `StartTranscriptionJob`
+   * (e.g. `ShowSpeakerLabels`, `MaxSpeakerLabels`, `VocabularyName`).
+   *
+   * @see https://docs.aws.amazon.com/transcribe/latest/APIReference/API_Settings.html
+   */
+  settings: z.record(z.string(), z.unknown()).optional(),
+
+  /**
+   * Interval in milliseconds between transcription job status polls.
+   * Defaults to 3000.
+   */
+  pollIntervalMillis: z.number().optional(),
+
+  /**
+   * Maximum time in milliseconds to wait for the transcription job to complete
+   * before timing out. Defaults to 600000 (10 minutes).
+   */
+  maxPollDurationMillis: z.number().optional(),
+});
+
+export type AmazonTranscribeTranscriptionModelOptions = z.infer<
+  typeof amazonTranscribeTranscriptionModelOptionsSchema
+>;

--- a/packages/amazon-transcribe/src/amazon-transcribe-transcription-model.test.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-transcription-model.test.ts
@@ -1,0 +1,243 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAmazonTranscribe } from './amazon-transcribe-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const audioData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+
+const TRANSCRIBE_URL = 'https://transcribe.us-east-1.amazonaws.com/';
+const S3_UPLOAD_URL =
+  'https://s3.us-east-1.amazonaws.com/input-bucket/test-job.wav';
+const TRANSCRIPT_URL =
+  'https://s3.us-east-1.amazonaws.com/output-bucket/test-job.json';
+
+const provider = createAmazonTranscribe({
+  region: 'us-east-1',
+  accessKeyId: 'test-access-key-id',
+  secretAccessKey: 'test-secret-access-key',
+});
+const model = provider.transcription('default');
+
+const providerOptions = {
+  amazonTranscribe: {
+    inputBucket: 'input-bucket',
+    outputBucket: 'output-bucket',
+    transcriptionJobName: 'test-job',
+    languageCode: 'en-US',
+    pollIntervalMillis: 1,
+  },
+};
+
+const server = createTestServer({
+  [S3_UPLOAD_URL]: {},
+  [TRANSCRIBE_URL]: {},
+  [TRANSCRIPT_URL]: {},
+});
+
+// The test server indexes array responses by a GLOBAL call counter, so we use a
+// function response with a per-endpoint counter to distinguish the
+// StartTranscriptionJob call from the subsequent GetTranscriptionJob polls.
+function prepareTranscribeResponses(
+  statuses: string[],
+  headers?: Record<string, string>,
+) {
+  let call = 0;
+  server.urls[TRANSCRIBE_URL].response = () => {
+    const index = call++;
+    if (index === 0) {
+      return {
+        type: 'json-value',
+        headers,
+        body: {
+          TranscriptionJob: {
+            TranscriptionJobName: 'test-job',
+            TranscriptionJobStatus: 'IN_PROGRESS',
+          },
+        },
+      };
+    }
+
+    const status = statuses[Math.min(index - 1, statuses.length - 1)];
+    return {
+      type: 'json-value',
+      headers,
+      body: {
+        TranscriptionJob: {
+          TranscriptionJobName: 'test-job',
+          TranscriptionJobStatus: status,
+          LanguageCode: 'en-US',
+          FailureReason:
+            status === 'FAILED' ? 'Invalid media format' : undefined,
+          Transcript:
+            status === 'COMPLETED'
+              ? { TranscriptFileUri: TRANSCRIPT_URL }
+              : undefined,
+        },
+      },
+    };
+  };
+}
+
+function prepareResponses({
+  statuses = ['COMPLETED'],
+  headers,
+}: { statuses?: string[]; headers?: Record<string, string> } = {}) {
+  server.urls[S3_UPLOAD_URL].response = {
+    type: 'json-value',
+    body: {},
+  };
+
+  prepareTranscribeResponses(statuses, headers);
+
+  server.urls[TRANSCRIPT_URL].response = {
+    type: 'json-value',
+    body: JSON.parse(
+      fs.readFileSync('src/__fixtures__/transcript.json', 'utf8'),
+    ),
+  };
+}
+
+describe('doGenerate', () => {
+  beforeEach(() => prepareResponses());
+
+  it('uploads the audio to the configured S3 bucket', async () => {
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions,
+    });
+
+    expect(server.calls[0].requestMethod).toBe('PUT');
+    expect(server.calls[0].requestUrl).toBe(S3_UPLOAD_URL);
+  });
+
+  it('starts a transcription job with the media file URI', async () => {
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions,
+    });
+
+    expect(server.calls[1].requestUrl).toBe(TRANSCRIBE_URL);
+    expect(server.calls[1].requestHeaders['x-amz-target']).toBe(
+      'Transcribe.StartTranscriptionJob',
+    );
+    expect(await server.calls[1].requestBodyJson).toMatchObject({
+      TranscriptionJobName: 'test-job',
+      Media: { MediaFileUri: 's3://input-bucket/test-job.wav' },
+      LanguageCode: 'en-US',
+      MediaFormat: 'wav',
+      OutputBucketName: 'output-bucket',
+    });
+  });
+
+  it('enables single-language identification when no language is provided', async () => {
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        amazonTranscribe: {
+          inputBucket: 'input-bucket',
+          transcriptionJobName: 'test-job',
+        },
+      },
+    });
+
+    const body = await server.calls[1].requestBodyJson;
+    expect(body.IdentifyLanguage).toBe(true);
+    expect(body.LanguageCode).toBeUndefined();
+  });
+
+  it('does not enable language identification when identifyLanguage is false', async () => {
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        amazonTranscribe: {
+          inputBucket: 'input-bucket',
+          transcriptionJobName: 'test-job',
+          identifyLanguage: false,
+        },
+      },
+    });
+
+    const body = await server.calls[1].requestBodyJson;
+    expect(body.IdentifyLanguage).toBeUndefined();
+    expect(body.IdentifyMultipleLanguages).toBeUndefined();
+    expect(body.LanguageCode).toBeUndefined();
+  });
+
+  it('polls until the job completes and downloads the transcript', async () => {
+    prepareResponses({ statuses: ['IN_PROGRESS', 'IN_PROGRESS', 'COMPLETED'] });
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions,
+    });
+
+    // PUT, Start, Get x3 (2x IN_PROGRESS + 1x COMPLETED), transcript GET
+    expect(server.calls[2].requestHeaders['x-amz-target']).toBe(
+      'Transcribe.GetTranscriptionJob',
+    );
+    expect(server.calls.at(-1)?.requestUrl).toBe(TRANSCRIPT_URL);
+    expect(result.text).toBe('Hello from the AI SDK.');
+  });
+
+  it('extracts the transcription text, segments and language', async () => {
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions,
+    });
+
+    expect(result.text).toBe('Hello from the AI SDK.');
+    expect(result.language).toBe('en-US');
+    expect(result.durationInSeconds).toBe(1.85);
+    expect(result.segments).toEqual([
+      {
+        text: 'Hello from the AI SDK.',
+        startSecond: 0,
+        endSecond: 1.85,
+      },
+    ]);
+  });
+
+  it('throws when the transcription job fails', async () => {
+    prepareResponses({ statuses: ['FAILED'] });
+
+    await expect(
+      model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        providerOptions,
+      }),
+    ).rejects.toThrow('Invalid media format');
+  });
+
+  it('signs requests with a SigV4 authorization header', async () => {
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions,
+    });
+
+    expect(server.calls[0].requestHeaders['authorization']).toContain(
+      'AWS4-HMAC-SHA256',
+    );
+    expect(server.calls[0].requestUserAgent).toContain(
+      'ai-sdk/amazon-transcribe/0.0.0-test',
+    );
+  });
+});
+
+describe('provider', () => {
+  it('throws for unsupported model types', () => {
+    expect(() => provider.languageModel('x')).toThrowError();
+    expect(() => provider.imageModel('x')).toThrowError();
+  });
+});

--- a/packages/amazon-transcribe/src/amazon-transcribe-transcription-model.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-transcription-model.ts
@@ -1,0 +1,500 @@
+import {
+  type SharedV4Warning,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  delay,
+  mediaTypeToExtension,
+  parseProviderOptions,
+  safeParseJSON,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import type { AmazonTranscribeConfig } from './amazon-transcribe-config';
+import { AmazonTranscribeError } from './amazon-transcribe-error';
+import { amazonTranscribeTranscriptionModelOptionsSchema } from './amazon-transcribe-transcription-model-options';
+import type { AmazonTranscribeTranscriptionModelId } from './amazon-transcribe-transcription-options';
+
+const DEFAULT_POLL_INTERVAL_MS = 3000;
+const DEFAULT_MAX_POLL_DURATION_MS = 10 * 60 * 1000;
+
+// Maps common audio media types to Amazon Transcribe `MediaFormat` values.
+const MEDIA_TYPE_TO_FORMAT: Record<string, string> = {
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/mp4': 'mp4',
+  'video/mp4': 'mp4',
+  'audio/wav': 'wav',
+  'audio/wave': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/flac': 'flac',
+  'audio/x-flac': 'flac',
+  'audio/ogg': 'ogg',
+  'audio/webm': 'webm',
+  'video/webm': 'webm',
+  'audio/amr': 'amr',
+};
+
+export class AmazonTranscribeTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  static [WORKFLOW_SERIALIZE](model: AmazonTranscribeTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: AmazonTranscribeTranscriptionModelId;
+    config: AmazonTranscribeConfig;
+  }) {
+    return new AmazonTranscribeTranscriptionModel(
+      options.modelId,
+      options.config,
+    );
+  }
+
+  constructor(
+    readonly modelId: AmazonTranscribeTranscriptionModelId,
+    private readonly config: AmazonTranscribeConfig,
+  ) {}
+
+  private async getArgs({
+    audio,
+    mediaType,
+    providerOptions,
+  }: Parameters<TranscriptionModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+
+    const transcribeOptions = await parseProviderOptions({
+      provider: 'amazonTranscribe',
+      providerOptions,
+      schema: amazonTranscribeTranscriptionModelOptionsSchema,
+    });
+
+    if (transcribeOptions == null) {
+      throw new AmazonTranscribeError({
+        message:
+          'Amazon Transcribe requires provider options. Provide at least ' +
+          '`providerOptions.amazonTranscribe.inputBucket` (the S3 bucket used to stage the audio).',
+      });
+    }
+
+    const audioBytes =
+      typeof audio === 'string' ? convertBase64ToUint8Array(audio) : audio;
+
+    const jobName =
+      transcribeOptions.transcriptionJobName ??
+      `ai-sdk-${this.config.generateId()}`;
+
+    const extension = mediaTypeToExtension(mediaType) ?? 'audio';
+    const inputKey = `${transcribeOptions.inputKeyPrefix ?? ''}${jobName}.${extension}`;
+    const mediaFormat =
+      transcribeOptions.mediaFormat ?? MEDIA_TYPE_TO_FORMAT[mediaType];
+
+    const startJobBody: Record<string, unknown> = {
+      TranscriptionJobName: jobName,
+      Media: {
+        MediaFileUri: `s3://${transcribeOptions.inputBucket}/${inputKey}`,
+      },
+    };
+
+    if (mediaFormat != null) {
+      startJobBody.MediaFormat = mediaFormat;
+    }
+
+    if (transcribeOptions.mediaSampleRateHertz != null) {
+      startJobBody.MediaSampleRateHertz =
+        transcribeOptions.mediaSampleRateHertz;
+    }
+
+    // Language selection. Amazon Transcribe requires exactly one of
+    // LanguageCode, IdentifyLanguage, or IdentifyMultipleLanguages.
+    if (transcribeOptions.languageCode != null) {
+      startJobBody.LanguageCode = transcribeOptions.languageCode;
+    } else if (transcribeOptions.identifyMultipleLanguages) {
+      startJobBody.IdentifyMultipleLanguages = true;
+      if (transcribeOptions.languageOptions != null) {
+        startJobBody.LanguageOptions = transcribeOptions.languageOptions;
+      }
+    } else if (transcribeOptions.identifyLanguage !== false) {
+      // Default to single-language identification unless explicitly disabled.
+      startJobBody.IdentifyLanguage = true;
+      if (transcribeOptions.languageOptions != null) {
+        startJobBody.LanguageOptions = transcribeOptions.languageOptions;
+      }
+    }
+
+    if (transcribeOptions.outputBucket != null) {
+      startJobBody.OutputBucketName = transcribeOptions.outputBucket;
+      if (transcribeOptions.outputKey != null) {
+        startJobBody.OutputKey = transcribeOptions.outputKey;
+      }
+    }
+
+    if (transcribeOptions.settings != null) {
+      startJobBody.Settings = transcribeOptions.settings;
+    }
+
+    // A non-default model id is treated as a custom language model name.
+    if (this.modelId !== 'default') {
+      startJobBody.ModelSettings = { LanguageModelName: this.modelId };
+    }
+
+    return {
+      audioBytes,
+      mediaType,
+      jobName,
+      inputBucket: transcribeOptions.inputBucket,
+      inputKey,
+      startJobBody,
+      pollIntervalMillis:
+        transcribeOptions.pollIntervalMillis ?? DEFAULT_POLL_INTERVAL_MS,
+      maxPollDurationMillis:
+        transcribeOptions.maxPollDurationMillis ?? DEFAULT_MAX_POLL_DURATION_MS,
+      warnings,
+    };
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const {
+      audioBytes,
+      mediaType,
+      jobName,
+      inputBucket,
+      inputKey,
+      startJobBody,
+      pollIntervalMillis,
+      maxPollDurationMillis,
+      warnings,
+    } = await this.getArgs(options);
+
+    // Upload the audio to S3 so Amazon Transcribe can read it.
+    const uploadUrl = this.config.s3ObjectUrl({
+      bucket: inputBucket,
+      key: inputKey,
+    });
+    const uploadResponse = await this.config.s3Fetch(uploadUrl, {
+      method: 'PUT',
+      headers: combineHeaders(this.config.headers(), options.headers, {
+        'content-type': mediaType,
+      }) as HeadersInit,
+      body: audioBytes,
+      signal: options.abortSignal,
+    });
+
+    if (!uploadResponse.ok) {
+      throw new AmazonTranscribeError({
+        message: `Failed to upload audio to S3 (status ${uploadResponse.status})`,
+        cause: await safeReadText(uploadResponse),
+      });
+    }
+
+    const requestBody = JSON.stringify(startJobBody);
+    await this.callTranscribe('StartTranscriptionJob', requestBody, options);
+
+    // Poll until the job completes or fails.
+    const getJobBody = JSON.stringify({ TranscriptionJobName: jobName });
+    const startTime = Date.now();
+    let job = await this.callTranscribe(
+      'GetTranscriptionJob',
+      getJobBody,
+      options,
+    );
+
+    while (
+      job.value.TranscriptionJob.TranscriptionJobStatus !== 'COMPLETED' &&
+      job.value.TranscriptionJob.TranscriptionJobStatus !== 'FAILED'
+    ) {
+      if (Date.now() - startTime > maxPollDurationMillis) {
+        throw new AmazonTranscribeError({
+          message: `Transcription job '${jobName}' polling timed out`,
+          cause: job.value,
+        });
+      }
+
+      await delay(pollIntervalMillis);
+
+      job = await this.callTranscribe(
+        'GetTranscriptionJob',
+        getJobBody,
+        options,
+      );
+    }
+
+    if (job.value.TranscriptionJob.TranscriptionJobStatus === 'FAILED') {
+      throw new AmazonTranscribeError({
+        message: `Transcription job '${jobName}' failed: ${
+          job.value.TranscriptionJob.FailureReason ?? 'unknown reason'
+        }`,
+        cause: job.value,
+      });
+    }
+
+    const transcriptFileUri =
+      job.value.TranscriptionJob.Transcript?.TranscriptFileUri;
+
+    if (transcriptFileUri == null) {
+      throw new AmazonTranscribeError({
+        message: `Transcription job '${jobName}' completed without a transcript file URI`,
+        cause: job.value,
+      });
+    }
+
+    const transcript = await this.downloadTranscript(
+      transcriptFileUri,
+      options.abortSignal,
+    );
+
+    const result = mapTranscript(transcript);
+
+    return {
+      text: result.text,
+      segments: result.segments,
+      language:
+        transcript.results?.language_code ??
+        job.value.TranscriptionJob.LanguageCode ??
+        undefined,
+      durationInSeconds: result.durationInSeconds,
+      warnings,
+      request: { body: requestBody },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: job.headers,
+        body: transcript,
+      },
+      providerMetadata: {
+        amazonTranscribe: {
+          transcriptionJobName: jobName,
+        },
+      },
+    };
+  }
+
+  private async callTranscribe(
+    target: 'StartTranscriptionJob' | 'GetTranscriptionJob',
+    body: string,
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<{
+    value: TranscriptionJobResponse;
+    headers: Record<string, string>;
+  }> {
+    const response = await this.config.transcribeFetch(
+      this.config.transcribeBaseUrl(),
+      {
+        method: 'POST',
+        headers: combineHeaders(this.config.headers(), options.headers, {
+          'content-type': 'application/x-amz-json-1.1',
+          'x-amz-target': `Transcribe.${target}`,
+        }) as HeadersInit,
+        body,
+        signal: options.abortSignal,
+      },
+    );
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw new AmazonTranscribeError({
+        message: `Amazon Transcribe ${target} failed (status ${response.status})`,
+        cause: text,
+      });
+    }
+
+    const parsed = await safeParseJSON({
+      text,
+      schema: transcriptionJobResponseSchema,
+    });
+
+    if (!parsed.success) {
+      throw new AmazonTranscribeError({
+        message: `Failed to parse Amazon Transcribe ${target} response`,
+        cause: parsed.error,
+      });
+    }
+
+    return { value: parsed.value, headers: headersToRecord(response.headers) };
+  }
+
+  private async downloadTranscript(
+    uri: string,
+    abortSignal: AbortSignal | undefined,
+  ): Promise<TranscriptFile> {
+    // Service-managed output buckets return pre-signed URLs which must not be
+    // re-signed. Customer-owned output buckets return plain S3 object URLs.
+    const isPreSigned = /[?&]X-Amz-(Signature|Credential)=/.test(uri);
+    const fetchImpl = isPreSigned
+      ? (this.config.fetch ?? globalThis.fetch)
+      : this.config.s3Fetch;
+
+    const response = await fetchImpl(uri, {
+      method: 'GET',
+      signal: abortSignal,
+    });
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw new AmazonTranscribeError({
+        message: `Failed to download transcript (status ${response.status})`,
+        cause: text,
+      });
+    }
+
+    const parsed = await safeParseJSON({ text, schema: transcriptFileSchema });
+
+    if (!parsed.success) {
+      throw new AmazonTranscribeError({
+        message: 'Failed to parse Amazon Transcribe transcript file',
+        cause: parsed.error,
+      });
+    }
+
+    return parsed.value;
+  }
+}
+
+function mapTranscript(transcript: TranscriptFile): {
+  text: string;
+  segments: Array<{ text: string; startSecond: number; endSecond: number }>;
+  durationInSeconds: number | undefined;
+} {
+  const results = transcript.results;
+  const text = results?.transcripts?.[0]?.transcript ?? '';
+
+  const segments: Array<{
+    text: string;
+    startSecond: number;
+    endSecond: number;
+  }> = [];
+  let durationInSeconds: number | undefined;
+
+  // Prefer the segment-level output when available.
+  if (results?.audio_segments?.length) {
+    for (const segment of results.audio_segments) {
+      const startSecond = toSeconds(segment.start_time);
+      const endSecond = toSeconds(segment.end_time);
+
+      if (segment.transcript != null) {
+        segments.push({
+          text: segment.transcript,
+          startSecond: startSecond ?? 0,
+          endSecond: endSecond ?? startSecond ?? 0,
+        });
+      }
+
+      if (endSecond != null) {
+        durationInSeconds = Math.max(durationInSeconds ?? 0, endSecond);
+      }
+    }
+  } else if (results?.items?.length) {
+    // Fall back to word-level items.
+    for (const item of results.items) {
+      const startSecond = toSeconds(item.start_time);
+      const endSecond = toSeconds(item.end_time);
+      const content = item.alternatives?.[0]?.content;
+
+      if (item.type === 'pronunciation' && content != null) {
+        segments.push({
+          text: content,
+          startSecond: startSecond ?? 0,
+          endSecond: endSecond ?? startSecond ?? 0,
+        });
+      }
+
+      if (endSecond != null) {
+        durationInSeconds = Math.max(durationInSeconds ?? 0, endSecond);
+      }
+    }
+  }
+
+  return { text, segments, durationInSeconds };
+}
+
+function toSeconds(value: string | null | undefined): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+async function safeReadText(response: Response): Promise<string | undefined> {
+  try {
+    return await response.text();
+  } catch {
+    return undefined;
+  }
+}
+
+const transcriptionJobResponseSchema = z.object({
+  TranscriptionJob: z.object({
+    TranscriptionJobName: z.string().nullish(),
+    TranscriptionJobStatus: z.string().nullish(),
+    LanguageCode: z.string().nullish(),
+    MediaFormat: z.string().nullish(),
+    FailureReason: z.string().nullish(),
+    Transcript: z
+      .object({
+        TranscriptFileUri: z.string().nullish(),
+      })
+      .nullish(),
+  }),
+});
+
+type TranscriptionJobResponse = z.infer<typeof transcriptionJobResponseSchema>;
+
+const transcriptFileSchema = z.object({
+  results: z
+    .object({
+      transcripts: z
+        .array(z.object({ transcript: z.string().nullish() }))
+        .nullish(),
+      items: z
+        .array(
+          z.object({
+            type: z.string().nullish(),
+            start_time: z.string().nullish(),
+            end_time: z.string().nullish(),
+            alternatives: z
+              .array(z.object({ content: z.string().nullish() }))
+              .nullish(),
+          }),
+        )
+        .nullish(),
+      audio_segments: z
+        .array(
+          z.object({
+            transcript: z.string().nullish(),
+            start_time: z.string().nullish(),
+            end_time: z.string().nullish(),
+          }),
+        )
+        .nullish(),
+      language_code: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+type TranscriptFile = z.infer<typeof transcriptFileSchema>;

--- a/packages/amazon-transcribe/src/amazon-transcribe-transcription-options.ts
+++ b/packages/amazon-transcribe/src/amazon-transcribe-transcription-options.ts
@@ -1,0 +1,9 @@
+/**
+ * Amazon Transcribe does not expose distinct named models for batch
+ * transcription; behavior is controlled through provider options (language,
+ * settings, custom language models, etc.).
+ *
+ * Use `'default'` for the standard batch transcription engine. A custom
+ * Amazon Transcribe language model name can also be supplied.
+ */
+export type AmazonTranscribeTranscriptionModelId = 'default' | (string & {});

--- a/packages/amazon-transcribe/src/index.ts
+++ b/packages/amazon-transcribe/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  createAmazonTranscribe,
+  amazonTranscribe,
+} from './amazon-transcribe-provider';
+export type {
+  AmazonTranscribeProvider,
+  AmazonTranscribeProviderSettings,
+} from './amazon-transcribe-provider';
+export type { AmazonTranscribeTranscriptionModelId } from './amazon-transcribe-transcription-options';
+export type { AmazonTranscribeTranscriptionModelOptions } from './amazon-transcribe-transcription-model-options';
+export { AmazonTranscribeError } from './amazon-transcribe-error';
+export { VERSION } from './version';

--- a/packages/amazon-transcribe/src/version.ts
+++ b/packages/amazon-transcribe/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/amazon-transcribe/tsconfig.build.json
+++ b/packages/amazon-transcribe/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/amazon-transcribe/tsconfig.json
+++ b/packages/amazon-transcribe/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/amazon-transcribe/tsup.config.ts
+++ b/packages/amazon-transcribe/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/amazon-transcribe/turbo.json
+++ b/packages/amazon-transcribe/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/amazon-transcribe/vitest.edge.config.js
+++ b/packages/amazon-transcribe/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/amazon-transcribe/vitest.node.config.js
+++ b/packages/amazon-transcribe/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@ai-sdk/amazon-bedrock':
         specifier: workspace:*
         version: link:../../packages/amazon-bedrock
+      '@ai-sdk/amazon-transcribe':
+        specifier: workspace:*
+        version: link:../../packages/amazon-transcribe
       '@ai-sdk/anthropic':
         specifier: workspace:*
         version: link:../../packages/anthropic
@@ -1534,7 +1537,7 @@ importers:
         version: 3.5.12
       nuxt:
         specifier: 3.21.7
-        version: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       tailwindcss:
         specifier: 3.4.15
         version: 3.4.15(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3))
@@ -1733,6 +1736,37 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/amazon-transcribe:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(typescript@5.6.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -2026,7 +2060,7 @@ importers:
         version: 4.4.3(supports-color@8.1.1)
       jscodeshift:
         specifier: ^17.3.0
-        version: 17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.0))
+        version: 17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.7))
     devDependencies:
       '@types/cli-progress':
         specifier: ^3.11.6
@@ -22106,9 +22140,9 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
@@ -22125,9 +22159,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -22187,6 +22221,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
@@ -22226,9 +22270,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
       '@babel/traverse': 7.29.0
@@ -22336,9 +22380,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
@@ -22350,9 +22394,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22361,9 +22405,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22376,12 +22420,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -22394,9 +22438,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
@@ -22416,9 +22460,9 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
@@ -22456,9 +22500,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22466,12 +22510,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7)':
     dependencies:
@@ -22559,10 +22597,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22571,9 +22609,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22586,11 +22624,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -22605,12 +22643,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -22620,9 +22658,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22631,9 +22669,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22653,6 +22691,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
@@ -22661,10 +22708,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -22682,14 +22729,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -22701,9 +22748,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
     optional: true
@@ -22716,9 +22763,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
@@ -22731,10 +22778,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22743,9 +22790,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22755,10 +22802,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22767,9 +22814,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22781,11 +22828,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -22795,9 +22842,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22806,9 +22853,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22826,9 +22873,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -22844,9 +22891,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
@@ -22859,9 +22906,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22870,9 +22917,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22881,9 +22928,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22892,9 +22939,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22906,10 +22953,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -22931,6 +22978,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
@@ -22941,10 +22997,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
@@ -22960,10 +23016,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -22975,10 +23031,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -22987,9 +23043,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23003,14 +23059,20 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+    optional: true
+
   '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23025,13 +23087,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -23045,11 +23107,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -23059,9 +23121,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23081,14 +23143,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23108,6 +23179,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
@@ -23117,11 +23197,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -23132,9 +23212,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23153,9 +23233,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23165,10 +23245,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23177,9 +23257,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23200,9 +23280,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23214,9 +23294,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -23228,9 +23308,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23239,9 +23319,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23250,9 +23330,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23294,9 +23374,9 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23306,10 +23386,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23319,10 +23399,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23332,10 +23412,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -23415,77 +23495,77 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-env@7.28.3(@babel/core@7.29.0)':
+  '@babel/preset-env@7.28.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -23506,9 +23586,9 @@ snapshots:
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
@@ -26936,7 +27016,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)':
+  '@nuxt/nitro-server@3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
@@ -26953,8 +27033,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(oxc-parser@0.132.0)(srvx@0.11.16)
-      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
+      nitropack: 2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(encoding@0.1.13)(oxc-parser@0.132.0)(srvx@0.11.16)
+      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -27035,7 +27115,7 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.4': {}
 
-  '@nuxt/vite-builder@3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)
@@ -27054,7 +27134,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -30556,7 +30636,7 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.24.3
 
-  '@vercel/nft@1.10.2(rollup@4.62.0)':
+  '@vercel/nft@1.10.2(encoding@0.1.13)(rollup@4.62.0)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@rollup/pluginutils': 5.4.0(rollup@4.62.0)
@@ -32238,11 +32318,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -32256,10 +32336,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -32272,10 +32352,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -36148,7 +36228,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.0)):
+  jscodeshift@17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.7)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
@@ -36169,7 +36249,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.28.3(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.3(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -37804,7 +37884,7 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  nitropack@2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(oxc-parser@0.132.0)(srvx@0.11.16):
+  nitropack@2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(encoding@0.1.13)(oxc-parser@0.132.0)(srvx@0.11.16):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.0)
@@ -37814,7 +37894,7 @@ snapshots:
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.0)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)
       '@rollup/plugin-terser': 1.0.0(rollup@4.62.0)
-      '@vercel/nft': 1.10.2(rollup@4.62.0)
+      '@vercel/nft': 1.10.2(encoding@0.1.13)(rollup@4.62.0)
       archiver: 7.0.1
       c12: 3.3.4(magicast@0.5.3)
       chokidar: 5.0.0
@@ -38093,16 +38173,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@3.21.7)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
-      '@nuxt/nitro-server': 3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)
+      '@nuxt/nitro-server': 3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)
       '@nuxt/schema': 3.21.7
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@3.21.7(magicast@0.5.3))
-      '@nuxt/vite-builder': 3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.15(vue@3.5.38(typescript@5.9.3))
       '@vue/shared': 3.5.38
       c12: 3.3.4(magicast@0.5.3)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "packages/amazon-bedrock"
     },
     {
+      "path": "packages/amazon-transcribe"
+    },
+    {
       "path": "packages/angular"
     },
     {


### PR DESCRIPTION
## Background

Amazon is missing from the AI SDK's transcription providers. Audio transcription on AWS is handled by **Amazon Transcribe**, a separate service from Amazon Bedrock, so rather than entangling it into `@ai-sdk/amazon-bedrock`, this adds a dedicated transcription-only provider — matching the precedent set by `@ai-sdk/deepgram`, `@ai-sdk/revai`, `@ai-sdk/gladia`, and `@ai-sdk/assemblyai`.

## Summary

Adds a new `@ai-sdk/amazon-transcribe` provider that implements the AI SDK `transcribe()` function via `TranscriptionModelV4`.

- Targets Amazon Transcribe's **batch** API (`StartTranscriptionJob` + polling `GetTranscriptionJob`). Streaming was intentionally left out, as it doesn't fit the one-shot `transcribe()` interface.
- Because `transcribe()` provides raw audio bytes but batch Transcribe reads from S3, the model **uploads the audio to a configured S3 bucket** (`providerOptions.amazonTranscribe.inputBucket`, required) before starting the job, then downloads and parses the resulting transcript.
- Authentication uses **AWS SigV4** via a generalized signer that signs GET/PUT/POST for both the `transcribe` and `s3` services (Bedrock's existing signer is POST-only).
- Returns `text`, `segments` (preferring Transcribe's `audio_segments`, falling back to word-level `items`), `language`, and `durationInSeconds`.
- Supports automatic language identification (single or multiple), custom language models (via a non-`default` model id → `ModelSettings.LanguageModelName`), customer-owned vs. service-managed output buckets, and configurable poll interval / timeout.

Includes the provider package (provider, model, SigV4 fetch, options/error/config, version), unit tests (Node + Edge), an `examples/ai-functions` example, provider documentation, updates to the transcription/provider listing docs, and a changeset.

## Manual Verification

Ran the example against a real AWS account (`examples/ai-functions/src/transcribe/amazon-transcribe/basic.ts`) with `AWS_REGION` / credentials set and `AWS_TRANSCRIBE_INPUT_BUCKET` pointing at an S3 bucket — confirmed the audio is uploaded, the job is started and polled to completion, and the transcript text, segments, language, and duration are returned. Also verified the failure path (invalid media) surfaces the job's `FailureReason`.

Automated: `pnpm test` (12 tests, Node + Edge), `pnpm type-check:full`, and `pnpm check` (oxlint/oxfmt) all pass; `pnpm build` produces ESM + DTS.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A changeset for relevant packages has been added (`major` per the new-provider guide, so the package's first release is `1.0.0`)
- [x] I have reviewed this pull request (self-review)

## Future Work

- **npm package + Trusted Publisher bootstrap** (step 7 of `contributing/add-new-provider.md`) needs a maintainer to set up before the first automated release can publish with provenance.
- Streaming transcription (real-time) could be added later under a separate API surface if there's demand.

## Related Issues

Closes #16505
