### PR TITLE
reproduction: could not reproduce wrapLanguageModel middleware transformParams does not affect streamText provider

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-15704.ts
+++ b/examples/ai-functions/src/reproduction/issue-15704.ts
@@ -1,0 +1,151 @@
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from '@ai-sdk/provider';
+import { generateText, streamText, wrapLanguageModel } from 'ai';
+
+const usage: LanguageModelV3Usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 1,
+    text: 1,
+    reasoning: 1,
+  },
+};
+
+const hasIncludeThoughts = (options: LanguageModelV3CallOptions) =>
+  (
+    options.providerOptions?.google as
+      | { thinkingConfig?: { includeThoughts?: boolean } }
+      | undefined
+  )?.thinkingConfig?.includeThoughts === true;
+
+function streamFromArray<T>(values: T[]): ReadableStream<T> {
+  return new ReadableStream<T>({
+    start(controller) {
+      for (const value of values) {
+        controller.enqueue(value);
+      }
+      controller.close();
+    },
+  });
+}
+
+async function main() {
+  const providerOptionsReached = {
+    generateText: false,
+    streamText: false,
+  };
+
+  const baseModel: LanguageModelV3 = {
+    specificationVersion: 'v3',
+    provider: 'fake-provider',
+    modelId: 'fake-model',
+    supportedUrls: {},
+    async doGenerate(options): Promise<LanguageModelV3GenerateResult> {
+      providerOptionsReached.generateText = hasIncludeThoughts(options);
+
+      return {
+        content: [
+          ...(hasIncludeThoughts(options)
+            ? ([{ type: 'reasoning', text: 'thinking' }] as const)
+            : []),
+          { type: 'text', text: 'hi' },
+        ],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage,
+        warnings: [],
+      };
+    },
+    async doStream(options) {
+      providerOptionsReached.streamText = hasIncludeThoughts(options);
+
+      const parts: LanguageModelV3StreamPart[] = [
+        { type: 'stream-start', warnings: [] },
+        ...(hasIncludeThoughts(options)
+          ? ([
+              { type: 'reasoning-start', id: 'reasoning-1' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'thinking',
+              },
+              { type: 'reasoning-end', id: 'reasoning-1' },
+            ] satisfies LanguageModelV3StreamPart[])
+          : []),
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'hi' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage,
+        },
+      ];
+
+      return { stream: streamFromArray(parts) };
+    },
+  };
+
+  const model = wrapLanguageModel({
+    model: baseModel,
+    middleware: {
+      specificationVersion: 'v3',
+      transformParams: async ({ params }) => {
+        (params.providerOptions ??= {}).google = {
+          thinkingConfig: { includeThoughts: true },
+        };
+        return params;
+      },
+    },
+  });
+
+  console.log('=== generateText ===');
+  const generateResult = await generateText({ model, prompt: 'hi' });
+  const generateHasReasoning = generateResult.reasoning.length > 0;
+  console.log('reasoning:', generateHasReasoning ? 'YES' : 'NO');
+
+  console.log('=== streamText ===');
+  const streamResult = streamText({ model, prompt: 'hi' });
+  for await (const _ of streamResult.fullStream) {
+    // Consume the stream the same way as the issue reproduction.
+  }
+  const streamHasReasoning = (await streamResult.reasoning).length > 0;
+  console.log('reasoning:', streamHasReasoning ? 'YES' : 'NO');
+
+  console.log(
+    JSON.stringify(
+      {
+        providerOptionsReached,
+        reasoning: {
+          generateText: generateHasReasoning,
+          streamText: streamHasReasoning,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (
+    !providerOptionsReached.generateText ||
+    !providerOptionsReached.streamText ||
+    !generateHasReasoning ||
+    !streamHasReasoning
+  ) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

wrapLanguageModel middleware transformParams does not affect streamText provider options

## Reproduction

- Classified #15704 as general library behavior for `wrapLanguageModel` transformed `providerOptions` reaching `streamText`, not as a reduced live-provider case.
- Added runnable reproduction script at `examples/ai-functions/src/reproduction/issue-15704.ts` using a fake `LanguageModelV3` that emits reasoning only when `providerOptions.google.thinkingConfig.includeThoughts` reaches the model.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-15704.ts`; observed `providerOptionsReached.generateText: true`, `providerOptionsReached.streamText: true`, `reasoning.generateText: true`, and `reasoning.streamText: true`.
- The expected issue behavior was `generateText` `reasoning/provider` options present but `streamText` `reasoning/provider` options missing; the script observed `streamText` received the transformed provider options.
- Google Vertex live-service reasoning comparison was not run because Google Vertex live-service checks are skipped by policy.
- Checks passed: `pnpm check`, `pnpm type-check`, `pnpm type-check:full`, and `pnpm -C examples/ai-functions type-check`.
- Attempted `pnpm konsistent:check`; pnpm reported `Command "konsistent:check" not found` in this checkout.

## Related Issues

Could not reproduce #15704