### PR TITLE
reproduction: could not reproduce Temperature is not longert supported on claude 4.7

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts
+++ b/examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts
@@ -1,0 +1,99 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import 'dotenv/config';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+const fixtureUrl = new URL(
+  '../../../../packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json',
+  import.meta.url,
+);
+
+async function main() {
+  let requestBody: unknown;
+  let responseFixture:
+    | {
+        status: number;
+        statusText: string;
+        headers: Record<string, string>;
+        body: unknown;
+      }
+    | undefined;
+
+  function extractFixtureHeaders(headers: Headers) {
+    const fixtureHeaders: Record<string, string> = {};
+
+    headers.forEach((value, name) => {
+      if (['content-type', 'request-id'].includes(name.toLowerCase())) {
+        fixtureHeaders[name] = value;
+      }
+    });
+
+    return fixtureHeaders;
+  }
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      requestBody =
+        typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body;
+
+      const response = await fetch(input, init);
+      const bodyText = await response.clone().text();
+
+      responseFixture = {
+        status: response.status,
+        statusText: response.statusText,
+        headers: extractFixtureHeaders(response.headers),
+        body: bodyText.length > 0 ? JSON.parse(bodyText) : null,
+      };
+
+      return response;
+    },
+  });
+
+  let result: unknown;
+  try {
+    const generation = await generateText({
+      model: anthropic('claude-opus-4-7'),
+      prompt: 'Reply with exactly OK.',
+      maxOutputTokens: 16,
+      temperature: 0.7,
+    });
+
+    result = {
+      ok: true,
+      text: generation.text,
+      warnings: generation.warnings,
+      usage: generation.usage,
+    };
+  } catch (error) {
+    result = {
+      ok: false,
+      error:
+        error instanceof Error
+          ? {
+              name: error.name,
+              message: error.message,
+            }
+          : error,
+    };
+  }
+
+  const fixture = {
+    issue: 14707,
+    model: 'claude-opus-4-7',
+    inputTemperature: 0.7,
+    requestBody,
+    response: responseFixture,
+    result,
+  };
+
+  await mkdir(new URL('.', fixtureUrl), { recursive: true });
+  await writeFile(fixtureUrl, `${JSON.stringify(fixture, null, 2)}\n`);
+
+  console.log(JSON.stringify(fixture, null, 2));
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json
+++ b/packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json
@@ -1,0 +1,80 @@
+{
+  "issue": 14707,
+  "model": "claude-opus-4-7",
+  "inputTemperature": 0.7,
+  "requestBody": {
+    "model": "claude-opus-4-7",
+    "max_tokens": 16,
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Reply with exactly OK."
+          }
+        ]
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": "application/json",
+      "request-id": "req_011CcnjVcHqLqQKPxvPHWZ5U"
+    },
+    "body": {
+      "model": "claude-opus-4-7",
+      "id": "msg_011CcnjVcgeY1HxJJJBmgZBe",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "OK"
+        }
+      ],
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 21,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 6,
+        "output_tokens_details": {
+          "thinking_tokens": 0
+        },
+        "service_tier": "standard",
+        "inference_geo": "global"
+      }
+    }
+  },
+  "result": {
+    "ok": true,
+    "text": "OK",
+    "warnings": [
+      {
+        "type": "unsupported",
+        "feature": "temperature",
+        "details": "temperature is not supported by claude-opus-4-7 and will be ignored"
+      }
+    ],
+    "usage": {
+      "inputTokens": 21,
+      "inputTokenDetails": {
+        "noCacheTokens": 21,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0
+      },
+      "outputTokens": 6,
+      "outputTokenDetails": {},
+      "totalTokens": 27
+    }
+  }
+}


### PR DESCRIPTION
## Bug

Temperature is not longert supported on claude 4.7

## Reproduction

- Classified as provider-specific Anthropic model capability behavior for Claude Opus 4.7 sampling parameters.
- Created runnable reproduction script at `examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts`.
- Exact live-provider command run: `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts`.
- Observed result: the SDK omitted `temperature` from the outgoing `claude-opus-4-7` request, Anthropic returned HTTP 200, and the generated text was `OK`.
- Recorded the live Anthropic `request/response` fixture at `packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json`.
- Expected issue behavior was an Anthropic API error containing ``temperature` is deprecated for this model.` when `temperature: 0.7` is provided.
- Current SDK behavior emits an unsupported-feature warning that `temperature` is ignored instead of sending the unsupported parameter.
- Validation passed with `pnpm -C examples/ai-functions type-check`, `pnpm check`, and `pnpm -C packages/anthropic test:node -- src/anthropic-language-model.test.ts -t "claude-opus-4-7 specific behavior"`.

## Related Issues

Could not reproduce #14707