### PR TITLE
[v6.0] fix: prevent HTTP MCP mid-stream disconnects from crashing the process

### DIFF
--- a/.changeset/tidy-dancers-happen.md
+++ b/.changeset/tidy-dancers-happen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Prevent streamable HTTP MCP background SSE disconnects from surfacing as unhandled promise rejections.

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -392,6 +392,54 @@ describe('HttpMCPTransport', () => {
     expect((error as Error).message).toContain('Failed to parse message');
   });
 
+  it('should handle rejected inbound SSE cancel after stream errors', async () => {
+    const streamError = new TypeError('terminated');
+    let streamController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+
+    const fetch = vi.fn(async () => {
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            streamController = controller;
+          },
+        }),
+        {
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      );
+    });
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      fetch,
+    });
+
+    const errors: unknown[] = [];
+    transport.onerror = error => {
+      errors.push(error);
+    };
+
+    await transport.start();
+
+    await vi.waitFor(() => {
+      expect(streamController).toBeDefined();
+    });
+
+    streamController!.error(streamError);
+
+    await vi.waitFor(() => {
+      expect(errors).toContain(streamError);
+    });
+
+    await transport.close();
+
+    await vi.waitFor(() => {
+      expect(errors.filter(error => error === streamError)).toHaveLength(2);
+    });
+  });
+
   it('should handle non-JSON-RPC response for notifications', async () => {
     server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
       switch (callNumber) {

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -140,7 +140,7 @@ export class HttpMCPTransport implements MCPTransport {
     }
     this.abortController = new AbortController();
 
-    void this.openInboundSse();
+    this.startInboundSse();
   }
 
   async close(): Promise<void> {
@@ -208,7 +208,7 @@ export class HttpMCPTransport implements MCPTransport {
           // If inbound SSE was not available earlier (e.g. 405 before init), try again now
           // Do not await to avoid blocking send()
           if (!this.inboundSseConnection) {
-            void this.openInboundSse();
+            this.startInboundSse();
           }
           return;
         }
@@ -297,7 +297,12 @@ export class HttpMCPTransport implements MCPTransport {
             }
           };
 
-          processEvents();
+          void processEvents().catch(error => {
+            if (error instanceof Error && error.name === 'AbortError') {
+              return;
+            }
+            this.onerror?.(error);
+          });
           return;
         }
 
@@ -342,10 +347,22 @@ export class HttpMCPTransport implements MCPTransport {
 
     const delay = this.getNextReconnectionDelay(this.inboundReconnectAttempts);
     this.inboundReconnectAttempts += 1;
-    setTimeout(async () => {
+    setTimeout(() => {
       if (this.abortController?.signal.aborted) return;
-      await this.openInboundSse(false, this.lastInboundEventId);
+      this.startInboundSse(false, this.lastInboundEventId);
     }, delay);
+  }
+
+  private startInboundSse(
+    triedAuth: boolean = false,
+    resumeToken?: string,
+  ): void {
+    void this.openInboundSse(triedAuth, resumeToken).catch(error => {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+      this.onerror?.(error);
+    });
   }
 
   // Open optional inbound SSE stream; best-effort and resumable
@@ -448,10 +465,25 @@ export class HttpMCPTransport implements MCPTransport {
       };
 
       this.inboundSseConnection = {
-        close: () => reader.cancel(),
+        close: () => {
+          void reader.cancel().catch(error => {
+            if (error instanceof Error && error.name === 'AbortError') {
+              return;
+            }
+            this.onerror?.(error);
+          });
+        },
       };
       this.inboundReconnectAttempts = 0;
-      processEvents();
+      void processEvents().catch(error => {
+        if (error instanceof Error && error.name === 'AbortError') {
+          return;
+        }
+        this.onerror?.(error);
+        if (!this.abortController?.signal.aborted) {
+          this.scheduleInboundSseReconnection();
+        }
+      });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         return;


### PR DESCRIPTION
## Background

Streamable HTTP MCP background SSE failures could escape as unhandled promise rejections after a mid-stream server disconnect, crashing Node processes instead of being contained by the transport error callback.

## Summary

Updated HttpMCPTransport to observe background inbound SSE startup, reconnect, reader-loop, and close/cancel promise rejections and route non-abort errors through the existing onerror path.

## Testing

Added regression coverage for an inbound SSE stream that errors and then rejects during reader cancellation; removed the temporary reproduction script and added a patch changeset.

## Related Issues

Fixes #16541

Backport of #16608

Co-authored-by: jouve <1096799+jouve@users.noreply.github.com>