### PR TITLE
reproduction: could not reproduce Temperature is not longert supported on claude 4.7

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts
+++ b/examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts
@@ -1,0 +1,133 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import 'dotenv/config';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../../..');
+const fixturePath = path.join(
+  repoRoot,
+  'packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json',
+);
+
+function redactHeaders(headers: Headers) {
+  const recordedHeaders = new Set([
+    'anthropic-version',
+    'authorization',
+    'content-type',
+    'date',
+    'request-id',
+    'user-agent',
+    'x-api-key',
+  ]);
+  const redactedHeaders = new Set(['authorization', 'x-api-key']);
+  const result: Record<string, string> = {};
+
+  headers.forEach((value, key) => {
+    if (!recordedHeaders.has(key.toLowerCase())) {
+      return;
+    }
+
+    result[key] = redactedHeaders.has(key.toLowerCase()) ? '[redacted]' : value;
+  });
+
+  return result;
+}
+
+async function readRequestBody(input: RequestInfo | URL, init?: RequestInit) {
+  if (typeof init?.body === 'string') {
+    return init.body;
+  }
+
+  if (input instanceof Request) {
+    return await input.clone().text();
+  }
+}
+
+async function main() {
+  const calls: Array<{
+    request: {
+      url: string;
+      method?: string;
+      headers: Record<string, string>;
+      body?: unknown;
+    };
+    response?: {
+      status: number;
+      headers: Record<string, string>;
+      body: unknown;
+    };
+  }> = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      const requestBodyText = await readRequestBody(input, init);
+      const call: (typeof calls)[number] = {
+        request: {
+          url: request.url,
+          method: request.method,
+          headers: redactHeaders(request.headers),
+          body:
+            requestBodyText == null ? undefined : JSON.parse(requestBodyText),
+        },
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      const responseText = await response.clone().text();
+      call.response = {
+        status: response.status,
+        headers: redactHeaders(response.headers),
+        body: responseText.length > 0 ? JSON.parse(responseText) : null,
+      };
+
+      return response;
+    },
+  });
+
+  const result = await generateText({
+    model: anthropic('claude-opus-4-7'),
+    prompt: 'Reply exactly with OK.',
+    maxOutputTokens: 5,
+    temperature: 0.7,
+  });
+
+  await mkdir(path.dirname(fixturePath), { recursive: true });
+  await writeFile(
+    fixturePath,
+    `${JSON.stringify(
+      {
+        model: 'claude-opus-4-7',
+        inputTemperature: 0.7,
+        text: result.text,
+        warnings: result.warnings,
+        calls,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        text: result.text,
+        warnings: result.warnings,
+        requestBody: calls[0]?.request.body,
+        responseStatus: calls[0]?.response?.status,
+        fixturePath: path.relative(repoRoot, fixturePath),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json
+++ b/packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json
@@ -1,0 +1,79 @@
+{
+  "model": "claude-opus-4-7",
+  "inputTemperature": 0.7,
+  "text": "OK",
+  "warnings": [
+    {
+      "type": "unsupported",
+      "feature": "temperature",
+      "details": "temperature is not supported by claude-opus-4-7 and will be ignored"
+    }
+  ],
+  "calls": [
+    {
+      "request": {
+        "url": "https://api.anthropic.com/v1/messages",
+        "method": "POST",
+        "headers": {
+          "anthropic-version": "2023-06-01",
+          "content-type": "application/json",
+          "user-agent": "ai/0.0.0-test ai-sdk/provider-utils/0.0.0-test runtime/node.js/22",
+          "x-api-key": "[redacted]"
+        },
+        "body": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 5,
+          "messages": [
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Reply exactly with OK."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json",
+          "date": "Tue, 07 Jul 2026 13:08:53 GMT",
+          "request-id": "req_011CcnkUPiddarVDRngNU9S9"
+        },
+        "body": {
+          "model": "claude-opus-4-7",
+          "id": "msg_011CcnkURCviqzbiZ4JFqtwp",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "OK"
+            }
+          ],
+          "stop_reason": "max_tokens",
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 21,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 5,
+            "output_tokens_details": {
+              "thinking_tokens": 0
+            },
+            "service_tier": "standard",
+            "inference_geo": "global"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Bug

Temperature is not longert supported on claude 4.7

## Reproduction

- Classified issue #14707 as provider-specific Anthropic model capability behavior for `claude-opus-4-7` sampling parameters.
- Created runnable reproduction script at `examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts`.
- Exact live-provider command run: `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts`.
- Recorded the live Anthropic `request/response` fixture at `packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json`.
- Observed result: Anthropic returned HTTP 200 with generated text `OK`, the outgoing request body omitted `temperature`, and the SDK emitted an unsupported-feature warning that `temperature` is ignored.
- Expected issue behavior was an Anthropic API error containing ``temperature` is deprecated for this model.`` when `temperature: 0.7` is provided.
- Validation passed with `pnpm -C examples/ai-functions type-check`, `pnpm check`, and `pnpm -C packages/anthropic test:node -- src/anthropic-messages-language-model.test.ts -t "claude-opus-4-7 specific behavior"`.

## Related Issues

Could not reproduce #14707