### PR TITLE
reproduction: could not reproduce Temperature is not longert supported on claude 4.7

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "type-check": "tsc --build"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts
+++ b/examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts
@@ -1,0 +1,210 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type * as AiModule from '../../../../packages/ai/src/index';
+import type * as AnthropicModule from '../../../../packages/anthropic/src/index';
+
+const modelId = 'claude-opus-4-7';
+const temperature = 0.7;
+const prompt = 'Respond with exactly OK.';
+const expectedIssueError = '`temperature` is deprecated for this model.';
+
+type JsonObject = Record<string, unknown>;
+type AiModuleWithDefault = typeof AiModule & { default?: typeof AiModule };
+type AnthropicModuleWithDefault = typeof AnthropicModule & {
+  default?: typeof AnthropicModule;
+};
+
+type RecordedRequest = {
+  url: string;
+  method: string;
+  body: unknown;
+};
+
+type RecordedResponse = {
+  status: number;
+  ok: boolean;
+  body: unknown;
+};
+
+async function requestBodyToText(body: BodyInit | null | undefined) {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  if (body instanceof URLSearchParams) {
+    return body.toString();
+  }
+
+  if (body instanceof Blob) {
+    return await body.text();
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return new TextDecoder().decode(body);
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return new TextDecoder().decode(body);
+  }
+
+  return String(body);
+}
+
+function parseJsonIfPossible(text: string | undefined) {
+  if (text == null || text.length === 0) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function hasOwnProperty(value: unknown, key: string) {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.prototype.hasOwnProperty.call(value, key)
+  );
+}
+
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    const extra = error as Error & {
+      statusCode?: number;
+      responseBody?: unknown;
+      data?: unknown;
+    };
+
+    return {
+      name: error.name,
+      message: error.message,
+      statusCode: extra.statusCode,
+      responseBody: extra.responseBody,
+      data: extra.data,
+    };
+  }
+
+  return { message: String(error) };
+}
+
+async function main() {
+  const anthropicModule =
+    (await import('../../../../packages/anthropic/src/index')) as AnthropicModuleWithDefault;
+  const aiModule =
+    (await import('../../../../packages/ai/src/index')) as AiModuleWithDefault;
+  const { createAnthropic } = anthropicModule.default ?? anthropicModule;
+  const { generateText } = aiModule.default ?? aiModule;
+
+  let recordedRequest: RecordedRequest | undefined;
+  let recordedResponse: RecordedResponse | undefined;
+  let outcome: JsonObject;
+  let caughtError: unknown;
+
+  const anthropic = createAnthropic({
+    fetch: async (url, options) => {
+      const requestText = await requestBodyToText(options?.body);
+      recordedRequest = {
+        url: String(url),
+        method: options?.method ?? 'POST',
+        body: parseJsonIfPossible(requestText),
+      };
+
+      const response = await fetch(url, options);
+      const responseText = await response.clone().text();
+      recordedResponse = {
+        status: response.status,
+        ok: response.ok,
+        body: parseJsonIfPossible(responseText),
+      };
+
+      return response;
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model: anthropic(modelId),
+      prompt,
+      temperature,
+      maxOutputTokens: 5,
+    });
+
+    outcome = {
+      type: 'success',
+      text: result.text,
+      warnings: result.warnings,
+    };
+  } catch (error) {
+    caughtError = error;
+    outcome = {
+      type: 'error',
+      error: serializeError(error),
+    };
+  }
+
+  const requestBodyIncludesTemperature = hasOwnProperty(
+    recordedRequest?.body,
+    'temperature',
+  );
+
+  const fixture = {
+    issue: 14707,
+    classification: 'provider-specific Anthropic model capability behavior',
+    modelId,
+    input: {
+      prompt,
+      temperature,
+      maxOutputTokens: 5,
+    },
+    expectedIssueError,
+    requestBodyIncludesTemperature,
+    request: recordedRequest,
+    response: recordedResponse,
+    sdkResult: outcome,
+  };
+
+  if (recordedResponse != null) {
+    const repoRoot = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../../..',
+    );
+    const fixturePath = path.join(
+      repoRoot,
+      'packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json',
+    );
+    await mkdir(path.dirname(fixturePath), { recursive: true });
+    await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        modelId,
+        suppliedTemperature: temperature,
+        expectedIssueError,
+        requestBodyIncludesTemperature,
+        responseStatus: recordedResponse?.status,
+        outcome,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (caughtError != null) {
+    throw caughtError;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "types": ["node"],
+    "typeRoots": [
+      "../../node_modules/.pnpm/@types+node@20.17.24/node_modules/@types"
+    ],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "./build",
+    "skipLibCheck": true,
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/anthropic"
+    }
+  ]
+}

--- a/packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json
+++ b/packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json
@@ -1,0 +1,76 @@
+{
+  "issue": 14707,
+  "classification": "provider-specific Anthropic model capability behavior",
+  "modelId": "claude-opus-4-7",
+  "input": {
+    "prompt": "Respond with exactly OK.",
+    "temperature": 0.7,
+    "maxOutputTokens": 5
+  },
+  "expectedIssueError": "`temperature` is deprecated for this model.",
+  "requestBodyIncludesTemperature": false,
+  "request": {
+    "url": "https://api.anthropic.com/v1/messages",
+    "method": "POST",
+    "body": {
+      "model": "claude-opus-4-7",
+      "max_tokens": 5,
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "Respond with exactly OK."
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "ok": true,
+    "body": {
+      "model": "claude-opus-4-7",
+      "id": "msg_011CcnoFbazh88NzQRDzyQqE",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "OK"
+        }
+      ],
+      "stop_reason": "max_tokens",
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 21,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 5,
+        "output_tokens_details": {
+          "thinking_tokens": 0
+        },
+        "service_tier": "standard",
+        "inference_geo": "global"
+      }
+    }
+  },
+  "sdkResult": {
+    "type": "success",
+    "text": "OK",
+    "warnings": [
+      {
+        "type": "unsupported-setting",
+        "setting": "temperature",
+        "details": "temperature is not supported by claude-opus-4-7 and will be ignored"
+      }
+    ]
+  }
+}

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -6198,6 +6198,52 @@ describe('claude-opus-4-7 specific behavior', () => {
     );
   });
 
+  it('should match issue #14707 live fixture by warning and stripping temperature', async () => {
+    const liveFixture = JSON.parse(
+      fs.readFileSync(
+        'src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json',
+        'utf8',
+      ),
+    ) as {
+      requestBodyIncludesTemperature: boolean;
+      response: { status: number; body: JSONValue };
+      sdkResult: {
+        text: string;
+        warnings: Array<{
+          type: string;
+          setting?: string;
+          details?: string;
+        }>;
+      };
+    };
+
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'json-value',
+      body: liveFixture.response.body,
+    };
+
+    const { content, warnings } = await opusModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Respond with exactly OK.' }],
+        },
+      ],
+      temperature: 0.7,
+      maxOutputTokens: 5,
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.temperature).toBeUndefined();
+    expect(liveFixture.requestBodyIncludesTemperature).toBe(false);
+    expect(liveFixture.response.status).toBe(200);
+    expect(content).toContainEqual({
+      type: 'text',
+      text: liveFixture.sdkResult.text,
+    });
+    expect(warnings).toEqual(liveFixture.sdkResult.warnings);
+  });
+
   it('should warn and strip topK when set', async () => {
     prepareJsonFixtureResponse('anthropic-text');
 


### PR DESCRIPTION
## Bug

Temperature is not longert supported on claude 4.7

## Reproduction

- Classified issue #14707 as provider-specific Anthropic model capability behavior for `claude-opus-4-7` sampling parameters.
- Created runnable reproduction script at `examples/ai-functions/src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts`.
- Exact live-provider command run: `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-14707-anthropic-claude-opus-4-7-temperature.ts`.
- Observed result: Anthropic returned HTTP 200 with generated text `OK`, the outgoing request body omitted `temperature`, and the SDK emitted an unsupported-setting warning that `temperature` is ignored.
- Expected issue behavior was an Anthropic API error containing ``temperature` is deprecated for this model.`` when `temperature: 0.7` is provided.
- Recorded the live Anthropic `request/response` fixture at `packages/anthropic/src/__fixtures__/issue-14707-claude-opus-4-7-temperature-live.json`.
- Added a provider unit test using the live fixture in `packages/anthropic/src/anthropic-messages-language-model.test.ts`.
- Validation passed with `pnpm check`, `pnpm type-check`, `pnpm -C examples/ai-functions type-check`, and `pnpm -C packages/anthropic test:node -- src/anthropic-messages-language-model.test.ts -t "issue #14707"`.

## Related Issues

Could not reproduce #14707