### PR TITLE
reproduction: could not reproduce generateObject: Effect Schema.Class via Schema.standardSchemaV1 returns 400 from

### DIFF
--- a/examples/ai-functions/src/reproduction/effect-schema-class-standard-schema.ts
+++ b/examples/ai-functions/src/reproduction/effect-schema-class-standard-schema.ts
@@ -1,0 +1,119 @@
+import { openai } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { Schema } from 'effect';
+
+class BettyReviewResult extends Schema.Class<BettyReviewResult>(
+  'BettyReviewResult',
+)({
+  rating: Schema.Number.pipe(Schema.between(1, 5)),
+  summary: Schema.String,
+  highlights: Schema.Array(Schema.String),
+  recommended: Schema.Boolean,
+}) {}
+
+type CaseResult =
+  | {
+      caseName: string;
+      ok: true;
+      object: unknown;
+    }
+  | {
+      caseName: string;
+      ok: false;
+      error: {
+        name?: string;
+        message?: string;
+        statusCode?: number;
+        data?: unknown;
+        cause?: unknown;
+      };
+    };
+
+type SerializedError = Extract<CaseResult, { ok: false }>['error'];
+
+function serializeError(error: unknown): SerializedError {
+  const value = error as {
+    name?: string;
+    message?: string;
+    statusCode?: number;
+    data?: unknown;
+    cause?: unknown;
+  };
+
+  return {
+    name: value.name,
+    message: value.message,
+    statusCode: value.statusCode,
+    data: value.data,
+    cause:
+      value.cause instanceof Error
+        ? { name: value.cause.name, message: value.cause.message }
+        : value.cause,
+  };
+}
+
+async function runCase(caseName: string, schema: unknown): Promise<CaseResult> {
+  try {
+    const result = await generateObject({
+      model: openai('gpt-4o-mini'),
+      schema: schema as any,
+      prompt:
+        "Write a short review for a cozy neighborhood diner called Betty's. Include a 1-5 rating, a one-line summary, three highlights, and whether you recommend it.",
+    });
+
+    return { caseName, ok: true, object: result.object };
+  } catch (error) {
+    return { caseName, ok: false, error: serializeError(error) };
+  }
+}
+
+async function main() {
+  const classDirectSchema = Schema.standardSchemaV1(BettyReviewResult);
+  const structFieldsSchema = Schema.standardSchemaV1(
+    Schema.Struct(BettyReviewResult.fields),
+  );
+
+  const standardMetadata = {
+    classDirectHasJsonSchema:
+      (classDirectSchema as any)['~standard'].jsonSchema != null,
+    structFieldsHasJsonSchema:
+      (structFieldsSchema as any)['~standard'].jsonSchema != null,
+    classDirectVendor: (classDirectSchema as any)['~standard'].vendor,
+    structFieldsVendor: (structFieldsSchema as any)['~standard'].vendor,
+  };
+
+  const [classDirect, structFields] = await Promise.all([
+    runCase('Schema.standardSchemaV1(BettyReviewResult)', classDirectSchema),
+    runCase(
+      'Schema.standardSchemaV1(Schema.Struct(BettyReviewResult.fields))',
+      structFieldsSchema,
+    ),
+  ]);
+
+  const issueReproduced =
+    !classDirect.ok &&
+    classDirect.error.statusCode === 400 &&
+    structFields.ok === true;
+
+  console.log(
+    JSON.stringify(
+      {
+        standardMetadata,
+        results: [classDirect, structFields],
+        issueReproduced,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (issueReproduced) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

generateObject: Effect Schema.Class via Schema.standardSchemaV1 returns 400 from provider

## Reproduction

- Classified issue #15155 as general library behavior because the failure occurs while AI SDK normalizes the schema before any provider request is made.
- Added runnable reproduction script at `examples/ai-functions/src/reproduction/effect-schema-class-standard-schema.ts`.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/effect-schema-class-standard-schema.ts`; both `Schema.standardSchemaV1(BettyReviewResult)` and `Schema.standardSchemaV1(Schema.Struct(BettyReviewResult.fields))` failed locally with `TypeError: Cannot read properties of undefined (reading 'input')`.
- The observed result did not match the reported issue behavior: class-direct should return an OpenAI HTTP 400 while the struct-wrapped schema should succeed.
- The script reported `issueReproduced: false` and showed both Effect schemas had `~standard.vendor: "effect"` but no `~standard.jsonSchema`.
- Ran `pnpm -C examples/ai-functions type-check`; it passed after fixing the script's error-result type to use `Extract<CaseResult, { ok: false }>['error']`.

## Related Issues

Could not reproduce #15155