### PR TITLE
reproduction: could not reproduce @ai-sdk/google Imagen The feature "size" is not supported.

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts
+++ b/examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateImage, type Warning } from 'ai';
+
+const fixturePath = fileURLToPath(
+  new URL(
+    '../../../../packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json',
+    import.meta.url,
+  ),
+);
+
+const capturedWarnings: Array<{
+  warnings: Warning[];
+  provider?: string;
+  model?: string;
+}> = [];
+
+(
+  globalThis as typeof globalThis & {
+    AI_SDK_LOG_WARNINGS?: (options: {
+      warnings: Warning[];
+      provider?: string;
+      model?: string;
+    }) => void;
+  }
+).AI_SDK_LOG_WARNINGS = options => {
+  capturedWarnings.push(options);
+};
+
+function redactImageBytes(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactImageBytes);
+  }
+
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      if (key === 'bytesBase64Encoded' && typeof entry === 'string') {
+        const sha256 = createHash('sha256').update(entry).digest('hex');
+        return [
+          key,
+          `<redacted base64 image bytes; length=${entry.length}; sha256=${sha256}>`,
+        ];
+      }
+
+      return [key, redactImageBytes(entry)];
+    }),
+  );
+}
+
+async function main() {
+  let recordedResponse: unknown;
+
+  const google = createGoogleGenerativeAI({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      const contentType = response.headers.get('content-type') ?? '';
+
+      if (contentType.includes('application/json')) {
+        try {
+          recordedResponse = await response.clone().json();
+        } catch {
+          recordedResponse = { error: 'Failed to parse JSON response body.' };
+        }
+      } else {
+        recordedResponse = await response.clone().text();
+      }
+
+      return response;
+    },
+  });
+
+  const result = await generateImage({
+    model: google.image('imagen-4.0-generate-001'),
+    prompt: 'a hamster in a hat',
+    aspectRatio: '4:3',
+    size: undefined,
+    n: 1,
+  });
+
+  if (recordedResponse !== undefined) {
+    await mkdir(dirname(fixturePath), { recursive: true });
+    await writeFile(
+      fixturePath,
+      `${JSON.stringify(redactImageBytes(recordedResponse), null, 2)}\n`,
+    );
+  }
+
+  const sizeWarnings = result.warnings.filter(
+    warning => warning.type === 'unsupported' && warning.feature === 'size',
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        imageCount: result.images.length,
+        resultWarnings: result.warnings,
+        capturedWarnings,
+        hasUnsupportedSizeWarning: sizeWarnings.length > 0,
+        fixturePath,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (sizeWarnings.length > 0) {
+    throw new Error(
+      'Reproduced issue #10843: generateImage returned an unsupported size warning even though size was undefined.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json
+++ b/packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json
@@ -1,0 +1,8 @@
+{
+  "predictions": [
+    {
+      "bytesBase64Encoded": "<redacted base64 image bytes; length=1755972; sha256=67797279455848f050cff0afb34315e420d722e4c8d2aa021b47c35f1a02113b>",
+      "mimeType": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Bug

[@ai-sdk/google] (Imagen) The feature "size" is not supported.

## Reproduction

- Classified as provider-specific Google Imagen behavior in `@ai-sdk/google`.
- Added runnable live reproduction script at `examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts`.
- Recorded the live Google Imagen JSON response with image bytes redacted at `packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json`.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-10843-google-imagen-size-warning.ts`; it returned `imageCount: 1`, `resultWarnings: []`, `capturedWarnings: []`, and `hasUnsupportedSizeWarning: false`.
- Expected issue behavior was an unsupported `size` warning when `size` is `undefined`; the current worktree did not emit that warning.
- Ran `pnpm -C examples/ai-functions type-check`; it passed.
- Ran `pnpm check`; it first found formatting in the new script, then `pnpm exec oxfmt --write examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts` fixed it and rerunning `pnpm check` passed.

## Related Issues

Could not reproduce #10843