### PR TITLE
reproduction: could not reproduce @ai-sdk/google Imagen The feature "size" is not supported.

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts
+++ b/examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts
@@ -1,0 +1,119 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const fixturePath = fileURLToPath(
+  new URL(
+    '../../../../packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json',
+    import.meta.url,
+  ),
+);
+
+function redactImageBytes(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactImageBytes);
+  }
+
+  if (value != null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        key === 'bytesBase64Encoded' && typeof nestedValue === 'string'
+          ? `<redacted ${nestedValue.length} chars>`
+          : redactImageBytes(nestedValue),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+async function main() {
+  const capturedWarnings: string[] = [];
+  const originalWarn = console.warn;
+
+  const google = createGoogleGenerativeAI({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      const responseText = await response.clone().text();
+      const responseBody = JSON.parse(responseText);
+
+      await mkdir(dirname(fixturePath), { recursive: true });
+      await writeFile(
+        fixturePath,
+        `${JSON.stringify(
+          {
+            request: {
+              url: input instanceof URL ? input.toString() : String(input),
+              method: init?.method ?? 'GET',
+              body:
+                typeof init?.body === 'string'
+                  ? JSON.parse(init.body)
+                  : undefined,
+            },
+            response: {
+              status: response.status,
+              body: redactImageBytes(responseBody),
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      return response;
+    },
+  });
+
+  console.warn = (...args) => {
+    capturedWarnings.push(args.map(String).join(' '));
+    originalWarn(...args);
+  };
+
+  try {
+    const result = await generateImage({
+      model: google.image('imagen-4.0-generate-001'),
+      prompt: 'a hamster in a hat',
+      aspectRatio: '4:3',
+      size: undefined,
+      n: 1,
+      providerOptions: {
+        google: {
+          numberOfImages: 1,
+        },
+      },
+    });
+
+    const unsupportedSizeWarning = 'The feature "size" is not supported.';
+    const hasUnsupportedSizeWarning =
+      result.warnings.some(
+        warning => warning.type === 'unsupported' && warning.feature === 'size',
+      ) ||
+      capturedWarnings.some(warning =>
+        warning.includes(unsupportedSizeWarning),
+      );
+
+    console.log(
+      JSON.stringify(
+        {
+          imageCount: result.images.length,
+          resultWarnings: result.warnings,
+          capturedWarnings,
+          hasUnsupportedSizeWarning,
+          fixturePath,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json
+++ b/packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "url": "https://generativelanguage.googleapis.com/v1beta/models/imagen-4.0-generate-001:predict",
+    "method": "POST",
+    "body": {
+      "instances": [
+        {
+          "prompt": "a hamster in a hat"
+        }
+      ],
+      "parameters": {
+        "sampleCount": 1,
+        "aspectRatio": "4:3"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "predictions": [
+        {
+          "mimeType": "image/png",
+          "bytesBase64Encoded": "<redacted 1949564 chars>"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Bug

[@ai-sdk/google] (Imagen) The feature "size" is not supported.

## Reproduction

- Classified issue #10843 as provider-specific Google Imagen behavior in `@ai-sdk/google`.
- Added runnable live reproduction script at `examples/ai-functions/src/reproduction/issue-10843-google-imagen-size-warning.ts`.
- Recorded the live Google Imagen response with image bytes redacted at `packages/google/src/__fixtures__/issue-10843-google-imagen-generate-image.json`.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-10843-google-imagen-size-warning.ts`; it returned `imageCount: 1`, `resultWarnings: []`, `capturedWarnings: []`, and `hasUnsupportedSizeWarning: false`.
- The recorded live request sent `sampleCount: 1` and `aspectRatio: "4:3"` and did not send a `size` parameter.
- Expected issue behavior was an unsupported `size` warning when `size` is `undefined`, but the current worktree did not emit that warning.
- Ran `pnpm -C examples/ai-functions type-check`; it passed.
- Ran `pnpm check`; it passed.

## Related Issues

Could not reproduce #10843