### PR TITLE
reproduction: could not reproduce processUIMessageStream drops providerMetadata from file chunks

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts
+++ b/examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts
@@ -1,0 +1,75 @@
+import {
+  readUIMessageStream,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai';
+
+const expectedProviderMetadata = {
+  customProvider: {
+    fileId: 'file-12670',
+  },
+};
+
+function createChunkStream(chunks: UIMessageChunk[]): ReadableStream<UIMessageChunk> {
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+
+      controller.close();
+    },
+  });
+}
+
+async function main() {
+  const stream = createChunkStream([
+    { type: 'start', messageId: 'msg-12670' },
+    { type: 'start-step' },
+    {
+      type: 'file',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,ZmFrZS1wbmc=',
+      providerMetadata: expectedProviderMetadata,
+    },
+    { type: 'finish-step' },
+    { type: 'finish' },
+  ]);
+
+  let latestMessage: UIMessage | undefined;
+
+  for await (const message of readUIMessageStream({ stream })) {
+    latestMessage = message;
+  }
+
+  const filePart = latestMessage?.parts.find(part => part.type === 'file');
+  const providerMetadataPreserved =
+    JSON.stringify(filePart?.providerMetadata) ===
+    JSON.stringify(expectedProviderMetadata);
+
+  console.log(
+    JSON.stringify(
+      {
+        providerMetadataPreserved,
+        filePart,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (filePart == null) {
+    throw new Error('No file part was produced from the UI message stream.');
+  }
+
+  if (!providerMetadataPreserved) {
+    throw new Error(
+      'Reproduced issue #12670: providerMetadata was not preserved on the file part.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

processUIMessageStream drops providerMetadata from file chunks

## Reproduction

- Classified issue #12670 as general library behavior; no live provider was needed.
- Created `examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts` to stream a `file` chunk with `customProvider.fileId` metadata through `readUIMessageStream`, which wraps `processUIMessageStream`.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts` and observed `providerMetadataPreserved: true` with `fileId: "file-12670"` on the resulting file part.
- The expected issue behavior was that `providerMetadata` would be dropped from the resulting `FileUIPart`, but the current worktree preserved it.
- Ran `pnpm -C examples/ai-functions type-check`; it completed successfully.

## Related Issues

Could not reproduce #12670