### PR TITLE
reproduction: could not reproduce processUIMessageStream drops providerMetadata from file chunks

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts
+++ b/examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts
@@ -1,0 +1,66 @@
+import { readUIMessageStream, type UIMessageChunk } from 'ai';
+
+function createStream(chunks: UIMessageChunk[]): ReadableStream<UIMessageChunk> {
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+async function main() {
+  const stream = createStream([
+    {
+      type: 'start',
+      messageId: 'msg-12670',
+    },
+    {
+      type: 'file',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,iVBORw0KGgo=',
+      providerMetadata: {
+        customProvider: {
+          fileId: 'file-12670',
+        },
+      },
+    },
+    {
+      type: 'finish',
+    },
+  ]);
+
+  let finalMessage;
+  for await (const message of readUIMessageStream({ stream })) {
+    finalMessage = message;
+  }
+
+  const filePart = finalMessage?.parts.find(part => part.type === 'file');
+  const fileId = filePart?.providerMetadata?.customProvider?.fileId;
+  const providerMetadataPreserved = fileId === 'file-12670';
+
+  console.log(
+    JSON.stringify(
+      {
+        providerMetadataPreserved,
+        fileId,
+        filePart,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!providerMetadataPreserved) {
+    throw new Error(
+      'Expected processUIMessageStream to preserve providerMetadata on file parts.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

processUIMessageStream drops providerMetadata from file chunks

## Reproduction

- Classified issue #12670 as general library behavior; no live provider was needed.
- Created `examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts` to stream a `file` chunk with `customProvider.fileId` metadata through `readUIMessageStream`.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts` and observed `providerMetadataPreserved: true` with `fileId: "file-12670"` on the resulting file part.
- The expected issue behavior was that `providerMetadata` would be dropped from the resulting `FileUIPart`, but the current worktree preserved it.
- Ran `pnpm -C examples/ai-functions type-check`; it completed successfully.

## Related Issues

Could not reproduce #12670