### PR TITLE
docs: document streamText tool execution error handling

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -1182,6 +1182,26 @@ toolErrors.forEach(toolError => {
 
 `streamText` sends errors as part of the `stream` result. Tool execution errors appear as `tool-error` parts, while other errors appear as `error` parts.
 
+A thrown error inside a tool's `execute` function does not throw from `streamText` or abort the stream. The AI SDK catches it, emits a `tool-error` part, and keeps streaming, so the `finish` parts still arrive and a multi-step run can continue. You can read these parts directly from `result.stream`:
+
+```ts
+const result = streamText({
+  // ... model, tools, prompt
+});
+
+for await (const part of result.stream) {
+  if (part.type === 'tool-error') {
+    // a tool's execute function threw; the stream keeps going
+    console.error(`Tool ${part.toolName} failed:`, part.error);
+  } else if (part.type === 'error') {
+    // errors outside of tool execution (e.g. the provider stream)
+    console.error('Stream error:', part.error);
+  }
+}
+```
+
+Because a tool failure is surfaced as a `tool-error` part instead of being thrown, multi-step runs send it back to the model as a tool result, letting the model recover or explain the failure on the next step without breaking the conversation.
+
 When using `toUIMessageStream`, you can pass an `onError` function to extract the error message from the error part and forward it as part of the stream response:
 
 ```ts

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -17926,6 +17926,19 @@ describe('streamText', () => {
           ]
         `);
     });
+
+    it('should keep streaming after a tool error (conversation not broken)', async () => {
+      const parts = await convertAsyncIterableToArray(result.stream);
+      const types = parts.map(part => part.type);
+
+      // the thrown tool error is surfaced as a tool-error part
+      expect(types).toContain('tool-error');
+
+      // and the stream still finishes cleanly instead of aborting
+      const toolErrorIndex = types.indexOf('tool-error');
+      const finishIndex = types.lastIndexOf('finish');
+      expect(finishIndex).toBeGreaterThan(toolErrorIndex);
+    });
   });
 
   describe('options.transform', () => {


### PR DESCRIPTION
## Summary

Addresses #13798. After the v6 `ToolExecutionError` reference page was removed, there was no docs coverage of what happens when a tool's `execute` function throws during `streamText`.

This documents the actual behavior (verified against `packages/ai/src/generate-text/execute-tool-call.ts` and `execute-tools-from-stream.ts`): a thrown tool error is caught and surfaced as a `tool-error` stream part rather than thrown, so the stream keeps going, the `finish` parts still arrive, and multi-step runs can recover.

- **Docs** (`content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx`): expand the `streamText` error-handling subsection with a snippet that reads `tool-error` parts directly from `result.stream` (the current, non-deprecated property) and clarifies the conversation is not broken.
- **Test** (`packages/ai/src/generate-text/stream-text.test.ts`): add an intent-revealing regression test in the existing `tool execution errors` block asserting a `tool-error` part is emitted and the stream still emits `finish` afterwards.

## Test plan

- [ ] CI: `pnpm test` (the new test complements the existing inline snapshot at `should include tool error part in the full stream`)
- [ ] Docs preview renders the new snippet

Note: opened as **draft** — local deps not installed, relying on CI for verification. Happy to adjust wording/placement.

Made with [Cursor](https://cursor.com)