### PR TITLE
reproduction: could not reproduce AIAPICallError: Invalid JSON response with GPT-5 models

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ai-sdk/openai": "workspace:*",
+    "ai": "workspace:*",
+    "dotenv": "16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/openai-gpt5-web-search-invalid-json.ts
+++ b/examples/ai-functions/src/reproduction/openai-gpt5-web-search-invalid-json.ts
@@ -1,0 +1,177 @@
+import 'dotenv/config';
+import {
+  type OpenAIResponsesProviderOptions,
+  createOpenAI,
+} from '@ai-sdk/openai';
+import { APICallError, generateText, stepCountIs } from 'ai';
+
+const iterations = Number(process.env.REPRO_ITERATIONS ?? 5);
+const modelId = process.env.REPRO_MODEL ?? 'gpt-5-mini';
+
+const openai = createOpenAI({
+  fetch: async (url, options) => {
+    const response = await fetch(url, options);
+    const bodyText = await response.clone().text();
+
+    console.log(
+      JSON.stringify(
+        {
+          fetch: {
+            url: String(url),
+            status: response.status,
+            contentType: response.headers.get('content-type'),
+            bodyLength: bodyText.length,
+            jsonParse: tryParseJson(bodyText).ok ? 'ok' : 'failed',
+            bodyPrefix: bodyText.slice(0, 300),
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    return response;
+  },
+});
+
+async function main() {
+  console.log(
+    `Running ${iterations} OpenAI Responses API attempt(s) with ${modelId}.`,
+  );
+
+  for (let attempt = 1; attempt <= iterations; attempt++) {
+    let stepNumber = 0;
+
+    console.log(`\n========== ATTEMPT ${attempt}/${iterations} ==========\n`);
+
+    try {
+      const result = await generateText({
+        model: openai.responses(modelId),
+        prompt:
+          'What happened in tech news today? Search the web, open a few pages, look for the keyword pattern "vercel", and summarize the findings in 3 bullet points.',
+        tools: {
+          web_search: openai.tools.webSearch({
+            searchContextSize: 'high',
+          }),
+        },
+        providerOptions: {
+          openai: {
+            reasoningEffort: 'high',
+          } satisfies OpenAIResponsesProviderOptions,
+        },
+        stopWhen: stepCountIs(5),
+        onStepFinish({ request, response, toolCalls, toolResults }) {
+          stepNumber++;
+          console.log(`\n========== STEP ${stepNumber} ==========\n`);
+          console.log(
+            JSON.stringify(
+              {
+                request,
+                responseBodyType: typeof response.body,
+                responseBodyKeys:
+                  response.body && typeof response.body === 'object'
+                    ? Object.keys(response.body)
+                    : undefined,
+                toolCalls: toolCalls.map(toolCall => ({
+                  toolName: toolCall.toolName,
+                  providerExecuted: toolCall.providerExecuted,
+                })),
+                toolResults: toolResults.map(toolResult => ({
+                  toolName: toolResult.toolName,
+                  providerExecuted: toolResult.providerExecuted,
+                })),
+              },
+              null,
+              2,
+            ),
+          );
+        },
+      });
+
+      console.log(
+        JSON.stringify(
+          {
+            attempt,
+            status: 'completed',
+            finishReason: result.finishReason,
+            steps: result.steps.length,
+            toolCalls: result.toolCalls.map(toolCall => ({
+              toolName: toolCall.toolName,
+              providerExecuted: toolCall.providerExecuted,
+            })),
+            toolResults: result.toolResults.map(toolResult => ({
+              toolName: toolResult.toolName,
+              providerExecuted: toolResult.providerExecuted,
+            })),
+            textPrefix: result.text.slice(0, 300),
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error(
+        JSON.stringify(
+          {
+            attempt,
+            status: 'failed',
+            error: serializeError(error),
+          },
+          null,
+          2,
+        ),
+      );
+
+      throw error;
+    }
+  }
+}
+
+function tryParseJson(text: string): { ok: true } | { ok: false } {
+  try {
+    JSON.parse(text);
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function serializeError(error: unknown) {
+  if (APICallError.isInstance(error)) {
+    return {
+      name: error.name,
+      message: error.message,
+      statusCode: error.statusCode,
+      url: error.url,
+      responseBody: error.responseBody,
+      cause:
+        error.cause instanceof Error
+          ? {
+              name: error.cause.name,
+              message: error.cause.message,
+            }
+          : error.cause,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      cause:
+        error.cause instanceof Error
+          ? {
+              name: error.cause.name,
+              message: error.cause.message,
+            }
+          : error.cause,
+    };
+  }
+
+  return error;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

AI_APICallError: Invalid JSON response with GPT-5 models

## Reproduction

- Classified issue #11030 as provider-specific to the OpenAI Responses API path using GPT-5 models with `openai.tools.webSearch`.
- Added runnable reproduction artifacts at `examples/ai-functions/src/reproduction/openai-gpt5-web-search-invalid-json.ts` and `examples/ai-functions/package.json`.
- Ran `pnpm -C examples/ai-functions exec tsx src/reproduction/openai-gpt5-web-search-invalid-json.ts`; all 5 live OpenAI attempts completed with HTTP 200 `application/json`, JSON parse `ok`, provider-executed `web_search` tool calls, and no `AI_APICallError`.
- Expected issue behavior was an intermittent `AI_APICallError: Invalid JSON response`, potentially before `onStepFinish` logging.
- Verified the finalized script with `REPRO_ITERATIONS=1 pnpm -C examples/ai-functions exec tsx src/reproduction/openai-gpt5-web-search-invalid-json.ts`; the live attempt completed successfully with JSON parse `ok` and provider-executed `web_search` tool calls.
- Ran `pnpm check`; it passed with 0 warnings and 0 errors.
- Ran `pnpm type-check`; it passed.
- Ran `pnpm -C examples/ai-functions exec tsc --noEmit --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --types node src/reproduction/openai-gpt5-web-search-invalid-json.ts`; it passed.
- `pnpm konsistent:check` could not run because no `konsistent:check` command was found.
- No OpenAI fixture or provider unit test was added because the live provider behavior did not reproduce the reported invalid JSON response.

## Related Issues

Could not reproduce #11030