### PR TITLE
feat(examples): add Google Cloud Run deployment guide and Hono Dockerfile

### DIFF
--- a/content/cookbook/15-api-servers/60-cloud-run.mdx
+++ b/content/cookbook/15-api-servers/60-cloud-run.mdx
@@ -1,0 +1,182 @@
+---
+title: Deploy to Google Cloud Run
+description: Deploy a Hono AI SDK server to Google Cloud Run with full streaming support.
+tags: ['api servers', 'streaming', 'deployment', 'cloud run', 'docker']
+---
+
+# Deploy to Google Cloud Run
+
+[Google Cloud Run](https://cloud.google.com/run) is a fully managed container platform that scales to zero and handles HTTPS, load balancing, and TLS automatically. It is a strong fit for AI SDK servers because streaming responses are returned as chunked HTTP, which Cloud Run passes through to clients without buffering—provided you set one critical response header.
+
+## The Streaming Gotcha: `X-Accel-Buffering`
+
+Cloud Run fronts your container with an nginx reverse proxy. By default, nginx buffers upstream responses before forwarding them. For ordinary JSON responses this is invisible. For [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) and streaming text, buffering means the client sees nothing until the entire response completes—which defeats the purpose of streaming entirely.
+
+Setting the `X-Accel-Buffering: no` response header on every streaming route instructs nginx to forward bytes as they arrive:
+
+```ts filename='server.ts' highlight="8"
+app.post('/text', async c => {
+  const result = streamText({
+    model: openai('gpt-4o'),
+    prompt: 'Write a short poem about coding.',
+  });
+  const response = createTextStreamResponse({
+    stream: toTextStream({ stream: result.stream }),
+  });
+  response.headers.set('X-Accel-Buffering', 'no'); // disable proxy buffering
+  return response;
+});
+```
+
+Apply this header to every route that streams—`/` (UI message stream), `/text`, `/stream-data`, and any similar endpoints.
+
+## Dockerfile
+
+The following Dockerfile packages a Hono AI SDK server as a standalone image. Place it alongside your `package.json` and `src/` folder:
+
+```dockerfile filename='Dockerfile'
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy manifests first for layer caching
+COPY package.json tsconfig.json ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/package.json ./
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+# Cloud Run injects PORT (default 8080).
+ENV PORT=8080
+EXPOSE 8080
+
+# Run TypeScript directly with tsx.
+CMD ["node_modules/.bin/tsx", "src/server.ts"]
+```
+
+<Note>
+  The server must read `process.env.PORT` for its listen port. Cloud Run sets
+  this variable automatically to `8080`. The full working example, including the
+  Dockerfile used to test this guide, lives at
+  [`examples/hono/`](https://github.com/vercel/ai/tree/main/examples/hono).
+</Note>
+
+## Build and Deploy
+
+### 1. Store your API key in Secret Manager
+
+```bash
+# Create the secret (one-time)
+echo -n "sk-..." | gcloud secrets create openai-api-key \
+  --data-file=- \
+  --project YOUR_PROJECT_ID
+
+# Or add a new version to an existing secret
+echo -n "sk-..." | gcloud secrets versions add openai-api-key \
+  --data-file=- \
+  --project YOUR_PROJECT_ID
+```
+
+### 2. Build the container image with Cloud Build
+
+```bash
+# Run from the directory that contains your Dockerfile
+gcloud builds submit \
+  --tag gcr.io/YOUR_PROJECT_ID/ai-sdk-hono \
+  --project YOUR_PROJECT_ID
+```
+
+### 3. Deploy to Cloud Run
+
+```bash
+gcloud run deploy ai-sdk-hono \
+  --image gcr.io/YOUR_PROJECT_ID/ai-sdk-hono \
+  --platform managed \
+  --region us-central1 \
+  --project YOUR_PROJECT_ID \
+  --allow-unauthenticated \
+  --port 8080 \
+  --update-secrets OPENAI_API_KEY=openai-api-key:latest
+```
+
+Cloud Run injects `OPENAI_API_KEY` from Secret Manager at runtime. Your API key is never baked into the image.
+
+Replace `OPENAI_API_KEY` (and the corresponding secret name) with the appropriate variable for your chosen provider—for example, `ANTHROPIC_API_KEY` for the Anthropic provider.
+
+### 4. Note the service URL
+
+After `gcloud run deploy` completes, the CLI prints the service URL:
+
+```
+Service URL: https://ai-sdk-hono-xxxxxxxxxxxx-uc.a.run.app
+```
+
+## Testing
+
+### Health check
+
+```bash
+curl https://YOUR_SERVICE_URL/health
+```
+
+Expected response:
+
+```
+Hono AI SDK example server is running!
+```
+
+### Streaming text
+
+```bash
+curl -N -X POST https://YOUR_SERVICE_URL/text \
+  --max-time 30
+```
+
+Tokens should arrive incrementally in the terminal. If the terminal waits until the response is complete before printing anything, the `X-Accel-Buffering: no` header is missing from that route.
+
+### Verify the header
+
+```bash
+curl -sI -X POST https://YOUR_SERVICE_URL/text | grep -i x-accel
+```
+
+Expected:
+
+```
+x-accel-buffering: no
+```
+
+## Environment Variables
+
+| Variable         | Required | Description                                                   |
+| ---------------- | -------- | ------------------------------------------------------------- |
+| `PORT`           | No       | Listen port. Cloud Run sets this automatically to `8080`.     |
+| `OPENAI_API_KEY` | Yes      | API key for your LLM provider. Inject via `--update-secrets`. |
+
+## Cleanup
+
+To delete the Cloud Run service and the container image:
+
+```bash
+gcloud run services delete ai-sdk-hono \
+  --region us-central1 \
+  --project YOUR_PROJECT_ID \
+  --quiet
+
+gcloud container images delete gcr.io/YOUR_PROJECT_ID/ai-sdk-hono \
+  --quiet \
+  --force-delete-tags
+```
+
+## Troubleshooting
+
+- Streaming not working when [proxied](/docs/troubleshooting/streaming-not-working-when-proxied)
+- Streaming not working when [deployed](/docs/troubleshooting/streaming-not-working-when-deployed)

--- a/examples/hono/Dockerfile
+++ b/examples/hono/Dockerfile
@@ -1,0 +1,52 @@
+# Build context: examples/hono/
+# docker build -t ai-sdk-hono .
+#
+# Cloud Run sets PORT automatically (default 8080). Pass your LLM provider key
+# via --update-secrets at deploy time, e.g.:
+#   gcloud run deploy ... --update-secrets OPENAI_API_KEY=openai-api-key:latest
+
+FROM node:22-alpine AS deps
+
+# Enable pnpm via corepack (Node 22 ships with corepack)
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+WORKDIR /app
+
+# Copy manifests first for better layer caching
+COPY package.json tsconfig.json ./
+COPY src/ ./src/
+
+# The repo uses pnpm workspaces; replace workspace:* refs with published
+# versions so this example can be built as a standalone image, and add
+# the pnpm.onlyBuiltDependencies config that pnpm 10+ requires to allow
+# esbuild's install script (needed by tsx).
+RUN node -e " \
+  const fs = require('fs'); \
+  const p = JSON.parse(fs.readFileSync('package.json', 'utf8')); \
+  p.dependencies['ai'] = '^7.0.16'; \
+  p.dependencies['@ai-sdk/openai'] = '^4.0.8'; \
+  p.pnpm = { onlyBuiltDependencies: ['esbuild'] }; \
+  fs.writeFileSync('package.json', JSON.stringify(p, null, 2)); \
+"
+
+RUN pnpm install --no-frozen-lockfile
+
+# ── Runtime image ──────────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+# tsx is a dev-dependency used to run TypeScript directly; keep it in the final
+# image because we're not doing a separate compile step here.
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/package.json ./
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+# Cloud Run injects PORT; fall back to 8080 for local docker run.
+ENV PORT=8080
+EXPOSE 8080
+
+# Run TypeScript directly with tsx (avoids a separate compile step and keeps
+# the image simple; switch to a tsc→node pipeline for production hardening).
+CMD ["node_modules/.bin/tsx", "src/server.ts"]

--- a/examples/hono/src/server.ts
+++ b/examples/hono/src/server.ts
@@ -33,9 +33,12 @@ app.post('/', async c => {
     model: openai('gpt-4o'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
-  return createUIMessageStreamResponse({
+  const response = createUIMessageStreamResponse({
     stream: toUIMessageStream({ stream: result.stream }),
   });
+  // Prevent nginx reverse proxies (e.g. Cloud Run) from buffering the SSE stream.
+  response.headers.set('X-Accel-Buffering', 'no');
+  return response;
 });
 
 app.post('/text', async c => {
@@ -44,9 +47,11 @@ app.post('/text', async c => {
     model: openai('gpt-4o'),
     prompt: 'Write a short poem about coding.',
   });
-  return createTextStreamResponse({
+  const response = createTextStreamResponse({
     stream: toTextStream({ stream: result.stream }),
   });
+  response.headers.set('X-Accel-Buffering', 'no');
+  return response;
 });
 
 app.post('/stream-data', async c => {
@@ -82,7 +87,9 @@ app.post('/stream-data', async c => {
       );
     },
   });
-  return createUIMessageStreamResponse({ stream });
+  const response = createUIMessageStreamResponse({ stream });
+  response.headers.set('X-Accel-Buffering', 'no');
+  return response;
 });
 
 // useChat example using Agent
@@ -91,13 +98,17 @@ app.post('/chat', async c => {
 
   const { messages } = await c.req.json();
 
-  return createAgentUIStreamResponse({
+  const response = createAgentUIStreamResponse({
     agent: openaiWebSearchAgent,
     uiMessages: messages,
   });
+  response.headers.set('X-Accel-Buffering', 'no');
+  return response;
 });
 
 app.get('/health', c => c.text('Hono AI SDK example server is running!'));
 
-console.log('Server starting on http://localhost:8080');
-serve({ fetch: app.fetch, port: 8080 });
+// Cloud Run injects PORT; fall back to 8080 for local development.
+const port = parseInt(process.env.PORT ?? '8080', 10);
+console.log(`Server starting on http://localhost:${port}`);
+serve({ fetch: app.fetch, port });


### PR DESCRIPTION
## Summary
- Adds `content/cookbook/15-api-servers/60-cloud-run.mdx`: a guide for deploying an AI SDK server to Google Cloud Run — Dockerfile, Cloud Build, Secret Manager key injection, and live testing.
- Adds `examples/hono/Dockerfile`: a two-stage pnpm build for the Hono example, binding to `$PORT` so Cloud Run injects the port at runtime.
- Updates `examples/hono/src/server.ts` (additive): reads the listen port from `process.env.PORT` (falls back to `8080`), and sets `X-Accel-Buffering: no` on every streaming response.

## Why `X-Accel-Buffering: no`
Cloud Run fronts containers with an nginx reverse proxy that, by default, buffers the whole upstream response before forwarding it. Streaming then works locally but silently degrades to a single lump response in production. Setting `X-Accel-Buffering: no` on each streaming route disables that buffering and restores incremental delivery. The example uses OpenAI by default; the guide notes swapping the provider env var (e.g. `ANTHROPIC_API_KEY`) for another provider.

## Verified
Deployed the example to a live Cloud Run service and confirmed the `X-Accel-Buffering: no` header makes tokens stream incrementally, while without it the proxy buffers them into a single response. `oxfmt` is clean on the changed files.
