### PR TITLE
feat(amazon-bedrock): add `providerOptions` schema and type for Bedrock image model requests

### DIFF
--- a/.changeset/early-radios-develop.md
+++ b/.changeset/early-radios-develop.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+feat(amazon-bedrock): add `providerOptions` schema and type for Bedrock image model requests

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -87,7 +87,6 @@
           "use": "aisdk/provider-model-file-must-export-model-class",
           "excludeFiles": [
             "${providerId}-video-model.ts",
-            "packages/amazon-bedrock/src/amazon-bedrock-image-model.ts",
             "packages/deepinfra/src/deepinfra-image-model.ts",
             "packages/fireworks/src/fireworks-image-model.ts",
             "packages/gateway/src/gateway-embedding-model.ts",

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -1048,10 +1048,13 @@ const { image } = await generateImage({
 });
 ```
 
-You can also pass the `providerOptions` object to the `generateImage` function to customize the generation behavior:
+You can also pass the `providerOptions` object to the `generateImage` function to customize the generation behavior. Use the `AmazonBedrockImageModelOptions` type to validate Amazon Bedrock image provider options. The preferred provider option key is `providerOptions.amazonBedrock`; the legacy `providerOptions.bedrock` key remains supported for backward compatibility:
 
 ```ts
-import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  amazonBedrock,
+  type AmazonBedrockImageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
 import { generateImage } from 'ai';
 
 const { image } = await generateImage({
@@ -1060,12 +1063,12 @@ const { image } = await generateImage({
   size: '512x512',
   seed: 42,
   providerOptions: {
-    bedrock: {
+    amazonBedrock: {
       quality: 'premium',
       negativeText: 'blurry, low quality',
       cfgScale: 7.5,
       style: 'PHOTOREALISM',
-    },
+    } satisfies AmazonBedrockImageModelOptions,
   },
 });
 ```
@@ -1114,18 +1117,18 @@ const { images } = await generateImage({
     images: [imageBuffer],
   },
   providerOptions: {
-    bedrock: {
+    amazonBedrock: {
       taskType: 'IMAGE_VARIATION',
-      similarityStrength: 0.7, // 0-1, higher = closer to original
+      similarityStrength: 0.7, // 0.2-1.0, higher = closer to original
       negativeText: 'bad quality, low resolution',
-    },
+    } satisfies AmazonBedrockImageModelOptions,
   },
 });
 ```
 
 - **similarityStrength** _number_
 
-  Controls how similar the output is to the input image. Values range from 0 to 1, where higher values produce results closer to the original.
+  Controls how similar the output is to the input image. Values range from 0.2 to 1.0, where higher values produce results closer to the original.
 
 #### Inpainting
 
@@ -1143,9 +1146,9 @@ const { images } = await generateImage({
     images: [imageBuffer],
   },
   providerOptions: {
-    bedrock: {
+    amazonBedrock: {
       maskPrompt: 'cat', // Describe what to replace
-    },
+    } satisfies AmazonBedrockImageModelOptions,
   },
   seed: 42,
 });
@@ -1185,11 +1188,11 @@ const { images } = await generateImage({
     images: [imageBuffer],
   },
   providerOptions: {
-    bedrock: {
+    amazonBedrock: {
       taskType: 'OUTPAINTING',
       maskPrompt: 'background',
       outPaintingMode: 'DEFAULT', // or 'PRECISE'
-    },
+    } satisfies AmazonBedrockImageModelOptions,
   },
 });
 ```
@@ -1211,9 +1214,9 @@ const { images } = await generateImage({
     images: [imageBuffer],
   },
   providerOptions: {
-    bedrock: {
+    amazonBedrock: {
       taskType: 'BACKGROUND_REMOVAL',
-    },
+    } satisfies AmazonBedrockImageModelOptions,
   },
 });
 ```
@@ -1237,7 +1240,7 @@ The following additional provider options are available for image editing:
 
 - **similarityStrength** _number_
 
-  For `IMAGE_VARIATION`: Controls similarity to the original (0-1).
+  For `IMAGE_VARIATION`: Controls similarity to the original (0.2-1.0).
 
 - **outPaintingMode** _string_
 

--- a/examples/ai-functions/src/generate-image/amazon-bedrock/basic.ts
+++ b/examples/ai-functions/src/generate-image/amazon-bedrock/basic.ts
@@ -1,4 +1,7 @@
-import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  amazonBedrock,
+  type AmazonBedrockImageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
 import { generateImage } from 'ai';
 import { presentImages } from '../../lib/present-image';
 import { run } from '../../lib/run';
@@ -11,9 +14,12 @@ run(async () => {
     size: '512x512',
     seed: 42,
     providerOptions: {
-      bedrock: {
+      amazonBedrock: {
         quality: 'premium',
-      },
+        negativeText: 'blurry, low quality',
+        cfgScale: 7.5,
+        style: 'PHOTOREALISM',
+      } satisfies AmazonBedrockImageModelOptions,
     },
   });
 

--- a/examples/ai-functions/src/generate-image/amazon-bedrock/edit-outpainting.ts
+++ b/examples/ai-functions/src/generate-image/amazon-bedrock/edit-outpainting.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from 'node:fs';
-import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  amazonBedrock,
+  type AmazonBedrockImageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
 import { generateImage } from 'ai';
 import { presentImages } from '../../lib/present-image';
 import { run } from '../../lib/run';
@@ -26,13 +29,13 @@ run(async () => {
       images: [imageBuffer],
     },
     providerOptions: {
-      bedrock: {
+      amazonBedrock: {
         taskType: 'OUTPAINTING',
         maskPrompt: 'background',
         outPaintingMode: 'DEFAULT',
         quality: 'standard',
         cfgScale: 7.0,
-      },
+      } satisfies AmazonBedrockImageModelOptions,
     },
   });
 

--- a/examples/ai-functions/src/generate-image/amazon-bedrock/edit-variations.ts
+++ b/examples/ai-functions/src/generate-image/amazon-bedrock/edit-variations.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from 'node:fs';
-import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  amazonBedrock,
+  type AmazonBedrockImageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
 import { generateImage } from 'ai';
 import { presentImages } from '../../lib/present-image';
 import { run } from '../../lib/run';
@@ -26,13 +29,13 @@ run(async () => {
       images: [imageBuffer],
     },
     providerOptions: {
-      bedrock: {
+      amazonBedrock: {
         taskType: 'IMAGE_VARIATION',
         similarityStrength: 0.7,
         negativeText: 'bad quality, low resolution, cartoon',
         quality: 'standard',
         cfgScale: 7.0,
-      },
+      } satisfies AmazonBedrockImageModelOptions,
     },
   });
 

--- a/packages/amazon-bedrock/src/amazon-bedrock-image-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-image-model-options.ts
@@ -1,0 +1,44 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const amazonBedrockImageModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      quality: z.enum(['standard', 'premium']).optional(),
+      negativeText: z.string().optional(),
+      cfgScale: z.number().optional(),
+      style: z
+        .enum([
+          '3D_ANIMATED_FAMILY_FILM',
+          'DESIGN_SKETCH',
+          'FLAT_VECTOR_ILLUSTRATION',
+          'GRAPHIC_NOVEL_ILLUSTRATION',
+          'MAXIMALISM',
+          'MIDCENTURY_RETRO',
+          'PHOTOREALISM',
+          'SOFT_DIGITAL_PAINTING',
+        ])
+        .optional(),
+      taskType: z
+        .enum([
+          'TEXT_IMAGE',
+          'IMAGE_VARIATION',
+          'INPAINTING',
+          'OUTPAINTING',
+          'BACKGROUND_REMOVAL',
+        ])
+        .optional(),
+      maskPrompt: z.string().optional(),
+      outPaintingMode: z.enum(['DEFAULT', 'PRECISE']).optional(),
+      similarityStrength: z.number().optional(),
+    }),
+  ),
+);
+
+export type AmazonBedrockImageModelOptions = InferSchema<
+  typeof amazonBedrockImageModelOptionsSchema
+>;

--- a/packages/amazon-bedrock/src/amazon-bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-image-model.test.ts
@@ -1,6 +1,7 @@
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { createAmazonBedrock } from './amazon-bedrock-provider';
 import { AmazonBedrockImageModel } from './amazon-bedrock-image-model';
+import type { AmazonBedrockImageModelOptions } from './amazon-bedrock-image-model-options';
 import { injectFetchHeaders } from './inject-fetch-headers';
 import { describe, it, expect } from 'vitest';
 
@@ -76,6 +77,106 @@ describe('doGenerate', () => {
         },
       }
     `);
+  });
+
+  it('should accept the new `amazonBedrock` providerOptions key', async () => {
+    await model.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: 1234,
+      providerOptions: {
+        amazonBedrock: {
+          negativeText: 'bad',
+          quality: 'premium',
+          cfgScale: 1.2,
+          style: 'PHOTOREALISM',
+        } satisfies AmazonBedrockImageModelOptions,
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "imageGenerationConfig": {
+          "cfgScale": 1.2,
+          "height": 1024,
+          "numberOfImages": 1,
+          "quality": "premium",
+          "seed": 1234,
+          "width": 1024,
+        },
+        "taskType": "TEXT_IMAGE",
+        "textToImageParams": {
+          "negativeText": "bad",
+          "style": "PHOTOREALISM",
+          "text": "A cute baby sea otter",
+        },
+      }
+    `);
+  });
+
+  it('should prefer `amazonBedrock` providerOptions over the legacy `bedrock` key', async () => {
+    await model.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {
+        bedrock: {
+          negativeText: 'legacy',
+          quality: 'standard',
+          cfgScale: 1,
+          style: 'DESIGN_SKETCH',
+        } satisfies AmazonBedrockImageModelOptions,
+        amazonBedrock: {
+          negativeText: 'preferred',
+          quality: 'premium',
+          cfgScale: 2,
+          style: 'PHOTOREALISM',
+        } satisfies AmazonBedrockImageModelOptions,
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "imageGenerationConfig": {
+          "cfgScale": 2,
+          "numberOfImages": 1,
+          "quality": "premium",
+        },
+        "taskType": "TEXT_IMAGE",
+        "textToImageParams": {
+          "negativeText": "preferred",
+          "style": "PHOTOREALISM",
+          "text": "A cute baby sea otter",
+        },
+      }
+    `);
+  });
+
+  it('should reject invalid provider options', async () => {
+    await expect(
+      model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {
+          amazonBedrock: {
+            quality: 'ultra',
+          },
+        },
+      }),
+    ).rejects.toThrow('invalid amazonBedrock provider options');
   });
 
   it('should properly combine headers from all sources', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
@@ -8,6 +8,7 @@ import {
   convertUint8ArrayToBase64,
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
+  parseProviderOptions,
   postJsonToApi,
   resolve,
   serializeModelOptions,
@@ -20,6 +21,7 @@ import {
   modelMaxImagesPerCall,
   type AmazonBedrockImageModelId,
 } from './amazon-bedrock-image-settings';
+import { amazonBedrockImageModelOptionsSchema } from './amazon-bedrock-image-model-options';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { z } from 'zod/v4';
 
@@ -85,8 +87,18 @@ export class AmazonBedrockImageModel implements ImageModelV4 {
 
     // Prefer the new `amazonBedrock` providerOptions key; fall back to the
     // legacy `bedrock` key for backward compatibility.
-    const amazonBedrockOptions = (providerOptions?.amazonBedrock ??
-      providerOptions?.bedrock) as Record<string, any> | undefined;
+    const amazonBedrockOptions =
+      (await parseProviderOptions({
+        provider: 'amazonBedrock',
+        providerOptions,
+        schema: amazonBedrockImageModelOptionsSchema,
+      })) ??
+      (await parseProviderOptions({
+        provider: 'bedrock',
+        providerOptions,
+        schema: amazonBedrockImageModelOptionsSchema,
+      })) ??
+      {};
 
     // Build image generation config (common to most modes)
     const imageGenerationConfig = {

--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -1,6 +1,7 @@
 export type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 
 export type { AmazonBedrockEmbeddingModelOptions } from './amazon-bedrock-embedding-model-options';
+export type { AmazonBedrockImageModelOptions } from './amazon-bedrock-image-model-options';
 export type {
   AmazonBedrockLanguageModelChatOptions,
   /** @deprecated Use `AmazonBedrockLanguageModelChatOptions` instead. */


### PR DESCRIPTION
## Background

Issue #14859 tracks remaining code consistency gaps where model classes do not yet expose typed provider options. The Amazon Bedrock image model still parsed its image `providerOptions` through an untyped raw object and was excluded from the model-options konsistent convention.

## Summary

- Added `AmazonBedrockImageModelOptions` for the implemented Nova Canvas image option surface.
- Switched Bedrock image request construction to parse `providerOptions.amazonBedrock`, falling back to legacy `providerOptions.bedrock`.
- Updated docs and examples to use the typed image option surface.
- Removed the Amazon Bedrock image model from the konsistent exclusion.

## Manual Verification

Run the relevant examples in `examples/ai-functions/src/generate-image/amazon-bedrock`.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

See #14859
