### PR TITLE
feat(harness): send `User-Agent` and `x-client-app` headers in harness adapters

### DIFF
--- a/.changeset/beige-spoons-join.md
+++ b/.changeset/beige-spoons-join.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-pi": patch
+---
+
+feat(harness): send `User-Agent` and `x-client-app` headers in harness adapters

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -134,6 +134,10 @@
               {
                 "name": "create${harnessId.toPascalCase()}",
                 "from": "./${harnessId}-harness"
+              },
+              {
+                "name": "VERSION",
+                "from": "./version"
               }
             ],
             "exportConstants": ["${harnessId.toCamelCase()}"],
@@ -143,7 +147,15 @@
                 "from": "./${harnessId}-harness"
               }
             ],
-            "haveFiles": ["${harnessId}-harness.ts"]
+            "haveFiles": ["${harnessId}-harness.ts", "version.ts"]
+          }
+        },
+        {
+          "name": "harness-version-file-must-export-version",
+          "description": "Every harness version file must export the package version.",
+          "for": { "files": ["version.ts"] },
+          "must": {
+            "exportConstants": ["VERSION"]
           }
         },
         {
@@ -175,7 +187,10 @@
           "description": "Every harness file must declare its built-in tools.",
           "for": { "files": ["${harnessId}-harness.ts"] },
           "must": {
-            "declareConstants": ["${harnessId.toConstantCase()}_BUILTIN_TOOLS"]
+            "declareConstants": [
+              "${harnessId.toConstantCase()}_CLIENT_APP",
+              "${harnessId.toConstantCase()}_BUILTIN_TOOLS"
+            ]
           }
         },
         {
@@ -198,6 +213,7 @@
           "for": { "files": ["${harnessId}-harness.ts"] },
           "must": {
             "useDeclarationOrder": [
+              "${harnessId.toConstantCase()}_CLIENT_APP",
               "${harnessId.toPascalCase()}HarnessSettings",
               "${harnessId.toConstantCase()}_BUILTIN_TOOLS",
               "${harnessId.toCamelCase()}BridgeCoordsSchema",

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -97,11 +97,13 @@ function fakeNetworkSandboxSessionForStartupFailure({
 function fakeNetworkSandboxSessionForStartupSuccess({
   bridgePortUrl,
   spawns,
+  spawnEnvs,
   writes,
   runs,
 }: {
   bridgePortUrl: string;
   spawns?: string[];
+  spawnEnvs?: Array<Record<string, string | undefined>>;
   writes: Array<{ path: string; content: string }>;
   runs: string[];
 }): HarnessV1NetworkSandboxSession {
@@ -123,8 +125,15 @@ function fakeNetworkSandboxSessionForStartupSuccess({
     }) => {
       writes.push({ path, content });
     },
-    spawn: async ({ command }: { command: string }) => {
+    spawn: async ({
+      command,
+      env,
+    }: {
+      command: string;
+      env?: Record<string, string | undefined>;
+    }) => {
       spawns?.push(command);
+      if (env) spawnEnvs?.push(env);
       return {
         stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
         stderr: textStream(''),
@@ -230,6 +239,7 @@ describe('createClaudeCode adapter', () => {
   it('quotes dynamic startup paths in shell commands', async () => {
     const runs: string[] = [];
     const spawns: string[] = [];
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const writes: Array<{ path: string; content: string }> = [];
     const harness = createClaudeCode();
     const session = await harness.doStart({
@@ -238,6 +248,7 @@ describe('createClaudeCode adapter', () => {
         bridgePortUrl: 'ws://127.0.0.1:1',
         runs,
         spawns,
+        spawnEnvs,
         writes,
       }),
       sessionWorkDir:
@@ -250,6 +261,9 @@ describe('createClaudeCode adapter', () => {
     expect(spawns).toEqual([
       "node /tmp/harness/claude-code/bridge.mjs --workdir '/vercel/sandbox/claude-code-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge'",
     ]);
+    expect(spawnEnvs.at(0)?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe(
+      'ai-sdk/harness-claude-code/0.0.0-test',
+    );
     await session.doDestroy();
   });
 

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -45,9 +45,15 @@ import {
   type InboundMessage,
   type OutboundMessage,
 } from './claude-code-bridge-protocol';
+import { VERSION } from './version';
 
 type ClaudeCodeChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 type ClaudeCodeRespawnStrategy = 'replay' | 'rerun';
+
+/**
+ * Value to use in User-Agent and `x-client-app` headers.
+ */
+const CLAUDE_CODE_CLIENT_APP = `ai-sdk/harness-claude-code/${VERSION}`;
 
 export type ClaudeCodeHarnessSettings = {
   readonly auth?: ClaudeCodeAuthOptions;
@@ -565,6 +571,13 @@ export function createClaudeCode(
       const token = randomBytes(32).toString('hex');
       const env = {
         ...resolveClaudeCodeEnv(settings.auth),
+        /*
+         * The Claude Agent SDK does not expose arbitrary model-request
+         * headers. It reads this environment variable and sends the value as
+         * `x-client-app`, while also appending `client-app/<value>` to
+         * `User-Agent`, so this is the attribution path for AI Gateway.
+         */
+        CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
         ...(sandboxHomeDir ? { HOME: sandboxHomeDir } : {}),

--- a/packages/harness-claude-code/src/index.ts
+++ b/packages/harness-claude-code/src/index.ts
@@ -8,5 +8,6 @@ import { createClaudeCode } from './claude-code-harness';
 export const claudeCode = createClaudeCode();
 
 export { createClaudeCode } from './claude-code-harness';
+export { VERSION } from './version';
 export type { ClaudeCodeHarnessSettings } from './claude-code-harness';
 export type { ClaudeCodeAuthOptions } from './claude-code-auth';

--- a/packages/harness-claude-code/src/version.ts
+++ b/packages/harness-claude-code/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-claude-code/tsup.config.ts
+++ b/packages/harness-claude-code/tsup.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from 'tsup';
 
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
 export default defineConfig([
   {
     entry: { index: 'src/index.ts' },
@@ -7,6 +11,9 @@ export default defineConfig([
     target: 'es2022',
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
   {
     entry: { 'bridge/index': 'src/bridge/index.ts' },
@@ -31,5 +38,8 @@ export default defineConfig([
       'ws',
       'zod',
     ],
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
 ]);

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -78,6 +78,7 @@ const cliShimDir = requireArg({
   name: '--cli-shim-dir',
 });
 const bootstrapDir = args.bootstrapDir ?? workdir;
+const HARNESS_CLIENT_APP = procEnv.AI_SDK_HARNESS_CLIENT_APP;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const codexSdk = codexSdkModule as any;
@@ -186,6 +187,14 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
         env_key: 'CODEX_API_KEY',
         wire_api: 'responses',
         supports_websockets: false,
+        ...(hasGatewayAuth && HARNESS_CLIENT_APP
+          ? {
+              http_headers: {
+                'User-Agent': HARNESS_CLIENT_APP,
+                'x-client-app': HARNESS_CLIENT_APP,
+              },
+            }
+          : {}),
       },
     };
   }

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -58,11 +58,13 @@ function fakeNetworkSandboxSessionForStartupSuccess({
   bridgePortUrl,
   runs,
   spawns,
+  spawnEnvs,
   writes,
 }: {
   bridgePortUrl: string;
   runs: string[];
   spawns: string[];
+  spawnEnvs?: Array<Record<string, string | undefined>>;
   writes: Array<{ path: string; content: string }>;
 }): HarnessV1NetworkSandboxSession {
   const session = {
@@ -80,8 +82,15 @@ function fakeNetworkSandboxSessionForStartupSuccess({
     }) => {
       writes.push({ path, content });
     },
-    spawn: async ({ command }: { command: string }) => {
+    spawn: async ({
+      command,
+      env,
+    }: {
+      command: string;
+      env?: Record<string, string | undefined>;
+    }) => {
       spawns.push(command);
+      if (env) spawnEnvs?.push(env);
       return {
         stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
         stderr: textStream(''),
@@ -164,6 +173,7 @@ describe('createCodex adapter', () => {
   it('quotes dynamic startup paths in shell commands', async () => {
     const runs: string[] = [];
     const spawns: string[] = [];
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const writes: Array<{ path: string; content: string }> = [];
     const harness = createCodex();
     const session = await harness.doStart({
@@ -172,6 +182,7 @@ describe('createCodex adapter', () => {
         bridgePortUrl: 'ws://127.0.0.1:1',
         runs,
         spawns,
+        spawnEnvs,
         writes,
       }),
       sessionWorkDir: '/vercel/sandbox/codex-s1; env > /tmp/workdir-leak #',
@@ -183,6 +194,9 @@ describe('createCodex adapter', () => {
     expect(spawns).toEqual([
       "node /tmp/harness/codex/bridge.mjs --workdir '/vercel/sandbox/codex-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge' --bootstrap-dir '/tmp/harness/codex' --cli-shim-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/codex'",
     ]);
+    expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
+      'ai-sdk/harness-codex/0.0.0-test',
+    );
     await session.doDestroy();
   });
 

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -42,6 +42,7 @@ import {
   type OutboundMessage,
 } from './codex-bridge-protocol';
 import { CLI_SHIM_FILENAME } from './bridge/cli-relay';
+import { VERSION } from './version';
 
 type CodexChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 type CodexRespawnStrategy = 'replay' | 'rerun';
@@ -61,6 +62,11 @@ type WriteSkillsResult = {
  * model deterministic and the telemetry (`gen_ai.request.model`) accurate.
  */
 const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';
+
+/**
+ * Value to use in User-Agent and `x-client-app` headers.
+ */
+const CODEX_CLIENT_APP = `ai-sdk/harness-codex/${VERSION}`;
 
 export type CodexHarnessSettings = {
   readonly auth?: CodexAuthOptions;
@@ -334,6 +340,7 @@ export function createCodex(
           : undefined;
       const env = {
         ...resolveCodexEnv(settings.auth),
+        AI_SDK_HARNESS_CLIENT_APP: CODEX_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
         ...(codexSkillSetup

--- a/packages/harness-codex/src/index.ts
+++ b/packages/harness-codex/src/index.ts
@@ -8,5 +8,6 @@ import { createCodex } from './codex-harness';
 export const codex = createCodex();
 
 export { createCodex } from './codex-harness';
+export { VERSION } from './version';
 export type { CodexHarnessSettings } from './codex-harness';
 export type { CodexAuthOptions } from './codex-auth';

--- a/packages/harness-codex/src/version.ts
+++ b/packages/harness-codex/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-codex/tsup.config.ts
+++ b/packages/harness-codex/tsup.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from 'tsup';
 
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
 export default defineConfig([
   {
     entry: { index: 'src/index.ts' },
@@ -7,6 +11,9 @@ export default defineConfig([
     target: 'es2022',
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
   {
     entry: {
@@ -31,5 +38,8 @@ export default defineConfig([
       'ws',
       'zod',
     ],
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
 ]);

--- a/packages/harness-deepagents/src/bridge/index.ts
+++ b/packages/harness-deepagents/src/bridge/index.ts
@@ -1,7 +1,7 @@
 // In-sandbox turn driver on `@ai-sdk/harness/bridge`; third-party imports stay external (tsup) and install in-sandbox from src/bridge/package.json — keep import/externals/deps in sync.
 
 import { randomUUID } from 'node:crypto';
-import { argv } from 'node:process';
+import { argv, env as procEnv } from 'node:process';
 import {
   runBridge,
   type BridgeEvent,
@@ -24,6 +24,7 @@ const NATIVE_TO_COMMON: Readonly<Record<string, string>> = {
   edit_file: 'edit',
   execute: 'bash',
 };
+const HARNESS_CLIENT_APP = procEnv.AI_SDK_HARNESS_CLIENT_APP;
 
 function toCommonName(nativeName: string): string {
   return NATIVE_TO_COMMON[nativeName] ?? nativeName;
@@ -48,14 +49,22 @@ function parseArgs(rawArgs: string[]): Record<string, string> {
 // `creator/model` slug (gateway translates); direct Anthropic wants the bare id.
 function buildModel(rawModel: string | undefined) {
   if (!rawModel) return undefined;
-  const baseUrl = process.env.ANTHROPIC_BASE_URL;
+  const baseUrl = procEnv.ANTHROPIC_BASE_URL;
   const model = baseUrl ? rawModel : rawModel.replace(/^anthropic[/:]/, '');
   return new ChatAnthropic({
     model,
-    ...(process.env.ANTHROPIC_API_KEY
-      ? { apiKey: process.env.ANTHROPIC_API_KEY }
-      : {}),
+    ...(procEnv.ANTHROPIC_API_KEY ? { apiKey: procEnv.ANTHROPIC_API_KEY } : {}),
     ...(baseUrl ? { anthropicApiUrl: baseUrl } : {}),
+    ...(procEnv.AI_GATEWAY_API_KEY && HARNESS_CLIENT_APP
+      ? {
+          clientOptions: {
+            defaultHeaders: {
+              'User-Agent': HARNESS_CLIENT_APP,
+              'x-client-app': HARNESS_CLIENT_APP,
+            },
+          },
+        }
+      : {}),
   });
 }
 

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -55,17 +55,28 @@ function textStream(text: string): ReadableStream<Uint8Array> {
   });
 }
 
-function fakeSandboxSession(): HarnessV1NetworkSandboxSession {
+function fakeSandboxSession({
+  spawnEnvs,
+}: {
+  spawnEnvs?: Array<Record<string, string | undefined>>;
+} = {}): HarnessV1NetworkSandboxSession {
   const session = {
     run: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     readTextFile: async () => null,
     writeTextFile: async () => {},
-    spawn: async () => ({
-      stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
-      stderr: textStream(''),
-      kill: async () => {},
-      wait: async () => ({ exitCode: 0 }),
-    }),
+    spawn: async ({
+      env,
+    }: {
+      env?: Record<string, string | undefined>;
+    } = {}) => {
+      if (env) spawnEnvs?.push(env);
+      return {
+        stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
+        stderr: textStream(''),
+        kill: async () => {},
+        wait: async () => ({ exitCode: 0 }),
+      };
+    },
   };
   return {
     id: 'test-sandbox',
@@ -131,6 +142,22 @@ describe('createDeepAgents', () => {
   it('exposes a lifecycle state schema for resume payloads', () => {
     const harness = createDeepAgents();
     expect(harness.lifecycleStateSchema).toBeDefined();
+  });
+
+  it('passes the harness client app to the bridge environment', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const harness = createDeepAgents();
+    const session = await harness.doStart({
+      sessionId: 'test-session',
+      sessionWorkDir: '/vercel/sandbox/deepagents-test-session',
+      sandboxSession: fakeSandboxSession({ spawnEnvs }),
+    } as unknown as Parameters<typeof harness.doStart>[0]);
+
+    expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
+      'ai-sdk/harness-deepagents/0.0.0-test',
+    );
+
+    await session.doDestroy();
   });
 
   it('resolves the turn when the channel closes with reason "suspended"', async () => {

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -39,11 +39,16 @@ import {
   type InboundMessage,
   type OutboundMessage,
 } from './deepagents-bridge-protocol';
+import { VERSION } from './version';
 
 type DeepAgentsChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 
 // Pure derived state in /tmp; reinstalled per sandbox, persistence is the provider snapshot.
 const BOOTSTRAP_DIR = '/tmp/harness/deepagents';
+/**
+ * Value to use in User-Agent and `x-client-app` headers.
+ */
+const DEEPAGENTS_CLIENT_APP = `ai-sdk/harness-deepagents/${VERSION}`;
 
 // Pinned ripgrep release + per-arch tarball checksums (verified before install).
 const RIPGREP_VERSION = '14.1.1';
@@ -283,6 +288,7 @@ export function createDeepAgents(
 
       const env = {
         ...resolveDeepAgentsEnv({ auth: settings.auth }),
+        AI_SDK_HARNESS_CLIENT_APP: DEEPAGENTS_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
       };

--- a/packages/harness-deepagents/src/index.ts
+++ b/packages/harness-deepagents/src/index.ts
@@ -4,5 +4,6 @@ import { createDeepAgents } from './deepagents-harness';
 export const deepAgents = createDeepAgents();
 
 export { createDeepAgents } from './deepagents-harness';
+export { VERSION } from './version';
 export type { DeepAgentsHarnessSettings } from './deepagents-harness';
 export type { DeepAgentsAuthOptions } from './deepagents-auth';

--- a/packages/harness-deepagents/src/version.ts
+++ b/packages/harness-deepagents/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-deepagents/tsup.config.ts
+++ b/packages/harness-deepagents/tsup.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from 'tsup';
 
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
 export default defineConfig([
   {
     entry: { index: 'src/index.ts' },
@@ -7,6 +11,9 @@ export default defineConfig([
     target: 'es2022',
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
   {
     entry: { 'bridge/index': 'src/bridge/index.ts' },
@@ -29,5 +36,8 @@ export default defineConfig([
       'ws',
       'zod',
     ],
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
 ]);

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -109,6 +109,7 @@ const TOOL_KIND: Readonly<Record<string, 'readonly' | 'edit' | 'bash'>> = {
   skill: 'edit',
   todowrite: 'edit',
 };
+const HARNESS_CLIENT_APP = procEnv.AI_SDK_HARNESS_CLIENT_APP;
 
 const args = parseArgs(argv.slice(2));
 const workdir = args.workdir ?? emitFatal('Missing --workdir argument.');
@@ -265,6 +266,9 @@ function buildProviderConfig(
         options: {
           apiKey: procEnv.AI_GATEWAY_API_KEY,
           baseURL: toOpenCodeGatewayBaseUrl(procEnv.AI_GATEWAY_BASE_URL),
+          ...(HARNESS_CLIENT_APP
+            ? { headers: { 'x-client-app': HARNESS_CLIENT_APP } }
+            : {}),
         },
         ...(modelID
           ? {

--- a/packages/harness-opencode/src/index.ts
+++ b/packages/harness-opencode/src/index.ts
@@ -7,5 +7,6 @@ import { createOpenCode } from './opencode-harness';
 export const openCode = createOpenCode();
 
 export { createOpenCode } from './opencode-harness';
+export { VERSION } from './version';
 export type { OpenCodeHarnessSettings } from './opencode-harness';
 export type { OpenCodeAuthOptions } from './opencode-auth';

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -237,6 +237,9 @@ describe('createOpenCode adapter', () => {
     expect(spawns.at(-1)?.env.XDG_CONFIG_HOME).toBe(
       '/home/vercel-sandbox/.config',
     );
+    expect(spawns.at(-1)?.env.AI_SDK_HARNESS_CLIENT_APP).toBe(
+      'ai-sdk/harness-opencode/0.0.0-test',
+    );
     expect(spawns.at(-1)?.command).toContain(
       "--skills-dir '/home/vercel-sandbox/.agents/skills'",
     );

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -47,6 +47,7 @@ import {
   type InboundMessage,
   type OutboundMessage,
 } from './opencode-bridge-protocol';
+import { VERSION } from './version';
 
 type OpenCodeChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 type OpenCodeRespawnStrategy = 'replay' | 'rerun';
@@ -54,6 +55,11 @@ type OpenCodeRespawnStrategy = 'replay' | 'rerun';
 type WriteSkillsResult = {
   readonly skillsDir: string;
 };
+
+/**
+ * Value to use in User-Agent and `x-client-app` headers.
+ */
+const OPENCODE_CLIENT_APP = `ai-sdk/harness-opencode/${VERSION}`;
 
 export type OpenCodeHarnessSettings = {
   readonly auth?: OpenCodeAuthOptions;
@@ -344,6 +350,7 @@ export function createOpenCode(
           model: settings.model,
           provider: settings.provider,
         }),
+        AI_SDK_HARNESS_CLIENT_APP: OPENCODE_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
         HOME: sandboxHomeDir,

--- a/packages/harness-opencode/src/version.ts
+++ b/packages/harness-opencode/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-opencode/tsup.config.ts
+++ b/packages/harness-opencode/tsup.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from 'tsup';
 
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
 export default defineConfig([
   {
     entry: { index: 'src/index.ts' },
@@ -7,6 +11,9 @@ export default defineConfig([
     target: 'es2022',
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
   {
     entry: {
@@ -27,5 +34,8 @@ export default defineConfig([
       'ws',
       'zod',
     ],
+    define: {
+      __PACKAGE_VERSION__: packageVersion,
+    },
   },
 ]);

--- a/packages/harness-pi/src/index.ts
+++ b/packages/harness-pi/src/index.ts
@@ -7,5 +7,6 @@ import { createPi } from './pi-harness';
 export const pi = createPi();
 
 export { createPi } from './pi-harness';
+export { VERSION } from './version';
 export type { PiHarnessSettings } from './pi-harness';
 export type { PiAuthOptions } from './pi-auth';

--- a/packages/harness-pi/src/pi-auth.test.ts
+++ b/packages/harness-pi/src/pi-auth.test.ts
@@ -33,6 +33,10 @@ describe('resolvePiEnv', () => {
       apiKey: 'gw-key',
       baseUrl: 'https://gw.example',
       authHeader: true,
+      headers: {
+        'User-Agent': 'ai-sdk/harness-pi/0.0.0-test',
+        'x-client-app': 'ai-sdk/harness-pi/0.0.0-test',
+      },
     });
   });
 
@@ -54,6 +58,10 @@ describe('resolvePiEnv', () => {
       apiKey: 'oidc-env',
       baseUrl: 'https://gw.example',
       authHeader: true,
+      headers: {
+        'User-Agent': 'ai-sdk/harness-pi/0.0.0-test',
+        'x-client-app': 'ai-sdk/harness-pi/0.0.0-test',
+      },
     });
   });
 
@@ -88,6 +96,13 @@ describe('resolvePiEnv', () => {
     );
     expect(anthropicCall?.[1].headers).toEqual({
       authorization: 'Bearer tok',
+    });
+    const gatewayCall = r.registerProvider.mock.calls.find(
+      call => call[0] === 'vercel-ai-gateway',
+    );
+    expect(gatewayCall?.[1].headers).toEqual({
+      'User-Agent': 'ai-sdk/harness-pi/0.0.0-test',
+      'x-client-app': 'ai-sdk/harness-pi/0.0.0-test',
     });
   });
 
@@ -130,6 +145,15 @@ describe('resolvePiEnv', () => {
     expect(env).toEqual({
       AI_GATEWAY_API_KEY: 'ambient',
       AI_GATEWAY_BASE_URL: 'https://amb',
+    });
+    expect(r.registerProvider).toHaveBeenCalledWith('vercel-ai-gateway', {
+      apiKey: 'ambient',
+      baseUrl: 'https://amb',
+      authHeader: true,
+      headers: {
+        'User-Agent': 'ai-sdk/harness-pi/0.0.0-test',
+        'x-client-app': 'ai-sdk/harness-pi/0.0.0-test',
+      },
     });
   });
 

--- a/packages/harness-pi/src/pi-auth.ts
+++ b/packages/harness-pi/src/pi-auth.ts
@@ -3,6 +3,7 @@ import type {
   ModelRegistry,
 } from '@earendil-works/pi-coding-agent';
 import { getAiGatewayAuthFromEnv } from '@ai-sdk/harness/utils';
+import { VERSION } from './version';
 
 type ProviderConfigInput = Parameters<ModelRegistry['registerProvider']>[1];
 
@@ -33,6 +34,27 @@ export type PiAuthOptions = {
 const DEFAULT_GATEWAY_BASE_URL = 'https://ai-gateway.vercel.sh';
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+const HARNESS_CLIENT_APP = `ai-sdk/harness-pi/${VERSION}`;
+
+function createGatewayProviderConfig({
+  apiKey,
+  baseUrl,
+  clientApp,
+}: {
+  apiKey: string;
+  baseUrl: string;
+  clientApp: string;
+}): ProviderConfigInput {
+  return {
+    apiKey,
+    baseUrl,
+    authHeader: true,
+    headers: {
+      'User-Agent': clientApp,
+      'x-client-app': clientApp,
+    },
+  };
+}
 
 function register(
   registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry },
@@ -55,14 +77,20 @@ export function resolvePiEnv({
   options,
   env,
   registries,
+  clientApp = HARNESS_CLIENT_APP,
 }: {
   options: PiAuthOptions | undefined;
   env: NodeJS.ProcessEnv;
   registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry };
+  clientApp?: string;
 }): Record<string, string> {
   const customEnvConfigured = hasConfiguredValue(options?.customEnv);
   if (customEnvConfigured) {
-    return applyCustomEnv(options!.customEnv ?? {}, registries);
+    return applyCustomEnv({
+      customEnv: options!.customEnv ?? {},
+      registries,
+      clientApp,
+    });
   }
 
   const gatewayConfigured = hasConfiguredValue(options?.gateway);
@@ -71,11 +99,16 @@ export function resolvePiEnv({
     const apiKey = options!.gateway?.apiKey ?? gatewayAuthFromEnv.apiKey;
     const baseUrl = options!.gateway?.baseUrl ?? gatewayAuthFromEnv.baseUrl;
     if (apiKey) {
-      register(registries, 'vercel-ai-gateway', apiKey, {
+      register(
+        registries,
+        'vercel-ai-gateway',
         apiKey,
-        baseUrl,
-        authHeader: true,
-      });
+        createGatewayProviderConfig({
+          apiKey,
+          baseUrl,
+          clientApp,
+        }),
+      );
       return { AI_GATEWAY_API_KEY: apiKey, AI_GATEWAY_BASE_URL: baseUrl };
     }
     return {};
@@ -83,11 +116,16 @@ export function resolvePiEnv({
 
   // Ambient gateway fallback.
   if (gatewayAuthFromEnv.apiKey) {
-    register(registries, 'vercel-ai-gateway', gatewayAuthFromEnv.apiKey, {
-      apiKey: gatewayAuthFromEnv.apiKey,
-      baseUrl: gatewayAuthFromEnv.baseUrl,
-      authHeader: true,
-    });
+    register(
+      registries,
+      'vercel-ai-gateway',
+      gatewayAuthFromEnv.apiKey,
+      createGatewayProviderConfig({
+        apiKey: gatewayAuthFromEnv.apiKey,
+        baseUrl: gatewayAuthFromEnv.baseUrl,
+        clientApp,
+      }),
+    );
     return {
       AI_GATEWAY_API_KEY: gatewayAuthFromEnv.apiKey,
       AI_GATEWAY_BASE_URL: gatewayAuthFromEnv.baseUrl,
@@ -97,20 +135,30 @@ export function resolvePiEnv({
   return {};
 }
 
-function applyCustomEnv(
-  customEnv: Record<string, string>,
-  registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry },
-): Record<string, string> {
+function applyCustomEnv({
+  customEnv,
+  registries,
+  clientApp,
+}: {
+  customEnv: Record<string, string>;
+  registries: { authStorage: AuthStorage; modelRegistry: ModelRegistry };
+  clientApp: string;
+}): Record<string, string> {
   const out: Record<string, string> = {};
 
   const gatewayKey = customEnv.AI_GATEWAY_API_KEY;
   if (gatewayKey) {
     const baseUrl = customEnv.AI_GATEWAY_BASE_URL ?? DEFAULT_GATEWAY_BASE_URL;
-    register(registries, 'vercel-ai-gateway', gatewayKey, {
-      apiKey: gatewayKey,
-      baseUrl,
-      authHeader: true,
-    });
+    register(
+      registries,
+      'vercel-ai-gateway',
+      gatewayKey,
+      createGatewayProviderConfig({
+        apiKey: gatewayKey,
+        baseUrl,
+        clientApp,
+      }),
+    );
     out.AI_GATEWAY_API_KEY = gatewayKey;
     out.AI_GATEWAY_BASE_URL = baseUrl;
   }

--- a/packages/harness-pi/src/pi-harness.ts
+++ b/packages/harness-pi/src/pi-harness.ts
@@ -8,6 +8,12 @@ import { z } from 'zod/v4';
 import type { PiAuthOptions } from './pi-auth';
 import { piResumeStateSchema } from './pi-resume-state';
 import { createPiSession, type PiThinkingLevel } from './pi-session';
+import { VERSION } from './version';
+
+/**
+ * Value to use in User-Agent and `x-client-app` headers.
+ */
+const PI_CLIENT_APP = `ai-sdk/harness-pi/${VERSION}`;
 
 /**
  * Configuration knobs for `createPi`. Pi runs as an in-process Node library
@@ -132,6 +138,7 @@ export function createPi(
             ? { thinkingLevel: settings.thinkingLevel }
             : {}),
         },
+        clientApp: PI_CLIENT_APP,
         isResume: lifecycleState != null,
         permissionMode: startOpts.permissionMode,
         builtinToolFiltering: startOpts.builtinToolFiltering,

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -72,6 +72,7 @@ describe('createPiSession', () => {
         sessionWorkDir: '/sandbox/work',
         skills: [],
         settings: {},
+        clientApp: 'ai-sdk/harness-pi/0.0.0-test',
         isResume: true,
         resumeSessionFileName: '../session.jsonl',
       }),
@@ -116,6 +117,7 @@ describe('createPiSession', () => {
       sessionWorkDir: '/sandbox/work',
       skills: [],
       settings: {},
+      clientApp: 'ai-sdk/harness-pi/0.0.0-test',
       isResume: false,
     });
     const toolSpecs: HarnessV1ToolSpec[] = [{ name: 'weather' }];
@@ -140,6 +142,7 @@ describe('createPiSession', () => {
       sessionWorkDir: '/sandbox/work',
       skills: [],
       settings: {},
+      clientApp: 'ai-sdk/harness-pi/0.0.0-test',
       isResume: true,
     });
     const resumedControl = await resumedSession.doContinueTurn({

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -195,6 +195,7 @@ export interface CreatePiSessionInput {
   readonly sessionWorkDir: string;
   readonly skills: ReadonlyArray<HarnessV1Skill>;
   readonly settings: PiSessionSettings;
+  readonly clientApp: string;
   readonly isResume: boolean;
   readonly permissionMode?: HarnessV1PermissionMode;
   readonly builtinToolFiltering?: HarnessV1BuiltinToolFiltering;
@@ -334,6 +335,7 @@ export async function createPiSession(
       authStorage,
       modelRegistry,
     },
+    clientApp: input.clientApp,
   });
   const resolveModel = createPiModelResolver(modelRegistry, resolverEnv);
   // Resolve once: deterministic given the configured model. This is the Pi

--- a/packages/harness-pi/src/version.ts
+++ b/packages/harness-pi/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-pi/tsup.config.ts
+++ b/packages/harness-pi/tsup.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from 'tsup';
 
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
 export default defineConfig({
   entry: { index: 'src/index.ts' },
   format: ['esm'],
   target: 'es2022',
   dts: true,
   sourcemap: true,
+  define: {
+    __PACKAGE_VERSION__: packageVersion,
+  },
 });

--- a/skills/add-harness-package/SKILL.md
+++ b/skills/add-harness-package/SKILL.md
@@ -127,6 +127,7 @@ If the runtime needs in-sandbox setup, expose `getBootstrap()`.
 Add only the concerns the runtime needs:
 
 - auth resolution — for AI Gateway support, use the central `getAiGatewayAuthFromEnv()` helper rather than reading env directly. This ensures both `VERCEL_OIDC_TOKEN` and `AI_GATEWAY_API_KEY` are accepted as Gateway credential. When the runtime resolves provider per model, resolve the provider from the model id and set that provider's env; if routing through the gateway, note that base-URL conventions differ per provider (e.g. an Anthropic client appends `/v1/messages` to a root base, an OpenAI client appends to a `/v1` base);
+- AI Gateway client attribution — follow the convention in existing harness packages: define a versioned client app value such as `ai-sdk/harness-<name>/${VERSION}` and use it for Gateway requests. Configure both `User-Agent` and `x-client-app` headers when the underlying runtime/SDK supports both; at least one of those two headers is required. If the runtime cannot set arbitrary headers directly, use the runtime-supported equivalent that produces one of those headers (e.g. an SDK client-app environment variable);
 - custom-tool schema translation — if you convert host tools' JSON Schema into the runtime's tool format, convert _recursively_ (nested objects, array `items`, enums, descriptions); a flat top-level-only conversion silently drops the model's structured guidance. Passing the JSON Schema through directly, if the runtime accepts it, avoids the problem;
 - skill or discovery-file materialization;
 - native protocol to harness stream/control translation;
@@ -214,6 +215,7 @@ Run relevant harness examples against a live sandbox **early** — don't rely on
 - [ ] Runtime placement handled without creating a hidden sandbox
 - [ ] Bridge assets copied during build, if bridge-backed
 - [ ] Auth resolution implemented, if needed
+- [ ] AI Gateway requests include `User-Agent` and/or `x-client-app` client attribution
 - [ ] Harness infra, skills, bridge code, and secrets kept out of `sessionWorkDir`
 - [ ] Session resume and turn continuation tested
 - [ ] Unit tests written and passing


### PR DESCRIPTION
## Background

Harness adapters route AI Gateway traffic through third-party SDKs, so client attribution has to be configured through each harness runtime. This adds consistent versioned attribution for the current harness packages.

## Summary

- Adds build-injected `VERSION` exports and versioned client app constants for all harness packages.
- Sends `User-Agent` and `x-client-app` for Codex, DeepAgents, and Pi gateway requests.
- Uses Claude Code's `CLAUDE_AGENT_SDK_CLIENT_APP` path, and keeps OpenCode to `x-client-app` where `User-Agent` overrides are not honored.
- Adds konsistent rules and focused tests for harness version files, exports, constants, and header/env propagation.

## Manual Verification

Run basic harness examples in `examples/ai-functions/src/harness`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
