### PR TITLE
fix(bytedance): rename inconsistent `ByteDanceVideoProviderOptions` to `ByteDanceVideoModelOptions`

### DIFF
--- a/.changeset/eight-garlics-drive.md
+++ b/.changeset/eight-garlics-drive.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/bytedance": patch
+---
+
+fix(bytedance): rename inconsistent `ByteDanceVideoProviderOptions` to `ByteDanceVideoModelOptions`

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -111,9 +111,7 @@
         },
         {
           "use": "aisdk/provider-video-model-file-must-export-model-class",
-          "excludeFiles": [
-            "packages/gateway/src/gateway-video-model.ts"
-          ]
+          "excludeFiles": ["packages/gateway/src/gateway-video-model.ts"]
         },
         "aisdk/provider-language-model-file-must-import-workflow-serialization",
         "aisdk/provider-model-options-file-must-export-model-options-type",

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -112,7 +112,6 @@
         {
           "use": "aisdk/provider-video-model-file-must-export-model-class",
           "excludeFiles": [
-            "packages/bytedance/src/bytedance-video-model.ts",
             "packages/gateway/src/gateway-video-model.ts"
           ]
         },

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -84,7 +84,7 @@ Generate videos from text prompts:
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -97,7 +97,7 @@ const { video } = await generateVideo({
   providerOptions: {
     bytedance: {
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 
@@ -111,7 +111,7 @@ Generate videos from a first-frame image with an optional text prompt:
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -125,7 +125,7 @@ const { video } = await generateVideo({
   providerOptions: {
     bytedance: {
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -137,7 +137,7 @@ Seedance 1.5 Pro supports generating synchronized audio alongside the video:
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -152,7 +152,7 @@ const { video } = await generateVideo({
     bytedance: {
       generateAudio: true,
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -164,7 +164,7 @@ Generate smooth transitions between a starting and ending keyframe image:
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -180,7 +180,7 @@ const { video } = await generateVideo({
       lastFrameImage: 'https://example.com/last-frame.jpg',
       generateAudio: true,
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -192,7 +192,7 @@ Using the Seedance 1.0 Lite I2V model, you can provide multiple reference images
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -210,7 +210,7 @@ const { video } = await generateVideo({
         'https://example.com/lawn.png',
       ],
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -222,7 +222,7 @@ Seedance 2.0 supports reference videos that guide the style, motion, or composit
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -236,7 +236,7 @@ const { video } = await generateVideo({
     bytedance: {
       referenceVideos: ['https://example.com/reference-video.mp4'],
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -248,7 +248,7 @@ Seedance 2.0 supports reference audio that is used as background music or sound 
 ```ts
 import {
   byteDance,
-  type ByteDanceVideoProviderOptions,
+  type ByteDanceVideoModelOptions,
 } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
@@ -262,14 +262,15 @@ const { video } = await generateVideo({
       referenceAudio: ['https://example.com/background-music.mp3'],
       generateAudio: true,
       watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
 
-### Video Provider Options
+### Video Model Options
 
-The following provider options are available via `providerOptions.bytedance`:
+The following options are available via `providerOptions.bytedance`. You can
+type them with `ByteDanceVideoModelOptions`.
 
 #### Generation Options
 
@@ -279,7 +280,8 @@ The following provider options are available via `providerOptions.bytedance`:
 
 - **generateAudio** _boolean_
 
-  Whether to generate synchronized audio for the video. Only supported by Seedance 1.5 Pro.
+  Whether to generate synchronized audio for the video. Supported by Seedance
+  1.5 Pro and Seedance 2.0.
 
 - **cameraFixed** _boolean_
 
@@ -305,7 +307,10 @@ The following provider options are available via `providerOptions.bytedance`:
 
 - **referenceImages** _string[]_
 
-  Array of reference image URLs (1-4 images) for multi-reference image-to-video generation. The model extracts key features from each image and reproduces them in the video. Use `[Image 1]`, `[Image 2]`, etc. in your prompt to reference specific images. Supported by Seedance 1.0 Lite I2V.
+  Array of reference image URLs for multi-reference image-to-video generation.
+  The model extracts key features from each image and reproduces them in the
+  video. Use `[Image 1]`, `[Image 2]`, etc. in your prompt to reference
+  specific images.
 
 #### Media Reference Options
 

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -82,10 +82,7 @@ For more on video generation with the AI SDK see [generateVideo()](/docs/referen
 Generate videos from text prompts:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -109,10 +106,7 @@ console.log(video.url);
 Generate videos from a first-frame image with an optional text prompt:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -135,10 +129,7 @@ const { video } = await generateVideo({
 Seedance 1.5 Pro supports generating synchronized audio alongside the video:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -162,10 +153,7 @@ const { video } = await generateVideo({
 Generate smooth transitions between a starting and ending keyframe image:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -190,10 +178,7 @@ const { video } = await generateVideo({
 Using the Seedance 1.0 Lite I2V model, you can provide multiple reference images (1-4) that the model uses to faithfully reproduce object shapes, colors, and textures:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -220,10 +205,7 @@ const { video } = await generateVideo({
 Seedance 2.0 supports reference videos that guide the style, motion, or composition of the generated video:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -246,10 +228,7 @@ const { video } = await generateVideo({
 Seedance 2.0 supports reference audio that is used as background music or sound for the generated video:
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({

--- a/examples/ai-functions/src/deprecated-options-types.test-d.ts
+++ b/examples/ai-functions/src/deprecated-options-types.test-d.ts
@@ -25,6 +25,10 @@ import type {
   BlackForestLabsImageProviderOptions,
 } from '@ai-sdk/black-forest-labs';
 import type {
+  ByteDanceVideoModelOptions,
+  ByteDanceVideoProviderOptions,
+} from '@ai-sdk/bytedance';
+import type {
   CohereChatModelOptions,
   CohereLanguageModelOptions,
   CohereRerankingModelOptions,
@@ -171,6 +175,12 @@ describe('deprecated provider options type aliases', () => {
   describe('@ai-sdk/black-forest-labs', () => {
     it('BlackForestLabsImageProviderOptions equals BlackForestLabsImageModelOptions', () => {
       expectTypeOf<BlackForestLabsImageProviderOptions>().toEqualTypeOf<BlackForestLabsImageModelOptions>();
+    });
+  });
+
+  describe('@ai-sdk/bytedance', () => {
+    it('ByteDanceVideoProviderOptions equals ByteDanceVideoModelOptions', () => {
+      expectTypeOf<ByteDanceVideoProviderOptions>().toEqualTypeOf<ByteDanceVideoModelOptions>();
     });
   });
 

--- a/examples/ai-functions/src/generate-video/bytedance/basic.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/basic.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -21,7 +18,7 @@ run(async () => {
           bytedance: {
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/generate-audio.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/generate-audio.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -21,7 +18,7 @@ run(async () => {
           bytedance: {
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/i2v-audio.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/i2v-audio.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -24,7 +21,7 @@ run(async () => {
             generateAudio: true,
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/i2v-first-last-frame.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/i2v-first-last-frame.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -26,7 +23,7 @@ run(async () => {
             generateAudio: true,
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/i2v-reference.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/i2v-reference.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -26,7 +23,7 @@ run(async () => {
             ],
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/i2v.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/i2v.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -23,7 +20,7 @@ run(async () => {
           bytedance: {
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/pro-fast.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/pro-fast.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -21,7 +18,7 @@ run(async () => {
           bytedance: {
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-edit.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-edit.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -28,7 +25,7 @@ run(async () => {
             generateAudio: true,
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-extend.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-extend.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -27,7 +24,7 @@ run(async () => {
             generateAudio: true,
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-i2v.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-i2v.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -23,7 +20,7 @@ run(async () => {
           bytedance: {
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-reference-audio.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-reference-audio.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -32,7 +29,7 @@ run(async () => {
             generateAudio: true,
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0.ts
@@ -1,7 +1,4 @@
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
@@ -21,7 +18,7 @@ run(async () => {
           bytedance: {
             watermark: false,
             pollTimeoutMs: 600000,
-          } satisfies ByteDanceVideoProviderOptions,
+          } satisfies ByteDanceVideoModelOptions,
         },
       }),
   );

--- a/packages/bytedance/README.md
+++ b/packages/bytedance/README.md
@@ -39,10 +39,7 @@ Generate video from a text prompt.
 Available models: `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`, `seedance-1-0-lite-t2v-250428`
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -67,10 +64,7 @@ Generate video from a first-frame image with an optional text prompt.
 Available models: `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`, `seedance-1-0-lite-i2v-250428`
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -93,10 +87,7 @@ const { video } = await generateVideo({
 Seedance 1.5 Pro supports generating synchronized audio alongside the video.
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -120,10 +111,7 @@ const { video } = await generateVideo({
 Generate smooth transitions between a starting and ending keyframe image.
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -150,10 +138,7 @@ Provide multiple reference images (1-4) that the model uses to faithfully reprod
 Available models: `seedance-1-0-lite-i2v-250428`
 
 ```ts
-import {
-  byteDance,
-  type ByteDanceVideoModelOptions,
-} from '@ai-sdk/bytedance';
+import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -180,20 +165,20 @@ const { video } = await generateVideo({
 Use `providerOptions.bytedance` to configure video generation. You can type the
 object with `ByteDanceVideoModelOptions`.
 
-| Option            | Description                                                                            |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| `watermark`       | Whether to add a watermark to the generated video                                      |
-| `generateAudio`   | Generate synchronized audio for supported Seedance models                              |
-| `cameraFixed`     | Whether to fix the camera during generation                                            |
-| `returnLastFrame` | Return the last frame of the generated video (useful for chaining)                     |
-| `serviceTier`     | `'default'` for online inference, `'flex'` for offline at 50% price                    |
-| `draft`           | Enable draft mode for low-cost 480p preview generation (Seedance 1.5 Pro only)         |
-| `lastFrameImage`  | URL of last frame image for first-and-last frame generation                            |
-| `referenceImages` | Array of reference image URLs for multi-reference generation                           |
-| `referenceVideos` | Array of reference video URLs for reference-guided generation                          |
-| `referenceAudio`  | Array of reference audio URLs for audio-guided generation                              |
-| `pollIntervalMs`  | Poll interval for async generation (default: 3000ms)                                   |
-| `pollTimeoutMs`   | Max wait time for generation (default: 300000ms)                                       |
+| Option            | Description                                                                    |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `watermark`       | Whether to add a watermark to the generated video                              |
+| `generateAudio`   | Generate synchronized audio for supported Seedance models                      |
+| `cameraFixed`     | Whether to fix the camera during generation                                    |
+| `returnLastFrame` | Return the last frame of the generated video (useful for chaining)             |
+| `serviceTier`     | `'default'` for online inference, `'flex'` for offline at 50% price            |
+| `draft`           | Enable draft mode for low-cost 480p preview generation (Seedance 1.5 Pro only) |
+| `lastFrameImage`  | URL of last frame image for first-and-last frame generation                    |
+| `referenceImages` | Array of reference image URLs for multi-reference generation                   |
+| `referenceVideos` | Array of reference video URLs for reference-guided generation                  |
+| `referenceAudio`  | Array of reference audio URLs for audio-guided generation                      |
+| `pollIntervalMs`  | Poll interval for async generation (default: 3000ms)                           |
+| `pollTimeoutMs`   | Max wait time for generation (default: 300000ms)                               |
 
 Supported aspect ratios: `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, `21:9`, `adaptive` (image-to-video only).
 

--- a/packages/bytedance/README.md
+++ b/packages/bytedance/README.md
@@ -39,7 +39,10 @@ Generate video from a text prompt.
 Available models: `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`, `seedance-1-0-lite-t2v-250428`
 
 ```ts
-import { byteDance } from '@ai-sdk/bytedance';
+import {
+  byteDance,
+  type ByteDanceVideoModelOptions,
+} from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -50,7 +53,7 @@ const { video } = await generateVideo({
   providerOptions: {
     bytedance: {
       watermark: false,
-    },
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 
@@ -64,7 +67,10 @@ Generate video from a first-frame image with an optional text prompt.
 Available models: `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`, `seedance-1-0-lite-i2v-250428`
 
 ```ts
-import { byteDance } from '@ai-sdk/bytedance';
+import {
+  byteDance,
+  type ByteDanceVideoModelOptions,
+} from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -77,7 +83,7 @@ const { video } = await generateVideo({
   providerOptions: {
     bytedance: {
       watermark: false,
-    },
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -87,7 +93,10 @@ const { video } = await generateVideo({
 Seedance 1.5 Pro supports generating synchronized audio alongside the video.
 
 ```ts
-import { byteDance } from '@ai-sdk/bytedance';
+import {
+  byteDance,
+  type ByteDanceVideoModelOptions,
+} from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -101,7 +110,7 @@ const { video } = await generateVideo({
     bytedance: {
       generateAudio: true,
       watermark: false,
-    },
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -111,7 +120,10 @@ const { video } = await generateVideo({
 Generate smooth transitions between a starting and ending keyframe image.
 
 ```ts
-import { byteDance } from '@ai-sdk/bytedance';
+import {
+  byteDance,
+  type ByteDanceVideoModelOptions,
+} from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -126,7 +138,7 @@ const { video } = await generateVideo({
       lastFrameImage: 'https://example.com/last-frame.jpg',
       generateAudio: true,
       watermark: false,
-    },
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
@@ -138,7 +150,10 @@ Provide multiple reference images (1-4) that the model uses to faithfully reprod
 Available models: `seedance-1-0-lite-i2v-250428`
 
 ```ts
-import { byteDance } from '@ai-sdk/bytedance';
+import {
+  byteDance,
+  type ByteDanceVideoModelOptions,
+} from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
@@ -155,25 +170,28 @@ const { video } = await generateVideo({
         'https://example.com/lawn.png',
       ],
       watermark: false,
-    },
+    } satisfies ByteDanceVideoModelOptions,
   },
 });
 ```
 
 ## Provider Options
 
-Use `providerOptions.bytedance` to configure video generation:
+Use `providerOptions.bytedance` to configure video generation. You can type the
+object with `ByteDanceVideoModelOptions`.
 
 | Option            | Description                                                                            |
 | ----------------- | -------------------------------------------------------------------------------------- |
 | `watermark`       | Whether to add a watermark to the generated video                                      |
-| `generateAudio`   | Generate synchronized audio (Seedance 1.5 Pro only)                                    |
+| `generateAudio`   | Generate synchronized audio for supported Seedance models                              |
 | `cameraFixed`     | Whether to fix the camera during generation                                            |
 | `returnLastFrame` | Return the last frame of the generated video (useful for chaining)                     |
 | `serviceTier`     | `'default'` for online inference, `'flex'` for offline at 50% price                    |
 | `draft`           | Enable draft mode for low-cost 480p preview generation (Seedance 1.5 Pro only)         |
 | `lastFrameImage`  | URL of last frame image for first-and-last frame generation                            |
-| `referenceImages` | Array of reference image URLs (1-4) for multi-reference generation (1.0 Lite I2V only) |
+| `referenceImages` | Array of reference image URLs for multi-reference generation                           |
+| `referenceVideos` | Array of reference video URLs for reference-guided generation                          |
+| `referenceAudio`  | Array of reference audio URLs for audio-guided generation                              |
 | `pollIntervalMs`  | Poll interval for async generation (default: 3000ms)                                   |
 | `pollTimeoutMs`   | Max wait time for generation (default: 300000ms)                                       |
 

--- a/packages/bytedance/src/bytedance-video-model-options.ts
+++ b/packages/bytedance/src/bytedance-video-model-options.ts
@@ -1,0 +1,37 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export type ByteDanceVideoModelOptions = {
+  watermark?: boolean | null;
+  generateAudio?: boolean | null;
+  cameraFixed?: boolean | null;
+  returnLastFrame?: boolean | null;
+  serviceTier?: 'default' | 'flex' | null;
+  draft?: boolean | null;
+  lastFrameImage?: string | null;
+  referenceImages?: string[] | null;
+  referenceVideos?: string[] | null;
+  referenceAudio?: string[] | null;
+  pollIntervalMs?: number | null;
+  pollTimeoutMs?: number | null;
+  [key: string]: unknown;
+};
+
+export const byteDanceVideoModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.looseObject({
+      watermark: z.boolean().nullish(),
+      generateAudio: z.boolean().nullish(),
+      cameraFixed: z.boolean().nullish(),
+      returnLastFrame: z.boolean().nullish(),
+      serviceTier: z.enum(['default', 'flex']).nullish(),
+      draft: z.boolean().nullish(),
+      lastFrameImage: z.string().nullish(),
+      referenceImages: z.array(z.string()).nullish(),
+      referenceVideos: z.array(z.string()).nullish(),
+      referenceAudio: z.array(z.string()).nullish(),
+      pollIntervalMs: z.number().positive().nullish(),
+      pollTimeoutMs: z.number().positive().nullish(),
+    }),
+  ),
+);

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -11,31 +11,17 @@ import {
   createJsonResponseHandler,
   delay,
   getFromApi,
-  lazySchema,
   parseProviderOptions,
   postJsonToApi,
   resolve,
-  zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { ByteDanceConfig } from './bytedance-config';
+import {
+  byteDanceVideoModelOptionsSchema,
+  type ByteDanceVideoModelOptions,
+} from './bytedance-video-model-options';
 import type { ByteDanceVideoModelId } from './bytedance-video-settings';
-
-export type ByteDanceVideoProviderOptions = {
-  watermark?: boolean | null;
-  generateAudio?: boolean | null;
-  cameraFixed?: boolean | null;
-  returnLastFrame?: boolean | null;
-  serviceTier?: 'default' | 'flex' | null;
-  draft?: boolean | null;
-  lastFrameImage?: string | null;
-  referenceImages?: string[] | null;
-  referenceVideos?: string[] | null;
-  referenceAudio?: string[] | null;
-  pollIntervalMs?: number | null;
-  pollTimeoutMs?: number | null;
-  [key: string]: unknown;
-};
 
 const HANDLED_PROVIDER_OPTIONS = new Set([
   'watermark',
@@ -51,25 +37,6 @@ const HANDLED_PROVIDER_OPTIONS = new Set([
   'pollIntervalMs',
   'pollTimeoutMs',
 ]);
-
-export const byteDanceVideoProviderOptionsSchema = lazySchema(() =>
-  zodSchema(
-    z.looseObject({
-      watermark: z.boolean().nullish(),
-      generateAudio: z.boolean().nullish(),
-      cameraFixed: z.boolean().nullish(),
-      returnLastFrame: z.boolean().nullish(),
-      serviceTier: z.enum(['default', 'flex']).nullish(),
-      draft: z.boolean().nullish(),
-      lastFrameImage: z.string().nullish(),
-      referenceImages: z.array(z.string()).nullish(),
-      referenceVideos: z.array(z.string()).nullish(),
-      referenceAudio: z.array(z.string()).nullish(),
-      pollIntervalMs: z.number().positive().nullish(),
-      pollTimeoutMs: z.number().positive().nullish(),
-    }),
-  ),
-);
 
 const RESOLUTION_MAP: Record<string, string> = {
   '864x496': '480p',
@@ -135,7 +102,7 @@ function resolveStartImage(
 
 function resolveReferenceImages(
   options: Parameters<Experimental_VideoModelV4['doGenerate']>[0],
-  byteDanceOptions: ByteDanceVideoProviderOptions | undefined,
+  byteDanceOptions: ByteDanceVideoModelOptions | undefined,
 ): string[] {
   if (options.frameImages != null && options.frameImages.length > 0) {
     return [];
@@ -152,7 +119,7 @@ function resolveReferenceImages(
 
 function resolveLastFrameImage(
   options: Parameters<Experimental_VideoModelV4['doGenerate']>[0],
-  byteDanceOptions: ByteDanceVideoProviderOptions | undefined,
+  byteDanceOptions: ByteDanceVideoModelOptions | undefined,
 ): string | undefined {
   const lastFrame = options.frameImages?.find(
     frame => frame.frameType === 'last_frame',
@@ -187,8 +154,8 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
     const byteDanceOptions = (await parseProviderOptions({
       provider: 'bytedance',
       providerOptions: options.providerOptions,
-      schema: byteDanceVideoProviderOptionsSchema,
-    })) as ByteDanceVideoProviderOptions | undefined;
+      schema: byteDanceVideoModelOptionsSchema,
+    })) as ByteDanceVideoModelOptions | undefined;
 
     // Warn about unsupported standard options
     if (options.fps) {

--- a/packages/bytedance/src/index.ts
+++ b/packages/bytedance/src/index.ts
@@ -3,6 +3,10 @@ export type {
   ByteDanceProviderSettings,
 } from './bytedance-provider';
 export { byteDance, createByteDance } from './bytedance-provider';
-export type { ByteDanceVideoProviderOptions } from './bytedance-video-model';
+export type {
+  ByteDanceVideoModelOptions,
+  /** @deprecated Use `ByteDanceVideoModelOptions` instead. */
+  ByteDanceVideoModelOptions as ByteDanceVideoProviderOptions,
+} from './bytedance-video-model-options';
 export type { ByteDanceVideoModelId } from './bytedance-video-settings';
 export { VERSION } from './version';


### PR DESCRIPTION
## Background

Issue #14859 tracks remaining provider consistency work where model classes should expose typed `providerOptions` surfaces. This handles the Bytedance video model entry without changing the existing `providerOptions.bytedance` runtime behavior.

## Summary

- Adds `ByteDanceVideoModelOptions` and moves the Bytedance video provider options schema into a dedicated model options file.
- Keeps `ByteDanceVideoProviderOptions` as a deprecated alias for backwards compatibility.
- Updates Bytedance video examples, docs, and README snippets to use the new type name.
- Removes the Bytedance video model from the relevant `konsistent` exclusion.

## Manual Verification

Run the `examples/ai-functions/src/generate-video/bytedance` examples.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

See #14859
