### PR TITLE
feat(ai): promote repairToolCall option to stable

### DIFF
--- a/.changeset/stable-repair-tool-call.md
+++ b/.changeset/stable-repair-tool-call.md
@@ -1,0 +1,6 @@
+---
+'ai': patch
+'@ai-sdk/workflow': patch
+---
+
+Promote the `repairToolCall` option to stable, with a deprecated `experimental_repairToolCall` alias for backwards compatibility.

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -702,7 +702,7 @@ For persistence, store `UIMessage[]` as your source of truth and call [`convertT
 
 ### Everything else
 
-Other options carry over with the same names: `prepareStep`, `onStepEnd`, `onEnd`, `onError`, `toolChoice`, `activeTools`, `timeout`, `experimental_repairToolCall`, `experimental_sandbox`, and the usual generation settings (`temperature`, `maxOutputTokens`, `topP`, …). `WorkflowAgent` additionally adds `prepareCall` (runs once before the loop) and the `experimental_onStart` / `experimental_onStepStart` / `onToolExecutionStart` / `onToolExecutionEnd` lifecycle callbacks documented above.
+Other options carry over with the same names: `prepareStep`, `onStepEnd`, `onEnd`, `onError`, `toolChoice`, `activeTools`, `timeout`, `repairToolCall`, `experimental_sandbox`, and the usual generation settings (`temperature`, `maxOutputTokens`, `topP`, …). `WorkflowAgent` additionally adds `prepareCall` (runs once before the loop) and the `experimental_onStart` / `experimental_onStepStart` / `onToolExecutionStart` / `onToolExecutionEnd` lifecycle callbacks documented above.
 
 ## Next Steps
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -1207,10 +1207,6 @@ return createUIMessageStreamResponse({
 
 ## Tool Call Repair
 
-<Note type="warning">
-  The tool call repair feature is experimental and may change in the future.
-</Note>
-
 Language models sometimes fail to generate valid tool calls,
 especially when the input schema is complex or the model is smaller.
 
@@ -1219,7 +1215,7 @@ in the next step to give it an opportunity to fix it.
 However, you may want to control how invalid tool calls are repaired without requiring
 additional steps that pollute the message history.
 
-You can use the `experimental_repairToolCall` function to attempt to repair the tool call
+You can use the `repairToolCall` function to attempt to repair the tool call
 with a custom function.
 
 You can use different strategies to repair the tool call:
@@ -1239,12 +1235,7 @@ const result = await generateText({
   tools,
   prompt,
 
-  experimental_repairToolCall: async ({
-    toolCall,
-    tools,
-    inputSchema,
-    error,
-  }) => {
+  repairToolCall: async ({ toolCall, tools, inputSchema, error }) => {
     if (NoSuchToolError.isInstance(error)) {
       return null; // do not attempt to fix invalid tool names
     }
@@ -1280,7 +1271,7 @@ const result = await generateText({
   tools,
   prompt,
 
-  experimental_repairToolCall: async ({
+  repairToolCall: async ({
     toolCall,
     tools,
     error,

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -811,7 +811,7 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_repairToolCall',
+      name: 'repairToolCall',
       type: '(options: ToolCallRepairOptions) => Promise<LanguageModelV4ToolCall | null>',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -855,7 +855,7 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_repairToolCall',
+      name: 'repairToolCall',
       type: '(options: ToolCallRepairOptions) => Promise<LanguageModelV4ToolCall | null>',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -133,7 +133,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Settings for controlling what data is included in step results. requestBody, requestMessages, and responseBody apply to generate(); requestBody, requestMessages, and rawChunks apply to stream().',
     },
     {
-      name: 'experimental_repairToolCall',
+      name: 'repairToolCall',
       type: 'ToolCallRepairFunction',
       isOptional: true,
       description:

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -116,7 +116,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
         'Default structured output specification. Per-stream values override this default.',
     },
     {
-      name: 'experimental_repairToolCall',
+      name: 'repairToolCall',
       type: 'ToolCallRepairFunction',
       isOptional: true,
       description:
@@ -528,7 +528,7 @@ const result = await agent.stream({
       description: 'Include raw, unprocessed chunks from the provider in the stream. Default: false.',
     },
     {
-      name: 'experimental_repairToolCall',
+      name: 'repairToolCall',
       type: 'ToolCallRepairFunction',
       isOptional: true,
       description: 'Callback to attempt automatic recovery when a tool call cannot be parsed.',

--- a/examples/ai-functions/src/generate-text/mock/tool-call-repair-change-tool.ts
+++ b/examples/ai-functions/src/generate-text/mock/tool-call-repair-change-tool.ts
@@ -40,7 +40,7 @@ run(async () => {
     },
     prompt: 'What are the tourist attractions in San Francisco?',
 
-    experimental_repairToolCall: async ({ toolCall }) => {
+    repairToolCall: async ({ toolCall }) => {
       return toolCall.toolName === 'attractions'
         ? {
             type: 'tool-call' as const,

--- a/examples/ai-functions/src/generate-text/mock/tool-call-repair-reask.ts
+++ b/examples/ai-functions/src/generate-text/mock/tool-call-repair-reask.ts
@@ -42,7 +42,7 @@ run(async () => {
     },
     prompt: 'What are the tourist attractions in San Francisco?',
 
-    experimental_repairToolCall: async ({
+    repairToolCall: async ({
       toolCall,
       tools,
       error,

--- a/examples/ai-functions/src/generate-text/mock/tool-call-repair-structured-model.ts
+++ b/examples/ai-functions/src/generate-text/mock/tool-call-repair-structured-model.ts
@@ -42,12 +42,7 @@ run(async () => {
     },
     prompt: 'What are the tourist attractions in San Francisco?',
 
-    experimental_repairToolCall: async ({
-      toolCall,
-      tools,
-      inputSchema,
-      error,
-    }) => {
+    repairToolCall: async ({ toolCall, tools, inputSchema, error }) => {
       if (NoSuchToolError.isInstance(error)) {
         return null; // do not attempt to fix invalid tool names
       }

--- a/examples/ai-functions/src/stream-text/mock/tool-call-repair-change-tool.ts
+++ b/examples/ai-functions/src/stream-text/mock/tool-call-repair-change-tool.ts
@@ -43,7 +43,7 @@ run(async () => {
     },
     prompt: 'What are the tourist attractions in San Francisco?',
 
-    experimental_repairToolCall: async ({ toolCall }) => {
+    repairToolCall: async ({ toolCall }) => {
       return toolCall.toolName === 'attractions'
         ? {
             type: 'tool-call' as const,

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -203,7 +203,7 @@ export async function chat(messages: UIMessage[], request: ChatRequestContext) {
   const result = await agent.stream({
     messages: modelMessages,
     writable: getWritable<ModelCallStreamPart>(),
-    experimental_repairToolCall: repairToolCall as any,
+    repairToolCall: repairToolCall as any,
   });
 
   return { messages: result.messages };

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -142,6 +142,13 @@ export type ToolLoopAgentSettings<
     /**
      * A function that attempts to repair a tool call that failed to parse.
      */
+    repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
+
+    /**
+     * A function that attempts to repair a tool call that failed to parse.
+     *
+     * @deprecated Use `repairToolCall` instead.
+     */
     experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
 
     /**

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -6450,6 +6450,77 @@ describe('generateText', () => {
     });
   });
 
+  describe('options.repairToolCall', () => {
+    const invalidToolCallModel = () =>
+      new MockLanguageModelV4({
+        doGenerate: async () => ({
+          ...dummyResponseValues,
+          content: [
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              input: `{ "value": broken`, // invalid JSON
+            },
+          ],
+        }),
+      });
+
+    const repairToolCallTools = {
+      tool1: tool({
+        inputSchema: z.object({ value: z.string() }),
+        execute: async ({ value }) => `result-${value}`,
+      }),
+    };
+
+    it('should use the repaired tool call', async () => {
+      const result = await generateText({
+        model: invalidToolCallModel(),
+        tools: repairToolCallTools,
+        prompt: 'test-input',
+        repairToolCall: async ({ toolCall }) => ({
+          ...toolCall,
+          input: `{ "value": "repaired" }`,
+        }),
+      });
+
+      expect(result.toolCalls).toStrictEqual([
+        expect.objectContaining({
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: { value: 'repaired' },
+        }),
+      ]);
+      expect(result.toolResults).toStrictEqual([
+        expect.objectContaining({ output: 'result-repaired' }),
+      ]);
+    });
+
+    it('should support the deprecated experimental_repairToolCall option', async () => {
+      const result = await generateText({
+        model: invalidToolCallModel(),
+        tools: repairToolCallTools,
+        prompt: 'test-input',
+        experimental_repairToolCall: async ({ toolCall }) => ({
+          ...toolCall,
+          input: `{ "value": "repaired" }`,
+        }),
+      });
+
+      expect(result.toolCalls).toStrictEqual([
+        expect.objectContaining({
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: { value: 'repaired' },
+        }),
+      ]);
+      expect(result.toolResults).toStrictEqual([
+        expect.objectContaining({ output: 'result-repaired' }),
+      ]);
+    });
+  });
+
   describe('options.activeTools', () => {
     it('should filter available tools to only the ones in activeTools', async () => {
       let tools:

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -247,7 +247,8 @@ export async function generateText<
   activeTools,
   toolOrder,
   prepareStep,
-  experimental_repairToolCall: repairToolCall,
+  experimental_repairToolCall,
+  repairToolCall = experimental_repairToolCall,
   experimental_refineToolInput: refineToolInput,
   experimental_download: download,
   runtimeContext = {} as RUNTIME_CONTEXT,
@@ -376,6 +377,13 @@ export async function generateText<
 
     /**
      * A function that attempts to repair a tool call that failed to parse.
+     */
+    repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
+
+    /**
+     * A function that attempts to repair a tool call that failed to parse.
+     *
+     * @deprecated Use `repairToolCall` instead.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -355,7 +355,8 @@ export function streamText<
   providerOptions,
   activeTools,
   toolOrder,
-  experimental_repairToolCall: repairToolCall,
+  experimental_repairToolCall,
+  repairToolCall = experimental_repairToolCall,
   experimental_refineToolInput: refineToolInput,
   experimental_transform: transform,
   experimental_download: download,
@@ -492,6 +493,13 @@ export function streamText<
 
     /**
      * A function that attempts to repair a tool call that failed to parse.
+     */
+    repairToolCall?: ToolCallRepairFunction<TOOLS>;
+
+    /**
+     * A function that attempts to repair a tool call that failed to parse.
+     *
+     * @deprecated Use `repairToolCall` instead.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<TOOLS>;
 

--- a/packages/workflow/src/test/agent-e2e-workflows.ts
+++ b/packages/workflow/src/test/agent-e2e-workflows.ts
@@ -143,7 +143,7 @@ export async function agentErrorToolE2e() {
 }
 
 // ============================================================================
-// experimental_repairToolCall serialization
+// repairToolCall serialization
 // ============================================================================
 
 async function repairToolCall({
@@ -179,7 +179,7 @@ export async function agentRepairToolCallE2e() {
   const result = await agent.stream({
     messages: [{ role: 'user', content: 'add 3 and 7' }],
     writable: getWritable(),
-    experimental_repairToolCall: repairToolCall as any,
+    repairToolCall: repairToolCall as any,
   });
   return {
     stepCount: result.steps.length,

--- a/packages/workflow/src/workflow-agent-e2e.integration.test.ts
+++ b/packages/workflow/src/workflow-agent-e2e.integration.test.ts
@@ -85,10 +85,10 @@ describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
   });
 
   // ==========================================================================
-  // experimental_repairToolCall serialization
+  // repairToolCall serialization
   // ==========================================================================
 
-  describe('experimental_repairToolCall', () => {
+  describe('repairToolCall', () => {
     it('callback survives serialization and repairs malformed tool input', async () => {
       const run = await start(agentRepairToolCallE2e, []);
       const rv = await run.returnValue;

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -2185,14 +2185,14 @@ describe('WorkflowAgent', () => {
       expect(Object.keys(lastCall.tools)).toEqual(['tool1']);
     });
 
-    it('should use constructor experimental_repairToolCall when not specified in stream()', async () => {
+    it('should use constructor repairToolCall when not specified in stream()', async () => {
       const mockModel = createMockModel();
       const repairFn: ToolCallRepairFunction<ToolSet> = vi.fn();
 
       const agent = new WorkflowAgent({
         model: mockModel,
         tools: {},
-        experimental_repairToolCall: repairFn,
+        repairToolCall: repairFn,
       });
 
       const mockWritable = new WritableStream({
@@ -3060,7 +3060,7 @@ describe('WorkflowAgent', () => {
       await agent.stream({
         messages: [{ role: 'user', content: 'test' }],
         writable: mockWritable,
-        experimental_repairToolCall: repairFn,
+        repairToolCall: repairFn,
       });
 
       // Verify repairToolCall is passed through to streamTextIterator

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -501,7 +501,16 @@ export type WorkflowAgentOptions<
     /**
      * Default function that attempts to repair a tool call that failed to parse.
      *
-     * Per-stream `experimental_repairToolCall` values passed to `stream()` override this default.
+     * Per-stream `repairToolCall` values passed to `stream()` override this default.
+     */
+    repairToolCall?: ToolCallRepairFunction<TTools>;
+
+    /**
+     * Default function that attempts to repair a tool call that failed to parse.
+     *
+     * Per-stream `repairToolCall` values passed to `stream()` override this default.
+     *
+     * @deprecated Use `repairToolCall` instead.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<TTools>;
 
@@ -942,6 +951,13 @@ export type WorkflowAgentStreamOptions<
     /**
      * A function that attempts to repair a tool call that failed to parse.
      */
+    repairToolCall?: ToolCallRepairFunction<TTools>;
+
+    /**
+     * A function that attempts to repair a tool call that failed to parse.
+     *
+     * @deprecated Use `repairToolCall` instead.
+     */
     experimental_repairToolCall?: ToolCallRepairFunction<TTools>;
 
     /**
@@ -1217,7 +1233,7 @@ export class WorkflowAgent<
     | Array<StopCondition<ToolSet, any>>;
   private activeTools?: ActiveTools<TBaseTools>;
   private output?: OutputSpecification<any, any>;
-  private experimentalRepairToolCall?: ToolCallRepairFunction<TBaseTools>;
+  private repairToolCall?: ToolCallRepairFunction<TBaseTools>;
   private experimentalDownload?: DownloadFunction;
   private experimentalSandbox?: SandboxSession;
   private prepareStep?: PrepareStepCallback<TBaseTools, TRuntimeContext>;
@@ -1255,7 +1271,8 @@ export class WorkflowAgent<
     this.stopWhen = options.stopWhen;
     this.activeTools = options.activeTools;
     this.output = options.output;
-    this.experimentalRepairToolCall = options.experimental_repairToolCall;
+    this.repairToolCall =
+      options.repairToolCall ?? options.experimental_repairToolCall;
     this.experimentalDownload = options.experimental_download;
     this.experimentalSandbox = options.experimental_sandbox;
     this.prepareStep = options.prepareStep;
@@ -2098,10 +2115,9 @@ export class WorkflowAgent<
       toolsContext,
       telemetry: effectiveTelemetry,
       includeRawChunks: options.includeRawChunks ?? false,
-      repairToolCall: (options.experimental_repairToolCall ??
-        this.experimentalRepairToolCall) as
-        | ToolCallRepairFunction<ToolSet>
-        | undefined,
+      repairToolCall: (options.repairToolCall ??
+        options.experimental_repairToolCall ??
+        this.repairToolCall) as ToolCallRepairFunction<ToolSet> | undefined,
       responseFormat: await (options.output ?? this.output)?.responseFormat,
       experimental_sandbox: sandbox,
     });


### PR DESCRIPTION
## Background

The `experimental_repairToolCall` option was introduced in December 2024 and has since matured: it is documented, covered by tests, and widely used to recover from tool calls that fail to parse. Following the graduation strategy in #16562, mature experimental APIs get a stable un-prefixed name while the `experimental_`-prefixed name is kept as a deprecated alias until v8, so this change is non-breaking.

## Summary

- Added a stable `repairToolCall` option to `generateText`, `streamText`, `ToolLoopAgent` settings, and `WorkflowAgent` (constructor defaults and `stream()` options). The existing `experimental_repairToolCall` option is kept as a `@deprecated` alias; when both are provided, `repairToolCall` wins.
- Internal plumbing (`stream-language-model-call.ts`, `parse-tool-call.ts`, workflow `stream-text-iterator.ts` / `do-stream-step.ts`) already used the un-prefixed name and is unchanged.
- Updated docs (tool-call repair guide, `generateText` / `streamText` / `ToolLoopAgent` / `WorkflowAgent` references, workflow agent guide) to the stable name and removed the "experimental" caveat from the tool call repair section.
- Updated examples (`examples/ai-functions` tool-call-repair examples, `examples/next-workflow` agent chat) to the stable name.
- Updated tests to use the stable name, added a `generateText` test for the new stable option, and kept one test verifying the deprecated `experimental_repairToolCall` alias still works.
- Added a patch changeset for `ai` and `@ai-sdk/workflow`.

## Manual Verification

Ran `pnpm tsx src/generate-text/mock/tool-call-repair-change-tool.ts` and `pnpm tsx src/stream-text/mock/tool-call-repair-change-tool.ts` in `examples/ai-functions` (both updated to the stable `repairToolCall` option, using `MockLanguageModelV3`). In both runs the mock model emitted a tool call for the non-existent tool `attractions`, the `repairToolCall` callback rewrote it to `cityAttractions`, and the output contained the repaired tool call:

```json
[
  {
    "type": "tool-call",
    "toolCallId": "call-1",
    "toolName": "cityAttractions",
    "input": { "city": "San Francisco" }
  }
]
```

In the streaming run, the repaired `tool-call` part was also emitted on the full stream before the `finish-step` part.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A review of open issues found several runtime-behavior problems with tool call repair — none affect the option's name or shape, and all remain fixable behind the stable API:

- Repair callback not invoked on tool-call validation errors (#8240) or when the provider response fails type validation before tool-call parsing (#6800).
- With `prepareStep`, the callback receives pre-`prepareStep` messages, breaking the re-ask strategy (#8974).
- Repaired tool calls inconsistently reflected in `UIMessage` vs `ModelMessage` (#7994, unreproduced).
- Open PR #14985 (strip `execute` from tools passed to the repair callback) touches `parse-tool-call.ts` as well and may need a trivial rebase after this PR.
- Remove the deprecated `experimental_repairToolCall` alias in v8.

## Related Issues

Closes #16884. Part of #16562.
