### PR TITLE
feat(ui/react): promote throttle option on useChat and useCompletion to stable

### DIFF
--- a/.changeset/stable-throttle.md
+++ b/.changeset/stable-throttle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Promote the `throttle` option on `useChat` and `useCompletion` to stable, with a deprecated `experimental_throttle` alias for backwards compatibility.

--- a/content/cookbook/01-next/25-markdown-chatbot-with-memoization.mdx
+++ b/content/cookbook/01-next/25-markdown-chatbot-with-memoization.mdx
@@ -90,7 +90,7 @@ MemoizedMarkdown.displayName = 'MemoizedMarkdown';
 
 ## Client
 
-Finally, on the client, use the `useChat` hook to manage the chat state and render the chat interface. You can use the `MemoizedMarkdown` component to render the message contents in Markdown format without compromising on performance. Additionally, you can render the form in its own component so as to not trigger unnecessary re-renders of the chat messages. You can also use the `experimental_throttle` option that will throttle data updates to a specified interval, helping to manage rendering performance.
+Finally, on the client, use the `useChat` hook to manage the chat state and render the chat interface. You can use the `MemoizedMarkdown` component to render the message contents in Markdown format without compromising on performance. Additionally, you can render the form in its own component so as to not trigger unnecessary re-renders of the chat messages. You can also use the `throttle` option that will throttle data updates to a specified interval, helping to manage rendering performance.
 
 ```typescript filename='app/page.tsx'
 "use client";
@@ -107,7 +107,7 @@ const chat = new Chat({
 });
 
 export default function Page() {
-  const { messages } = useChat({ chat, experimental_throttle: 50 });
+  const { messages } = useChat({ chat, throttle: 50 });
 
   return (
     <div className="flex flex-col w-full max-w-xl py-24 mx-auto stretch">

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -326,12 +326,12 @@ When the user clicks the "Regenerate" button, the AI provider will regenerate th
 <Note>This feature is currently only available for React.</Note>
 
 By default, the `useChat` hook will trigger a render every time a new chunk is received.
-You can throttle the UI updates with the `experimental_throttle` option.
+You can throttle the UI updates with the `throttle` option.
 
 ```tsx filename="page.tsx" highlight="2-3"
 const { messages, ... } = useChat({
   // Throttle the messages and data updates to 50ms:
-  experimental_throttle: 50
+  throttle: 50
 })
 ```
 

--- a/content/docs/04-ai-sdk-ui/05-completion.mdx
+++ b/content/docs/04-ai-sdk-ui/05-completion.mdx
@@ -143,12 +143,12 @@ When the user clicks the "Stop" button, the fetch request will be aborted. This 
 <Note>This feature is currently only available for React.</Note>
 
 By default, the `useCompletion` hook will trigger a render every time a new chunk is received.
-You can throttle the UI updates with the `experimental_throttle` option.
+You can throttle the UI updates with the `throttle` option.
 
 ```tsx filename="page.tsx" highlight="2-3"
 const { completion, ... } = useCompletion({
   // Throttle the completion and data updates to 50ms:
-  experimental_throttle: 50
+  throttle: 50
 })
 ```
 

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -334,7 +334,7 @@ Allows you to easily create a conversational user interface for your chatbot app
         'Optional callback function that is called when a data part is received.',
     },
     {
-      name: 'experimental_throttle',
+      name: 'throttle',
       type: 'number',
       isOptional: true,
       description:

--- a/content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx
@@ -113,7 +113,7 @@ Allows you to create text completion based capabilities for your application. It
         'Optional. A custom fetch function to be used for the API call. Defaults to the global fetch function.',
     },
     {
-      name: 'experimental_throttle',
+      name: 'throttle',
       type: 'number',
       isOptional: true,
       description:

--- a/content/docs/09-troubleshooting/50-react-maximum-update-depth-exceeded.mdx
+++ b/content/docs/09-troubleshooting/50-react-maximum-update-depth-exceeded.mdx
@@ -18,14 +18,14 @@ need updating (e.g. Markdown). Throttling can mitigate this.
 
 ## Solution
 
-Use the `experimental_throttle` option to throttle the UI updates:
+Use the `throttle` option to throttle the UI updates:
 
 ### `useChat`
 
 ```tsx filename="page.tsx" highlight="2-3"
 const { messages, ... } = useChat({
   // Throttle the messages and data updates to 50ms:
-  experimental_throttle: 50
+  throttle: 50
 })
 ```
 
@@ -34,6 +34,6 @@ const { messages, ... } = useChat({
 ```tsx filename="page.tsx" highlight="2-3"
 const { completion, ... } = useCompletion({
   // Throttle the completion and data updates to 50ms:
-  experimental_throttle: 50
+  throttle: 50
 })
 ```

--- a/examples/ai-e2e-next/app/api/chat/throttle/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/throttle/route.ts
@@ -12,7 +12,15 @@ export async function POST(req: Request) {
         {
           type: 'start-step',
         },
-        ...Array(5000).fill({ type: 'text', value: 'T\n' }),
+        {
+          type: 'text-start',
+          id: 'text-1',
+        },
+        ...Array(5000).fill({ type: 'text-delta', id: 'text-1', delta: 'T\n' }),
+        {
+          type: 'text-end',
+          id: 'text-1',
+        },
         {
           type: 'finish-step',
         },

--- a/examples/ai-e2e-next/app/api/use-completion-throttle/route.ts
+++ b/examples/ai-e2e-next/app/api/use-completion-throttle/route.ts
@@ -12,7 +12,15 @@ export async function POST(req: Request) {
         {
           type: 'start-step',
         },
-        ...Array(5000).fill({ type: 'text', value: 'T\n' }),
+        {
+          type: 'text-start',
+          id: 'text-1',
+        },
+        ...Array(5000).fill({ type: 'text-delta', id: 'text-1', delta: 'T\n' }),
+        {
+          type: 'text-end',
+          id: 'text-1',
+        },
         {
           type: 'finish-step',
         },

--- a/examples/ai-e2e-next/app/chat/throttle/page.tsx
+++ b/examples/ai-e2e-next/app/chat/throttle/page.tsx
@@ -13,7 +13,7 @@ export default function Chat() {
 
   const { messages, status, sendMessage } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat/throttle' }),
-    experimental_throttle: 50,
+    throttle: 50,
   });
 
   return (

--- a/examples/ai-e2e-next/app/use-completion-throttle/page.tsx
+++ b/examples/ai-e2e-next/app/use-completion-throttle/page.tsx
@@ -11,7 +11,7 @@ export default function Chat() {
 
   const { completion, input, handleInputChange, handleSubmit } = useCompletion({
     api: '/api/use-completion-throttle',
-    experimental_throttle: 50,
+    throttle: 50,
   });
 
   return (

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -49,6 +49,11 @@ export type UseChatOptions<UI_MESSAGE extends UIMessage> = (
    * Custom throttle wait in ms for the chat messages and data updates.
    * Default is undefined, which disables throttling.
    */
+  throttle?: number;
+
+  /**
+   * @deprecated Use `throttle` instead.
+   */
   experimental_throttle?: number;
 
   /**
@@ -58,10 +63,12 @@ export type UseChatOptions<UI_MESSAGE extends UIMessage> = (
 };
 
 export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
-  experimental_throttle: throttleWaitMs,
+  throttle,
+  experimental_throttle,
   resume = false,
   ...options
 }: UseChatOptions<UI_MESSAGE> = {}): UseChatHelpers<UI_MESSAGE> {
+  const throttleWaitMs = throttle ?? experimental_throttle;
   // the Chat instance is created once and not recreated when options change,
   // so it would normally keep the callbacks/transport from the first render forever
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2303,7 +2303,7 @@ describe('use-chat', () => {
     });
   });
 
-  describe('experimental_throttle', () => {
+  describe('throttle', () => {
     const throttleMs = 50;
 
     beforeEach(() => {
@@ -2317,7 +2317,7 @@ describe('use-chat', () => {
 
     setupTestComponent(() => {
       const { messages, sendMessage, status } = useChat({
-        experimental_throttle: throttleMs,
+        throttle: throttleMs,
         generateId: mockId(),
       });
 
@@ -2342,7 +2342,7 @@ describe('use-chat', () => {
       );
     });
 
-    it('should throttle UI updates when experimental_throttle is set', async () => {
+    it('should throttle UI updates when throttle is set', async () => {
       const controller = new TestResponseController();
 
       server.urls['/api/chat'].response = {
@@ -2385,6 +2385,83 @@ describe('use-chat', () => {
       expect(screen.getByTestId('message-1')).toHaveTextContent(
         'AI: Hello There',
       );
+    });
+  });
+
+  describe('experimental_throttle (deprecated)', () => {
+    const throttleMs = 50;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    setupTestComponent(() => {
+      const { messages, sendMessage, status } = useChat({
+        experimental_throttle: throttleMs,
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          <div data-testid="status">{status.toString()}</div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+        </div>
+      );
+    });
+
+    it('should throttle UI updates when the deprecated experimental_throttle option is set', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }),
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+
+      expect(screen.getByTestId('message-1')).not.toHaveTextContent(
+        'AI: Hello',
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
     });
   });
 

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -73,14 +73,21 @@ export function useCompletion({
   fetch,
   onFinish,
   onError,
-  experimental_throttle: throttleWaitMs,
+  throttle: throttleWait,
+  experimental_throttle,
 }: UseCompletionOptions & {
   /**
    * Custom throttle wait in ms for the completion and data updates.
    * Default is undefined, which disables throttling.
    */
+  throttle?: number;
+
+  /**
+   * @deprecated Use `throttle` instead.
+   */
   experimental_throttle?: number;
 } = {}): UseCompletionHelpers {
+  const throttleWaitMs = throttleWait ?? experimental_throttle;
   // Generate an unique id for the completion if not provided.
   const hookId = useId();
   const completionId = id || hookId;


### PR DESCRIPTION
## Background

The `experimental_throttle` option on `useChat` and `useCompletion` in `@ai-sdk/react` has matured since its introduction in November 2024. Per the graduation strategy in #16562, mature experimental APIs get a stable un-prefixed name while the `experimental_`-prefixed name is kept as a deprecated alias until v8, so this change is non-breaking. It is a single option on two stable hooks and is widely referenced in the documentation.

## Summary

- Added a stable `throttle?: number` option to `useChat` and `useCompletion` in `@ai-sdk/react`. The existing `experimental_throttle` option remains as a `@deprecated` alias; the stable option wins when both are provided (`throttle ?? experimental_throttle`).
- Updated docs (`useChat`/`useCompletion` reference, chatbot and completion guides, troubleshooting guide, memoization cookbook) to use the stable option name.
- Updated the `examples/ai-e2e-next` throttle example pages to the stable option, and fixed their API routes, which were still emitting the outdated `{ type: 'text' }` UI message stream chunk format and no longer worked with the current protocol (`text-start`/`text-delta`/`text-end`).
- Updated tests to use the stable option, and added a test that verifies the deprecated `experimental_throttle` alias still works.
- Added a patch changeset for `@ai-sdk/react`.

## Manual Verification

Ran the `examples/ai-e2e-next` app locally (`pnpm dev`), opened `/chat/throttle` (which now uses `throttle: 50` in `useChat`), and sent a chat message in the browser. The simulated 5000-chunk response streamed in and rendered progressively until the full response was displayed and the chat returned to the ready state. Throttling was confirmed via the page's render counter: the component rendered ~125 times for the 5000 streamed chunks (mid-stream: 38 renders for the first ~1400 chunks), instead of once per chunk without throttling.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A review of open issues found no open problems with the throttle option itself. Follow-ups:

- The troubleshooting guide entry for "Maximum update depth exceeded" (#6166) recommends this option as the fix; consider revisiting that issue now that the option is stable.
- Stale docs PR #10501 (ReactMarkdown → Streamdown migration) also edits `content/cookbook/01-next/25-markdown-chatbot-with-memoization.mdx` and may need a trivial rebase if revived.
- Remove the deprecated `experimental_throttle` alias in v8.

## Related Issues

Closes #16885. Part of #16562.