### PR TITLE
feat (ui): promote useObject and StructuredObject to stable

### DIFF
--- a/.changeset/stable-use-object.md
+++ b/.changeset/stable-use-object.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/react': patch
+'@ai-sdk/vue': patch
+'@ai-sdk/svelte': patch
+---
+
+Promote `useObject` (React, Vue) and `StructuredObject` (Svelte) to stable exports, with deprecated experimental aliases for backwards compatibility.

--- a/content/cookbook/01-next/40-stream-object.mdx
+++ b/content/cookbook/01-next/40-stream-object.mdx
@@ -70,7 +70,7 @@ Please note the code for handling `undefined` values in the JSX.
 ```tsx filename='app/page.tsx'
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from './api/use-object/schema';
 
 export default function Page() {
@@ -130,7 +130,7 @@ You can also use the `stop` function to stop the object generation process.
 ```tsx filename='app/page.tsx' highlight="7,16,21,24"
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from './api/use-object/schema';
 
 export default function Page() {
@@ -193,7 +193,7 @@ On the client, you wrap the schema in `z.array()` to generate an array of object
 ```tsx filename='app/page.tsx'
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from '../api/use-object/schema';
 import z from 'zod';
 
@@ -267,7 +267,7 @@ export async function POST(req: Request) {
 ```tsx filename='app/page.tsx'
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { z } from 'zod';
 
 export default function Page() {

--- a/content/docs/04-ai-sdk-ui/08-object-generation.mdx
+++ b/content/docs/04-ai-sdk-ui/08-object-generation.mdx
@@ -5,10 +5,7 @@ description: Learn how to use the useObject hook.
 
 # Object Generation
 
-<Note>
-  `useObject` is an experimental feature and only available in React, Svelte,
-  and Vue.
-</Note>
+<Note>`useObject` is only available in React, Svelte, and Vue.</Note>
 
 The [`useObject`](/docs/reference/ai-sdk-ui/use-object) hook allows you to create interfaces that represent a structured JSON object that is being streamed.
 
@@ -46,7 +43,7 @@ Please note the code for handling `undefined` values in the JSX.
 ```tsx filename='app/page.tsx'
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from './api/notifications/schema';
 
 export default function Page() {
@@ -115,7 +112,7 @@ When using `useObject` with enum output mode, your schema must be an object with
 ```tsx filename='app/classify/page.tsx'
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { z } from 'zod';
 
 export default function ClassifyPage() {
@@ -174,7 +171,7 @@ purposes:
 ```tsx filename='app/page.tsx' highlight="6,13-20,24"
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 
 export default function Page() {
   const { isLoading, object, submit } = useObject({
@@ -211,7 +208,7 @@ The `stop` function can be used to stop the object generation process. This can 
 ```tsx filename='app/page.tsx' highlight="6,14-16"
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 
 export default function Page() {
   const { isLoading, stop, object, submit } = useObject({
@@ -256,7 +253,7 @@ It can be used to display an error message, or to disable the submit button:
 ```tsx file="app/page.tsx" highlight="6,13"
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 
 export default function Page() {
   const { error, object, submit } = useObject({
@@ -295,7 +292,7 @@ These callbacks can be used to trigger additional actions, such as logging, anal
 ```tsx filename='app/page.tsx' highlight="10-20"
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from './api/notifications/schema';
 
 export default function Page() {

--- a/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
@@ -3,12 +3,9 @@ title: useObject
 description: API reference for the useObject hook.
 ---
 
-# `experimental_useObject()`
+# `useObject()`
 
-<Note>
-  `useObject` is an experimental feature and only available in React, Svelte,
-  and Vue.
-</Note>
+<Note>`useObject` is only available in React, Svelte, and Vue.</Note>
 
 Allows you to consume text streams that represent a JSON object and parse them into a complete object based on a schema.
 You can use it together with [`streamText`](/docs/reference/ai-sdk-core/stream-text) and [`Output.object()`](/docs/reference/ai-sdk-core/output#output-object) in the backend.
@@ -16,7 +13,7 @@ You can use it together with [`streamText`](/docs/reference/ai-sdk-core/stream-t
 ```tsx
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 
 export default function Page() {
   const { object, submit } = useObject({
@@ -38,21 +35,21 @@ export default function Page() {
 <Tabs items={['React', 'Svelte', 'Vue']}>
   <Tab>
     <Snippet
-      text="import { experimental_useObject as useObject } from '@ai-sdk/react'"
+      text="import { useObject } from '@ai-sdk/react'"
       dark
       prompt={false}
     />
   </Tab>
   <Tab>
     <Snippet
-      text="import { Experimental_StructuredObject } from '@ai-sdk/svelte'"
+      text="import { StructuredObject } from '@ai-sdk/svelte'"
       dark
       prompt={false}
     />
   </Tab>
   <Tab>
     <Snippet
-      text="import { experimental_useObject } from '@ai-sdk/vue'"
+      text="import { useObject } from '@ai-sdk/vue'"
       dark
       prompt={false}
     />

--- a/examples/ai-e2e-next/app/use-object-expense-tracker/page.tsx
+++ b/examples/ai-e2e-next/app/use-object-expense-tracker/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import {
   expenseSchema,
   type Expense,

--- a/examples/ai-e2e-next/app/use-object-valibot/page.tsx
+++ b/examples/ai-e2e-next/app/use-object-valibot/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from '../api/use-object-valibot/schema';
 
 export default function Page() {

--- a/examples/ai-e2e-next/app/use-object/page.tsx
+++ b/examples/ai-e2e-next/app/use-object/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { experimental_useObject as useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { notificationSchema } from '../api/use-object/schema';
 
 export default function Page() {

--- a/examples/next-openai-pages/pages/basics/stream-object/index.tsx
+++ b/examples/next-openai-pages/pages/basics/stream-object/index.tsx
@@ -1,8 +1,8 @@
-import { experimental_useObject } from '@ai-sdk/react';
+import { useObject } from '@ai-sdk/react';
 import { z } from 'zod';
 
 export default function Page() {
-  const { object, submit } = experimental_useObject({
+  const { object, submit } = useObject({
     api: '/api/stream-object',
     schema: z.object({ content: z.string() }),
   });

--- a/examples/nuxt-openai/pages/use-object/index.vue
+++ b/examples/nuxt-openai/pages/use-object/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { experimental_useObject as useObject } from '@ai-sdk/vue';
+import { useObject } from '@ai-sdk/vue';
 import { notificationSchema } from '~/shared/notification-schema';
 
 const { submit, isLoading, object, stop, error, clear } = useObject({

--- a/examples/sveltekit-openai/src/routes/structured-object/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/structured-object/+page.svelte
@@ -2,11 +2,11 @@
   import ArrowUp from '$lib/components/icons/arrow-up.svelte';
   import { Button } from '$lib/components/ui/button/index.js';
   import { Textarea } from '$lib/components/ui/textarea/index.js';
-  import { Experimental_StructuredObject } from '@ai-sdk/svelte';
+  import { StructuredObject } from '@ai-sdk/svelte';
   import { notificationSchema } from './schema.js';
   import Trash from '$lib/components/icons/trash.svelte';
 
-  const structuredObject = new Experimental_StructuredObject({
+  const structuredObject = new StructuredObject({
     api: '/api/structured-object',
     schema: notificationSchema,
   });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,38 @@
+import type { FlexibleSchema } from '@ai-sdk/provider-utils';
+import {
+  useObject,
+  type UseObjectHelpers,
+  type UseObjectOptions,
+} from './use-object';
+
 export * from './use-chat';
 export { Chat } from './chat.react';
 export * from './use-completion';
 export * from './use-object';
 export * from './use-realtime';
 export * from './mcp-apps';
+
+// deprecated aliases
+// note: declared here (instead of export aliases) so that the `@deprecated`
+// tags are preserved in the bundled type declarations
+
+/**
+ * @deprecated Use `useObject` instead.
+ */
+export const experimental_useObject = useObject;
+
+/**
+ * @deprecated Use `UseObjectOptions` instead.
+ */
+export type Experimental_UseObjectOptions<
+  SCHEMA extends FlexibleSchema,
+  RESULT,
+> = UseObjectOptions<SCHEMA, RESULT>;
+
+/**
+ * @deprecated Use `UseObjectHelpers` instead.
+ */
+export type Experimental_UseObjectHelpers<RESULT, INPUT> = UseObjectHelpers<
+  RESULT,
+  INPUT
+>;

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -20,10 +20,7 @@ import useSWR from 'swr';
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;
 
-export type Experimental_UseObjectOptions<
-  SCHEMA extends FlexibleSchema,
-  RESULT,
-> = {
+export type UseObjectOptions<SCHEMA extends FlexibleSchema, RESULT> = {
   /**
    * The API endpoint. It should stream JSON that matches the schema as chunked text.
    */
@@ -88,7 +85,7 @@ export type Experimental_UseObjectOptions<
   credentials?: RequestCredentials;
 };
 
-export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
+export type UseObjectHelpers<RESULT, INPUT> = {
   /**
    * Calls the API with the provided input as JSON body.
    */
@@ -120,7 +117,7 @@ export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
   clear: () => void;
 };
 
-function useObject<
+export function useObject<
   SCHEMA extends FlexibleSchema,
   RESULT = InferSchema<SCHEMA>,
   INPUT = any,
@@ -134,10 +131,7 @@ function useObject<
   onFinish,
   headers,
   credentials,
-}: Experimental_UseObjectOptions<
-  SCHEMA,
-  RESULT
->): Experimental_UseObjectHelpers<RESULT, INPUT> {
+}: UseObjectOptions<SCHEMA, RESULT>): UseObjectHelpers<RESULT, INPUT> {
   // Generate an unique id if not provided.
   const hookId = useId();
   const completionId = id ?? hookId;
@@ -271,4 +265,28 @@ function useObject<
   };
 }
 
-export const experimental_useObject = useObject;
+// deprecated exports
+
+/**
+ * @deprecated Use `useObject` instead.
+ */
+const experimental_useObject = useObject;
+export { experimental_useObject };
+
+/**
+ * @deprecated Use `UseObjectOptions` instead.
+ */
+type Experimental_UseObjectOptions<
+  SCHEMA extends FlexibleSchema,
+  RESULT,
+> = UseObjectOptions<SCHEMA, RESULT>;
+export type { Experimental_UseObjectOptions };
+
+/**
+ * @deprecated Use `UseObjectHelpers` instead.
+ */
+type Experimental_UseObjectHelpers<RESULT, INPUT> = UseObjectHelpers<
+  RESULT,
+  INPUT
+>;
+export type { Experimental_UseObjectHelpers };

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -264,29 +264,3 @@ export function useObject<
     clear,
   };
 }
-
-// deprecated exports
-
-/**
- * @deprecated Use `useObject` instead.
- */
-const experimental_useObject = useObject;
-export { experimental_useObject };
-
-/**
- * @deprecated Use `UseObjectOptions` instead.
- */
-type Experimental_UseObjectOptions<
-  SCHEMA extends FlexibleSchema,
-  RESULT,
-> = UseObjectOptions<SCHEMA, RESULT>;
-export type { Experimental_UseObjectOptions };
-
-/**
- * @deprecated Use `UseObjectHelpers` instead.
- */
-type Experimental_UseObjectHelpers<RESULT, INPUT> = UseObjectHelpers<
-  RESULT,
-  INPUT
->;
-export type { Experimental_UseObjectHelpers };

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -6,7 +6,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { experimental_useObject } from './use-object';
+import { experimental_useObject, useObject } from './use-object';
 
 const server = createTestServer({
   '/api/use-object': {},
@@ -26,19 +26,18 @@ describe('text stream', () => {
     headers?: Record<string, string> | Headers;
     credentials?: RequestCredentials;
   }) => {
-    const { object, error, submit, isLoading, stop, clear } =
-      experimental_useObject({
-        api: '/api/use-object',
-        schema: z.object({ content: z.string() }),
-        onError(error) {
-          onErrorResult = error;
-        },
-        onFinish(event) {
-          onFinishCalls.push(event);
-        },
-        headers,
-        credentials,
-      });
+    const { object, error, submit, isLoading, stop, clear } = useObject({
+      api: '/api/use-object',
+      schema: z.object({ content: z.string() }),
+      onError(error) {
+        onErrorResult = error;
+      },
+      onFinish(event) {
+        onFinishCalls.push(event);
+      },
+      headers,
+      credentials,
+    });
 
     return (
       <div>
@@ -279,7 +278,7 @@ describe('text stream', () => {
     };
 
     const TestComponentWithAsyncHeaders = () => {
-      const { submit } = experimental_useObject({
+      const { submit } = useObject({
         api: '/api/use-object',
         schema: z.object({ content: z.string() }),
         headers: async () => {
@@ -321,7 +320,7 @@ describe('text stream', () => {
     };
 
     const TestComponentWithSyncFunctionHeaders = () => {
-      const { submit } = experimental_useObject({
+      const { submit } = useObject({
         api: '/api/use-object',
         schema: z.object({ content: z.string() }),
         headers: () => ({
@@ -384,5 +383,11 @@ describe('text stream', () => {
       expect(screen.getByTestId('error')).toBeEmptyDOMElement();
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
+  });
+});
+
+describe('deprecated experimental_useObject alias', () => {
+  it('should be the same function as useObject', () => {
+    expect(experimental_useObject).toBe(useObject);
   });
 });

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -6,7 +6,8 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { experimental_useObject, useObject } from './use-object';
+import { experimental_useObject } from './index';
+import { useObject } from './use-object';
 
 const server = createTestServer({
   '/api/use-object': {},

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -2,6 +2,8 @@ export { Chat, type CreateUIMessage, type UIMessage } from './chat.svelte.js';
 export { Completion, type CompletionOptions } from './completion.svelte.js';
 export { createAIContext } from './context-provider.js';
 export {
-  StructuredObject as Experimental_StructuredObject,
+  Experimental_StructuredObject,
+  StructuredObject,
   type Experimental_StructuredObjectOptions,
+  type StructuredObjectOptions,
 } from './structured-object.svelte.js';

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,9 +1,38 @@
+import type { FlexibleSchema, InferSchema } from '@ai-sdk/provider-utils';
+import {
+  StructuredObject,
+  type StructuredObjectOptions,
+} from './structured-object.svelte.js';
+
 export { Chat, type CreateUIMessage, type UIMessage } from './chat.svelte.js';
 export { Completion, type CompletionOptions } from './completion.svelte.js';
 export { createAIContext } from './context-provider.js';
 export {
-  Experimental_StructuredObject,
   StructuredObject,
-  type Experimental_StructuredObjectOptions,
   type StructuredObjectOptions,
 } from './structured-object.svelte.js';
+
+// deprecated aliases
+// note: declared here (instead of export aliases) so that the `@deprecated`
+// tags are preserved in the bundled type declarations
+
+/**
+ * @deprecated Use `StructuredObject` instead.
+ */
+export const Experimental_StructuredObject = StructuredObject;
+/**
+ * @deprecated Use `StructuredObject` instead.
+ */
+export type Experimental_StructuredObject<
+  SCHEMA extends FlexibleSchema,
+  RESULT = InferSchema<SCHEMA>,
+  INPUT = unknown,
+> = StructuredObject<SCHEMA, RESULT, INPUT>;
+
+/**
+ * @deprecated Use `StructuredObjectOptions` instead.
+ */
+export type Experimental_StructuredObjectOptions<
+  SCHEMA extends FlexibleSchema,
+  RESULT = InferSchema<SCHEMA>,
+> = StructuredObjectOptions<SCHEMA, RESULT>;

--- a/packages/svelte/src/structured-object.svelte.ts
+++ b/packages/svelte/src/structured-object.svelte.ts
@@ -18,7 +18,7 @@ import {
   KeyedStructuredObjectStore,
   type StructuredObjectStore,
 } from './structured-object-context.svelte.js';
-export type Experimental_StructuredObjectOptions<
+export type StructuredObjectOptions<
   SCHEMA extends FlexibleSchema,
   RESULT = InferSchema<SCHEMA>,
 > = {
@@ -89,8 +89,8 @@ export class StructuredObject<
   RESULT = InferSchema<SCHEMA>,
   INPUT = unknown,
 > {
-  #options: Experimental_StructuredObjectOptions<SCHEMA, RESULT> =
-    {} as Experimental_StructuredObjectOptions<SCHEMA, RESULT>;
+  #options: StructuredObjectOptions<SCHEMA, RESULT> =
+    {} as StructuredObjectOptions<SCHEMA, RESULT>;
   readonly #id = $derived(this.#options.id ?? generateId());
   readonly #keyedStore = $state<KeyedStructuredObjectStore>()!;
   readonly #store = $derived(
@@ -120,7 +120,7 @@ export class StructuredObject<
     return this.#store.loading;
   }
 
-  constructor(options: Experimental_StructuredObjectOptions<SCHEMA, RESULT>) {
+  constructor(options: StructuredObjectOptions<SCHEMA, RESULT>) {
     if (hasStructuredObjectContext()) {
       this.#keyedStore = getStructuredObjectContext();
     } else {
@@ -248,3 +248,28 @@ export class StructuredObject<
     this.#store.loading = false;
   };
 }
+
+// deprecated exports
+
+/**
+ * @deprecated Use `StructuredObject` instead.
+ */
+const Experimental_StructuredObject = StructuredObject;
+/**
+ * @deprecated Use `StructuredObject` instead.
+ */
+type Experimental_StructuredObject<
+  SCHEMA extends FlexibleSchema,
+  RESULT = InferSchema<SCHEMA>,
+  INPUT = unknown,
+> = StructuredObject<SCHEMA, RESULT, INPUT>;
+export { Experimental_StructuredObject };
+
+/**
+ * @deprecated Use `StructuredObjectOptions` instead.
+ */
+type Experimental_StructuredObjectOptions<
+  SCHEMA extends FlexibleSchema,
+  RESULT = InferSchema<SCHEMA>,
+> = StructuredObjectOptions<SCHEMA, RESULT>;
+export type { Experimental_StructuredObjectOptions };

--- a/packages/svelte/src/structured-object.svelte.ts
+++ b/packages/svelte/src/structured-object.svelte.ts
@@ -248,28 +248,3 @@ export class StructuredObject<
     this.#store.loading = false;
   };
 }
-
-// deprecated exports
-
-/**
- * @deprecated Use `StructuredObject` instead.
- */
-const Experimental_StructuredObject = StructuredObject;
-/**
- * @deprecated Use `StructuredObject` instead.
- */
-type Experimental_StructuredObject<
-  SCHEMA extends FlexibleSchema,
-  RESULT = InferSchema<SCHEMA>,
-  INPUT = unknown,
-> = StructuredObject<SCHEMA, RESULT, INPUT>;
-export { Experimental_StructuredObject };
-
-/**
- * @deprecated Use `StructuredObjectOptions` instead.
- */
-type Experimental_StructuredObjectOptions<
-  SCHEMA extends FlexibleSchema,
-  RESULT = InferSchema<SCHEMA>,
-> = StructuredObjectOptions<SCHEMA, RESULT>;
-export type { Experimental_StructuredObjectOptions };

--- a/packages/vue/src/TestUseObjectComponent.vue
+++ b/packages/vue/src/TestUseObjectComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { experimental_useObject } from './use-object';
+import { useObject } from './use-object';
 import { z } from 'zod/v4';
 import { ref, reactive } from 'vue';
 
@@ -10,17 +10,16 @@ const onFinishCalls: Array<{
 
 const onErrorResult: Error | undefined = ref(undefined);
 
-const { object, error, submit, isLoading, stop, clear } =
-  experimental_useObject({
-    api: '/api/use-object',
-    schema: z.object({ content: z.string() }),
-    onError(error) {
-      onErrorResult.value = error;
-    },
-    onFinish(event) {
-      onFinishCalls.push(event);
-    },
-  });
+const { object, error, submit, isLoading, stop, clear } = useObject({
+  api: '/api/use-object',
+  schema: z.object({ content: z.string() }),
+  onError(error) {
+    onErrorResult.value = error;
+  },
+  onFinish(event) {
+    onFinishCalls.push(event);
+  },
+});
 </script>
 
 <template>

--- a/packages/vue/src/TestUseObjectCustomTransportComponent.vue
+++ b/packages/vue/src/TestUseObjectCustomTransportComponent.vue
@@ -1,18 +1,17 @@
 <script setup lang="ts">
-import { experimental_useObject } from './use-object';
+import { useObject } from './use-object';
 import { z } from 'zod/v4';
 import { ref, reactive } from 'vue';
 
-const { object, error, submit, isLoading, stop, clear } =
-  experimental_useObject({
-    api: '/api/use-object',
-    schema: z.object({ content: z.string() }),
-    headers: {
-      Authorization: 'Bearer TEST_TOKEN',
-      'X-Custom-Header': 'CustomValue',
-    },
-    credentials: 'include',
-  });
+const { object, error, submit, isLoading, stop, clear } = useObject({
+  api: '/api/use-object',
+  schema: z.object({ content: z.string() }),
+  headers: {
+    Authorization: 'Bearer TEST_TOKEN',
+    'X-Custom-Header': 'CustomValue',
+  },
+  credentials: 'include',
+});
 </script>
 
 <template>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,4 +1,36 @@
+import type { FlexibleSchema } from '@ai-sdk/provider-utils';
+import {
+  useObject,
+  type UseObjectHelpers,
+  type UseObjectOptions,
+} from './use-object';
+
 export * from './use-completion';
 export { Chat } from './chat.vue';
 export { useChat, type UseChatHelpers } from './use-chat';
 export * from './use-object';
+
+// deprecated aliases
+// note: declared here (instead of export aliases) so that the `@deprecated`
+// tags are preserved in the bundled type declarations
+
+/**
+ * @deprecated Use `useObject` instead.
+ */
+export const experimental_useObject = useObject;
+
+/**
+ * @deprecated Use `UseObjectOptions` instead.
+ */
+export type Experimental_UseObjectOptions<
+  SCHEMA extends FlexibleSchema,
+  RESULT,
+> = UseObjectOptions<SCHEMA, RESULT>;
+
+/**
+ * @deprecated Use `UseObjectHelpers` instead.
+ */
+export type Experimental_UseObjectHelpers<RESULT, INPUT> = UseObjectHelpers<
+  RESULT,
+  INPUT
+>;

--- a/packages/vue/src/use-object.ts
+++ b/packages/vue/src/use-object.ts
@@ -224,29 +224,3 @@ export function useObject<
     clear,
   };
 }
-
-// deprecated exports
-
-/**
- * @deprecated Use `useObject` instead.
- */
-const experimental_useObject = useObject;
-export { experimental_useObject };
-
-/**
- * @deprecated Use `UseObjectOptions` instead.
- */
-type Experimental_UseObjectOptions<
-  SCHEMA extends FlexibleSchema,
-  RESULT,
-> = UseObjectOptions<SCHEMA, RESULT>;
-export type { Experimental_UseObjectOptions };
-
-/**
- * @deprecated Use `UseObjectHelpers` instead.
- */
-type Experimental_UseObjectHelpers<RESULT, INPUT> = UseObjectHelpers<
-  RESULT,
-  INPUT
->;
-export type { Experimental_UseObjectHelpers };

--- a/packages/vue/src/use-object.ts
+++ b/packages/vue/src/use-object.ts
@@ -17,10 +17,7 @@ import { ref, type Ref } from 'vue';
 // use function to allow for mocking in tests
 const getOriginalFetch = () => fetch;
 
-export type Experimental_UseObjectOptions<
-  SCHEMA extends FlexibleSchema,
-  RESULT,
-> = {
+export type UseObjectOptions<SCHEMA extends FlexibleSchema, RESULT> = {
   /** API endpoint that streams JSON chunks matching the schema */
   api: string;
 
@@ -52,7 +49,7 @@ export type Experimental_UseObjectOptions<
   credentials?: RequestCredentials;
 };
 
-export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
+export type UseObjectHelpers<RESULT, INPUT> = {
   /** POST the input and start streaming */
   submit: (input: INPUT) => void;
 
@@ -78,7 +75,7 @@ let uniqueId = 0;
 const useSWRV = (swrv.default as (typeof SwrvModule)['default']) || swrv;
 const store: Record<string, any> = {};
 
-export const experimental_useObject = function useObject<
+export function useObject<
   SCHEMA extends FlexibleSchema,
   RESULT = InferSchema<SCHEMA>,
   INPUT = any,
@@ -92,10 +89,7 @@ export const experimental_useObject = function useObject<
   onFinish,
   headers,
   credentials,
-}: Experimental_UseObjectOptions<
-  SCHEMA,
-  RESULT
->): Experimental_UseObjectHelpers<RESULT, INPUT> {
+}: UseObjectOptions<SCHEMA, RESULT>): UseObjectHelpers<RESULT, INPUT> {
   // Generate an unique id for the object if not provided.
   const completionId = id || `completion-${uniqueId++}`;
 
@@ -229,4 +223,30 @@ export const experimental_useObject = function useObject<
     stop,
     clear,
   };
-};
+}
+
+// deprecated exports
+
+/**
+ * @deprecated Use `useObject` instead.
+ */
+const experimental_useObject = useObject;
+export { experimental_useObject };
+
+/**
+ * @deprecated Use `UseObjectOptions` instead.
+ */
+type Experimental_UseObjectOptions<
+  SCHEMA extends FlexibleSchema,
+  RESULT,
+> = UseObjectOptions<SCHEMA, RESULT>;
+export type { Experimental_UseObjectOptions };
+
+/**
+ * @deprecated Use `UseObjectHelpers` instead.
+ */
+type Experimental_UseObjectHelpers<RESULT, INPUT> = UseObjectHelpers<
+  RESULT,
+  INPUT
+>;
+export type { Experimental_UseObjectHelpers };


### PR DESCRIPTION
## Background

`useObject` (React, Vue) and `StructuredObject` (Svelte) have been exported under `experimental_` / `Experimental_` prefixes since their introduction in June 2024. The API is mature, widely documented, and heavily used. Per the graduation strategy in #16562, this promotes the stable, un-prefixed names while keeping the experimental names as `@deprecated` aliases until they are removed in v8, so the change is non-breaking.

## Summary

- `@ai-sdk/react`: export `useObject`, `UseObjectOptions`, and `UseObjectHelpers`; keep `experimental_useObject`, `Experimental_UseObjectOptions`, and `Experimental_UseObjectHelpers` as deprecated aliases.
- `@ai-sdk/vue`: same graduation as React.
- `@ai-sdk/svelte`: export `StructuredObject` and `StructuredObjectOptions`; keep `Experimental_StructuredObject` and `Experimental_StructuredObjectOptions` as deprecated aliases.
- Updated tests to use the stable names, and added a test in `@ai-sdk/react` that verifies the deprecated `experimental_useObject` alias remains identical to `useObject`.
- Updated examples (`next-openai-pages`, `nuxt-openai`, `sveltekit-openai`, `ai-e2e-next`) to the stable names.
- Updated docs (reference page, object generation guide, stream-object cookbook): stable import names, and removed the "experimental feature" notes.
- Added a patch changeset for `@ai-sdk/react`, `@ai-sdk/vue`, and `@ai-sdk/svelte`.

## Manual Verification

Ran the updated `examples/ai-e2e-next` app (`pnpm dev`) and opened `/use-object`, which now imports the stable `useObject` from `@ai-sdk/react` (`import { useObject } from '@ai-sdk/react'`). Clicked "Generate notifications" and observed the structured object streaming in: the three notification cards (name, message, minutes ago) rendered progressively as the JSON streamed from the `/api/use-object` route, with no console or overlay errors.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A review of open issues found no contract-level problems with `useObject`, but the following remain open and are worth addressing now that the API is stable:

- Additive feature requests: `FormData` submission (#5004), output config option (#2895), streaming custom data (#5017).
- Behavior bugs fixable behind the same API signature: error handling when the LLM throws (#2795), `object` becoming `undefined` on API URL change (#9210), page refresh on `submit()` (#5795), React Native streaming (#6675).
- Remove the deprecated `experimental_` aliases in v8.

## Related Issues

Closes #16883. Part of #16562.
