### PR TITLE
feat(fireworks): add `providerOptions` schema and type for Fireworks image model requests

### DIFF
--- a/.changeset/plenty-eggs-explain.md
+++ b/.changeset/plenty-eggs-explain.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/fireworks": patch
+---
+
+feat(fireworks): add `providerOptions` schema and type for Fireworks image model requests

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -89,7 +89,6 @@
             "${providerId}-video-model.ts",
             "packages/amazon-bedrock/src/amazon-bedrock-image-model.ts",
             "packages/deepinfra/src/deepinfra-image-model.ts",
-            "packages/fireworks/src/fireworks-image-model.ts",
             "packages/gateway/src/gateway-embedding-model.ts",
             "packages/gateway/src/gateway-image-model.ts",
             "packages/gateway/src/gateway-language-model.ts",

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -351,13 +351,19 @@ You can create Fireworks image models using the `.image()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
-import { fireworks } from '@ai-sdk/fireworks';
+import { fireworks, type FireworksImageModelOptions } from '@ai-sdk/fireworks';
 import { generateImage } from 'ai';
 
 const { image } = await generateImage({
   model: fireworks.image('accounts/fireworks/models/flux-1-dev-fp8'),
   prompt: 'A futuristic cityscape at sunset',
   aspectRatio: '16:9',
+  providerOptions: {
+    fireworks: {
+      guidance_scale: 4.5,
+      num_inference_steps: 8,
+    } satisfies FireworksImageModelOptions,
+  },
 });
 ```
 
@@ -367,6 +373,48 @@ const { image } = await generateImage({
   or check the model's documentation on [Fireworks models
   page](https://fireworks.ai/models) for more details.
 </Note>
+
+### Provider Options
+
+Fireworks image models support flexible provider options through the `providerOptions.fireworks` object. Use the `FireworksImageModelOptions` type to validate known Fireworks image options while still allowing model-specific options to pass through.
+
+The following typed provider options are available:
+
+- **guidance_scale** _number_
+
+  Classifier-free guidance scale for the image diffusion process.
+
+- **num_inference_steps** _number_
+
+  Number of denoising steps for FLUX workflow image generation.
+
+- **output_format** _'jpeg' | 'png'_
+
+  Desired output format for FLUX Kontext image generation and editing.
+
+- **prompt_upsampling** _boolean_
+
+  Whether Fireworks should automatically modify the prompt for more creative generation.
+
+- **safety_tolerance** _number_
+
+  Moderation tolerance level for inputs and outputs, from `0` to `6`. Fireworks limits image-to-image requests to `2`.
+
+- **webhook_url** _string_
+
+  URL to receive webhook notifications for async Kontext requests.
+
+- **webhook_secret** _string_
+
+  Secret for webhook signature verification.
+
+- **cfg_scale** _number_
+
+  Guidance scale for legacy `image_generation` models.
+
+- **steps** _number_
+
+  Number of generation steps for legacy `image_generation` models.
 
 ### Image Editing
 
@@ -393,7 +441,8 @@ const { images } = await generateImage({
   providerOptions: {
     fireworks: {
       output_format: 'jpeg',
-    },
+      safety_tolerance: 2,
+    } satisfies FireworksImageModelOptions,
   },
 });
 ```

--- a/examples/ai-functions/src/generate-image/fireworks/async.ts
+++ b/examples/ai-functions/src/generate-image/fireworks/async.ts
@@ -1,4 +1,4 @@
-import { fireworks } from '@ai-sdk/fireworks';
+import { fireworks, type FireworksImageModelOptions } from '@ai-sdk/fireworks';
 import { generateImage } from 'ai';
 import { presentImages } from '../../lib/present-image';
 import { run } from '../../lib/run';
@@ -8,6 +8,13 @@ run(async () => {
     model: fireworks.image('accounts/fireworks/models/flux-kontext-pro'),
     prompt: 'A burrito launched through a tunnel',
     aspectRatio: '1:1',
+    providerOptions: {
+      fireworks: {
+        output_format: 'png',
+        prompt_upsampling: true,
+        safety_tolerance: 2,
+      } satisfies FireworksImageModelOptions,
+    },
   });
 
   await presentImages(result.images);

--- a/examples/ai-functions/src/generate-image/fireworks/edit-style.ts
+++ b/examples/ai-functions/src/generate-image/fireworks/edit-style.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { fireworks } from '@ai-sdk/fireworks';
+import { fireworks, type FireworksImageModelOptions } from '@ai-sdk/fireworks';
 import { generateImage } from 'ai';
 import { presentImages } from '../../lib/present-image';
 import { run } from '../../lib/run';
@@ -26,6 +26,12 @@ run(async () => {
       images: [imageBuffer],
     },
     aspectRatio: '1:1',
+    providerOptions: {
+      fireworks: {
+        output_format: 'jpeg',
+        safety_tolerance: 2,
+      } satisfies FireworksImageModelOptions,
+    },
   });
 
   console.log('OUTPUT IMAGE:');

--- a/examples/ai-functions/src/generate-image/fireworks/flux-options.ts
+++ b/examples/ai-functions/src/generate-image/fireworks/flux-options.ts
@@ -5,18 +5,14 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateImage({
-    model: fireworks.image(
-      'accounts/fireworks/models/stable-diffusion-xl-1024-v1-0',
-    ),
-    prompt: 'A burrito launched through a tunnel',
-    size: '1024x1024',
-    seed: 0,
-    n: 2,
+    model: fireworks.image('accounts/fireworks/models/flux-1-schnell-fp8'),
+    prompt: 'A luminous glass greenhouse floating over a forest at dawn',
+    aspectRatio: '16:9',
+    seed: 42,
     providerOptions: {
       fireworks: {
-        // https://fireworks.ai/models/fireworks/stable-diffusion-xl-1024-v1-0/playground
-        cfg_scale: 10,
-        steps: 30,
+        guidance_scale: 4.5,
+        num_inference_steps: 8,
       } satisfies FireworksImageModelOptions,
     },
   });

--- a/packages/fireworks/src/fireworks-image-model-options.ts
+++ b/packages/fireworks/src/fireworks-image-model-options.ts
@@ -1,0 +1,61 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const fireworksImageModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.looseObject({
+      /**
+       * Classifier-free guidance scale for the image diffusion process.
+       */
+      guidance_scale: z.number().optional(),
+
+      /**
+       * Number of denoising steps for the image generation process.
+       */
+      num_inference_steps: z.number().int().optional(),
+
+      /**
+       * Desired output image format.
+       */
+      output_format: z.enum(['jpeg', 'png']).optional(),
+
+      /**
+       * URL to receive webhook notifications for async Kontext requests.
+       */
+      webhook_url: z.string().optional(),
+
+      /**
+       * Secret for webhook signature verification.
+       */
+      webhook_secret: z.string().optional(),
+
+      /**
+       * Whether Fireworks should automatically modify the prompt for more creative generation.
+       */
+      prompt_upsampling: z.boolean().optional(),
+
+      /**
+       * Moderation tolerance level for inputs and outputs.
+       */
+      safety_tolerance: z.number().int().min(0).max(6).optional(),
+
+      /**
+       * Guidance scale for legacy image_generation models.
+       */
+      cfg_scale: z.number().optional(),
+
+      /**
+       * Number of generation steps for legacy image_generation models.
+       */
+      steps: z.number().int().optional(),
+    }),
+  ),
+);
+
+export type FireworksImageModelOptions = InferSchema<
+  typeof fireworksImageModelOptionsSchema
+>;

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -2,6 +2,7 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it, vi } from 'vitest';
 import { FireworksImageModel } from './fireworks-image-model';
+import type { FireworksImageModelOptions } from './fireworks-image-model-options';
 
 const prompt = 'A cute baby sea otter';
 
@@ -158,7 +159,11 @@ describe('FireworksImageModel', () => {
         size: undefined,
         aspectRatio: '16:9',
         seed: 42,
-        providerOptions: { fireworks: { additional_param: 'value' } },
+        providerOptions: {
+          fireworks: {
+            additional_param: 'value',
+          } satisfies FireworksImageModelOptions,
+        },
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -181,7 +186,11 @@ describe('FireworksImageModel', () => {
         size: undefined,
         aspectRatio: '16:9',
         seed: 42,
-        providerOptions: { fireworks: { additional_param: 'value' } },
+        providerOptions: {
+          fireworks: {
+            additional_param: 'value',
+          } satisfies FireworksImageModelOptions,
+        },
       });
 
       expect(server.calls[0].requestMethod).toStrictEqual('POST');
@@ -296,6 +305,88 @@ describe('FireworksImageModel', () => {
         seed: 42,
         samples: 1,
       });
+    });
+
+    it('should pass typed workflow provider options to the API', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {
+          fireworks: {
+            guidance_scale: 4.5,
+            num_inference_steps: 8,
+          } satisfies FireworksImageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "aspect_ratio": "1:1",
+          "guidance_scale": 4.5,
+          "num_inference_steps": 8,
+          "prompt": "A cute baby sea otter",
+          "samples": 1,
+        }
+      `);
+    });
+
+    it('should pass typed image_generation provider options to the API', async () => {
+      const sizeModel = createSizeModel();
+
+      await sizeModel.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {
+          fireworks: {
+            cfg_scale: 10,
+            steps: 30,
+          } satisfies FireworksImageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "cfg_scale": 10,
+          "height": "1024",
+          "prompt": "A cute baby sea otter",
+          "samples": 1,
+          "steps": 30,
+          "width": "1024",
+        }
+      `);
+    });
+
+    it('should reject invalid provider options', async () => {
+      const model = createBasicModel();
+
+      await expect(
+        model.doGenerate({
+          prompt,
+          files: undefined,
+          mask: undefined,
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {
+            fireworks: {
+              output_format: 'webp',
+            },
+          },
+        }),
+      ).rejects.toThrow('invalid fireworks provider options');
     });
 
     describe('warnings', () => {
@@ -709,7 +800,7 @@ describe('FireworksImageModel', () => {
           fireworks: {
             output_format: 'jpeg',
             safety_tolerance: 2,
-          },
+          } satisfies FireworksImageModelOptions,
         },
       });
 
@@ -951,8 +1042,12 @@ describe('FireworksImageModel', () => {
         providerOptions: {
           fireworks: {
             safety_tolerance: 6,
+            output_format: 'jpeg',
+            prompt_upsampling: true,
+            webhook_url: 'https://example.com/webhook',
+            webhook_secret: 'secret',
             input_image: 'base64-image-data',
-          },
+          } satisfies FireworksImageModelOptions,
         },
       });
 
@@ -960,6 +1055,10 @@ describe('FireworksImageModel', () => {
         prompt,
         samples: 1,
         safety_tolerance: 6,
+        output_format: 'jpeg',
+        prompt_upsampling: true,
+        webhook_url: 'https://example.com/webhook',
+        webhook_secret: 'secret',
         input_image: 'base64-image-data',
       });
     });

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -8,6 +8,7 @@ import {
   delay,
   getFromApi,
   isSameOrigin,
+  parseProviderOptions,
   postJsonToApi,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
@@ -18,6 +19,7 @@ import {
   asyncPollResponseSchema,
   asyncSubmitResponseSchema,
 } from './fireworks-image-api';
+import { fireworksImageModelOptionsSchema } from './fireworks-image-model-options';
 import type { FireworksImageModelId } from './fireworks-image-options';
 
 const DEFAULT_POLL_INTERVAL_MILLIS = 500;
@@ -204,6 +206,12 @@ export class FireworksImageModel implements ImageModelV4 {
     const splitSize = size?.split('x');
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const combinedHeaders = combineHeaders(this.config.headers?.(), headers);
+    const fireworksOptions =
+      (await parseProviderOptions({
+        provider: 'fireworks',
+        providerOptions,
+        schema: fireworksImageModelOptionsSchema,
+      })) ?? {};
 
     const body = {
       prompt,
@@ -212,7 +220,7 @@ export class FireworksImageModel implements ImageModelV4 {
       samples: n,
       ...(inputImage && { input_image: inputImage }),
       ...(splitSize && { width: splitSize[0], height: splitSize[1] }),
-      ...(providerOptions.fireworks ?? {}),
+      ...fireworksOptions,
     };
 
     // Handle async models that require polling (e.g., flux-kontext-*)

--- a/packages/fireworks/src/index.ts
+++ b/packages/fireworks/src/index.ts
@@ -10,6 +10,7 @@ export type {
   FireworksEmbeddingModelOptions as FireworksEmbeddingProviderOptions,
 } from './fireworks-embedding-options';
 export { FireworksImageModel } from './fireworks-image-model';
+export type { FireworksImageModelOptions } from './fireworks-image-model-options';
 export type { FireworksImageModelId } from './fireworks-image-options';
 export { fireworks, createFireworks } from './fireworks-provider';
 export type {


### PR DESCRIPTION
## Background

Issue #14859 tracks provider model classes that still need typed `providerOptions`. The Fireworks image model was one of the remaining exclusions because it forwarded raw `providerOptions.fireworks` values.

## Summary

- Added `FireworksImageModelOptions` for known Fireworks image request options while preserving model-specific pass-through.
- Parse Fireworks image `providerOptions` before request construction so invalid known options are rejected consistently.
- Updated Fireworks image docs and examples to use the typed options surface.
- Removed the Fireworks image model from the konsistent exclusion list.

## Manual Verification

Run the examples in `examples/ai-functions/src/generate-image/fireworks`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

See #14859
