### PR TITLE
fix(provider/xai): send reasoning effort "none" for top-level `reasoning: 'none'`

### DIFF
--- a/.changeset/violet-clouds-brake.md
+++ b/.changeset/violet-clouds-brake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix: send reasoning effort `none` to the xAI API when the top-level `reasoning: 'none'` option is set

--- a/.changeset/wild-planets-argue.md
+++ b/.changeset/wild-planets-argue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix: omit the reasoning effort parameter and emit an unsupported warning when the top-level `reasoning` option is used with xAI models that reject it (`grok-4.20-reasoning`, `grok-4.20-non-reasoning`, and dated variants)

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -893,6 +893,53 @@ describe('XaiResponsesLanguageModel', () => {
           const requestBody = await server.calls[0].requestBodyJson;
           expect(requestBody.reasoning.effort).toBe('high');
         });
+
+        it('should omit reasoning effort and warn for models that do not support it', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.20-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          const result = await createModel('grok-4.20-reasoning').doGenerate({
+            prompt: TEST_PROMPT,
+            reasoning: 'none',
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning).toBeUndefined();
+          expect(result.warnings).toContainEqual({
+            type: 'unsupported',
+            feature: 'reasoning',
+            details: 'reasoning "none" is not supported by this model.',
+          });
+        });
+
+        it('should still pass providerOptions reasoningEffort for models that do not support top-level reasoning', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.20-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel('grok-4.20-reasoning').doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                reasoningEffort: 'none',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.effort).toBe('none');
+        });
       });
 
       it('should warn about unsupported stopSequences', async () => {

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -831,6 +831,70 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      describe('top-level reasoning', () => {
+        it('should map top-level reasoning to reasoning effort', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.3',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            reasoning: 'high',
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.effort).toBe('high');
+        });
+
+        it('should map top-level reasoning none to reasoning effort "none"', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.3',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            reasoning: 'none',
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.effort).toBe('none');
+        });
+
+        it('should prefer providerOptions reasoningEffort over top-level reasoning', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.3',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            reasoning: 'none',
+            providerOptions: {
+              xai: {
+                reasoningEffort: 'high',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.effort).toBe('high');
+        });
+      });
+
       it('should warn about unsupported stopSequences', async () => {
         prepareJsonResponse({
           id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -168,7 +168,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
       options.reasoningEffort ??
       (isCustomReasoning(reasoning)
         ? reasoning === 'none'
-          ? undefined
+          ? 'none'
           : mapReasoningToProviderEffort({
               reasoning,
               effortMap: {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -25,6 +25,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import type { z } from 'zod/v4';
 import { getResponseMetadata } from '../get-response-metadata';
+import { supportsReasoningEffort } from '../supports-reasoning-effort';
 import { xaiFailedResponseHandler } from '../xai-error';
 import { convertToXaiResponsesInput } from './convert-to-xai-responses-input';
 import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
@@ -164,23 +165,30 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
       }
     }
 
-    const resolvedReasoningEffort =
-      options.reasoningEffort ??
-      (isCustomReasoning(reasoning)
-        ? reasoning === 'none'
-          ? 'none'
-          : mapReasoningToProviderEffort({
-              reasoning,
-              effortMap: {
-                minimal: 'low',
-                low: 'low',
-                medium: 'medium',
-                high: 'high',
-                xhigh: 'high',
-              },
-              warnings,
-            })
-        : undefined);
+    let resolvedReasoningEffort = options.reasoningEffort;
+    if (resolvedReasoningEffort == null && isCustomReasoning(reasoning)) {
+      if (!supportsReasoningEffort(this.modelId)) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'reasoning',
+          details: `reasoning "${reasoning}" is not supported by this model.`,
+        });
+      } else if (reasoning === 'none') {
+        resolvedReasoningEffort = 'none';
+      } else {
+        resolvedReasoningEffort = mapReasoningToProviderEffort({
+          reasoning,
+          effortMap: {
+            minimal: 'low',
+            low: 'low',
+            medium: 'medium',
+            high: 'high',
+            xhigh: 'high',
+          },
+          warnings,
+        });
+      }
+    }
 
     const baseArgs: Record<string, unknown> = {
       model: this.modelId,

--- a/packages/xai/src/supports-reasoning-effort.test.ts
+++ b/packages/xai/src/supports-reasoning-effort.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { supportsReasoningEffort } from './supports-reasoning-effort';
+
+describe('supportsReasoningEffort', () => {
+  it.each([
+    'grok-4.3',
+    'grok-latest',
+    'grok-4.20-multi-agent',
+    'grok-4.20-multi-agent-0309',
+    'grok-3-mini',
+  ])('should return true for %s', modelId => {
+    expect(supportsReasoningEffort(modelId)).toBe(true);
+  });
+
+  it.each([
+    'grok-4.20-reasoning',
+    'grok-4.20-non-reasoning',
+    'grok-4.20-0309-reasoning',
+    'grok-4.20-0309-non-reasoning',
+  ])('should return false for %s', modelId => {
+    expect(supportsReasoningEffort(modelId)).toBe(false);
+  });
+});

--- a/packages/xai/src/supports-reasoning-effort.ts
+++ b/packages/xai/src/supports-reasoning-effort.ts
@@ -1,0 +1,12 @@
+/**
+ * The grok-4.20 reasoning and non-reasoning models (including dated variants
+ * such as `grok-4.20-0309-reasoning`) reject the reasoning effort parameter
+ * with an invalid-argument error for every value, including `none`.
+ * Other models such as `grok-4.3`, `grok-latest`, and
+ * `grok-4.20-multi-agent` accept it.
+ */
+const modelsWithoutReasoningEffort = /^grok-4\.20(-\d{4})?-(non-)?reasoning$/;
+
+export function supportsReasoningEffort(modelId: string): boolean {
+  return !modelsWithoutReasoningEffort.test(modelId);
+}

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1328,6 +1328,49 @@ describe('XaiChatLanguageModel', () => {
       );
     });
 
+    it('should omit reasoning_effort and warn for models that do not support it', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      const modelWithoutReasoningEffort = new XaiChatLanguageModel(
+        'grok-4.20-reasoning',
+        testConfig,
+      );
+
+      const result = await modelWithoutReasoningEffort.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'none',
+      });
+
+      expect(
+        (await server.calls[0].requestBodyJson).reasoning_effort,
+      ).toBeUndefined();
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'reasoning',
+        details: 'reasoning "none" is not supported by this model.',
+      });
+    });
+
+    it('should still pass providerOptions reasoningEffort for models that do not support top-level reasoning', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      const modelWithoutReasoningEffort = new XaiChatLanguageModel(
+        'grok-4.20-reasoning',
+        testConfig,
+      );
+
+      await modelWithoutReasoningEffort.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: { reasoningEffort: 'none' },
+        },
+      });
+
+      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+        'none',
+      );
+    });
+
     it('should extract reasoning content', async () => {
       prepareJsonFixtureResponse('xai-text');
 

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1299,7 +1299,7 @@ describe('XaiChatLanguageModel', () => {
       );
     });
 
-    it('should not set reasoning_effort for top-level reasoning none', async () => {
+    it('should map top-level reasoning none to reasoning_effort: "none"', async () => {
       prepareJsonFixtureResponse('xai-text');
 
       await reasoningModel.doGenerate({
@@ -1307,9 +1307,9 @@ describe('XaiChatLanguageModel', () => {
         reasoning: 'none',
       });
 
-      expect(
-        (await server.calls[0].requestBodyJson).reasoning_effort,
-      ).toBeUndefined();
+      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+        'none',
+      );
     });
 
     it('should prefer providerOptions reasoningEffort over top-level reasoning', async () => {

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -31,6 +31,7 @@ import { convertToXaiChatMessages } from './convert-to-xai-chat-messages';
 import { convertXaiChatUsage } from './convert-xai-chat-usage';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapXaiFinishReason } from './map-xai-finish-reason';
+import { supportsReasoningEffort } from './supports-reasoning-effort';
 import {
   xaiLanguageModelChatOptions,
   type XaiChatModelId,
@@ -139,6 +140,31 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
     });
     warnings.push(...toolWarnings);
 
+    let reasoningEffort = options.reasoningEffort;
+    if (reasoningEffort == null && isCustomReasoning(reasoning)) {
+      if (!supportsReasoningEffort(this.modelId)) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'reasoning',
+          details: `reasoning "${reasoning}" is not supported by this model.`,
+        });
+      } else if (reasoning === 'none') {
+        reasoningEffort = 'none';
+      } else {
+        reasoningEffort = mapReasoningToProviderEffort({
+          reasoning,
+          effortMap: {
+            minimal: 'low',
+            low: 'low',
+            medium: 'medium',
+            high: 'high',
+            xhigh: 'high',
+          },
+          warnings,
+        });
+      }
+    }
+
     const baseArgs = {
       // model id
       model: this.modelId,
@@ -153,23 +179,7 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
       temperature,
       top_p: topP,
       seed,
-      reasoning_effort:
-        options.reasoningEffort ??
-        (isCustomReasoning(reasoning)
-          ? reasoning === 'none'
-            ? 'none'
-            : mapReasoningToProviderEffort({
-                reasoning,
-                effortMap: {
-                  minimal: 'low',
-                  low: 'low',
-                  medium: 'medium',
-                  high: 'high',
-                  xhigh: 'high',
-                },
-                warnings,
-              })
-          : undefined),
+      reasoning_effort: reasoningEffort,
 
       // parallel function calling
       parallel_function_calling: options.parallel_function_calling,

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -157,7 +157,7 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
         options.reasoningEffort ??
         (isCustomReasoning(reasoning)
           ? reasoning === 'none'
-            ? undefined
+            ? 'none'
             : mapReasoningToProviderEffort({
                 reasoning,
                 effortMap: {


### PR DESCRIPTION
## Background

The xAI API supports disabling reasoning on `grok-4.3` and newer reasoning models by sending `reasoning: { effort: "none" }` (Responses API) / `reasoning_effort: "none"` (Chat Completions API). When the parameter is omitted, xAI defaults to `effort: "low"`, so the model still reasons.

The xAI provider explicitly mapped the top-level `reasoning: 'none'` call option to `undefined`, silently dropping it from the request — without even emitting a warning. Users who requested `reasoning: 'none'` still got (and paid for) reasoning tokens. The `providerOptions: { xai: { reasoningEffort: 'none' } }` escape hatch already forwarded `'none'` correctly, and the OpenAI provider passes top-level `'none'` straight through, so this was an inconsistency introduced in #13648, presumably before xAI supported `none`.

Additionally, probing the live API revealed that `grok-4.20-reasoning` and `grok-4.20-non-reasoning` (including dated variants like `grok-4.20-0309-reasoning`) reject the reasoning effort parameter entirely — **any** value, not just `'none'` — with `400 invalid-argument: Model X does not support parameter reasoningEffort.` So the top-level `reasoning` option already caused request failures on those models before this PR.

## Summary

- Map the top-level `reasoning: 'none'` option to effort `'none'` in both the Responses API model (`xai-responses-language-model.ts`) and the Chat Completions model (`xai-chat-language-model.ts`), instead of dropping it.
- Omit the reasoning effort parameter and emit an `unsupported` warning when the top-level `reasoning` option is used with models that reject the parameter (`supports-reasoning-effort.ts`). Explicit `providerOptions.xai.reasoningEffort` is still passed through verbatim.
- Updated the chat model test that locked in the old behavior, and added top-level `reasoning` coverage for the Responses API model (mapping, `'none'`, `providerOptions` precedence, and unsupported-model gating).
- Added patch changesets for `@ai-sdk/xai`.

## Manual Verification

Ran the following against the live xAI API (via `examples/ai-functions`), logging the request body with a custom `fetch`:

```ts
import { createXai } from '@ai-sdk/xai';
import { generateText } from 'ai';

const xai = createXai({
  fetch: async (url, init) => {
    console.dir(JSON.parse(init.body), { depth: Infinity });
    return fetch(url, init);
  },
});

const result = await generateText({
  model: xai('grok-4.3'),
  prompt: `How many "r"s are in the word "strawberry", and what is the square root of 144? Then, how much is the product of both of the resulting values? Think hard about it. Only respond with the resulting final number, nothing more.`,
  reasoning: 'none',
});

console.log(result.finalStep.reasoning);
console.log(result.text);
```

**Before the fix**: the request body contained no `reasoning` field, and `result.finalStep.reasoning` contained reasoning content (xAI defaults to `effort: "low"`).

**After the fix**: the request body contains `reasoning: { effort: 'none' }` and the response contains no reasoning content.

Also verified against the live API with `reasoning: 'none'` on models that reject the parameter:

- `grok-4.3` → `reasoning: { effort: 'none' }` sent, no reasoning tokens, no warnings.
- `grok-4.20-reasoning` → parameter omitted, request succeeds (would be a 400 otherwise), `unsupported` warning surfaced.
- `grok-4.20-non-reasoning` → parameter omitted, request succeeds, `unsupported` warning surfaced.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16892