### PR TITLE
feat(provider/xai): support `imageDetail` provider option on image file parts

### DIFF
--- a/.changeset/olive-donkeys-search.md
+++ b/.changeset/olive-donkeys-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat: support `imageDetail` provider option on image file parts to control image processing resolution

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -212,6 +212,42 @@ const { text } = await generateText({
 });
 ```
 
+You can control the resolution at which the model processes an image with
+the `imageDetail` provider option on the image part:
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: xai('grok-4.3'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What do you see in this image?' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: fs.readFileSync('./image.png'),
+          providerOptions: {
+            xai: { imageDetail: 'low' },
+          },
+        },
+      ],
+    },
+  ],
+});
+```
+
+The following image detail values are supported:
+
+- **low**: processes the image at reduced resolution and consumes fewer input tokens.
+- **high**: processes the image at full resolution.
+- **auto**: lets the xAI API decide.
+
+When not set, the image is processed at full resolution.
+
 ### Web Search Tool
 
 The web search tool enables autonomous web research with optional domain filtering and image understanding:

--- a/examples/ai-functions/src/generate-text/xai/image-detail.ts
+++ b/examples/ai-functions/src/generate-text/xai/image-detail.ts
@@ -1,0 +1,29 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai('grok-4.3'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image in detail.' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: fs.readFileSync('./data/comic-cat.png'),
+            // process the image at reduced resolution (fewer input tokens)
+            providerOptions: { xai: { imageDetail: 'low' } },
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Usage:', result.usage);
+});

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -2,8 +2,8 @@ import { convertToXaiChatMessages } from './convert-to-xai-chat-messages';
 import { describe, it, expect } from 'vitest';
 
 describe('convertToXaiChatMessages', () => {
-  it('should convert simple text messages', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert simple text messages', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
     ]);
 
@@ -11,8 +11,8 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([{ role: 'user', content: 'Hello' }]);
   });
 
-  it('should convert system messages', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert system messages', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       { role: 'system', content: 'You are a helpful assistant.' },
     ]);
 
@@ -22,8 +22,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should convert assistant messages', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert assistant messages', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       { role: 'assistant', content: [{ type: 'text', text: 'Hello there!' }] },
     ]);
 
@@ -33,8 +33,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should convert messages with image parts', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert messages with image parts', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'user',
         content: [
@@ -63,8 +63,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should convert image URLs', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert image URLs', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'user',
         content: [
@@ -94,8 +94,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should convert image file parts with provider reference', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert image file parts with provider reference', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'user',
         content: [
@@ -125,8 +125,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should convert non-image file parts with provider reference', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert non-image file parts with provider reference', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'user',
         content: [
@@ -156,8 +156,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should throw error when provider reference is missing xai key', () => {
-    expect(() => {
+  it('should throw error when provider reference is missing xai key', async () => {
+    await expect(
       convertToXaiChatMessages([
         {
           role: 'user',
@@ -172,14 +172,14 @@ describe('convertToXaiChatMessages', () => {
             },
           ],
         },
-      ]);
-    }).toThrow(
+      ]),
+    ).rejects.toThrow(
       "No provider reference found for provider 'xai'. Available providers: openai",
     );
   });
 
-  it('should throw error for unsupported file types', () => {
-    expect(() => {
+  it('should throw error for unsupported file types', async () => {
+    await expect(
       convertToXaiChatMessages([
         {
           role: 'user',
@@ -191,12 +191,12 @@ describe('convertToXaiChatMessages', () => {
             },
           ],
         },
-      ]);
-    }).toThrow('file part media type application/pdf');
+      ]),
+    ).rejects.toThrow('file part media type application/pdf');
   });
 
-  it('should convert tool calls and tool responses', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should convert tool calls and tool responses', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'assistant',
         content: [
@@ -245,8 +245,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should handle multiple tool calls in one message', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should handle multiple tool calls in one message', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'assistant',
         content: [
@@ -293,8 +293,8 @@ describe('convertToXaiChatMessages', () => {
     ]);
   });
 
-  it('should handle mixed content with text and tool calls', () => {
-    const { messages, warnings } = convertToXaiChatMessages([
+  it('should handle mixed content with text and tool calls', async () => {
+    const { messages, warnings } = await convertToXaiChatMessages([
       {
         role: 'assistant',
         content: [
@@ -331,8 +331,8 @@ describe('convertToXaiChatMessages', () => {
   describe('top-level-only media type resolution', () => {
     const pngBase64 = 'iVBORw0KGgo=';
 
-    it('passes full image/png through unchanged for inline data', () => {
-      const { messages } = convertToXaiChatMessages([
+    it('passes full image/png through unchanged for inline data', async () => {
+      const { messages } = await convertToXaiChatMessages([
         {
           role: 'user',
           content: [
@@ -351,8 +351,8 @@ describe('convertToXaiChatMessages', () => {
       });
     });
 
-    it('detects image subtype from inline bytes for top-level "image"', () => {
-      const { messages } = convertToXaiChatMessages([
+    it('detects image subtype from inline bytes for top-level "image"', async () => {
+      const { messages } = await convertToXaiChatMessages([
         {
           role: 'user',
           content: [
@@ -371,8 +371,8 @@ describe('convertToXaiChatMessages', () => {
       });
     });
 
-    it('passes through URL source for top-level-only image', () => {
-      const { messages } = convertToXaiChatMessages([
+    it('passes through URL source for top-level-only image', async () => {
+      const { messages } = await convertToXaiChatMessages([
         {
           role: 'user',
           content: [
@@ -394,8 +394,8 @@ describe('convertToXaiChatMessages', () => {
       });
     });
 
-    it('normalizes image/* wildcard via detection', () => {
-      const { messages } = convertToXaiChatMessages([
+    it('normalizes image/* wildcard via detection', async () => {
+      const { messages } = await convertToXaiChatMessages([
         {
           role: 'user',
           content: [

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -6,15 +6,19 @@ import {
 import {
   convertToBase64,
   getTopLevelMediaType,
+  parseProviderOptions,
   resolveFullMediaType,
   resolveProviderReference,
 } from '@ai-sdk/provider-utils';
-import type { XaiChatPrompt } from './xai-chat-prompt';
+import type { XaiChatPrompt, XaiUserMessageContent } from './xai-chat-prompt';
+import { xaiFilePartProviderOptions } from './xai-file-part-options';
 
-export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
+export async function convertToXaiChatMessages(
+  prompt: LanguageModelV4Prompt,
+): Promise<{
   messages: XaiChatPrompt;
   warnings: Array<SharedV4Warning>;
-} {
+}> {
   const messages: XaiChatPrompt = [];
   const warnings: Array<SharedV4Warning> = [];
 
@@ -31,54 +35,68 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
           break;
         }
 
-        messages.push({
-          role: 'user',
-          content: content.map(part => {
-            switch (part.type) {
-              case 'text': {
-                return { type: 'text', text: part.text };
-              }
-              case 'file': {
-                switch (part.data.type) {
-                  case 'reference': {
-                    return {
-                      type: 'file',
-                      file: {
-                        file_id: resolveProviderReference({
-                          reference: part.data.reference,
-                          provider: 'xai',
+        const userContent: Array<XaiUserMessageContent> = [];
+
+        for (const part of content) {
+          switch (part.type) {
+            case 'text': {
+              userContent.push({ type: 'text', text: part.text });
+              break;
+            }
+            case 'file': {
+              switch (part.data.type) {
+                case 'reference': {
+                  userContent.push({
+                    type: 'file',
+                    file: {
+                      file_id: resolveProviderReference({
+                        reference: part.data.reference,
+                        provider: 'xai',
+                      }),
+                    },
+                  });
+                  break;
+                }
+                case 'text': {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: 'text file parts',
+                  });
+                }
+                case 'url':
+                case 'data': {
+                  if (getTopLevelMediaType(part.mediaType) === 'image') {
+                    const filePartOptions = await parseProviderOptions({
+                      provider: 'xai',
+                      providerOptions: part.providerOptions,
+                      schema: xaiFilePartProviderOptions,
+                    });
+
+                    userContent.push({
+                      type: 'image_url',
+                      image_url: {
+                        url:
+                          part.data.type === 'url'
+                            ? part.data.url.toString()
+                            : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
+                        ...(filePartOptions?.imageDetail != null && {
+                          detail: filePartOptions.imageDetail,
                         }),
                       },
-                    };
-                  }
-                  case 'text': {
+                    });
+                  } else {
                     throw new UnsupportedFunctionalityError({
-                      functionality: 'text file parts',
+                      functionality: `file part media type ${part.mediaType}`,
                     });
                   }
-                  case 'url':
-                  case 'data': {
-                    if (getTopLevelMediaType(part.mediaType) === 'image') {
-                      return {
-                        type: 'image_url',
-                        image_url: {
-                          url:
-                            part.data.type === 'url'
-                              ? part.data.url.toString()
-                              : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
-                        },
-                      };
-                    } else {
-                      throw new UnsupportedFunctionalityError({
-                        functionality: `file part media type ${part.mediaType}`,
-                      });
-                    }
-                  }
+                  break;
                 }
               }
+              break;
             }
-          }),
-        });
+          }
+        }
+
+        messages.push({ role: 'user', content: userContent });
 
         break;
       }

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -4,6 +4,7 @@ export type {
   XaiLanguageModelChatOptions as XaiProviderOptions,
 } from './xai-chat-language-model-options';
 export type { XaiErrorData } from './xai-error';
+export type { XaiFilePartProviderOptions } from './xai-file-part-options';
 export type {
   XaiLanguageModelResponsesOptions,
   /** @deprecated Use `XaiLanguageModelResponsesOptions` instead. */

--- a/packages/xai/src/responses/convert-to-xai-responses-input.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.ts
@@ -6,9 +6,11 @@ import {
 import {
   convertToBase64,
   getTopLevelMediaType,
+  parseProviderOptions,
   resolveFullMediaType,
   resolveProviderReference,
 } from '@ai-sdk/provider-utils';
+import { xaiFilePartProviderOptions } from '../xai-file-part-options';
 import type {
   XaiResponsesInput,
   XaiResponsesUserMessageContentPart,
@@ -71,9 +73,18 @@ export async function convertToXaiResponsesInput({
                         ? block.data.url.toString()
                         : `data:${resolveFullMediaType({ part: block })};base64,${convertToBase64(block.data.data)}`;
 
+                    const filePartOptions = await parseProviderOptions({
+                      provider: 'xai',
+                      providerOptions: block.providerOptions,
+                      schema: xaiFilePartProviderOptions,
+                    });
+
                     contentParts.push({
                       type: 'input_image',
                       image_url: imageUrl,
+                      ...(filePartOptions?.imageDetail != null && {
+                        detail: filePartOptions.imageDetail,
+                      }),
                     });
                   } else if (block.data.type === 'url') {
                     // xAI's Responses API accepts non-image documents (PDF, text, CSV, etc.)

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -26,7 +26,11 @@ export type XaiResponsesSystemMessage = {
 
 export type XaiResponsesUserMessageContentPart =
   | { type: 'input_text'; text: string }
-  | { type: 'input_image'; image_url: string }
+  | {
+      type: 'input_image';
+      image_url: string;
+      detail?: 'low' | 'high' | 'auto';
+    }
   | { type: 'input_file'; file_id: string }
   | { type: 'input_file'; file_url: string };
 

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -942,6 +942,90 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      describe('image detail', () => {
+        it('should pass detail from the imageDetail provider option on image parts', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.3',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel('grok-4.3').doGenerate({
+            prompt: [
+              {
+                role: 'user',
+                content: [
+                  { type: 'text', text: 'What is in this image?' },
+                  {
+                    type: 'file',
+                    mediaType: 'image/png',
+                    data: { type: 'data', data: Buffer.from([0, 1, 2, 3]) },
+                    providerOptions: { xai: { imageDetail: 'high' } },
+                  },
+                ],
+              },
+            ],
+          });
+
+          expect((await server.calls[0].requestBodyJson).input).toEqual([
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'What is in this image?' },
+                {
+                  type: 'input_image',
+                  image_url: 'data:image/png;base64,AAECAw==',
+                  detail: 'high',
+                },
+              ],
+            },
+          ]);
+        });
+
+        it('should not set detail when the imageDetail provider option is not set', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4.3',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel('grok-4.3').doGenerate({
+            prompt: [
+              {
+                role: 'user',
+                content: [
+                  { type: 'text', text: 'What is in this image?' },
+                  {
+                    type: 'file',
+                    mediaType: 'image/png',
+                    data: { type: 'data', data: Buffer.from([0, 1, 2, 3]) },
+                  },
+                ],
+              },
+            ],
+          });
+
+          expect((await server.calls[0].requestBodyJson).input).toEqual([
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'What is in this image?' },
+                {
+                  type: 'input_image',
+                  image_url: 'data:image/png;base64,AAECAw==',
+                },
+              ],
+            },
+          ]);
+        });
+      });
+
       it('should warn about unsupported stopSequences', async () => {
         prepareJsonResponse({
           id: 'resp_123',

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1203,6 +1203,78 @@ describe('XaiChatLanguageModel', () => {
     });
   });
 
+  describe('image detail', () => {
+    it('should pass detail from the imageDetail provider option on image parts', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What is in this image?' },
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: { type: 'data', data: Buffer.from([0, 1, 2, 3]) },
+                providerOptions: { xai: { imageDetail: 'low' } },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect((await server.calls[0].requestBodyJson).messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,AAECAw==',
+                detail: 'low',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should not set detail when the imageDetail provider option is not set', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What is in this image?' },
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: { type: 'data', data: Buffer.from([0, 1, 2, 3]) },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect((await server.calls[0].requestBodyJson).messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,AAECAw==' },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
   describe('reasoning models', () => {
     const reasoningModel = new XaiChatLanguageModel('grok-3-mini', testConfig);
 

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -126,7 +126,7 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
 
     // convert ai sdk messages to xai format
     const { messages, warnings: messageWarnings } =
-      convertToXaiChatMessages(prompt);
+      await convertToXaiChatMessages(prompt);
     warnings.push(...messageWarnings);
 
     // prepare tools for xai

--- a/packages/xai/src/xai-chat-prompt.ts
+++ b/packages/xai/src/xai-chat-prompt.ts
@@ -18,7 +18,10 @@ export interface XaiUserMessage {
 
 export type XaiUserMessageContent =
   | { type: 'text'; text: string }
-  | { type: 'image_url'; image_url: { url: string } }
+  | {
+      type: 'image_url';
+      image_url: { url: string; detail?: 'low' | 'high' | 'auto' };
+    }
   | { type: 'file'; file: { file_id: string } };
 
 export interface XaiAssistantMessage {

--- a/packages/xai/src/xai-file-part-options.ts
+++ b/packages/xai/src/xai-file-part-options.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod/v4';
+
+// provider options for file parts (images) in user messages
+export const xaiFilePartProviderOptions = z.object({
+  /**
+   * Controls the resolution at which the model processes the image.
+   * `low` processes the image at reduced resolution and consumes fewer
+   * input tokens, `high` processes the image at full resolution, and
+   * `auto` lets the API decide. Defaults to full resolution when not set.
+   *
+   * Note: the xAI API silently ignores invalid values, so the value is
+   * validated client-side.
+   *
+   * @see https://docs.x.ai/developers/model-capabilities/images/understanding
+   */
+  imageDetail: z.enum(['low', 'high', 'auto']).optional(),
+});
+
+export type XaiFilePartProviderOptions = z.infer<
+  typeof xaiFilePartProviderOptions
+>;


### PR DESCRIPTION
## Background

The xAI API supports an optional `detail` parameter on image input parts ([docs](https://docs.x.ai/developers/model-capabilities/images/understanding)), controlling the resolution at which the model processes images. Verified against the live xAI API with `grok-4.3` on a 2126×1417 image: `detail: "low"` reduces image input tokens from 2541 to 396 (~6.4×) on both the Responses API and the Chat Completions API. The AI SDK xAI provider previously offered no way to set it.

The xAI API does not validate the `detail` value (arbitrary strings are accepted and silently treated as the default), so the provider validates the option client-side.

This follows the OpenAI provider's precedent of a part-level `providerOptions.<provider>.imageDetail` option, and builds on #9007 by @gerynugrh, which proposed `detail` support for the chat converter before the Responses API implementation (now the default code path) existed.

## Summary

- New `xaiFilePartProviderOptions` schema with `imageDetail: z.enum(['low', 'high', 'auto']).optional()`, validated via `parseProviderOptions`.
- The Responses API converter (`convert-to-xai-responses-input.ts`) maps it to `{ type: 'input_image', image_url, detail }`.
- The Chat Completions converter (`convert-to-xai-chat-messages.ts`) maps it to `{ type: 'image_url', image_url: { url, detail } }` (converter is now async to support validated part-level provider options).
- Tests for both models, example, and provider docs update.

## Manual Verification

Ran the new example against the live xAI API (`examples/ai-functions/src/generate-text/xai/image-detail.ts`), logging the request body with a custom `fetch`:

```ts
import { xai } from '@ai-sdk/xai';
import { generateText } from 'ai';
import fs from 'node:fs';

const result = await generateText({
  model: xai('grok-4.3'),
  messages: [
    {
      role: 'user',
      content: [
        { type: 'text', text: 'Describe the image in detail.' },
        {
          type: 'file',
          mediaType: 'image/png',
          data: fs.readFileSync('./data/comic-cat.png'),
          providerOptions: {
            xai: { imageDetail: 'low' },
          },
        },
      ],
    },
  ],
});
```

Verified that the request body contains `detail: 'low'` on the image part (for both `xai(...)` responses models and `xai.chat(...)` models), and that input token usage drops accordingly compared to `imageDetail: 'high'`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16894
Supersedes #9007