### PR TITLE
docs(ai): add ToolLoopAgent testing example

### DIFF
--- a/content/docs/03-ai-sdk-core/55-testing.mdx
+++ b/content/docs/03-ai-sdk-core/55-testing.mdx
@@ -179,6 +179,88 @@ const result = streamText({
 });
 ```
 
+### ToolLoopAgent
+
+You can test a `ToolLoopAgent` by returning a tool call from the mock model,
+letting the agent execute the tool, and then returning the final text from the
+next mock response.
+
+```ts
+import { isStepCount, tool, ToolLoopAgent } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+import { expect, test } from 'vitest';
+import { z } from 'zod';
+
+test('ToolLoopAgent calls tools and returns the final answer', async () => {
+  const model = new MockLanguageModelV4({
+    doGenerate: [
+      {
+        content: [
+          {
+            type: 'tool-call',
+            toolCallType: 'function',
+            toolCallId: 'call-1',
+            toolName: 'weather',
+            input: JSON.stringify({ city: 'San Francisco' }),
+          },
+        ],
+        finishReason: { unified: 'tool-calls', raw: undefined },
+        usage: {
+          inputTokens: {
+            total: 3,
+            noCache: 3,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 6,
+            text: 6,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      },
+      {
+        content: [{ type: 'text', text: 'It is sunny in San Francisco.' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 8,
+            noCache: 8,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 7,
+            text: 7,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      },
+    ],
+  });
+
+  const agent = new ToolLoopAgent({
+    model,
+    stopWhen: isStepCount(3),
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ city: z.string() }),
+        execute: async ({ city }) => `Weather in ${city}: sunny`,
+      }),
+    },
+  });
+
+  const result = await agent.generate({
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  expect(result.text).toBe('It is sunny in San Francisco.');
+  expect(model.doGenerateCalls).toHaveLength(2);
+});
+```
+
 ### Simulate UI Message Stream Responses
 
 You can also simulate [UI Message Stream](/docs/ai-sdk-ui/stream-protocol#ui-message-stream) responses for testing,


### PR DESCRIPTION
## Summary

Adds a `ToolLoopAgent` example to the AI SDK Core testing docs.

The example shows how to test a multi-step agent loop deterministically with `MockLanguageModelV4`: the first mock model response emits a tool call, the agent executes the tool, and the second mock response returns the final answer.

## Why

The testing page already covered `generateText`, `streamText`, and structured output examples, but did not show how to test `ToolLoopAgent` flows. This gives agent builders a copyable pattern for testing tool execution without calling a real provider.

Fixes #12616.

## Validation

- `git diff --cached --check` before commit
- Local SSH signature verification for commit `b986dc3472182afcd291ca4f7d0ada4b10ca0040`

Full workspace install/check was not run because the monorepo dependency install exceeded available local disk space.
