### PR TITLE
docs(xai): clarify reasoning effort model support

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -138,7 +138,9 @@ Supported values:
   tasks.
 
 <Note>
-  Not every Grok model accepts every value. See xAI's [reasoning
+  Not every Grok model accepts `reasoningEffort`. In particular,
+  `grok-4.20-reasoning`, `grok-4.20-non-reasoning`, and their dated variants
+  reject the parameter for every value. See xAI's [reasoning
   docs](https://docs.x.ai/docs/guides/reasoning) for the values supported by
   your selected model. `'none'` requires `grok-4.3` or newer.
 </Note>
@@ -477,7 +479,7 @@ import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const result = await generateText({
-  model: xai.responses('grok-4.20-non-reasoning'),
+  model: xai.responses('grok-4.3'),
   providerOptions: {
     xai: {
       reasoningEffort: 'high',
@@ -491,7 +493,7 @@ The following provider options are available:
 
 - **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
 
-  Control the reasoning effort for the model. See [Reasoning Effort](#reasoning-effort) for details on each value. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
+  Control the reasoning effort for models that support the parameter. See [Reasoning Effort](#reasoning-effort) for details on each value. `grok-4.20-reasoning`, `grok-4.20-non-reasoning`, and their dated variants do not accept `reasoningEffort`. `'none'` disables reasoning entirely (requires `grok-4.3` or newer).
 
 - **logprobs** _boolean_
 

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -16,6 +16,8 @@ export const xaiLanguageModelResponsesOptions = z.object({
    * Possible values are `none` (disables reasoning entirely; supported by
    * `grok-4.3` and newer reasoning models), `low` (uses fewer reasoning
    * tokens), `medium`, and `high` (uses more reasoning tokens).
+   * `grok-4.20-reasoning`, `grok-4.20-non-reasoning`, and their dated
+   * variants reject the parameter for every value.
    *
    * @see https://docs.x.ai/docs/guides/reasoning
    */

--- a/packages/xai/src/xai-chat-language-model-options.ts
+++ b/packages/xai/src/xai-chat-language-model-options.ts
@@ -59,8 +59,10 @@ export const xaiLanguageModelChatOptions = z.object({
    * - `medium`: More thinking for less-latency-sensitive applications.
    * - `high`: Uses more reasoning tokens for deeper thinking.
    *
-   * Note: Not every Grok model accepts every value. Refer to xAI's docs for
-   * the values supported by your selected model.
+   * Note: Not every Grok model accepts `reasoningEffort`.
+   * `grok-4.20-reasoning`, `grok-4.20-non-reasoning`, and their dated
+   * variants reject the parameter for every value. Refer to xAI's docs for the
+   * values supported by your selected model.
    *
    * @see https://docs.x.ai/docs/guides/reasoning
    */


### PR DESCRIPTION
## Summary
- update xAI provider docs to call out models that reject `reasoningEffort`
- switch the Responses API provider-options example to `grok-4.3`, which supports the option
- mirror the note in chat and Responses provider option JSDoc

Fixes #11116

## Verification
- `git diff --check -- content/providers/01-ai-sdk-providers/01-xai.mdx packages/xai/src/xai-chat-language-model-options.ts packages/xai/src/responses/xai-responses-language-model-options.ts`
- `npx -y prettier@3.6.2 --check --single-quote content/providers/01-ai-sdk-providers/01-xai.mdx packages/xai/src/xai-chat-language-model-options.ts packages/xai/src/responses/xai-responses-language-model-options.ts`
- confirmed GitHub reports the pushed commit signature as verified
- compared docs wording with `supportsReasoningEffort` and xAI's current reasoning docs