### PR TITLE
fix(ai,policy-opa): use own-property checks when resolving per-tool approvals

### DIFF
--- a/.changeset/tool-approval-inherited-property-names.md
+++ b/.changeset/tool-approval-inherited-property-names.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/policy-opa': patch
+'ai': patch
+---
+
+Use own-property checks when resolving per-tool approvals so tool names and approval ids that match inherited object properties (e.g. `constructor`, `toString`, `valueOf`, `__proto__`) are treated as unconfigured/absent.
+
+- `@ai-sdk/policy-opa`: `wrapMcpTools` builds its per-tool map with a null prototype and reads supplied approvals via an own-property check, and `shadow` guards its per-tool map lookup the same way.
+- `ai`: tool and tool-context lookups keyed by a model- or client-supplied name now go through an own-property check (`getOwn`), so a name matching an inherited object property resolves to "no such tool"/"unconfigured" instead of a prototype value. This covers the approval path (per-tool approval resolution and replay re-validation) as well as tool-call parsing, execution, streaming callbacks, and UI message conversion/validation. The human-in-the-loop approval matching (`collectToolApprovals`) and streaming tool-name maps are built with a null prototype so a client-supplied id that matches an inherited property no longer slips past the "unknown approval" / "tool call not found" guards.

--- a/packages/ai/src/generate-text/collect-tool-approvals.test.ts
+++ b/packages/ai/src/generate-text/collect-tool-approvals.test.ts
@@ -335,6 +335,44 @@ describe('collectToolApprovals', () => {
     );
   });
 
+  it.each(['toString', 'constructor', 'valueOf', '__proto__'])(
+    'should throw for an unknown approvalId that matches the inherited object property "%s"',
+    approvalId => {
+      // Guards against inherited-property lookups: an approvalId that is not an
+      // own key of the request map must be treated as unknown, not resolved to
+      // a value on Object.prototype.
+      expect(() =>
+        collectToolApprovals({
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: { value: 'test-input' },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-approval-response',
+                  approvalId, // no request with this id exists
+                  approved: true,
+                },
+              ],
+            },
+          ],
+        }),
+      ).toThrow(
+        `Tool approval response references unknown approvalId: ${JSON.stringify(approvalId)}`,
+      );
+    },
+  );
+
   it('should work for 2 approvals, 2 rejections, 1 approval with tool result, 1 rejection with tool result', () => {
     const result = collectToolApprovals({
       messages: [

--- a/packages/ai/src/generate-text/collect-tool-approvals.ts
+++ b/packages/ai/src/generate-text/collect-tool-approvals.ts
@@ -36,8 +36,19 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
     };
   }
 
-  // gather tool calls and prepare lookup
-  const toolCallsByToolCallId: Record<string, TypedToolCall<TOOLS>> = {};
+  // gather tool calls and prepare lookup.
+  //
+  // These maps are keyed by client-supplied ids (`toolCallId`, `approvalId`)
+  // from the message history. Using `Object.create(null)` gives them no
+  // prototype, so an id that matches an inherited object property (e.g.
+  // `toString`, `constructor`, `__proto__`) is treated as absent instead of
+  // resolving to a prototype value and slipping past the `== null` guards
+  // below (which would otherwise skip the InvalidToolApproval /
+  // ToolCallNotFound checks).
+  const toolCallsByToolCallId: Record<
+    string,
+    TypedToolCall<TOOLS>
+  > = Object.create(null);
   for (const message of messages) {
     if (message.role === 'assistant' && typeof message.content !== 'string') {
       const content = message.content;
@@ -51,7 +62,7 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
 
   // gather approval responses and prepare lookup
   const toolApprovalRequestsByApprovalId: Record<string, ToolApprovalRequest> =
-    {};
+    Object.create(null);
   for (const message of messages) {
     if (message.role === 'assistant' && typeof message.content !== 'string') {
       const content = message.content;
@@ -64,7 +75,9 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
   }
 
   // gather tool results from the last tool message
-  const toolResults: Record<string, TypedToolResult<TOOLS>> = {};
+  const toolResults: Record<string, TypedToolResult<TOOLS>> = Object.create(
+    null,
+  );
   for (const part of lastMessage.content) {
     if (part.type === 'tool-result') {
       toolResults[part.toolCallId] = part as TypedToolResult<TOOLS>;

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -13,6 +13,7 @@ import {
   type TimeoutConfiguration,
 } from '../prompt/request-options';
 import type { TelemetryDispatcher } from '../telemetry/telemetry';
+import { getOwn } from '../util/get-own';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { notify } from '../util/notify';
 import { now } from '../util/now';
@@ -83,7 +84,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   | undefined
 > {
   const { toolName, toolCallId, input } = toolCall;
-  const tool = tools?.[toolName];
+  const tool = getOwn(tools, toolName);
 
   if (!isExecutableTool(tool)) {
     return undefined;
@@ -91,7 +92,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
 
   const context = await validateToolContext({
     toolName,
-    context: toolsContext?.[toolName as keyof typeof toolsContext],
+    context: getOwn(toolsContext, toolName),
     contextSchema: tool.contextSchema,
   });
 

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -9,6 +9,7 @@ import type {
 } from '@ai-sdk/provider-utils';
 import type { TimeoutConfiguration } from '../prompt/request-options';
 import type { Telemetry, TelemetryDispatcher } from '../telemetry/telemetry';
+import { getOwn } from '../util/get-own';
 import { executeToolCall } from './execute-tool-call';
 import { resolveToolApproval } from './resolve-tool-approval';
 import type { LanguageModelStreamPart } from './stream-language-model-call';
@@ -95,7 +96,7 @@ export function executeToolsFromStream<
               return;
             }
 
-            const tool = tools?.[chunk.toolName];
+            const tool = getOwn(tools, chunk.toolName);
 
             if (tool == null) {
               // ignore tool calls for tools that are not available,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -50,6 +50,7 @@ import {
   type LanguageModelUsage,
 } from '../types/usage';
 import type { DownloadFunction } from '../util/download/download-function';
+import { getOwn } from '../util/get-own';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
 import { now as originalNow } from '../util/now';
@@ -717,7 +718,7 @@ export async function generateText<
           const modelOutput = await createToolModelOutput({
             toolCallId: output.toolCallId,
             input: output.input,
-            tool: tools?.[output.toolName],
+            tool: getOwn(tools, output.toolName),
             output:
               output.type === 'tool-result' ? output.output : output.error,
             errorMode: output.type === 'tool-error' ? 'text' : 'none',
@@ -1040,7 +1041,7 @@ export async function generateText<
                   continue; // ignore invalid tool calls
                 }
 
-                const tool = tools?.[toolCall.toolName];
+                const tool = getOwn(tools, toolCall.toolName);
 
                 if (tool == null) {
                   // ignore tool calls for tools that are not available,
@@ -1234,7 +1235,7 @@ export async function generateText<
               // the client tool's result is sent back.
               for (const toolCall of stepToolCalls) {
                 if (!toolCall.providerExecuted) continue;
-                const tool = tools?.[toolCall.toolName];
+                const tool = getOwn(tools, toolCall.toolName);
                 if (tool?.type === 'provider' && tool.supportsDeferredResults) {
                   // Check if this tool call already has a result in the current response
                   const hasResultInResponse = currentModelResponse.content.some(
@@ -1699,7 +1700,7 @@ function asContent<TOOLS extends ToolSet>({
         // result may be deferred to a later turn. In this case, there's no matching tool-call
         // in the current response.
         if (toolCall == null) {
-          const tool = tools?.[part.toolName];
+          const tool = getOwn(tools, part.toolName);
           const supportsDeferredResults =
             tool?.type === 'provider' && tool.supportsDeferredResults;
 

--- a/packages/ai/src/generate-text/invoke-tool-callbacks-from-stream.ts
+++ b/packages/ai/src/generate-text/invoke-tool-callbacks-from-stream.ts
@@ -1,4 +1,6 @@
 import type { Context, ModelMessage, ToolSet } from '@ai-sdk/provider-utils';
+import { createIdMap } from '../util/create-id-map';
+import { getOwn } from '../util/get-own';
 import type { LanguageModelStreamPart } from './stream-language-model-call';
 
 export function invokeToolCallbacksFromStream<
@@ -19,7 +21,7 @@ export function invokeToolCallbacksFromStream<
 }): ReadableStream<LanguageModelStreamPart<TOOLS>> {
   if (tools == null) return stream;
 
-  const ongoingToolCallToolNames: Record<string, string> = {};
+  const ongoingToolCallToolNames: Record<string, string> = createIdMap();
 
   return stream.pipeThrough(
     new TransformStream({
@@ -30,7 +32,7 @@ export function invokeToolCallbacksFromStream<
           case 'tool-input-start': {
             ongoingToolCallToolNames[chunk.id] = chunk.toolName;
 
-            const tool = tools?.[chunk.toolName];
+            const tool = getOwn(tools, chunk.toolName);
             if (tool?.onInputStart != null) {
               await tool.onInputStart({
                 toolCallId: chunk.id,
@@ -45,7 +47,7 @@ export function invokeToolCallbacksFromStream<
 
           case 'tool-input-delta': {
             const toolName = ongoingToolCallToolNames[chunk.id];
-            const tool = tools?.[toolName];
+            const tool = getOwn(tools, toolName);
 
             if (tool?.onInputDelta != null) {
               await tool.onInputDelta({
@@ -62,7 +64,7 @@ export function invokeToolCallbacksFromStream<
 
           case 'tool-call': {
             const toolName = ongoingToolCallToolNames[chunk.toolCallId];
-            const tool = tools?.[toolName];
+            const tool = getOwn(tools, toolName);
 
             delete ongoingToolCallToolNames[chunk.toolCallId];
 

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -80,6 +80,32 @@ describe('parseToolCall', () => {
     `);
   });
 
+  it('should not treat an inherited object property as a refinement for a tool whose name collides with it', async () => {
+    // `refineToolInput` is keyed by tool name; a tool named after an
+    // Object.prototype member must not resolve to the inherited method and be
+    // invoked as a refiner. With no own entry for `toString`, the raw parsed
+    // input is returned unchanged.
+    const result = await parseToolCall({
+      toolCall: {
+        type: 'tool-call',
+        toolName: 'toString',
+        toolCallId: '123',
+        input: '{"value": "raw"}',
+      },
+      tools: {
+        toString: tool({
+          inputSchema: z.object({ value: z.string() }),
+        }),
+      } as const,
+      repairToolCall: undefined,
+      refineToolInput: { testTool: () => ({ value: 'refined' }) } as any,
+      messages: [],
+      instructions: undefined,
+    });
+
+    expect(result.input).toEqual({ value: 'raw' });
+  });
+
   it('should successfully parse a valid provider-executed dynamic tool call', async () => {
     const result = await parseToolCall({
       toolCall: {

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -122,7 +122,7 @@ async function refineParsedToolCallInput<TOOLS extends ToolSet>({
   toolCall: TypedToolCall<TOOLS>;
   refineToolInput: ToolInputRefinement<TOOLS> | undefined;
 }): Promise<TypedToolCall<TOOLS>> {
-  const refine = refineToolInput?.[toolCall.toolName];
+  const refine = getOwn(refineToolInput, toolCall.toolName);
 
   if (refine == null) {
     return toolCall;

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -11,6 +11,7 @@ import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { ToolCallRepairError } from '../error/tool-call-repair-error';
 import type { Instructions } from '../prompt';
+import { getOwn } from '../util/get-own';
 import type { DynamicToolCall, TypedToolCall } from './tool-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
 import type { ToolInputRefinement } from './tool-input-refinement';
@@ -66,7 +67,7 @@ export async function parseToolCall<TOOLS extends ToolSet>({
           toolCall,
           tools,
           inputSchema: async ({ toolName }) => {
-            const { inputSchema } = tools[toolName];
+            const inputSchema = getOwn(tools, toolName)?.inputSchema;
             return await asSchema(inputSchema).jsonSchema;
           },
           instructions,
@@ -95,7 +96,7 @@ export async function parseToolCall<TOOLS extends ToolSet>({
     // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
     const input = parsedInput.success ? parsedInput.value : toolCall.input;
-    const tool = tools?.[toolCall.toolName];
+    const tool = getOwn(tools, toolCall.toolName);
 
     // TODO AI SDK 6: special invalid tool call parts
     return {
@@ -169,7 +170,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
 }): Promise<TypedToolCall<TOOLS>> {
   const toolName = toolCall.toolName as keyof TOOLS & string;
 
-  const tool = tools[toolName];
+  const tool = getOwn(tools, toolName);
 
   if (tool == null) {
     // provider-executed dynamic tools are not part of our list of tools:

--- a/packages/ai/src/generate-text/resolve-tool-approval.test.ts
+++ b/packages/ai/src/generate-text/resolve-tool-approval.test.ts
@@ -338,6 +338,70 @@ describe('resolveToolApproval', () => {
     });
   });
 
+  describe('tool names that match inherited object properties', () => {
+    const createToolCallNamed = (toolName: string) => ({
+      type: 'tool-call' as const,
+      toolCallId: 'call-1',
+      toolName: toolName as never,
+      input: { city: 'Berlin' },
+      dynamic: false as const,
+    });
+
+    // Regression guard for the fix: `toolApproval[toolName]` used to resolve
+    // through the prototype chain, so a tool literally named `constructor`
+    // would pick up `Object.prototype.constructor` (a function) and be invoked
+    // as if it were a per-tool approval callback. With an own-property check it
+    // is treated as unconfigured and honors the configured fallback instead.
+    for (const toolName of ['constructor', 'toString', 'valueOf']) {
+      it(`does not execute a tool named "${toolName}" when the fallback is denied`, async () => {
+        const result = await resolveToolApproval({
+          tools: {
+            [toolName]: tool({ inputSchema: z.object({ city: z.string() }) }),
+          },
+          // simulates the total map produced by wrapMcpTools
+          toolApproval: { [toolName]: 'denied' },
+          toolCall: createToolCallNamed(toolName),
+          messages: [...messages],
+          toolsContext: {},
+          runtimeContext: {},
+        });
+
+        expect(result).toEqual({ type: 'denied' });
+      });
+
+      it(`pauses a tool named "${toolName}" for approval when the fallback is user-approval`, async () => {
+        const result = await resolveToolApproval({
+          tools: {
+            [toolName]: tool({ inputSchema: z.object({ city: z.string() }) }),
+          },
+          toolApproval: { [toolName]: 'user-approval' },
+          toolCall: createToolCallNamed(toolName),
+          messages: [...messages],
+          toolsContext: {},
+          runtimeContext: {},
+        });
+
+        expect(result).toEqual({ type: 'user-approval' });
+      });
+
+      it(`treats an unconfigured tool named "${toolName}" as not-applicable rather than reading the inherited property`, async () => {
+        const result = await resolveToolApproval({
+          tools: {
+            [toolName]: tool({ inputSchema: z.object({ city: z.string() }) }),
+          },
+          // plain object map that does NOT list the colliding name
+          toolApproval: { weather: 'denied' } as never,
+          toolCall: createToolCallNamed(toolName),
+          messages: [...messages],
+          toolsContext: {},
+          runtimeContext: {},
+        });
+
+        expect(result).toEqual({ type: 'not-applicable' });
+      });
+    }
+  });
+
   it('normalizes a user-defined static string approval value before checking tool-defined approval', async () => {
     const toolDefinedNeedsApproval = vi.fn(() => true);
 

--- a/packages/ai/src/generate-text/resolve-tool-approval.ts
+++ b/packages/ai/src/generate-text/resolve-tool-approval.ts
@@ -9,6 +9,7 @@ import type {
   ToolApprovalConfiguration,
   ToolApprovalStatus,
 } from './tool-approval-configuration';
+import { getOwn } from '../util/get-own';
 import type { TypedToolCall } from './tool-call';
 import { validateToolContext } from './validate-tool-context';
 
@@ -75,13 +76,17 @@ export async function resolveToolApproval<
   }
 
   const toolName = toolCall.toolName;
-  const tool = tools?.[toolName];
+  // `toolName` can be client-controlled, so look tools/approvals up by own
+  // property only: a name that matches an inherited object property (e.g.
+  // `constructor`, `toString`) resolves to "no such tool"/"unconfigured"
+  // instead of a value on `Object.prototype`.
+  const tool = getOwn(tools, toolName);
 
   // assume that the input has been validated and matches the tool's input schema
   const input = toolCall.input as InferToolInput<TOOLS[keyof TOOLS]>;
 
   // user-defined per-tool approval
-  const userDefinedToolApprovalStatus = toolApproval?.[toolName];
+  const userDefinedToolApprovalStatus = getOwn(toolApproval, toolName);
   if (userDefinedToolApprovalStatus != null) {
     const approvalStatus: ToolApprovalStatus | undefined =
       typeof userDefinedToolApprovalStatus === 'function'
@@ -90,8 +95,7 @@ export async function resolveToolApproval<
             messages,
             toolContext: await validateToolContext({
               toolName,
-              context:
-                toolsContext?.[toolName as keyof InferToolSetContext<TOOLS>],
+              context: getOwn(toolsContext, toolName),
               contextSchema: tool?.contextSchema,
             }),
             runtimeContext,
@@ -113,8 +117,7 @@ export async function resolveToolApproval<
           messages,
           context: await validateToolContext({
             toolName,
-            context:
-              toolsContext?.[toolName as keyof InferToolSetContext<TOOLS>],
+            context: getOwn(toolsContext, toolName),
             contextSchema: tool?.contextSchema,
           }),
         })

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -16,6 +16,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { resolveLanguageModel } from '../model/resolve-model';
+import { getOwn } from '../util/get-own';
 import type { Instructions, Prompt } from '../prompt';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
@@ -715,7 +716,7 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
         }
 
         case 'tool-input-start': {
-          const tool = tools?.[chunk.toolName];
+          const tool = getOwn(tools, chunk.toolName);
 
           controller.enqueue({
             ...chunk,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -74,6 +74,7 @@ import { consumeStream } from '../util/consume-stream';
 import { createIdMap } from '../util/create-id-map';
 import { createStitchableStream } from '../util/create-stitchable-stream';
 import type { DownloadFunction } from '../util/download/download-function';
+import { getOwn } from '../util/get-own';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
 import { notify } from '../util/notify';
@@ -1694,7 +1695,7 @@ class DefaultStreamTextResult<
                 output: await createToolModelOutput({
                   toolCallId: output.toolCallId,
                   input: output.input,
-                  tool: tools?.[output.toolName],
+                  tool: getOwn(tools, output.toolName),
                   output:
                     output.type === 'tool-result'
                       ? output.output
@@ -2240,7 +2241,7 @@ class DefaultStreamTextResult<
                   // the client tool's result is sent back.
                   for (const toolCall of stepToolCalls) {
                     if (toolCall.providerExecuted !== true) continue;
-                    const tool = tools?.[toolCall.toolName];
+                    const tool = getOwn(tools, toolCall.toolName);
                     if (
                       tool?.type === 'provider' &&
                       tool.supportsDeferredResults

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -5,6 +5,7 @@ import type {
   ToolModelMessage,
 } from '../prompt';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
+import { getOwn } from '../util/get-own';
 import type { ContentPart } from './content-part';
 import type { ToolSet } from '@ai-sdk/provider-utils';
 
@@ -97,7 +98,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         const output = await createToolModelOutput({
           toolCallId: part.toolCallId,
           input: part.input,
-          tool: tools?.[part.toolName],
+          tool: getOwn(tools, part.toolName),
           output: part.output,
           errorMode: 'none',
         });
@@ -114,7 +115,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         const output = await createToolModelOutput({
           toolCallId: part.toolCallId,
           input: part.input,
-          tool: tools?.[part.toolName],
+          tool: getOwn(tools, part.toolName),
           output: part.error,
           errorMode: 'json',
         });
@@ -189,7 +190,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
     const output = await createToolModelOutput({
       toolCallId: part.toolCallId,
       input: part.input,
-      tool: tools?.[part.toolName],
+      tool: getOwn(tools, part.toolName),
       output: part.type === 'tool-result' ? part.output : part.error,
       errorMode: part.type === 'tool-error' ? 'text' : 'none',
     });

--- a/packages/ai/src/generate-text/validate-tool-approvals.ts
+++ b/packages/ai/src/generate-text/validate-tool-approvals.ts
@@ -9,6 +9,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { InvalidToolApprovalSignatureError } from '../error/invalid-tool-approval-signature-error';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
+import { getOwn } from '../util/get-own';
 import type { CollectedToolApprovals } from './collect-tool-approvals';
 import { resolveToolApproval } from './resolve-tool-approval';
 import { verifyToolApprovalSignature } from './tool-approval-signature';
@@ -47,7 +48,11 @@ export async function validateApprovedToolApprovals<
 
   for (const approval of approvedToolApprovals) {
     const { toolCall, approvalRequest } = approval;
-    const tool = tools?.[toolCall.toolName];
+    // Look up the tool by own property only: `toolName` comes from
+    // client-supplied history, so a name matching an inherited object property
+    // (e.g. `constructor`, `toString`) must resolve to "no such tool" rather
+    // than a prototype value that would silently skip input validation below.
+    const tool = getOwn(tools, toolCall.toolName);
 
     if (toolApprovalSecret != null) {
       if (approvalRequest.signature == null) {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -11,6 +11,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import { MessageConversionError } from '../prompt/message-conversion-error';
+import { getOwn } from '../util/get-own';
 import {
   getToolName,
   isCustomContentUIPart,
@@ -256,7 +257,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                           part.state === 'output-error'
                             ? part.errorText
                             : part.output,
-                        tool: options?.tools?.[toolName],
+                        tool: getOwn(options?.tools, toolName),
                         errorMode:
                           part.state === 'output-error' ? 'json' : 'none',
                       }),
@@ -375,7 +376,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                             toolPart.state === 'output-error'
                               ? toolPart.errorText
                               : toolPart.output,
-                          tool: options?.tools?.[toolName],
+                          tool: getOwn(options?.tools, toolName),
                           errorMode:
                             toolPart.state === 'output-error' ? 'text' : 'none',
                         }),

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -9,6 +9,7 @@ import {
 import { z } from 'zod/v4';
 import { InvalidArgumentError } from '../error';
 import { jsonValueSchema } from '../types/json-value';
+import { getOwn } from '../util/get-own';
 import { providerMetadataSchema } from '../types/provider-metadata';
 import type {
   DataUIPart,
@@ -456,7 +457,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
               InferUIMessageTools<UI_MESSAGE>
             >;
             const toolName = toolPart.type.slice(5);
-            const tool = tools[toolName];
+            const tool = getOwn(tools, toolName);
 
             if (
               !tool &&

--- a/packages/ai/src/util/get-own.test.ts
+++ b/packages/ai/src/util/get-own.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getOwn } from './get-own';
+
+describe('getOwn', () => {
+  it('returns own properties', () => {
+    expect(getOwn({ a: 1, b: 2 }, 'a')).toBe(1);
+  });
+
+  it('returns undefined for absent keys', () => {
+    expect(getOwn({ a: 1 }, 'missing')).toBeUndefined();
+  });
+
+  it('returns undefined for inherited object properties rather than a prototype value', () => {
+    for (const key of ['constructor', 'toString', 'valueOf', '__proto__']) {
+      expect(getOwn({ a: 1 }, key)).toBeUndefined();
+    }
+  });
+
+  it('still returns an own property that shadows an inherited name', () => {
+    expect(getOwn({ toString: 'shadowed' }, 'toString')).toBe('shadowed');
+  });
+
+  it('returns undefined for null/undefined objects', () => {
+    expect(getOwn(undefined, 'a')).toBeUndefined();
+    expect(getOwn(null, 'a')).toBeUndefined();
+  });
+});

--- a/packages/ai/src/util/get-own.ts
+++ b/packages/ai/src/util/get-own.ts
@@ -1,0 +1,18 @@
+/**
+ * Reads a property by an untrusted key, ignoring inherited prototype members.
+ *
+ * Tool sets, tool contexts, and similar lookup objects are indexed by names
+ * that can come from model output or client-supplied message history. Plain
+ * bracket access (`obj[name]`) resolves names such as `constructor`,
+ * `toString`, or `__proto__` to values on `Object.prototype`, which would slip
+ * past the `== null` / `!value` guards that treat an unknown name as "not
+ * present". This helper returns `undefined` unless `key` is an own property.
+ */
+export function getOwn<T extends object>(
+  obj: T | undefined | null,
+  key: string,
+): T[keyof T] | undefined {
+  return obj != null && Object.hasOwn(obj, key)
+    ? obj[key as keyof T]
+    : undefined;
+}

--- a/packages/policy-opa/src/shadow.test.ts
+++ b/packages/policy-opa/src/shadow.test.ts
@@ -135,6 +135,31 @@ describe('shadow', () => {
     ]);
   });
 
+  it('treats per-tool-map tool names that match inherited object properties as unconfigured', async () => {
+    const events: PolicyDecisionEvent[] = [];
+    // A plain object map inherits `constructor`, `toString`, `valueOf`, etc.
+    // from `Object.prototype`. None of these tools are configured here, so
+    // each must be reported as not-applicable rather than resolving to (and
+    // invoking) the inherited prototype function.
+    const map = { search: 'approved' as const };
+
+    const wrapped = shadow<AnyTools>(
+      map as unknown as ToolApprovalConfiguration<AnyTools, unknown>,
+      { onDecision: event => void events.push(event) },
+    );
+
+    for (const toolName of ['constructor', 'toString', 'valueOf']) {
+      await callApproval(wrapped, toolName);
+    }
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(events.map(e => e.decision)).toEqual([
+      { type: 'not-applicable' },
+      { type: 'not-applicable' },
+      { type: 'not-applicable' },
+    ]);
+  });
+
   it('swallows errors thrown from onDecision so enforcement is unaffected', async () => {
     const denyOriginal = async () => ({ type: 'denied' }) as never;
 

--- a/packages/policy-opa/src/shadow.ts
+++ b/packages/policy-opa/src/shadow.ts
@@ -137,7 +137,16 @@ async function evaluateApproval(
   }
 
   const map = approval as Record<string, unknown>;
-  const perTool = map[args.toolCall.toolName];
+  // Own-property check so a tool name that matches an inherited object
+  // property (e.g. `constructor`, `toString`, `valueOf`) is treated as
+  // unconfigured instead of resolving to a prototype value and being invoked
+  // as if it were a per-tool approval callback.
+  const perTool = Object.prototype.hasOwnProperty.call(
+    map,
+    args.toolCall.toolName,
+  )
+    ? map[args.toolCall.toolName]
+    : undefined;
   if (perTool == null) return undefined;
   if (typeof perTool === 'function') {
     return await (

--- a/packages/policy-opa/src/wrap-mcp-tools.test.ts
+++ b/packages/policy-opa/src/wrap-mcp-tools.test.ts
@@ -156,5 +156,58 @@ describe('wrapMcpTools', () => {
       expect(toolApproval.createIssue).toBe('denied');
       expect(toolApproval.deleteRepo).toBe('denied');
     });
+
+    describe('tool names that match inherited object properties', () => {
+      // These names resolve to values through `Object.prototype`, so a naive
+      // `approval[name]` read would pick up an inherited value instead of
+      // undefined and skip the fallback. They must be treated exactly like any
+      // other unlisted tool.
+      const inheritedTools = {
+        constructor: dummyTool('a tool literally named constructor'),
+        toString: dummyTool('a tool literally named toString'),
+        valueOf: dummyTool('a tool literally named valueOf'),
+        unlistedDelete: dummyTool('an ordinary unlisted tool'),
+        search: dummyTool('an explicitly listed tool'),
+      };
+      type InheritedTools = typeof inheritedTools;
+
+      it('applies the "denied" fallback to unlisted inherited-property names', () => {
+        const { toolApproval } = wrapMcpTools<InheritedTools>(
+          inheritedTools,
+          { search: 'approved' } as never,
+          { default: 'denied' },
+        );
+
+        if (typeof toolApproval === 'function') {
+          throw new Error('expected per-tool object form');
+        }
+
+        expect(toolApproval.constructor).toBe('denied');
+        expect(toolApproval.toString).toBe('denied');
+        expect(toolApproval.valueOf).toBe('denied');
+        // regression guard: an ordinary unlisted tool still gets the fallback
+        expect(toolApproval.unlistedDelete).toBe('denied');
+        // an explicitly listed tool keeps its configured decision
+        expect(toolApproval.search).toBe('approved');
+      });
+
+      it('applies the "user-approval" fallback to unlisted inherited-property names', () => {
+        const { toolApproval } = wrapMcpTools<InheritedTools>(
+          inheritedTools,
+          { search: 'approved' } as never,
+          { default: 'user-approval' },
+        );
+
+        if (typeof toolApproval === 'function') {
+          throw new Error('expected per-tool object form');
+        }
+
+        expect(toolApproval.constructor).toBe('user-approval');
+        expect(toolApproval.toString).toBe('user-approval');
+        expect(toolApproval.valueOf).toBe('user-approval');
+        expect(toolApproval.unlistedDelete).toBe('user-approval');
+        expect(toolApproval.search).toBe('approved');
+      });
+    });
   });
 });

--- a/packages/policy-opa/src/wrap-mcp-tools.ts
+++ b/packages/policy-opa/src/wrap-mcp-tools.ts
@@ -74,9 +74,16 @@ export function wrapMcpTools<
   // Per-tool map form: fill in any tool that the user did not list with the
   // fallback decision. We use `Object.keys(tools)` (not the approval keys) so
   // the result is total over the discovered surface.
-  const filled = {} as Record<keyof TOOLS, unknown>;
+  // `Object.create(null)` gives the result no prototype, and we read the
+  // supplied approval with an own-property check, so tool names that match
+  // inherited object properties (e.g. `constructor`, `toString`, `valueOf`)
+  // are treated as unconfigured and receive the fallback.
+  const filled = Object.create(null) as Record<keyof TOOLS, unknown>;
   for (const name of Object.keys(tools) as Array<keyof TOOLS>) {
-    filled[name] = approval[name] ?? fallback;
+    const configured = Object.prototype.hasOwnProperty.call(approval, name)
+      ? approval[name]
+      : undefined;
+    filled[name] = configured ?? fallback;
   }
 
   // `filled` is a plain per-tool map; cast to the SDK's map arm, which TS


### PR DESCRIPTION
## What

Tool sets, tool contexts, and per-tool approval maps are indexed by names that come from model output or client-supplied message history. Plain bracket access (`tools[name]`) resolves names that match inherited object properties (`constructor`, `toString`, `valueOf`, `__proto__`) to values on `Object.prototype` instead of `undefined`, which can slip past the "unknown tool" / "unconfigured approval" guards.

This routes those lookups through a new `getOwn` helper (own-property check via `Object.hasOwn`), builds the human-in-the-loop approval-matching maps with a null prototype, and adds the same own-property guards in policy-opa `wrapMcpTools` and `shadow`.

Behavior is identical for every real tool set, since tool names are always own properties. The only change is that an inherited-property name now reads as absent.

## Flow

Happy path (real tool named `weather`, unchanged):
1. Model or client references `weather`.
2. `getOwn(tools, "weather")` finds it as an own property and returns the tool.
3. Approval, validation, and execution proceed exactly as before.

Unhappy path (name collides with a prototype member, e.g. `constructor`):
1. Model or client references `constructor`, which is not a registered tool.
2. Before: `tools["constructor"]` returned `Object.prototype.constructor` (a function), passed the `!= null` guard, and could be treated as a tool or invoked as an approval callback.
3. After: `getOwn(tools, "constructor")` returns `undefined`, so the name routes to the safe "no such tool" / "unconfigured, apply fallback" branch (`NoSuchToolError`, denied/user-approval fallback, etc.).

## Notes

Covers the approval path (per-tool resolution and replay re-validation), tool-call parsing, execution, streaming callbacks, and UI message conversion/validation. Includes a `getOwn` unit test plus regression tests in `wrap-mcp-tools`, `shadow`, `resolve-tool-approval`, and `collect-tool-approvals`.