### PR TITLE
fix(react): align local dev react version

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,8 @@
     "@vitejs/plugin-react": "^4.7.0",
     "jsdom": "^24.1.3",
     "msw": "2.6.4",
-    "react-dom": "^19.2.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
     "zod": "3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3324,12 +3324,9 @@ importers:
       ai:
         specifier: workspace:*
         version: link:../ai
-      react:
-        specifier: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-        version: 19.2.6
       swr:
         specifier: ^2.4.1
-        version: 2.4.1(react@19.2.6)
+        version: 2.4.1(react@18.3.1)
       throttleit:
         specifier: 2.1.0
         version: 2.1.0
@@ -3342,7 +3339,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -3367,9 +3364,12 @@ importers:
       msw:
         specifier: 2.6.4
         version: 2.6.4(@types/node@22.19.19)(typescript@5.8.3)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.6
-        version: 19.2.6(react@19.2.6)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^7.2.0
         version: 7.2.0(@swc/core@1.15.3(@swc/helpers@0.5.21))(postcss@8.5.15)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))(typescript@5.8.3)
@@ -40857,11 +40857,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swr@2.4.1(react@19.2.6):
+  swr@2.4.1(react@18.3.1):
     dependencies:
       dequal: 2.0.3
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   swrv@1.2.0(vue@3.5.38(typescript@5.8.3)):
     dependencies:
@@ -41893,9 +41893,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  use-sync-external-store@1.6.0(react@19.2.6):
+  use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
-      react: 19.2.6
+      react: 18.3.1
 
   utif@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes #16890.

`examples/next-openai-pages` runs React 18, but the workspace-linked `@ai-sdk/react` package resolved its local dev React through `react-dom@19.2.6`. In the Pages Router bundle this put `@ai-sdk/react` hooks on React 19 while the renderer was React DOM 18, producing the reported invalid-hook-call / `useId` crash.

This aligns `@ai-sdk/react` local dev/test dependencies to React 18 + React DOM 18, matching the package's lowest supported peer and the sibling `@ai-sdk/rsc` local test setup. The published peer dependency remains unchanged, so consumers can still use the existing React 18/19 peer range.

No changeset is included because this only changes local dev/test dependency resolution; no runtime code or published peer range changes.

## Verification

- Reproduced before the fix in a browser on `/basics/stream-object`: `Invalid hook call` and `TypeError: Cannot read properties of null (reading 'useId')`, with `@ai-sdk/react` resolving `react@19.2.6` and the renderer resolving `react-dom@18.3.1`.
- After the fix, `npx pnpm@10.33.4 -C examples/next-openai-pages why react` reports one version: `react@18.3.1`.
- After the fix, `npx pnpm@10.33.4 -C examples/next-openai-pages why react-dom` reports one version: `react-dom@18.3.1`.
- Browser probe of `http://localhost:3104/basics/stream-object`: status 200, body renders `Generate`, no page errors, no invalid-hook-call console errors.
- `npx pnpm@10.33.4 install --frozen-lockfile --ignore-scripts`
- `npx pnpm@10.33.4 --filter @ai-sdk/react... build`
- `npx pnpm@10.33.4 -C packages/react test`
- `npx pnpm@10.33.4 -C packages/react type-check`
- `npx pnpm@10.33.4 check`
- `npx pnpm@10.33.4 --filter @ai-sdk/openai... build`
- `npx pnpm@10.33.4 -C examples/next-openai-pages build`
- `git diff --check`

Note: `packages/react` tests print existing jsdom `HTMLFormElement.prototype.requestSubmit` not-implemented noise, but Vitest reports 6 files / 66 tests passed. The example production build emits existing Edge Runtime warnings from SDK internals, then completes successfully.