### PR TITLE
fix (provider/groq): report cached prompt tokens as cacheRead

### DIFF
--- a/.changeset/groq-cached-prompt-tokens.md
+++ b/.changeset/groq-cached-prompt-tokens.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix (provider/groq): report cached prompt tokens as `cacheRead`
+
+`convertGroqUsage` parsed `prompt_tokens_details.cached_tokens` but never used it, so a prompt-cache hit was reported as `cacheRead: undefined` and `noCache: <full prompt>`. Cached tokens are now surfaced as `cacheRead`, with `noCache` reduced accordingly.

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { convertGroqUsage } from "./convert-groq-usage";
+import { describe, it, expect } from 'vitest';
+import { convertGroqUsage } from './convert-groq-usage';
 
-describe("convertGroqUsage", () => {
-  it("should return undefined values when usage is null", () => {
+describe('convertGroqUsage', () => {
+  it('should return undefined values when usage is null', () => {
     const result = convertGroqUsage(null);
 
     expect(result).toStrictEqual({
@@ -21,7 +21,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should return undefined values when usage is undefined", () => {
+  it('should return undefined values when usage is undefined', () => {
     const result = convertGroqUsage(undefined);
 
     expect(result).toStrictEqual({
@@ -40,7 +40,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should report cached prompt tokens as cacheRead and reduce noCache", () => {
+  it('should report cached prompt tokens as cacheRead and reduce noCache', () => {
     const result = convertGroqUsage({
       prompt_tokens: 1000,
       completion_tokens: 5,
@@ -57,7 +57,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should convert basic usage without token details", () => {
+  it('should convert basic usage without token details', () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -82,7 +82,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should extract reasoning tokens from completion_tokens_details", () => {
+  it('should extract reasoning tokens from completion_tokens_details', () => {
     const result = convertGroqUsage({
       prompt_tokens: 79,
       completion_tokens: 40,
@@ -113,7 +113,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should handle null reasoning_tokens in completion_tokens_details", () => {
+  it('should handle null reasoning_tokens in completion_tokens_details', () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -144,7 +144,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should handle null completion_tokens_details", () => {
+  it('should handle null completion_tokens_details', () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -171,7 +171,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should handle zero reasoning tokens", () => {
+  it('should handle zero reasoning tokens', () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -202,7 +202,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should handle all tokens being reasoning tokens", () => {
+  it('should handle all tokens being reasoning tokens', () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 50,
@@ -233,7 +233,7 @@ describe("convertGroqUsage", () => {
     });
   });
 
-  it("should handle missing prompt_tokens and completion_tokens", () => {
+  it('should handle missing prompt_tokens and completion_tokens', () => {
     const result = convertGroqUsage({});
 
     expect(result).toStrictEqual({

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { convertGroqUsage } from './convert-groq-usage';
+import { describe, it, expect } from "vitest";
+import { convertGroqUsage } from "./convert-groq-usage";
 
-describe('convertGroqUsage', () => {
-  it('should return undefined values when usage is null', () => {
+describe("convertGroqUsage", () => {
+  it("should return undefined values when usage is null", () => {
     const result = convertGroqUsage(null);
 
     expect(result).toStrictEqual({
@@ -21,7 +21,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should return undefined values when usage is undefined', () => {
+  it("should return undefined values when usage is undefined", () => {
     const result = convertGroqUsage(undefined);
 
     expect(result).toStrictEqual({
@@ -40,7 +40,24 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should convert basic usage without token details', () => {
+  it("should report cached prompt tokens as cacheRead and reduce noCache", () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 1000,
+      completion_tokens: 5,
+      prompt_tokens_details: {
+        cached_tokens: 900,
+      },
+    });
+
+    expect(result.inputTokens).toStrictEqual({
+      total: 1000,
+      noCache: 100,
+      cacheRead: 900,
+      cacheWrite: undefined,
+    });
+  });
+
+  it("should convert basic usage without token details", () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -65,7 +82,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should extract reasoning tokens from completion_tokens_details', () => {
+  it("should extract reasoning tokens from completion_tokens_details", () => {
     const result = convertGroqUsage({
       prompt_tokens: 79,
       completion_tokens: 40,
@@ -96,7 +113,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should handle null reasoning_tokens in completion_tokens_details', () => {
+  it("should handle null reasoning_tokens in completion_tokens_details", () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -127,7 +144,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should handle null completion_tokens_details', () => {
+  it("should handle null completion_tokens_details", () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -154,7 +171,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should handle zero reasoning tokens', () => {
+  it("should handle zero reasoning tokens", () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 10,
@@ -185,7 +202,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should handle all tokens being reasoning tokens', () => {
+  it("should handle all tokens being reasoning tokens", () => {
     const result = convertGroqUsage({
       prompt_tokens: 20,
       completion_tokens: 50,
@@ -216,7 +233,7 @@ describe('convertGroqUsage', () => {
     });
   });
 
-  it('should handle missing prompt_tokens and completion_tokens', () => {
+  it("should handle missing prompt_tokens and completion_tokens", () => {
     const result = convertGroqUsage({});
 
     expect(result).toStrictEqual({

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV4Usage } from '@ai-sdk/provider';
+import type { LanguageModelV4Usage } from "@ai-sdk/provider";
 
 export function convertGroqUsage(
   usage:
@@ -19,7 +19,7 @@ export function convertGroqUsage(
           | undefined;
       }
     | undefined
-    | null,
+    | null
 ): LanguageModelV4Usage {
   if (usage == null) {
     return {
@@ -40,6 +40,9 @@ export function convertGroqUsage(
 
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens ?? undefined;
+  const noCacheTokens =
+    cachedTokens != null ? promptTokens - cachedTokens : promptTokens;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? undefined;
   const textTokens =
@@ -50,8 +53,8 @@ export function convertGroqUsage(
   return {
     inputTokens: {
       total: promptTokens,
-      noCache: promptTokens,
-      cacheRead: undefined,
+      noCache: noCacheTokens,
+      cacheRead: cachedTokens,
       cacheWrite: undefined,
     },
     outputTokens: {

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV4Usage } from "@ai-sdk/provider";
+import type { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export function convertGroqUsage(
   usage:
@@ -19,7 +19,7 @@ export function convertGroqUsage(
           | undefined;
       }
     | undefined
-    | null
+    | null,
 ): LanguageModelV4Usage {
   if (usage == null) {
     return {


### PR DESCRIPTION
Fixes #16899

`convertGroqUsage` declares `prompt_tokens_details.cached_tokens` in its input type but never reads it: `cacheRead` is hardcoded to `undefined` and `noCache` to the full `prompt_tokens`. So when Groq reports a prompt-cache hit, the SDK loses it entirely and reports the whole prompt as uncached.

This reads `cached_tokens` and surfaces it as `cacheRead`, reducing `noCache` by the cached amount, mirroring the existing `reasoning_tokens` handling a few lines above. When there are no cached tokens the behavior is unchanged.

Added a regression test asserting that `{ prompt_tokens: 1000, prompt_tokens_details: { cached_tokens: 900 } }` yields `cacheRead: 900` and `noCache: 100`; it fails on `main` and passes with this change. Patch changeset included.

Note: I could not run the repo's `oxfmt`/`oxlint` locally (the `@oxfmt/binding-darwin-*` native binary fails to load in my environment), so I formatted the change to match the surrounding code by hand and verified the package's vitest suite passes. Happy to adjust if CI formatting flags anything.
