### PR TITLE
reproduction: Support updated OpenAI inputfile types

### DIFF
--- a/examples/ai-functions/src/reproduction/openai-input-file-csv-default.ts
+++ b/examples/ai-functions/src/reproduction/openai-input-file-csv-default.ts
@@ -1,0 +1,58 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+async function main() {
+  try {
+    await generateText({
+      model: openai.responses('gpt-4.1-nano'),
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'What names appear in the CSV? Reply with just the names.',
+            },
+            {
+              type: 'file',
+              filename: 'names.csv',
+              mediaType: 'text/csv',
+              data: Buffer.from('name,role\nAda,engineer\nGrace,scientist\n'),
+            },
+          ],
+        },
+      ],
+      maxOutputTokens: 40,
+      providerOptions: {
+        openai: {
+          store: false,
+        },
+      },
+    });
+
+    console.log(
+      JSON.stringify({
+        issueReproduced: false,
+        observed: 'The CSV file was accepted by the AI SDK.',
+      }),
+    );
+  } catch (error) {
+    console.log(
+      JSON.stringify(
+        {
+          issueReproduced: true,
+          observed: error instanceof Error ? error.message : String(error),
+          expected:
+            'OpenAI-supported text/csv files should be sent as input_file without an unsupported functionality error.',
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/openai/src/responses/__fixtures__/openai-input-file-csv.json
+++ b/packages/openai/src/responses/__fixtures__/openai-input-file-csv.json
@@ -1,0 +1,91 @@
+{
+  "id": "resp_0ea91f8f0111eb2a016a4df98dd20081a0902ca3f462d5a511",
+  "object": "response",
+  "created_at": 1783495055,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1783495056,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": 40,
+  "max_tool_calls": null,
+  "model": "gpt-4.1-nano-2025-04-14",
+  "moderation": null,
+  "output": [
+    {
+      "id": "msg_0ea91f8f0111eb2a016a4df990ac4c81a0844864aa1e105462",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Ada,Grace"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": null,
+    "effort": null,
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": false,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tool_usage": {
+    "image_gen": {
+      "input_tokens": 0,
+      "input_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "output_tokens": 0,
+      "output_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "total_tokens": 0
+    },
+    "web_search": {
+      "num_requests": 0
+    }
+  },
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 68,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 4,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 72
+  },
+  "user": null,
+  "metadata": {}
+}

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -241,6 +241,72 @@ describe('OpenAIResponsesLanguageModel', () => {
   }
 
   describe('doGenerate', () => {
+    it('reproduction #12842: should send OpenAI-supported CSV files as input_file by default', async () => {
+      prepareJsonFixtureResponse('openai-input-file-csv');
+
+      const result = await createModel('gpt-4.1-nano').doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'What names appear in the CSV? Reply with just the names separated by comma.',
+              },
+              {
+                type: 'file',
+                filename: 'names.csv',
+                mediaType: 'text/csv',
+                data: {
+                  type: 'data',
+                  data: Buffer.from(
+                    'name,role\nAda,engineer\nGrace,scientist\n',
+                  ),
+                },
+              },
+            ],
+          },
+        ],
+        maxOutputTokens: 40,
+        providerOptions: {
+          openai: {
+            store: false,
+          } satisfies OpenAILanguageModelResponsesOptions,
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: 'text',
+          text: 'Ada,Grace',
+          providerMetadata: {
+            openai: {
+              itemId: 'msg_0ea91f8f0111eb2a016a4df990ac4c81a0844864aa1e105462',
+            },
+          },
+        },
+      ]);
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        input: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'What names appear in the CSV? Reply with just the names separated by comma.',
+              },
+              {
+                type: 'input_file',
+                filename: 'names.csv',
+                file_data:
+                  'data:text/csv;base64,bmFtZSxyb2xlCkFkYSxlbmdpbmVlcgpHcmFjZSxzY2llbnRpc3QK',
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     describe('basic text response', () => {
       beforeEach(() => {
         server.urls['https://api.openai.com/v1/responses'].response = {


### PR DESCRIPTION
## Bug

Support updated OpenAI input_file types

## Reproduction

- Classified as provider-specific OpenAI Responses `input_file` behavior.
- A live OpenAI Responses API call with `text/csv` `input_file` returned HTTP 200 and `Ada,Grace`; the response is recorded in `packages/openai/src/responses/__fixtures__/openai-input-file-csv.json`.
- Reproduction script added at `examples/ai-functions/src/reproduction/openai-input-file-csv-default.ts`; command `pnpm -C examples/ai-functions exec tsx src/reproduction/openai-input-file-csv-default.ts` prints `issueReproduced: true` with `'file part media type text/csv' functionality not supported.`
- Provider unit reproduction added in `packages/openai/src/responses/openai-responses-language-model.test.ts`; expected SDK behavior is to send OpenAI-supported `text/csv` files as `input_file` by default.
- Local checks run: `pnpm check`, `pnpm type-check`, `pnpm konsistent:check`, `pnpm -C packages/openai type-check`, and `pnpm -C examples/ai-functions type-check` all passed after fixes.
- Check fixes made: formatted `examples/ai-functions/src/reproduction/openai-input-file-csv-default.ts` with `pnpm exec oxfmt examples/ai-functions/src/reproduction/openai-input-file-csv-default.ts` and regenerated the ignored konsistent provider artifact with `pnpm --filter konsistent-provider build`.
- Focused reproduction test command `pnpm -C packages/openai exec vitest --config vitest.node.config.js --run src/responses/openai-responses-language-model.test.ts -t "reproduction #12842"` fails with 1 failed test due to `AI_UnsupportedFunctionalityError: 'file part media type text/csv' functionality not supported.`

## Related Issues

Reproduces #12842