### PR TITLE
[v5.0] fix: Google provider marks Gemini external HTTPS file URLs as unsupported

### DIFF
--- a/.changeset/green-gemini-files.md
+++ b/.changeset/green-gemini-files.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Pass documented Gemini external HTTPS file URLs through without downloading them.

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-=======
-import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
 import { isUrlSupported } from '@ai-sdk/provider-utils';
->>>>>>> 7401c2c14 (fix: Google provider marks Gemini external HTTPS file URLs as unsupported (#16757))
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createGoogleGenerativeAI } from './google-provider';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
@@ -276,12 +272,12 @@ describe('google-provider', () => {
   });
 
   it('should support documented external HTTPS URLs for Gemini models that accept external URLs', () => {
-    const provider = createGoogle({
+    const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
     });
     provider('gemini-3.5-flash');
 
-    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
     const supportedUrlsFunction = call[1].supportedUrls;
 
     expect(supportedUrlsFunction).toBeDefined();
@@ -341,12 +337,12 @@ describe('google-provider', () => {
   });
 
   it('should not support external HTTPS URLs for Gemini 2.0 models', () => {
-    const provider = createGoogle({
+    const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
     });
     provider('gemini-2.0-flash');
 
-    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
     const supportedUrlsFunction = call[1].supportedUrls;
 
     expect(supportedUrlsFunction).toBeDefined();

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -1,3 +1,8 @@
+<<<<<<< HEAD
+=======
+import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
+import { isUrlSupported } from '@ai-sdk/provider-utils';
+>>>>>>> 7401c2c14 (fix: Google provider marks Gemini external HTTPS file URLs as unsupported (#16757))
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createGoogleGenerativeAI } from './google-provider';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
@@ -268,6 +273,93 @@ describe('google-provider', () => {
         ],
       }
     `);
+  });
+
+  it('should support documented external HTTPS URLs for Gemini models that accept external URLs', () => {
+    const provider = createGoogle({
+      apiKey: 'test-api-key',
+    });
+    provider('gemini-3.5-flash');
+
+    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+
+    expect(supportedUrlsFunction).toBeDefined();
+
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+
+    const supportedExternalUrlMediaTypes = [
+      'text/html',
+      'text/css',
+      'text/plain',
+      'text/xml',
+      'text/csv',
+      'text/rtf',
+      'text/javascript',
+      'application/json',
+      'application/pdf',
+      'image/bmp',
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'video/mp4',
+      'video/mpeg',
+      'video/quicktime',
+      'video/avi',
+      'video/x-flv',
+      'video/mpg',
+      'video/webm',
+      'video/wmv',
+      'video/3gpp',
+    ];
+
+    for (const mediaType of supportedExternalUrlMediaTypes) {
+      expect(
+        isUrlSupported({
+          url: 'https://example.com/file',
+          mediaType,
+          supportedUrls,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      isUrlSupported({
+        url: 'http://example.com/file.txt',
+        mediaType: 'text/plain',
+        supportedUrls,
+      }),
+    ).toBe(false);
+
+    expect(
+      isUrlSupported({
+        url: 'https://example.com/file.md',
+        mediaType: 'text/markdown',
+        supportedUrls,
+      }),
+    ).toBe(false);
+  });
+
+  it('should not support external HTTPS URLs for Gemini 2.0 models', () => {
+    const provider = createGoogle({
+      apiKey: 'test-api-key',
+    });
+    provider('gemini-2.0-flash');
+
+    const call = vi.mocked(GoogleLanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+
+    expect(supportedUrlsFunction).toBeDefined();
+
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+
+    expect(
+      isUrlSupported({
+        url: 'https://example.com/file.txt',
+        mediaType: 'text/plain',
+        supportedUrls,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -98,6 +98,37 @@ Optional function to generate a unique ID for each request.
   name?: string;
 }
 
+const supportedExternalUrlMediaTypes = [
+  'text/html',
+  'text/css',
+  'text/plain',
+  'text/xml',
+  'text/csv',
+  'text/rtf',
+  'text/javascript',
+  'application/json',
+  'application/pdf',
+  'image/bmp',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'video/mp4',
+  'video/mpeg',
+  'video/quicktime',
+  'video/avi',
+  'video/x-flv',
+  'video/mpg',
+  'video/webm',
+  'video/wmv',
+  'video/3gpp',
+];
+
+const externalHttpsUrlPattern = /^https:\/\/.*$/;
+
+function supportsExternalFileUrls(modelId: string) {
+  return /(^|\/)gemini-/.test(modelId) && !/(^|\/)gemini-2\.0/.test(modelId);
+}
+
 /**
 Create a Google Generative AI provider instance.
  */
@@ -140,6 +171,14 @@ export function createGoogleGenerativeAI(
           ),
           new RegExp(`^https://youtu\\.be/[\\w-]+(?:\\?[\\w=&.-]*)?$`),
         ],
+        ...(supportsExternalFileUrls(modelId)
+          ? Object.fromEntries(
+              supportedExternalUrlMediaTypes.map(mediaType => [
+                mediaType,
+                [externalHttpsUrlPattern],
+              ]),
+            )
+          : {}),
       }),
       fetch: options.fetch,
     });


### PR DESCRIPTION
## Background

Gemini-supported public or signed HTTPS file URLs were being treated as unsupported, causing the SDK to download them instead of passing fileUri through to Google.

## Summary

Added Google supportedUrls entries for the documented external HTTPS file MIME types, gated to Gemini models except the Gemini 2.0 family.

## Testing

Added Google provider regression tests covering documented external HTTPS MIME types, rejecting HTTP and undocumented MIME types, and preserving Gemini 2.0 external URL exclusion.

## Related Issues

Fixes #16751

Backport of #16757

Co-authored-by: matthew-gizmo <252567302+matthew-gizmo@users.noreply.github.com>