### PR TITLE
fix(mcp): handle SSE responses missing the frame terminator

### DIFF
--- a/.changeset/mcp-sse-missing-frame-terminator.md
+++ b/.changeset/mcp-sse-missing-frame-terminator.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Fix `createMCPClient` hanging when an MCP server using the HTTP transport returns an SSE response that omits the blank-line frame terminator (`\n\n`) and keeps the connection open. The HTTP transport now dispatches an SSE event as soon as its `data:` payload forms complete JSON, and also processes a trailing frame when the stream closes without a final newline.

--- a/.changeset/mcp-sse-missing-frame-terminator.md
+++ b/.changeset/mcp-sse-missing-frame-terminator.md
@@ -2,4 +2,4 @@
 '@ai-sdk/mcp': patch
 ---
 
-Fix `createMCPClient` hanging when an MCP server using the HTTP transport returns an SSE response that omits the blank-line frame terminator (`\n\n`) and keeps the connection open. The HTTP transport now dispatches an SSE event as soon as its `data:` payload forms complete JSON, and also processes a trailing frame when the stream closes without a final newline.
+Fix `createMCPClient` hanging when an MCP server returns an SSE response that omits the blank-line frame terminator (`\n\n`) and keeps the connection open. The HTTP and SSE transports now dispatch an SSE event as soon as its `data:` payload forms complete JSON, and also process a trailing frame when the stream closes without a final newline.

--- a/packages/mcp/src/tool/json-event-source-parser-stream.test.ts
+++ b/packages/mcp/src/tool/json-event-source-parser-stream.test.ts
@@ -1,0 +1,132 @@
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+import { JsonEventSourceParserStream } from './json-event-source-parser-stream';
+
+function parseChunks(chunks: string[]) {
+  return convertReadableStreamToArray(
+    convertArrayToReadableStream(chunks).pipeThrough(
+      new JsonEventSourceParserStream(),
+    ),
+  );
+}
+
+describe('JsonEventSourceParserStream', () => {
+  describe('spec-compliant frames', () => {
+    it('should parse a frame terminated by a blank line', async () => {
+      expect(
+        await parseChunks(['data: {"jsonrpc":"2.0","id":1,"result":{}}\n\n']),
+      ).toEqual([
+        {
+          event: undefined,
+          data: '{"jsonrpc":"2.0","id":1,"result":{}}',
+          id: undefined,
+        },
+      ]);
+    });
+
+    it('should parse event and id fields', async () => {
+      expect(
+        await parseChunks(['id: 42\nevent: message\ndata: {"ok":true}\n\n']),
+      ).toEqual([{ event: 'message', data: '{"ok":true}', id: '42' }]);
+    });
+
+    it('should keep the last event id across events', async () => {
+      expect(
+        await parseChunks(['id: 1\ndata: {"a":1}\n\ndata: {"b":2}\n\n']),
+      ).toEqual([
+        { event: undefined, data: '{"a":1}', id: '1' },
+        { event: undefined, data: '{"b":2}', id: '1' },
+      ]);
+    });
+
+    it('should ignore comment lines', async () => {
+      expect(await parseChunks([': ping\ndata: {"a":1}\n\n'])).toEqual([
+        { event: undefined, data: '{"a":1}', id: undefined },
+      ]);
+    });
+
+    it('should handle CRLF line endings', async () => {
+      expect(
+        await parseChunks(['event: message\r\ndata: {"a":1}\r\n\r\n']),
+      ).toEqual([{ event: 'message', data: '{"a":1}', id: undefined }]);
+    });
+
+    it('should dispatch non-JSON data only when the frame is terminated', async () => {
+      expect(await parseChunks(['data: not json\n', '\n'])).toEqual([
+        { event: undefined, data: 'not json', id: undefined },
+      ]);
+    });
+
+    it('should drop non-JSON data when the stream ends without a terminator', async () => {
+      expect(await parseChunks(['data: not json\n'])).toEqual([]);
+    });
+  });
+
+  describe('frames missing the blank-line terminator', () => {
+    it('should dispatch a complete JSON data line without waiting for a blank line', async () => {
+      const stream = new TransformStream<string, string>();
+      const events = stream.readable
+        .pipeThrough(new JsonEventSourceParserStream())
+        .getReader();
+
+      const writer = stream.writable.getWriter();
+      // connection stays open: no blank line, no close
+      await writer.write('data: {"jsonrpc":"2.0","id":1,"result":{}}\n');
+
+      expect((await events.read()).value).toEqual({
+        event: undefined,
+        data: '{"jsonrpc":"2.0","id":1,"result":{}}',
+        id: undefined,
+      });
+    });
+
+    it('should include preceding event and id fields in early-dispatched frames', async () => {
+      const stream = new TransformStream<string, string>();
+      const events = stream.readable
+        .pipeThrough(new JsonEventSourceParserStream())
+        .getReader();
+
+      const writer = stream.writable.getWriter();
+      await writer.write('id: 7\nevent: message\ndata: {"ok":true}\n');
+
+      expect((await events.read()).value).toEqual({
+        event: 'message',
+        data: '{"ok":true}',
+        id: '7',
+      });
+    });
+
+    it('should not dispatch the same frame again when the terminator arrives later', async () => {
+      expect(await parseChunks(['data: {"a":1}\n', '\n'])).toEqual([
+        { event: undefined, data: '{"a":1}', id: undefined },
+      ]);
+    });
+
+    it('should buffer JSON split across chunks until it is complete', async () => {
+      expect(
+        await parseChunks(['data: {"jsonrpc":"2.0",', '"id":1,"result":{}}\n']),
+      ).toEqual([
+        {
+          event: undefined,
+          data: '{"jsonrpc":"2.0","id":1,"result":{}}',
+          id: undefined,
+        },
+      ]);
+    });
+
+    it('should buffer JSON split across multiple data lines until it is complete', async () => {
+      expect(await parseChunks(['data: {"a":\ndata: 1}\n\n'])).toEqual([
+        { event: undefined, data: '{"a":\n1}', id: undefined },
+      ]);
+    });
+
+    it('should dispatch a trailing JSON frame when the stream ends without a newline', async () => {
+      expect(await parseChunks(['data: {"a":1}'])).toEqual([
+        { event: undefined, data: '{"a":1}', id: undefined },
+      ]);
+    });
+  });
+});

--- a/packages/mcp/src/tool/json-event-source-parser-stream.ts
+++ b/packages/mcp/src/tool/json-event-source-parser-stream.ts
@@ -1,0 +1,141 @@
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+
+export interface JsonServerSentEvent {
+  event?: string;
+  data: string;
+  id?: string;
+}
+
+/**
+ * Server-Sent Events parser stream for JSON payloads (such as JSON-RPC
+ * messages in MCP transports).
+ *
+ * It follows the SSE specification (events are dispatched when a blank line
+ * terminates the frame), with one relaxation: because every MCP payload is a
+ * single JSON value, an event is also dispatched as soon as its accumulated
+ * `data:` lines form complete, parseable JSON.
+ *
+ * This is required for interoperability with MCP servers that send
+ * `data: {...}\n` without the trailing blank line (`\n\n`) and keep the
+ * connection open. A spec-strict parser buffers such frames forever and the
+ * client hangs (e.g. `initialize` never resolves).
+ *
+ * Incomplete JSON (e.g. a message split across network chunks or multiple
+ * `data:` lines) is buffered until it either parses or the frame is
+ * terminated normally, so spec-compliant servers are unaffected. Pending
+ * data that parses as JSON is also dispatched when the stream ends without
+ * a final frame terminator.
+ */
+export class JsonEventSourceParserStream extends TransformStream<
+  string,
+  JsonServerSentEvent
+> {
+  constructor() {
+    let lineBuffer = '';
+    let dataBuffer = '';
+    let hasData = false;
+    let eventType: string | undefined;
+    let lastEventId: string | undefined;
+
+    const dispatch = (
+      controller: TransformStreamDefaultController<JsonServerSentEvent>,
+    ) => {
+      controller.enqueue({
+        event: eventType,
+        data: dataBuffer,
+        id: lastEventId,
+      });
+      dataBuffer = '';
+      hasData = false;
+      eventType = undefined;
+    };
+
+    const processLine = async (
+      line: string,
+      controller: TransformStreamDefaultController<JsonServerSentEvent>,
+    ) => {
+      if (line === '') {
+        if (dataBuffer !== '') {
+          dispatch(controller);
+        } else {
+          hasData = false;
+          eventType = undefined;
+        }
+        return;
+      }
+
+      if (line.startsWith(':')) {
+        return;
+      }
+
+      const colonIndex = line.indexOf(':');
+      const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+      let value = colonIndex === -1 ? '' : line.slice(colonIndex + 1);
+      if (value.startsWith(' ')) {
+        value = value.slice(1);
+      }
+
+      switch (field) {
+        case 'data': {
+          dataBuffer = hasData ? `${dataBuffer}\n${value}` : value;
+          hasData = true;
+
+          // Relaxation for servers that omit the frame terminator:
+          // dispatch as soon as the accumulated data is complete JSON.
+          if ((await safeParseJSON({ text: dataBuffer })).success) {
+            dispatch(controller);
+          }
+          break;
+        }
+        case 'event':
+          eventType = value;
+          break;
+        case 'id':
+          if (!value.includes('\u0000')) {
+            lastEventId = value;
+          }
+          break;
+        default:
+          break;
+      }
+    };
+
+    super({
+      async transform(chunk, controller) {
+        lineBuffer += chunk;
+
+        let start = 0;
+        let i = 0;
+        while (i < lineBuffer.length) {
+          const char = lineBuffer[i];
+          if (char === '\n') {
+            await processLine(lineBuffer.slice(start, i), controller);
+            start = i + 1;
+            i++;
+          } else if (char === '\r') {
+            // a trailing \r may be followed by \n in the next chunk
+            if (i === lineBuffer.length - 1) {
+              break;
+            }
+            await processLine(lineBuffer.slice(start, i), controller);
+            i += lineBuffer[i + 1] === '\n' ? 2 : 1;
+            start = i;
+          } else {
+            i++;
+          }
+        }
+        lineBuffer = lineBuffer.slice(start);
+      },
+      async flush(controller) {
+        // process a final line that was not newline-terminated
+        if (lineBuffer !== '') {
+          const line = lineBuffer.endsWith('\r')
+            ? lineBuffer.slice(0, -1)
+            : lineBuffer;
+          lineBuffer = '';
+          await processLine(line, controller);
+        }
+      },
+    });
+  }
+}

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -159,6 +159,130 @@ describe('HttpMCPTransport', () => {
     await client.close();
   });
 
+  it('should initialize MCP client from SSE response missing the frame terminator when the connection stays open', async () => {
+    // https://github.com/vercel/ai/issues/16865
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:4000/stream'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return {
+            type: 'controlled-stream',
+            controller,
+            headers: { 'content-type': 'text/event-stream' },
+          };
+        case 2:
+          return { type: 'empty', status: 202 };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    const clientPromise = createMCPClient({
+      transport: {
+        type: 'http',
+        url: 'http://localhost:4000/stream',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(server.calls[1]?.requestMethod).toBe('POST');
+    });
+
+    // single trailing newline, no blank-line frame terminator,
+    // and the connection stays open
+    controller.write(
+      `data: ${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 0,
+        result: {
+          protocolVersion: LATEST_PROTOCOL_VERSION,
+          capabilities: {},
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+        },
+      })}\n`,
+    );
+
+    const client = await clientPromise;
+    expect(client.serverInfo).toEqual({
+      name: 'test-server',
+      version: '1.0.0',
+    });
+
+    await client.close();
+  });
+
+  it('should handle SSE response missing the frame terminator when the stream closes', async () => {
+    transport = new HttpMCPTransport({ url: 'http://localhost:4000/stream' });
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:4000/stream'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return {
+            type: 'controlled-stream',
+            controller,
+            headers: { 'content-type': 'text/event-stream' },
+          };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+
+    const msgPromise = new Promise(resolve => {
+      transport.onmessage = msg => resolve(msg);
+    });
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 2,
+      params: {},
+    });
+
+    // no trailing newline at all before the stream closes
+    controller.write(
+      `data: ${JSON.stringify({ jsonrpc: '2.0', id: 2, result: { ok: true } })}`,
+    );
+    controller.close();
+
+    expect(await msgPromise).toEqual({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { ok: true },
+    });
+  });
+
+  it('should handle inbound SSE messages missing the frame terminator', async () => {
+    const controller = new TestResponseController();
+    server.urls['http://localhost:4000/mcp'].response = {
+      type: 'controlled-stream',
+      controller,
+      headers: { 'content-type': 'text/event-stream' },
+    };
+
+    const message = { jsonrpc: '2.0' as const, id: 1, result: { ok: true } };
+    const messagePromise = new Promise(resolve => {
+      transport.onmessage = msg => resolve(msg);
+    });
+
+    await transport.start();
+    await vi.waitFor(() => {
+      expect(server.calls[0]?.requestMethod).toBe('GET');
+    });
+
+    // single trailing newline, no blank line, connection stays open
+    controller.write(`data: ${JSON.stringify(message)}\n`);
+
+    expect(await messagePromise).toEqual(message);
+  });
+
   it('should (re)open inbound SSE after 202 Accepted', async () => {
     const controller = new TestResponseController();
 

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -1,10 +1,10 @@
 import {
-  EventSourceParserStream,
   withUserAgentSuffix,
   getRuntimeEnvironmentUserAgent,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
+import { JsonEventSourceParserStream } from './json-event-source-parser-stream';
 import {
   parseJSONRPCMessage,
   validateJSONRPCMessage,
@@ -324,7 +324,7 @@ export class HttpMCPTransport implements MCPTransport {
 
           const stream = response.body
             .pipeThrough(new TextDecoderStream())
-            .pipeThrough(new EventSourceParserStream());
+            .pipeThrough(new JsonEventSourceParserStream());
           const reader = stream.getReader();
 
           const processEvents = async () => {
@@ -484,7 +484,7 @@ export class HttpMCPTransport implements MCPTransport {
 
       const stream = response.body
         .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new EventSourceParserStream());
+        .pipeThrough(new JsonEventSourceParserStream());
       const reader = stream.getReader();
 
       const processEvents = async () => {

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -111,6 +111,42 @@ describe('SseMCPTransport', () => {
     await transport.close();
   });
 
+  it('should handle JSON-RPC messages missing the frame terminator', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const messagePromise = new Promise(resolve => {
+      transport.onmessage = msg => resolve(msg);
+    });
+
+    const connectPromise = transport.start();
+
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+
+    await connectPromise;
+
+    const testMessage = {
+      jsonrpc: '2.0' as const,
+      method: 'test',
+      params: { foo: 'bar' },
+      id: '1',
+    };
+
+    // single trailing newline, no blank-line frame terminator,
+    // and the connection stays open
+    controller.write(`event: message\ndata: ${JSON.stringify(testMessage)}\n`);
+
+    expect(await messagePromise).toEqual(testMessage);
+
+    await transport.close();
+  });
+
   it('should handle JSON-RPC messages without explicit event field', async () => {
     const controller = new TestResponseController();
 

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -1,10 +1,10 @@
 import {
-  EventSourceParserStream,
   withUserAgentSuffix,
   getRuntimeEnvironmentUserAgent,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
+import { JsonEventSourceParserStream } from './json-event-source-parser-stream';
 import { parseJSONRPCMessage, type JSONRPCMessage } from './json-rpc-message';
 import type { MCPTransport } from './mcp-transport';
 import { VERSION } from '../version';
@@ -142,7 +142,7 @@ export class SseMCPTransport implements MCPTransport {
 
           const stream = response.body
             .pipeThrough(new TextDecoderStream())
-            .pipeThrough(new EventSourceParserStream());
+            .pipeThrough(new JsonEventSourceParserStream());
 
           const reader = stream.getReader();
 


### PR DESCRIPTION
## Background

`createMCPClient` with the HTTP transport hangs indefinitely when an MCP server returns a `text/event-stream` response that contains a valid `data:` JSON-RPC payload but omits the SSE frame terminator (`\n\n`) and keeps the connection open. Real-world servers do this (e.g. Productboard MCP at `https://mcp.productboard.com`), so `initialize` never resolves and the client hangs until an external timeout.

Root cause: both the POST response path and the inbound GET stream in `HttpMCPTransport` pipe through `EventSourceParserStream` (eventsource-parser), which only dispatches an event after a blank line ends the frame. If the terminator never arrives and the connection stays open, `reader.read()` waits forever.

## Summary

- Added `JsonEventSourceParserStream` in `packages/mcp`: an SSE parser stream for JSON payloads. It keeps spec-compliant behavior (dispatch on blank line), with one relaxation: since every MCP payload is a single JSON value, an event is also dispatched as soon as its accumulated `data:` lines form complete, parseable JSON (validated via `safeParseJSON`, no direct `JSON.parse`). It also processes a trailing frame when the stream closes without a final newline.
- `HttpMCPTransport` now uses it for both the POST response stream and the inbound GET SSE stream, and `SseMCPTransport` uses it for its event stream (the `endpoint` event carries a URL, not JSON, so it is still dispatched only by a spec-compliant blank line).
- Spec-compliant servers are unaffected: incomplete JSON (split across chunks or multiple `data:` lines) keeps buffering until it parses or the frame is terminated normally, non-JSON data is still only dispatched on a blank line, and an early-dispatched frame is not dispatched again when its terminator arrives later.
- Added parser unit tests and four transport regression tests (kept-open unterminated frame via `createMCPClient` initialize, stream closing without terminator, inbound GET SSE without terminator, and an SSE-transport message without terminator). All four regression tests time out on `main` and pass with this change.

## Manual Verification

Ran the reproduction from #16865 (a local `node:http` server that responds to `initialize` with `data: {...}\n`, no blank line, no `res.end()`) against this branch with `tsx`:

- Before: `initialize` hangs until the external 5s timeout.
- After: `initialize` resolves with the server info and a subsequent `tools/list` (also sent without a frame terminator) completes.

Also ran the full `@ai-sdk/mcp` test suite (`pnpm test`: node + edge, 262 tests each) and package `type-check`, plus `oxlint`/`oxfmt` on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16865
