### PR TITLE
fix(deepgram): send paragraphs, intents, sentiment, replace, and keyterm transcription options

### DIFF
--- a/.changeset/deepgram-transcription-dropped-options.md
+++ b/.changeset/deepgram-transcription-dropped-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepgram': patch
+---
+
+Fix transcription provider options `paragraphs`, `intents`, `sentiment`, `replace`, and `keyterm` being accepted by the options schema but never sent to the Deepgram API.

--- a/packages/deepgram/src/deepgram-transcription-model.test.ts
+++ b/packages/deepgram/src/deepgram-transcription-model.test.ts
@@ -97,6 +97,29 @@ describe('doGenerate', () => {
       expect(requestUrl).toContain('detect_language=true');
     });
 
+    it('should pass paragraphs, intents, sentiment, replace, and keyterm as query parameters', async () => {
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        providerOptions: {
+          deepgram: {
+            paragraphs: true,
+            intents: true,
+            sentiment: true,
+            replace: 'REDACTED',
+            keyterm: 'galileo',
+          },
+        },
+      });
+
+      const requestUrl = server.calls[0].requestUrl;
+      expect(requestUrl).toContain('paragraphs=true');
+      expect(requestUrl).toContain('intents=true');
+      expect(requestUrl).toContain('sentiment=true');
+      expect(requestUrl).toContain('replace=REDACTED');
+      expect(requestUrl).toContain('keyterm=galileo');
+    });
+
     it('should return detected language from response', async () => {
       const result = await model.doGenerate({
         audio: audioData,

--- a/packages/deepgram/src/deepgram-transcription-model.ts
+++ b/packages/deepgram/src/deepgram-transcription-model.ts
@@ -69,10 +69,15 @@ export class DeepgramTranscriptionModel implements TranscriptionModelV4 {
       body.detect_entities = deepgramOptions.detectEntities ?? undefined;
       body.detect_language = deepgramOptions.detectLanguage ?? undefined;
       body.filler_words = deepgramOptions.fillerWords ?? undefined;
+      body.intents = deepgramOptions.intents ?? undefined;
+      body.keyterm = deepgramOptions.keyterm ?? undefined;
       body.language = deepgramOptions.language ?? undefined;
+      body.paragraphs = deepgramOptions.paragraphs ?? undefined;
       body.punctuate = deepgramOptions.punctuate ?? undefined;
       body.redact = deepgramOptions.redact ?? undefined;
+      body.replace = deepgramOptions.replace ?? undefined;
       body.search = deepgramOptions.search ?? undefined;
+      body.sentiment = deepgramOptions.sentiment ?? undefined;
       body.smart_format = deepgramOptions.smartFormat ?? undefined;
       body.summarize = deepgramOptions.summarize ?? undefined;
       body.topics = deepgramOptions.topics ?? undefined;


### PR DESCRIPTION
## Background

`@ai-sdk/deepgram`'s transcription options schema declares `paragraphs`, `intents`, `sentiment`, `replace`, and `keyterm` (and `DeepgramTranscriptionAPITypes` lists the matching request parameters), but `getArgs()` never copies these five fields into the request body. Setting them via `providerOptions.deepgram` passes validation and then silently does nothing — the corresponding Deepgram features (paragraph formatting, intent recognition, sentiment analysis, redaction replacement, key term prompting) never activate.

Same class of bug as #16894 (xai `imageDetail` accepted but not sent) and #16663 (alibaba resolution ignored).

## Summary

- Map `paragraphs`, `intents`, `sentiment`, `replace`, and `keyterm` from the parsed provider options into the request body in `getArgs()`, alongside the options that were already forwarded (kept the list alphabetical).
- Added a regression test asserting all five options appear as query parameters on the outgoing request; it fails on `main` (none of the parameters are present) and passes with this change.

## Manual Verification

Ran the new test against `main` to confirm it reproduces the bug (all five `toContain` assertions fail because the query string only contains `model` and `diarize`), then with the fix (passes). Full `@ai-sdk/deepgram` suite (`pnpm test`: node + edge) and `pnpm type-check` pass; `oxlint`/`oxfmt` clean on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16910
