### PR TITLE
fix(perplexity): throw on unsupported file media types instead of silently dropping them

### DIFF
--- a/.changeset/perplexity-silent-file-drop.md
+++ b/.changeset/perplexity-silent-file-drop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/perplexity': patch
+---
+
+Fix file parts with unsupported media types being silently dropped from the prompt. Unsupported file media types now throw `UnsupportedFunctionalityError` like other providers, and PDFs passed with a top-level-only `application` media type are now detected from their bytes and sent as `file_url` parts instead of being discarded.

--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -172,9 +172,48 @@ describe('convertToPerplexityMessages', () => {
       });
     });
 
-    it('accepts top-level-only "application" mediaType for PDF without error', () => {
+    it('converts top-level-only "application" mediaType PDF bytes to a file_url part', () => {
       const pdfBase64 = 'JVBERi0xLjQ=';
 
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'application',
+              data: { type: 'data' as const, data: pdfBase64 },
+              filename: 'doc.pdf',
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'file_url',
+        file_url: { url: pdfBase64 },
+        file_name: 'doc.pdf',
+      });
+    });
+
+    it('throws for unsupported file media types instead of silently dropping them', () => {
+      expect(() =>
+        convertToPerplexityMessages([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'audio/mpeg',
+                data: { type: 'data' as const, data: 'AAAA' },
+              },
+            ],
+          },
+        ]),
+      ).toThrow(UnsupportedFunctionalityError);
+    });
+
+    it('throws for top-level-only "application" mediaType with a URL source', () => {
       expect(() =>
         convertToPerplexityMessages([
           {
@@ -183,13 +222,15 @@ describe('convertToPerplexityMessages', () => {
               {
                 type: 'file',
                 mediaType: 'application',
-                data: { type: 'data' as const, data: pdfBase64 },
-                filename: 'doc.pdf',
+                data: {
+                  type: 'url' as const,
+                  url: new URL('https://example.com/doc.pdf'),
+                },
               },
             ],
           },
         ]),
-      ).not.toThrow();
+      ).toThrow(UnsupportedFunctionalityError);
     });
 
     it('normalizes image/* wildcard via detection', () => {

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -57,7 +57,14 @@ export function convertToPerplexityMessages(
                   }
                   case 'url':
                   case 'data': {
-                    if (part.mediaType === 'application/pdf') {
+                    const isPdf =
+                      part.mediaType === 'application/pdf' ||
+                      (part.data.type === 'data' &&
+                        getTopLevelMediaType(part.mediaType) ===
+                          'application' &&
+                        resolveFullMediaType({ part }) === 'application/pdf');
+
+                    if (isPdf) {
                       return part.data.type === 'url'
                         ? {
                             type: 'file_url',
@@ -76,9 +83,9 @@ export function convertToPerplexityMessages(
                             },
                             file_name: part.filename || `document-${index}.pdf`,
                           };
-                    } else if (
-                      getTopLevelMediaType(part.mediaType) === 'image'
-                    ) {
+                    }
+
+                    if (getTopLevelMediaType(part.mediaType) === 'image') {
                       return part.data.type === 'url'
                         ? {
                             type: 'image_url',
@@ -97,7 +104,10 @@ export function convertToPerplexityMessages(
                             },
                           };
                     }
-                    return undefined;
+
+                    throw new UnsupportedFunctionalityError({
+                      functionality: `file part media type ${part.mediaType}`,
+                    });
                   }
                 }
               }


### PR DESCRIPTION
## Background

`convertToPerplexityMessages` silently drops file parts it does not recognize. Any file that is not an image and not exactly `application/pdf` (e.g. `audio/mpeg`, `text/csv`, `application/msword`) falls through to a bare `return undefined` that is then removed by `.filter(Boolean)` — no error, no warning, the content just vanishes from the prompt. A real PDF passed with a top-level-only `application` media type is also dropped, because the PDF branch uses strict `=== 'application/pdf'` equality while the image branch normalizes top-level-only types via `resolveFullMediaType`.

Every other OpenAI-style converter in the repo (openai, mistral, groq, xai, alibaba, openai-compatible, huggingface) throws `UnsupportedFunctionalityError` for unsupported file media types — perplexity was the lone outlier that silently discarded content.

## Summary

- PDFs are now detected via `resolveFullMediaType` when the media type is the top-level-only `application` form with inline bytes, so `mediaType: 'application'` + `%PDF` bytes produces a proper `file_url` part instead of being discarded.
- Unsupported file media types now throw `UnsupportedFunctionalityError` (`file part media type <mediaType>`), matching the sibling converters' behavior and wording.
- Strengthened the existing test that only asserted `.not.toThrow()` for the top-level-only `application` PDF case (it was passing while the PDF was silently dropped) to assert the emitted `file_url` content, and added two tests: unsupported media type throws, and top-level-only `application` with a URL source throws (subtype cannot be determined without bytes).

## Manual Verification

Ran the updated/new tests against `main`'s converter: all three fail there (the PDF-content assertion fails because the message content is empty, and both throw-assertions fail because nothing throws), and all pass with this change. Full `@ai-sdk/perplexity` suite passes (`pnpm test`: node + edge, 34 tests each) plus package `type-check`; `oxlint`/`oxfmt` clean on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #16914
