### PR TITLE
fix(azure): omit api-version for foundry v1 endpoints

### DIFF
--- a/.changeset/azure-foundry-project-v1.md
+++ b/.changeset/azure-foundry-project-v1.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure': patch
+---
+
+Omit api-version query parameters for Azure AI Foundry project OpenAI-compatible v1 endpoints.

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -93,6 +93,10 @@ const server = createTestServer({
   'https://test-resource.openai.azure.com/openai/v1/embeddings': {},
   'https://test-resource.openai.azure.com/openai/v1/images/generations': {},
   'https://test-resource.openai.azure.com/openai/v1/responses': {},
+  'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/responses':
+    {},
+  'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions':
+    {},
   'https://test-resource.openai.azure.com/openai/v1/audio/transcriptions': {},
   'https://test-resource.openai.azure.com/openai/v1/audio/speech': {},
   'https://our-gateway.example.com/azure/chat/completions': {},
@@ -272,6 +276,56 @@ describe('responses (default language model)', () => {
         `"https://test-resource.openai.azure.com/openai/v1/responses?api-version=v1"`,
       );
     });
+
+    it('should omit api-version for Azure AI Foundry project v1 baseURL', async () => {
+      server.urls[
+        'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/responses'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'resp_foundry',
+          object: 'response',
+          created_at: 1741257730,
+          status: 'completed',
+          model: 'test-deployment',
+          output: [
+            {
+              id: 'msg_foundry',
+              type: 'message',
+              status: 'completed',
+              role: 'assistant',
+              content: [
+                {
+                  type: 'output_text',
+                  text: '',
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 4,
+            output_tokens: 30,
+            total_tokens: 34,
+          },
+          incomplete_details: null,
+        },
+      };
+
+      const provider = createAzure({
+        baseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai',
+        apiKey: 'test-api-key',
+      });
+
+      await provider('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
+        `"https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/responses"`,
+      );
+    });
   });
 });
 
@@ -410,6 +464,42 @@ describe('chat', () => {
 
       expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
         `"https://our-gateway.example.com/azure/chat/completions"`,
+      );
+    });
+
+    it('should omit api-version for Azure AI Foundry project v1 chat baseURL', async () => {
+      server.urls[
+        'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-foundry',
+          object: 'chat.completion',
+          created: 0,
+          model: 'test-deployment',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        },
+      };
+
+      const provider = createAzure({
+        baseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai',
+        apiKey: 'test-api-key',
+      });
+
+      await provider.chat('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
+        `"https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions"`,
       );
     });
   });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -114,7 +114,7 @@ export interface AzureOpenAIProviderSettings {
    * Use a different URL prefix for API calls, e.g. to use proxy servers. Either this or `resourceName` can be used.
    * When a baseURL is provided, the resourceName is ignored.
    *
-   * With an Azure OpenAI baseURL, the resolved URL is `{baseURL}/v1{path}`.
+   * With an Azure OpenAI or Azure AI Foundry project baseURL, the resolved URL is `{baseURL}/v1{path}`.
    * With a non-Azure custom gateway baseURL, the resolved URL is `{baseURL}{path}`.
    */
   baseURL?: string;
@@ -155,10 +155,27 @@ export interface AzureOpenAIProviderSettings {
   useDeploymentBasedUrls?: boolean;
 }
 
-function isAzureOpenAIBaseURL(baseURL: string | undefined) {
-  return (
-    baseURL == null || new URL(baseURL).hostname.endsWith('.openai.azure.com')
-  );
+type AzureEndpointKind = 'azure-openai' | 'foundry-project' | 'custom';
+
+function getAzureEndpointKind(baseURL: string | undefined): AzureEndpointKind {
+  if (baseURL == null) {
+    return 'azure-openai';
+  }
+
+  const url = new URL(baseURL);
+
+  if (url.hostname.endsWith('.openai.azure.com')) {
+    return 'azure-openai';
+  }
+
+  if (
+    url.hostname.endsWith('.services.ai.azure.com') &&
+    /^\/api\/projects\/[^/]+\/openai\/?$/.test(url.pathname)
+  ) {
+    return 'foundry-project';
+  }
+
+  return 'custom';
 }
 
 /**
@@ -221,7 +238,7 @@ export function createAzure(
     });
 
   const apiVersion = options.apiVersion ?? 'v1';
-  const useAzureOpenAIEndpoint = isAzureOpenAIBaseURL(options.baseURL);
+  const azureEndpointKind = getAzureEndpointKind(options.baseURL);
 
   const url = ({ path, modelId }: { path: string; modelId: string }) => {
     const baseUrlPrefix = withoutTrailingSlash(
@@ -232,7 +249,7 @@ export function createAzure(
     if (options.useDeploymentBasedUrls) {
       // Use deployment-based format for compatibility with certain Azure OpenAI models
       fullUrl = new URL(`${baseUrlPrefix}/deployments/${modelId}${path}`);
-    } else if (!useAzureOpenAIEndpoint) {
+    } else if (azureEndpointKind === 'custom') {
       // Custom gateways can own Azure routing and versioning themselves.
       fullUrl = new URL(`${baseUrlPrefix}${path}`);
     } else {
@@ -240,7 +257,10 @@ export function createAzure(
       fullUrl = new URL(`${baseUrlPrefix}/v1${path}`);
     }
 
-    if (useAzureOpenAIEndpoint || options.useDeploymentBasedUrls) {
+    if (
+      azureEndpointKind === 'azure-openai' ||
+      options.useDeploymentBasedUrls
+    ) {
       fullUrl.searchParams.set('api-version', apiVersion);
     }
 


### PR DESCRIPTION
## Summary
- detect Azure AI Foundry project OpenAI-compatible base URLs separately from custom gateways
- route Foundry project base URLs through `/openai/v1/*` without appending `api-version`
- keep standard Azure OpenAI and deployment-based URLs on their existing `api-version` behavior

Fixes #14009.

## Tests
- `npx pnpm@10.33.4 --filter @ai-sdk/azure... build`
- `npx pnpm@10.33.4 -C packages/azure test:node -- azure-openai-provider.test.ts` (64 passed)
- `npx pnpm@10.33.4 -C packages/azure test:edge -- azure-openai-provider.test.ts` (64 passed)
- `npx pnpm@10.33.4 -C packages/azure type-check`
- `npx pnpm@10.33.4 exec oxlint packages/azure/src/azure-openai-provider.ts packages/azure/src/azure-openai-provider.test.ts --deny-warnings`
- `npx pnpm@10.33.4 exec oxfmt --check packages/azure/src/azure-openai-provider.ts packages/azure/src/azure-openai-provider.test.ts .changeset/azure-foundry-project-v1.md`
- `npx pnpm@10.33.4 changeset status --since origin/main`
- `git diff --check`