### PR TITLE
reproduction: could not reproduce processUIMessageStream drops providerMetadata from file chunks

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts
+++ b/examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readUIMessageStream, streamText } from 'ai';
+import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
+
+const expectedProviderMetadata = {
+  customProvider: { fileId: 'file-12670' },
+};
+
+async function main() {
+  const model = new MockLanguageModelV4({
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: { type: 'data', data: 'iVBORw0KGgo=' },
+            providerMetadata: expectedProviderMetadata,
+          },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 1,
+                text: 1,
+                reasoning: undefined,
+              },
+            },
+          },
+        ],
+      }),
+    }),
+  });
+
+  const uiStream = streamText({
+    model,
+    prompt: 'give me a file',
+  }).toUIMessageStream();
+
+  let filePart:
+    | Extract<
+        Awaited<ReturnType<typeof readUIMessageStream>> extends AsyncIterable<
+          infer MESSAGE
+        >
+          ? MESSAGE extends { parts: Array<infer PART> }
+            ? PART
+            : never
+          : never,
+        { type: 'file' }
+      >
+    | undefined;
+
+  for await (const message of readUIMessageStream({ stream: uiStream })) {
+    filePart = message.parts.find(part => part.type === 'file') ?? filePart;
+  }
+
+  const observedProviderMetadata = filePart?.providerMetadata;
+
+  console.log(
+    JSON.stringify(
+      {
+        providerMetadataPreserved:
+          JSON.stringify(observedProviderMetadata) ===
+          JSON.stringify(expectedProviderMetadata),
+        observedProviderMetadata,
+        expectedProviderMetadata,
+        filePart,
+      },
+      null,
+      2,
+    ),
+  );
+
+  assert.deepEqual(
+    observedProviderMetadata,
+    expectedProviderMetadata,
+    'Expected streamText().toUIMessageStream() -> readUIMessageStream() to preserve file providerMetadata',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

processUIMessageStream drops providerMetadata from file chunks

## Reproduction

- `examples/ai-functions/src/reproduction/issue-12670-process-ui-message-stream-file-provider-metadata.ts` creates a full mock-model round trip through `streamText().toUIMessageStream()` and `readUIMessageStream()`.
- Observed on the current workspace `ai` package (`packages/ai/package.json` version 7.0.17) that the resulting `file` UI part retained `providerMetadata.customProvider.fileId === "file-12670"`.
- Expected issue behavior was for the resulting `FileUIPart` to have `providerMetadata` dropped or `undefined`.
- Classified as general library behavior; no live provider or external API documentation was needed.

## Related Issues

Could not reproduce #12670