### PR TITLE
fix(workflow): align package exports with esm build

### DIFF
--- a/.changeset/quiet-workflows-publish.md
+++ b/.changeset/quiet-workflows-publish.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/workflow": patch
+---
+
+Align the workflow package export map with its ESM build output.

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@ai-sdk/workflow",
   "version": "1.0.18",
+  "type": "module",
   "description": "WorkflowAgent for building AI agents with AI SDK",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "source": "./src/index.ts",
   "files": [
@@ -33,8 +33,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- mark `@ai-sdk/workflow` as an ESM package so its ESM-only `tsup` build emits the files advertised by `package.json`
- align the package export map with the emitted `dist/index.js` / `dist/index.d.ts` files and neighboring AI SDK package conventions
- remove stale `module` / `require` entries that pointed at non-published or unsupported outputs

Fixes #16925.

## Tests

- `pnpm --filter @ai-sdk/workflow build`
- `pnpm --filter @ai-sdk/workflow type-check`
- `pnpm prettier --check packages/workflow/package.json .changeset/quiet-workflows-publish.md`
- `git diff --check`
- manifest file-existence check for `main`, `types`, `exports[\".\"].import`, `exports[\".\"].types`, and `exports[\".\"].default`
- `pnpm --filter @ai-sdk/workflow pack --pack-destination <temp-dir>`

`pnpm --filter @ai-sdk/workflow test:node` currently fails before tests run in this local install because the package-local Vitest config cannot resolve `vite`. That appears unrelated to this manifest diff; build, type-check, formatting, and package/tarball shape checks pass.