### PR TITLE
fix(amazon-bedrock): recover malformed Nova tool calls

### DIFF
--- a/.changeset/nova-malformed-tool-use.md
+++ b/.changeset/nova-malformed-tool-use.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Recover Nova malformed tool-use text for matching Bedrock tools.

--- a/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
@@ -112,6 +112,7 @@ export const BEDROCK_STOP_REASONS = [
   'guardrail_intervened',
   'tool-calls',
   'tool_use',
+  'malformed_tool_use',
 ] as const;
 
 export type AmazonBedrockStopReason = (typeof BEDROCK_STOP_REASONS)[number];

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -4814,6 +4814,185 @@ describe('doGenerate', () => {
     expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
   });
 
+  it('should recover Nova malformed JSON response tool calls', async () => {
+    server.urls[novaGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                text: `<tools>
+<__function=json>
+<__parameter=category>billing</__parameter>
+<__parameter=priority>medium</__parameter>
+<__parameter=customer>{"name":"Alex","accountId":"acct_123","plan":"pro"}</__parameter>
+<__parameter=tags>["invoice","refund"]</__parameter>
+<__parameter=summary>Customer asks about a duplicate charge</__parameter>
+</__function>
+</tools>`,
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'malformed_tool_use',
+      },
+    };
+
+    const result = await novaModel.doGenerate({
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'Classify this' }] },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            category: { type: 'string' },
+            priority: { type: 'string' },
+            customer: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                accountId: { type: 'string' },
+                plan: { type: 'string' },
+              },
+              required: ['name', 'accountId', 'plan'],
+            },
+            tags: { type: 'array', items: { type: 'string' } },
+            summary: { type: 'string' },
+          },
+          required: ['category', 'priority', 'customer', 'tags', 'summary'],
+        },
+      },
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: JSON.stringify({
+          category: 'billing',
+          priority: 'medium',
+          customer: { name: 'Alex', accountId: 'acct_123', plan: 'pro' },
+          tags: ['invoice', 'refund'],
+          summary: 'Customer asks about a duplicate charge',
+        }),
+      },
+    ]);
+    expect(result.finishReason).toEqual({
+      unified: 'stop',
+      raw: 'malformed_tool_use',
+    });
+    expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
+  });
+
+  it('should recover Nova malformed forced tool calls', async () => {
+    server.urls[novaGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                text: `<tools>
+<__function=lookupCustomer>
+<__parameter=customerId>"cust_123"</__parameter>
+<__parameter=includeHistory>true</__parameter>
+<__parameter=score>0.8</__parameter>
+</__function>
+</tools>`,
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 20, totalTokens: 24 },
+        stopReason: 'malformed_tool_use',
+      },
+    };
+
+    const result = await novaModel.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'lookupCustomer',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              customerId: { type: 'string' },
+              includeHistory: { type: 'boolean' },
+              score: { type: 'number' },
+            },
+            required: ['customerId'],
+          },
+        },
+      ],
+      toolChoice: { type: 'tool', toolName: 'lookupCustomer' },
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'test-id',
+        toolName: 'lookupCustomer',
+        input: JSON.stringify({
+          customerId: 'cust_123',
+          includeHistory: true,
+          score: 0.8,
+        }),
+      },
+    ]);
+    expect(result.finishReason).toEqual({
+      unified: 'tool-calls',
+      raw: 'malformed_tool_use',
+    });
+  });
+
+  it('should not recover malformed tool text for unknown tools', async () => {
+    const text = `<tools>
+<__function=deleteCustomer>
+<__parameter=customerId>"cust_123"</__parameter>
+</__function>
+</tools>`;
+
+    server.urls[novaGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ text }],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 20, totalTokens: 24 },
+        stopReason: 'malformed_tool_use',
+      },
+    };
+
+    const result = await novaModel.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'lookupCustomer',
+          inputSchema: {
+            type: 'object',
+            properties: { customerId: { type: 'string' } },
+          },
+        },
+      ],
+    });
+
+    expect(result.content).toEqual([{ type: 'text', text }]);
+    expect(result.finishReason).toEqual({
+      unified: 'other',
+      raw: 'malformed_tool_use',
+    });
+  });
+
   it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {
     server.urls[newerAnthropicGenerateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -52,6 +52,7 @@ import { convertToAmazonBedrockChatMessages } from './convert-to-amazon-bedrock-
 import { mapAmazonBedrockFinishReason } from './map-amazon-bedrock-finish-reason';
 import { isMistralModel, normalizeToolCallId } from './normalize-tool-call-id';
 import type { AmazonBedrockReasoningMetadata } from './amazon-bedrock-reasoning-metadata';
+import { parseMalformedToolCall } from './parse-malformed-tool-call';
 
 type AmazonBedrockChatConfig = {
   baseUrl: () => string;
@@ -497,11 +498,36 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
 
     const content: Array<LanguageModelV4Content> = [];
     let isJsonResponseFromTool = false;
+    let isMalformedToolUseRecovered = false;
+    const isMistral = isMistralModel(this.modelId);
+    const toolNames = new Set(
+      (args.toolConfig?.tools ?? []).flatMap(tool =>
+        'toolSpec' in tool ? [tool.toolSpec.name] : [],
+      ),
+    );
 
     // map response content to content array
     for (const part of response.output.message.content) {
       // text
       if (part.text != null) {
+        if (response.stopReason === 'malformed_tool_use') {
+          const parsedToolCall = await parseMalformedToolCall({
+            generateToolCallId: () =>
+              normalizeToolCallId(this.config.generateId(), isMistral),
+            isJsonResponseTool: toolName =>
+              usesJsonResponseTool && toolName === 'json',
+            text: part.text,
+            toolNames,
+          });
+
+          if (parsedToolCall != null) {
+            isMalformedToolUseRecovered = true;
+            isJsonResponseFromTool ||= parsedToolCall.isJsonResponseFromTool;
+            content.push(...parsedToolCall.content);
+            continue;
+          }
+        }
+
         content.push({ type: 'text', text: part.text });
       }
 
@@ -552,7 +578,6 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
             text: JSON.stringify(part.toolUse.input),
           });
         } else {
-          const isMistral = isMistralModel(this.modelId);
           const rawToolCallId =
             part.toolUse?.toolUseId ?? this.config.generateId();
           content.push({
@@ -615,6 +640,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
         unified: mapAmazonBedrockFinishReason(
           response.stopReason as AmazonBedrockStopReason,
           isJsonResponseFromTool,
+          isMalformedToolUseRecovered,
         ),
         raw: response.stopReason ?? undefined,
       },

--- a/packages/amazon-bedrock/src/map-amazon-bedrock-finish-reason.ts
+++ b/packages/amazon-bedrock/src/map-amazon-bedrock-finish-reason.ts
@@ -4,6 +4,7 @@ import type { AmazonBedrockStopReason } from './amazon-bedrock-api-types';
 export function mapAmazonBedrockFinishReason(
   finishReason: AmazonBedrockStopReason,
   isJsonResponseFromTool?: boolean,
+  isMalformedToolUseRecovered?: boolean,
 ): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case 'stop_sequence':
@@ -16,6 +17,12 @@ export function mapAmazonBedrockFinishReason(
       return 'content-filter';
     case 'tool_use':
       return isJsonResponseFromTool ? 'stop' : 'tool-calls';
+    case 'malformed_tool_use':
+      return isMalformedToolUseRecovered
+        ? isJsonResponseFromTool
+          ? 'stop'
+          : 'tool-calls'
+        : 'other';
     default:
       return 'other';
   }

--- a/packages/amazon-bedrock/src/parse-malformed-tool-call.ts
+++ b/packages/amazon-bedrock/src/parse-malformed-tool-call.ts
@@ -1,0 +1,87 @@
+import type { LanguageModelV4Content } from '@ai-sdk/provider';
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+
+const malformedFunctionStartPattern = /<__function=([^>\s]+)>/g;
+const malformedParameterPattern =
+  /<__parameter=([^>\s]+)>([\s\S]*?)<\/__parameter>/g;
+
+export async function parseMalformedToolCall({
+  generateToolCallId,
+  isJsonResponseTool,
+  text,
+  toolNames,
+}: {
+  generateToolCallId: () => string;
+  isJsonResponseTool: (toolName: string) => boolean;
+  text: string;
+  toolNames: Set<string>;
+}): Promise<
+  | {
+      content: Array<LanguageModelV4Content>;
+      isJsonResponseFromTool: boolean;
+    }
+  | undefined
+> {
+  if (toolNames.size === 0 || !text.includes('<tools>')) {
+    return undefined;
+  }
+
+  const functionStarts = Array.from(
+    text.matchAll(malformedFunctionStartPattern),
+  );
+
+  if (functionStarts.length === 0) {
+    return undefined;
+  }
+
+  const content: Array<LanguageModelV4Content> = [];
+  let isJsonResponseFromTool = false;
+
+  for (let i = 0; i < functionStarts.length; i++) {
+    const startMatch = functionStarts[i];
+    const toolName = startMatch[1];
+
+    if (!toolNames.has(toolName)) {
+      return undefined;
+    }
+
+    const blockStart = startMatch.index + startMatch[0].length;
+    const nextBlockStart = functionStarts[i + 1]?.index ?? text.length;
+    const closingTagIndex = text.indexOf('</__function>', blockStart);
+    const blockEnd =
+      closingTagIndex !== -1 && closingTagIndex < nextBlockStart
+        ? closingTagIndex
+        : nextBlockStart;
+
+    const input = await parseParameters(text.slice(blockStart, blockEnd));
+    const inputJson = JSON.stringify(input);
+
+    if (isJsonResponseTool(toolName)) {
+      isJsonResponseFromTool = true;
+      content.push({ type: 'text', text: inputJson });
+    } else {
+      content.push({
+        type: 'tool-call',
+        toolCallId: generateToolCallId(),
+        toolName,
+        input: inputJson,
+      });
+    }
+  }
+
+  return { content, isJsonResponseFromTool };
+}
+
+async function parseParameters(text: string): Promise<Record<string, unknown>> {
+  const input: Record<string, unknown> = {};
+
+  for (const parameterMatch of text.matchAll(malformedParameterPattern)) {
+    const [, name, rawValue] = parameterMatch;
+    const trimmedValue = rawValue.trim();
+    const parsedValue = await safeParseJSON({ text: trimmedValue });
+
+    input[name] = parsedValue.success ? parsedValue.value : trimmedValue;
+  }
+
+  return input;
+}


### PR DESCRIPTION
## Summary

- recover Nova `malformed_tool_use` responses when Bedrock returns the internal tool-call payload as text
- only recover payloads whose function name matches a tool sent in the request
- preserve the existing structured-output convention by converting recovered `json` tool calls into JSON text, while regular tools remain tool-call parts
- leave unmatched internal-looking text unchanged

Fixes #16926.

## Tests

- `pnpm --filter @ai-sdk/amazon-bedrock build`
- `pnpm --filter @ai-sdk/amazon-bedrock type-check`
- `pnpm --filter @ai-sdk/amazon-bedrock test`
- `pnpm --filter @ai-sdk/amazon-bedrock exec vitest run --config vitest.node.config.js src/amazon-bedrock-chat-language-model.test.ts`
- `pnpm exec oxfmt --check packages/amazon-bedrock/src/parse-malformed-tool-call.ts packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts packages/amazon-bedrock/src/amazon-bedrock-api-types.ts packages/amazon-bedrock/src/map-amazon-bedrock-finish-reason.ts .changeset/nova-malformed-tool-use.md`
- `pnpm exec oxlint packages/amazon-bedrock/src/parse-malformed-tool-call.ts packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts packages/amazon-bedrock/src/amazon-bedrock-api-types.ts packages/amazon-bedrock/src/map-amazon-bedrock-finish-reason.ts`
- `git diff --check`
- `pnpm changeset status --since origin/main`
