### PR TITLE
docs(provider): add AxioRank community provider

### DIFF
--- a/content/providers/05-community-providers/52-axiorank.mdx
+++ b/content/providers/05-community-providers/52-axiorank.mdx
@@ -1,0 +1,64 @@
+---
+title: AxioRank
+description: Learn how to use the AxioRank guardrail middleware for the AI SDK.
+---
+
+# AxioRank
+
+[AxioRank](https://axiorank.com) is the security gateway for AI agents. Its AI SDK middleware wraps any language model so every `generateText`, `streamText`, and `generateObject` call is governed:
+
+- **Prompt inspection** for prompt injection, jailbreaks, and secrets or PII leaking into the model.
+- **Completion inspection and redaction** for leaked secrets and PII in the model's output.
+- **Tool-call inspection** that strips a proposed tool call before the AI SDK executes it.
+- **Local or hosted**: run the bundled detectors in-process with no key, or point at the hosted AxioRank gateway for your workspace's real policy, audit trail, and completion redaction.
+
+Because it is a `LanguageModelMiddleware`, it composes with any provider through `wrapLanguageModel`.
+
+## Setup
+
+The AxioRank middleware is available in the `@axiorank/ai-sdk` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @axiorank/ai-sdk" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @axiorank/ai-sdk" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @axiorank/ai-sdk" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @axiorank/ai-sdk" dark />
+  </Tab>
+</Tabs>
+
+## Usage
+
+Wrap any model with `wrapLanguageModel` and the AxioRank middleware:
+
+```ts
+import { generateText, wrapLanguageModel } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { createAxioRankMiddleware } from '@axiorank/ai-sdk';
+
+const model = wrapLanguageModel({
+  model: openai('gpt-4o'),
+  middleware: createAxioRankMiddleware({ apiKey: process.env.AXIORANK_API_KEY }),
+});
+
+// The prompt, the completion, and any proposed tool calls are all governed.
+const { text } = await generateText({ model, prompt: 'Hello!' });
+```
+
+Leave the API key off to run the detectors locally, with no key and no network:
+
+```ts
+const model = wrapLanguageModel({
+  model: openai('gpt-4o'),
+  middleware: createAxioRankMiddleware(),
+});
+```
+
+You can obtain an API key from the [AxioRank dashboard](https://app.axiorank.com). Learn more in the [AxioRank documentation](https://axiorank.com/docs).
+


### PR DESCRIPTION
## Background

The AI SDK community-providers docs already list security and gateway integrations (Cencori, Portkey, Helicone, Cloudflare AI Gateway), but there is no entry for AxioRank, which ships a first-class AI SDK guardrail as `@axiorank/ai-sdk`.

## Summary

Adds `content/providers/05-community-providers/52-axiorank.mdx` documenting the AxioRank guardrail middleware. `createAxioRankMiddleware()` returns a `LanguageModelMiddleware` that, via `wrapLanguageModel`, inspects the prompt, inspects and redacts the completion, and strips a denied proposed tool call on every `generateText` / `streamText` / `generateObject`. It runs locally with no key, or against the hosted AxioRank gateway for a workspace's real policy, audit trail, and redaction.

The page follows the same structure as the existing community-provider entries (frontmatter, intro, feature list, Setup tabs, Usage). Docs only, no code changes.

## Manual Verification

- `@axiorank/ai-sdk@0.1.0` is published on npm; `npm install @axiorank/ai-sdk ai` installs it with only `ai` as a peer dependency.
- The usage snippet runs against the AI SDK: `wrapLanguageModel({ model, middleware: createAxioRankMiddleware() })` returns a governed model.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)