### PR TITLE
fix(groq): expose cache read usage

### DIFF
--- a/.changeset/groq-cache-read-usage.md
+++ b/.changeset/groq-cache-read-usage.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/groq": patch
+---
+
+Populate Groq cache read usage from prompt token details.

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -65,6 +65,37 @@ describe('convertGroqUsage', () => {
     });
   });
 
+  it('should extract cached tokens from prompt_tokens_details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 1000,
+      completion_tokens: 10,
+      prompt_tokens_details: {
+        cached_tokens: 900,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 1000,
+        noCache: 100,
+        cacheRead: 900,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 10,
+        text: 10,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 1000,
+        completion_tokens: 10,
+        prompt_tokens_details: {
+          cached_tokens: 900,
+        },
+      },
+    });
+  });
+
   it('should extract reasoning tokens from completion_tokens_details', () => {
     const result = convertGroqUsage({
       prompt_tokens: 79,

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -39,6 +39,7 @@ export function convertGroqUsage(
   }
 
   const promptTokens = usage.prompt_tokens ?? 0;
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens ?? undefined;
   const completionTokens = usage.completion_tokens ?? 0;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? undefined;
@@ -50,8 +51,8 @@ export function convertGroqUsage(
   return {
     inputTokens: {
       total: promptTokens,
-      noCache: promptTokens,
-      cacheRead: undefined,
+      noCache: promptTokens - (cachedTokens ?? 0),
+      cacheRead: cachedTokens,
       cacheWrite: undefined,
     },
     outputTokens: {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -286,9 +286,9 @@ describe('doGenerate', () => {
     expect(usage).toMatchInlineSnapshot(`
       {
         "inputTokens": {
-          "cacheRead": undefined,
+          "cacheRead": 15,
           "cacheWrite": undefined,
-          "noCache": 20,
+          "noCache": 5,
           "total": 20,
         },
         "outputTokens": {


### PR DESCRIPTION
## Summary

- read Groq `prompt_tokens_details.cached_tokens` into `usage.inputTokens.cacheRead`
- subtract cached prompt tokens from `usage.inputTokens.noCache`
- add converter coverage and update the existing Groq cached-input usage assertion

Fixes #16899.

## Tests

- `pnpm --filter @ai-sdk/groq exec vitest run --config vitest.node.config.js src/convert-groq-usage.test.ts src/groq-chat-language-model.test.ts` (52 passed)
- `pnpm --filter @ai-sdk/groq test` (node: 96 passed; edge: 96 passed)
- `pnpm --filter @ai-sdk/groq type-check`
- `pnpm --filter @ai-sdk/groq build`
- `pnpm exec oxfmt --check packages/groq/src/convert-groq-usage.ts packages/groq/src/convert-groq-usage.test.ts packages/groq/src/groq-chat-language-model.test.ts .changeset/groq-cache-read-usage.md`
- `pnpm exec oxlint packages/groq/src/convert-groq-usage.ts packages/groq/src/convert-groq-usage.test.ts packages/groq/src/groq-chat-language-model.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --check`
