### PR TITLE
fix(ai): wait for chat stop cleanup

### DIFF
--- a/.changeset/chat-stop-awaits-abort.md
+++ b/.changeset/chat-stop-awaits-abort.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Make `Chat.stop()` wait for the aborted stream request to finish cleanup before resolving, so callers can safely clear or replace messages after stopping an active stream.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -904,6 +904,64 @@ describe('Chat', () => {
     });
   });
 
+  it('should wait for abort handling before resolving stop', async () => {
+    let controller: ReadableStreamDefaultController<UIMessageChunk>;
+    const responseStream = new ReadableStream<UIMessageChunk>({
+      start: controllerArg => {
+        controller = controllerArg;
+
+        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: 'start-step' });
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'Hello',
+        });
+      },
+    });
+
+    const chat = new TestChat({
+      id: '123',
+      generateId: mockId(),
+      transport: {
+        sendMessages: async options => {
+          options.abortSignal?.addEventListener('abort', () => {
+            setTimeout(() => {
+              controller.error(new DOMException('Aborted', 'AbortError'));
+            }, 10);
+          });
+          return responseStream;
+        },
+        reconnectToStream: () => {
+          throw new Error('not implemented');
+        },
+      },
+    });
+
+    void chat.sendMessage({ text: 'Hello, world!' });
+
+    while ((chat.messages[1]?.parts[1] as any)?.text !== 'Hello') {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    let stopResolved = false;
+    const stopPromise = chat.stop().then(() => {
+      stopResolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(stopResolved).toBe(false);
+    expect(chat.status).toBe('streaming');
+
+    await vi.advanceTimersByTimeAsync(10);
+    await stopPromise;
+
+    expect(stopResolved).toBe(true);
+    expect(chat.status).toBe('ready');
+  });
+
   it('should include the metadata of text message', async () => {
     server.urls['http://localhost:3000/api/chat'].response = {
       type: 'stream-chunks',

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -254,6 +254,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   private sendAutomaticallyWhen?: ChatInit<UI_MESSAGE>['sendAutomaticallyWhen'];
 
   private activeResponse: ActiveResponse<UI_MESSAGE> | undefined = undefined;
+  private activeRequest: Promise<void> | undefined = undefined;
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -586,9 +587,13 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   stop = async () => {
     if (this.status !== 'streaming' && this.status !== 'submitted') return;
 
+    const activeRequest = this.activeRequest;
+
     if (this.activeResponse?.abortController) {
       this.activeResponse.abortController.abort();
     }
+
+    await activeRequest;
   };
 
   private async shouldSendAutomatically(): Promise<boolean> {
@@ -606,7 +611,25 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     return result as boolean;
   }
 
-  private async makeRequest({
+  private async makeRequest(
+    options: {
+      trigger: 'submit-message' | 'resume-stream' | 'regenerate-message';
+      messageId?: string;
+    } & ChatRequestOptions,
+  ) {
+    const activeRequest = this.doMakeRequest(options);
+    this.activeRequest = activeRequest;
+
+    try {
+      await activeRequest;
+    } finally {
+      if (this.activeRequest === activeRequest) {
+        this.activeRequest = undefined;
+      }
+    }
+  }
+
+  private async doMakeRequest({
     trigger,
     metadata,
     headers,
@@ -735,7 +758,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       if (isAbort || (err as any).name === 'AbortError') {
         isAbort = true;
         this.setStatus({ status: 'ready' });
-        return null;
+        return;
       }
 
       isError = true;


### PR DESCRIPTION
## Summary

- make `Chat.stop()` wait for the active stream request to finish abort cleanup before resolving
- keep the existing immediate abort signal behavior, but give callers a reliable boundary before clearing or replacing messages
- add regression coverage proving `stop()` remains pending until delayed abort handling sets status back to `ready`

Refs #13962.

## Tests

- `npx -y pnpm@10.33.4 install --frozen-lockfile --ignore-scripts`
- `npx -y pnpm@10.33.4 --filter ai... build`
- `npx -y pnpm@10.33.4 -C packages/ai exec vitest --config vitest.node.config.js --run src/ui/chat.test.ts -t "wait for abort handling"` (1 passed)
- `npx -y pnpm@10.33.4 -C packages/ai exec vitest --config vitest.node.config.js --run src/ui/chat.test.ts` (28 passed)
- `npx -y pnpm@10.33.4 -C packages/ai exec vitest --config vitest.edge.config.js --run src/ui/chat.test.ts` (28 passed)
- `npx -y pnpm@10.33.4 -C packages/ai type-check`
- `npx -y pnpm@10.33.4 exec oxfmt --check packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts .changeset/chat-stop-awaits-abort.md`
- `npx -y pnpm@10.33.4 exec oxlint packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts --deny-warnings`
- `git diff --check`
- `npx -y pnpm@10.33.4 changeset status --since origin/main`
