### PR TITLE
feat(mistral): add `providerOptions` schema and type for Mistral embedding model requests

### DIFF
--- a/.changeset/unlucky-months-learn.md
+++ b/.changeset/unlucky-months-learn.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mistral": patch
+---
+
+feat(mistral): add `providerOptions` schema and type for Mistral embedding model requests

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -97,7 +97,6 @@
             "packages/gateway/src/gateway-reranking-model.ts",
             "packages/gateway/src/gateway-speech-model.ts",
             "packages/gateway/src/gateway-transcription-model.ts",
-            "packages/mistral/src/mistral-embedding-model.ts",
             "packages/openai-compatible/src/image/openai-compatible-image-model.ts"
           ]
         },

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -347,6 +347,43 @@ const { embedding } = await embed({
 });
 ```
 
+Mistral embedding models support additional provider options through
+`providerOptions.mistral`. You can validate them with
+`MistralEmbeddingModelOptions`:
+
+```ts
+import { mistral, type MistralEmbeddingModelOptions } from '@ai-sdk/mistral';
+import { embed } from 'ai';
+
+const { embedding } = await embed({
+  model: mistral.embedding('mistral-embed'),
+  value: 'sunny day at the beach',
+  providerOptions: {
+    mistral: {
+      metadata: { source: 'knowledge-base' },
+      outputDimension: 1024,
+      outputDtype: 'float',
+    } satisfies MistralEmbeddingModelOptions,
+  },
+});
+```
+
+The following optional provider options are available for Mistral embedding
+models:
+
+- **metadata** _Record&lt;string, unknown&gt;_
+
+  Additional metadata to attach to the embedding request.
+
+- **outputDimension** _number_
+
+  The dimension of the output embeddings when supported by the model.
+
+- **outputDtype** _string_
+
+  The data type of the output embeddings when supported by the model. Accepts
+  `'float'`, `'int8'`, `'uint8'`, `'binary'`, or `'ubinary'`.
+
 ### Model Capabilities
 
 | Model           | Default Dimensions |

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -342,8 +342,8 @@ import { mistral } from '@ai-sdk/mistral';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: mistral.embedding('mistral-embed'),
-  value: 'sunny day at the beach',
+  model: mistral.embedding('codestral-embed-2505'),
+  value: 'function add(a: number, b: number) { return a + b; }',
 });
 ```
 

--- a/examples/ai-functions/src/embed-many/mistral/provider-options.ts
+++ b/examples/ai-functions/src/embed-many/mistral/provider-options.ts
@@ -1,0 +1,30 @@
+import { mistral, type MistralEmbeddingModelOptions } from '@ai-sdk/mistral';
+import { embedMany } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embeddings, usage, warnings } = await embedMany({
+    model: mistral.embedding('codestral-embed-2505'),
+    values: [
+      'function add(a: number, b: number) { return a + b; }',
+      'function subtract(a: number, b: number) { return a - b; }',
+      'function multiply(a: number, b: number) { return a * b; }',
+    ],
+    providerOptions: {
+      mistral: {
+        metadata: {
+          source: 'examples/ai-functions',
+          useCase: 'batch-embedding-provider-options',
+        },
+        outputDimension: 1024,
+        outputDtype: 'int8',
+      } satisfies MistralEmbeddingModelOptions,
+    },
+  });
+
+  console.log('embedding count:', embeddings.length);
+  console.log('embedding dimensions:', embeddings[0].length);
+  console.log(embeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed/mistral/provider-options.ts
+++ b/examples/ai-functions/src/embed/mistral/provider-options.ts
@@ -1,0 +1,25 @@
+import { mistral, type MistralEmbeddingModelOptions } from '@ai-sdk/mistral';
+import { embed } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embedding, usage, warnings } = await embed({
+    model: mistral.embedding('codestral-embed-2505'),
+    value: 'function add(a: number, b: number) { return a + b; }',
+    providerOptions: {
+      mistral: {
+        metadata: {
+          source: 'examples/ai-functions',
+          useCase: 'single-embedding-provider-options',
+        },
+        outputDimension: 1024,
+        outputDtype: 'float',
+      } satisfies MistralEmbeddingModelOptions,
+    },
+  });
+
+  console.log('embedding dimensions:', embedding.length);
+  console.log(embedding);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -8,4 +8,5 @@ export type {
   /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
   MistralLanguageModelChatOptions as MistralLanguageModelOptions,
 } from './mistral-chat-language-model-options';
+export type { MistralEmbeddingModelOptions } from './mistral-embedding-model-options';
 export { VERSION } from './version';

--- a/packages/mistral/src/mistral-embedding-model-options.test.ts
+++ b/packages/mistral/src/mistral-embedding-model-options.test.ts
@@ -1,0 +1,37 @@
+import {
+  mistralEmbeddingModelOptions,
+  type MistralEmbeddingModelOptions,
+} from './mistral-embedding-model-options';
+import { describe, expect, it } from 'vitest';
+
+describe('mistralEmbeddingModelOptions', () => {
+  it('accepts supported embedding provider options', () => {
+    const options: MistralEmbeddingModelOptions = {
+      metadata: { source: 'test' },
+      outputDimension: 1024,
+      outputDtype: 'float',
+    };
+
+    expect(mistralEmbeddingModelOptions.safeParse(options).success).toBe(true);
+  });
+
+  it('accepts all supported output dtypes', () => {
+    for (const outputDtype of [
+      'float',
+      'int8',
+      'uint8',
+      'binary',
+      'ubinary',
+    ] satisfies Array<MistralEmbeddingModelOptions['outputDtype']>) {
+      expect(
+        mistralEmbeddingModelOptions.safeParse({ outputDtype }).success,
+      ).toBe(true);
+    }
+  });
+
+  it('rejects invalid output dtype values', () => {
+    expect(
+      mistralEmbeddingModelOptions.safeParse({ outputDtype: 'base64' }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/mistral/src/mistral-embedding-model-options.ts
+++ b/packages/mistral/src/mistral-embedding-model-options.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod/v4';
+
+export type MistralEmbeddingModelId =
+  | 'mistral-embed'
+  | 'codestral-embed-2505'
+  | (string & {});
+
+export const mistralEmbeddingModelOptions = z.object({
+  /**
+   * Additional metadata to attach to the embedding request.
+   */
+  metadata: z.record(z.string(), z.any()).optional(),
+
+  /**
+   * The dimension of the output embeddings when supported by the model.
+   */
+  outputDimension: z.number().int().positive().optional(),
+
+  /**
+   * The data type of the output embeddings when supported by the model.
+   */
+  outputDtype: z
+    .enum(['float', 'int8', 'uint8', 'binary', 'ubinary'])
+    .optional(),
+});
+
+export type MistralEmbeddingModelOptions = z.infer<
+  typeof mistralEmbeddingModelOptions
+>;

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -5,6 +5,7 @@ import {
 import {
   combineHeaders,
   createJsonResponseHandler,
+  parseProviderOptions,
   postJsonToApi,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
@@ -12,7 +13,10 @@ import {
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import type { MistralEmbeddingModelId } from './mistral-embedding-options';
+import {
+  mistralEmbeddingModelOptions,
+  type MistralEmbeddingModelId,
+} from './mistral-embedding-model-options';
 import { mistralFailedResponseHandler } from './mistral-error';
 
 type MistralEmbeddingConfig = {
@@ -60,6 +64,7 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
     values,
     abortSignal,
     headers,
+    providerOptions,
   }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
     Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
   > {
@@ -72,6 +77,13 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
       });
     }
 
+    const mistralOptions =
+      (await parseProviderOptions({
+        provider: 'mistral',
+        providerOptions,
+        schema: mistralEmbeddingModelOptions,
+      })) ?? {};
+
     const {
       responseHeaders,
       value: response,
@@ -82,6 +94,9 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
       body: {
         model: this.modelId,
         input: values,
+        metadata: mistralOptions.metadata,
+        output_dimension: mistralOptions.outputDimension,
+        output_dtype: mistralOptions.outputDtype,
         encoding_format: 'float',
       },
       failedResponseHandler: mistralFailedResponseHandler,

--- a/packages/mistral/src/mistral-embedding-options.ts
+++ b/packages/mistral/src/mistral-embedding-options.ts
@@ -1,1 +1,0 @@
-export type MistralEmbeddingModelId = 'mistral-embed' | (string & {});

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -13,7 +13,7 @@ import {
 import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-language-model-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
-import type { MistralEmbeddingModelId } from './mistral-embedding-options';
+import type { MistralEmbeddingModelId } from './mistral-embedding-model-options';
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV4 {


### PR DESCRIPTION
## Background

From issue #14859: This addresses the Mistral embedding model task by adding an explicit `providerOptions` schema/type and removing the temporary `konsistent` exclusion.

## Summary

- Added `MistralEmbeddingModelOptions` and schema validation for Mistral embedding provider options.
- Pass `metadata`, `output_dimension`, and `output_dtype` through to Mistral embedding requests.
- Added docs, schema tests, and ai-functions examples using `codestral-embed-2505` for options that require model support.
- Removed `mistral-embedding-model.ts` from the konsistent exclusion list.

## Manual Verification

Run the relevant examples in `examples/ai-functions/src/embed/mistral`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

See #14859
