### PR TITLE
docs(examples): clarify next-fastapi template path

### DIFF
--- a/examples/next-fastapi/README.md
+++ b/examples/next-fastapi/README.md
@@ -7,15 +7,15 @@ These examples show you how to use the [AI SDK](https://ai-sdk.dev/docs) with [N
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-fastapi next-fastapi-app
+npx create-next-app --example https://github.com/vercel/ai --example-path examples/next-fastapi next-fastapi-app
 ```
 
 ```bash
-yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-fastapi next-fastapi-app
+yarn create next-app --example https://github.com/vercel/ai --example-path examples/next-fastapi next-fastapi-app
 ```
 
 ```bash
-pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-fastapi next-fastapi-app
+pnpm create next-app --example https://github.com/vercel/ai --example-path examples/next-fastapi next-fastapi-app
 ```
 
 You will also need [Python 3.6+](https://www.python.org/downloads) and [virtualenv](https://virtualenv.pypa.io/en/latest/installation.html) installed to run the FastAPI server.


### PR DESCRIPTION
## Summary
- update the next-fastapi README to pass the GitHub repo and example path separately
- use `--example-path examples/next-fastapi` for npm, yarn, and pnpm create-next-app commands

Fixes #12666

## Verification
- `git diff --check -- examples/next-fastapi/README.md`
- `npx -y create-next-app@latest --example https://github.com/vercel/ai --example-path examples/next-fastapi next-fastapi-codex-20260708 --yes --skip-install --disable-git`
- confirmed GitHub reports the pushed commit signature as verified