### PR TITLE
docs(ai): clarify embedMany batching limits

### DIFF
--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -123,6 +123,13 @@ const { embeddings, usage } = await embedMany({
 });
 ```
 
+`maxParallelCalls` controls how many embedding requests can run concurrently
+after `embedMany` has split the input by the model's maximum values-per-call
+limit. It does not limit the number of values per request and does not split by
+estimated token count. For providers with a total token limit per embedding
+request, pre-batch your input values to keep each request under that provider's
+limit.
+
 ### Retries
 
 Both `embed` and `embedMany` accept an optional `maxRetries` parameter of type `number`

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -7,8 +7,11 @@ description: API Reference for embedMany.
 
 Embed several values using an embedding model.
 
-`embedMany` automatically splits large requests into smaller chunks if the model
-has a limit on how many embeddings can be generated in a single call.
+`embedMany` automatically splits large requests into smaller chunks when the
+model declares a limit on how many embeddings can be generated in a single call.
+This split is based on the number of values, not an estimated token count or
+character length. If your provider enforces a total token limit per embedding
+request, batch your input values before calling `embedMany`.
 
 ```ts
 import { embedMany } from 'ai';
@@ -77,7 +80,7 @@ const { embeddings } = await embedMany({
       type: 'number',
       isOptional: true,
       description:
-        'Maximum number of concurrent requests to the provider. Default: Infinity.',
+        'Maximum number of concurrent requests to the provider after value-based chunking. This does not change how many values are sent in each request. Default: Infinity.',
     },
     {
       name: 'telemetry',


### PR DESCRIPTION
## Summary
- clarify that `embedMany` auto-splitting is based on the model's max values per call
- note that it does not split by estimated token count or character length
- clarify that `maxParallelCalls` controls concurrency, not request size

Fixes #10082

## Verification
- `git diff --check -- content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx content/docs/03-ai-sdk-core/30-embeddings.mdx`
- `npx -y prettier@3.6.2 --check --single-quote content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx content/docs/03-ai-sdk-core/30-embeddings.mdx`
- confirmed wording against `packages/ai/src/embed/embed-many.ts`
- confirmed GitHub reports the pushed commit signature as verified