### PR TITLE
feat(provider/xai): add grok-4.5 model id

### DIFF
--- a/.changeset/xai-grok-4-5.md
+++ b/.changeset/xai-grok-4-5.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/xai': patch
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/xai): add grok-4.5 model id

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -111,6 +111,7 @@ Here are the capabilities of popular models:
 
 | Provider                                           | Model                                       | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | -------------------------------------------------- | ------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| [xAI Grok](/providers/ai-sdk-providers/xai)        | `grok-4.5`                                  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)        | `grok-4`                                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)        | `grok-3`                                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)        | `grok-3-mini`                               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -506,7 +506,7 @@ import { generateText, tool } from 'ai';
 import { z } from 'zod';
 
 const { text } = await generateText({
-  model: 'xai/grok-4',
+  model: 'xai/grok-4.5',
   prompt: 'What is the weather like in San Francisco?',
   tools: {
     getWeather: tool({

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -73,10 +73,10 @@ You can use the following optional settings to customize the xAI provider instan
 ## Language Models
 
 You can create [xAI models](https://console.x.ai) using a provider instance. The
-first argument is the model id, e.g. `grok-4.20-non-reasoning`.
+first argument is the model id, e.g. `grok-4.5`.
 
 ```ts
-const model = xai('grok-4.20-non-reasoning');
+const model = xai('grok-4.5');
 ```
 
 <Note>
@@ -95,7 +95,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: xai('grok-4.20-non-reasoning'),
+  model: xai('grok-4.5'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -116,7 +116,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: xai('grok-4.3'),
+  model: xai('grok-4.5'),
   prompt: 'Explain quantum entanglement.',
   providerOptions: {
     xai: { reasoningEffort: 'medium' },
@@ -173,7 +173,7 @@ calling pattern.
 The xAI Responses API is the default when using `xai(modelId)` (since AI SDK 7). You can also use `xai.responses(modelId)` explicitly. This enables the model to autonomously orchestrate tool calls and research on xAI's servers.
 
 ```ts
-const model = xai.responses('grok-4.20-non-reasoning');
+const model = xai.responses('grok-4.5');
 ```
 
 The Responses API provides server-side tools that the model can autonomously execute during its reasoning process:
@@ -195,7 +195,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: xai.responses('grok-3'),
+  model: xai.responses('grok-4.5'),
   messages: [
     {
       role: 'user',
@@ -220,7 +220,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: xai('grok-4.3'),
+  model: xai('grok-4.5'),
   messages: [
     {
       role: 'user',
@@ -558,6 +558,7 @@ The following provider options are available:
 
 | Model                         | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      | Reasoning           |
 | ----------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `grok-4.5`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `grok-4.20-reasoning`         | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `grok-4.20-non-reasoning`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `grok-4-1-fast-reasoning`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -19,6 +19,7 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 
 | Provider                                                   | Model                                               | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ---------------------------------------------------------- | --------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| [xAI Grok](/providers/ai-sdk-providers/xai)                | `grok-4.5`                                          | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                | `grok-4-fast-reasoning`                             | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                | `grok-4`                                            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                | `grok-3`                                            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-e2e-next/app/api/chat/xai/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/xai/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: xai('grok-3'),
+    model: xai('grok-4.5'),
     messages: await convertToModelMessages(messages),
   });
 

--- a/examples/ai-functions/src/e2e/xai.test.ts
+++ b/examples/ai-functions/src/e2e/xai.test.ts
@@ -20,6 +20,7 @@ createFeatureTestSuite({
   models: {
     invalidModel: provider.chat('no-such-model'),
     languageModels: [
+      createChatModel('grok-4.5'),
       createChatModel('grok-4-1-fast-reasoning'),
       createChatModel('grok-4-1-fast-non-reasoning'),
       createChatModel('grok-4'),

--- a/examples/ai-functions/src/generate-text/gateway/image-base64.ts
+++ b/examples/ai-functions/src/generate-text/gateway/image-base64.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/gateway/image-data-url.ts
+++ b/examples/ai-functions/src/generate-text/gateway/image-data-url.ts
@@ -9,7 +9,7 @@ run(async () => {
   const dataUrl = `data:image/png;base64,${base64Data}`;
 
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/gateway/image-url.ts
+++ b/examples/ai-functions/src/generate-text/gateway/image-url.ts
@@ -3,7 +3,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/gateway/output-object.ts
+++ b/examples/ai-functions/src/generate-text/gateway/output-object.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3-beta',
+    model: 'xai/grok-4.5',
     output: Output.object({
       schema: z.object({
         recipe: z.object({

--- a/examples/ai-functions/src/generate-text/gateway/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-call.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-functions/src/generate-text/xai/basic.ts
+++ b/examples/ai-functions/src/generate-text/xai/basic.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/xai/chat.ts
+++ b/examples/ai-functions/src/generate-text/xai/chat.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.chat('grok-3-beta'),
+    model: xai.chat('grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/xai/code-execution.ts
+++ b/examples/ai-functions/src/generate-text/xai/code-execution.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     prompt:
       'Calculate the compound interest for $10,000 at 5% annually for 10 years',
     tools: {

--- a/examples/ai-functions/src/generate-text/xai/image-detail.ts
+++ b/examples/ai-functions/src/generate-text/xai/image-detail.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai('grok-4.3'),
+    model: xai('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/xai/logprobs.ts
+++ b/examples/ai-functions/src/generate-text/xai/logprobs.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.responses('grok-4-latest'),
+    model: xai.responses('grok-4.5'),
     prompt: 'write one short sentence about san francisco',
     providerOptions: {
       xai: {

--- a/examples/ai-functions/src/generate-text/xai/output-object-name-description.ts
+++ b/examples/ai-functions/src/generate-text/xai/output-object-name-description.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     output: Output.object({
       schema: z.object({
         name: z.string(),

--- a/examples/ai-functions/src/generate-text/xai/responses-output-object.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.responses('grok-3-beta'),
+    model: xai.responses('grok-4.5'),
     output: Output.object({
       schema: z.object({
         recipe: z.object({

--- a/examples/ai-functions/src/generate-text/xai/responses-usage-full.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-usage-full.ts
@@ -3,6 +3,7 @@ import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-functions/src/generate-text/xai/responses-web-search-image-search.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-web-search-image-search.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.responses('grok-4.3'),
+    model: xai.responses('grok-4.5'),
     tools: {
       web_search: xai.tools.webSearch({ enableImageSearch: true }),
     },

--- a/examples/ai-functions/src/generate-text/xai/structured-output.ts
+++ b/examples/ai-functions/src/generate-text/xai/structured-output.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const { output } = await generateText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     output: Output.object({
       schema: z.object({
         name: z.string(),

--- a/examples/ai-functions/src/generate-text/xai/usage-full.ts
+++ b/examples/ai-functions/src/generate-text/xai/usage-full.ts
@@ -3,6 +3,7 @@ import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-functions/src/registry/stream-text-xai.ts
+++ b/examples/ai-functions/src/registry/stream-text-xai.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: registry.languageModel('xai:grok-3-beta'),
+    model: registry.languageModel('xai:grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/output-object.ts
+++ b/examples/ai-functions/src/stream-text/gateway/output-object.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     output: Output.object({
       schema: z.object({
         characters: z.array(

--- a/examples/ai-functions/src/stream-text/xai/basic.ts
+++ b/examples/ai-functions/src/stream-text/xai/basic.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/xai/chat.ts
+++ b/examples/ai-functions/src/stream-text/xai/chat.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai.chat('grok-3-beta'),
+    model: xai.chat('grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/xai/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/xai/chatbot.ts
@@ -18,7 +18,7 @@ run(async () => {
     messages.push({ role: 'user', content: userInput });
 
     const result = streamText({
-      model: xai('grok-3-beta'),
+      model: xai('grok-4.5'),
       tools: {
         weather: tool({
           description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/xai/code-execution.ts
+++ b/examples/ai-functions/src/stream-text/xai/code-execution.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const response = streamText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     prompt:
       //   "Call the web_search tool with the query 'What is the capital of France?'",
       'Calculate the compound interest for $10,000 at 5% annually for 10 years',

--- a/examples/ai-functions/src/stream-text/xai/image.ts
+++ b/examples/ai-functions/src/stream-text/xai/image.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai('grok-3'),
+    model: xai('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/stream-text/xai/logprobs.ts
+++ b/examples/ai-functions/src/stream-text/xai/logprobs.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai('grok-4-latest'),
+    model: xai('grok-4.5'),
     prompt: 'write one short sentence about san francisco',
     include: {
       rawChunks: true,

--- a/examples/ai-functions/src/stream-text/xai/output-object-name-description.ts
+++ b/examples/ai-functions/src/stream-text/xai/output-object-name-description.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     output: Output.object({
       schema: z.object({
         name: z.string(),

--- a/examples/ai-functions/src/stream-text/xai/output-object.ts
+++ b/examples/ai-functions/src/stream-text/xai/output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     output: Output.object({
       schema: z.object({
         characters: z.array(

--- a/examples/ai-functions/src/stream-text/xai/raw-chunks.ts
+++ b/examples/ai-functions/src/stream-text/xai/raw-chunks.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai('grok-3'),
+    model: xai('grok-4.5'),
     prompt: 'Count from 1 to 3 slowly.',
     include: {
       rawChunks: true,

--- a/examples/ai-functions/src/stream-text/xai/responses-image.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-image.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai.responses('grok-3'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/stream-text/xai/responses-output-object.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai.responses('grok-3-beta'),
+    model: xai.responses('grok-4.5'),
     output: Output.object({
       schema: z.object({
         characters: z.array(

--- a/examples/ai-functions/src/stream-text/xai/responses-usage-full.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-usage-full.ts
@@ -3,6 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-functions/src/stream-text/xai/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/xai/tool-call.ts
@@ -14,7 +14,7 @@ run(async () => {
   let toolResponseAvailable = false;
 
   const result = streamText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-functions/src/stream-text/xai/usage-full.ts
+++ b/examples/ai-functions/src/stream-text/xai/usage-full.ts
@@ -3,6 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-functions/src/upload-file/xai/image-with-stream.ts
+++ b/examples/ai-functions/src/upload-file/xai/image-with-stream.ts
@@ -17,7 +17,7 @@ run(async () => {
   console.log('Provider metadata:', providerMetadata);
 
   const result = streamText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/upload-file/xai/image.ts
+++ b/examples/ai-functions/src/upload-file/xai/image.ts
@@ -17,7 +17,7 @@ run(async () => {
   console.log('Provider metadata:', providerMetadata);
 
   const result = await generateText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/upload-file/xai/pdf.ts
+++ b/examples/ai-functions/src/upload-file/xai/pdf.ts
@@ -17,7 +17,7 @@ run(async () => {
   console.log('Provider metadata:', providerMetadata);
 
   const result = await generateText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/upload-file/xai/text.ts
+++ b/examples/ai-functions/src/upload-file/xai/text.ts
@@ -17,7 +17,7 @@ run(async () => {
   console.log('Provider metadata:', providerMetadata);
 
   const result = await generateText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -180,6 +180,7 @@ export type GatewayModelId =
   | 'xai/grok-4.20-reasoning'
   | 'xai/grok-4.20-reasoning-beta'
   | 'xai/grok-4.3'
+  | 'xai/grok-4.5'
   | 'xai/grok-build-0.1'
   | 'xiaomi/mimo-v2-flash'
   | 'xiaomi/mimo-v2-pro'

--- a/packages/xai/src/responses/xai-responses-language-model-options.ts
+++ b/packages/xai/src/responses/xai-responses-language-model-options.ts
@@ -4,6 +4,7 @@ export type XaiResponsesModelId =
   | 'grok-4.20-non-reasoning'
   | 'grok-4.20-reasoning'
   | 'grok-4.3'
+  | 'grok-4.5'
   | 'grok-latest'
   | (string & {});
 

--- a/packages/xai/src/xai-chat-language-model-options.ts
+++ b/packages/xai/src/xai-chat-language-model-options.ts
@@ -5,6 +5,7 @@ export type XaiChatModelId =
   | 'grok-4.20-non-reasoning'
   | 'grok-4.20-reasoning'
   | 'grok-4.3'
+  | 'grok-4.5'
   | 'grok-latest'
   | (string & {});
 


### PR DESCRIPTION
## Background

xAI released a new model, `grok-4.5`. The model id was missing from the xAI provider and AI Gateway model id unions, so users did not get autocomplete/type support for it.

## Summary

- Added `grok-4.5` to `XaiChatModelId` and `XaiResponsesModelId` in `@ai-sdk/xai`
- Added `xai/grok-4.5` to `GatewayModelId` in `@ai-sdk/gateway`
- Updated examples that used prior general-purpose grok models (`grok-3`, `grok-3-beta`, `grok-4`, `grok-4-latest`, `grok-4.3`) to `grok-4.5`; examples that deliberately target a specific model variant (`-mini`, `-fast`, `-non-reasoning`, `grok-code-fast-1`, model-named example files) were left unchanged
- Added `grok-4.5` to the model list arrays in the `usage-full` examples and the xAI/gateway e2e test suites
- Updated docs: basic usage snippets in the xAI provider page, the gateway tool-usage snippet, and added `grok-4.5` rows to the model capability tables (xAI provider page, providers index, foundations)

## Manual Verification

Run one of the updated examples, e.g.:

```bash
cd examples/ai-functions
pnpm tsx src/generate-text/xai/basic.ts
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
