### PR TITLE
feat(provider/xai): add grok-4.5 model id (v5)

### DIFF
--- a/.changeset/xai-grok-4-5.md
+++ b/.changeset/xai-grok-4-5.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/xai': patch
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/xai): add grok-4.5 model id

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -104,6 +104,7 @@ Here are the capabilities of popular models:
 
 | Provider                                                                 | Model                                       | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ------------------------------------------------------------------------ | ------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-4.5`                                  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-4`                                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-3`                                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-3-fast`                               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -355,7 +355,7 @@ import { generateText, tool } from "ai";
 import { z } from "zod";
 
 const { text } = await generateText({
-  model: "xai/grok-4",
+  model: "xai/grok-4.5",
   prompt: "What is the weather like in San Francisco?",
   tools: {
     getWeather: tool({

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -73,10 +73,10 @@ You can use the following optional settings to customize the xAI provider instan
 ## Language Models
 
 You can create [xAI models](https://console.x.ai) using a provider instance. The
-first argument is the model id, e.g. `grok-3`.
+first argument is the model id, e.g. `grok-4.5`.
 
 ```ts
-const model = xai('grok-3');
+const model = xai('grok-4.5');
 ```
 
 By default, `xai(modelId)` uses the Chat API. To use the Responses API with server-side agentic tools, explicitly use `xai.responses(modelId)`.
@@ -90,7 +90,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: xai('grok-3'),
+  model: xai('grok-4.5'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -153,7 +153,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: xai.responses('grok-2-vision-1212'),
+  model: xai.responses('grok-4.5'),
   messages: [
     {
       role: 'user',
@@ -628,6 +628,7 @@ console.log('Sources:', await result.sources);
 
 | Model                       | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      | Reasoning           |
 | --------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `grok-4.5`                  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `grok-4-fast-non-reasoning` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 | `grok-4-fast-reasoning`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `grok-code-fast-1`          | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -19,6 +19,7 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 
 | Provider                                                                 | Model                                               | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ------------------------------------------------------------------------ | --------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-4.5`                                          | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-4`                                            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-3`                                            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-3-fast`                                       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-core/src/e2e/gateway.test.ts
+++ b/examples/ai-core/src/e2e/gateway.test.ts
@@ -11,7 +11,7 @@ const createChatModel = (modelId: string) =>
 createFeatureTestSuite({
   name: 'Gateway',
   models: {
-    languageModels: [createChatModel('xai/grok-3-beta')],
+    languageModels: [createChatModel('xai/grok-4.5')],
   },
   timeout: 30000,
 })();

--- a/examples/ai-core/src/e2e/xai.test.ts
+++ b/examples/ai-core/src/e2e/xai.test.ts
@@ -20,6 +20,7 @@ createFeatureTestSuite({
   models: {
     invalidModel: provider.chat('no-such-model'),
     languageModels: [
+      createChatModel('grok-4.5'),
       createChatModel('grok-4'),
       createChatModel('grok-3-beta'),
       createChatModel('grok-3-fast-beta'),

--- a/examples/ai-core/src/generate-object/gateway.ts
+++ b/examples/ai-core/src/generate-object/gateway.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 async function main() {
   const result = await generateObject({
-    model: 'xai/grok-3-beta',
+    model: 'xai/grok-4.5',
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-object/xai-responses.ts
+++ b/examples/ai-core/src/generate-object/xai-responses.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateObject({
-    model: xai.responses('grok-3-beta'),
+    model: xai.responses('grok-4.5'),
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-object/xai-structured-outputs-name-description.ts
+++ b/examples/ai-core/src/generate-object/xai-structured-outputs-name-description.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function main() {
   const result = await generateObject({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     schemaName: 'recipe',
     schemaDescription: 'A recipe for lasagna.',
     schema: z.object({

--- a/examples/ai-core/src/generate-object/xai.ts
+++ b/examples/ai-core/src/generate-object/xai.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function main() {
   const result = await generateObject({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-text/gateway-image-base64.ts
+++ b/examples/ai-core/src/generate-text/gateway-image-base64.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 
 async function main() {
   const result = await generateText({
-    model: 'xai/grok-2-vision',
+    model: 'xai/grok-4.5',
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-text/gateway-image-data-url.ts
+++ b/examples/ai-core/src/generate-text/gateway-image-data-url.ts
@@ -9,7 +9,7 @@ async function main() {
   const dataUrl = `data:image/png;base64,${base64Data}`;
 
   const result = await generateText({
-    model: 'xai/grok-2-vision',
+    model: 'xai/grok-4.5',
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-text/gateway-image-url.ts
+++ b/examples/ai-core/src/generate-text/gateway-image-url.ts
@@ -3,7 +3,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: 'xai/grok-2-vision',
+    model: 'xai/grok-4.5',
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-text/gateway-tool-call.ts
+++ b/examples/ai-core/src/generate-text/gateway-tool-call.ts
@@ -5,7 +5,7 @@ import { weatherTool } from '../tools/weather-tool';
 
 async function main() {
   const result = await generateText({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-core/src/generate-text/xai-code-execution.ts
+++ b/examples/ai-core/src/generate-text/xai-code-execution.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     prompt:
       'Calculate the compound interest for $10,000 at 5% annually for 10 years',
     tools: {

--- a/examples/ai-core/src/generate-text/xai-responses-image.ts
+++ b/examples/ai-core/src/generate-text/xai-responses-image.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai.responses('grok-2-vision-1212'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-text/xai-responses-usage-full.ts
+++ b/examples/ai-core/src/generate-text/xai-responses-usage-full.ts
@@ -3,6 +3,7 @@ import { generateText } from 'ai';
 import { run } from '../lib/run';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-core/src/generate-text/xai-search.ts
+++ b/examples/ai-core/src/generate-text/xai-search.ts
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 
 async function main() {
   const result = await generateText({
-    model: xai('grok-3-latest'),
+    model: xai('grok-4.5'),
     prompt: 'What are the latest developments in AI?',
     providerOptions: {
       xai: {

--- a/examples/ai-core/src/generate-text/xai-structured-output.ts
+++ b/examples/ai-core/src/generate-text/xai-structured-output.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function main() {
   const { experimental_output } = await generateText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     experimental_output: Output.object({
       schema: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-text/xai-usage-full.ts
+++ b/examples/ai-core/src/generate-text/xai-usage-full.ts
@@ -3,6 +3,7 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-core/src/generate-text/xai.ts
+++ b/examples/ai-core/src/generate-text/xai.ts
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 
 async function main() {
   const result = await generateText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-core/src/registry/stream-text-xai.ts
+++ b/examples/ai-core/src/registry/stream-text-xai.ts
@@ -3,7 +3,7 @@ import { registry } from './setup-registry';
 
 async function main() {
   const result = streamText({
-    model: registry.languageModel('xai:grok-3-beta'),
+    model: registry.languageModel('xai:grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-core/src/stream-object/gateway.ts
+++ b/examples/ai-core/src/stream-object/gateway.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 async function main() {
   const result = streamObject({
-    model: 'xai/grok-3',
+    model: 'xai/grok-4.5',
     schema: z.object({
       characters: z.array(
         z.object({

--- a/examples/ai-core/src/stream-object/xai-responses.ts
+++ b/examples/ai-core/src/stream-object/xai-responses.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamObject({
-    model: xai.responses('grok-3-beta'),
+    model: xai.responses('grok-4.5'),
     schema: z.object({
       characters: z.array(
         z.object({

--- a/examples/ai-core/src/stream-object/xai-structured-outputs-name-description.ts
+++ b/examples/ai-core/src/stream-object/xai-structured-outputs-name-description.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function main() {
   const result = streamObject({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     schemaName: 'recipe',
     schemaDescription: 'A recipe for lasagna.',
     schema: z.object({

--- a/examples/ai-core/src/stream-object/xai.ts
+++ b/examples/ai-core/src/stream-object/xai.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function main() {
   const result = streamObject({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     schema: z.object({
       characters: z.array(
         z.object({

--- a/examples/ai-core/src/stream-text/xai-chatbot.ts
+++ b/examples/ai-core/src/stream-text/xai-chatbot.ts
@@ -18,7 +18,7 @@ async function main() {
     messages.push({ role: 'user', content: userInput });
 
     const result = streamText({
-      model: xai('grok-3-beta'),
+      model: xai('grok-4.5'),
       tools: {
         weather: tool({
           description: 'Get the weather in a location',

--- a/examples/ai-core/src/stream-text/xai-code-execution.ts
+++ b/examples/ai-core/src/stream-text/xai-code-execution.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const response = streamText({
-    model: xai.responses('grok-4'),
+    model: xai.responses('grok-4.5'),
     prompt:
       //   "Call the web_search tool with the query 'What is the capital of France?'",
       'Calculate the compound interest for $10,000 at 5% annually for 10 years',

--- a/examples/ai-core/src/stream-text/xai-image.ts
+++ b/examples/ai-core/src/stream-text/xai-image.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 
 async function main() {
   const result = streamText({
-    model: xai('grok-2-vision-1212'),
+    model: xai('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/stream-text/xai-raw-chunks.ts
+++ b/examples/ai-core/src/stream-text/xai-raw-chunks.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = streamText({
-    model: xai('grok-3'),
+    model: xai('grok-4.5'),
     prompt: 'Count from 1 to 3 slowly.',
     includeRawChunks: true,
   });

--- a/examples/ai-core/src/stream-text/xai-responses-image.ts
+++ b/examples/ai-core/src/stream-text/xai-responses-image.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: xai.responses('grok-2-vision-1212'),
+    model: xai.responses('grok-4.5'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/stream-text/xai-responses-usage-full.ts
+++ b/examples/ai-core/src/stream-text/xai-responses-usage-full.ts
@@ -3,6 +3,7 @@ import { streamText } from 'ai';
 import { run } from '../lib/run';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-core/src/stream-text/xai-search.ts
+++ b/examples/ai-core/src/stream-text/xai-search.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = streamText({
-    model: xai('grok-3-latest'),
+    model: xai('grok-4.5'),
     prompt:
       'What are the latest posts and activities from @nishimiya? Summarize their recent content and interests.',
     providerOptions: {

--- a/examples/ai-core/src/stream-text/xai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/xai-tool-call.ts
@@ -14,7 +14,7 @@ async function main() {
   let toolResponseAvailable = false;
 
   const result = streamText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-core/src/stream-text/xai-usage-full.ts
+++ b/examples/ai-core/src/stream-text/xai-usage-full.ts
@@ -3,6 +3,7 @@ import { xai } from '@ai-sdk/xai';
 import { streamText } from 'ai';
 
 const models = [
+  'grok-4.5',
   'grok-4',
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',

--- a/examples/ai-core/src/stream-text/xai.ts
+++ b/examples/ai-core/src/stream-text/xai.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = streamText({
-    model: xai('grok-3-beta'),
+    model: xai('grok-4.5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -180,6 +180,7 @@ export type GatewayModelId =
   | 'xai/grok-4.20-reasoning'
   | 'xai/grok-4.20-reasoning-beta'
   | 'xai/grok-4.3'
+  | 'xai/grok-4.5'
   | 'xai/grok-build-0.1'
   | 'xiaomi/mimo-v2-flash'
   | 'xiaomi/mimo-v2-pro'

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 
 export type XaiResponsesModelId =
+  | 'grok-4.5'
   | 'grok-4-1'
   | 'grok-4-1-fast-reasoning'
   | 'grok-4-1-fast-non-reasoning'

--- a/packages/xai/src/xai-chat-options.ts
+++ b/packages/xai/src/xai-chat-options.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 
 // https://console.x.ai and see "View models"
 export type XaiChatModelId =
+  | 'grok-4.5'
   | 'grok-4-1'
   | 'grok-4-1-fast-reasoning'
   | 'grok-4-1-fast-non-reasoning'


### PR DESCRIPTION
## Background

xAI released a new model, `grok-4.5`. The model id was missing from the xAI provider and AI Gateway model id unions, so users did not get autocomplete/type support for it.

Backport of the equivalent `main` change to `release-v5.0`.

## Summary

- Added `grok-4.5` to `XaiChatModelId` and `XaiResponsesModelId` in `@ai-sdk/xai`
- Added `xai/grok-4.5` to `GatewayModelId` in `@ai-sdk/gateway`
- Updated examples that used prior general-purpose grok models (`grok-2-vision-1212`, `grok-3`, `grok-3-beta`, `grok-3-latest`, `grok-4`) to `grok-4.5`; examples that deliberately target a specific model variant (`-mini`, `-fast`, `-non-reasoning`, `grok-code-fast-1`, model-named example files) were left unchanged
- Added `grok-4.5` to the model list arrays in the `usage-full` examples and the xAI/gateway e2e test suites
- Updated docs: basic usage snippets in the xAI provider page, the gateway tool-usage snippet, and added `grok-4.5` rows to the model capability tables (xAI provider page, providers index, foundations)

## Manual Verification

Run one of the updated examples, e.g.:

```bash
cd examples/ai-core
pnpm tsx src/generate-text/xai.ts
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
