### PR TITLE
fix(mcp): prevent unhandled rejection process crash on stream disconnect

### DIFF
--- a/.changeset/calm-parrots-prevent.md
+++ b/.changeset/calm-parrots-prevent.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): prevent unhandled promise rejection process crash when HTTP or SSE transport connection is closed mid-stream by catching reader.closed

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -326,6 +326,7 @@ export class HttpMCPTransport implements MCPTransport {
             .pipeThrough(new TextDecoderStream())
             .pipeThrough(new EventSourceParserStream());
           const reader = stream.getReader();
+          void reader.closed.catch(() => {});
 
           const processEvents = async () => {
             try {
@@ -486,6 +487,7 @@ export class HttpMCPTransport implements MCPTransport {
         .pipeThrough(new TextDecoderStream())
         .pipeThrough(new EventSourceParserStream());
       const reader = stream.getReader();
+      void reader.closed.catch(() => {});
 
       const processEvents = async () => {
         try {

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -145,6 +145,7 @@ export class SseMCPTransport implements MCPTransport {
             .pipeThrough(new EventSourceParserStream());
 
           const reader = stream.getReader();
+          void reader.closed.catch(() => {});
 
           const processEvents = async () => {
             try {


### PR DESCRIPTION
### Description
This pull request resolves a critical process-terminating issue in both `HttpMCPTransport` and `SseMCPTransport` (package `@ai-sdk/mcp`) where a downstream server disconnect or connection reset (e.g., `ECONNRESET`, `TypeError: terminated`) mid-stream causes an **Unhandled Promise Rejection**, crashing the entire Node.js process.

### Root Cause
Under the Web Streams API, when `stream.getReader()` is called, it returns a reader that contains a `reader.closed` promise.
If the underlying connection drops or the stream errors out (e.g., during Server-Sent Events read), the `reader.closed` promise automatically rejects with that error.
In both `HttpMCPTransport` (during POST and optional GET inbound SSE streams) and `SseMCPTransport`, the `reader.closed` promise is never awaited or handled with a `.catch()` block. Consequently, when the network drops, the rejected `reader.closed` promise bubbles up as an unhandled promise rejection, causing Node.js to exit.

### Solution
Attached a simple `.catch(() => {})` handler directly to the `reader.closed` promise immediately after calling `stream.getReader()` in all transport files:
- `packages/mcp/src/tool/mcp-http-transport.ts` (POST stream in `send` and GET stream in `openInboundSse`)
- `packages/mcp/src/tool/mcp-sse-transport.ts` (GET stream in `establishConnection`)

Since any actual stream errors are already caught, reported to `this.onerror`, and trigger appropriate reconnection/cleanup logic inside the `processEvents()` read loop, ignoring the parallel rejection of `reader.closed` is safe and prevents the unhandled promise rejection from crashing the process.

### Verification
- Verified that all unit and integration tests under `packages/mcp` compile and pass successfully:
  - `pnpm --filter @ai-sdk/mcp test:node` (Node.js runtime: 245/245 passed)
  - `pnpm --filter @ai-sdk/mcp test:edge` (Edge runtime: 245/245 passed)
- Ran the linter and formatter checks using `pnpm check` and verified zero warnings or errors.
