### PR TITLE
feat(core): add support for generator-based tool progress/steps streaming

### DIFF
--- a/.changeset/tool-progress-updates.md
+++ b/.changeset/tool-progress-updates.md
@@ -1,0 +1,6 @@
+---
+"ai": patch
+"@ai-sdk/provider-utils": patch
+---
+
+feat(core): add support for generator-based tool progress/steps streaming

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -142,7 +142,14 @@ export async function executeToolCall<TOOLS extends ToolSet>({
               });
 
               for await (const part of stream) {
-                if (part.type === 'preliminary') {
+                if (part.type === 'progress') {
+                  onPreliminaryToolResult?.({
+                    type: 'tool-progress',
+                    toolCallId,
+                    toolName,
+                    progress: part.progress,
+                  } as any);
+                } else if (part.type === 'preliminary') {
                   onPreliminaryToolResult?.({
                     ...toolCall,
                     type: 'tool-result',

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -513,6 +513,13 @@ export type TextStreamToolResultPart<TOOLS extends ToolSet> = {
   type: 'tool-result';
 } & TypedToolResult<TOOLS>;
 
+export type TextStreamToolProgressPart = {
+  type: 'tool-progress';
+  toolCallId: string;
+  toolName: string;
+  progress: unknown;
+};
+
 export type TextStreamToolErrorPart<TOOLS extends ToolSet> = {
   type: 'tool-error';
 } & TypedToolError<TOOLS>;
@@ -585,6 +592,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
   | TextStreamReasoningFilePart
   | TextStreamToolCallPart<TOOLS>
   | TextStreamToolResultPart<TOOLS>
+  | TextStreamToolProgressPart
   | TextStreamToolErrorPart<TOOLS>
   | TextStreamToolOutputDeniedPart<TOOLS>
   | TextStreamToolApprovalRequestPart<TOOLS>

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -29230,6 +29230,208 @@ describe('streamText', () => {
       expect(events).toEqual(['first', 'second']);
     });
   });
+
+  describe('streamText tool progress steps', () => {
+    it('should stream progress updates and final output for generator tool', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'searchEngine',
+              input: `{ "query": "Vercel AI SDK" }`,
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        _internal: {
+          generateId: mockId(),
+          generateCallId: () => 'test-telemetry-call-id',
+        },
+        tools: {
+          searchEngine: tool({
+            inputSchema: z.object({ query: z.string() }),
+            async *execute() {
+              yield { type: 'progress', status: 'Searching Google...' };
+              yield { type: 'progress', status: 'Summarizing results...' };
+              return 'final summary of search';
+            },
+          }),
+        },
+      });
+
+      expect(await convertReadableStreamToArray(result.fullStream))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "type": "start",
+            },
+            {
+              "request": {
+                "body": undefined,
+                "messages": undefined,
+              },
+              "type": "start-step",
+              "warnings": [],
+            },
+            {
+              "input": {
+                "query": "Vercel AI SDK",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "searchEngine",
+              "type": "tool-call",
+            },
+            {
+              "progress": {
+                "status": "Searching Google...",
+                "type": "progress",
+              },
+              "toolCallId": "call-1",
+              "toolName": "searchEngine",
+              "type": "tool-progress",
+            },
+            {
+              "progress": {
+                "status": "Summarizing results...",
+                "type": "progress",
+              },
+              "toolCallId": "call-1",
+              "toolName": "searchEngine",
+              "type": "tool-progress",
+            },
+            {
+              "dynamic": false,
+              "input": {
+                "query": "Vercel AI SDK",
+              },
+              "output": "final summary of search",
+              "toolCallId": "call-1",
+              "toolName": "searchEngine",
+              "type": "tool-result",
+            },
+            {
+              "finishReason": "stop",
+              "performance": {
+                "effectiveOutputTokensPerSecond": 0,
+                "effectiveTotalTokensPerSecond": 0,
+                "inputTokensPerSecond": 0,
+                "outputTokensPerSecond": 0,
+                "responseTimeMs": 0,
+                "stepTimeMs": 0,
+                "timeBetweenOutputChunksMs": undefined,
+                "timeToFirstOutputMs": 0,
+                "toolExecutionMs": {
+                  "call-1": 0,
+                },
+              },
+              "providerMetadata": undefined,
+              "rawFinishReason": "stop",
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "raw": undefined,
+                "totalTokens": 13,
+              },
+            },
+            {
+              "finishReason": "stop",
+              "rawFinishReason": "stop",
+              "totalUsage": {
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "totalTokens": 13,
+              },
+              "type": "finish",
+            },
+          ]
+        `);
+
+      expect(await convertReadableStreamToArray(result.toUIMessageStream()))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "type": "start",
+            },
+            {
+              "type": "start-step",
+            },
+            {
+              "input": {
+                "query": "Vercel AI SDK",
+              },
+              "toolCallId": "call-1",
+              "toolName": "searchEngine",
+              "type": "tool-input-available",
+            },
+            {
+              "progress": {
+                "status": "Searching Google...",
+                "type": "progress",
+              },
+              "toolCallId": "call-1",
+              "type": "tool-progress",
+            },
+            {
+              "progress": {
+                "status": "Summarizing results...",
+                "type": "progress",
+              },
+              "toolCallId": "call-1",
+              "type": "tool-progress",
+            },
+            {
+              "output": "final summary of search",
+              "toolCallId": "call-1",
+              "type": "tool-output-available",
+            },
+            {
+              "type": "finish-step",
+            },
+            {
+              "finishReason": "stop",
+              "type": "finish",
+            },
+          ]
+        `);
+    });
+  });
 });
 
 async function expectUndefinedUnhandledRejections({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -178,6 +178,7 @@ const isOutputChunkType = {
   'tool-call': true,
   'tool-result': true,
   'tool-error': true,
+  'tool-progress': true,
   'tool-execution-end': false,
   'model-call-start': false,
   'model-call-response-metadata': false,
@@ -2085,7 +2086,8 @@ class DefaultStreamTextResult<
                     case 'tool-input-start':
                     case 'tool-input-end':
                     case 'tool-input-delta':
-                    case 'tool-approval-request': {
+                    case 'tool-approval-request':
+                    case 'tool-progress': {
                       controller.enqueue(chunk);
                       break;
                     }

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -325,6 +325,14 @@ export function toUIMessageChunk<
       };
     }
 
+    case 'tool-progress': {
+      return {
+        type: 'tool-progress',
+        toolCallId: part.toolCallId,
+        progress: part.progress,
+      };
+    }
+
     case 'error': {
       return {
         type: 'error',

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -120,6 +120,11 @@ export const uiMessageChunkSchema = lazySchema(() =>
         toolCallId: z.string(),
       }),
       z.strictObject({
+        type: z.literal('tool-progress'),
+        toolCallId: z.string(),
+        progress: z.unknown(),
+      }),
+      z.strictObject({
         type: z.literal('reasoning-start'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
@@ -328,6 +333,11 @@ export type UIMessageChunk<
   | {
       type: 'tool-output-denied';
       toolCallId: string;
+    }
+  | {
+      type: 'tool-progress';
+      toolCallId: string;
+      progress: unknown;
     }
   | {
       type: 'tool-input-start';

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -749,6 +749,18 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               break;
             }
 
+            case 'tool-progress': {
+              const toolInvocation = getToolInvocation(chunk.toolCallId);
+              if (toolInvocation != null) {
+                if (toolInvocation.steps == null) {
+                  toolInvocation.steps = [];
+                }
+                toolInvocation.steps.push(chunk.progress);
+                write();
+              }
+              break;
+            }
+
             case 'tool-output-available': {
               const toolInvocation = getToolInvocation(chunk.toolCallId);
 

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -288,6 +288,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
    * Whether the tool call was executed by the provider.
    */
   providerExecuted?: boolean;
+  steps?: unknown[];
 } & (
   | {
       state: 'input-streaming';
@@ -406,6 +407,7 @@ export type DynamicToolUIPart = {
    * Whether the tool call was executed by the provider.
    */
   providerExecuted?: boolean;
+  steps?: unknown[];
 } & (
   | {
       state: 'input-streaming';

--- a/packages/provider-utils/src/types/execute-tool.test.ts
+++ b/packages/provider-utils/src/types/execute-tool.test.ts
@@ -121,4 +121,35 @@ describe('executeTool', () => {
       { type: 'final', output: 'Berlin:req-2:2' },
     ]);
   });
+
+  it('yields progress events and final return value for generator-based tool execution', async () => {
+    const generatorTool = tool({
+      inputSchema: z.object({}),
+      execute: async function* () {
+        yield { type: 'progress', message: 'Step 1' };
+        yield { type: 'progress', message: 'Step 2' };
+        return 'final result';
+      },
+    });
+
+    const results: Array<any> = [];
+
+    for await (const result of executeTool({
+      tool: generatorTool as any,
+      input: {},
+      options: {
+        toolCallId: 'tool-call-1',
+        messages: [],
+        context: undefined,
+      },
+    })) {
+      results.push(result);
+    }
+
+    expect(results).toEqual([
+      { type: 'progress', progress: { type: 'progress', message: 'Step 1' } },
+      { type: 'progress', progress: { type: 'progress', message: 'Step 2' } },
+      { type: 'final', output: 'final result' },
+    ]);
+  });
 });

--- a/packages/provider-utils/src/types/execute-tool.ts
+++ b/packages/provider-utils/src/types/execute-tool.ts
@@ -29,18 +29,35 @@ export async function* executeTool<TOOL extends Tool>({
   input: InferToolInput<TOOL>;
   options: ToolExecutionOptions<InferToolContext<TOOL>>;
 }): AsyncGenerator<
+  | { type: 'progress'; progress: unknown }
   | { type: 'preliminary'; output: InferToolOutput<TOOL> }
   | { type: 'final'; output: InferToolOutput<TOOL> }
 > {
   const result = tool.execute(input, options);
 
   if (isAsyncIterable(result)) {
+    const iterator = result[Symbol.asyncIterator]();
+    let next = await iterator.next();
     let lastOutput: InferToolOutput<TOOL> | undefined;
-    for await (const output of result) {
-      lastOutput = output;
-      yield { type: 'preliminary', output };
+
+    while (!next.done) {
+      const value = next.value;
+      if (
+        value &&
+        typeof value === 'object' &&
+        'type' in value &&
+        value.type === 'progress'
+      ) {
+        yield { type: 'progress', progress: value };
+      } else {
+        lastOutput = value as any;
+        yield { type: 'preliminary', output: lastOutput! };
+      }
+      next = await iterator.next();
     }
-    yield { type: 'final', output: lastOutput! };
+
+    const finalOutput = next.value !== undefined ? next.value : lastOutput;
+    yield { type: 'final', output: finalOutput as any };
   } else {
     yield { type: 'final', output: await result };
   }


### PR DESCRIPTION
This PR adds support for streaming intermediate progress/sub-steps from generator-based tools (AsyncGenerator).

### Why is this needed?
Previously, the AI SDK supported AsyncIterable return values from tools, but forced every yielded value to match the final output schema of the tool. This meant progress logs, search state updates, and status messages could not easily be streamed without breaking the LLM's understanding of the final tool output type.

### How it works:
1. Generator-based tools can now yield progress update objects matching `{ type: 'progress', ... }` and return the final tool output using `return output`.
2. `@ai-sdk/provider-utils` (`executeTool`) captures intermediate yields of type `progress` as `{ type: 'progress', progress }`, and uses the final returned value of the generator as the final `tool-result`.
3. The stream controllers propagate `tool-progress` chunks to the client.
4. On the client, the UI stream processes `tool-progress` chunks and appends them to a new `steps` array field inside the corresponding message tool parts (`ToolUIPart` and `DynamicToolUIPart`).
5. Type definitions (`UIMessageChunk`, `UIToolInvocation`, `DynamicToolUIPart`) are fully updated and tested.