### PR TITLE
feat(harness): add ACP, Grok Build, and Cursor sandbox adapters

### DIFF
--- a/.changeset/harness-acp-grok-cursor.md
+++ b/.changeset/harness-acp-grok-cursor.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/harness-acp': minor
+'@ai-sdk/harness-grok': minor
+'@ai-sdk/harness-cursor': minor
+---
+
+Add ACP-based harness adapters for Grok Build and Cursor sandbox, plus shared `@ai-sdk/harness-acp` foundation package.

--- a/content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx
+++ b/content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx
@@ -16,7 +16,9 @@ The AI SDK includes the following harness adapters:
 
 - [Claude Code](/providers/ai-sdk-harnesses/claude-code) (`@ai-sdk/harness-claude-code`)
 - [Codex](/providers/ai-sdk-harnesses/codex) (`@ai-sdk/harness-codex`)
+- [Cursor](/providers/ai-sdk-harnesses/cursor) (`@ai-sdk/harness-cursor`)
 - [Deep Agents](/providers/ai-sdk-harnesses/deepagents) (`@ai-sdk/harness-deepagents`)
+- [Grok](/providers/ai-sdk-harnesses/grok) (`@ai-sdk/harness-grok`)
 - [OpenCode](/providers/ai-sdk-harnesses/opencode) (`@ai-sdk/harness-opencode`)
 - [Pi](/providers/ai-sdk-harnesses/pi) (`@ai-sdk/harness-pi`)
 
@@ -32,6 +34,8 @@ The AI SDK includes the following harness adapters:
 | ------------------------------------------------------ | ---------------- | ------------------- | ------------------- | ---------------------- | -------------------------------------- |
 | [Claude Code](/providers/ai-sdk-harnesses/claude-code) | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    | <Check size={18} />                    |
 | [Codex](/providers/ai-sdk-harnesses/codex)             | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Cross size={18} />    | <Cross size={18} />                    |
+| [Cursor](/providers/ai-sdk-harnesses/cursor)         | Sandbox bridge   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} />    | <Check size={18} /> via auto-rejection |
 | [Deep Agents](/providers/ai-sdk-harnesses/deepagents)  | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    | <Check size={18} /> via auto-rejection |
+| [Grok](/providers/ai-sdk-harnesses/grok)             | Sandbox bridge   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} />    | <Check size={18} /> via auto-rejection |
 | [OpenCode](/providers/ai-sdk-harnesses/opencode)       | Sandbox bridge   | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    | <Check size={18} /> via auto-rejection |
 | [Pi](/providers/ai-sdk-harnesses/pi)                   | Host process     | <Check size={18} /> | <Check size={18} /> | <Check size={18} />    | <Check size={18} />                    |

--- a/content/providers/02-ai-sdk-harnesses/06-grok.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-grok.mdx
@@ -1,0 +1,179 @@
+---
+title: Grok
+description: Learn how to use the Grok Build harness adapter.
+---
+
+# Grok Harness
+
+The Grok harness adapter connects `HarnessAgent` to Grok Build through the
+`grok agent stdio` CLI (Agent Client Protocol). The adapter runs an ACP bridge
+inside the sandbox and streams Grok session events back to the host over a
+sandbox-exposed WebSocket.
+
+<Note>
+  Harness packages are **experimental**. Expect breaking changes between
+  releases as this early API gets further refined.
+</Note>
+
+## Setup
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet
+      text="pnpm add @ai-sdk/harness @ai-sdk/harness-grok @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+  <Tab>
+    <Snippet
+      text="npm install @ai-sdk/harness @ai-sdk/harness-grok @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+  <Tab>
+    <Snippet
+      text="yarn add @ai-sdk/harness @ai-sdk/harness-grok @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+  <Tab>
+    <Snippet
+      text="bun add @ai-sdk/harness @ai-sdk/harness-grok @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+</Tabs>
+
+The adapter bootstraps the Grok CLI and ACP bridge dependencies inside the
+sandbox when the first session starts.
+
+## Import
+
+```ts
+import { grok, createGrok } from '@ai-sdk/harness-grok';
+```
+
+`grok` is equivalent to `createGrok()` with its default configuration.
+
+## Basic Usage
+
+```ts
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { grok } from '@ai-sdk/harness-grok';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const agent = new HarnessAgent({
+  harness: grok,
+  sandbox: createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+  }),
+});
+
+const session = await agent.createSession();
+
+let exitCode = 0;
+try {
+  const result = await agent.stream({
+    session,
+    prompt: 'Check the test failures and fix the production code.',
+  });
+
+  for await (const part of result.stream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+} catch (err) {
+  exitCode = 1;
+  console.error(err);
+} finally {
+  await session.destroy();
+  process.exit(exitCode);
+}
+```
+
+To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
+Vercel Sandbox, and one of the variables listed under [authentication](#authentication)
+for Grok.
+
+## Adapter Settings
+
+Use `createGrok()` to configure the runtime:
+
+```ts
+const harness = createGrok({
+  model: 'grok-build-0.1',
+  auth: { apiKey: process.env.XAI_API_KEY },
+  startupTimeoutMs: 120_000,
+});
+```
+
+Settings:
+
+- `auth`: xAI API key settings.
+- `model`: Grok Build model id. If omitted, the adapter uses its pinned default.
+- `port`: bridge port override.
+- `startupTimeoutMs`: maximum time to wait for the bridge to start.
+
+## Authentication
+
+The adapter supports API key and OAuth authentication.
+
+### API key (headless / CI)
+
+Set `XAI_API_KEY` on the host or pass explicit auth:
+
+```ts
+const harness = createGrok({
+  auth: { apiKey: process.env.XAI_API_KEY },
+});
+```
+
+### OAuth (interactive)
+
+When no API key is provided, the adapter uses `xai.oauth`. Bootstrap OAuth
+inside the sandbox with `ensureGrokSandboxOAuth()` in `sandboxConfig.onSession`:
+
+```ts
+import { createGrok, ensureGrokSandboxOAuth } from '@ai-sdk/harness-grok';
+
+const agent = new HarnessAgent({
+  harness: createGrok(),
+  sandbox,
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir }) => {
+      const oauth = await ensureGrokSandboxOAuth({ session, sessionWorkDir });
+      if (!oauth.ready) throw new Error(oauth.question);
+    },
+  },
+});
+```
+
+Supported environment variables:
+
+- `VERCEL_OIDC_TOKEN`
+- `XAI_API_KEY`
+
+## Sandbox
+
+Grok requires a network sandbox with at least one exposed port,
+e.g. `@ai-sdk/sandbox-vercel`:
+
+```ts
+const sandbox = createVercelSandbox({
+  runtime: 'node24',
+  ports: [4000],
+});
+```
+
+## Known Limitations
+
+- No replay/rerun resume ladder parity with `harness-codex` yet.
+- Cursor Cloud (`@cursor/sdk`) is out of scope for this adapter.
+
+## Related
+
+- [HarnessAgent](/docs/ai-sdk-harnesses/harness-agent)
+- [Harness tools](/docs/ai-sdk-harnesses/tools)
+- [Harness adapters](/docs/ai-sdk-harnesses/harness-adapters)

--- a/content/providers/02-ai-sdk-harnesses/07-cursor.mdx
+++ b/content/providers/02-ai-sdk-harnesses/07-cursor.mdx
@@ -1,0 +1,164 @@
+---
+title: Cursor
+description: Learn how to use the Cursor sandbox harness adapter.
+---
+
+# Cursor Harness
+
+The Cursor harness adapter connects `HarnessAgent` to the Cursor sandbox agent
+through `agent acp` (Agent Client Protocol stdio). The adapter runs an ACP
+bridge inside the sandbox and streams Cursor session events back to the host
+over a sandbox-exposed WebSocket.
+
+<Note>
+  Harness packages are **experimental**. Expect breaking changes between
+  releases as this early API gets further refined.
+</Note>
+
+<Note>
+  This adapter covers Cursor sandbox (`agent acp`) only. Cursor Cloud
+  (`@cursor/sdk`) is out of scope and requires a separate SDK-style adapter.
+</Note>
+
+## Setup
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet
+      text="pnpm add @ai-sdk/harness @ai-sdk/harness-cursor @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+  <Tab>
+    <Snippet
+      text="npm install @ai-sdk/harness @ai-sdk/harness-cursor @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+  <Tab>
+    <Snippet
+      text="yarn add @ai-sdk/harness @ai-sdk/harness-cursor @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+  <Tab>
+    <Snippet
+      text="bun add @ai-sdk/harness @ai-sdk/harness-cursor @ai-sdk/sandbox-vercel"
+      dark
+    />
+  </Tab>
+</Tabs>
+
+The adapter bootstraps the Cursor CLI and ACP bridge dependencies inside the
+sandbox when the first session starts.
+
+## Import
+
+```ts
+import { cursor, createCursor } from '@ai-sdk/harness-cursor';
+```
+
+`cursor` is equivalent to `createCursor()` with its default configuration.
+
+## Basic Usage
+
+```ts
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { cursor } from '@ai-sdk/harness-cursor';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const agent = new HarnessAgent({
+  harness: cursor,
+  sandbox: createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+  }),
+});
+
+const session = await agent.createSession();
+
+let exitCode = 0;
+try {
+  const result = await agent.stream({
+    session,
+    prompt: 'Check the test failures and fix the production code.',
+  });
+
+  for await (const part of result.stream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+} catch (err) {
+  exitCode = 1;
+  console.error(err);
+} finally {
+  await session.destroy();
+  process.exit(exitCode);
+}
+```
+
+To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN` for
+Vercel Sandbox and `CURSOR_API_KEY` for Cursor.
+
+## Adapter Settings
+
+Use `createCursor()` to configure the runtime:
+
+```ts
+const harness = createCursor({
+  model: 'default',
+  startupTimeoutMs: 120_000,
+  onAskQuestion: async (question) => {
+    throw new Error(`Need answer: ${question}`);
+  },
+});
+```
+
+Settings:
+
+- `auth`: Cursor API key settings.
+- `model`: Cursor model id. If omitted, the adapter uses its pinned default.
+- `onAskQuestion`: host handler for Cursor ACP question prompts.
+- `startupTimeoutMs`: maximum time to wait for the bridge to start.
+
+## Authentication
+
+By default, authentication is resolved from the host environment and forwarded
+to the sandbox.
+
+Supported environment variables:
+
+- `VERCEL_OIDC_TOKEN`
+- `CURSOR_API_KEY`
+
+You can also pass explicit auth settings:
+
+```ts
+const harness = createCursor({
+  auth: { apiKey: process.env.CURSOR_API_KEY },
+});
+```
+
+## Sandbox
+
+Cursor requires a network sandbox with at least one exposed port,
+e.g. `@ai-sdk/sandbox-vercel`:
+
+```ts
+const sandbox = createVercelSandbox({
+  runtime: 'node24',
+  ports: [4000],
+});
+```
+
+## Known Limitations
+
+- No replay/rerun resume ladder parity with `harness-codex` yet.
+- Cursor Cloud (`@cursor/sdk`) is not covered by this package.
+
+## Related
+
+- [HarnessAgent](/docs/ai-sdk-harnesses/harness-agent)
+- [Harness tools](/docs/ai-sdk-harnesses/tools)
+- [Harness adapters](/docs/ai-sdk-harnesses/harness-adapters)

--- a/content/providers/02-ai-sdk-harnesses/index.mdx
+++ b/content/providers/02-ai-sdk-harnesses/index.mdx
@@ -22,6 +22,16 @@ and response primitives.
       href: '/providers/ai-sdk-harnesses/codex',
     },
     {
+      title: 'Cursor',
+      description: 'Use Cursor sandbox through the AI SDK harness abstraction.',
+      href: '/providers/ai-sdk-harnesses/cursor',
+    },
+    {
+      title: 'Grok',
+      description: 'Use Grok Build through the AI SDK harness abstraction.',
+      href: '/providers/ai-sdk-harnesses/grok',
+    },
+    {
       title: 'OpenCode',
       description: 'Use OpenCode through the AI SDK harness abstraction.',
       href: '/providers/ai-sdk-harnesses/opencode',

--- a/examples/harness-e2e-next/tsconfig.json
+++ b/examples/harness-e2e-next/tsconfig.json
@@ -53,6 +53,12 @@
       "path": "../../packages/harness-codex"
     },
     {
+      "path": "../../packages/harness-deepagents"
+    },
+    {
+      "path": "../../packages/harness-opencode"
+    },
+    {
       "path": "../../packages/harness-pi"
     },
     {

--- a/examples/harness-e2e-tui/tsconfig.json
+++ b/examples/harness-e2e-tui/tsconfig.json
@@ -44,6 +44,12 @@
       "path": "../../packages/harness-codex"
     },
     {
+      "path": "../../packages/harness-deepagents"
+    },
+    {
+      "path": "../../packages/harness-opencode"
+    },
+    {
       "path": "../../packages/harness-pi"
     },
     {

--- a/packages/HARNESS_ACP_UPSTREAM.md
+++ b/packages/HARNESS_ACP_UPSTREAM.md
@@ -16,8 +16,9 @@ Source of truth for early development: [ai-sdk-harnesses](https://github.com/akv
 - [x] Add provider docs under `content/providers/02-ai-sdk-harnesses`
 - [x] Add harness-adapters table entry
 - [x] Run `pnpm update-references` at monorepo root
-- [ ] `pnpm build` + `pnpm test` in each package
-- [ ] Open RFC issue linking production validation (personal-assistant coder PM)
+- [x] `pnpm build` + `pnpm test` in each package
+- [x] Open RFC issue linking production validation (personal-assistant coder PM) — [#16956](https://github.com/vercel/ai/issues/16956)
+- [x] Draft PR — [#16957](https://github.com/vercel/ai/pull/16957) (ready to mark after RFC ACK)
 
 ## Out of scope (follow-up)
 

--- a/packages/HARNESS_ACP_UPSTREAM.md
+++ b/packages/HARNESS_ACP_UPSTREAM.md
@@ -1,0 +1,26 @@
+# Harness ACP / Grok / Cursor (staging for upstream PR)
+
+Packages added on branch `feat/harness-acp-grok-cursor`:
+
+| Package | Description |
+|---------|-------------|
+| `@ai-sdk/harness-acp` | Generic ACP stdio sandbox harness |
+| `@ai-sdk/harness-grok` | Grok Build (`grok agent stdio`) |
+| `@ai-sdk/harness-cursor` | Cursor sandbox (`agent acp`) |
+
+Source of truth for early development: [ai-sdk-harnesses](https://github.com/akvilander/ai-sdk-harnesses) (`@akvilander/ai-sdk-harness-*` on npm staging).
+
+## Before opening PR to vercel/ai
+
+- [ ] Add changesets (`pnpm changeset`) — patch for each new package
+- [ ] Add provider docs under `content/docs`
+- [ ] Add harness-adapters table entry
+- [ ] Run `pnpm update-references` at monorepo root
+- [ ] `pnpm build` + `pnpm test` in each package
+- [ ] Open RFC issue linking production validation (personal-assistant coder PM)
+
+## Out of scope (follow-up)
+
+- `@ai-sdk/harness-cursor-cloud` for `@cursor/sdk` (Pi-style host adapter)
+- Replay/rerun resume ladder parity with `harness-codex`
+- Grok OAuth bootstrap helper in package (document `sandboxConfig.onSession` pattern)

--- a/packages/HARNESS_ACP_UPSTREAM.md
+++ b/packages/HARNESS_ACP_UPSTREAM.md
@@ -12,10 +12,10 @@ Source of truth for early development: [ai-sdk-harnesses](https://github.com/akv
 
 ## Before opening PR to vercel/ai
 
-- [ ] Add changesets (`pnpm changeset`) — patch for each new package
-- [ ] Add provider docs under `content/docs`
-- [ ] Add harness-adapters table entry
-- [ ] Run `pnpm update-references` at monorepo root
+- [x] Add changesets (`pnpm changeset`) — patch for each new package
+- [x] Add provider docs under `content/providers/02-ai-sdk-harnesses`
+- [x] Add harness-adapters table entry
+- [x] Run `pnpm update-references` at monorepo root
 - [ ] `pnpm build` + `pnpm test` in each package
 - [ ] Open RFC issue linking production validation (personal-assistant coder PM)
 
@@ -23,4 +23,3 @@ Source of truth for early development: [ai-sdk-harnesses](https://github.com/akv
 
 - `@ai-sdk/harness-cursor-cloud` for `@cursor/sdk` (Pi-style host adapter)
 - Replay/rerun resume ladder parity with `harness-codex`
-- Grok OAuth bootstrap helper in package (document `sandboxConfig.onSession` pattern)

--- a/packages/harness-acp/CHANGELOG.md
+++ b/packages/harness-acp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ai-sdk/harness-acp
+
+## 1.0.0
+
+### Minor Changes
+
+- Initial release: generic ACP stdio harness for `HarnessAgent` with sandbox WebSocket bridge

--- a/packages/harness-acp/README.md
+++ b/packages/harness-acp/README.md
@@ -4,8 +4,6 @@ Generic [Agent Client Protocol](https://agentclientprotocol.com/) harness for AI
 
 Runs ACP stdio agents inside Vercel Sandbox via a WebSocket NDJSON bridge (stdin is not exposed to the host through sandbox `spawn`).
 
-Upstream target: `@ai-sdk/harness-acp`.
-
 ## Usage
 
 ```ts
@@ -19,4 +17,4 @@ const harness = createAcpHarness({
 });
 ```
 
-Prefer `@akvilander/ai-sdk-harness-grok` or `@akvilander/ai-sdk-harness-cursor` for known CLIs.
+Prefer `@ai-sdk/harness-grok` or `@ai-sdk/harness-cursor` for known CLIs.

--- a/packages/harness-acp/README.md
+++ b/packages/harness-acp/README.md
@@ -1,0 +1,22 @@
+# @ai-sdk/harness-acp
+
+Generic [Agent Client Protocol](https://agentclientprotocol.com/) harness for AI SDK `HarnessAgent`.
+
+Runs ACP stdio agents inside Vercel Sandbox via a WebSocket NDJSON bridge (stdin is not exposed to the host through sandbox `spawn`).
+
+Upstream target: `@ai-sdk/harness-acp`.
+
+## Usage
+
+```ts
+import { createAcpHarness } from '@ai-sdk/harness-acp';
+
+const harness = createAcpHarness({
+  harnessId: 'my-agent',
+  getBootstrap: async () => ({ /* HarnessV1Bootstrap */ }),
+  command: 'my-agent acp',
+  authMethodId: 'my.auth',
+});
+```
+
+Prefer `@akvilander/ai-sdk-harness-grok` or `@akvilander/ai-sdk-harness-cursor` for known CLIs.

--- a/packages/harness-acp/package.json
+++ b/packages/harness-acp/package.json
@@ -11,6 +11,9 @@
     "dist/**/*",
     "src",
     "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
     "CHANGELOG.md",
     "README.md"
   ],
@@ -35,7 +38,7 @@
   "dependencies": {
     "@ai-sdk/harness": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
-    "ws": "^8.21.0"
+    "ws": "8.21.0"
   },
   "peerDependencies": {
     "zod": "^3.25.76 || ^4.1.8"
@@ -44,10 +47,8 @@
     "@types/node": "22.19.19",
     "@types/ws": "^8.5.13",
     "@vercel/ai-tsconfig": "workspace:*",
-    "del-cli": "^6.0.0",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
-    "vitest": "^3.2.4",
     "zod": "3.25.76"
   },
   "engines": {
@@ -69,6 +70,7 @@
   "keywords": [
     "ai",
     "harness",
-    "acp"
+    "acp",
+    "agent-client-protocol"
   ]
 }

--- a/packages/harness-acp/package.json
+++ b/packages/harness-acp/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@ai-sdk/harness-acp",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json && pnpm copy-bridge-assets",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.mkdir('dist/bridge', { recursive: true }); await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/index.mjs', 'dist/bridge/index.mjs'); })\"",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/harness": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*",
+    "ws": "^8.21.0"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@types/ws": "^8.5.13",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "del-cli": "^6.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "vitest": "^3.2.4",
+    "zod": "3.25.76"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/harness-acp"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "harness",
+    "acp"
+  ]
+}

--- a/packages/harness-acp/src/acp-bootstrap.ts
+++ b/packages/harness-acp/src/acp-bootstrap.ts
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { HarnessV1Bootstrap } from "@ai-sdk/harness";
+
+const BRIDGE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "bridge");
+
+async function readBridgeAsset(name: string): Promise<string> {
+  return readFile(path.join(BRIDGE_DIR, name), "utf8");
+}
+
+export async function acpBridgeBootstrapFiles(
+  bootstrapDir: string,
+): Promise<HarnessV1Bootstrap["files"]> {
+  const [pkg, bridge] = await Promise.all([
+    readBridgeAsset("package.json"),
+    readBridgeAsset("index.mjs"),
+  ]);
+  return [
+    { path: `${bootstrapDir}/package.json`, content: pkg },
+    { path: `${bootstrapDir}/bridge.mjs`, content: bridge },
+  ];
+}
+
+export const ACP_BRIDGE_INSTALL_COMMANDS = (bootstrapDir: string) => [
+  { command: `mkdir -p ${bootstrapDir}` },
+  {
+    command: `cd ${bootstrapDir} && npm install --omit=dev`,
+  },
+];

--- a/packages/harness-acp/src/acp-bridge-protocol.ts
+++ b/packages/harness-acp/src/acp-bridge-protocol.ts
@@ -1,0 +1,48 @@
+import {
+  harnessV1BridgeHelloSchema,
+  harnessV1BridgeInboundCommandSchemas,
+  harnessV1BridgeReadySchema,
+  harnessV1BridgeSandboxLogSchema,
+} from "@ai-sdk/harness";
+import { z } from "zod/v4";
+
+export const acpRpcLineSchema = z.object({
+  type: z.literal("rpc-line"),
+  line: z.string(),
+  seq: z.number().optional(),
+});
+
+export const acpOutboundMessageSchema = z.discriminatedUnion("type", [
+  harnessV1BridgeHelloSchema,
+  harnessV1BridgeSandboxLogSchema,
+  acpRpcLineSchema,
+  z.object({
+    type: z.literal("error"),
+    error: z.unknown(),
+  }),
+]);
+
+export type AcpOutboundMessage = z.infer<typeof acpOutboundMessageSchema>;
+
+export const acpRpcSendSchema = z.object({
+  type: z.literal("rpc-send"),
+  line: z.string(),
+});
+
+export const acpInboundMessageSchema = z.discriminatedUnion("type", [
+  acpRpcSendSchema,
+  ...harnessV1BridgeInboundCommandSchemas,
+]);
+
+export type AcpInboundMessage = z.infer<typeof acpInboundMessageSchema>;
+
+export const acpBridgeReadySchema = harnessV1BridgeReadySchema;
+export type AcpBridgeReady = z.infer<typeof acpBridgeReadySchema>;
+
+export const acpBridgeCoordsSchema = z.object({
+  port: z.number(),
+  token: z.string(),
+  lastSeenEventId: z.number(),
+});
+
+export type AcpBridgeCoords = z.infer<typeof acpBridgeCoordsSchema>;

--- a/packages/harness-acp/src/acp-bridge.ts
+++ b/packages/harness-acp/src/acp-bridge.ts
@@ -1,0 +1,159 @@
+import { HarnessCapabilityUnsupportedError } from "@ai-sdk/harness";
+import { SandboxChannel } from "@ai-sdk/harness/utils";
+import type { HarnessV1NetworkSandboxSession } from "@ai-sdk/harness";
+import { WebSocket } from "ws";
+
+import {
+  acpOutboundMessageSchema,
+  type AcpInboundMessage,
+  type AcpOutboundMessage,
+} from "./acp-bridge-protocol.js";
+
+export const ACP_BRIDGE_PORT = 4000;
+
+export type AcpBridgeChannel = SandboxChannel<AcpOutboundMessage, AcpInboundMessage>;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function openWebSocket(url: string, timeoutMs: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      cleanup();
+      try {
+        ws.terminate();
+      } catch {
+        // best-effort
+      }
+      reject(new Error(`WebSocket open timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("open", onOpen);
+      ws.off("error", onError);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolve(ws);
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    ws.on("open", onOpen);
+    ws.on("error", onError);
+  });
+}
+
+function waitForBridgeHello(ws: WebSocket, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("close", onClose);
+      ws.off("error", onError);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onMessage = (raw: Buffer | ArrayBuffer | Buffer[]) => {
+      try {
+        const text = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw);
+        const parsed = JSON.parse(text) as { type?: string };
+        if (parsed.type === "bridge-hello") settle();
+      } catch {
+        // wait for valid hello
+      }
+    };
+    const onClose = () => settle(new Error("WebSocket closed before bridge-hello"));
+    const onError = (err: Error) => settle(err);
+    const timer = setTimeout(
+      () => settle(new Error(`bridge did not send bridge-hello within ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    timer.unref?.();
+    ws.on("message", onMessage);
+    ws.on("close", onClose);
+    ws.on("error", onError);
+  });
+}
+
+export async function openBridgeWebSocket(input: {
+  wsUrl: string;
+  timeoutMs: number;
+}): Promise<WebSocket> {
+  const deadline = Date.now() + input.timeoutMs;
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    attempt++;
+    let ws: WebSocket | undefined;
+    try {
+      const remaining = Math.max(1, deadline - Date.now());
+      ws = await openWebSocket(input.wsUrl, Math.min(10_000, remaining));
+      await waitForBridgeHello(ws, Math.min(5_000, Math.max(1, deadline - Date.now())));
+      return ws;
+    } catch (err) {
+      lastError = err;
+      try {
+        ws?.close();
+      } catch {
+        // best-effort
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await sleep(Math.min(250 * attempt, 1_000, remaining));
+    }
+  }
+
+  throw new Error(
+    `ACP bridge WebSocket handshake failed within ${input.timeoutMs}ms after ${attempt} attempt(s). Last error: ${formatUnknownError(lastError)}`,
+  );
+}
+
+export function resolveBridgePort(
+  sandboxSession: HarnessV1NetworkSandboxSession,
+  override?: number,
+): number {
+  if (override !== undefined) return override;
+  if (sandboxSession.ports.length > 0) return sandboxSession.ports[0]!;
+  throw new HarnessCapabilityUnsupportedError({
+    harnessId: "acp",
+    message:
+      "ACP harness needs a TCP port exposed by the sandbox. Create the sandbox with ports: [4000].",
+  });
+}
+
+export async function buildBridgeWsUrl(input: {
+  sandboxSession: HarnessV1NetworkSandboxSession;
+  port: number;
+  token: string;
+}): Promise<string> {
+  const base = await input.sandboxSession.getPortUrl({
+    port: input.port,
+    protocol: "ws",
+  });
+  return `${base}?agent_bridge_token=${encodeURIComponent(input.token)}`;
+}
+
+export function createAcpBridgeChannel(input: {
+  connect: () => Promise<WebSocket>;
+  initialLastSeenEventId?: number;
+}): AcpBridgeChannel {
+  return new SandboxChannel<AcpOutboundMessage, AcpInboundMessage>({
+    connect: input.connect,
+    outboundSchema: acpOutboundMessageSchema,
+    initialLastSeenEventId: input.initialLastSeenEventId ?? 0,
+  });
+}

--- a/packages/harness-acp/src/acp-session.ts
+++ b/packages/harness-acp/src/acp-session.ts
@@ -1,0 +1,314 @@
+import { randomBytes } from "node:crypto";
+import { markBridgeStarting, waitForBridgeReady } from "@ai-sdk/harness/utils";
+import type {
+  HarnessV1NetworkSandboxSession,
+  HarnessV1StreamPart,
+  HarnessV1ToolSpec,
+} from "@ai-sdk/harness";
+import type {
+  Experimental_SandboxProcess,
+  Experimental_SandboxSession,
+} from "@ai-sdk/provider-utils";
+import { z } from "zod/v4";
+
+import {
+  ACP_BRIDGE_PORT,
+  buildBridgeWsUrl,
+  createAcpBridgeChannel,
+  openBridgeWebSocket,
+  resolveBridgePort,
+  type AcpBridgeChannel,
+} from "./acp-bridge.js";
+import { acpBridgeCoordsSchema } from "./acp-bridge-protocol.js";
+import { NdjsonRpcClient } from "./ndjson-rpc.js";
+import {
+  closeTextStream,
+  createAcpStreamMapperState,
+  finishStream,
+  mapSessionUpdate,
+  toolSpecsToMcpServers,
+} from "./stream-mapper.js";
+import { WsAcpRpcTransport } from "./ws-rpc-transport.js";
+
+export type AcpRpcHandlerRegistration = (rpc: NdjsonRpcClient) => () => void;
+
+export async function runAcpPromptTurn(input: {
+  rpc: NdjsonRpcClient;
+  acpSessionId: string;
+  prompt: string;
+  tools: ReadonlyArray<HarnessV1ToolSpec>;
+  instructions?: string;
+  instructionsApplied?: boolean;
+  emit: (event: HarnessV1StreamPart) => void;
+  hostToolNames: Set<string>;
+  getControl: () =>
+    | {
+        submitToolResult(input: {
+          toolCallId: string;
+          output: unknown;
+          isError?: boolean;
+        }): PromiseLike<void>;
+      }
+    | undefined;
+  registerRpcHandlers?: AcpRpcHandlerRegistration;
+}): Promise<{ stopReason?: string; instructionsApplied: boolean }> {
+  const mapper = createAcpStreamMapperState();
+  input.emit({ type: "stream-start" });
+
+  let instructionsApplied = input.instructionsApplied ?? false;
+  let promptText = input.prompt;
+  if (input.instructions && !instructionsApplied) {
+    promptText = `${input.instructions}\n\n${input.prompt}`;
+    instructionsApplied = true;
+  }
+
+  const offUpdate = input.rpc.onNotification("session/update", (params) => {
+    const update = (params as { update?: Record<string, unknown> } | undefined)?.update;
+    if (update?.sessionUpdate === "tool_call") {
+      const toolCall = update as {
+        toolCallId?: string;
+        toolName?: string;
+        input?: unknown;
+      };
+      if (toolCall.toolCallId && toolCall.toolName && input.hostToolNames.has(toolCall.toolName)) {
+        void handleHostToolCall(input, toolCall);
+        return;
+      }
+    }
+
+    for (const part of mapSessionUpdate(mapper, params)) {
+      input.emit(part);
+    }
+  });
+
+  const offPermission = input.rpc.onRequest("session/request_permission", async () => ({
+    outcome: { outcome: "selected", optionId: "allow-once" },
+  }));
+
+  const offExtensions = input.registerRpcHandlers?.(input.rpc) ?? (() => {});
+
+  try {
+    const result = (await input.rpc.request(
+      "session/prompt",
+      {
+        sessionId: input.acpSessionId,
+        prompt: [{ type: "text", text: promptText }],
+        mcpServers: toolSpecsToMcpServers(input.tools),
+      },
+      1_800_000,
+    )) as { stopReason?: string };
+
+    for (const part of closeTextStream(mapper)) {
+      input.emit(part);
+    }
+    for (const part of finishStream()) {
+      input.emit(part);
+    }
+
+    return { stopReason: result.stopReason, instructionsApplied };
+  } finally {
+    offUpdate();
+    offPermission();
+    offExtensions();
+  }
+}
+
+async function handleHostToolCall(
+  input: {
+    emit: (event: HarnessV1StreamPart) => void;
+    getControl: () =>
+      | {
+          submitToolResult(input: {
+            toolCallId: string;
+            output: unknown;
+            isError?: boolean;
+          }): PromiseLike<void>;
+        }
+      | undefined;
+  },
+  toolCall: { toolCallId?: string; toolName?: string; input?: unknown },
+): Promise<void> {
+  if (!toolCall.toolCallId || !toolCall.toolName) return;
+
+  const payload =
+    typeof toolCall.input === "string" ? toolCall.input : JSON.stringify(toolCall.input ?? {});
+
+  input.emit({
+    type: "tool-call",
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    input: payload,
+  });
+
+  input.getControl();
+}
+
+export const acpLifecycleStateSchema = z.object({
+  acpSessionId: z.string().optional(),
+  instructionsApplied: z.boolean().optional(),
+  bridge: acpBridgeCoordsSchema.optional(),
+});
+
+export interface AcpHarnessConfig {
+  harnessId: string;
+  command: string;
+  authMethodId: string;
+  authMeta?: Record<string, unknown>;
+  model?: string;
+  env?: Record<string, string>;
+  clientName?: string;
+  clientVersion?: string;
+  registerRpcHandlers?: AcpRpcHandlerRegistration;
+}
+
+export interface SpawnedAcpBridge {
+  port: number;
+  token: string;
+  channel: AcpBridgeChannel;
+  proc: Experimental_SandboxProcess;
+}
+
+export async function attachAcpBridge(input: {
+  sandboxSession: HarnessV1NetworkSandboxSession;
+  coords: z.infer<typeof acpBridgeCoordsSchema>;
+  timeoutMs?: number;
+  abortSignal?: AbortSignal;
+}): Promise<AcpBridgeChannel> {
+  const wsUrl = await buildBridgeWsUrl({
+    sandboxSession: input.sandboxSession,
+    port: input.coords.port,
+    token: input.coords.token,
+  });
+  return createAcpBridgeChannel({
+    initialLastSeenEventId: input.coords.lastSeenEventId,
+    connect: () =>
+      openBridgeWebSocket({
+        wsUrl,
+        timeoutMs: input.timeoutMs ?? 30_000,
+      }),
+  });
+}
+
+export async function spawnAcpBridge(input: {
+  sandboxSession: HarnessV1NetworkSandboxSession;
+  session: Experimental_SandboxSession;
+  sessionWorkDir: string;
+  bootstrapDir: string;
+  bridgeStateDir: string;
+  config: AcpHarnessConfig;
+  token?: string;
+  abortSignal?: AbortSignal;
+  startupTimeoutMs?: number;
+}): Promise<SpawnedAcpBridge> {
+  const port = resolveBridgePort(input.sandboxSession, ACP_BRIDGE_PORT);
+  const token = input.token ?? randomBytes(32).toString("hex");
+  const timeoutMs = input.startupTimeoutMs ?? 120_000;
+
+  await markBridgeStarting({
+    sandbox: input.session,
+    bridgeStateDir: input.bridgeStateDir,
+    bridgeType: input.config.harnessId,
+    abortSignal: input.abortSignal,
+  });
+
+  await input.sandboxSession.setPorts?.([port], {
+    abortSignal: input.abortSignal,
+  });
+
+  await input.session.run({
+    command: `mkdir -p ${input.bridgeStateDir}`,
+    abortSignal: input.abortSignal,
+  });
+
+  const env = {
+    ...(input.config.env ?? {}),
+    BRIDGE_CHANNEL_TOKEN: token,
+    BRIDGE_WS_PORT: String(port),
+    ACP_COMMAND: input.config.command,
+    ACP_CWD: input.sessionWorkDir,
+  };
+
+  const proc = await input.session.spawn({
+    command: `node ${input.bootstrapDir}/bridge.mjs --workdir ${input.sessionWorkDir} --bridge-state-dir ${input.bridgeStateDir}`,
+    workingDirectory: input.sessionWorkDir,
+    env,
+    abortSignal: input.abortSignal,
+  });
+
+  const { port: boundPort } = await waitForBridgeReady({
+    proc,
+    sandbox: input.session,
+    bridgeStateDir: input.bridgeStateDir,
+    bridgeType: input.config.harnessId,
+    timeoutMs,
+    abortSignal: input.abortSignal,
+  });
+
+  const wsUrl = await buildBridgeWsUrl({
+    sandboxSession: input.sandboxSession,
+    port: boundPort,
+    token,
+  });
+
+  const channel = createAcpBridgeChannel({
+    connect: () => openBridgeWebSocket({ wsUrl, timeoutMs }),
+  });
+
+  return { port: boundPort, token, channel, proc };
+}
+
+export async function initializeAcpSession(input: {
+  rpc: NdjsonRpcClient;
+  sessionWorkDir: string;
+  config: AcpHarnessConfig;
+  tools: ReadonlyArray<HarnessV1ToolSpec>;
+  existingSessionId?: string;
+  skipInitialize?: boolean;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  if (!input.skipInitialize) {
+    await input.rpc.request("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+      clientInfo: {
+        name: input.config.clientName ?? "ai-sdk-harness-acp",
+        version: input.config.clientVersion ?? "0.1.0",
+      },
+    });
+
+    await input.rpc.request("authenticate", {
+      methodId: input.config.authMethodId,
+      ...(input.config.authMeta ? { _meta: input.config.authMeta } : {}),
+    });
+  }
+
+  if (input.existingSessionId) {
+    await input.rpc.request("session/load", { sessionId: input.existingSessionId });
+    return input.existingSessionId;
+  }
+
+  const created = (await input.rpc.request("session/new", {
+    cwd: input.sessionWorkDir,
+    ...(input.config.model ? { model: input.config.model } : {}),
+    mcpServers: toolSpecsToMcpServers(input.tools),
+  })) as { sessionId?: string };
+
+  if (!created.sessionId) {
+    throw new Error("ACP session/new did not return sessionId");
+  }
+  return created.sessionId;
+}
+
+export async function createAcpRpcClient(input: {
+  channel: AcpBridgeChannel;
+  abortSignal?: AbortSignal;
+  resume?: boolean;
+}): Promise<NdjsonRpcClient> {
+  const transport = new WsAcpRpcTransport(input.channel, input.abortSignal);
+  const rpc = new NdjsonRpcClient(transport);
+  await transport.connect(input.resume ? { resume: true } : undefined);
+  return rpc;
+}

--- a/packages/harness-acp/src/bridge/index.mjs
+++ b/packages/harness-acp/src/bridge/index.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * In-sandbox ACP bridge: WebSocket transport + JSON-RPC stdio proxy.
+ * Mirrors @ai-sdk/harness/bridge semantics (token auth, seq replay, bridge-ready).
+ */
+import { spawn } from "node:child_process";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { env as procEnv, pid, stdout } from "node:process";
+import { WebSocketServer } from "ws";
+
+const WS_OPEN = 1;
+
+function parseArgs(argv) {
+  let workdir = procEnv.ACP_CWD ?? procEnv.PWD ?? procEnv.HOME ?? "/";
+  let bridgeStateDir = `${workdir}/.bridge-state`;
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--workdir" && argv[i + 1]) {
+      workdir = argv[++i];
+    } else if (argv[i] === "--bridge-state-dir" && argv[i + 1]) {
+      bridgeStateDir = argv[++i];
+    }
+  }
+  return { workdir, bridgeStateDir };
+}
+
+function serialiseError(err) {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message, stack: err.stack };
+  }
+  return err;
+}
+
+function spawnAcpChild(command, workdir) {
+  const wrapped =
+    "if command -v stdbuf >/dev/null 2>&1; then exec stdbuf -oL -eL bash -c " +
+    JSON.stringify(command) +
+    "; else exec bash -c " +
+    JSON.stringify(command) +
+    "; fi";
+  return spawn("bash", ["-c", wrapped], {
+    cwd: workdir,
+    env: { ...procEnv, PYTHONUNBUFFERED: "1" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+const { workdir, bridgeStateDir } = parseArgs(process.argv);
+const expectedToken = procEnv.BRIDGE_CHANNEL_TOKEN ?? "";
+const bridgeWsPort = parseInt(procEnv.BRIDGE_WS_PORT ?? "0", 10);
+const acpCommand = procEnv.ACP_COMMAND ?? "grok agent stdio";
+
+const bridgeMetaPath = `${bridgeStateDir}/bridge-meta.json`;
+const eventLogPath = `${bridgeStateDir}/event-log.ndjson`;
+
+let currentBoundPort = 0;
+let activeSocket;
+let seqCounter = 0;
+let eventLog = [];
+let diskBuffer = "";
+let flushPromise = null;
+
+try {
+  await mkdir(bridgeStateDir, { recursive: true });
+} catch {
+  // best-effort
+}
+
+const flushEventsToDisk = async () => {
+  while (diskBuffer.length > 0) {
+    const buf = diskBuffer;
+    diskBuffer = "";
+    await appendFile(eventLogPath, buf).catch(() => {});
+  }
+};
+
+const scheduleEventFlush = () => {
+  if (flushPromise) return;
+  flushPromise = new Promise((resolve) => {
+    setImmediate(() => {
+      void flushEventsToDisk().finally(resolve);
+    });
+  }).finally(() => {
+    flushPromise = null;
+    if (diskBuffer.length > 0) scheduleEventFlush();
+  });
+};
+
+if (procEnv.BRIDGE_REPLAY_FROM_DISK === "1" && existsSync(eventLogPath)) {
+  try {
+    const lines = readFileSync(eventLogPath, "utf8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    eventLog = lines.map((line) => ({
+      seq: JSON.parse(line).seq,
+      line,
+    }));
+    seqCounter = eventLog.at(-1)?.seq ?? 0;
+  } catch {
+    eventLog = [];
+    seqCounter = 0;
+  }
+}
+
+const writeBridgeMeta = async (state) => {
+  try {
+    await writeFile(
+      bridgeMetaPath,
+      JSON.stringify({ type: "acp", port: currentBoundPort, state, pid }),
+    );
+  } catch {
+    // best-effort
+  }
+};
+
+const sendControl = (msg) => {
+  if (activeSocket?.readyState === WS_OPEN) {
+    try {
+      activeSocket.send(JSON.stringify(msg));
+    } catch {
+      // best-effort
+    }
+  }
+};
+
+const emit = (event) => {
+  const seq = ++seqCounter;
+  const line = JSON.stringify({ ...event, seq });
+  eventLog.push({ seq, line });
+  diskBuffer += `${line}\n`;
+  scheduleEventFlush();
+  if (activeSocket?.readyState === WS_OPEN) {
+    try {
+      activeSocket.send(line);
+    } catch {
+      // replay on reconnect
+    }
+  }
+};
+
+const replay = (ws, afterSeq) => {
+  for (const entry of eventLog) {
+    if (entry.seq > afterSeq && ws.readyState === WS_OPEN) {
+      ws.send(entry.line);
+    }
+  }
+};
+
+const child = spawnAcpChild(acpCommand, workdir);
+let stdoutBuffer = "";
+const stderrTail = [];
+const MAX_STDERR = 40;
+
+child.stdout.on("data", (chunk) => {
+  stdoutBuffer += chunk.toString();
+  const lines = stdoutBuffer.split("\n");
+  stdoutBuffer = lines.pop() ?? "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    emit({ type: "rpc-line", line });
+  }
+});
+
+child.stderr.on("data", (chunk) => {
+  const text = chunk.toString();
+  process.stderr.write(chunk);
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    stderrTail.push(trimmed);
+    if (stderrTail.length > MAX_STDERR) stderrTail.shift();
+    emit({ type: "sandbox-log", source: "acp", stream: "stderr", line: trimmed });
+  }
+});
+
+child.on("error", (error) => {
+  emit({
+    type: "error",
+    error: serialiseError(error),
+  });
+});
+
+child.on("exit", (code) => {
+  emit({
+    type: "error",
+    error: { message: `ACP child exited with code ${String(code ?? 1)}` },
+  });
+});
+
+const handleInbound = (msg, ws) => {
+  switch (msg.type) {
+    case "rpc-send":
+      if (msg.line) {
+        child.stdin.write(msg.line.trimEnd() + "\n");
+      }
+      return;
+    case "resume":
+      replay(ws, msg.lastSeenEventId ?? 0);
+      return;
+    case "shutdown":
+      void writeBridgeMeta("done");
+      try {
+        ws.close(1000, "shutdown");
+      } finally {
+        wss.close(() => process.exit(0));
+        setTimeout(() => process.exit(0), 1000).unref();
+      }
+      return;
+    case "detach":
+      void writeBridgeMeta("done");
+      sendControl({ type: "bridge-detach", data: { stderrTail } });
+      try {
+        ws.close(1000, "detach");
+      } finally {
+        wss.close(() => process.exit(0));
+        setTimeout(() => process.exit(0), 1000).unref();
+      }
+      return;
+    case "abort":
+      return;
+    default:
+      return;
+  }
+};
+
+void writeBridgeMeta("init");
+
+const wss = new WebSocketServer({ port: bridgeWsPort, host: "0.0.0.0" });
+
+wss.on("listening", () => {
+  const addr = wss.address();
+  currentBoundPort = typeof addr === "object" && addr ? addr.port : 0;
+  void writeBridgeMeta("waiting");
+  stdout.write(JSON.stringify({ type: "bridge-ready", port: currentBoundPort }) + "\n");
+});
+
+wss.on("connection", (ws, req) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (url.searchParams.get("agent_bridge_token") !== expectedToken) {
+    ws.close(1008, "unauthorized");
+    return;
+  }
+
+  activeSocket = ws;
+  sendControl({
+    type: "bridge-hello",
+    state: "waiting",
+    lastSeq: seqCounter,
+  });
+
+  ws.on("message", (raw) => {
+    let parsed;
+    try {
+      const text = typeof raw === "string" ? raw : Buffer.from(raw).toString("utf8");
+      parsed = JSON.parse(text);
+    } catch (err) {
+      sendControl({
+        type: "error",
+        error: `protocol parse error: ${err?.message ?? String(err)}`,
+      });
+      return;
+    }
+    handleInbound(parsed, ws);
+  });
+
+  ws.on("close", () => {
+    if (activeSocket === ws) activeSocket = undefined;
+  });
+});
+
+process.on("uncaughtException", (err) => {
+  emit({ type: "error", error: serialiseError(err) });
+});
+process.on("unhandledRejection", (err) => {
+  emit({ type: "error", error: serialiseError(err) });
+});
+
+await new Promise((resolve, reject) => {
+  if (wss.address() != null) {
+    resolve();
+    return;
+  }
+  wss.once("listening", resolve);
+  wss.once("error", reject);
+});

--- a/packages/harness-acp/src/bridge/package.json
+++ b/packages/harness-acp/src/bridge/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "harness-acp-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ws": "8.21.0"
+  }
+}

--- a/packages/harness-acp/src/create-acp-harness.ts
+++ b/packages/harness-acp/src/create-acp-harness.ts
@@ -1,0 +1,366 @@
+import {
+  commonTool,
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1,
+  type HarnessV1Bootstrap,
+  type HarnessV1BuiltinTool as HarnessV1BuiltinToolType,
+  type HarnessV1ContinueTurnOptions,
+  type HarnessV1ContinueTurnState,
+  type HarnessV1PromptControl,
+  type HarnessV1PromptTurnOptions,
+  type HarnessV1ResumeSessionState,
+  type HarnessV1Session,
+  type HarnessV1StartOptions,
+  type HarnessV1StreamPart,
+} from "@ai-sdk/harness";
+import type { Experimental_SandboxProcess } from "@ai-sdk/provider-utils";
+import { z } from "zod/v4";
+
+import type { AcpBridgeChannel } from "./acp-bridge.js";
+import {
+  acpLifecycleStateSchema,
+  attachAcpBridge,
+  createAcpRpcClient,
+  initializeAcpSession,
+  runAcpPromptTurn,
+  spawnAcpBridge,
+  type AcpHarnessConfig,
+} from "./acp-session.js";
+import type { NdjsonRpcClient } from "./ndjson-rpc.js";
+import { hostToolNames } from "./stream-mapper.js";
+
+export type AcpHarnessSettings = {
+  readonly harnessId: string;
+  readonly getBootstrap: () => Promise<HarnessV1Bootstrap>;
+  readonly command: string;
+  readonly authMethodId: string;
+  readonly authMeta?: Record<string, unknown>;
+  readonly model?: string;
+  readonly env?: Record<string, string>;
+  readonly port?: number;
+  readonly startupTimeoutMs?: number;
+  readonly builtinTools?: Record<string, HarnessV1BuiltinToolType>;
+  readonly registerRpcHandlers?: AcpHarnessConfig["registerRpcHandlers"];
+};
+
+const DEFAULT_BUILTIN_TOOLS = {
+  read: commonTool("read", {
+    nativeName: "read",
+    toolUseKind: "readonly",
+    description: "Read file contents.",
+    inputSchema: z.object({ file_path: z.string() }),
+  }),
+  write: commonTool("write", {
+    nativeName: "write",
+    toolUseKind: "edit",
+    description: "Write file contents.",
+    inputSchema: z.object({ file_path: z.string(), content: z.string() }),
+  }),
+  edit: commonTool("edit", {
+    nativeName: "edit",
+    toolUseKind: "edit",
+    description: "Edit a file.",
+    inputSchema: z.object({
+      file_path: z.string(),
+      old_string: z.string(),
+      new_string: z.string(),
+    }),
+  }),
+  bash: commonTool("bash", {
+    nativeName: "bash",
+    toolUseKind: "bash",
+    description: "Run a shell command.",
+    inputSchema: z.object({ command: z.string() }),
+  }),
+  grep: commonTool("grep", {
+    nativeName: "grep",
+    toolUseKind: "readonly",
+    description: "Search file contents.",
+    inputSchema: z.object({ pattern: z.string() }),
+  }),
+  glob: commonTool("glob", {
+    nativeName: "glob",
+    toolUseKind: "readonly",
+    description: "Find files by glob pattern.",
+    inputSchema: z.object({ pattern: z.string() }),
+  }),
+  webSearch: commonTool("webSearch", {
+    nativeName: "web_search",
+    toolUseKind: "readonly",
+    description: "Search the web.",
+    inputSchema: z.object({ query: z.string() }),
+  }),
+} as const;
+
+interface AcpSessionState {
+  acpSessionId?: string;
+  instructionsApplied: boolean;
+  bridgePort: number;
+  bridgeToken: string;
+  channel: AcpBridgeChannel;
+  proc?: Experimental_SandboxProcess;
+  rpc: NdjsonRpcClient;
+  bridgeStateDir: string;
+  bootstrapDir: string;
+  attached: boolean;
+}
+
+function createAcpHarnessSession(input: {
+  sessionId: string;
+  config: AcpHarnessConfig;
+  state: AcpSessionState;
+  isResume: boolean;
+  modelId?: string;
+}): HarnessV1Session {
+  let activeControl: HarnessV1PromptControl | undefined;
+
+  return {
+    sessionId: input.sessionId,
+    isResume: input.isResume,
+    modelId: input.modelId ?? input.config.model,
+
+    doPromptTurn: async (options: HarnessV1PromptTurnOptions) => {
+      if (!input.state.rpc || !input.state.acpSessionId) {
+        throw new Error("ACP session is not initialized");
+      }
+
+      const hostNames = hostToolNames(options.tools ?? []);
+      let doneResolve!: () => void;
+      let doneReject!: (error: unknown) => void;
+      const done = new Promise<void>((resolve, reject) => {
+        doneResolve = resolve;
+        doneReject = reject;
+      });
+
+      const control: HarnessV1PromptControl = {
+        submitToolResult: async (result) => {
+          await input.state.rpc.request("session/tool_result", {
+            sessionId: input.state.acpSessionId,
+            toolCallId: result.toolCallId,
+            output: result.output,
+            isError: result.isError,
+          });
+        },
+        done,
+      };
+      activeControl = control;
+
+      void (async () => {
+        try {
+          const turn = await runAcpPromptTurn({
+            rpc: input.state.rpc,
+            acpSessionId: input.state.acpSessionId!,
+            prompt:
+              typeof options.prompt === "string" ? options.prompt : JSON.stringify(options.prompt),
+            tools: options.tools ?? [],
+            instructions: options.instructions,
+            instructionsApplied: input.state.instructionsApplied,
+            emit: options.emit,
+            hostToolNames: hostNames,
+            getControl: () => activeControl,
+            registerRpcHandlers: input.config.registerRpcHandlers,
+          });
+          input.state.instructionsApplied = turn.instructionsApplied;
+          doneResolve();
+        } catch (error) {
+          options.emit({ type: "error", error });
+          doneReject(error);
+        }
+      })();
+
+      return control;
+    },
+
+    doContinueTurn: async (options: HarnessV1ContinueTurnOptions) => {
+      return createAcpHarnessSession(input).doPromptTurn({
+        prompt: "",
+        tools: options.tools,
+        emit: options.emit,
+        abortSignal: options.abortSignal,
+      });
+    },
+
+    doCompact: async () => {
+      throw new HarnessCapabilityUnsupportedError({
+        harnessId: input.config.harnessId,
+        message: `Harness '${input.config.harnessId}' does not support manual compaction.`,
+      });
+    },
+
+    doSuspendTurn: async (): Promise<HarnessV1ContinueTurnState> => {
+      const lastSeenEventId = await input.state.channel.suspend();
+      return {
+        type: "continue-turn",
+        harnessId: input.config.harnessId,
+        specificationVersion: "harness-v1",
+        data: {
+          acpSessionId: input.state.acpSessionId,
+          instructionsApplied: input.state.instructionsApplied,
+          bridge: {
+            port: input.state.bridgePort,
+            token: input.state.bridgeToken,
+            lastSeenEventId,
+          },
+        },
+      };
+    },
+
+    doDetach: async (): Promise<HarnessV1ResumeSessionState> => {
+      const lastSeenEventId = await input.state.channel.suspend();
+      return {
+        type: "resume-session",
+        harnessId: input.config.harnessId,
+        specificationVersion: "harness-v1",
+        data: {
+          acpSessionId: input.state.acpSessionId,
+          instructionsApplied: input.state.instructionsApplied,
+          bridge: {
+            port: input.state.bridgePort,
+            token: input.state.bridgeToken,
+            lastSeenEventId,
+          },
+        },
+      };
+    },
+
+    doStop: async (): Promise<HarnessV1ResumeSessionState> => {
+      const lastSeenEventId = await input.state.channel.suspend();
+      await input.state.rpc.close();
+      return {
+        type: "resume-session",
+        harnessId: input.config.harnessId,
+        specificationVersion: "harness-v1",
+        data: {
+          acpSessionId: input.state.acpSessionId,
+          instructionsApplied: input.state.instructionsApplied,
+          bridge: {
+            port: input.state.bridgePort,
+            token: input.state.bridgeToken,
+            lastSeenEventId,
+          },
+        },
+      };
+    },
+
+    doDestroy: async () => {
+      input.state.channel.beginClose();
+      input.state.channel.send({ type: "shutdown" });
+      await input.state.rpc.close();
+      try {
+        await input.state.proc?.kill();
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+export function createAcpHarness(settings: AcpHarnessSettings): HarnessV1 {
+  return {
+    specificationVersion: "harness-v1",
+    harnessId: settings.harnessId,
+    builtinTools: settings.builtinTools ?? DEFAULT_BUILTIN_TOOLS,
+    lifecycleStateSchema: acpLifecycleStateSchema,
+    getBootstrap: settings.getBootstrap,
+
+    doStart: async (startOpts: HarnessV1StartOptions) => {
+      const sandboxSession = startOpts.sandboxSession;
+      const session = sandboxSession.restricted();
+      const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
+      const resumeData = acpLifecycleStateSchema.safeParse(lifecycleState?.data).data;
+      const coords = resumeData?.bridge;
+      const isResume = lifecycleState != null;
+
+      const bootstrap = await settings.getBootstrap();
+      const bootstrapDir = bootstrap.bootstrapDir;
+      const bridgeStateDir = `${bootstrapDir}/bridge-state`;
+      const config: AcpHarnessConfig = {
+        harnessId: settings.harnessId,
+        command: settings.command,
+        authMethodId: settings.authMethodId,
+        authMeta: settings.authMeta,
+        model: settings.model,
+        env: settings.env,
+        registerRpcHandlers: settings.registerRpcHandlers,
+      };
+
+      let channel: AcpBridgeChannel | undefined;
+      let proc: Experimental_SandboxProcess | undefined;
+      let bridgePort = coords?.port ?? 0;
+      let bridgeToken = coords?.token ?? "";
+      let attached = false;
+
+      if (coords) {
+        try {
+          channel = await attachAcpBridge({
+            sandboxSession,
+            coords,
+            abortSignal: startOpts.abortSignal,
+          });
+          bridgePort = coords.port;
+          bridgeToken = coords.token;
+          attached = true;
+        } catch {
+          // Bridge gone — respawn below.
+        }
+      }
+
+      if (!channel) {
+        const spawned = await spawnAcpBridge({
+          sandboxSession,
+          session,
+          sessionWorkDir: startOpts.sessionWorkDir,
+          bootstrapDir,
+          bridgeStateDir,
+          config,
+          abortSignal: startOpts.abortSignal,
+          startupTimeoutMs: settings.startupTimeoutMs,
+        });
+        channel = spawned.channel;
+        proc = spawned.proc;
+        bridgePort = spawned.port;
+        bridgeToken = spawned.token;
+        attached = false;
+      }
+
+      const rpc = await createAcpRpcClient({
+        channel,
+        abortSignal: startOpts.abortSignal,
+        resume: attached,
+      });
+
+      const acpSessionId = await initializeAcpSession({
+        rpc,
+        sessionWorkDir: startOpts.sessionWorkDir,
+        config,
+        tools: [],
+        existingSessionId: resumeData?.acpSessionId,
+        skipInitialize: attached && Boolean(resumeData?.acpSessionId),
+        abortSignal: startOpts.abortSignal,
+      });
+
+      const state: AcpSessionState = {
+        acpSessionId,
+        instructionsApplied: resumeData?.instructionsApplied ?? false,
+        bridgePort,
+        bridgeToken,
+        channel,
+        proc,
+        rpc,
+        bridgeStateDir,
+        bootstrapDir,
+        attached,
+      };
+
+      return createAcpHarnessSession({
+        sessionId: startOpts.sessionId,
+        config,
+        state,
+        isResume,
+        modelId: settings.model,
+      });
+    },
+  };
+}
+
+export type { HarnessV1StreamPart };

--- a/packages/harness-acp/src/index.ts
+++ b/packages/harness-acp/src/index.ts
@@ -1,0 +1,5 @@
+export { createAcpHarness } from "./create-acp-harness.js";
+export type { AcpHarnessSettings } from "./create-acp-harness.js";
+export { acpBridgeBootstrapFiles, ACP_BRIDGE_INSTALL_COMMANDS } from "./acp-bootstrap.js";
+export type { AcpHarnessConfig, AcpRpcHandlerRegistration } from "./acp-session.js";
+export { VERSION } from "./version.js";

--- a/packages/harness-acp/src/ndjson-rpc.ts
+++ b/packages/harness-acp/src/ndjson-rpc.ts
@@ -1,0 +1,170 @@
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id?: number;
+  result?: unknown;
+  error?: { code?: number; message?: string; data?: unknown };
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse | JsonRpcNotification;
+
+export interface NdjsonTransport {
+  send(message: JsonRpcMessage): Promise<void>;
+  onMessage(handler: (message: JsonRpcMessage) => void): () => void;
+  close(): Promise<void>;
+}
+
+type RequestHandler = (params: unknown, id: number) => Promise<unknown>;
+
+export class NdjsonRpcClient {
+  private nextId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+  private readonly notificationHandlers = new Map<
+    string,
+    Array<(params: unknown) => void | Promise<void>>
+  >();
+  private readonly requestHandlers = new Map<string, RequestHandler>();
+
+  constructor(private readonly transport: NdjsonTransport) {
+    this.transport.onMessage((message) => {
+      void this.handleMessage(message);
+    });
+  }
+
+  onNotification(method: string, handler: (params: unknown) => void | Promise<void>): () => void {
+    const handlers = this.notificationHandlers.get(method) ?? [];
+    handlers.push(handler);
+    this.notificationHandlers.set(method, handlers);
+    return () => {
+      const current = this.notificationHandlers.get(method) ?? [];
+      this.notificationHandlers.set(
+        method,
+        current.filter((entry) => entry !== handler),
+      );
+    };
+  }
+
+  onRequest(method: string, handler: RequestHandler): () => void {
+    this.requestHandlers.set(method, handler);
+    return () => {
+      this.requestHandlers.delete(method);
+    };
+  }
+
+  async request(method: string, params?: unknown, timeoutMs = 120_000): Promise<unknown> {
+    const id = this.nextId++;
+    const payload: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+
+      void this.transport.send(payload).catch((error) => {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async notify(method: string, params?: unknown): Promise<void> {
+    await this.transport.send({ jsonrpc: "2.0", method, params });
+  }
+
+  respond(id: number, result: unknown): Promise<void> {
+    return this.transport.send({ jsonrpc: "2.0", id, result });
+  }
+
+  respondError(id: number, message: string): Promise<void> {
+    return this.transport.send({
+      jsonrpc: "2.0",
+      id,
+      error: { message },
+    });
+  }
+
+  async close(): Promise<void> {
+    for (const [, pending] of this.pending) {
+      pending.reject(new Error("RPC client closed"));
+    }
+    this.pending.clear();
+    await this.transport.close();
+  }
+
+  private async handleMessage(message: JsonRpcMessage): Promise<void> {
+    if (
+      "method" in message &&
+      message.method &&
+      "id" in message &&
+      typeof message.id === "number"
+    ) {
+      const handler = this.requestHandlers.get(message.method);
+      if (handler) {
+        try {
+          const result = await handler(message.params, message.id);
+          await this.respond(message.id, result);
+        } catch (error) {
+          await this.respondError(
+            message.id,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      }
+      return;
+    }
+
+    if ("method" in message && message.method && !("id" in message)) {
+      const handlers = this.notificationHandlers.get(message.method) ?? [];
+      for (const handler of handlers) {
+        await handler(message.params);
+      }
+      return;
+    }
+
+    if (!("id" in message) || typeof message.id !== "number") return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+
+    if ("error" in message && message.error) {
+      pending.reject(new Error(message.error.message ?? JSON.stringify(message.error)));
+      return;
+    }
+
+    pending.resolve("result" in message ? (message.result ?? {}) : {});
+  }
+}
+
+export function parseNdjsonLine(line: string): JsonRpcMessage | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  return JSON.parse(trimmed) as JsonRpcMessage;
+}

--- a/packages/harness-acp/src/stream-mapper.test.ts
+++ b/packages/harness-acp/src/stream-mapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  closeTextStream,
+  createAcpStreamMapperState,
+  finishStream,
+  mapSessionUpdate,
+} from "./stream-mapper.js";
+
+describe("mapSessionUpdate", () => {
+  it("maps agent_message_chunk to text stream parts", () => {
+    const state = createAcpStreamMapperState();
+    const parts = mapSessionUpdate(state, {
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { text: "Hello" },
+      },
+    });
+
+    expect(parts).toEqual([
+      { type: "text-start", id: "assistant-text" },
+      { type: "text-delta", id: "assistant-text", delta: "Hello" },
+    ]);
+    expect(state.textOpen).toBe(true);
+  });
+
+  it("maps tool_call updates", () => {
+    const state = createAcpStreamMapperState();
+    const parts = mapSessionUpdate(state, {
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-1",
+        toolName: "bash",
+        input: { command: "ls" },
+      },
+    });
+
+    expect(parts).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "tc-1",
+        toolName: "bash",
+        input: JSON.stringify({ command: "ls" }),
+      },
+    ]);
+  });
+});
+
+describe("closeTextStream", () => {
+  it("emits text-end when stream was open", () => {
+    const state = createAcpStreamMapperState();
+    state.textOpen = true;
+    expect(closeTextStream(state)).toEqual([{ type: "text-end", id: "assistant-text" }]);
+    expect(state.textOpen).toBe(false);
+  });
+});
+
+describe("finishStream", () => {
+  it("returns a finish part", () => {
+    expect(finishStream()[0]?.type).toBe("finish");
+  });
+});

--- a/packages/harness-acp/src/stream-mapper.ts
+++ b/packages/harness-acp/src/stream-mapper.ts
@@ -1,0 +1,98 @@
+import type { HarnessV1StreamPart, HarnessV1ToolSpec } from "@ai-sdk/harness";
+
+export interface AcpStreamMapperState {
+  textId: string;
+  textOpen: boolean;
+  assistantText: string;
+}
+
+export function createAcpStreamMapperState(): AcpStreamMapperState {
+  return {
+    textId: "assistant-text",
+    textOpen: false,
+    assistantText: "",
+  };
+}
+
+export function mapSessionUpdate(
+  state: AcpStreamMapperState,
+  params: unknown,
+): HarnessV1StreamPart[] {
+  const update = (params as { update?: Record<string, unknown> } | undefined)?.update;
+  if (!update) return [];
+
+  const sessionUpdate = update.sessionUpdate;
+  if (sessionUpdate === "agent_message_chunk") {
+    const content = update.content as { text?: string } | undefined;
+    const delta = content?.text ?? "";
+    if (!delta) return [];
+
+    state.assistantText += delta;
+    const parts: HarnessV1StreamPart[] = [];
+    if (!state.textOpen) {
+      state.textOpen = true;
+      parts.push({ type: "text-start", id: state.textId });
+    }
+    parts.push({ type: "text-delta", id: state.textId, delta });
+    return parts;
+  }
+
+  if (sessionUpdate === "tool_call") {
+    const toolCall = update as {
+      toolCallId?: string;
+      toolName?: string;
+      input?: unknown;
+    };
+    if (!toolCall.toolCallId || !toolCall.toolName) return [];
+    return [
+      {
+        type: "tool-call",
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        input:
+          typeof toolCall.input === "string"
+            ? toolCall.input
+            : JSON.stringify(toolCall.input ?? {}),
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function closeTextStream(state: AcpStreamMapperState): HarnessV1StreamPart[] {
+  if (!state.textOpen) return [];
+  state.textOpen = false;
+  return [{ type: "text-end", id: state.textId }];
+}
+
+export function finishStream(): HarnessV1StreamPart[] {
+  return [
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: undefined },
+      totalUsage: {
+        inputTokens: {
+          total: undefined,
+          noCache: undefined,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+      },
+    },
+  ];
+}
+
+export function toolSpecsToMcpServers(tools: ReadonlyArray<HarnessV1ToolSpec>): unknown[] {
+  if (tools.length === 0) return [];
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  }));
+}
+
+export function hostToolNames(tools: ReadonlyArray<HarnessV1ToolSpec>): Set<string> {
+  return new Set(tools.map((tool) => tool.name));
+}

--- a/packages/harness-acp/src/version.ts
+++ b/packages/harness-acp/src/version.ts
@@ -1,0 +1,4 @@
+declare const __PACKAGE_VERSION__: string | undefined;
+
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== "undefined" ? __PACKAGE_VERSION__ : "0.0.0-test";

--- a/packages/harness-acp/src/ws-rpc-transport.ts
+++ b/packages/harness-acp/src/ws-rpc-transport.ts
@@ -1,0 +1,57 @@
+import type { JsonRpcMessage, NdjsonTransport } from "./ndjson-rpc.js";
+import { parseNdjsonLine } from "./ndjson-rpc.js";
+import type { AcpBridgeChannel } from "./acp-bridge.js";
+
+export class WsAcpRpcTransport implements NdjsonTransport {
+  private readonly messageHandlers = new Set<(message: JsonRpcMessage) => void>();
+  private offRpcLine: (() => void) | undefined;
+  private onParentAbort: (() => void) | undefined;
+
+  constructor(
+    private readonly channel: AcpBridgeChannel,
+    private readonly abortSignal?: AbortSignal,
+  ) {}
+
+  async connect(opts?: { resume?: boolean }): Promise<void> {
+    if (this.abortSignal) {
+      this.onParentAbort = () => {
+        this.channel.beginClose();
+        void this.channel.close();
+      };
+      this.abortSignal.addEventListener("abort", this.onParentAbort, { once: true });
+    }
+
+    this.offRpcLine = this.channel.on("rpc-line", (event) => {
+      const message = parseNdjsonLine(event.line);
+      if (!message) return;
+      for (const handler of this.messageHandlers) {
+        handler(message);
+      }
+    });
+
+    await this.channel.open(opts?.resume ? { resume: true } : undefined);
+  }
+
+  onMessage(handler: (message: JsonRpcMessage) => void): () => void {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  async send(message: JsonRpcMessage): Promise<void> {
+    this.channel.send({
+      type: "rpc-send",
+      line: JSON.stringify(message),
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.abortSignal && this.onParentAbort) {
+      this.abortSignal.removeEventListener("abort", this.onParentAbort);
+      this.onParentAbort = undefined;
+    }
+    this.offRpcLine?.();
+    this.messageHandlers.clear();
+    this.channel.beginClose();
+    await this.channel.close();
+  }
+}

--- a/packages/harness-acp/tsconfig.build.json
+++ b/packages/harness-acp/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/harness-acp/tsconfig.build.json
+++ b/packages/harness-acp/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false
-  },
-  "exclude": ["src/**/*.test.ts"]
+    "composite": false
+  }
 }

--- a/packages/harness-acp/tsconfig.json
+++ b/packages/harness-acp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/harness-acp/tsconfig.json
+++ b/packages/harness-acp/tsconfig.json
@@ -1,15 +1,18 @@
 {
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "outDir": "dist",
+    "composite": true,
     "rootDir": "src",
-    "noEmit": true
+    "outDir": "dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    { "path": "../harness" },
+    { "path": "../provider-utils" }
+  ]
 }

--- a/packages/harness-acp/tsup.config.ts
+++ b/packages/harness-acp/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+const packageVersion = JSON.stringify(
+  (await import("./package.json", { with: { type: "json" } })).default.version,
+);
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  target: "es2022",
+  dts: true,
+  sourcemap: true,
+  define: {
+    __PACKAGE_VERSION__: packageVersion,
+  },
+});

--- a/packages/harness-acp/turbo.json
+++ b/packages/harness-acp/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/harness-acp/vitest.node.config.js
+++ b/packages/harness-acp/vitest.node.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+  },
+});

--- a/packages/harness-cursor/CHANGELOG.md
+++ b/packages/harness-cursor/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ai-sdk/harness-cursor
+
+## 1.0.0
+
+### Minor Changes
+
+- Initial release: Cursor sandbox harness via `agent acp` (ACP stdio)

--- a/packages/harness-cursor/README.md
+++ b/packages/harness-cursor/README.md
@@ -1,15 +1,13 @@
-# @akvilander/ai-sdk-harness-cursor
+# @ai-sdk/harness-cursor
 
 Cursor sandbox harness for AI SDK `HarnessAgent` via `agent acp` (ACP stdio).
-
-Upstream target: `@ai-sdk/harness-cursor`.
 
 **Note:** Cursor Cloud (`@cursor/sdk`) is not covered — use a separate SDK-style adapter.
 
 ## Setup
 
 ```bash
-pnpm add @akvilander/ai-sdk-harness-cursor @ai-sdk/harness @ai-sdk/sandbox-vercel
+pnpm add @ai-sdk/harness-cursor @ai-sdk/harness @ai-sdk/sandbox-vercel
 ```
 
 Requires `CURSOR_API_KEY` and `VERCEL_OIDC_TOKEN` for sandbox.
@@ -18,7 +16,7 @@ Requires `CURSOR_API_KEY` and `VERCEL_OIDC_TOKEN` for sandbox.
 
 ```ts
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { cursor } from '@akvilander/ai-sdk-harness-cursor';
+import { cursor } from '@ai-sdk/harness-cursor';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 
 const agent = new HarnessAgent({

--- a/packages/harness-cursor/README.md
+++ b/packages/harness-cursor/README.md
@@ -1,0 +1,39 @@
+# @akvilander/ai-sdk-harness-cursor
+
+Cursor sandbox harness for AI SDK `HarnessAgent` via `agent acp` (ACP stdio).
+
+Upstream target: `@ai-sdk/harness-cursor`.
+
+**Note:** Cursor Cloud (`@cursor/sdk`) is not covered — use a separate SDK-style adapter.
+
+## Setup
+
+```bash
+pnpm add @akvilander/ai-sdk-harness-cursor @ai-sdk/harness @ai-sdk/sandbox-vercel
+```
+
+Requires `CURSOR_API_KEY` and `VERCEL_OIDC_TOKEN` for sandbox.
+
+## Usage
+
+```ts
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { cursor } from '@akvilander/ai-sdk-harness-cursor';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const agent = new HarnessAgent({
+  harness: cursor,
+  sandbox: createVercelSandbox({ runtime: 'node24', ports: [4000] }),
+});
+```
+
+## Cursor ACP extensions
+
+```ts
+createCursor({
+  onAskQuestion: async (question) => {
+    // Host app collects user input
+    throw new Error(`Need answer: ${question}`);
+  },
+});
+```

--- a/packages/harness-cursor/package.json
+++ b/packages/harness-cursor/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@ai-sdk/harness-cursor",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:node": "vitest --config vitest.node.config.js --run --passWithNoTests"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/harness": "workspace:*",
+    "@ai-sdk/harness-acp": "workspace:*"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "del-cli": "^6.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "vitest": "^3.2.4",
+    "zod": "3.25.76"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/harness-cursor"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "harness",
+    "cursor"
+  ]
+}

--- a/packages/harness-cursor/package.json
+++ b/packages/harness-cursor/package.json
@@ -10,6 +10,11 @@
   "files": [
     "dist/**/*",
     "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {
@@ -39,10 +44,8 @@
   "devDependencies": {
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
-    "del-cli": "^6.0.0",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
-    "vitest": "^3.2.4",
     "zod": "3.25.76"
   },
   "engines": {

--- a/packages/harness-cursor/src/cursor-acp-extensions.ts
+++ b/packages/harness-cursor/src/cursor-acp-extensions.ts
@@ -1,0 +1,41 @@
+import type { AcpRpcHandlerRegistration } from "@ai-sdk/harness-acp";
+
+export type CursorAcpExtensionSettings = {
+  /**
+   * Called when Cursor sends `cursor/ask_question` over ACP.
+   * Return a user answer string, or throw to cancel the question flow.
+   */
+  readonly onAskQuestion?: (question: string) => Promise<string>;
+};
+
+export function createCursorAcpExtensions(
+  settings: CursorAcpExtensionSettings = {},
+): AcpRpcHandlerRegistration {
+  return (rpc) => {
+    const offAskQuestion = rpc.onRequest("cursor/ask_question", async (params) => {
+      const request = params as {
+        questions?: Array<{ id?: string; prompt?: string; options?: Array<{ label?: string }> }>;
+      };
+      const firstQuestion = request.questions?.[0];
+      const questionText =
+        firstQuestion?.prompt ??
+        firstQuestion?.options?.map((option) => option.label).join(", ") ??
+        "Need user input";
+
+      if (settings.onAskQuestion) {
+        await settings.onAskQuestion(questionText);
+      }
+
+      return { outcome: { outcome: "cancelled" } };
+    });
+
+    const offCreatePlan = rpc.onRequest("cursor/create_plan", async () => ({
+      outcome: { outcome: "accepted" },
+    }));
+
+    return () => {
+      offAskQuestion();
+      offCreatePlan();
+    };
+  };
+}

--- a/packages/harness-cursor/src/cursor-auth.ts
+++ b/packages/harness-cursor/src/cursor-auth.ts
@@ -1,0 +1,13 @@
+export type CursorAuthOptions = {
+  readonly apiKey?: string;
+};
+
+export function resolveCursorEnv(auth?: CursorAuthOptions): Record<string, string> {
+  const apiKey = auth?.apiKey ?? process.env.CURSOR_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Cursor harness requires CURSOR_API_KEY (env) or createCursor({ auth: { apiKey } }).",
+    );
+  }
+  return { CURSOR_API_KEY: apiKey };
+}

--- a/packages/harness-cursor/src/cursor-bootstrap.ts
+++ b/packages/harness-cursor/src/cursor-bootstrap.ts
@@ -1,0 +1,24 @@
+import type { HarnessV1Bootstrap } from "@ai-sdk/harness";
+import {
+  acpBridgeBootstrapFiles,
+  ACP_BRIDGE_INSTALL_COMMANDS,
+} from "@ai-sdk/harness-acp";
+
+const BOOTSTRAP_DIR = "/tmp/harness/cursor";
+
+export async function getCursorBootstrap(): Promise<HarnessV1Bootstrap> {
+  const bridgeFiles = await acpBridgeBootstrapFiles(BOOTSTRAP_DIR);
+  return {
+    harnessId: "cursor",
+    bootstrapDir: BOOTSTRAP_DIR,
+    files: bridgeFiles,
+    commands: [
+      ...ACP_BRIDGE_INSTALL_COMMANDS(BOOTSTRAP_DIR),
+      {
+        command:
+          "command -v agent >/dev/null 2>&1 || curl -fsSL https://cursor.com/install | bash",
+      },
+      { command: "agent --version || agent --help" },
+    ],
+  };
+}

--- a/packages/harness-cursor/src/cursor-harness.ts
+++ b/packages/harness-cursor/src/cursor-harness.ts
@@ -1,0 +1,29 @@
+import { createAcpHarness } from "@ai-sdk/harness-acp";
+import type { HarnessV1 } from "@ai-sdk/harness";
+
+import { createCursorAcpExtensions, type CursorAcpExtensionSettings } from "./cursor-acp-extensions.js";
+import { getCursorBootstrap } from "./cursor-bootstrap.js";
+import { resolveCursorEnv, type CursorAuthOptions } from "./cursor-auth.js";
+
+const DEFAULT_CURSOR_MODEL = "default";
+
+export type CursorHarnessSettings = CursorAcpExtensionSettings & {
+  readonly auth?: CursorAuthOptions;
+  readonly model?: string;
+  readonly startupTimeoutMs?: number;
+};
+
+export function createCursor(settings: CursorHarnessSettings = {}): HarnessV1 {
+  const env = resolveCursorEnv(settings.auth);
+
+  return createAcpHarness({
+    harnessId: "cursor",
+    getBootstrap: getCursorBootstrap,
+    command: "agent acp",
+    authMethodId: "cursor_login",
+    model: settings.model ?? DEFAULT_CURSOR_MODEL,
+    env,
+    startupTimeoutMs: settings.startupTimeoutMs,
+    registerRpcHandlers: createCursorAcpExtensions(settings),
+  });
+}

--- a/packages/harness-cursor/src/index.ts
+++ b/packages/harness-cursor/src/index.ts
@@ -1,0 +1,9 @@
+import { createCursor } from "./cursor-harness.js";
+
+export const cursor = createCursor();
+
+export { createCursor } from "./cursor-harness.js";
+export type { CursorHarnessSettings } from "./cursor-harness.js";
+export type { CursorAuthOptions } from "./cursor-auth.js";
+export type { CursorAcpExtensionSettings } from "./cursor-acp-extensions.js";
+export { VERSION } from "./version.js";

--- a/packages/harness-cursor/src/version.ts
+++ b/packages/harness-cursor/src/version.ts
@@ -1,0 +1,4 @@
+declare const __PACKAGE_VERSION__: string | undefined;
+
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== "undefined" ? __PACKAGE_VERSION__ : "0.0.0-test";

--- a/packages/harness-cursor/tsconfig.build.json
+++ b/packages/harness-cursor/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/harness-cursor/tsconfig.build.json
+++ b/packages/harness-cursor/tsconfig.build.json
@@ -1,9 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "composite": false
   }
 }

--- a/packages/harness-cursor/tsconfig.json
+++ b/packages/harness-cursor/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/harness-cursor/tsconfig.json
+++ b/packages/harness-cursor/tsconfig.json
@@ -1,11 +1,18 @@
 {
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "skipLibCheck": true,
-    "noEmit": true
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
   },
-  "include": ["src/**/*.ts"]
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    { "path": "../harness" },
+    { "path": "../harness-acp" }
+  ]
 }

--- a/packages/harness-cursor/tsup.config.ts
+++ b/packages/harness-cursor/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+const packageVersion = JSON.stringify(
+  (await import("./package.json", { with: { type: "json" } })).default.version,
+);
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  target: "es2022",
+  dts: true,
+  sourcemap: true,
+  define: {
+    __PACKAGE_VERSION__: packageVersion,
+  },
+});

--- a/packages/harness-cursor/turbo.json
+++ b/packages/harness-cursor/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/harness-cursor/vitest.node.config.js
+++ b/packages/harness-cursor/vitest.node.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+  },
+});

--- a/packages/harness-grok/CHANGELOG.md
+++ b/packages/harness-grok/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ai-sdk/harness-grok
+
+## 1.0.0
+
+### Minor Changes
+
+- Initial release: Grok Build harness via `grok agent stdio` (ACP) with API key and OAuth helpers

--- a/packages/harness-grok/README.md
+++ b/packages/harness-grok/README.md
@@ -1,0 +1,39 @@
+# @akvilander/ai-sdk-harness-grok
+
+Grok Build harness for AI SDK `HarnessAgent` via `grok agent stdio` (ACP).
+
+Upstream target: `@ai-sdk/harness-grok`.
+
+## Setup
+
+```bash
+pnpm add @akvilander/ai-sdk-harness-grok @ai-sdk/harness @ai-sdk/sandbox-vercel
+```
+
+## Usage
+
+```ts
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { grok } from '@akvilander/ai-sdk-harness-grok';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const agent = new HarnessAgent({
+  harness: grok,
+  sandbox: createVercelSandbox({ runtime: 'node24', ports: [4000] }),
+});
+```
+
+## Authentication
+
+- `XAI_API_KEY` — headless API key auth (`xai.api_key`)
+- Without API key — OAuth (`xai.oauth`); run device login in `sandboxConfig.onSession` before the first turn
+
+## Settings
+
+```ts
+createGrok({
+  model: 'grok-build-0.1',
+  auth: { apiKey: process.env.XAI_API_KEY },
+  startupTimeoutMs: 120_000,
+});
+```

--- a/packages/harness-grok/README.md
+++ b/packages/harness-grok/README.md
@@ -25,8 +25,35 @@ const agent = new HarnessAgent({
 
 ## Authentication
 
-- `XAI_API_KEY` — headless API key auth (`xai.api_key`)
-- Without API key — OAuth (`xai.oauth`); run device login in `sandboxConfig.onSession` before the first turn
+Both paths are supported:
+
+| Path | Host env | ACP auth | Sandbox setup |
+|------|----------|----------|---------------|
+| **API key** | `XAI_API_KEY` | `xai.api_key` | Key forwarded into sandbox automatically |
+| **OAuth** | omit `XAI_API_KEY` | `xai.oauth` | `ensureGrokSandboxOAuth()` in `sandboxConfig.onSession` |
+
+### API key (headless / CI)
+
+```ts
+createGrok({ auth: { apiKey: process.env.XAI_API_KEY } });
+```
+
+### OAuth (interactive)
+
+```ts
+import { ensureGrokSandboxOAuth } from '@akvilander/ai-sdk-harness-grok';
+
+const agent = new HarnessAgent({
+  harness: createGrok(), // no auth → xai.oauth
+  sandbox,
+  sandboxConfig: {
+    onSession: async ({ session, sessionWorkDir }) => {
+      const oauth = await ensureGrokSandboxOAuth({ session, sessionWorkDir });
+      if (!oauth.ready) throw new Error(oauth.question); // contains device login URL
+    },
+  },
+});
+```
 
 ## Settings
 

--- a/packages/harness-grok/README.md
+++ b/packages/harness-grok/README.md
@@ -1,20 +1,18 @@
-# @akvilander/ai-sdk-harness-grok
+# @ai-sdk/harness-grok
 
 Grok Build harness for AI SDK `HarnessAgent` via `grok agent stdio` (ACP).
-
-Upstream target: `@ai-sdk/harness-grok`.
 
 ## Setup
 
 ```bash
-pnpm add @akvilander/ai-sdk-harness-grok @ai-sdk/harness @ai-sdk/sandbox-vercel
+pnpm add @ai-sdk/harness-grok @ai-sdk/harness @ai-sdk/sandbox-vercel
 ```
 
 ## Usage
 
 ```ts
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grok } from '@akvilander/ai-sdk-harness-grok';
+import { grok } from '@ai-sdk/harness-grok';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 
 const agent = new HarnessAgent({
@@ -41,7 +39,7 @@ createGrok({ auth: { apiKey: process.env.XAI_API_KEY } });
 ### OAuth (interactive)
 
 ```ts
-import { ensureGrokSandboxOAuth } from '@akvilander/ai-sdk-harness-grok';
+import { ensureGrokSandboxOAuth } from '@ai-sdk/harness-grok';
 
 const agent = new HarnessAgent({
   harness: createGrok(), // no auth → xai.oauth

--- a/packages/harness-grok/package.json
+++ b/packages/harness-grok/package.json
@@ -1,23 +1,33 @@
 {
-  "name": "@akvilander/ai-sdk-harness-grok",
-  "version": "0.1.0",
+  "name": "@ai-sdk/harness-grok",
+  "version": "1.0.0",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
   "files": [
     "dist/**/*",
     "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
-    "clean": "rm -rf dist",
-    "type-check": "tsc --noEmit",
-    "test": "vitest --config vitest.node.config.js --run"
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:node": "vitest --config vitest.node.config.js --run"
   },
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
@@ -25,27 +35,35 @@
     }
   },
   "dependencies": {
-    "@akvilander/ai-sdk-harness-acp": "workspace:*",
-    "@ai-sdk/harness": "^1.0.18",
-    "@ai-sdk/provider-utils": "^5.0.5"
+    "@ai-sdk/harness": "workspace:*",
+    "@ai-sdk/harness-acp": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
   },
   "peerDependencies": {
     "zod": "^3.25.76 || ^4.1.8"
   },
   "devDependencies": {
-    "@types/node": "^22.19.19",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",
-    "typescript": "^5.8.3",
-    "vitest": "^3.2.4",
-    "zod": "^4.1.8"
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
   },
   "engines": {
     "node": ">=22"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/akvilander/ai-sdk-harnesses",
+    "url": "https://github.com/vercel/ai",
     "directory": "packages/harness-grok"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
   },
   "keywords": [
     "ai",

--- a/packages/harness-grok/package.json
+++ b/packages/harness-grok/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@ai-sdk/harness-grok",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:node": "vitest --config vitest.node.config.js --run --passWithNoTests"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/harness": "workspace:*",
+    "@ai-sdk/harness-acp": "workspace:*"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "del-cli": "^6.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "vitest": "^3.2.4",
+    "zod": "3.25.76"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/harness-grok"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "harness",
+    "grok",
+    "xai"
+  ]
+}

--- a/packages/harness-grok/package.json
+++ b/packages/harness-grok/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "@ai-sdk/harness-grok",
-  "version": "1.0.0",
+  "name": "@akvilander/ai-sdk-harness-grok",
+  "version": "0.1.0",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "source": "./src/index.ts",
   "files": [
     "dist/**/*",
     "src",
@@ -14,15 +13,11 @@
   ],
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
-    "build:watch": "pnpm clean && tsup --watch",
-    "clean": "del-cli dist *.tsbuildinfo",
-    "type-check": "tsc --build",
-    "test": "pnpm test:node",
-    "test:watch": "vitest --config vitest.node.config.js",
-    "test:node": "vitest --config vitest.node.config.js --run --passWithNoTests"
+    "clean": "rm -rf dist",
+    "type-check": "tsc --noEmit",
+    "test": "vitest --config vitest.node.config.js --run"
   },
   "exports": {
-    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
@@ -30,36 +25,27 @@
     }
   },
   "dependencies": {
-    "@ai-sdk/harness": "workspace:*",
-    "@ai-sdk/harness-acp": "workspace:*"
+    "@akvilander/ai-sdk-harness-acp": "workspace:*",
+    "@ai-sdk/harness": "^1.0.18",
+    "@ai-sdk/provider-utils": "^5.0.5"
   },
   "peerDependencies": {
     "zod": "^3.25.76 || ^4.1.8"
   },
   "devDependencies": {
-    "@types/node": "22.19.19",
-    "@vercel/ai-tsconfig": "workspace:*",
-    "del-cli": "^6.0.0",
+    "@types/node": "^22.19.19",
     "tsup": "^8.5.1",
-    "typescript": "5.8.3",
+    "typescript": "^5.8.3",
     "vitest": "^3.2.4",
-    "zod": "3.25.76"
+    "zod": "^4.1.8"
   },
   "engines": {
     "node": ">=22"
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
-  "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/vercel/ai",
+    "url": "https://github.com/akvilander/ai-sdk-harnesses",
     "directory": "packages/harness-grok"
-  },
-  "bugs": {
-    "url": "https://github.com/vercel/ai/issues"
   },
   "keywords": [
     "ai",

--- a/packages/harness-grok/src/grok-auth.test.ts
+++ b/packages/harness-grok/src/grok-auth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGrokDeviceLoginOutput } from "./grok-oauth.js";
+import { resolveGrokAuthMethodId, resolveGrokEnv } from "./grok-auth.js";
+
+describe("resolveGrokAuthMethodId", () => {
+  it("uses api_key when XAI_API_KEY is set", () => {
+    expect(resolveGrokAuthMethodId({ apiKey: "xai-test" })).toBe("xai.api_key");
+  });
+
+  it("uses oauth when no api key", () => {
+    expect(resolveGrokAuthMethodId({})).toBe("xai.oauth");
+  });
+});
+
+describe("resolveGrokEnv", () => {
+  it("forwards api key to sandbox env", () => {
+    expect(resolveGrokEnv({ apiKey: "secret" })).toEqual({ XAI_API_KEY: "secret" });
+  });
+
+  it("returns empty env for oauth mode", () => {
+    expect(resolveGrokEnv({})).toEqual({});
+  });
+});
+
+describe("parseGrokDeviceLoginOutput", () => {
+  it("parses device login URL and code", () => {
+    const parsed = parseGrokDeviceLoginOutput(
+      "Visit https://x.ai/oauth/device?code=ABC-123\nEnter code: ABC-123",
+    );
+    expect(parsed?.url).toContain("https://x.ai/oauth");
+    expect(parsed?.userCode).toBe("ABC-123");
+  });
+});

--- a/packages/harness-grok/src/grok-auth.ts
+++ b/packages/harness-grok/src/grok-auth.ts
@@ -1,0 +1,14 @@
+export type GrokAuthOptions = {
+  readonly apiKey?: string;
+};
+
+export function resolveGrokEnv(auth?: GrokAuthOptions): Record<string, string> {
+  const apiKey = auth?.apiKey ?? process.env.XAI_API_KEY;
+  if (!apiKey) return {};
+  return { XAI_API_KEY: apiKey };
+}
+
+export function resolveGrokAuthMethodId(auth?: GrokAuthOptions): "xai.api_key" | "xai.oauth" {
+  const apiKey = auth?.apiKey ?? process.env.XAI_API_KEY;
+  return apiKey ? "xai.api_key" : "xai.oauth";
+}

--- a/packages/harness-grok/src/grok-bootstrap.ts
+++ b/packages/harness-grok/src/grok-bootstrap.ts
@@ -1,0 +1,28 @@
+import type { HarnessV1Bootstrap } from "@ai-sdk/harness";
+import {
+  acpBridgeBootstrapFiles,
+  ACP_BRIDGE_INSTALL_COMMANDS,
+} from "@ai-sdk/harness-acp";
+
+const BOOTSTRAP_DIR = "/tmp/harness/grok";
+const GROK_BIN_DIR = `${BOOTSTRAP_DIR}/bin`;
+export const GROK_CLI = `${GROK_BIN_DIR}/grok`;
+
+export async function getGrokBootstrap(): Promise<HarnessV1Bootstrap> {
+  const bridgeFiles = await acpBridgeBootstrapFiles(BOOTSTRAP_DIR);
+  return {
+    harnessId: "grok",
+    bootstrapDir: BOOTSTRAP_DIR,
+    files: bridgeFiles,
+    commands: [
+      ...ACP_BRIDGE_INSTALL_COMMANDS(BOOTSTRAP_DIR),
+      {
+        command: [
+          `mkdir -p ${GROK_BIN_DIR}`,
+          `test -x ${GROK_CLI} || (export GROK_BIN_DIR=${GROK_BIN_DIR} && curl -fsSL https://x.ai/cli/install.sh | bash)`,
+        ].join(" && "),
+      },
+      { command: `${GROK_CLI} --version || ${GROK_CLI} --help` },
+    ],
+  };
+}

--- a/packages/harness-grok/src/grok-harness.ts
+++ b/packages/harness-grok/src/grok-harness.ts
@@ -1,0 +1,35 @@
+import { createAcpHarness } from "@ai-sdk/harness-acp";
+import type { HarnessV1 } from "@ai-sdk/harness";
+
+import { getGrokBootstrap, GROK_CLI } from "./grok-bootstrap.js";
+import {
+  resolveGrokAuthMethodId,
+  resolveGrokEnv,
+  type GrokAuthOptions,
+} from "./grok-auth.js";
+
+const DEFAULT_GROK_MODEL = "grok-build-0.1";
+
+export type GrokHarnessSettings = {
+  readonly auth?: GrokAuthOptions;
+  readonly model?: string;
+  readonly port?: number;
+  readonly startupTimeoutMs?: number;
+};
+
+export function createGrok(settings: GrokHarnessSettings = {}): HarnessV1 {
+  const authMethodId = resolveGrokAuthMethodId(settings.auth);
+  const env = resolveGrokEnv(settings.auth);
+  const hasApiKey = Boolean(env.XAI_API_KEY);
+
+  return createAcpHarness({
+    harnessId: "grok",
+    getBootstrap: getGrokBootstrap,
+    command: `${GROK_CLI} --no-auto-update agent stdio`,
+    authMethodId,
+    ...(hasApiKey ? { authMeta: { headless: true } } : {}),
+    model: settings.model ?? DEFAULT_GROK_MODEL,
+    ...(hasApiKey ? { env } : {}),
+    startupTimeoutMs: settings.startupTimeoutMs,
+  });
+}

--- a/packages/harness-grok/src/grok-oauth.ts
+++ b/packages/harness-grok/src/grok-oauth.ts
@@ -1,0 +1,83 @@
+import type { Experimental_SandboxSession } from "@ai-sdk/provider-utils";
+
+import { GROK_CLI } from "./grok-bootstrap.js";
+
+const URL_PATTERN = /https:\/\/[^\s"'<>]+/i;
+const USER_CODE_LINE = /(?:enter\s+)?code[:\s]+([A-Z0-9-]+)/i;
+
+export function parseGrokDeviceLoginOutput(
+  output: string,
+): { url: string; userCode?: string } | undefined {
+  const urlMatch = output.match(URL_PATTERN);
+  if (!urlMatch) return undefined;
+  const url = urlMatch[0].replace(/[.,)]+$/, "");
+  const codeMatch = output.match(USER_CODE_LINE);
+  const userCode = codeMatch?.[1];
+  return { url, userCode };
+}
+
+export function formatGrokLoginQuestion(parsed: { url: string; userCode?: string }): string {
+  const codeLine = parsed.userCode ? ` Code: ${parsed.userCode}.` : "";
+  return `Grok harness needs OAuth in the sandbox.${codeLine} Open ${parsed.url} — complete login, then retry.`;
+}
+
+export async function grokAuthFileExists(
+  session: Experimental_SandboxSession,
+  homeDir: string,
+): Promise<boolean> {
+  const result = (await session.run({
+    command: `test -f ${homeDir}/.grok/auth.json && echo ok`,
+    workingDirectory: homeDir,
+  })) as { exitCode?: number; stdout?: string };
+  return (result.stdout ?? "").includes("ok");
+}
+
+export async function runGrokDeviceLogin(input: {
+  session: Experimental_SandboxSession;
+  sessionWorkDir: string;
+  homeDir?: string;
+}): Promise<{ url: string; userCode?: string } | undefined> {
+  const home = input.homeDir ?? "/vercel/sandbox";
+  const result = (await input.session.run({
+    command: [
+      `export HOME=${home}`,
+      `mkdir -p ${home}/.grok`,
+      `timeout 120 ${GROK_CLI} login --device-auth 2>&1 || true`,
+    ].join(" && "),
+    workingDirectory: input.sessionWorkDir,
+    env: { HOME: home },
+  })) as { stdout?: string; stderr?: string };
+
+  return parseGrokDeviceLoginOutput(`${result.stdout ?? ""}\n${result.stderr ?? ""}`);
+}
+
+/**
+ * Ensure Grok OAuth credentials exist in the sandbox before the first harness turn.
+ * Use from `HarnessAgent` `sandboxConfig.onSession` when `XAI_API_KEY` is unset.
+ */
+export async function ensureGrokSandboxOAuth(input: {
+  session: Experimental_SandboxSession;
+  sessionWorkDir: string;
+  homeDir?: string;
+}): Promise<{ ready: true } | { ready: false; question: string }> {
+  const homeDir = input.homeDir ?? "/vercel/sandbox";
+  if (await grokAuthFileExists(input.session, homeDir)) {
+    return { ready: true };
+  }
+
+  const parsed = await runGrokDeviceLogin({
+    session: input.session,
+    sessionWorkDir: input.sessionWorkDir,
+    homeDir,
+  });
+
+  if (!parsed) {
+    return {
+      ready: false,
+      question:
+        "Could not start Grok device login in the sandbox. Set XAI_API_KEY on the host or retry OAuth.",
+    };
+  }
+
+  return { ready: false, question: formatGrokLoginQuestion(parsed) };
+}

--- a/packages/harness-grok/src/index.ts
+++ b/packages/harness-grok/src/index.ts
@@ -5,4 +5,11 @@ export const grok = createGrok();
 export { createGrok } from "./grok-harness.js";
 export type { GrokHarnessSettings } from "./grok-harness.js";
 export type { GrokAuthOptions } from "./grok-auth.js";
+export {
+  ensureGrokSandboxOAuth,
+  formatGrokLoginQuestion,
+  grokAuthFileExists,
+  parseGrokDeviceLoginOutput,
+  runGrokDeviceLogin,
+} from "./grok-oauth.js";
 export { VERSION } from "./version.js";

--- a/packages/harness-grok/src/index.ts
+++ b/packages/harness-grok/src/index.ts
@@ -1,0 +1,8 @@
+import { createGrok } from "./grok-harness.js";
+
+export const grok = createGrok();
+
+export { createGrok } from "./grok-harness.js";
+export type { GrokHarnessSettings } from "./grok-harness.js";
+export type { GrokAuthOptions } from "./grok-auth.js";
+export { VERSION } from "./version.js";

--- a/packages/harness-grok/src/version.ts
+++ b/packages/harness-grok/src/version.ts
@@ -1,0 +1,4 @@
+declare const __PACKAGE_VERSION__: string | undefined;
+
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== "undefined" ? __PACKAGE_VERSION__ : "0.0.0-test";

--- a/packages/harness-grok/tsconfig.build.json
+++ b/packages/harness-grok/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/harness-grok/tsconfig.build.json
+++ b/packages/harness-grok/tsconfig.build.json
@@ -1,9 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "composite": false
   }
 }

--- a/packages/harness-grok/tsconfig.json
+++ b/packages/harness-grok/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/harness-grok/tsconfig.json
+++ b/packages/harness-grok/tsconfig.json
@@ -1,11 +1,19 @@
 {
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "skipLibCheck": true,
-    "noEmit": true
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
   },
-  "include": ["src/**/*.ts"]
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    { "path": "../harness" },
+    { "path": "../harness-acp" },
+    { "path": "../provider-utils" }
+  ]
 }

--- a/packages/harness-grok/tsup.config.ts
+++ b/packages/harness-grok/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+const packageVersion = JSON.stringify(
+  (await import("./package.json", { with: { type: "json" } })).default.version,
+);
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  target: "es2022",
+  dts: true,
+  sourcemap: true,
+  define: {
+    __PACKAGE_VERSION__: packageVersion,
+  },
+});

--- a/packages/harness-grok/turbo.json
+++ b/packages/harness-grok/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/harness-grok/vitest.node.config.js
+++ b/packages/harness-grok/vitest.node.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2553,6 +2553,37 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/harness-acp:
+    dependencies:
+      '@ai-sdk/harness':
+        specifier: workspace:*
+        version: link:../harness
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/harness-claude-code:
     dependencies:
       '@ai-sdk/harness':
@@ -2627,6 +2658,31 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/harness-cursor:
+    dependencies:
+      '@ai-sdk/harness':
+        specifier: workspace:*
+        version: link:../harness
+      '@ai-sdk/harness-acp':
+        specifier: workspace:*
+        version: link:../harness-acp
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/harness-deepagents:
     dependencies:
       '@ai-sdk/harness':
@@ -2660,6 +2716,34 @@ importers:
       deepagents:
         specifier: 1.10.2
         version: 1.10.2(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0))(openai@6.38.0(ws@8.21.0)(zod@3.25.76))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.7)(vue@3.5.38(typescript@5.8.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/harness-grok:
+    dependencies:
+      '@ai-sdk/harness':
+        specifier: workspace:*
+        version: link:../harness
+      '@ai-sdk/harness-acp':
+        specifier: workspace:*
+        version: link:../harness-acp
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -79,13 +79,22 @@
       "path": "packages/groq"
     },
     {
+      "path": "packages/harness-acp"
+    },
+    {
       "path": "packages/harness-claude-code"
     },
     {
       "path": "packages/harness-codex"
     },
     {
+      "path": "packages/harness-cursor"
+    },
+    {
       "path": "packages/harness-deepagents"
+    },
+    {
+      "path": "packages/harness-grok"
     },
     {
       "path": "packages/harness-opencode"


### PR DESCRIPTION
## Summary

Adds three experimental harness adapters for ACP stdio agents in Vercel Sandbox:

- `@ai-sdk/harness-acp` — shared ACP bridge, session, and stream mapper
- `@ai-sdk/harness-grok` — Grok Build (`grok agent stdio`) with API key + OAuth helpers
- `@ai-sdk/harness-cursor` — Cursor sandbox (`agent acp`)

**RFC:** vercel/ai#16956

**Staging / prior art:** https://github.com/akvilander/ai-sdk-harnesses

## Reviewer guide

| Area | Files |
|------|-------|
| ACP foundation | `packages/harness-acp/src/*` |
| Grok adapter | `packages/harness-grok/src/*` |
| Cursor adapter | `packages/harness-cursor/src/*` |
| Docs | `content/providers/02-ai-sdk-harnesses/06-grok.mdx`, `07-cursor.mdx` |
| Adapter index | `content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx` |

Architecture: `HarnessAgent` → thin adapter → `createAcpHarness` → sandbox WS bridge → ACP stdio CLI.

## Verification

```bash
pnpm install --filter @ai-sdk/harness-acp... --filter @ai-sdk/harness-grok... --filter @ai-sdk/harness-cursor...
pnpm --filter @ai-sdk/harness-acp... build
pnpm --filter @ai-sdk/harness-acp test
pnpm --filter @ai-sdk/harness-grok test
```

- harness-acp: 4 tests (stream-mapper)
- harness-grok: 5 tests (grok-auth)
- Live smoke (staging repo): Grok `pong` via Vercel Sandbox in ~30s (API key)

## Known limitations / follow-ups

- No replay/rerun resume ladder (codex parity) — attach-or-respawn only
- Cursor Cloud (`@cursor/sdk`) out of scope — separate host adapter
- OAuth documented via `sandboxConfig.onSession` + `ensureGrokSandboxOAuth()`

## Changeset

`.changeset/harness-acp-grok-cursor.md` — minor for all three new packages.