### PR TITLE
feat(langchain): restore UI messages from LangChain history

### DIFF
--- a/.changeset/langchain-ui-message-restore.md
+++ b/.changeset/langchain-ui-message-restore.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+feat(langchain): add helpers to restore AI SDK UI messages from LangChain messages and LangGraph state snapshots.
+
+The new `baseMessagesToUIMessages` helper converts LangChain message history back
+to AI SDK `UIMessage` objects, including tool calls and matching tool results.
+The new `stateSnapshotToUIMessages` helper reads LangGraph snapshots and restores
+pending human-in-the-loop tool approvals from snapshot interrupts.

--- a/content/providers/06-adapters/01-langchain.mdx
+++ b/content/providers/06-adapters/01-langchain.mdx
@@ -35,6 +35,8 @@ enabling you to use LangChain models and LangGraph agents with AI SDK UI compone
 ## Features
 
 - Convert AI SDK `UIMessage` to LangChain `BaseMessage` format using `toBaseMessages`
+- Restore AI SDK `UIMessage` objects from LangChain `BaseMessage` history using `baseMessagesToUIMessages`
+- Restore chat history from LangGraph `StateSnapshot` objects using `stateSnapshotToUIMessages`
 - Transform LangChain/LangGraph streams to AI SDK `UIMessageStream` using `toUIMessageStream`
 - Support for `streamEvents()` output for granular event streaming and observability
 - `LangSmithDeploymentTransport` for connecting directly to a deployed LangGraph graph
@@ -471,6 +473,43 @@ const langchainMessages = convertModelMessages(modelMessages);
 - `modelMessages`: `ModelMessage[]` - Array of model messages
 
 **Returns:** `BaseMessage[]`
+
+### `baseMessagesToUIMessages(messages)`
+
+Converts LangChain `BaseMessage` objects to AI SDK `UIMessage` objects. Tool
+results are folded into the matching assistant tool part by `tool_call_id`,
+which makes the result suitable for `useChat`'s `messages`.
+
+```ts
+import { baseMessagesToUIMessages } from '@ai-sdk/langchain';
+
+const uiMessages = baseMessagesToUIMessages(langchainMessages);
+```
+
+**Parameters:**
+
+- `messages`: `BaseMessage[]` - Array of LangChain messages
+
+**Returns:** `UIMessage[]`
+
+### `stateSnapshotToUIMessages(snapshot)`
+
+Converts a LangGraph `StateSnapshot` to AI SDK `UIMessage` objects. This reads
+messages from `snapshot.values.messages` and restores pending human-in-the-loop
+tool approvals from LangGraph interrupts.
+
+```ts
+import { stateSnapshotToUIMessages } from '@ai-sdk/langchain';
+
+const state = await agent.getState({ configurable: { thread_id: threadId } });
+const uiMessages = stateSnapshotToUIMessages(state);
+```
+
+**Parameters:**
+
+- `snapshot`: `StateSnapshot` - LangGraph state snapshot returned by `getState`
+
+**Returns:** `UIMessage[]`
 
 ### `toUIMessageStream(stream)`
 

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -36,10 +36,10 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/provider-utils": "workspace:*",
     "ai": "workspace:*"
   },
   "devDependencies": {
-    "@ai-sdk/provider-utils": "workspace:*",
     "@langchain/core": "^1.1.46",
     "@langchain/langgraph": "^1.3.0",
     "@types/node": "22.19.19",

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -6,12 +6,16 @@ import {
   toUIMessageStream,
   toBaseMessages,
   convertModelMessages,
+  baseMessagesToUIMessages,
+  stateSnapshotToUIMessages,
 } from './adapter';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ModelMessage, UIMessage } from 'ai';
 import {
   AIMessage,
   AIMessageChunk,
+  ChatMessage,
+  FunctionMessage,
   HumanMessage,
   SystemMessage,
   ToolMessage,
@@ -1390,6 +1394,689 @@ describe('toBaseMessages', () => {
         image_url: { url: 'data:image/png;base64,abc123' },
       },
     ]);
+  });
+});
+
+describe('baseMessagesToUIMessages', () => {
+  it('should convert system and user messages', () => {
+    const result = baseMessagesToUIMessages([
+      new SystemMessage({ id: 'system-1', content: 'Be helpful.' }),
+      new HumanMessage({ id: 'human-1', content: 'Hello!' }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'system-1',
+        role: 'system',
+        parts: [{ type: 'text', text: 'Be helpful.' }],
+      },
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello!' }],
+      },
+    ]);
+  });
+
+  it('should fold ToolMessage results into matching assistant tool parts', () => {
+    const result = baseMessagesToUIMessages([
+      new HumanMessage({ id: 'human-1', content: 'Weather in Recife?' }),
+      new AIMessage({
+        id: 'assistant-1',
+        content: 'I will check.',
+        tool_calls: [
+          {
+            id: 'call-weather',
+            name: 'get_weather',
+            args: { city: 'Recife' },
+          },
+        ],
+      }),
+      new ToolMessage({
+        id: 'tool-1',
+        tool_call_id: 'call-weather',
+        content: 'Sunny, 29C',
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Weather in Recife?' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'I will check.' },
+          {
+            type: 'dynamic-tool',
+            toolName: 'get_weather',
+            toolCallId: 'call-weather',
+            state: 'output-available',
+            input: { city: 'Recife' },
+            output: 'Sunny, 29C',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert plain Python AIMessageChunk objects from RemoteGraph', () => {
+    const result = baseMessagesToUIMessages([
+      {
+        id: 'assistant-python',
+        type: 'AIMessageChunk',
+        content: 'Restored from Python',
+      },
+    ] as any);
+
+    expect(result).toEqual([
+      {
+        id: 'assistant-python',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Restored from Python' }],
+      },
+    ]);
+  });
+
+  it('should convert ChatMessage instances using their chat role', () => {
+    const result = baseMessagesToUIMessages([
+      new ChatMessage({ id: 'chat-1', role: 'assistant', content: 'Hi' }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'chat-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Hi' }],
+      },
+    ]);
+  });
+
+  it('should preserve FunctionMessage content as a dynamic tool result', () => {
+    const result = baseMessagesToUIMessages([
+      new FunctionMessage({
+        id: 'function-1',
+        name: 'lookup',
+        content: 'Function result',
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'function-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName: 'lookup',
+            toolCallId: 'function-1',
+            state: 'output-available',
+            input: {},
+            output: 'Function result',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should restore image URLs with an image media type for round trips', async () => {
+    const uiMessages = baseMessagesToUIMessages([
+      new HumanMessage({
+        id: 'human-image',
+        content: [
+          { type: 'text', text: 'Describe this image.' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/image.png' },
+          },
+        ],
+      }),
+    ]);
+
+    expect(uiMessages).toEqual([
+      {
+        id: 'human-image',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'Describe this image.' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            url: 'https://example.com/image.png',
+          },
+        ],
+      },
+    ]);
+
+    const roundTripped = await toBaseMessages(uiMessages);
+    expect(roundTripped[0].content).toEqual([
+      { type: 'text', text: 'Describe this image.' },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/image.png' },
+      },
+    ]);
+  });
+
+  it('should keep empty messages valid with an empty text part', () => {
+    const result = baseMessagesToUIMessages([
+      new AIMessage({ id: 'assistant-empty', content: '' }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'assistant-empty',
+        role: 'assistant',
+        parts: [{ type: 'text', text: '' }],
+      },
+    ]);
+  });
+
+  it('should create unique UI message ids when LangChain ids repeat', () => {
+    const result = baseMessagesToUIMessages([
+      new HumanMessage({ id: 'duplicate-id', content: 'First' }),
+      new HumanMessage({ id: 'duplicate-id', content: 'Second' }),
+    ]);
+
+    expect(result.map(message => message.id)).toEqual([
+      'duplicate-id',
+      'duplicate-id-1',
+    ]);
+  });
+
+  it('should synthesize tool call ids per message to avoid collisions', () => {
+    const result = baseMessagesToUIMessages([
+      {
+        id: 'assistant-1',
+        type: 'ai',
+        content: '',
+        additional_kwargs: {
+          tool_calls: [
+            {
+              function: {
+                name: 'lookup',
+                arguments: '{"query":"first"}',
+              },
+            },
+          ],
+        },
+      },
+      {
+        id: 'assistant-2',
+        type: 'ai',
+        content: '',
+        additional_kwargs: {
+          tool_calls: [
+            {
+              function: {
+                name: 'lookup',
+                arguments: '{"query":"second"}',
+              },
+            },
+          ],
+        },
+      },
+    ] as any);
+
+    expect(result[0].parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call_assistant-1_0',
+    });
+    expect(result[1].parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call_assistant-2_0',
+    });
+  });
+
+  it('should restore non-string tool errors with default error text', () => {
+    const result = baseMessagesToUIMessages([
+      new ToolMessage({
+        id: 'tool-error',
+        tool_call_id: 'call-error',
+        content: [{ type: 'json', value: { message: 'boom' } }] as any,
+        status: 'error',
+      }),
+    ]);
+
+    expect(result[0].parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-error',
+      state: 'output-error',
+      input: {},
+      errorText: 'Tool execution failed',
+    });
+  });
+
+  it('should preserve citation source ids and provider metadata like streaming', () => {
+    const result = baseMessagesToUIMessages([
+      new AIMessage({
+        id: 'assistant-source',
+        content: [
+          {
+            type: 'text',
+            text: 'Cited text',
+            annotations: [
+              {
+                type: 'citation',
+                url: 'https://example.com/source',
+                title: 'Example source',
+                citedText: 'Cited text',
+                startIndex: 0,
+                endIndex: 10,
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+
+    expect(result[0].parts).toContainEqual({
+      type: 'source-url',
+      sourceId: 'https://example.com/source',
+      url: 'https://example.com/source',
+      title: 'Example source',
+      providerMetadata: {
+        langchain: {
+          citedText: 'Cited text',
+          startIndex: 0,
+          endIndex: 10,
+        },
+      },
+    });
+  });
+});
+
+describe('stateSnapshotToUIMessages', () => {
+  it('should read messages from snapshot values', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new HumanMessage({ id: 'human-1', content: 'Hello snapshot' }),
+        ],
+      },
+    } as any);
+
+    expect(result).toEqual([
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello snapshot' }],
+      },
+    ]);
+  });
+
+  it('should mark matching interrupted tool calls as approval requested', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-delete',
+                name: 'delete_file',
+                args: { filename: 'report.pdf' },
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    name: 'delete_file',
+                    args: { filename: 'report.pdf' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolName: 'delete_file',
+          toolCallId: 'call-delete',
+          state: 'approval-requested',
+          input: { filename: 'report.pdf' },
+          approval: { id: 'call-delete' },
+        },
+      ],
+    });
+  });
+
+  it('should not convert completed matching tool calls back to approval requested', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-delete-complete',
+                name: 'delete_file',
+                args: { filename: 'report.pdf' },
+              },
+            ],
+          }),
+          new ToolMessage({
+            id: 'tool-1',
+            tool_call_id: 'call-delete-complete',
+            content: 'Deleted',
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    name: 'delete_file',
+                    args: { filename: 'report.pdf' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolName: 'delete_file',
+          toolCallId: 'call-delete-complete',
+          state: 'output-available',
+          input: { filename: 'report.pdf' },
+          output: 'Deleted',
+        },
+        {
+          type: 'dynamic-tool',
+          toolName: 'delete_file',
+          state: 'approval-requested',
+        },
+      ],
+    });
+  });
+
+  it('should dedupe interrupts exposed at the snapshot root and task level', () => {
+    const interruptValue = {
+      actionRequests: [
+        {
+          name: 'delete_file',
+          args: { filename: 'report.pdf' },
+        },
+      ],
+    };
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-delete-complete',
+                name: 'delete_file',
+                args: { filename: 'report.pdf' },
+              },
+            ],
+          }),
+          new ToolMessage({
+            id: 'tool-1',
+            tool_call_id: 'call-delete-complete',
+            content: 'Deleted',
+          }),
+        ],
+      },
+      interrupts: [
+        {
+          value: interruptValue,
+        },
+      ],
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: interruptValue,
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const approvalParts = result[0].parts.filter(
+      part =>
+        part.type === 'dynamic-tool' && part.state === 'approval-requested',
+    );
+
+    expect(result[0].parts).toHaveLength(2);
+    expect(approvalParts).toHaveLength(1);
+  });
+
+  it('should match interrupts without args to tool calls with empty input', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-no-args',
+                name: 'confirm',
+                args: {},
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    name: 'confirm',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-no-args',
+          state: 'approval-requested',
+          input: {},
+        },
+      ],
+    });
+    expect(result[0].parts).toHaveLength(1);
+  });
+
+  it('should match interrupts by tool call id before input key', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-delete',
+                name: 'delete_file',
+                args: { filename: 'old.pdf' },
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    id: 'call-delete',
+                    name: 'delete_file',
+                    args: { filename: 'new.pdf' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-delete',
+          state: 'approval-requested',
+          input: { filename: 'old.pdf' },
+        },
+      ],
+    });
+    expect(result[0].parts).toHaveLength(1);
+  });
+
+  it('should match interrupts with stable object key order', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-reorder',
+                name: 'send_email',
+                args: { to: 'a@example.com', subject: 'Hi' },
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    name: 'send_email',
+                    args: { subject: 'Hi', to: 'a@example.com' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-reorder',
+          state: 'approval-requested',
+        },
+      ],
+    });
+    expect(result[0].parts).toHaveLength(1);
+  });
+
+  it('should read prebuilt HumanInterrupt action_request values', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new AIMessage({
+            id: 'assistant-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-prebuilt',
+                name: 'send_email',
+                args: { to: 'a@example.com' },
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: [
+                {
+                  action_request: {
+                    action: 'send_email',
+                    args: { to: 'a@example.com' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-prebuilt',
+          state: 'approval-requested',
+        },
+      ],
+    });
+    expect(result[0].parts).toHaveLength(1);
   });
 });
 

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -1,13 +1,22 @@
 import {
+  AIMessage,
+  AIMessageChunk,
   SystemMessage,
+  ToolMessage,
   type BaseMessage,
-  type AIMessageChunk,
 } from '@langchain/core/messages';
+import type { StateSnapshot } from '@langchain/langgraph';
+import { secureJsonParse } from '@ai-sdk/provider-utils';
 import {
   convertToModelMessages,
+  type JSONValue,
   type UIMessage,
   type UIMessageChunk,
   type ModelMessage,
+  type ProviderMetadata,
+  type UIDataTypes,
+  type UIMessagePart,
+  type UITools,
 } from 'ai';
 import {
   convertToolResultPart,
@@ -20,9 +29,892 @@ import {
   extractReasoningFromContentBlocks,
   extractCitationsFromContentBlocks,
   emitSourceChunks,
+  extractReasoningFromValuesMessage,
+  getMessageId,
+  extractImageOutputs,
 } from './utils';
-import type { LangGraphEventState } from './types';
+import type { LangGraphEventState, NormalizedCitation } from './types';
 import type { StreamCallbacks } from './stream-callbacks';
+
+type AnyUIMessage = UIMessage<unknown, UIDataTypes, UITools>;
+type AnyUIMessagePart = UIMessagePart<UIDataTypes, UITools>;
+
+type LangChainToolCall = {
+  id?: string;
+  name?: string;
+  args?: unknown;
+};
+
+type InterruptActionRequest = {
+  id?: string;
+  name: string;
+  input: unknown;
+};
+
+function getMessageData(message: unknown): Record<string, unknown> {
+  if (message == null || typeof message !== 'object') {
+    return {};
+  }
+
+  const record = message as Record<string, unknown>;
+  if (
+    record.type === 'constructor' &&
+    record.kwargs != null &&
+    typeof record.kwargs === 'object'
+  ) {
+    return record.kwargs as Record<string, unknown>;
+  }
+
+  return record;
+}
+
+function normalizeChatRole(role: unknown): string | undefined {
+  switch (role) {
+    case 'system':
+      return 'system';
+    case 'human':
+    case 'user':
+      return 'human';
+    case 'ai':
+    case 'assistant':
+      return 'ai';
+    case 'tool':
+      return 'tool';
+    default:
+      return undefined;
+  }
+}
+
+function normalizeMessageType(
+  type: unknown,
+  data: Record<string, unknown>,
+): string | undefined {
+  switch (type) {
+    case 'system':
+    case 'SystemMessage':
+    case 'SystemMessageChunk':
+      return 'system';
+    case 'human':
+    case 'user':
+    case 'HumanMessage':
+    case 'HumanMessageChunk':
+      return 'human';
+    case 'ai':
+    case 'assistant':
+    case 'AIMessage':
+    case 'AIMessageChunk':
+      return 'ai';
+    case 'tool':
+    case 'ToolMessage':
+    case 'ToolMessageChunk':
+      return 'tool';
+    case 'function':
+    case 'FunctionMessage':
+    case 'FunctionMessageChunk':
+      return 'function';
+    case 'generic':
+    case 'ChatMessage':
+    case 'ChatMessageChunk':
+      return normalizeChatRole(data.role) ?? 'human';
+    default:
+      return typeof type === 'string' ? type : undefined;
+  }
+}
+
+function getMessageType(message: unknown): string | undefined {
+  const data = getMessageData(message);
+
+  if (message != null && typeof message === 'object') {
+    const typedMessage = message as { _getType?: () => string };
+    if (typeof typedMessage._getType === 'function') {
+      return normalizeMessageType(typedMessage._getType(), data);
+    }
+  }
+
+  const record = message as Record<string, unknown> | undefined;
+  if (record?.type === 'constructor' && Array.isArray(record.id)) {
+    const constructorId = record.id as string[];
+    if (constructorId.includes('SystemMessage')) return 'system';
+    if (constructorId.includes('HumanMessage')) return 'human';
+    if (
+      constructorId.includes('AIMessage') ||
+      constructorId.includes('AIMessageChunk')
+    ) {
+      return 'ai';
+    }
+    if (constructorId.includes('ToolMessage')) return 'tool';
+    if (constructorId.includes('FunctionMessage')) return 'function';
+    if (constructorId.includes('ChatMessage')) {
+      return normalizeChatRole(data.role) ?? 'human';
+    }
+  }
+
+  return normalizeMessageType(record?.type, data);
+}
+
+function createMessageId(message: unknown, index: number): string {
+  return getMessageId(message) ?? `langchain-message-${index}`;
+}
+
+function makeUniqueId(baseId: string, usedIds: Set<string>): string {
+  let id = baseId;
+  let counter = 1;
+
+  while (usedIds.has(id)) {
+    id = `${baseId}-${counter}`;
+    counter++;
+  }
+
+  usedIds.add(id);
+  return id;
+}
+
+function createUniqueMessageId(
+  message: unknown,
+  index: number,
+  usedIds: Set<string>,
+): string {
+  return makeUniqueId(createMessageId(message, index), usedIds);
+}
+
+function parseToolInput(input: unknown): unknown {
+  if (typeof input !== 'string') {
+    return input ?? {};
+  }
+
+  try {
+    return secureJsonParse(input);
+  } catch {
+    return input;
+  }
+}
+
+function normalizeToolInput(input: unknown): unknown {
+  return parseToolInput(input);
+}
+
+function normalizeForStableStringify(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeForStableStringify);
+  }
+
+  if (value != null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entryValue]) => entryValue !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entryValue]) => [
+          key,
+          normalizeForStableStringify(entryValue),
+        ]),
+    );
+  }
+
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeForStableStringify(value));
+}
+
+function getToolRequestKey(toolName: string, input: unknown): string {
+  return `${toolName}:${stableStringify(normalizeToolInput(input))}`;
+}
+
+function getInterruptActionRequestKey(request: InterruptActionRequest): string {
+  return request.id == null
+    ? `tool:${getToolRequestKey(request.name, request.input)}`
+    : `id:${request.id}`;
+}
+
+function getSyntheticToolCallId(
+  message: unknown,
+  messageIndex: number,
+  toolCallIndex: number,
+): string {
+  return `call_${getMessageId(message) ?? messageIndex}_${toolCallIndex}`;
+}
+
+function getToolCalls(
+  message: unknown,
+  messageIndex: number,
+): LangChainToolCall[] {
+  if (AIMessage.isInstance(message) || AIMessageChunk.isInstance(message)) {
+    return (message.tool_calls ?? []).map((toolCall, index) => ({
+      id: toolCall.id ?? getSyntheticToolCallId(message, messageIndex, index),
+      name: toolCall.name ?? 'unknown',
+      args: normalizeToolInput(toolCall.args),
+    }));
+  }
+
+  const data = getMessageData(message);
+  if (Array.isArray(data.tool_calls)) {
+    return (data.tool_calls as LangChainToolCall[]).map((toolCall, index) => ({
+      ...toolCall,
+      id: toolCall.id ?? getSyntheticToolCallId(message, messageIndex, index),
+      name: toolCall.name ?? 'unknown',
+      args: normalizeToolInput(toolCall.args),
+    }));
+  }
+
+  const additionalKwargs = data.additional_kwargs;
+  if (
+    additionalKwargs != null &&
+    typeof additionalKwargs === 'object' &&
+    Array.isArray((additionalKwargs as { tool_calls?: unknown }).tool_calls)
+  ) {
+    return (
+      (
+        additionalKwargs as {
+          tool_calls: Array<{
+            id?: string;
+            function?: { name?: string; arguments?: string };
+          }>;
+        }
+      ).tool_calls ?? []
+    ).map((toolCall, index) => ({
+      id: toolCall.id ?? getSyntheticToolCallId(message, messageIndex, index),
+      name: toolCall.function?.name ?? 'unknown',
+      args: normalizeToolInput(toolCall.function?.arguments),
+    }));
+  }
+
+  return [];
+}
+
+function getTextPartsFromContent(
+  content: unknown,
+  { includeFiles = true }: { includeFiles?: boolean } = {},
+): AnyUIMessagePart[] {
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', text: content }] : [];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const parts: AnyUIMessagePart[] = [];
+
+  for (const block of content) {
+    if (block == null || typeof block !== 'object') continue;
+    const blockRecord = block as Record<string, unknown>;
+
+    if (blockRecord.type === 'text' && typeof blockRecord.text === 'string') {
+      parts.push({ type: 'text', text: blockRecord.text });
+      continue;
+    }
+
+    if (
+      blockRecord.type === 'image_url' &&
+      blockRecord.image_url != null &&
+      typeof blockRecord.image_url === 'object'
+    ) {
+      if (!includeFiles) continue;
+
+      const imageUrl = blockRecord.image_url as { url?: unknown };
+      if (typeof imageUrl.url === 'string') {
+        parts.push({
+          type: 'file',
+          mediaType: getImageMediaType(imageUrl.url),
+          url: imageUrl.url,
+        });
+      }
+      continue;
+    }
+
+    if (blockRecord.type === 'file') {
+      if (!includeFiles) continue;
+
+      const mediaType =
+        typeof blockRecord.mimeType === 'string'
+          ? blockRecord.mimeType
+          : typeof blockRecord.mediaType === 'string'
+            ? blockRecord.mediaType
+            : 'application/octet-stream';
+      const filename =
+        typeof blockRecord.filename === 'string'
+          ? blockRecord.filename
+          : undefined;
+
+      if (typeof blockRecord.url === 'string') {
+        parts.push({
+          type: 'file',
+          mediaType,
+          filename,
+          url: blockRecord.url,
+        });
+      } else if (typeof blockRecord.data === 'string') {
+        parts.push({
+          type: 'file',
+          mediaType,
+          filename,
+          url: blockRecord.data.startsWith('data:')
+            ? blockRecord.data
+            : `data:${mediaType};base64,${blockRecord.data}`,
+        });
+      }
+    }
+  }
+
+  return parts;
+}
+
+function getImageMediaType(url: string): string {
+  const dataUrlMatch = /^data:([^;,]+)[;,]/.exec(url);
+  if (dataUrlMatch?.[1]?.startsWith('image/')) {
+    return dataUrlMatch[1];
+  }
+
+  try {
+    const extension = new URL(url).pathname.toLowerCase().split('.').pop();
+    switch (extension) {
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'gif':
+        return 'image/gif';
+      case 'webp':
+        return 'image/webp';
+      case 'png':
+        return 'image/png';
+    }
+  } catch {
+    // Fall back to PNG below for non-URL strings.
+  }
+
+  return 'image/png';
+}
+
+function createUIPartsFromMessageContent(
+  message: unknown,
+  options?: { includeFiles?: boolean },
+): AnyUIMessagePart[] {
+  const data = getMessageData(message);
+  return getTextPartsFromContent(data.content, options);
+}
+
+function ensureNonEmptyParts(parts: AnyUIMessagePart[]): AnyUIMessagePart[] {
+  return parts.length > 0 ? parts : [{ type: 'text', text: '' }];
+}
+
+function getToolOutput(message: unknown): {
+  output: unknown;
+  errorText?: string;
+} {
+  const data = getMessageData(message);
+  const content = data.content;
+  const output = (() => {
+    if ('artifact' in data && data.artifact !== undefined) {
+      return data.artifact;
+    }
+
+    if (typeof content === 'string') {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      const textBlocks = content.filter(
+        (block): block is { type: 'text'; text: string } =>
+          block != null &&
+          typeof block === 'object' &&
+          (block as { type?: unknown }).type === 'text' &&
+          typeof (block as { text?: unknown }).text === 'string',
+      );
+
+      return textBlocks.length === content.length
+        ? textBlocks.map(block => block.text).join('')
+        : content;
+    }
+
+    return content;
+  })();
+
+  if (data.status === 'error') {
+    return {
+      output,
+      errorText: typeof output === 'string' ? output : 'Tool execution failed',
+    };
+  }
+
+  return { output };
+}
+
+function getToolCallId(message: unknown): string | undefined {
+  if (ToolMessage.isInstance(message)) {
+    return message.tool_call_id;
+  }
+
+  const data = getMessageData(message);
+  return typeof data.tool_call_id === 'string' ? data.tool_call_id : undefined;
+}
+
+function addAssistantReasoningParts(
+  message: unknown,
+  parts: AnyUIMessagePart[],
+) {
+  const reasoning =
+    extractReasoningFromValuesMessage(message) ??
+    extractReasoningFromContentBlocks(message);
+
+  if (reasoning) {
+    parts.push({ type: 'reasoning', text: reasoning, state: 'done' });
+  }
+}
+
+function buildSourceProviderMetadata(
+  citation: NormalizedCitation,
+): ProviderMetadata | undefined {
+  const langchain: Record<string, JSONValue> = {};
+
+  if (typeof citation.citedText === 'string') {
+    langchain.citedText = citation.citedText;
+  }
+  if (typeof citation.startIndex === 'number') {
+    langchain.startIndex = citation.startIndex;
+  }
+  if (typeof citation.endIndex === 'number') {
+    langchain.endIndex = citation.endIndex;
+  }
+  if (typeof citation.source === 'string') {
+    langchain.source = citation.source;
+  }
+
+  return Object.keys(langchain).length > 0 ? { langchain } : undefined;
+}
+
+function addAssistantSourceParts(
+  message: unknown,
+  messageId: string,
+  parts: AnyUIMessagePart[],
+) {
+  const citations = extractCitationsFromContentBlocks(message);
+  const emittedSourceIds = new Set<string>();
+
+  for (const citation of citations) {
+    if (citation.url) {
+      if (emittedSourceIds.has(citation.url)) continue;
+      emittedSourceIds.add(citation.url);
+
+      const providerMetadata = buildSourceProviderMetadata(citation);
+      parts.push({
+        type: 'source-url',
+        sourceId: citation.url,
+        url: citation.url,
+        ...(citation.title ? { title: citation.title } : {}),
+        ...(providerMetadata ? { providerMetadata } : {}),
+      });
+      continue;
+    }
+
+    const title = citation.title ?? citation.source;
+    if (!title) continue;
+
+    const sourceId = `${messageId}:${title}:${citation.citedText ?? ''}:${citation.startIndex ?? ''}:${citation.endIndex ?? ''}`;
+    if (emittedSourceIds.has(sourceId)) continue;
+    emittedSourceIds.add(sourceId);
+
+    const providerMetadata = buildSourceProviderMetadata(citation);
+    parts.push({
+      type: 'source-document',
+      sourceId,
+      mediaType: 'text/plain',
+      title,
+      ...(providerMetadata ? { providerMetadata } : {}),
+    });
+  }
+}
+
+function addAssistantImageParts(message: unknown, parts: AnyUIMessagePart[]) {
+  const additionalKwargs = getMessageData(message).additional_kwargs;
+  if (additionalKwargs == null || typeof additionalKwargs !== 'object') return;
+
+  for (const imageOutput of extractImageOutputs(
+    additionalKwargs as Record<string, unknown>,
+  )) {
+    if (!imageOutput.result) continue;
+
+    const mediaType = `image/${imageOutput.output_format || 'png'}`;
+    parts.push({
+      type: 'file',
+      mediaType,
+      url: `data:${mediaType};base64,${imageOutput.result}`,
+    });
+  }
+}
+
+function addToolCallParts(
+  message: unknown,
+  messageIndex: number,
+  parts: AnyUIMessagePart[],
+  toolPartsById: Map<
+    string,
+    Extract<AnyUIMessagePart, { type: 'dynamic-tool' }>
+  >,
+) {
+  for (const toolCall of getToolCalls(message, messageIndex)) {
+    if (!toolCall.id || !toolCall.name) continue;
+
+    const part = {
+      type: 'dynamic-tool' as const,
+      toolName: toolCall.name,
+      toolCallId: toolCall.id,
+      state: 'input-available' as const,
+      input: normalizeToolInput(toolCall.args),
+    };
+
+    toolPartsById.set(toolCall.id, part);
+    parts.push(part);
+  }
+}
+
+function collectInterruptActionRequests(snapshot: unknown) {
+  const requests: InterruptActionRequest[] = [];
+  const seenRequests = new Set<string>();
+
+  function visitActionRequest(actionRequest: unknown) {
+    if (actionRequest == null || typeof actionRequest !== 'object') return;
+
+    const action = actionRequest as Record<string, unknown>;
+    const name =
+      typeof action.name === 'string'
+        ? action.name
+        : typeof action.action === 'string'
+          ? action.action
+          : typeof action.action_name === 'string'
+            ? action.action_name
+            : undefined;
+    if (!name) return;
+
+    const request = {
+      id:
+        typeof action.id === 'string'
+          ? action.id
+          : typeof action.tool_call_id === 'string'
+            ? action.tool_call_id
+            : typeof action.toolCallId === 'string'
+              ? action.toolCallId
+              : undefined,
+      name,
+      input: normalizeToolInput(
+        action.args ?? action.arguments ?? action.input ?? action.action_input,
+      ),
+    };
+    const requestKey = getInterruptActionRequestKey(request);
+    if (seenRequests.has(requestKey)) return;
+
+    seenRequests.add(requestKey);
+    requests.push(request);
+  }
+
+  function visitInterruptValue(value: unknown) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visitInterruptValue(item);
+      }
+      return;
+    }
+
+    if (value == null || typeof value !== 'object') return;
+
+    const record = value as Record<string, unknown>;
+    const actionRequests = record.actionRequests ?? record.action_requests;
+    if (Array.isArray(actionRequests)) {
+      for (const actionRequest of actionRequests) {
+        visitActionRequest(actionRequest);
+      }
+    }
+
+    const prebuiltActionRequest = record.action_request ?? record.actionRequest;
+    if (prebuiltActionRequest != null) {
+      visitActionRequest(prebuiltActionRequest);
+    }
+  }
+
+  if (snapshot != null && typeof snapshot === 'object') {
+    const record = snapshot as Record<string, unknown>;
+    const values = record.values;
+
+    if (values != null && typeof values === 'object') {
+      const valuesInterrupt = (values as Record<string, unknown>).__interrupt__;
+      if (Array.isArray(valuesInterrupt)) {
+        for (const interrupt of valuesInterrupt) {
+          visitInterruptValue(
+            interrupt != null && typeof interrupt === 'object'
+              ? (interrupt as Record<string, unknown>).value
+              : interrupt,
+          );
+        }
+      }
+    }
+
+    const interrupts = record.interrupts;
+    if (Array.isArray(interrupts) && interrupts.length > 0) {
+      for (const interrupt of interrupts) {
+        visitInterruptValue(
+          interrupt != null && typeof interrupt === 'object'
+            ? (interrupt as Record<string, unknown>).value
+            : interrupt,
+        );
+      }
+    } else {
+      const tasks = record.tasks;
+      if (!Array.isArray(tasks)) return requests;
+
+      for (const task of tasks) {
+        if (task == null || typeof task !== 'object') continue;
+
+        const taskInterrupts = (task as Record<string, unknown>).interrupts;
+        if (!Array.isArray(taskInterrupts)) continue;
+
+        for (const interrupt of taskInterrupts) {
+          visitInterruptValue(
+            interrupt != null && typeof interrupt === 'object'
+              ? (interrupt as Record<string, unknown>).value
+              : interrupt,
+          );
+        }
+      }
+    }
+  }
+
+  return requests;
+}
+
+function applyInterrupts(
+  messages: AnyUIMessage[],
+  requests: InterruptActionRequest[],
+) {
+  type ToolPartLocation = {
+    message: AnyUIMessage;
+    partIndex: number;
+    part: Extract<AnyUIMessagePart, { type: 'dynamic-tool' }>;
+  };
+
+  const interruptiblePartsById = new Map<string, ToolPartLocation>();
+  const interruptiblePartsByKey = new Map<string, ToolPartLocation[]>();
+  const usedToolCallIds = new Set<string>();
+
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue;
+
+    for (let partIndex = 0; partIndex < message.parts.length; partIndex++) {
+      const part = message.parts[partIndex];
+      if (part.type !== 'dynamic-tool') continue;
+
+      usedToolCallIds.add(part.toolCallId);
+
+      if (
+        part.state !== 'input-available' &&
+        part.state !== 'input-streaming' &&
+        part.state !== 'approval-requested'
+      ) {
+        continue;
+      }
+
+      const location = { message, partIndex, part };
+      interruptiblePartsById.set(part.toolCallId, location);
+
+      const partKey = getToolRequestKey(part.toolName, part.input);
+      const locations = interruptiblePartsByKey.get(partKey) ?? [];
+      locations.push(location);
+      interruptiblePartsByKey.set(partKey, locations);
+    }
+  }
+
+  requests.forEach((request, requestIndex) => {
+    const matchingLocation =
+      (request.id ? interruptiblePartsById.get(request.id) : undefined) ??
+      interruptiblePartsByKey
+        .get(getToolRequestKey(request.name, request.input))
+        ?.at(-1);
+
+    const matchingPart = matchingLocation?.part;
+    const toolCallId = matchingPart
+      ? matchingPart.toolCallId
+      : makeUniqueId(
+          request.id ?? `langgraph-interrupt-${requestIndex}`,
+          usedToolCallIds,
+        );
+    const approval = {
+      id: toolCallId,
+    };
+
+    if (matchingPart != null && matchingLocation != null) {
+      const approvalPart: Extract<AnyUIMessagePart, { type: 'dynamic-tool' }> =
+        {
+          type: 'dynamic-tool',
+          toolName: matchingPart.toolName,
+          toolCallId,
+          title: matchingPart.title,
+          toolMetadata: matchingPart.toolMetadata,
+          providerExecuted: matchingPart.providerExecuted,
+          callProviderMetadata: matchingPart.callProviderMetadata,
+          state: 'approval-requested',
+          input: matchingPart.input,
+          approval,
+        };
+      matchingLocation.message.parts[matchingLocation.partIndex] = approvalPart;
+      return;
+    }
+
+    let assistantMessage = messages.findLast(
+      message => message.role === 'assistant',
+    );
+    if (assistantMessage == null) {
+      assistantMessage = {
+        id: `langgraph-interrupt-message-${messages.length}`,
+        role: 'assistant',
+        parts: [],
+      };
+      messages.push(assistantMessage);
+    }
+
+    assistantMessage.parts.push({
+      type: 'dynamic-tool',
+      toolName: request.name,
+      toolCallId,
+      state: 'approval-requested',
+      input: normalizeToolInput(request.input),
+      approval,
+    });
+  });
+}
+
+/**
+ * Converts LangChain BaseMessage objects to AI SDK UIMessage objects.
+ *
+ * ToolMessage entries are folded back into the assistant tool invocation with
+ * the matching tool call id so the result can be passed to useChat as messages.
+ */
+export function baseMessagesToUIMessages(messages: BaseMessage[]): UIMessage[] {
+  const uiMessages: AnyUIMessage[] = [];
+  const usedMessageIds = new Set<string>();
+  const toolPartsById = new Map<
+    string,
+    Extract<AnyUIMessagePart, { type: 'dynamic-tool' }>
+  >();
+
+  messages.forEach((message, index) => {
+    const type = getMessageType(message);
+
+    if (type === 'system') {
+      const parts = ensureNonEmptyParts(
+        createUIPartsFromMessageContent(message, { includeFiles: false }),
+      );
+      uiMessages.push({
+        id: createUniqueMessageId(message, index, usedMessageIds),
+        role: 'system',
+        parts,
+      });
+      return;
+    }
+
+    if (type === 'human' || type === 'user') {
+      const parts = ensureNonEmptyParts(
+        createUIPartsFromMessageContent(message),
+      );
+      uiMessages.push({
+        id: createUniqueMessageId(message, index, usedMessageIds),
+        role: 'user',
+        parts,
+      });
+      return;
+    }
+
+    if (type === 'ai' || type === 'assistant') {
+      const messageId = createUniqueMessageId(message, index, usedMessageIds);
+      const parts: AnyUIMessagePart[] = [];
+      addAssistantReasoningParts(message, parts);
+      parts.push(...createUIPartsFromMessageContent(message));
+      addAssistantSourceParts(message, messageId, parts);
+      addAssistantImageParts(message, parts);
+      addToolCallParts(message, index, parts, toolPartsById);
+
+      uiMessages.push({
+        id: messageId,
+        role: 'assistant',
+        parts: ensureNonEmptyParts(parts),
+      });
+      return;
+    }
+
+    if (type === 'tool' || type === 'function') {
+      const toolCallId = getToolCallId(message);
+      const fallbackToolCallId = toolCallId ?? createMessageId(message, index);
+
+      const toolPart = toolCallId ? toolPartsById.get(toolCallId) : undefined;
+      const { output, errorText } = getToolOutput(message);
+
+      if (toolPart != null) {
+        if (errorText != null) {
+          delete (toolPart as { output?: unknown }).output;
+          Object.assign(toolPart, {
+            state: 'output-error',
+            errorText,
+          });
+        } else {
+          delete (toolPart as { errorText?: string }).errorText;
+          Object.assign(toolPart, {
+            state: 'output-available',
+            output,
+          });
+        }
+        return;
+      }
+
+      const data = getMessageData(message);
+      const toolName =
+        typeof data.name === 'string' && data.name ? data.name : 'unknown';
+      const fallbackToolPart =
+        errorText != null
+          ? {
+              type: 'dynamic-tool' as const,
+              toolName,
+              toolCallId: fallbackToolCallId,
+              state: 'output-error' as const,
+              input: {},
+              errorText,
+            }
+          : {
+              type: 'dynamic-tool' as const,
+              toolName,
+              toolCallId: fallbackToolCallId,
+              state: 'output-available' as const,
+              input: {},
+              output,
+            };
+
+      uiMessages.push({
+        id: createUniqueMessageId(message, index, usedMessageIds),
+        role: 'assistant',
+        parts: [fallbackToolPart],
+      });
+    }
+  });
+
+  return uiMessages;
+}
+
+/**
+ * Converts a LangGraph StateSnapshot into AI SDK UIMessage objects.
+ */
+export function stateSnapshotToUIMessages(
+  snapshot: StateSnapshot,
+): UIMessage[] {
+  const values = (snapshot as unknown as { values?: unknown }).values;
+  const messages =
+    values != null &&
+    typeof values === 'object' &&
+    Array.isArray((values as { messages?: unknown }).messages)
+      ? ((values as { messages: BaseMessage[] }).messages ?? [])
+      : [];
+
+  const uiMessages = baseMessagesToUIMessages(messages) as AnyUIMessage[];
+  applyInterrupts(uiMessages, collectInterruptActionRequests(snapshot));
+
+  return uiMessages;
+}
 
 /**
  * Converts AI SDK UIMessages to LangChain BaseMessage objects.

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -1,4 +1,6 @@
 export {
+  baseMessagesToUIMessages,
+  stateSnapshotToUIMessages,
   toBaseMessages,
   toUIMessageStream,
   convertModelMessages,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2827,13 +2827,13 @@ importers:
 
   packages/langchain:
     dependencies:
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
       ai:
         specifier: workspace:*
         version: link:../ai
     devDependencies:
-      '@ai-sdk/provider-utils':
-        specifier: workspace:*
-        version: link:../provider-utils
       '@langchain/core':
         specifier: ^1.1.46
         version: 1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)


### PR DESCRIPTION
﻿## Summary

Fixes #12680.

Adds LangChain restore helpers so persisted LangChain/LangGraph message history can be converted back into AI SDK `UIMessage` objects:

- export `baseMessagesToUIMessages` for LangChain `BaseMessage[]` history
- export `stateSnapshotToUIMessages` for LangGraph snapshots, including pending human-in-the-loop approvals from snapshot interrupts
- restore tool calls/results, serialized RemoteGraph messages, citations/sources, image outputs, and duplicate-safe message/tool ids
- document the new helpers and add a patch changeset for `@ai-sdk/langchain`

## Validation

- `pnpm install --frozen-lockfile`
- `corepack pnpm@10.33.4 -C packages/langchain type-check`
- `corepack pnpm@10.33.4 -C packages/langchain test:node src/adapter.test.ts`
- `corepack pnpm@10.33.4 -C packages/langchain test`
- `corepack pnpm@10.33.4 -C packages/langchain build`
- `corepack pnpm@10.33.4 type-check:full`
- `corepack pnpm@10.33.4 exec ultracite check packages/langchain/src/adapter.ts packages/langchain/src/adapter.test.ts packages/langchain/src/index.ts packages/langchain/package.json content/providers/06-adapters/01-langchain.mdx .changeset/langchain-ui-message-restore.md pnpm-lock.yaml`
- `git diff --check`
