### PR TITLE
fix(policy-opa): fail closed for per-tool approval functions in wrapMcpTools

### DIFF
--- a/.changeset/wrap-mcp-tools-per-tool-function-fallback.md
+++ b/.changeset/wrap-mcp-tools-per-tool-function-fallback.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/policy-opa': patch
+---
+
+`wrapMcpTools`: per-tool approval functions now fail closed. In the per-tool map form, a per-tool approval function that returns a "no opinion" result (`not-applicable` or `undefined`) is now forced through the configured fallback (`user-approval` by default), matching the generic-function form. Previously such a result passed through and the tool resolved to `not-applicable`, letting it run without an approval request. Static per-tool statuses the caller configured explicitly are unchanged.

--- a/packages/policy-opa/src/wrap-mcp-tools.test.ts
+++ b/packages/policy-opa/src/wrap-mcp-tools.test.ts
@@ -209,5 +209,98 @@ describe('wrapMcpTools', () => {
         expect(toolApproval.search).toBe('approved');
       });
     });
+
+    describe('per-tool approval functions', () => {
+      // A per-tool approval function that returns a "no opinion" result
+      // (`not-applicable`/`undefined`) must fall back to the default, exactly
+      // like the generic-function form. Otherwise the tool would resolve to
+      // `not-applicable` and run unapproved, defeating the wrapper's purpose.
+      it('forces a not-applicable result through the fallback', async () => {
+        const { toolApproval } = wrapMcpTools<Tools>(tools, {
+          search: (() => ({ type: 'not-applicable' })) as never,
+        });
+
+        if (typeof toolApproval === 'function') {
+          throw new Error('expected per-tool object form');
+        }
+
+        const entry = toolApproval.search;
+        if (typeof entry !== 'function') {
+          throw new Error('expected wrapped per-tool function');
+        }
+
+        const status = await (entry as (...args: unknown[]) => unknown)(
+          {},
+          {} as never,
+        );
+        expect(status).toBe('user-approval');
+      });
+
+      it('forces an undefined result through the configured default', async () => {
+        const { toolApproval } = wrapMcpTools<Tools>(
+          tools,
+          { search: (() => undefined) as never },
+          { default: 'denied' },
+        );
+
+        if (typeof toolApproval === 'function') {
+          throw new Error('expected per-tool object form');
+        }
+
+        const entry = toolApproval.search;
+        if (typeof entry !== 'function') {
+          throw new Error('expected wrapped per-tool function');
+        }
+
+        const status = await (entry as (...args: unknown[]) => unknown)(
+          {},
+          {} as never,
+        );
+        expect(status).toBe('denied');
+      });
+
+      it('passes a decision through unchanged when the function has an opinion', async () => {
+        const decision = { type: 'denied', reason: 'never' };
+        const { toolApproval } = wrapMcpTools<Tools>(tools, {
+          deleteRepo: (() => decision) as never,
+        });
+
+        if (typeof toolApproval === 'function') {
+          throw new Error('expected per-tool object form');
+        }
+
+        const entry = toolApproval.deleteRepo;
+        if (typeof entry !== 'function') {
+          throw new Error('expected wrapped per-tool function');
+        }
+
+        const status = await (entry as (...args: unknown[]) => unknown)(
+          {},
+          {} as never,
+        );
+        expect(status).toEqual(decision);
+      });
+
+      it('forwards input and options to the wrapped function', async () => {
+        const calls: unknown[][] = [];
+        const { toolApproval } = wrapMcpTools<Tools>(tools, {
+          search: ((...args: unknown[]) => {
+            calls.push(args);
+            return 'approved';
+          }) as never,
+        });
+
+        if (typeof toolApproval === 'function') {
+          throw new Error('expected per-tool object form');
+        }
+
+        const entry = toolApproval.search as (...args: unknown[]) => unknown;
+        const input = { arg: 'value' };
+        const options = { toolCallId: 'call-1' };
+        await entry(input, options as never);
+
+        expect(calls).toEqual([[input, options]]);
+      });
+    });
   });
 });

--- a/packages/policy-opa/src/wrap-mcp-tools.ts
+++ b/packages/policy-opa/src/wrap-mcp-tools.ts
@@ -83,7 +83,25 @@ export function wrapMcpTools<
     const configured = Object.prototype.hasOwnProperty.call(approval, name)
       ? approval[name]
       : undefined;
-    filled[name] = configured ?? fallback;
+
+    if (configured == null) {
+      // Tool the user did not list: force it through the fallback.
+      filled[name] = fallback;
+    } else if (typeof configured === 'function') {
+      // Per-tool approval function: mirror the generic-function form so a
+      // "no opinion" result (`not-applicable`/`undefined`) is forced through
+      // the fallback instead of letting the tool run unapproved.
+      const original = configured as (
+        ...args: unknown[]
+      ) => Promise<unknown> | unknown;
+      filled[name] = async (...args: unknown[]) => {
+        const status = await original(...args);
+        return isNotApplicable(status) ? fallback : status;
+      };
+    } else {
+      // Static status the user explicitly configured: keep it as-is.
+      filled[name] = configured;
+    }
   }
 
   // `filled` is a plain per-tool map; cast to the SDK's map arm, which TS


### PR DESCRIPTION
## Background

Follow-up hardening to #16900 (VULN-13170), which closed the inherited-property
approval bypass in `wrapMcpTools`.

While reviewing that fix I found a separate, still-open gap in the same helper.
`wrapMcpTools` documents that the resulting approval configuration is *total*:
every discovered tool is gated by the supplied approval "when it has an opinion"
or by the `default` otherwise (`user-approval` by default). The generic-function
form already enforces this — it normalizes a "no opinion" result
(`not-applicable`/`undefined`) to the fallback. The **per-tool map form did
not**: it only substituted the fallback for missing entries
(`configured ?? fallback`), so a per-tool approval *function* that returned
`not-applicable`/`undefined` passed straight through. The tool then resolved to
`not-applicable`, which the core treats as "no approval required", and it ran
without an approval request — i.e. the per-tool function **failed open** instead
of falling back to the default.

## Summary

- `packages/policy-opa/src/wrap-mcp-tools.ts`: in the per-tool map form, wrap
  per-tool approval **functions** so a `not-applicable`/`undefined` result is
  forced through the configured fallback, mirroring the generic-function form.
  Functions that return an actual decision are passed through unchanged, and
  their `input`/`options` arguments are forwarded intact. Static per-tool
  statuses that the caller configured explicitly are left as-is.
- `packages/policy-opa/src/wrap-mcp-tools.test.ts`: add tests covering a
  per-tool function that returns `not-applicable` (→ fallback), one that returns
  `undefined` (→ configured default), one that returns a real decision
  (unchanged), and argument forwarding.
- Patch changeset for `@ai-sdk/policy-opa`.

## Manual Verification

Confirmed the before/after behavior on the per-tool map form:

- Before this change, `wrapMcpTools(tools, { search: () => 'not-applicable' })`
  produced an entry that resolved to `not-applicable`, so the tool executed with
  no approval request (fail open).
- After this change, the same configuration resolves `search` to the fallback
  (`user-approval`, or the configured `default`), so the call pauses for a
  decision (fail closed). A per-tool function returning an explicit
  `approved`/`denied` decision is unaffected.

Also ran the full package suite (node + edge, 76 passing), `pnpm type-check`,
and `oxlint`/`oxfmt` — all clean.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The per-tool map form still passes an **explicit static** `'not-applicable'` /
`{ type: 'not-applicable' }` entry through unchanged. This PR deliberately does
not alter that: unlike a function's runtime "no opinion", a static
`not-applicable` is arguably an explicit caller decision ("this tool needs no
approval"), and overriding it would contradict the "preserves explicit per-tool
entries" behavior. Worth a follow-up discussion on whether a security-oriented
default-deny wrapper should also refuse to honor a static `not-applicable`.

## Related Issues

Follow-up to #16900 (VULN-13170).
