### PR TITLE
docs: use <InstallPackages /> component

### DIFF
--- a/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
+++ b/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
@@ -55,9 +55,7 @@ Install `ai` and `@ai-sdk/react`, the AI SDK package and the AI SDK's React pack
   [building custom providers](/providers/community-providers/custom-providers)
   in the [providers](/providers) section.
 </Note>
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/react" />
-</div>
+<InstallPackages packages="ai @ai-sdk/react" />
 
 ### Configure your Vercel AI Gateway API key
 

--- a/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
+++ b/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
@@ -56,22 +56,7 @@ Install `ai` and `@ai-sdk/react`, the AI SDK package and the AI SDK's React pack
   in the [providers](/providers) section.
 </Note>
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/react" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai @ai-sdk/react" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai @ai-sdk/react" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add ai @ai-sdk/react" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/react" />
 </div>
 
 ### Configure your Vercel AI Gateway API key

--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -66,9 +66,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 You can also use [first-party](/providers/ai-sdk-providers), [OpenAI-compatible](/providers/openai-compatible-providers), and [community](/providers/community-providers) provider packages directly. Install the package and create a provider instance. For example, to use Anthropic:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/anthropic" />
-</div>
+<InstallPackages packages="@ai-sdk/anthropic" />
 
 ```ts
 import { anthropic } from '@ai-sdk/anthropic';

--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -67,20 +67,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 You can also use [first-party](/providers/ai-sdk-providers), [OpenAI-compatible](/providers/openai-compatible-providers), and [community](/providers/community-providers) provider packages directly. Install the package and create a provider instance. For example, to use Anthropic:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/anthropic" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/anthropic" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/anthropic" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="bun add @ai-sdk/anthropic" dark />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/anthropic" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -50,22 +50,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
 </Note>
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai @ai-sdk/react zod" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add ai @ai-sdk/react zod" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/react zod" />
 </div>
 
 ### Configure your AI Gateway API key
@@ -151,22 +136,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -49,9 +49,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
   providers](/providers/ai-sdk-providers) for more information.
 </Note>
 
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/react zod" />
-</div>
+<InstallPackages packages="ai @ai-sdk/react zod" />
 
 ### Configure your AI Gateway API key
 
@@ -135,9 +133,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -47,9 +47,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
   providers](/providers/ai-sdk-providers) for more information.
 </Note>
 
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/react zod" />
-</div>
+<InstallPackages packages="ai @ai-sdk/react zod" />
 
 ### Configure your AI Gateway API key
 
@@ -139,9 +137,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -48,22 +48,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
 </Note>
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai @ai-sdk/react zod" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add ai @ai-sdk/react zod" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/react zod" />
 </div>
 
 ### Configure your AI Gateway API key
@@ -155,22 +140,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -41,20 +41,7 @@ Install `ai` and `@ai-sdk/svelte`, the AI package and AI SDK's Svelte bindings. 
   providers](/providers/ai-sdk-providers) for more information.
 </Note>
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add -D ai @ai-sdk/svelte zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install -D ai @ai-sdk/svelte zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add -D ai @ai-sdk/svelte zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="bun add -d ai @ai-sdk/svelte zod" dark />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/svelte zod" dev />
 </div>
 
 ### Configure your AI Gateway API key
@@ -152,22 +139,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -40,9 +40,7 @@ Install `ai` and `@ai-sdk/svelte`, the AI package and AI SDK's Svelte bindings. 
   provider or model by installing its package. Check out available [AI SDK
   providers](/providers/ai-sdk-providers) for more information.
 </Note>
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/svelte zod" dev />
-</div>
+<InstallPackages packages="ai @ai-sdk/svelte zod" dev />
 
 ### Configure your AI Gateway API key
 
@@ -138,9 +136,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -41,9 +41,7 @@ Install `ai` and `@ai-sdk/vue`. The Vercel AI Gateway provider ships with the `a
   [building custom providers](/providers/community-providers/custom-providers)
   in the [providers](/providers) section.
 </Note>
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/vue zod" />
-</div>
+<InstallPackages packages="ai @ai-sdk/vue zod" />
 
 ### Configure Vercel AI Gateway API key
 
@@ -146,9 +144,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -42,22 +42,7 @@ Install `ai` and `@ai-sdk/vue`. The Vercel AI Gateway provider ships with the `a
   in the [providers](/providers) section.
 </Note>
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/vue zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai @ai-sdk/vue zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai @ai-sdk/vue zod" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add ai @ai-sdk/vue zod" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/vue zod" />
 </div>
 
 ### Configure Vercel AI Gateway API key
@@ -162,22 +147,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -157,9 +157,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -158,22 +158,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -41,9 +41,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
   providers](/providers/ai-sdk-providers) for more information.
 </Note>
 
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/react zod" />
-</div>
+<InstallPackages packages="ai @ai-sdk/react zod" />
 
 ### Configure your AI Gateway API key
 
@@ -131,9 +129,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';
@@ -684,9 +680,7 @@ Several functions that are internally used by the AI SDK might not available in 
 
 First, install the following packages:
 
-<div className="my-4">
-  <InstallPackages packages="@ungap/structured-clone @stardazed/streams-text-encoding" />
-</div>
+<InstallPackages packages="@ungap/structured-clone @stardazed/streams-text-encoding" />
 
 Then create a new file in the root of your project with the following polyfills:
 

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -42,20 +42,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
 </Note>
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="bun add ai @ai-sdk/react zod" dark />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/react zod" />
 </div>
 
 ### Configure your AI Gateway API key
@@ -145,22 +132,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts
@@ -713,32 +685,7 @@ Several functions that are internally used by the AI SDK might not available in 
 First, install the following packages:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet
-        text="pnpm add @ungap/structured-clone @stardazed/streams-text-encoding"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="npm install @ungap/structured-clone @stardazed/streams-text-encoding"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="yarn add @ungap/structured-clone @stardazed/streams-text-encoding"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="bun add @ungap/structured-clone @stardazed/streams-text-encoding"
-        dark
-      />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="@ungap/structured-clone @stardazed/streams-text-encoding" />
 </div>
 
 Then create a new file in the root of your project with the following polyfills:

--- a/content/docs/02-getting-started/08-tanstack-start.mdx
+++ b/content/docs/02-getting-started/08-tanstack-start.mdx
@@ -41,9 +41,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
   providers](/providers/ai-sdk-providers) for more information.
 </Note>
 
-<div className="my-4">
-  <InstallPackages packages="ai @ai-sdk/react zod" />
-</div>
+<InstallPackages packages="ai @ai-sdk/react zod" />
 
 ### Configure your AI Gateway API key
 
@@ -134,9 +132,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/openai" />
-</div>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/docs/02-getting-started/08-tanstack-start.mdx
+++ b/content/docs/02-getting-started/08-tanstack-start.mdx
@@ -42,22 +42,7 @@ Install `ai` and `@ai-sdk/react`, the AI package and AI SDK's React hooks. The A
 </Note>
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai @ai-sdk/react zod" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai @ai-sdk/react zod" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add ai @ai-sdk/react zod" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="ai @ai-sdk/react zod" />
 </div>
 
 ### Configure your AI Gateway API key
@@ -150,22 +135,7 @@ model: gateway('anthropic/claude-sonnet-4.5');
 To use a different provider, install its package and create a provider instance. For example, to use OpenAI directly:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/openai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/openai" dark />
-    </Tab>
-
-    <Tab>
-      <Snippet text="bun add @ai-sdk/openai" dark />
-    </Tab>
-
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/openai" />
 </div>
 
 ```ts

--- a/content/docs/02-getting-started/09-coding-agents.mdx
+++ b/content/docs/02-getting-started/09-coding-agents.mdx
@@ -34,20 +34,7 @@ Once you've installed the `ai` package, you already have the full AI SDK documen
 Install the `ai` package if you haven't already:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add ai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install ai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add ai" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="bun add ai" dark />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="ai" />
 </div>
 
 After installation, your agent can reference the bundled source code and documentation at paths like:
@@ -71,20 +58,7 @@ AI SDK DevTools gives you full visibility into your AI SDK calls during developm
 Install the DevTools package:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/devtools" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/devtools" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/devtools" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="bun add @ai-sdk/devtools" dark />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/devtools" />
 </div>
 
 ### Register the integration

--- a/content/docs/02-getting-started/09-coding-agents.mdx
+++ b/content/docs/02-getting-started/09-coding-agents.mdx
@@ -33,9 +33,7 @@ Once you've installed the `ai` package, you already have the full AI SDK documen
 
 Install the `ai` package if you haven't already:
 
-<div className="my-4">
-  <InstallPackages packages="ai" />
-</div>
+<InstallPackages packages="ai" />
 
 After installation, your agent can reference the bundled source code and documentation at paths like:
 
@@ -57,9 +55,7 @@ AI SDK DevTools gives you full visibility into your AI SDK calls during developm
 
 Install the DevTools package:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/devtools" />
-</div>
+<InstallPackages packages="@ai-sdk/devtools" />
 
 ### Register the integration
 

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -13,9 +13,7 @@ results while a preconfigured harness powers these results.
 
 Install the core harness package, a harness adapter, and a sandbox provider:
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel" />
-</div>
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel" />
 
 Bridge-backed harnesses such as Claude Code and Codex require using real network sandbox
 like `@ai-sdk/sandbox-vercel`. Host-runtime harnesses such as Pi can also run with

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -14,32 +14,7 @@ results while a preconfigured harness powers these results.
 Install the core harness package, a harness adapter, and a sandbox provider:
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet
-        text="pnpm add @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="npm install @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="yarn add @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="bun add @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel" />
 </div>
 
 Bridge-backed harnesses such as Claude Code and Codex require using real network sandbox

--- a/content/docs/03-ai-sdk-harnesses/06-workflow-utilities.mdx
+++ b/content/docs/03-ai-sdk-harnesses/06-workflow-utilities.mdx
@@ -19,20 +19,7 @@ integration.
 ## Installation
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet text="pnpm add @ai-sdk/workflow-harness workflow" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="npm install @ai-sdk/workflow-harness workflow" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="yarn add @ai-sdk/workflow-harness workflow" dark />
-    </Tab>
-    <Tab>
-      <Snippet text="bun add @ai-sdk/workflow-harness workflow" dark />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/workflow-harness workflow" />
 </div>
 
 Install the core harness package, a harness adapter, and a sandbox provider as

--- a/content/docs/03-ai-sdk-harnesses/06-workflow-utilities.mdx
+++ b/content/docs/03-ai-sdk-harnesses/06-workflow-utilities.mdx
@@ -18,9 +18,7 @@ integration.
 
 ## Installation
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/workflow-harness workflow" />
-</div>
+<InstallPackages packages="@ai-sdk/workflow-harness workflow" />
 
 Install the core harness package, a harness adapter, and a sandbox provider as
 shown in [HarnessAgent](/docs/ai-sdk-harnesses/harness-agent).

--- a/content/docs/03-ai-sdk-harnesses/08-terminal-ui.mdx
+++ b/content/docs/03-ai-sdk-harnesses/08-terminal-ui.mdx
@@ -13,32 +13,7 @@ session for the lifetime of the terminal UI.
 ## Installation
 
 <div className="my-4">
-  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-    <Tab>
-      <Snippet
-        text="pnpm add @ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="npm install @ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="yarn add @ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="bun add @ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-        dark
-      />
-    </Tab>
-  </Tabs>
+  <InstallPackages packages="@ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel" />
 </div>
 
 ## Example

--- a/content/docs/03-ai-sdk-harnesses/08-terminal-ui.mdx
+++ b/content/docs/03-ai-sdk-harnesses/08-terminal-ui.mdx
@@ -12,9 +12,7 @@ session for the lifetime of the terminal UI.
 
 ## Installation
 
-<div className="my-4">
-  <InstallPackages packages="@ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel" />
-</div>
+<InstallPackages packages="@ai-sdk/tui @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel" />
 
 ## Example
 

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -12,21 +12,7 @@ The [xAI Grok](https://x.ai) provider contains language model support for the [x
 The xAI Grok provider is available via the `@ai-sdk/xai` module. You can
 install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/xai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/xai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/xai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/xai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/xai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/02-vercel.mdx
+++ b/content/providers/01-ai-sdk-providers/02-vercel.mdx
@@ -27,21 +27,7 @@ You can create your Vercel API key at [v0.dev](https://v0.dev/chat/settings/keys
 
 The Vercel provider is available via the `@ai-sdk/vercel` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/vercel" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/vercel" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/vercel" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/vercel" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/vercel" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -11,21 +11,7 @@ The [OpenAI](https://openai.com/) provider contains language model support for t
 
 The OpenAI provider is available in the `@ai-sdk/openai` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/openai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai" />
 
 ## Provider Instance
 
@@ -363,20 +349,7 @@ The [`ai-sdk-openai-websocket-fetch`](https://www.npmjs.com/package/ai-sdk-opena
 package provides a drop-in `fetch` replacement that routes streaming requests
 through a persistent WebSocket connection.
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-openai-websocket-fetch" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-openai-websocket-fetch" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-openai-websocket-fetch" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-openai-websocket-fetch" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-openai-websocket-fetch" />
 
 Pass the WebSocket fetch to `createOpenAI` via the `fetch` option:
 

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -11,21 +11,7 @@ The [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai
 
 The Azure OpenAI provider is available in the `@ai-sdk/azure` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/azure" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/azure" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/azure" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/azure" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/azure" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -11,21 +11,7 @@ The [Anthropic](https://www.anthropic.com/) provider contains language model sup
 
 The Anthropic provider is available in the `@ai-sdk/anthropic` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/anthropic" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/anthropic" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/anthropic" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/anthropic" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/anthropic" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/06-open-responses.mdx
+++ b/content/providers/01-ai-sdk-providers/06-open-responses.mdx
@@ -11,20 +11,7 @@ The [Open Responses](https://www.openresponses.org/) provider contains language 
 
 The Open Responses provider is available in the `@ai-sdk/open-responses` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/open-responses" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/open-responses" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/open-responses" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/open-responses" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/open-responses" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
+++ b/content/providers/01-ai-sdk-providers/07-anthropic-aws.mdx
@@ -13,20 +13,7 @@ This differs from [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock) i
 
 The Claude Platform on AWS provider is available in the `@ai-sdk/anthropic-aws` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/anthropic-aws" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/anthropic-aws" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/anthropic-aws" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/anthropic-aws" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/anthropic-aws" />
 
 ### Prerequisites
 

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -11,21 +11,7 @@ The Amazon Bedrock provider for the [AI SDK](/docs) contains language model supp
 
 The Bedrock provider is available in the `@ai-sdk/amazon-bedrock` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/amazon-bedrock" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/amazon-bedrock" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/amazon-bedrock" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/amazon-bedrock" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/amazon-bedrock" />
 
 ### Prerequisites
 
@@ -110,21 +96,7 @@ _Usage:_
 
 `@aws-sdk/credential-providers` package provides a set of credential providers that can be used to create a credential provider chain.
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @aws-sdk/credential-providers" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @aws-sdk/credential-providers" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @aws-sdk/credential-providers" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @aws-sdk/credential-providers" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@aws-sdk/credential-providers" />
 
 ```ts
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -12,21 +12,7 @@ The [Groq](https://groq.com/) provider contains language model support for the G
 The Groq provider is available via the `@ai-sdk/groq` module.
 You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/groq" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/groq" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/groq" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/groq" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/groq" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/10-fal.mdx
+++ b/content/providers/01-ai-sdk-providers/10-fal.mdx
@@ -11,21 +11,7 @@ description: Learn how to use Fal AI models with the AI SDK.
 
 The Fal provider is available via the `@ai-sdk/fal` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/fal" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/fal" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/fal" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/fal" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/fal" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/100-assemblyai.mdx
+++ b/content/providers/01-ai-sdk-providers/100-assemblyai.mdx
@@ -11,21 +11,7 @@ The [AssemblyAI](https://assemblyai.com/) provider contains transcription model 
 
 The AssemblyAI provider is available in the `@ai-sdk/assemblyai` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/assemblyai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/assemblyai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/assemblyai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/assemblyai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/assemblyai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/11-deepinfra.mdx
+++ b/content/providers/01-ai-sdk-providers/11-deepinfra.mdx
@@ -11,21 +11,7 @@ The [DeepInfra](https://deepinfra.com) provider contains support for state-of-th
 
 The DeepInfra provider is available via the `@ai-sdk/deepinfra` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/deepinfra" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/deepinfra" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/deepinfra" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/deepinfra" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/deepinfra" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/110-deepgram.mdx
+++ b/content/providers/01-ai-sdk-providers/110-deepgram.mdx
@@ -11,21 +11,7 @@ The [Deepgram](https://deepgram.com/) provider contains language model support f
 
 The Deepgram provider is available in the `@ai-sdk/deepgram` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/deepgram" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/deepgram" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/deepgram" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/deepgram" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/deepgram" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/12-black-forest-labs.mdx
+++ b/content/providers/01-ai-sdk-providers/12-black-forest-labs.mdx
@@ -11,21 +11,7 @@ description: Learn how to use Black Forest Labs models with the AI SDK.
 
 The Black Forest Labs provider is available via the `@ai-sdk/black-forest-labs` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/black-forest-labs" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/black-forest-labs" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/black-forest-labs" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/black-forest-labs" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/black-forest-labs" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/120-gladia.mdx
+++ b/content/providers/01-ai-sdk-providers/120-gladia.mdx
@@ -11,21 +11,7 @@ The [Gladia](https://gladia.io/) provider contains language model support for th
 
 The Gladia provider is available in the `@ai-sdk/gladia` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/gladia" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/gladia" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/gladia" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/gladia" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/gladia" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/140-lmnt.mdx
+++ b/content/providers/01-ai-sdk-providers/140-lmnt.mdx
@@ -11,21 +11,7 @@ The [LMNT](https://lmnt.com/) provider contains speech model support for the LMN
 
 The LMNT provider is available in the `@ai-sdk/lmnt` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/lmnt" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/lmnt" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/lmnt" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/lmnt" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/lmnt" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -12,21 +12,7 @@ the [Google](https://ai.google.dev/api/rest) APIs.
 
 The Google provider is available in the `@ai-sdk/google` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/google" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/google" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/google" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/google" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/google" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/150-hume.mdx
+++ b/content/providers/01-ai-sdk-providers/150-hume.mdx
@@ -11,21 +11,7 @@ The [Hume](https://hume.ai/) provider contains support for the Hume text-to-spee
 
 The Hume provider is available in the `@ai-sdk/hume` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/hume" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/hume" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/hume" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/hume" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/hume" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -20,24 +20,7 @@ The Google Vertex provider for the [AI SDK](/docs) contains language model suppo
 
 The Google Vertex, Google Vertex Anthropic, Google Vertex xAI, and Google Vertex MaaS providers are available in the `@ai-sdk/google-vertex` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/google-vertex" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/google-vertex" dark />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ai-sdk/google-vertex @google-cloud/vertexai"
-      dark
-    />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/google-vertex" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/google-vertex" />
 
 ## Google Vertex Provider Usage
 

--- a/content/providers/01-ai-sdk-providers/160-revai.mdx
+++ b/content/providers/01-ai-sdk-providers/160-revai.mdx
@@ -11,21 +11,7 @@ The [Rev.ai](https://www.rev.ai/) provider contains language model support for t
 
 The Rev.ai provider is available in the `@ai-sdk/revai` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/revai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/revai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/revai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/revai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/revai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/170-baseten.mdx
+++ b/content/providers/01-ai-sdk-providers/170-baseten.mdx
@@ -11,17 +11,7 @@ description: Learn how to use Baseten models with the AI SDK.
 
 The Baseten provider is available via the `@ai-sdk/baseten` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/baseten" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/baseten" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/baseten" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/baseten" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/170-huggingface.mdx
+++ b/content/providers/01-ai-sdk-providers/170-huggingface.mdx
@@ -13,21 +13,7 @@ API keys can be obtained from [Hugging Face Settings](https://huggingface.co/set
 
 The Hugging Face provider is available via the `@ai-sdk/huggingface` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/huggingface" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/huggingface" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/huggingface" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/huggingface" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/huggingface" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/180-quiverai.mdx
+++ b/content/providers/01-ai-sdk-providers/180-quiverai.mdx
@@ -11,21 +11,7 @@ description: Learn how to use QuiverAI models with the AI SDK.
 
 The QuiverAI provider is available via the `@ai-sdk/quiverai` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/quiverai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/quiverai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/quiverai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/quiverai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/quiverai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -11,21 +11,7 @@ The [Mistral AI](https://mistral.ai/) provider contains language model support f
 
 The Mistral provider is available in the `@ai-sdk/mistral` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/mistral" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/mistral" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/mistral" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/mistral" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/mistral" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/24-togetherai.mdx
+++ b/content/providers/01-ai-sdk-providers/24-togetherai.mdx
@@ -12,21 +12,7 @@ The [Together.ai](https://together.ai) provider contains support for 200+ open-s
 The Together.ai provider is available via the `@ai-sdk/togetherai` module. You can
 install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/togetherai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/togetherai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/togetherai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/togetherai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/togetherai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/25-cohere.mdx
+++ b/content/providers/01-ai-sdk-providers/25-cohere.mdx
@@ -11,21 +11,7 @@ The [Cohere](https://cohere.com/) provider contains language and embedding model
 
 The Cohere provider is available in the `@ai-sdk/cohere` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/cohere" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/cohere" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/cohere" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/cohere" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/cohere" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -11,21 +11,7 @@ description: Learn how to use Fireworks models with the AI SDK.
 
 The Fireworks provider is available via the `@ai-sdk/fireworks` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/fireworks" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/fireworks" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/fireworks" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/fireworks" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/fireworks" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/27-voyage.mdx
+++ b/content/providers/01-ai-sdk-providers/27-voyage.mdx
@@ -11,20 +11,7 @@ The [Voyage AI](https://www.voyageai.com/) provider contains embedding and reran
 
 The Voyage AI provider is available in the `@ai-sdk/voyage` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/voyage" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/voyage" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/voyage" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/voyage" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/voyage" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -13,20 +13,7 @@ API keys can be obtained from the [DeepSeek Platform](https://platform.deepseek.
 
 The DeepSeek provider is available via the `@ai-sdk/deepseek` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/deepseek" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/deepseek" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/deepseek" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/deepseek" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/deepseek" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -13,20 +13,7 @@ API keys can be obtained from the [Moonshot Platform](https://platform.moonshot.
 
 The Moonshot AI provider is available via the `@ai-sdk/moonshotai` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/moonshotai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/moonshotai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/moonshotai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/moonshotai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/moonshotai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -13,20 +13,7 @@ API keys can be obtained from the [Console](https://modelstudio.console.alibabac
 
 The Alibaba provider is available via the `@ai-sdk/alibaba` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/alibaba" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/alibaba" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/alibaba" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/alibaba" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/alibaba" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -13,21 +13,7 @@ API keys can be obtained from the [Cerebras Platform](https://cloud.cerebras.ai)
 
 The Cerebras provider is available via the `@ai-sdk/cerebras` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/cerebras" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/cerebras" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/cerebras" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/cerebras" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/cerebras" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/60-replicate.mdx
+++ b/content/providers/01-ai-sdk-providers/60-replicate.mdx
@@ -12,21 +12,7 @@ It is a popular choice for running image generation models.
 
 The Replicate provider is available via the `@ai-sdk/replicate` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/replicate" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/replicate" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/replicate" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/replicate" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/replicate" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/65-prodia.mdx
+++ b/content/providers/01-ai-sdk-providers/65-prodia.mdx
@@ -11,21 +11,7 @@ description: Learn how to use Prodia models with the AI SDK.
 
 The Prodia provider is available via the `@ai-sdk/prodia` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/prodia" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/prodia" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/prodia" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/prodia" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/prodia" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/70-perplexity.mdx
+++ b/content/providers/01-ai-sdk-providers/70-perplexity.mdx
@@ -13,21 +13,7 @@ API keys can be obtained from the [Perplexity Platform](https://docs.perplexity.
 
 The Perplexity provider is available via the `@ai-sdk/perplexity` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/perplexity" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/perplexity" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/perplexity" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/perplexity" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/perplexity" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/80-luma.mdx
+++ b/content/providers/01-ai-sdk-providers/80-luma.mdx
@@ -11,21 +11,7 @@ description: Learn how to use Luma AI models with the AI SDK.
 
 The Luma provider is available via the `@ai-sdk/luma` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/luma" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/luma" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/luma" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/luma" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/luma" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -11,21 +11,7 @@ The [ByteDance](https://www.bytedance.com/) provider contains support for the Se
 
 The ByteDance provider is available via the `@ai-sdk/bytedance` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/bytedance" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/bytedance" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/bytedance" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/bytedance" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/bytedance" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/85-klingai.mdx
+++ b/content/providers/01-ai-sdk-providers/85-klingai.mdx
@@ -11,21 +11,7 @@ The [Kling AI](https://klingai.com/) provider contains support for Kling AI's vi
 
 The Kling AI provider is available in the `@ai-sdk/klingai` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/klingai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/klingai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/klingai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/klingai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/klingai" />
 
 ## Provider Instance
 

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -11,21 +11,7 @@ The [ElevenLabs](https://elevenlabs.io/) provider contains language model suppor
 
 The ElevenLabs provider is available in the `@ai-sdk/elevenlabs` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/elevenlabs" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/elevenlabs" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/elevenlabs" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/elevenlabs" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/elevenlabs" />
 
 ## Provider Instance
 

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -17,32 +17,7 @@ WebSocket.
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add @ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel" />
 
 The adapter bootstraps the Claude Code bridge dependencies inside the sandbox
 when the first session starts.

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -16,32 +16,7 @@ Codex thread events back to the host over a sandbox-exposed WebSocket.
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel" />
 
 The adapter bootstraps the Codex bridge dependencies inside the sandbox when
 the first session starts.

--- a/content/providers/02-ai-sdk-harnesses/03-pi.mdx
+++ b/content/providers/02-ai-sdk-harnesses/03-pi.mdx
@@ -17,32 +17,7 @@ inside the sandbox.
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @ai-sdk/harness @ai-sdk/harness-pi @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @ai-sdk/harness @ai-sdk/harness-pi @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ai-sdk/harness @ai-sdk/harness-pi @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add @ai-sdk/harness @ai-sdk/harness-pi @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-pi @ai-sdk/sandbox-vercel" />
 
 ## Import
 

--- a/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
+++ b/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
@@ -17,32 +17,7 @@ the host over a sandbox-exposed WebSocket.
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @ai-sdk/harness @ai-sdk/harness-opencode @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @ai-sdk/harness @ai-sdk/harness-opencode @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ai-sdk/harness @ai-sdk/harness-opencode @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add @ai-sdk/harness @ai-sdk/harness-opencode @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-opencode @ai-sdk/sandbox-vercel" />
 
 The adapter bootstraps the OpenCode bridge dependencies inside the sandbox when
 the first session starts. The bridge package depends on `@opencode-ai/sdk` and

--- a/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
+++ b/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
@@ -18,32 +18,7 @@ sandbox-exposed WebSocket.
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @ai-sdk/harness @ai-sdk/harness-deepagents @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @ai-sdk/harness @ai-sdk/harness-deepagents @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ai-sdk/harness @ai-sdk/harness-deepagents @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add @ai-sdk/harness @ai-sdk/harness-deepagents @ai-sdk/sandbox-vercel"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-deepagents @ai-sdk/sandbox-vercel" />
 
 The adapter bootstraps the bridge's Node dependencies (the `deepagents` package
 and LangChain) inside the sandbox via `pnpm` when the first session starts.

--- a/content/providers/03-observability/axiom.mdx
+++ b/content/providers/03-observability/axiom.mdx
@@ -23,21 +23,7 @@ First, you'll need an Axiom organization, a dataset to send traces to, and an AP
 
 Install the Axiom package in your project:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add axiom" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install axiom" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add axiom" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add axiom" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="axiom" />
 
 ### 3. Set Environment Variables
 
@@ -65,32 +51,7 @@ To send data to Axiom, configure a tracer. For example, use a dedicated instrume
 
 1. Install dependencies:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm i dotenv @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/semantic-conventions @opentelemetry/api"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm i dotenv @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/semantic-conventions @opentelemetry/api"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add dotenv @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/semantic-conventions @opentelemetry/api"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add dotenv @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/semantic-conventions @opentelemetry/api"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="dotenv @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/semantic-conventions @opentelemetry/api" />
 
 2. Create instrumentation file:
 

--- a/content/providers/03-observability/helicone.mdx
+++ b/content/providers/03-observability/helicone.mdx
@@ -11,20 +11,7 @@ description: Monitor and optimize your AI SDK applications with minimal configur
 
 The Helicone provider is available in the `@helicone/ai-sdk-provider` package. Install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @helicone/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @helicone/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @helicone/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @helicone/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@helicone/ai-sdk-provider" />
 
 Setting up Helicone:
 

--- a/content/providers/03-observability/laminar.mdx
+++ b/content/providers/03-observability/laminar.mdx
@@ -40,21 +40,7 @@ Copy the prompt below and paste it to your coding agent, for it to integrate ful
 
 To setup Laminar manually, first install the `@lmnr-ai/lmnr` package.
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @lmnr-ai/lmnr" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @lmnr-ai/lmnr" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @lmnr-ai/lmnr" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @lmnr-ai/lmnr" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@lmnr-ai/lmnr" />
 
 ### Get your project API key and set in the environment
 

--- a/content/providers/03-observability/langsmith.mdx
+++ b/content/providers/03-observability/langsmith.mdx
@@ -24,20 +24,7 @@ Use of LangChain's open-source frameworks is not necessary.
 Install an [AI SDK model provider](/providers/ai-sdk-providers) and the [LangSmith client SDK](https://npmjs.com/package/langsmith).
 The code snippets below will use the [AI SDK's OpenAI provider](/providers/ai-sdk-providers/openai), but you can use any [other supported provider](/providers/ai-sdk-providers) as well.
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai langsmith" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai langsmith" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai langsmith" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/openai langsmith" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai langsmith" />
 
 Next, set required environment variables.
 

--- a/content/providers/03-observability/langwatch.mdx
+++ b/content/providers/03-observability/langwatch.mdx
@@ -11,21 +11,7 @@ description: Track, monitor, guardrail and evaluate your AI SDK applications wit
 
 Obtain your `LANGWATCH_API_KEY` from the [LangWatch dashboard](https://app.langwatch.com/).
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add langwatch" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install langwatch" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add langwatch" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add langwatch" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="langwatch" />
 
 Ensure `LANGWATCH_API_KEY` is set:
 

--- a/content/providers/03-observability/latitude.mdx
+++ b/content/providers/03-observability/latitude.mdx
@@ -17,20 +17,7 @@ Latitude's SDK registers a global OpenTelemetry tracer. Once you register the AI
 
 Install both packages:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @latitude-data/telemetry @ai-sdk/otel" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @latitude-data/telemetry @ai-sdk/otel" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @latitude-data/telemetry @ai-sdk/otel" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @latitude-data/telemetry @ai-sdk/otel" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@latitude-data/telemetry @ai-sdk/otel" />
 
 Sign in at [app.latitude.so](https://app.latitude.so) and grab your API key and project slug from the dashboard. Set them in your environment:
 

--- a/content/providers/03-observability/raindrop.mdx
+++ b/content/providers/03-observability/raindrop.mdx
@@ -13,20 +13,7 @@ Raindrop supports the AI SDK v7 telemetry interface directly, so you can use `re
 
 Install the Raindrop AI SDK integration:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @raindrop-ai/ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @raindrop-ai/ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @raindrop-ai/ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @raindrop-ai/ai-sdk" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@raindrop-ai/ai-sdk" />
 
 Set your Raindrop write key (create one in the [Raindrop dashboard](https://www.raindrop.ai/)):
 

--- a/content/providers/04-openai-compatible-providers/30-lmstudio.mdx
+++ b/content/providers/04-openai-compatible-providers/30-lmstudio.mdx
@@ -15,21 +15,7 @@ You can start the local server under the [Local Server tab](https://lmstudio.ai/
 The LM Studio provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API.
 You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai-compatible" />
 
 ## Provider Instance
 

--- a/content/providers/04-openai-compatible-providers/35-nim.mdx
+++ b/content/providers/04-openai-compatible-providers/35-nim.mdx
@@ -12,21 +12,7 @@ description: Use NVIDIA NIM OpenAI compatible API with the AI SDK.
 The NVIDIA NIM provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API.
 You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai-compatible" />
 
 ## Provider Instance
 

--- a/content/providers/04-openai-compatible-providers/45-clarifai.mdx
+++ b/content/providers/04-openai-compatible-providers/45-clarifai.mdx
@@ -11,17 +11,7 @@ description: Use Clarifai OpenAI compatible API with the AI SDK.
 
 The Clarifai provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai-compatible" />
 
 ## Provider Instance
 

--- a/content/providers/04-openai-compatible-providers/45-heroku.mdx
+++ b/content/providers/04-openai-compatible-providers/45-heroku.mdx
@@ -13,17 +13,7 @@ You can deploy models that are OpenAI API compatible and use them with the AI SD
 The Heroku provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API.
 You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai-compatible" />
 
 ### Heroku Setup
 

--- a/content/providers/04-openai-compatible-providers/50-nearai.mdx
+++ b/content/providers/04-openai-compatible-providers/50-nearai.mdx
@@ -11,20 +11,7 @@ description: Use the NEAR AI Cloud OpenAI compatible API with the AI SDK.
 
 The NEAR AI Cloud provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai-compatible" />
 
 ## Provider Instance
 

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -23,21 +23,7 @@ The general setup and provider instance creation is the same for all of these pr
 
 The OpenAI Compatible provider is available via the `@ai-sdk/openai-compatible` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/openai-compatible" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/02-a2a.mdx
+++ b/content/providers/05-community-providers/02-a2a.mdx
@@ -24,21 +24,7 @@ Learn more about A2A at the [A2A Project Site](https://a2aproject.github.io/A2A/
 
 Install the `a2a-ai-provider` from npm:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add a2a-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install a2a-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add a2a-ai-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add a2a-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="a2a-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/03-acp.mdx
+++ b/content/providers/05-community-providers/03-acp.mdx
@@ -22,20 +22,7 @@ Learn more about ACP in the [Agent Client Protocol Documentation](https://agentc
 
 The ACP provider is available in the `@mcpc-tech/acp-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @mcpc-tech/acp-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @mcpc-tech/acp-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @mcpc-tech/acp-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @mcpc-tech/acp-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@mcpc-tech/acp-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/04-aihubmix.mdx
+++ b/content/providers/05-community-providers/04-aihubmix.mdx
@@ -11,17 +11,7 @@ The [Aihubmix](https://aihubmix.com/) provider contains unified access to multip
 
 The Aihubmix provider is available in the `@aihubmix/ai-sdk-provider` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet text="pnpm add @aihubmix/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @aihubmix/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @aihubmix/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@aihubmix/ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/05-aimlapi.mdx
+++ b/content/providers/05-community-providers/05-aimlapi.mdx
@@ -11,20 +11,7 @@ The [AI/ML API](https://aimlapi.com/?utm_source=aimlapi-vercel-ai&utm_medium=git
 
 The AI/ML API provider is available via the `@ai-ml.api/aimlapi-vercel-ai` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-ml.api/aimlapi-vercel-ai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-ml.api/aimlapi-vercel-ai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-ml.api/aimlapi-vercel-ai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ai-ml.api/aimlapi-vercel-ai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-ml.api/aimlapi-vercel-ai" />
 
 ### API Key
 

--- a/content/providers/05-community-providers/06-anthropic-vertex-ai.mdx
+++ b/content/providers/05-community-providers/06-anthropic-vertex-ai.mdx
@@ -22,21 +22,7 @@ description: Learn how to use the Anthropic Vertex provider for the AI SDK.
 
 The AnthropicVertex provider is available in the `anthropic-vertex-ai` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add anthropic-vertex-ai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install anthropic-vertex-ai" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add anthropic-vertex-ai" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add anthropic-vertex-ai" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="anthropic-vertex-ai" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/09-browser-ai.mdx
+++ b/content/providers/05-community-providers/09-browser-ai.mdx
@@ -14,54 +14,15 @@ It currently provides a model provider for Chrome & Edge's native browser AI mod
 
 The `@browser-ai/core` (formerly `@built-in-ai`) package is the AI SDK provider for Chrome and Edge browser's built-in AI models. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @browser-ai/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @browser-ai/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @browser-ai/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @browser-ai/core" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@browser-ai/core" />
 
 The `@browser-ai/web-llm` package is the AI SDK provider for popular open-source models using the WebLLM inference engine. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @browser-ai/web-llm" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @browser-ai/web-llm" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @browser-ai/web-llm" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @browser-ai/web-llm" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@browser-ai/web-llm" />
 
 The `@browser-ai/transformers-js` package is the AI SDK provider for popular open-source models using Transformers.js. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @browser-ai/transformers-js" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @browser-ai/transformers-js" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @browser-ai/transformers-js" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @browser-ai/transformers-js" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@browser-ai/transformers-js" />
 
 ## Provider Instances
 

--- a/content/providers/05-community-providers/10-claude-code.mdx
+++ b/content/providers/05-community-providers/10-claude-code.mdx
@@ -28,20 +28,7 @@ npm install ai-sdk-provider-claude-code@ai-sdk-v4 ai@^4.0.0
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-claude-code" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-provider-claude-code" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-provider-claude-code" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-provider-claude-code" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-provider-claude-code" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/11-cloudflare-ai-gateway.mdx
+++ b/content/providers/05-community-providers/11-cloudflare-ai-gateway.mdx
@@ -19,21 +19,7 @@ The Cloudflare AI Gateway Provider is a library that integrates Cloudflare's AI 
 
 The Cloudflare AI Gateway Provider is available in the `ai-gateway-provider` module. Install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-gateway-provider" />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-gateway-provider" />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-gateway-provider" />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add ai-gateway-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-gateway-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/12-cloudflare-workers-ai.mdx
+++ b/content/providers/05-community-providers/12-cloudflare-workers-ai.mdx
@@ -11,21 +11,7 @@ description: Learn how to use the Cloudflare Workers AI provider for the AI SDK.
 
 The Cloudflare Workers AI provider is available in the `workers-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add workers-ai-provider" />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install workers-ai-provider" />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add workers-ai-provider" />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add workers-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="workers-ai-provider" />
 
 Then, setup an AI binding in your Cloudflare Workers project `wrangler.toml` file:
 

--- a/content/providers/05-community-providers/13-codex-cli.mdx
+++ b/content/providers/05-community-providers/13-codex-cli.mdx
@@ -24,20 +24,7 @@ npm install ai-sdk-provider-codex-cli@ai-sdk-v5 ai@^5.0.0
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-codex-cli" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-provider-codex-cli" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-provider-codex-cli" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-provider-codex-cli" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-provider-codex-cli" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/14-crosshatch.mdx
+++ b/content/providers/05-community-providers/14-crosshatch.mdx
@@ -20,21 +20,7 @@ It creates language model objects that can be used with the `generateText` and `
 The Crosshatch provider is available via the `@crosshatch/ai-provider` module.
 You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @crosshatch/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @crosshatch/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @crosshatch/ai-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @crosshatch/ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@crosshatch/ai-provider" />
 
 The [Crosshatch](https://crosshatch.io/) provider supports all of their available models such as OpenAI's GPT and Anthropic's Claude. This provider also supports the querying interface for controlling Crosshatch's custom data integration behaviors. This provider wraps the existing underlying providers ([@ai-sdk/openai](/providers/ai-sdk-providers/openai), [@ai-sdk/anthropic](/providers/ai-sdk-providers/openai).
 

--- a/content/providers/05-community-providers/16-firemoon.mdx
+++ b/content/providers/05-community-providers/16-firemoon.mdx
@@ -17,20 +17,7 @@ The Firemoon provider for the AI SDK enables you to use these models with a simp
 
 The Firemoon provider is available via the `@firemoon/ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @firemoon/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @firemoon/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @firemoon/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @firemoon/ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@firemoon/ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/17-friendliai.mdx
+++ b/content/providers/05-community-providers/17-friendliai.mdx
@@ -14,21 +14,7 @@ It creates language model objects that can be used with the `generateText` and `
 The Friendli provider is available via the `@friendliai/ai-provider` module.
 You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @friendliai/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @friendliai/ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @friendliai/ai-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @friendliai/ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@friendliai/ai-provider" />
 
 ### Credentials
 

--- a/content/providers/05-community-providers/18-gemini-cli.mdx
+++ b/content/providers/05-community-providers/18-gemini-cli.mdx
@@ -28,20 +28,7 @@ npm install ai-sdk-provider-gemini-cli@ai-sdk-v4 ai@^4.0.0
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-gemini-cli" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-provider-gemini-cli" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-provider-gemini-cli" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-provider-gemini-cli" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-provider-gemini-cli" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/19-helicone.mdx
+++ b/content/providers/05-community-providers/19-helicone.mdx
@@ -19,20 +19,7 @@ Learn more about Helicone's capabilities in the [Helicone Documentation](https:/
 
 The Helicone provider is available in the `@helicone/ai-sdk-provider` package. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @helicone/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @helicone/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @helicone/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @helicone/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@helicone/ai-sdk-provider" />
 
 ## Get started
 

--- a/content/providers/05-community-providers/21-jina-ai.mdx
+++ b/content/providers/05-community-providers/21-jina-ai.mdx
@@ -11,20 +11,7 @@ description: Learn how to use the Jina AI provider.
 
 The Jina provider is available in the `jina-ai-provider` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add jina-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install jina-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add jina-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add jina-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="jina-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/22-langdb.mdx
+++ b/content/providers/05-community-providers/22-langdb.mdx
@@ -24,21 +24,7 @@ LangDB provides OpenAI-compatible APIs, enabling developers to connect with mult
 
 The LangDB provider is available via the `@langdb/vercel-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @langdb/vercel-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @langdb/vercel-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @langdb/vercel-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @langdb/vercel-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@langdb/vercel-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/23-letta.mdx
+++ b/content/providers/05-community-providers/23-letta.mdx
@@ -24,20 +24,7 @@ See the [Letta documentation](https://docs.letta.com/connecting-model-providers/
 
 You can install the Letta provider with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @letta-ai/vercel-ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @letta-ai/vercel-ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @letta-ai/vercel-ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @letta-ai/vercel-ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@letta-ai/vercel-ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/24-llama-cpp.mdx
+++ b/content/providers/05-community-providers/24-llama-cpp.mdx
@@ -45,20 +45,7 @@ brew install cmake
 
 The llama.cpp provider is available in the `ai-sdk-llama-cpp` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-llama-cpp" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-llama-cpp" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-llama-cpp" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-llama-cpp" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-llama-cpp" />
 
 The installation will automatically compile llama.cpp as a static library with Metal support and build the native Node.js addon.
 

--- a/content/providers/05-community-providers/25-llamagate.mdx
+++ b/content/providers/05-community-providers/25-llamagate.mdx
@@ -21,20 +21,7 @@ Learn more about LlamaGate's capabilities in the [LlamaGate Documentation](https
 
 The LlamaGate provider is available in the `@llamagate/ai-sdk-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @llamagate/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @llamagate/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @llamagate/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @llamagate/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@llamagate/ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/27-mem0.mdx
+++ b/content/providers/05-community-providers/27-mem0.mdx
@@ -17,20 +17,7 @@ This library brings enhanced AI interaction capabilities to your applications by
 
 The Mem0 provider is available in the `@mem0/vercel-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @mem0/vercel-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @mem0/vercel-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @mem0/vercel-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @mem0/vercel-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@mem0/vercel-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/28-minimax.mdx
+++ b/content/providers/05-community-providers/28-minimax.mdx
@@ -13,20 +13,7 @@ API keys can be obtained from the [MiniMax Platform](https://platform.minimax.io
 
 The MiniMax provider is available via the `vercel-minimax-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add vercel-minimax-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install vercel-minimax-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add vercel-minimax-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add vercel-minimax-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="vercel-minimax-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/29-mixedbread.mdx
+++ b/content/providers/05-community-providers/29-mixedbread.mdx
@@ -11,21 +11,7 @@ description: Learn how to use the Mixedbread provider.
 
 The Mixedbread provider is available in the `mixedbread-ai-provider` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add mixedbread-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install mixedbread-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add mixedbread-ai-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add mixedbread-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="mixedbread-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/30-ollama.mdx
+++ b/content/providers/05-community-providers/30-ollama.mdx
@@ -44,37 +44,11 @@ Choose and install your preferred Ollama provider:
 
 ### ollama-ai-provider-v2
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ollama-ai-provider-v2" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ollama-ai-provider-v2" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ollama-ai-provider-v2" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ollama-ai-provider-v2" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ollama-ai-provider-v2" />
 
 ### ai-sdk-ollama
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-ollama" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-ollama" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-ollama" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-ollama" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-ollama" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/31-opencode-sdk.mdx
+++ b/content/providers/05-community-providers/31-opencode-sdk.mdx
@@ -24,20 +24,7 @@ npm install ai-sdk-provider-opencode-sdk@ai-sdk-v5 ai@^5.0.0
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-opencode-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-provider-opencode-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-provider-opencode-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-provider-opencode-sdk" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-provider-opencode-sdk" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/32-openrouter.mdx
+++ b/content/providers/05-community-providers/32-openrouter.mdx
@@ -20,21 +20,7 @@ Learn more about OpenRouter's capabilities in the [OpenRouter Documentation](htt
 
 The OpenRouter provider is available in the `@openrouter/ai-sdk-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @openrouter/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @openrouter/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @openrouter/ai-sdk-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @openrouter/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@openrouter/ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/33-portkey.mdx
+++ b/content/providers/05-community-providers/33-portkey.mdx
@@ -20,21 +20,7 @@ Learn more at [Portkey docs for the AI SDK](https://docs.portkey.ai/docs/integra
 
 The Portkey provider is available in the `@portkey-ai/vercel-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @portkey-ai/vercel-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @portkey-ai/vercel-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @portkey-ai/vercel-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @portkey-ai/vercel-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@portkey-ai/vercel-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/34-qwen.mdx
+++ b/content/providers/05-community-providers/34-qwen.mdx
@@ -17,21 +17,7 @@ description: Learn how to use the Qwen provider.
 
 The Qwen provider is available in the `qwen-ai-provider` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add qwen-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install qwen-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add qwen-ai-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add qwen-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="qwen-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/35-react-native-apple.mdx
+++ b/content/providers/05-community-providers/35-react-native-apple.mdx
@@ -11,20 +11,7 @@ description: Learn how to use the Apple provider for on-device AI.
 
 The Apple provider is available in the `@react-native-ai/apple` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @react-native-ai/apple" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @react-native-ai/apple" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @react-native-ai/apple" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @react-native-ai/apple" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@react-native-ai/apple" />
 
 ### Prerequisites
 

--- a/content/providers/05-community-providers/36-requesty.mdx
+++ b/content/providers/05-community-providers/36-requesty.mdx
@@ -21,21 +21,7 @@ Learn more about Requesty's capabilities in the [Requesty Documentation](https:/
 
 The Requesty provider is available in the `@requesty/ai-sdk` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @requesty/ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @requesty/ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @requesty/ai-sdk" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add @requesty/ai-sdk" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@requesty/ai-sdk" />
 
 ## API Key Setup
 

--- a/content/providers/05-community-providers/37-runpod.mdx
+++ b/content/providers/05-community-providers/37-runpod.mdx
@@ -11,20 +11,7 @@ The official [Runpod](https://runpod.io) provider contains language model and im
 
 The Runpod provider is available in the `@runpod/ai-sdk-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @runpod/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @runpod/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @runpod/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @runpod/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@runpod/ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/38-sambanova.mdx
+++ b/content/providers/05-community-providers/38-sambanova.mdx
@@ -13,21 +13,7 @@ API keys can be obtained from the [SambaNova Cloud Platform](https://cloud.samba
 
 The SambaNova provider is available via the `sambanova-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add sambanova-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install sambanova-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add sambanova-ai-provider" dark />
-  </Tab>
-
-  <Tab>
-    <Snippet text="bun add sambanova-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="sambanova-ai-provider" />
 
 ### Environment variables
 

--- a/content/providers/05-community-providers/39-sap-ai.mdx
+++ b/content/providers/05-community-providers/39-sap-ai.mdx
@@ -25,37 +25,11 @@ Both providers offer:
 
 ### @jerome-benoit/sap-ai-provider (recommended)
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @jerome-benoit/sap-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @jerome-benoit/sap-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @jerome-benoit/sap-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @jerome-benoit/sap-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@jerome-benoit/sap-ai-provider" />
 
 ### @jerome-benoit/sap-ai-provider-v2
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @jerome-benoit/sap-ai-provider-v2" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @jerome-benoit/sap-ai-provider-v2" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @jerome-benoit/sap-ai-provider-v2" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @jerome-benoit/sap-ai-provider-v2" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@jerome-benoit/sap-ai-provider-v2" />
 
 Authentication is handled automatically via the `AICORE_SERVICE_KEY` environment variable (local) or `VCAP_SERVICES` (SAP BTP).
 

--- a/content/providers/05-community-providers/40-sarvam.mdx
+++ b/content/providers/05-community-providers/40-sarvam.mdx
@@ -11,20 +11,7 @@ The Sarvam AI Provider is a library developed to integrate with the AI SDK. This
 
 The Sarvam provider is available in the `sarvam-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add sarvam-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install sarvam-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add sarvam-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add sarvam-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="sarvam-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/41-soniox.mdx
+++ b/content/providers/05-community-providers/41-soniox.mdx
@@ -10,20 +10,7 @@ For more information, see the [Soniox Documentation](https://soniox.com/docs).
 
 ## Installation
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @soniox/vercel-ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @soniox/vercel-ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @soniox/vercel-ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @soniox/vercel-ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@soniox/vercel-ai-sdk-provider" />
 
 ## Authentication
 

--- a/content/providers/05-community-providers/42-supermemory.mdx
+++ b/content/providers/05-community-providers/42-supermemory.mdx
@@ -20,20 +20,7 @@ Learn more about Supermemory's capabilities in the [Supermemory Documentation](h
 
 The Supermemory provider is available in the `@supermemory/tools` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @supermemory/tools" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @supermemory/tools" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @supermemory/tools" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @supermemory/tools" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@supermemory/tools" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/43-voyage-ai.mdx
+++ b/content/providers/05-community-providers/43-voyage-ai.mdx
@@ -11,20 +11,7 @@ description: Learn how to use the Voyage AI provider.
 
 The Voyage provider is available in the `voyage-ai-provider` module. You can install it with
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add voyage-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install voyage-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add voyage-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add voyage-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="voyage-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/44-zhipu.mdx
+++ b/content/providers/05-community-providers/44-zhipu.mdx
@@ -9,20 +9,7 @@ description: Learn how to use the Zhipu (Z.AI) provider.
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add zhipu-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm i zhipu-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add zhipu-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add zhipu-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="zhipu-ai-provider" />
 
 Set up your `.env` file / environment with your API key.
 

--- a/content/providers/05-community-providers/45-vectorstores.mdx
+++ b/content/providers/05-community-providers/45-vectorstores.mdx
@@ -11,20 +11,7 @@ The [vectorstores provider](https://www.vectorstores.org/integration/vercel/) in
 
 The vectorstores provider is available in the `@vectorstores/vercel` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @vectorstores/vercel @vectorstores/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @vectorstores/vercel @vectorstores/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @vectorstores/vercel @vectorstores/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @vectorstores/vercel @vectorstores/core" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@vectorstores/vercel @vectorstores/core" />
 
 ## Document Indexing
 

--- a/content/providers/05-community-providers/46-codex-app-server.mdx
+++ b/content/providers/05-community-providers/46-codex-app-server.mdx
@@ -22,20 +22,7 @@ The [ai-sdk-provider-codex-app-server](https://github.com/pablof7z/ai-sdk-provid
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-codex-app-server" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install ai-sdk-provider-codex-app-server" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add ai-sdk-provider-codex-app-server" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add ai-sdk-provider-codex-app-server" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="ai-sdk-provider-codex-app-server" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/47-apertis.mdx
+++ b/content/providers/05-community-providers/47-apertis.mdx
@@ -17,17 +17,7 @@ description: Apertis AI Provider for the AI SDK
 
 ## Setup
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet text="pnpm add @apertis/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @apertis/ai-sdk-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @apertis/ai-sdk-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@apertis/ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/48-ollm.mdx
+++ b/content/providers/05-community-providers/48-ollm.mdx
@@ -19,20 +19,7 @@ Learn more about OLLM's capabilities in the [OLLM Website](https://ollm.com).
 
 The OLLM provider is available in the `@ofoundation/ollm` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @ofoundation/ollm" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ofoundation/ollm" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ofoundation/ollm" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @ofoundation/ollm" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ofoundation/ollm" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/49-cencori.mdx
+++ b/content/providers/05-community-providers/49-cencori.mdx
@@ -18,11 +18,7 @@ With Cencori, you get:
 
 The Cencori provider is available in the `cencori` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>```bash pnpm add cencori ```</Tab>
-  <Tab>```bash npm install cencori ```</Tab>
-  <Tab>```bash yarn add cencori ```</Tab>
-</Tabs>
+<InstallPackages packages="cencori" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/50-hindsight.mdx
+++ b/content/providers/05-community-providers/50-hindsight.mdx
@@ -37,32 +37,7 @@ Sign up and get your API URL from the [Hindsight dashboard](https://ui.hindsight
 
 ## Installation
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @vectorize-io/hindsight-ai-sdk @vectorize-io/hindsight-client"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @vectorize-io/hindsight-ai-sdk @vectorize-io/hindsight-client"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @vectorize-io/hindsight-ai-sdk @vectorize-io/hindsight-client"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="bun add @vectorize-io/hindsight-ai-sdk @vectorize-io/hindsight-client"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@vectorize-io/hindsight-ai-sdk @vectorize-io/hindsight-client" />
 
 ## Creating Tools
 

--- a/content/providers/05-community-providers/51-nia.mdx
+++ b/content/providers/05-community-providers/51-nia.mdx
@@ -21,20 +21,7 @@ Learn more in the [Nia documentation](https://docs.trynia.ai/).
 
 The Nia adapter is available in the `@nozomioai/nia-ai-sdk` package. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add @nozomioai/nia-ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @nozomioai/nia-ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @nozomioai/nia-ai-sdk" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add @nozomioai/nia-ai-sdk" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@nozomioai/nia-ai-sdk" />
 
 If you want to use Nia middleware with a model provider, install that provider as well. For example:
 

--- a/content/providers/05-community-providers/51-zeroentropy.mdx
+++ b/content/providers/05-community-providers/51-zeroentropy.mdx
@@ -11,20 +11,7 @@ description: Learn how to use the ZeroEntropy community provider.
 
 The ZeroEntropy provider is available in the `zeroentropy-ai-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    <Snippet text="pnpm add zeroentropy-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install zeroentropy-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add zeroentropy-ai-provider" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="bun add zeroentropy-ai-provider" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="zeroentropy-ai-provider" />
 
 ## Provider Instance
 

--- a/content/providers/05-community-providers/98-flowise.mdx
+++ b/content/providers/05-community-providers/98-flowise.mdx
@@ -11,26 +11,7 @@ The **[Flowise provider](https://github.com/ahmedrowaihi/flowise-ai-sdk-provider
 
 The Flowise provider is available in the `@ahmedrowaihi/flowise-vercel-ai-sdk-provider` module. You can install it with:
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet
-      text="pnpm add @ahmedrowaihi/flowise-vercel-ai-sdk-provider"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="npm install @ahmedrowaihi/flowise-vercel-ai-sdk-provider"
-      dark
-    />
-  </Tab>
-  <Tab>
-    <Snippet
-      text="yarn add @ahmedrowaihi/flowise-vercel-ai-sdk-provider"
-      dark
-    />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ahmedrowaihi/flowise-vercel-ai-sdk-provider" />
 
 ## Provider Instance
 

--- a/content/providers/06-adapters/01-langchain.mdx
+++ b/content/providers/06-adapters/01-langchain.mdx
@@ -18,17 +18,7 @@ enabling you to use LangChain models and LangGraph agents with AI SDK UI compone
 
 ## Installation
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>
-    <Snippet text="pnpm add @ai-sdk/langchain @langchain/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="npm install @ai-sdk/langchain @langchain/core" dark />
-  </Tab>
-  <Tab>
-    <Snippet text="yarn add @ai-sdk/langchain @langchain/core" dark />
-  </Tab>
-</Tabs>
+<InstallPackages packages="@ai-sdk/langchain @langchain/core" />
 
 <Note>`@langchain/core` is a required peer dependency.</Note>
 


### PR DESCRIPTION
## Background

code like this is duplicated everywhere in AI SDK docs:

```tsx
<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
  <Tab>
    <Snippet text="pnpm add @ai-sdk/anthropic" dark />
  </Tab>
  <Tab>
    <Snippet text="npm install @ai-sdk/anthropic" dark />
  </Tab>
  <Tab>
    <Snippet text="yarn add @ai-sdk/anthropic" dark />
  </Tab>

  <Tab>
    <Snippet text="bun add @ai-sdk/anthropic" dark />
  </Tab>
</Tabs>
```

## Summary

`<InstallPackages />` replaces that:

```tsx
<InstallPackages packages="@ai-sdk/anthropic" />
```

* also removed wrapping `<div />` from many `<Tabs />`
* removed `@google-cloud/vertexai` from the vertex yarn command. idk why it was there.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)