### PR TITLE
fix(ai): cancel audio stream when streamTranscribe doStream rejects

### DIFF
--- a/.changeset/stream-transcribe-cancel-audio.md
+++ b/.changeset/stream-transcribe-cancel-audio.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Cancel the caller's `audio` stream when `experimental_streamTranscribe` fails before or during streaming. Previously, when the model's `doStream` rejected before a stream existed (e.g. missing API key or other auth failure), the audio stream was never consumed or cancelled, so an upstream producer piping into it would hang forever.

--- a/packages/ai/src/transcribe/stream-transcribe.test.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.test.ts
@@ -228,6 +228,71 @@ describe('experimental_streamTranscribe', () => {
     });
   });
 
+  it('should cancel the audio stream when doStream rejects', async () => {
+    let audioCancelReason: unknown;
+    const audioStream = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        audioCancelReason = reason;
+      },
+    });
+
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () => {
+          throw new Error('authentication failed');
+        },
+      }),
+      audio: audioStream,
+      inputAudioFormat,
+    });
+
+    await expect(
+      convertAsyncIterableToArray(result.fullStream),
+    ).rejects.toThrow('authentication failed');
+    await expect(result.text).rejects.toThrow('authentication failed');
+    await vi.waitFor(() => {
+      expect(audioCancelReason).toMatchObject({
+        message: 'authentication failed',
+      });
+    });
+  });
+
+  it('should not interfere with a model-owned audio stream when the model stream errors mid-pipe', async () => {
+    let audioReaderTaken = false;
+    const audioStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+    });
+
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async ({ audio: modelAudio }) => {
+          // the model takes ownership of the audio stream, as providers do:
+          void modelAudio.getReader();
+          audioReaderTaken = true;
+          return {
+            stream: new ReadableStream<TranscriptionModelV4StreamPart>({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.error(new Error('connection lost'));
+              },
+            }),
+            response: { timestamp: testDate, modelId: 'test-model-id' },
+          };
+        },
+      }),
+      audio: audioStream,
+      inputAudioFormat,
+    });
+
+    await expect(
+      convertAsyncIterableToArray(result.fullStream),
+    ).rejects.toThrow('connection lost');
+    expect(audioReaderTaken).toBe(true);
+    await expect(result.text).rejects.toThrow('connection lost');
+  });
+
   it('should cancel the model stream when fullStream is cancelled early', async () => {
     let modelStreamCancelled = false;
 

--- a/packages/ai/src/transcribe/stream-transcribe.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.ts
@@ -272,6 +272,12 @@ export function streamTranscribe({
     const reason =
       error ?? new Error('Transcription stream was cancelled or errored.');
     rejectPendingPromises(reason);
+    // When `doStream` rejects before the model stream exists (e.g. auth or
+    // header resolution failure), nothing has taken ownership of `audio` yet,
+    // so cancel it directly — otherwise an upstream producer piping into it
+    // hangs forever. When the model did take a reader, `audio` is locked and
+    // the cancel rejects, which is fine: the model's cleanup owns it then.
+    audio.cancel(reason).catch(() => {});
     transform.writable.abort(reason).catch(() => {
       // the writable is already errored when the model stream failed mid-pipe
     });


### PR DESCRIPTION
## Background

Review finding on #16776 (streaming transcription via AI Gateway): when a transcription model's `doStream` rejects **before** the model stream exists — e.g. `GatewayAuthenticationError` from missing `AI_GATEWAY_API_KEY`, header resolution failure, or a pre-stream `UnsupportedFunctionalityError` in other providers — nothing takes ownership of the caller's `audio` stream. `streamTranscribe` rejects the result promises and aborts the transform, but never cancels `audio`, so an upstream producer piping into it (e.g. a microphone feed via `pipeTo`) blocks on backpressure forever.

The gateway `doStream` added in #16776 makes this trivially easy to hit (missing API key is the most common first-run failure), but the gap is in `streamTranscribe` itself and affects all providers.

## Summary

- `packages/ai/src/transcribe/stream-transcribe.ts`: cancel `audio` (with the failure reason) in the pipeline `catch`. When the model already took a reader, `audio` is locked and the cancel rejects — swallowed, since the model's own cleanup owns cancellation in that case (e.g. the gateway model's `cleanup` in #16776).
- Regression test: `doStream` rejection now cancels the caller's audio stream with the failure reason. The test is committed separately before the fix (note: CI only runs on PRs against `main`/`release-v*`, so there is no CI run on this PR — check out the `test` commit to see the test fail without the fix).
- Companion test: a model that takes a reader mid-stream is not interfered with when the model stream errors mid-pipe.

Part of the pre-merge fixes for #16776 (1 of 6).
