### PR TITLE
fix(gateway): strip undefined header values before the WebSocket constructor

### DIFF
--- a/packages/gateway/src/gateway-transcription-model.test.ts
+++ b/packages/gateway/src/gateway-transcription-model.test.ts
@@ -385,6 +385,25 @@ describe('GatewayTranscriptionModel', () => {
       });
     });
 
+    it('should strip undefined header values before passing headers to the WebSocket constructor', async () => {
+      const model = createStreamingTestModel();
+
+      const result = await model.doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+        // `Record<string, string | undefined>` is the documented way to unset
+        // a header; header-capable WebSocket implementations like `ws` throw
+        // on undefined header values (ERR_HTTP_INVALID_HEADER_VALUE).
+        headers: { 'Custom-Header': 'test-value', 'X-Unset-Header': undefined },
+      });
+
+      void result.stream.cancel();
+      const headers = MockWebSocket.instances[0].options?.headers ?? {};
+      expect(headers).not.toHaveProperty('X-Unset-Header');
+      expect(Object.values(headers)).not.toContain(undefined);
+      expect(headers).toMatchObject({ 'Custom-Header': 'test-value' });
+    });
+
     it('should send the session start frame on open', async () => {
       const model = createStreamingTestModel();
 

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -17,6 +17,7 @@ import {
   parseTranscriptionStreamPart,
   postJsonToApi,
   readWebSocketMessageText,
+  removeUndefinedEntries,
   resolve,
   TRANSCRIPTION_STREAM_AUDIO_DONE_FRAME_TYPE,
   TRANSCRIPTION_STREAM_START_FRAME_TYPE,
@@ -278,8 +279,11 @@ function createGatewayTranscriptionStream({
       try {
         const WebSocketConstructor = getWebSocketConstructor(webSocket);
         // Native `WebSocket` ignores headers (auth rides the subprotocols);
-        // header-capable implementations like `ws` forward them.
-        socket = new WebSocketConstructor(url, protocols, { headers });
+        // header-capable implementations like `ws` forward them — and throw
+        // on undefined header values, so those entries are stripped first.
+        socket = new WebSocketConstructor(url, protocols, {
+          headers: removeUndefinedEntries(headers),
+        });
       } catch (error) {
         finishWithError(error);
         return;


### PR DESCRIPTION
## Background

Review finding on #16776: `combineHeaders` preserves `undefined` entries (`Record<string, string | undefined>` is the documented way to unset a header, see `TranscriptionModelV4StreamOptions['headers']`), and `GatewayTranscriptionModel.doStream` passed the combined record verbatim to the WebSocket constructor. Header-capable implementations like `ws` forward `options.headers` to Node's `http.request`, which throws `ERR_HTTP_INVALID_HEADER_VALUE` on an `undefined` value — so `doStream` errored immediately while `doGenerate` with identical headers worked (the HTTP path strips `undefined` via `normalizeHeaders`). Reproduced with the repo's own `ws@8.21.0`.

## Summary

- `packages/gateway/src/gateway-transcription-model.ts`: pass `removeUndefinedEntries(headers)` to the WebSocket constructor (preserves header-name casing, unlike `normalizeHeaders`).
- Regression test: `undefined` header values no longer reach the constructor. The test is committed separately before the fix (note: CI only runs on PRs against `main`/`release-v*`, so there is no CI run on this PR — check out the `test` commit to see the test fail without the fix).

No changeset: this only fixes code introduced on the base branch (#16776), which already carries the `@ai-sdk/gateway` changeset.

Part of the pre-merge fixes for #16776 (2 of 6).