### PR TITLE
fix(provider-utils,gateway): harden the transcription-stream envelope

### DIFF
--- a/packages/gateway/src/gateway-transcription-model.test.ts
+++ b/packages/gateway/src/gateway-transcription-model.test.ts
@@ -627,6 +627,31 @@ describe('GatewayTranscriptionModel', () => {
       await assertion;
     });
 
+    it('should JSON-stringify object error part payloads without a message in the terminal error', async () => {
+      const model = createStreamingTestModel();
+
+      const result = await model.doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      });
+
+      const partsPromise = convertReadableStreamToArray(result.stream);
+      const ws = MockWebSocket.instances[0];
+      ws.open();
+      await flush();
+
+      const assertion = expect(partsPromise).rejects.toSatisfy(
+        err =>
+          GatewayError.isInstance(err) &&
+          err.message.includes('{"code":"overloaded"}') &&
+          !err.message.includes('[object Object]'),
+      );
+      ws.message({ type: 'error', error: { code: 'overloaded' } });
+      await flush();
+      ws.onclose?.({});
+      await assertion;
+    });
+
     it('should error the stream with the generic message when the socket closes without finish or error part', async () => {
       const model = createStreamingTestModel();
 

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -1,10 +1,11 @@
-import type {
-  Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
-  Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
-  Experimental_TranscriptionModelV4StreamResult as TranscriptionModelV4StreamResult,
-  SharedV4ProviderMetadata,
-  SharedV4Warning,
-  TranscriptionModelV4,
+import {
+  getErrorMessage,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
+  type Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
+  type Experimental_TranscriptionModelV4StreamResult as TranscriptionModelV4StreamResult,
+  type SharedV4ProviderMetadata,
+  type SharedV4Warning,
+  type TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -441,5 +442,6 @@ function getServerErrorMessage(error: unknown): string {
   ) {
     return error.message;
   }
-  return String(error);
+  // JSON-stringifies object payloads (`String` would yield '[object Object]').
+  return getErrorMessage(error);
 }

--- a/packages/provider-utils/src/transcription-stream-envelope.test.ts
+++ b/packages/provider-utils/src/transcription-stream-envelope.test.ts
@@ -205,6 +205,33 @@ describe('serializeTranscriptionStreamPart', () => {
       '{"type":"response-metadata","timestamp":"2026-01-01T00:00:00.000Z","modelId":"openai/gpt-realtime-whisper"}',
     );
   });
+
+  it('should serialize Error payloads in error parts with their name and message', () => {
+    // `Error` properties are non-enumerable, so a plain JSON.stringify would
+    // serialize the payload to `{}` and lose the message end-to-end.
+    expect(
+      serializeTranscriptionStreamPart({
+        type: 'error',
+        error: new Error('rate limited'),
+      }),
+    ).toBe(
+      '{"type":"error","error":{"name":"Error","message":"rate limited"}}',
+    );
+  });
+
+  it('should round-trip an error part with an Error payload', () => {
+    expect(
+      parseTranscriptionStreamPart(
+        serializeTranscriptionStreamPart({
+          type: 'error',
+          error: new TypeError('bad input'),
+        }),
+      ),
+    ).toEqual({
+      type: 'error',
+      error: { name: 'TypeError', message: 'bad input' },
+    });
+  });
 });
 
 describe('parseTranscriptionStreamPart', () => {
@@ -283,5 +310,44 @@ describe('parseTranscriptionStreamPart', () => {
         JSON.stringify({ type: 'some-future-part' }),
       ),
     ).toBeUndefined();
+  });
+
+  // Known-type frames with a malformed shape (e.g. from a drifted server
+  // version) are rejected rather than passed through: downstream SDK code
+  // dereferences the required fields and would otherwise fail with an opaque
+  // TypeError mid-stream.
+  it.each<[string, Record<string, unknown>]>([
+    ['stream-start without warnings', { type: 'stream-start' }],
+    [
+      'stream-start with non-array warnings',
+      { type: 'stream-start', warnings: 'none' },
+    ],
+    ['transcript-delta without delta', { type: 'transcript-delta', id: 's1' }],
+    [
+      'transcript-delta with non-string delta',
+      { type: 'transcript-delta', delta: 42 },
+    ],
+    ['transcript-partial without text', { type: 'transcript-partial' }],
+    [
+      'transcript-partial with non-string text',
+      { type: 'transcript-partial', text: 42 },
+    ],
+    ['transcript-final without text', { type: 'transcript-final' }],
+    ['finish without text', { type: 'finish', segments: [] }],
+    ['finish without segments', { type: 'finish', text: 'Hello' }],
+    [
+      'finish with non-array segments',
+      { type: 'finish', text: 'Hello', segments: {} },
+    ],
+    [
+      'response-metadata with a non-string timestamp',
+      { type: 'response-metadata', timestamp: {} },
+    ],
+    [
+      'response-metadata with an unparsable timestamp',
+      { type: 'response-metadata', timestamp: 'not-a-date' },
+    ],
+  ])('should return undefined for %s', (_name, part) => {
+    expect(parseTranscriptionStreamPart(JSON.stringify(part))).toBeUndefined();
   });
 });

--- a/packages/provider-utils/src/transcription-stream-envelope.ts
+++ b/packages/provider-utils/src/transcription-stream-envelope.ts
@@ -22,7 +22,8 @@ import { secureJsonParse } from './secure-json-parse';
  * 4. Every server→client TEXT frame is one JSON-serialized
  *    `TranscriptionModelV4StreamPart` (flattened, no wrapper). `Date` values
  *    (`response-metadata.timestamp`) serialize to ISO 8601 strings and are
- *    revived by `parseTranscriptionStreamPart`.
+ *    revived by `parseTranscriptionStreamPart`. `Error` payloads in `error`
+ *    parts serialize as `{ name, message }`.
  * 5. The server closes with code 1000 after the `finish` part; on failure it
  *    sends an `error` part and closes non-1000. A close without a prior
  *    `finish` is an error.
@@ -82,17 +83,6 @@ export type Experimental_TranscriptionStreamClientFrame =
       /** Unrecognized frame type; ignore for forward compatibility. */
       type: 'unknown';
     };
-
-const knownStreamPartTypes = new Set<TranscriptionModelV4StreamPart['type']>([
-  'error',
-  'finish',
-  'raw',
-  'response-metadata',
-  'stream-start',
-  'transcript-delta',
-  'transcript-final',
-  'transcript-partial',
-]);
 
 /**
  * Server-side: parse a client TEXT frame. Validates envelope shape only and
@@ -180,18 +170,31 @@ export function parseTranscriptionStreamClientFrame(
   }
 }
 
-/** Server-side: serialize a transcription stream part as one TEXT frame. */
+/**
+ * Server-side: serialize a transcription stream part as one TEXT frame.
+ * `Error` payloads in `error` parts serialize as `{ name, message }` —
+ * `Error` properties are non-enumerable, so a plain `JSON.stringify` would
+ * serialize them to `{}` and lose the message end-to-end.
+ */
 export function serializeTranscriptionStreamPart(
   part: TranscriptionModelV4StreamPart,
 ): string {
+  if (part.type === 'error' && part.error instanceof Error) {
+    return JSON.stringify({
+      ...part,
+      error: { name: part.error.name, message: part.error.message },
+    });
+  }
   return JSON.stringify(part);
 }
 
 /**
  * Client-side: parse a server TEXT frame into a transcription stream part.
- * Returns `undefined` for malformed or unsafe (prototype-polluting) JSON and
- * unknown part types (parsed with `secureJsonParse`). Revives
- * `response-metadata.timestamp` to a `Date`.
+ * Returns `undefined` for malformed or unsafe (prototype-polluting) JSON
+ * (parsed with `secureJsonParse`), unknown part types, and known part types
+ * whose required fields are missing or mistyped — downstream SDK code
+ * dereferences those fields, so a drifted server must not crash the stream.
+ * Revives `response-metadata.timestamp` to a `Date`.
  */
 export function parseTranscriptionStreamPart(
   text: string,
@@ -209,16 +212,42 @@ export function parseTranscriptionStreamPart(
 
   const part = value as TranscriptionModelV4StreamPart;
 
-  if (!knownStreamPartTypes.has(part.type)) {
-    return undefined;
-  }
+  switch (part.type) {
+    case 'stream-start':
+      return Array.isArray(part.warnings) ? part : undefined;
 
-  if (part.type === 'response-metadata') {
-    return {
-      ...part,
-      timestamp: part.timestamp != null ? new Date(part.timestamp) : undefined,
-    };
-  }
+    case 'transcript-delta':
+      return typeof part.delta === 'string' ? part : undefined;
 
-  return part;
+    case 'transcript-partial':
+    case 'transcript-final':
+      return typeof part.text === 'string' ? part : undefined;
+
+    case 'finish':
+      return typeof part.text === 'string' && Array.isArray(part.segments)
+        ? part
+        : undefined;
+
+    case 'response-metadata': {
+      // Envelope rule 4: timestamps ride as ISO 8601 strings.
+      const timestamp: unknown = part.timestamp;
+      if (timestamp == null) {
+        return { ...part, timestamp: undefined };
+      }
+      if (typeof timestamp !== 'string') {
+        return undefined;
+      }
+      const revived = new Date(timestamp);
+      return Number.isNaN(revived.getTime())
+        ? undefined
+        : { ...part, timestamp: revived };
+    }
+
+    case 'raw':
+    case 'error':
+      return part;
+
+    default:
+      return undefined;
+  }
 }


### PR DESCRIPTION
## Background

Review findings on #16776. The envelope is the wire contract the AI Gateway server will implement against published `@ai-sdk/provider-utils`, so these need to land before the server side ships:

1. **Lax server-part parsing**: `parseTranscriptionStreamPart` validated only the `type` field and cast the rest unchecked. A known-type frame with a malformed shape from a drifted server version flowed into SDK code that dereferences required fields — e.g. `{"type":"stream-start"}` without `warnings` reaches `logWarnings`, which throws `TypeError: Cannot read properties of undefined (reading 'length')` and fails the whole stream opaquely; `{"type":"response-metadata","timestamp":{}}` revived to an Invalid Date in `result.responses`.
2. **Error payloads lost end-to-end**: `serializeTranscriptionStreamPart` was a bare `JSON.stringify`, and `Error` properties are non-enumerable — `{ type: 'error', error: new Error('rate limited') }` serialized to `{"type":"error","error":{}}`. On the client, `getServerErrorMessage` fell back to `String(error)`, rendering the terminal close error as `AI Gateway transcription stream failed: [object Object]`.

## Summary

- `packages/provider-utils/src/transcription-stream-envelope.ts`:
  - `parseTranscriptionStreamPart` now validates the required fields per part type (`stream-start.warnings` array, `transcript-delta.delta` string, `transcript-partial`/`transcript-final`/`finish` `text` string, `finish.segments` array, `response-metadata.timestamp` nullish or a parsable ISO 8601 string) and returns `undefined` for malformed known-type frames — consistent with the existing malformed-JSON and unknown-type handling, so a drifted server degrades to skipped frames instead of a mid-stream `TypeError`.
  - `serializeTranscriptionStreamPart` serializes `Error` payloads in `error` parts as `{ name, message }`; envelope spec doc updated (rule 4).
- `packages/gateway/src/gateway-transcription-model.ts`: `getServerErrorMessage` falls back to `getErrorMessage` from `@ai-sdk/provider` (JSON-stringifies object payloads) instead of `String(error)`.
- Tests are committed separately before the fix (note: CI only runs on PRs against `main`/`release-v*`, so there is no CI run on this PR — check out the `test` commit to see the 15 new tests fail without the fix).

No changeset: this only fixes code introduced on the base branch (#16776), which already carries changesets for both packages.

Part of the pre-merge fixes for #16776 (3 of 6).