### PR TITLE
fix(ai): drop the hardcoded gateway version from the streaming-transcription error

### DIFF
--- a/packages/ai/src/transcribe/stream-transcribe.test.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.test.ts
@@ -17,6 +17,7 @@ import {
   vi,
 } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
+import { customProvider } from '../registry/custom-provider';
 import { MockTranscriptionModelV4 } from '../test/mock-transcription-model-v4';
 import { streamTranscribe } from './stream-transcribe';
 
@@ -165,6 +166,32 @@ describe('experimental_streamTranscribe', () => {
         inputAudioFormat,
       }),
     ).toThrow(UnsupportedFunctionalityError);
+  });
+
+  it('should not promise a specific gateway version in the unsupported-model error for string model ids', () => {
+    globalThis.AI_SDK_DEFAULT_PROVIDER = customProvider({
+      transcriptionModels: { 'test-model-id': new MockTranscriptionModelV4() },
+    });
+
+    try {
+      let error: unknown;
+      try {
+        streamTranscribe({ model: 'test-model-id', audio, inputAudioFormat });
+      } catch (thrownError) {
+        error = thrownError;
+      }
+
+      expect(error).toBeInstanceOf(UnsupportedFunctionalityError);
+      const message = (error as Error).message;
+      expect(message).toContain(
+        'String model IDs resolve through the global provider',
+      );
+      // the `ai` package cannot know which @ai-sdk/gateway version ships
+      // streaming transcription, so the message must not name one:
+      expect(message).not.toMatch(/\d+\.\d+\.\d+/);
+    } finally {
+      delete globalThis.AI_SDK_DEFAULT_PROVIDER;
+    }
   });
 
   it('should reject final promises when no transcript is returned', async () => {

--- a/packages/ai/src/transcribe/stream-transcribe.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.ts
@@ -116,7 +116,7 @@ export function streamTranscribe({
           ? ' String model IDs resolve through the global provider (AI Gateway by default).' +
             ' If that provider does not support streaming transcription, pass a provider model' +
             " instance instead (e.g. openai.transcription('gpt-realtime-whisper'))" +
-            ' or upgrade @ai-sdk/gateway to 4.0.13 or later for streaming transcription support.'
+            ' or upgrade @ai-sdk/gateway to a version with streaming transcription support.'
           : ''),
     });
   }


### PR DESCRIPTION
## Background

Review finding on #16776: the `experimental_streamTranscribe` unsupported-model error message told users to "upgrade @ai-sdk/gateway to 4.0.13 or later for streaming transcription support". The `ai` package cannot keep a cross-package version claim true — and it is already false: @ai-sdk/gateway 4.0.13 and 4.0.14 have shipped on npm without `doStream`, so a user following the message upgrades and hits the identical error again.

## Summary

- `packages/ai/src/transcribe/stream-transcribe.ts`: the message now says "upgrade @ai-sdk/gateway to a version with streaming transcription support" — no version number.
- Regression test: the string-model-id error message must not contain a semver-looking version. The test is committed separately before the fix (note: CI only runs on PRs against `main`/`release-v*`, so there is no CI run on this PR — check out the `test` commit to see the test fail without the fix).

No new changeset: the base branch's `streaming-transcribe-error-message` changeset already covers this message change and its wording remains accurate.

Part of the pre-merge fixes for #16776 (4 of 6).