### PR TITLE
fix highlighting misalignment on video generation docs page

### DIFF
--- a/content/docs/03-ai-sdk-core/38-video-generation.mdx
+++ b/content/docs/03-ai-sdk-core/38-video-generation.mdx
@@ -146,7 +146,7 @@ const { videos } = await generateVideo({
 
 Some video models support generating videos from an input image. You can provide an image using the prompt object:
 
-```tsx highlight={"5-7"}
+```tsx highlight={"5-8"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/38-video-generation.mdx
+++ b/content/docs/03-ai-sdk-core/38-video-generation.mdx
@@ -37,7 +37,7 @@ const uint8Array = video.uint8Array; // Uint8Array video data
 The aspect ratio is specified as a string in the format `{width}:{height}`.
 Models only support a few aspect ratios, and the supported aspect ratios are different for each model and provider.
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -53,7 +53,7 @@ const { video } = await generateVideo({
 The resolution is specified as a string in the format `{width}x{height}`.
 Models only support specific resolutions, and the supported resolutions are different for each model and provider.
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -68,7 +68,7 @@ const { video } = await generateVideo({
 
 Some video models support specifying the duration of the generated video in seconds.
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -83,7 +83,7 @@ const { video } = await generateVideo({
 
 Some video models allow you to specify the frames per second for the generated video.
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -98,7 +98,7 @@ const { video } = await generateVideo({
 
 Some video models can generate audio alongside the video. Use the `generateAudio` option to control this:
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -113,7 +113,7 @@ const { video } = await generateVideo({
 
 `experimental_generateVideo` supports generating multiple videos at once:
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -146,7 +146,7 @@ const { videos } = await generateVideo({
 
 Some video models support generating videos from an input image. You can provide an image using the prompt object:
 
-```tsx highlight={"7-10"}
+```tsx highlight={"5-7"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -177,7 +177,7 @@ Some video models support first-last-frame generation, where you provide the
 starting and/or ending frames of the video. Use the `frameImages` option to pass
 role-tagged images in a provider-agnostic way:
 
-```tsx highlight={"5-16"}
+```tsx highlight={"4-13"}
 const { video } = await generateVideo({
   model: __VIDEO_MODEL__,
   prompt: 'The cat walks across the scene and transforms into a dog by the end',
@@ -200,7 +200,7 @@ Some video models support reference-to-video generation, where you provide one o
 more reference images or videos that the model incorporates into the generated video. Use the `inputReferences` option to pass
 these inputs in a provider-agnostic way:
 
-```tsx highlight={"5-8"}
+```tsx highlight={"4-7"}
 const { video } = await generateVideo({
   model: __VIDEO_MODEL__,
   prompt: 'The two characters meet in a bustling market',
@@ -213,7 +213,7 @@ const { video } = await generateVideo({
 
 For URL-based video references, use the object form with an explicit `mediaType`:
 
-```tsx highlight={"5-10"}
+```tsx highlight={"4-9"}
 const { video } = await generateVideo({
   model: __VIDEO_MODEL__,
   prompt: 'Match the motion in the reference clip',
@@ -235,7 +235,7 @@ only image references warn and ignore a video reference).
 You can provide a seed to the `experimental_generateVideo` function to control the output of the video generation process.
 If supported by the model, the same seed will always produce the same video.
 
-```tsx highlight={"7"}
+```tsx highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -273,7 +273,7 @@ const { video } = await generateVideo({
 type [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 that you can use to abort the video generation process or set a timeout.
 
-```ts highlight={"7"}
+```ts highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -295,7 +295,7 @@ Video generation is an asynchronous process that can take several minutes to com
 
 You can configure the polling timeout using provider-specific options. Each provider exports a type for its options that you can use with `satisfies` for type safety:
 
-```tsx highlight={"10-12"}
+```tsx highlight={"9-11"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { fal, type FalVideoModelOptions } from '@ai-sdk/fal';
 
@@ -322,7 +322,7 @@ const { video } = await generateVideo({
 `experimental_generateVideo` accepts an optional `headers` parameter of type `Record<string, string>`
 that you can use to add custom headers to the video generation request.
 
-```ts highlight={"7"}
+```ts highlight={"6"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 


### PR DESCRIPTION
This PR fixes existing highlighting misalignment on the video generation docs page