### PR TITLE
fix(amazon-bedrock): return request.body from doGenerate and doStream

### DIFF
--- a/.changeset/bedrock-request-body.md
+++ b/.changeset/bedrock-request-body.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): return `request.body` from `doGenerate` and `doStream`. Previously the Bedrock provider never populated the `request` field, so observability/tracing tools received `undefined` instead of the Converse API request payload.

--- a/packages/amazon-bedrock/src/__snapshots__/amazon-bedrock-chat-language-model.test.ts.snap
+++ b/packages/amazon-bedrock/src/__snapshots__/amazon-bedrock-chat-language-model.test.ts.snap
@@ -44,6 +44,29 @@ There are 3 r's.",
       },
     },
   },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
+    },
+  },
   "response": {
     "headers": {
       "content-length": "865",
@@ -105,6 +128,29 @@ There are **3** "r"s in "strawberry."",
       "usage": {
         "cacheWriteInputTokens": 0,
       },
+    },
+  },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
     },
   },
   "response": {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -1049,6 +1049,43 @@ describe('doStream', () => {
     `);
   });
 
+  it('should return the request body', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [],
+    };
+
+    const result = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(result.request?.body).toMatchInlineSnapshot(`
+      {
+        "additionalModelRequestFields": undefined,
+        "additionalModelResponseFieldPaths": [
+          "/delta/stop_sequence",
+        ],
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "Hello",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "system": [
+          {
+            "text": "System Prompt",
+          },
+        ],
+      }
+    `);
+  });
+
   it('should support guardrails', async () => {
     setupMockEventStreamHandler();
     server.urls[streamUrl].response = {
@@ -3223,6 +3260,36 @@ describe('doGenerate', () => {
       });
 
       expect(result).toMatchSnapshot();
+    });
+
+    it('should return the request body', async () => {
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.request?.body).toMatchInlineSnapshot(`
+        {
+          "additionalModelRequestFields": undefined,
+          "additionalModelResponseFieldPaths": [
+            "/delta/stop_sequence",
+          ],
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "system": [
+            {
+              "text": "System Prompt",
+            },
+          ],
+        }
+      `);
     });
 
     it('should extract usage', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -619,6 +619,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
         raw: response.stopReason ?? undefined,
       },
       usage: convertAmazonBedrockUsage(response.usage),
+      request: { body: args },
       response: {
         id: responseHeaders?.['x-amzn-requestid'] ?? undefined,
         timestamp:
@@ -1043,7 +1044,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           },
         }),
       ),
-      // TODO request?
+      request: { body: args },
       response: { headers: responseHeaders },
     };
   }


### PR DESCRIPTION
## Background

`AmazonBedrockChatLanguageModel.doGenerate()` and `doStream()` never populated the `request` field of their result (there was an explicit `// TODO request?` in `doStream`). Consumers that rely on `request.body` for observability/tracing — e.g. [Mastra](https://github.com/mastra-ai/mastra), which uses it to populate span inputs — received `undefined` instead of the Converse API request payload, resulting in empty tracing attributes.

Other providers (`@ai-sdk/anthropic`, `@ai-sdk/google`, `@ai-sdk/cohere`, …) already return `request: { body: args }`, so this gap was specific to the Bedrock provider.

## Summary

- Return `request: { body: args }` from both `doGenerate()` and `doStream()` (where `args` is the Converse API command built by `getArgs()`), matching the behavior of the other providers.
- Removed the stale `// TODO request?` marker.
- Added regression tests for both methods asserting `result.request?.body` contains the request payload, and updated the affected `doGenerate` result snapshots (purely additive — only the new `request` field).

## Manual Verification

Verified with the provider's mock-server test harness (no live AWS credentials required):

- The new `should return the request body` tests assert `result.request?.body` for both `doGenerate` and `doStream`. Their inline snapshots show the real Converse command (`messages`, `system`, `additionalModelResponseFieldPaths`, …) — i.e. the payload that was previously `undefined`.
- The updated `doGenerate` result snapshots confirm `request.body` matches the body actually sent to the mock server (`server.calls[0].requestBodyJson`).
- Full package suite green: `pnpm test` in `packages/amazon-bedrock` → **132 passed**. `pnpm check` (oxlint + oxfmt) clean, and `@ai-sdk/amazon-bedrock` builds with type declarations.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) — not needed; `request.body` is already part of the `LanguageModelV4` result contract, this only fixes the Bedrock provider to honor it
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13927
