### PR TITLE
fix(amazon-bedrock): support inference profile ARNs as model ids

### DIFF
--- a/.changeset/bedrock-inference-profile-arn.md
+++ b/.changeset/bedrock-inference-profile-arn.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): support inference profile ARNs as model ids. The provider built request URLs with `encodeURIComponent(modelId)`, which encodes the `/` in an application inference profile ARN (e.g. `arn:aws:bedrock:...:application-inference-profile/abc123`) to `%2F` and made Bedrock reject it with `400 The provided model identifier is invalid`. Model ids are now encoded per path segment so slashes stay literal, matching the path format Bedrock expects.

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -41,6 +41,7 @@ import {
   type AmazonBedrockLanguageModelChatOptions,
   type AmazonBedrockChatModelId,
 } from './amazon-bedrock-chat-language-model-options';
+import { encodeModelId } from './amazon-bedrock-encode-model-id';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { createAmazonBedrockEventStreamResponseHandler } from './amazon-bedrock-event-stream-response-handler';
 import { prepareTools } from './amazon-bedrock-prepare-tools';
@@ -1049,7 +1050,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = encodeModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}`;
   }
 }

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -19,6 +19,7 @@ import {
   amazonBedrockEmbeddingModelOptionsSchema,
   type AmazonBedrockEmbeddingModelId,
 } from './amazon-bedrock-embedding-model-options';
+import { encodeModelId } from './amazon-bedrock-encode-model-id';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { z } from 'zod/v4';
 
@@ -59,7 +60,7 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
   ) {}
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = encodeModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 

--- a/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { encodeModelId } from './amazon-bedrock-encode-model-id';
+
+describe('encodeModelId', () => {
+  it('encodes a standard model id (colon percent-encoded, no slashes)', () => {
+    expect(encodeModelId('us.amazon.nova-2-lite-v1:0')).toBe(
+      'us.amazon.nova-2-lite-v1%3A0',
+    );
+  });
+
+  it('leaves a plain model id without special characters unchanged', () => {
+    expect(encodeModelId('anthropic.claude-3-haiku-20240307-v1:0')).toBe(
+      'anthropic.claude-3-haiku-20240307-v1%3A0',
+    );
+  });
+
+  it('preserves the slash in an application inference profile ARN', () => {
+    expect(
+      encodeModelId(
+        'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz',
+      ),
+    ).toBe(
+      'arn%3Aaws%3Abedrock%3Aus-east-1%3A123456789012%3Aapplication-inference-profile/abc123xyz',
+    );
+  });
+
+  it('encodes each segment of a multi-slash path individually', () => {
+    expect(encodeModelId('a b/c:d/e')).toBe('a%20b/c%3Ad/e');
+  });
+});

--- a/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-encode-model-id.ts
@@ -1,0 +1,19 @@
+/**
+ * Encodes a Bedrock model identifier for use in a REST API URL path.
+ *
+ * Standard model ids (e.g. `us.amazon.nova-2-lite-v1:0`) contain no slashes and
+ * are encoded as a single segment. Inference profile ARNs, however, contain a
+ * slash (e.g.
+ * `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123`).
+ * Bedrock's REST API treats the model id as a greedy path label and expects the
+ * slash to stay literal — encoding it to `%2F` (as a plain `encodeURIComponent`
+ * would) makes Bedrock reject the request with
+ * `400 The provided model identifier is invalid`.
+ *
+ * Encoding each `/`-separated segment individually keeps slashes literal while
+ * still percent-encoding every other special character (such as the `:` in an
+ * ARN), matching the path format Bedrock documents for inference profiles.
+ */
+export function encodeModelId(modelId: string): string {
+  return modelId.split('/').map(encodeURIComponent).join('/');
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-image-model.ts
@@ -22,6 +22,7 @@ import {
   type AmazonBedrockImageModelId,
 } from './amazon-bedrock-image-settings';
 import { amazonBedrockImageModelOptionsSchema } from './amazon-bedrock-image-model-options';
+import { encodeModelId } from './amazon-bedrock-encode-model-id';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { z } from 'zod/v4';
 
@@ -57,7 +58,7 @@ export class AmazonBedrockImageModel implements ImageModelV4 {
   }
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = encodeModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -21,6 +21,7 @@ import {
   createSigV4FetchFunction,
   type AmazonBedrockCredentials,
 } from '../amazon-bedrock-sigv4-fetch';
+import { encodeModelId } from '../amazon-bedrock-encode-model-id';
 import { createAmazonBedrockAnthropicFetch } from './amazon-bedrock-anthropic-fetch';
 import type { AmazonBedrockAnthropicModelId } from './amazon-bedrock-anthropic-options';
 import { VERSION } from '../version';
@@ -258,7 +259,7 @@ export function createAmazonBedrockAnthropic(
       fetch: fetchFunction,
 
       buildRequestUrl: (baseURL, isStreaming) =>
-        `${baseURL}/model/${encodeURIComponent(modelId)}/${
+        `${baseURL}/model/${encodeModelId(modelId)}/${
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 


### PR DESCRIPTION
## Background

`@ai-sdk/amazon-bedrock` can't be used with [AWS Bedrock application inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html). Passing an inference profile ARN as the model id fails with `400 The provided model identifier is invalid`.

The provider builds REST URLs by interpolating the model id with `encodeURIComponent(modelId)`. For a standard id (`us.amazon.nova-2-lite-v1:0`) that's fine, but an inference profile ARN contains a slash:

```
arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz
```

`encodeURIComponent` turns that `/` into `%2F`. Bedrock treats the model id as a greedy path label and expects the slash to stay literal — its own docs show the ARN unencoded in the path, e.g. `POST /model/arn:aws:bedrock:us-east-1:111122223333:prompt/PROMPT12345:1/converse` ([Converse API reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html)) — so `%2F` is rejected. (Colons already work either way, which is why standard ids with encoded `:` succeed.)

Fixes #14117

## Summary

- Add a shared `encodeModelId` helper that encodes each `/`-separated segment individually (`modelId.split('/').map(encodeURIComponent).join('/')`), keeping slashes literal while still percent-encoding every other special character.
- Use it in all four URL builders that previously called `encodeURIComponent(modelId)`: chat (`getUrl`), embedding (`getUrl`), image (`getUrl`), and the Bedrock-Anthropic `buildRequestUrl`.
- Slash-free model ids encode identically to before, so existing behavior is unchanged.

## Manual Verification

- New unit tests for `encodeModelId` assert that a standard id still percent-encodes its colon (`us.amazon.nova-2-lite-v1:0` → `us.amazon.nova-2-lite-v1%3A0`) and that an inference profile ARN keeps its slash literal (`arn%3Aaws%3A…%3Aapplication-inference-profile/abc123xyz`).
- The full `@ai-sdk/amazon-bedrock` suite still passes unchanged (**410 tests**), confirming the swap is behavior-preserving for existing (slash-free) model ids — no request URLs changed for them.
- `pnpm check` (oxlint + oxfmt) clean; the package builds with type declarations.
- The resulting path matches AWS's documented inference-profile URL format (literal `/`, percent-encoded `:`).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) — not needed; no public API or docs surface changes
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14117
