### PR TITLE
fix(perplexity): throw on unsupported file media types instead of silently dropping them

### DIFF
--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -172,9 +172,31 @@ describe('convertToPerplexityMessages', () => {
       });
     });
 
-    it('accepts top-level-only "application" mediaType for PDF without error', () => {
+    it('accepts top-level-only "application" mediaType for PDF via detection', () => {
       const pdfBase64 = 'JVBERi0xLjQ=';
 
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'application',
+              data: { type: 'data' as const, data: pdfBase64 },
+              filename: 'doc.pdf',
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'file_url',
+        file_url: { url: pdfBase64 },
+        file_name: 'doc.pdf',
+      });
+    });
+
+    it('throws for unsupported file media types', () => {
       expect(() =>
         convertToPerplexityMessages([
           {
@@ -182,14 +204,14 @@ describe('convertToPerplexityMessages', () => {
             content: [
               {
                 type: 'file',
-                mediaType: 'application',
-                data: { type: 'data' as const, data: pdfBase64 },
-                filename: 'doc.pdf',
+                mediaType: 'audio/mpeg',
+                data: { type: 'data' as const, data: 'SUQzBA==' },
+                filename: 'clip.mp3',
               },
             ],
           },
         ]),
-      ).not.toThrow();
+      ).toThrow(UnsupportedFunctionalityError);
     });
 
     it('normalizes image/* wildcard via detection', () => {

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -57,7 +57,38 @@ export function convertToPerplexityMessages(
                   }
                   case 'url':
                   case 'data': {
-                    if (part.mediaType === 'application/pdf') {
+                    const topLevelType = getTopLevelMediaType(part.mediaType);
+
+                    if (topLevelType === 'image') {
+                      return part.data.type === 'url'
+                        ? {
+                            type: 'image_url',
+                            image_url: {
+                              url: part.data.url.toString(),
+                            },
+                          }
+                        : {
+                            type: 'image_url',
+                            image_url: {
+                              url: `data:${resolveFullMediaType({
+                                part,
+                              })};base64,${
+                                typeof part.data.data === 'string'
+                                  ? part.data.data
+                                  : convertUint8ArrayToBase64(part.data.data)
+                              }`,
+                            },
+                          };
+                    }
+
+                    if (topLevelType === 'application') {
+                      const fullMediaType = resolveFullMediaType({ part });
+                      if (fullMediaType !== 'application/pdf') {
+                        throw new UnsupportedFunctionalityError({
+                          functionality: `file part media type ${fullMediaType}`,
+                        });
+                      }
+
                       return part.data.type === 'url'
                         ? {
                             type: 'file_url',
@@ -76,28 +107,11 @@ export function convertToPerplexityMessages(
                             },
                             file_name: part.filename || `document-${index}.pdf`,
                           };
-                    } else if (
-                      getTopLevelMediaType(part.mediaType) === 'image'
-                    ) {
-                      return part.data.type === 'url'
-                        ? {
-                            type: 'image_url',
-                            image_url: {
-                              url: part.data.url.toString(),
-                            },
-                          }
-                        : {
-                            type: 'image_url',
-                            image_url: {
-                              url: `data:${resolveFullMediaType({ part })};base64,${
-                                typeof part.data.data === 'string'
-                                  ? part.data.data
-                                  : convertUint8ArrayToBase64(part.data.data)
-                              }`,
-                            },
-                          };
                     }
-                    return undefined;
+
+                    throw new UnsupportedFunctionalityError({
+                      functionality: `file part media type "${part.mediaType}"`,
+                    });
                   }
                 }
               }


### PR DESCRIPTION
## Problem

`convertToPerplexityMessages` silently dropped file parts it didn't recognize instead of throwing `UnsupportedFunctionalityError` like every other OpenAI-style provider converter (openai, mistral, groq, xai, alibaba, openai-compatible, huggingface).

Two categories of input vanished with no error and no warning:

1. Any file that is not an image and not exactly `application/pdf` (e.g. `audio/mpeg`, `video/mp4`, `text/csv`). The `url`/`data` branch ended with a bare `return undefined`, which `.filter(Boolean)` then removed.
2. A real PDF passed with a top-level-only `application` media type. The image branch normalizes top-level-only types via `getTopLevelMediaType`/`resolveFullMediaType`, but the PDF branch used strict equality `part.mediaType === 'application/pdf'`, so the PDF fell through both branches and was discarded.

The existing test `accepts top-level-only "application" mediaType for PDF without error` only asserted `.not.toThrow()`, so it passed while the PDF was dropped and the resulting message content was empty.

Fixes #16914

## Fix

- Resolve the full media type for application parts via `resolveFullMediaType` (sniffable bytes handling for top-level-only types), and throw `UnsupportedFunctionalityError` for anything other than `application/pdf`, matching the openai converter.
- Unsupported top-level types (audio, video, etc.) now throw instead of being silently dropped.
- Strengthened the test to assert the PDF is actually present in the output (not just that it doesn't throw), and added a test asserting unsupported media types throw.

## Verification

- `pnpm --filter @ai-sdk/perplexity test:node` → 35 passed (35)
- `pnpm --filter @ai-sdk/perplexity type-check` → clean
- Prettier + lefthook pre-commit hooks passed on the commit.

I agree to follow this project's Code of Conduct.