### PR TITLE
[v6.0] fix: standalone Google threshold provider option is silently ignored

### DIFF
--- a/.changeset/quiet-gemini-otters.md
+++ b/.changeset/quiet-gemini-otters.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Expand standalone Google `threshold` provider options into safety settings.

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -943,6 +943,74 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should expand standalone threshold provider option into safetySettings', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          threshold: 'BLOCK_NONE',
+        },
+      },
+    });
+
+    const expectedSafetySettings = [
+      {
+        category: 'HARM_CATEGORY_HATE_SPEECH',
+        threshold: 'BLOCK_NONE',
+      },
+      {
+        category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+        threshold: 'BLOCK_NONE',
+      },
+      {
+        category: 'HARM_CATEGORY_HARASSMENT',
+        threshold: 'BLOCK_NONE',
+      },
+      {
+        category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+        threshold: 'BLOCK_NONE',
+      },
+    ];
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.safetySettings).toEqual(
+      expect.arrayContaining(expectedSafetySettings),
+    );
+    expect(requestBody.safetySettings).toHaveLength(
+      expectedSafetySettings.length,
+    );
+  });
+
+  it('should let safetySettings take precedence over standalone threshold provider option', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          threshold: 'BLOCK_NONE',
+          safetySettings: [
+            {
+              category: 'HARM_CATEGORY_HATE_SPEECH',
+              threshold: 'BLOCK_ONLY_HIGH',
+            },
+          ],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.safetySettings).toEqual([
+      {
+        category: 'HARM_CATEGORY_HATE_SPEECH',
+        threshold: 'BLOCK_ONLY_HIGH',
+      },
+    ]);
+  });
+
   it('should pass tools and toolChoice', async () => {
     prepareJsonFixtureResponse('google-text');
 

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -50,7 +50,18 @@ import {
 } from './google-json-accumulator';
 import { mapGoogleGenerativeAIFinishReason } from './map-google-generative-ai-finish-reason';
 
+<<<<<<< HEAD:packages/google/src/google-generative-ai-language-model.ts
 type GoogleGenerativeAIConfig = {
+=======
+const configurableSafetySettingCategories = [
+  'HARM_CATEGORY_HATE_SPEECH',
+  'HARM_CATEGORY_DANGEROUS_CONTENT',
+  'HARM_CATEGORY_HARASSMENT',
+  'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+] as const;
+
+type GoogleConfig = {
+>>>>>>> 96d40bccc (fix: standalone Google threshold provider option is silently ignored (#16922)):packages/google/src/google-language-model.ts
   provider: string;
   baseURL: string;
   headers: Resolvable<Record<string, string | undefined>>;
@@ -223,6 +234,16 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         ? (googleOptions?.streamFunctionCallArguments ?? false)
         : undefined;
 
+    const safetyThreshold = googleOptions?.threshold;
+    const safetySettings =
+      googleOptions?.safetySettings ??
+      (safetyThreshold != null
+        ? configurableSafetySettingCategories.map(category => ({
+            category,
+            threshold: safetyThreshold,
+          }))
+        : undefined);
+
     const toolConfig =
       googleToolConfig ||
       streamFunctionCallArguments ||
@@ -282,7 +303,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         },
         contents,
         systemInstruction: isGemmaModel ? undefined : systemInstruction,
-        safetySettings: googleOptions?.safetySettings,
+        safetySettings,
         tools: googleTools,
         toolConfig,
         cachedContent: googleOptions?.cachedContent,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -50,9 +50,6 @@ import {
 } from './google-json-accumulator';
 import { mapGoogleGenerativeAIFinishReason } from './map-google-generative-ai-finish-reason';
 
-<<<<<<< HEAD:packages/google/src/google-generative-ai-language-model.ts
-type GoogleGenerativeAIConfig = {
-=======
 const configurableSafetySettingCategories = [
   'HARM_CATEGORY_HATE_SPEECH',
   'HARM_CATEGORY_DANGEROUS_CONTENT',
@@ -60,8 +57,7 @@ const configurableSafetySettingCategories = [
   'HARM_CATEGORY_SEXUALLY_EXPLICIT',
 ] as const;
 
-type GoogleConfig = {
->>>>>>> 96d40bccc (fix: standalone Google threshold provider option is silently ignored (#16922)):packages/google/src/google-language-model.ts
+type GoogleGenerativeAIConfig = {
   provider: string;
   baseURL: string;
   headers: Resolvable<Record<string, string | undefined>>;


### PR DESCRIPTION
## Background

The documented @ai-sdk/google standalone threshold provider option validated successfully but was ignored, leaving Google safety defaults in effect.

## Summary

Mapped standalone google threshold values into safetySettings for the four configurable harm categories, while preserving explicit safetySettings precedence.

## Testing

Kept and simplified the regression test for threshold expansion and added coverage that explicit safetySettings override the standalone threshold.

## Related Issues

Fixes #16912

Backport of #16922

Co-authored-by: abhay-codes07 <182421137+abhay-codes07@users.noreply.github.com>