### PR TITLE
reproduction: could not reproduce @ai-sdk/anthropic: ANTHROPICBASEURL not normalized — bare-host form silently

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-15580-anthropic-base-url.ts
+++ b/examples/ai-functions/src/reproduction/issue-15580-anthropic-base-url.ts
@@ -1,0 +1,74 @@
+async function main() {
+  const originalBaseURL = process.env.ANTHROPIC_BASE_URL;
+  const observedUrls: string[] = [];
+
+  try {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+
+    const { createAnthropic } = await import('@ai-sdk/anthropic');
+    const { generateText } = await import('ai');
+
+    const anthropic = createAnthropic({
+      apiKey: 'test-api-key',
+      fetch: async url => {
+        observedUrls.push(url.toString());
+
+        return new Response(
+          JSON.stringify({
+            type: 'message',
+            id: 'msg_issue_15580',
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'text', text: 'OK' }],
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      },
+    });
+
+    const result = await generateText({
+      model: anthropic('claude-haiku-4-5-20251001'),
+      prompt: 'Say OK.',
+      maxOutputTokens: 1,
+    });
+
+    const observedUrl = observedUrls[0];
+    const expectedUrl = 'https://api.anthropic.com/v1/messages';
+    const reportedBugUrl = 'https://api.anthropic.com/messages';
+
+    console.log(
+      JSON.stringify(
+        {
+          text: result.text,
+          observedUrl,
+          expectedUrl,
+          reportedBugUrl,
+        },
+        null,
+        2,
+      ),
+    );
+
+    if (observedUrl !== expectedUrl) {
+      throw new Error(
+        `Expected ${expectedUrl}, but @ai-sdk/anthropic requested ${observedUrl}`,
+      );
+    }
+  } finally {
+    if (originalBaseURL === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalBaseURL;
+    }
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/issue-15580-bare-base-url-live-success.json
+++ b/packages/anthropic/src/__fixtures__/issue-15580-bare-base-url-live-success.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "baseURL": "https://api.anthropic.com",
+    "url": "https://api.anthropic.com/v1/messages"
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": {
+      "model": "claude-haiku-4-5-20251001",
+      "id": "msg_011CcrGDxk5QuYL3wajReRmB",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "OK"
+        }
+      ],
+      "stop_reason": "max_tokens",
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 11,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 1,
+        "service_tier": "standard",
+        "inference_geo": "not_available"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Bug

@ai-sdk/anthropic: ANTHROPIC_BASE_URL not normalized — bare-host form silently produces 404 in Claude Code / Cursor environments

## Reproduction

- Issue #15580 is provider-specific to `@ai-sdk/anthropic` base URL handling.
- Current `packages/anthropic/src/anthropic-provider.ts` normalizes `ANTHROPIC_BASE_URL=https://api.anthropic.com` to the versioned Anthropic API URL.
- A live Anthropic call with `ANTHROPIC_BASE_URL=https://api.anthropic.com` reached `https://api.anthropic.com/v1/messages` and returned `200 OK` with text `OK`; the reported issue behavior would request `https://api.anthropic.com/messages` and return `404 Not Found`.
- Recorded the live success response in `packages/anthropic/src/__fixtures__/issue-15580-bare-base-url-live-success.json`.
- Added `examples/ai-functions/src/reproduction/issue-15580-anthropic-base-url.ts`, which observed `https://api.anthropic.com/v1/messages` instead of the reported `https://api.anthropic.com/messages`.

## Relevant Documentation

- https://platform.claude.com/docs/en/api/overview
- https://platform.claude.com/docs/en/cli-sdks-libraries/sdks/typescript
- https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions

## Related Issues

Could not reproduce #15580