### PR TITLE
[v5.0] fix: @ai-sdk/perplexity silently drops unsupported file parts and top-level-only PDF attachments

### DIFF
--- a/.changeset/perplexity-file-media-types.md
+++ b/.changeset/perplexity-file-media-types.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/perplexity': patch
+---
+
+Fix Perplexity prompt conversion for file parts with unsupported media types and top-level PDF media types.

--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -81,28 +81,6 @@ describe('convertToPerplexityMessages', () => {
         ]);
       }).toThrow(UnsupportedFunctionalityError);
     });
-<<<<<<< HEAD
-=======
-
-    it('should throw for file parts with provider references', () => {
-      expect(() =>
-        convertToPerplexityMessages([
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'file',
-                data: {
-                  type: 'reference' as const,
-                  reference: { perplexity: 'file-ref-123' },
-                },
-                mediaType: 'image/png',
-              },
-            ],
-          },
-        ]),
-      ).toThrow(UnsupportedFunctionalityError);
-    });
   });
 
   describe('top-level-only media type resolution', () => {
@@ -116,7 +94,7 @@ describe('convertToPerplexityMessages', () => {
             {
               type: 'file',
               mediaType: 'image/png',
-              data: { type: 'data' as const, data: pngBase64 },
+              data: pngBase64,
             },
           ],
         },
@@ -136,7 +114,7 @@ describe('convertToPerplexityMessages', () => {
             {
               type: 'file',
               mediaType: 'image',
-              data: { type: 'data' as const, data: pngBase64 },
+              data: pngBase64,
             },
           ],
         },
@@ -156,10 +134,7 @@ describe('convertToPerplexityMessages', () => {
             {
               type: 'file',
               mediaType: 'image',
-              data: {
-                type: 'url' as const,
-                url: new URL('https://example.com/x.png'),
-              },
+              data: new URL('https://example.com/x.png'),
             },
           ],
         },
@@ -181,7 +156,7 @@ describe('convertToPerplexityMessages', () => {
             {
               type: 'file',
               mediaType: 'application',
-              data: { type: 'data' as const, data: pdfBase64 },
+              data: pdfBase64,
               filename: 'doc.pdf',
             },
           ],
@@ -204,10 +179,7 @@ describe('convertToPerplexityMessages', () => {
               {
                 type: 'file',
                 mediaType: 'audio/mpeg',
-                data: {
-                  type: 'data' as const,
-                  data: 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4',
-                },
+                data: 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4',
                 filename: 'clip.mp3',
               },
             ],
@@ -224,7 +196,7 @@ describe('convertToPerplexityMessages', () => {
             {
               type: 'file',
               mediaType: 'image/*',
-              data: { type: 'data' as const, data: pngBase64 },
+              data: pngBase64,
             },
           ],
         },
@@ -235,6 +207,5 @@ describe('convertToPerplexityMessages', () => {
         image_url: { url: `data:image/png;base64,${pngBase64}` },
       });
     });
->>>>>>> 7927171aa (fix: @ai-sdk/perplexity silently drops unsupported file parts and top-level-only PDF attachments (#16972))
   });
 });

--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -81,5 +81,160 @@ describe('convertToPerplexityMessages', () => {
         ]);
       }).toThrow(UnsupportedFunctionalityError);
     });
+<<<<<<< HEAD
+=======
+
+    it('should throw for file parts with provider references', () => {
+      expect(() =>
+        convertToPerplexityMessages([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: {
+                  type: 'reference' as const,
+                  reference: { perplexity: 'file-ref-123' },
+                },
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ]),
+      ).toThrow(UnsupportedFunctionalityError);
+    });
+  });
+
+  describe('top-level-only media type resolution', () => {
+    const pngBase64 = 'iVBORw0KGgo=';
+
+    it('passes full image/png through unchanged for inline data', () => {
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: { type: 'data' as const, data: pngBase64 },
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'image_url',
+        image_url: { url: `data:image/png;base64,${pngBase64}` },
+      });
+    });
+
+    it('detects image subtype from inline bytes for top-level "image"', () => {
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image',
+              data: { type: 'data' as const, data: pngBase64 },
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'image_url',
+        image_url: { url: `data:image/png;base64,${pngBase64}` },
+      });
+    });
+
+    it('passes through URL source for top-level-only image', () => {
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image',
+              data: {
+                type: 'url' as const,
+                url: new URL('https://example.com/x.png'),
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'image_url',
+        image_url: { url: 'https://example.com/x.png' },
+      });
+    });
+
+    it('converts a top-level-only "application" PDF into a file_url part', () => {
+      const pdfBase64 = 'JVBERi0xLjQ=';
+
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'application',
+              data: { type: 'data' as const, data: pdfBase64 },
+              filename: 'doc.pdf',
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'file_url',
+        file_url: { url: pdfBase64 },
+        file_name: 'doc.pdf',
+      });
+    });
+
+    it('throws for unsupported file media types instead of dropping them', () => {
+      expect(() =>
+        convertToPerplexityMessages([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'audio/mpeg',
+                data: {
+                  type: 'data' as const,
+                  data: 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4',
+                },
+                filename: 'clip.mp3',
+              },
+            ],
+          },
+        ]),
+      ).toThrow(UnsupportedFunctionalityError);
+    });
+
+    it('normalizes image/* wildcard via detection', () => {
+      const result = convertToPerplexityMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/*',
+              data: { type: 'data' as const, data: pngBase64 },
+            },
+          ],
+        },
+      ]);
+
+      expect((result[0].content as unknown[])[0]).toEqual({
+        type: 'image_url',
+        image_url: { url: `data:image/png;base64,${pngBase64}` },
+      });
+    });
+>>>>>>> 7927171aa (fix: @ai-sdk/perplexity silently drops unsupported file parts and top-level-only PDF attachments (#16972))
   });
 });

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -1,4 +1,5 @@
 import {
+  type LanguageModelV2FilePart,
   type LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
@@ -6,7 +7,121 @@ import type {
   PerplexityMessageContent,
   PerplexityPrompt,
 } from './perplexity-language-model-prompt';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
+import {
+  convertBase64ToUint8Array,
+  convertUint8ArrayToBase64,
+} from '@ai-sdk/provider-utils';
+
+type MediaTypeSignature = {
+  mediaType: string;
+  bytesPrefix: Array<number | null>;
+};
+
+const mediaTypeSignaturesByTopLevelType: Record<string, MediaTypeSignature[]> =
+  {
+    application: [
+      {
+        mediaType: 'application/pdf',
+        bytesPrefix: [0x25, 0x50, 0x44, 0x46], // %PDF
+      },
+    ],
+    image: [
+      {
+        mediaType: 'image/gif',
+        bytesPrefix: [0x47, 0x49, 0x46], // GIF
+      },
+      {
+        mediaType: 'image/png',
+        bytesPrefix: [0x89, 0x50, 0x4e, 0x47], // PNG
+      },
+      {
+        mediaType: 'image/jpeg',
+        bytesPrefix: [0xff, 0xd8], // JPEG
+      },
+      {
+        mediaType: 'image/webp',
+        bytesPrefix: [
+          0x52,
+          0x49,
+          0x46,
+          0x46, // "RIFF"
+          null,
+          null,
+          null,
+          null, // file size (variable)
+          0x57,
+          0x45,
+          0x42,
+          0x50, // "WEBP"
+        ],
+      },
+    ],
+  };
+
+function getTopLevelMediaType(mediaType: string): string {
+  const slashIndex = mediaType.indexOf('/');
+  return slashIndex === -1 ? mediaType : mediaType.substring(0, slashIndex);
+}
+
+function isFullMediaType(mediaType: string): boolean {
+  const slashIndex = mediaType.indexOf('/');
+  if (slashIndex === -1) {
+    return false;
+  }
+
+  const subtype = mediaType.substring(slashIndex + 1);
+  return subtype.length > 0 && subtype !== '*';
+}
+
+function detectMediaType({
+  data,
+  topLevelType,
+}: {
+  data: string | Uint8Array;
+  topLevelType: string;
+}) {
+  const signatures = mediaTypeSignaturesByTopLevelType[topLevelType];
+
+  if (signatures == null) {
+    return undefined;
+  }
+
+  const bytes =
+    typeof data === 'string'
+      ? convertBase64ToUint8Array(data.substring(0, Math.min(data.length, 24)))
+      : data;
+
+  return signatures.find(signature =>
+    signature.bytesPrefix.every(
+      (byte, index) => byte === null || bytes[index] === byte,
+    ),
+  )?.mediaType;
+}
+
+function resolveFullMediaType(part: LanguageModelV2FilePart): string {
+  if (isFullMediaType(part.mediaType)) {
+    return part.mediaType;
+  }
+
+  if (part.data instanceof URL) {
+    throw new UnsupportedFunctionalityError({
+      functionality: `file of media type "${part.mediaType}" must specify subtype since it is not passed as inline bytes`,
+    });
+  }
+
+  const detected = detectMediaType({
+    data: part.data,
+    topLevelType: getTopLevelMediaType(part.mediaType),
+  });
+
+  if (detected != null) {
+    return detected;
+  }
+
+  throw new UnsupportedFunctionalityError({
+    functionality: `file of media type "${part.mediaType}" must specify subtype since it could not be auto-detected`,
+  });
+}
 
 export function convertToPerplexityMessages(
   prompt: LanguageModelV2Prompt,
@@ -24,8 +139,10 @@ export function convertToPerplexityMessages(
       case 'assistant': {
         const hasMultipartContent = content.some(
           part =>
-            (part.type === 'file' && part.mediaType.startsWith('image/')) ||
-            (part.type === 'file' && part.mediaType === 'application/pdf'),
+            (part.type === 'file' &&
+              getTopLevelMediaType(part.mediaType) === 'image') ||
+            (part.type === 'file' &&
+              getTopLevelMediaType(part.mediaType) === 'application'),
         );
 
         const messageContent = content
@@ -38,8 +155,17 @@ export function convertToPerplexityMessages(
                 };
               }
               case 'file': {
-<<<<<<< HEAD
-                if (part.mediaType === 'application/pdf') {
+                const topLevelMediaType = getTopLevelMediaType(part.mediaType);
+
+                if (topLevelMediaType === 'application') {
+                  const fullMediaType = resolveFullMediaType(part);
+
+                  if (fullMediaType !== 'application/pdf') {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: `file part media type ${fullMediaType}`,
+                    });
+                  }
+
                   return part.data instanceof URL
                     ? {
                         type: 'file_url',
@@ -58,7 +184,7 @@ export function convertToPerplexityMessages(
                         },
                         file_name: part.filename || `document-${index}.pdf`,
                       };
-                } else if (part.mediaType.startsWith('image/')) {
+                } else if (topLevelMediaType === 'image') {
                   return part.data instanceof URL
                     ? {
                         type: 'image_url',
@@ -69,83 +195,18 @@ export function convertToPerplexityMessages(
                     : {
                         type: 'image_url',
                         image_url: {
-                          url: `data:${part.mediaType ?? 'image/jpeg'};base64,${
+                          url: `data:${resolveFullMediaType(part)};base64,${
                             typeof part.data === 'string'
                               ? part.data
                               : convertUint8ArrayToBase64(part.data)
                           }`,
                         },
                       };
-=======
-                switch (part.data.type) {
-                  case 'reference': {
-                    throw new UnsupportedFunctionalityError({
-                      functionality: 'file parts with provider references',
-                    });
-                  }
-                  case 'text': {
-                    throw new UnsupportedFunctionalityError({
-                      functionality: 'text file parts',
-                    });
-                  }
-                  case 'url':
-                  case 'data': {
-                    const topLevelMediaType = getTopLevelMediaType(
-                      part.mediaType,
-                    );
-
-                    if (topLevelMediaType === 'application') {
-                      const fullMediaType = resolveFullMediaType({ part });
-
-                      if (fullMediaType !== 'application/pdf') {
-                        throw new UnsupportedFunctionalityError({
-                          functionality: `file part media type ${fullMediaType}`,
-                        });
-                      }
-
-                      return part.data.type === 'url'
-                        ? {
-                            type: 'file_url',
-                            file_url: {
-                              url: part.data.url.toString(),
-                            },
-                            file_name: part.filename,
-                          }
-                        : {
-                            type: 'file_url',
-                            file_url: {
-                              url:
-                                typeof part.data.data === 'string'
-                                  ? part.data.data
-                                  : convertUint8ArrayToBase64(part.data.data),
-                            },
-                            file_name: part.filename || `document-${index}.pdf`,
-                          };
-                    } else if (topLevelMediaType === 'image') {
-                      return part.data.type === 'url'
-                        ? {
-                            type: 'image_url',
-                            image_url: {
-                              url: part.data.url.toString(),
-                            },
-                          }
-                        : {
-                            type: 'image_url',
-                            image_url: {
-                              url: `data:${resolveFullMediaType({ part })};base64,${
-                                typeof part.data.data === 'string'
-                                  ? part.data.data
-                                  : convertUint8ArrayToBase64(part.data.data)
-                              }`,
-                            },
-                          };
-                    }
-                    throw new UnsupportedFunctionalityError({
-                      functionality: `file part media type ${part.mediaType}`,
-                    });
-                  }
->>>>>>> 7927171aa (fix: @ai-sdk/perplexity silently drops unsupported file parts and top-level-only PDF attachments (#16972))
                 }
+
+                throw new UnsupportedFunctionalityError({
+                  functionality: `file part media type ${part.mediaType}`,
+                });
               }
             }
           })

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -38,6 +38,7 @@ export function convertToPerplexityMessages(
                 };
               }
               case 'file': {
+<<<<<<< HEAD
                 if (part.mediaType === 'application/pdf') {
                   return part.data instanceof URL
                     ? {
@@ -75,6 +76,75 @@ export function convertToPerplexityMessages(
                           }`,
                         },
                       };
+=======
+                switch (part.data.type) {
+                  case 'reference': {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: 'file parts with provider references',
+                    });
+                  }
+                  case 'text': {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: 'text file parts',
+                    });
+                  }
+                  case 'url':
+                  case 'data': {
+                    const topLevelMediaType = getTopLevelMediaType(
+                      part.mediaType,
+                    );
+
+                    if (topLevelMediaType === 'application') {
+                      const fullMediaType = resolveFullMediaType({ part });
+
+                      if (fullMediaType !== 'application/pdf') {
+                        throw new UnsupportedFunctionalityError({
+                          functionality: `file part media type ${fullMediaType}`,
+                        });
+                      }
+
+                      return part.data.type === 'url'
+                        ? {
+                            type: 'file_url',
+                            file_url: {
+                              url: part.data.url.toString(),
+                            },
+                            file_name: part.filename,
+                          }
+                        : {
+                            type: 'file_url',
+                            file_url: {
+                              url:
+                                typeof part.data.data === 'string'
+                                  ? part.data.data
+                                  : convertUint8ArrayToBase64(part.data.data),
+                            },
+                            file_name: part.filename || `document-${index}.pdf`,
+                          };
+                    } else if (topLevelMediaType === 'image') {
+                      return part.data.type === 'url'
+                        ? {
+                            type: 'image_url',
+                            image_url: {
+                              url: part.data.url.toString(),
+                            },
+                          }
+                        : {
+                            type: 'image_url',
+                            image_url: {
+                              url: `data:${resolveFullMediaType({ part })};base64,${
+                                typeof part.data.data === 'string'
+                                  ? part.data.data
+                                  : convertUint8ArrayToBase64(part.data.data)
+                              }`,
+                            },
+                          };
+                    }
+                    throw new UnsupportedFunctionalityError({
+                      functionality: `file part media type ${part.mediaType}`,
+                    });
+                  }
+>>>>>>> 7927171aa (fix: @ai-sdk/perplexity silently drops unsupported file parts and top-level-only PDF attachments (#16972))
                 }
               }
             }


### PR DESCRIPTION
## Background

Perplexity file prompt parts could disappear silently, causing unsupported files to be omitted without an error and top-level-only PDF media types to be lost.

## Summary

Updated Perplexity message conversion to resolve application file media types, preserve resolved PDFs as file_url parts, and throw UnsupportedFunctionalityError for unsupported file media types.

## Testing

Added regression coverage for converting a top-level-only application PDF to file_url and for throwing on unsupported audio/mpeg file parts; added a patch changeset for @ai-sdk/perplexity.

## Related Issues

Fixes #16914

Backport of #16972

Co-authored-by: abhay-codes07 <182421137+abhay-codes07@users.noreply.github.com>