### PR TITLE
reproduction: could not reproduce xAI tool calls return finishReason: "stop" instead of

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12218-gateway-xai-tool-finish-reason.ts
+++ b/examples/ai-functions/src/reproduction/issue-12218-gateway-xai-tool-finish-reason.ts
@@ -1,0 +1,49 @@
+import { createGateway } from '@ai-sdk/gateway';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  const gateway = createGateway({
+    apiKey: process.env.AI_GATEWAY_API_KEY,
+  });
+
+  const result = await generateText({
+    model: gateway('xai/grok-4.1-fast-reasoning'),
+    prompt: "What's the weather in Seoul?",
+    tools: {
+      getWeather: tool({
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+      }),
+    },
+    include: {
+      responseBody: true,
+    },
+  });
+
+  const summary = {
+    finishReason: result.finishReason,
+    rawFinishReason: result.rawFinishReason,
+    toolCalls: result.toolCalls,
+    responseBody: result.response.body,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (result.toolCalls.length === 0) {
+    throw new Error('Expected at least one tool call.');
+  }
+
+  if (result.finishReason !== 'tool-calls') {
+    throw new Error(
+      `Expected finishReason "tool-calls" when tool calls are present, got ${JSON.stringify(
+        result.finishReason,
+      )}.`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

xAI tool calls return `finishReason: "stop"` instead of `"tool-calls"`

## Reproduction

- Classified as a provider-specific AI `Gateway/xAI` finish-reason mapping report.
- Created runnable reproduction script at `examples/ai-functions/src/reproduction/issue-12218-gateway-xai-tool-finish-reason.ts`.
- Live AI Gateway call to `xai/grok-4.1-fast-reasoning` produced a `getWeather` tool call with `finishReason: "tool-calls"`.
- Expected issue behavior was a tool call with `finishReason: "stop"`, but the observed live response body returned `finishReason.unified: "tool-calls"` and `raw: "tool_calls"`.

## Relevant Documentation

- https://vercel.com/changelog/grok-4-1-fast-models-now-available-on-vercel-ai-gateway
- https://vercel.com/docs/ai-gateway/models-and-providers
- https://vercel.com/ai-gateway/models/grok-4.1-fast-reasoning/providers
- https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text
- https://docs.x.ai/developers/tools/function-calling

## Related Issues

Could not reproduce #12218