### PR TITLE
reproduction: anthropic provider: toolChoice 'none' strips tools from request,

### DIFF
--- a/examples/ai-functions/src/reproduction/anthropic-tool-choice-none.ts
+++ b/examples/ai-functions/src/reproduction/anthropic-tool-choice-none.ts
@@ -1,0 +1,124 @@
+import 'dotenv/config';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs/promises';
+
+const fixtureUrl = new URL(
+  '../../../../packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-history.json',
+  import.meta.url,
+);
+
+async function main() {
+  let requestBody: unknown;
+  let responseBody: unknown;
+  let responseText: string | undefined;
+
+  const anthropic = createAnthropic({
+    fetch: async (url, options) => {
+      requestBody = JSON.parse(String(options?.body ?? '{}'));
+
+      const response = await fetch(url, options);
+      const text = await response.clone().text();
+      responseText = text;
+
+      try {
+        responseBody = JSON.parse(text);
+      } catch {
+        responseBody = text;
+      }
+
+      return response;
+    },
+  });
+
+  const prompt = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Search for climate change.' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'toolu_repro_123',
+          toolName: 'search',
+          input: { query: 'climate change' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'toolu_repro_123',
+          toolName: 'search',
+          output: {
+            type: 'text',
+            value:
+              'Climate change refers to long-term shifts in temperatures and weather patterns.',
+          },
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Now summarize what you found in one sentence.' },
+      ],
+    },
+  ] satisfies LanguageModelV4Prompt;
+
+  const modelId = process.env.ANTHROPIC_REPRO_MODEL ?? 'claude-haiku-4-5';
+
+  const result = await anthropic(modelId).doGenerate({
+    prompt,
+    maxOutputTokens: 128,
+    tools: [
+      {
+        type: 'function',
+        name: 'search',
+        description: 'Search for information',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    toolChoice: { type: 'none' },
+  });
+
+  await fs.writeFile(fixtureUrl, `${JSON.stringify(responseBody, null, 2)}\n`);
+
+  console.log(
+    JSON.stringify(
+      {
+        modelId,
+        requestHasTools:
+          typeof requestBody === 'object' &&
+          requestBody !== null &&
+          'tools' in requestBody,
+        requestToolChoice:
+          typeof requestBody === 'object' && requestBody !== null
+            ? (requestBody as { tool_choice?: unknown }).tool_choice
+            : undefined,
+        content: result.content,
+        finishReason: result.finishReason,
+        usage: result.usage,
+        responseBody,
+        responseTextLength: responseText?.length,
+        fixturePath: fixtureUrl.pathname,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-history.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-history.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CcrQf7PcKMFA65YhVDk1Q",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Climate change refers to long-term shifts in temperatures and weather patterns."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 105,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 17,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/anthropic-tool-choice-none-reproduction.test.ts
+++ b/packages/anthropic/src/anthropic-tool-choice-none-reproduction.test.ts
@@ -1,0 +1,141 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createAnthropic({
+  apiKey: 'test-api-key',
+  generateId: mockId({ prefix: 'id' }),
+});
+
+const prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Search for climate change.' }],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_repro_123',
+        toolName: 'search',
+        input: { query: 'climate change' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_repro_123',
+        toolName: 'search',
+        output: {
+          type: 'text',
+          value:
+            'Climate change refers to long-term shifts in temperatures and weather patterns.',
+        },
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Now summarize what you found in one sentence.',
+      },
+    ],
+  },
+] satisfies LanguageModelV4Prompt;
+
+describe('issue #12378 reproduction', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+
+  it('should retain tools and send tool_choice none when tool_use/tool_result history is present', async () => {
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/anthropic-tool-choice-none-history.json',
+          'utf8',
+        ),
+      ),
+    };
+
+    await provider('claude-sonnet-4-5').doGenerate({
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          description: 'Search for information',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      toolChoice: { type: 'none' },
+      prompt,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Search for climate change.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_repro_123',
+              name: 'search',
+              input: { query: 'climate change' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_repro_123',
+              content:
+                'Climate change refers to long-term shifts in temperatures and weather patterns.',
+            },
+            {
+              type: 'text',
+              text: 'Now summarize what you found in one sentence.',
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: 'search',
+          description: 'Search for information',
+          input_schema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      tool_choice: { type: 'none' },
+    });
+  });
+});


### PR DESCRIPTION
## Bug

anthropic provider: toolChoice 'none' strips tools from request, causing empty response with tool_use history

## Reproduction

- `examples/ai-functions/src/reproduction/anthropic-tool-choice-none.ts` is a runnable live-provider reproduction that observed `toolChoice: { type: 'none' }` producing an Anthropic request with no `tools` and no `tool_choice`.
- `packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-history.json` records a live Anthropic Messages API response for the stripped-tools request.
- `packages/anthropic/src/anthropic-tool-choice-none-reproduction.test.ts` asserts the expected behavior: retain the `tools` array and send `tool_choice: { "type": "none" }` when `tool_use`/`tool_result` history is present.
- Current supported Anthropic models returned text instead of empty `content: []`, but the provider-side request-stripping behavior reported in the issue reproduced.
- The originally reported `claude-sonnet-4-20250514` live call returned a 404 `model: claude-sonnet-4-20250514` error on July 9, 2026.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/api/messages

## Related Issues

Reproduces #12378