### PR TITLE
reproduction: could not reproduce xAI tool calls return finishReason: "stop" instead of

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12218-gateway-xai-tool-finish-reason.ts
+++ b/examples/ai-functions/src/reproduction/issue-12218-gateway-xai-tool-finish-reason.ts
@@ -1,0 +1,56 @@
+import { createGateway } from '@ai-sdk/gateway';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const gateway = createGateway();
+
+  const result = await generateText({
+    model: gateway('xai/grok-4.1-fast-reasoning'),
+    prompt: "What's the weather in Seoul? Use the getWeather tool.",
+    toolChoice: 'required',
+    tools: {
+      getWeather: tool({
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+      }),
+    },
+  });
+
+  const summary = {
+    finishReason: result.finishReason,
+    rawFinishReason: result.rawFinishReason,
+    toolCalls: result.toolCalls.map(toolCall => ({
+      toolName: toolCall.toolName,
+      toolCallId: toolCall.toolCallId,
+      input: toolCall.input,
+    })),
+    content: result.content,
+    responseBody: result.response.body,
+    steps: result.steps.map(step => ({
+      finishReason: step.finishReason,
+      rawFinishReason: step.rawFinishReason,
+      toolCalls: step.toolCalls.map(toolCall => ({
+        toolName: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        input: toolCall.input,
+      })),
+      content: step.content,
+      responseBody: step.response.body,
+    })),
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (result.toolCalls.length > 0 && result.finishReason !== 'tool-calls') {
+    throw new Error(
+      `Issue #12218 reproduced: expected finishReason "tool-calls" when tool calls are present, got ${JSON.stringify(result.finishReason)}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/gateway/src/__fixtures__/issue-12218-gateway-xai-tool-finish-reason.json
+++ b/packages/gateway/src/__fixtures__/issue-12218-gateway-xai-tool-finish-reason.json
@@ -1,0 +1,83 @@
+{
+  "content": [
+    {
+      "type": "tool-call",
+      "toolCallId": "call_23921261",
+      "toolName": "getWeather",
+      "input": "{\"city\":\"Seoul\"}"
+    }
+  ],
+  "finishReason": {
+    "unified": "tool-calls",
+    "raw": "tool_calls"
+  },
+  "usage": {
+    "inputTokens": {
+      "total": 875,
+      "noCache": 224,
+      "cacheRead": 651
+    },
+    "outputTokens": {
+      "total": 124,
+      "text": 26,
+      "reasoning": 98
+    },
+    "raw": {
+      "prompt_tokens": 875,
+      "completion_tokens": 26,
+      "total_tokens": 999,
+      "prompt_tokens_details": {
+        "cached_tokens": 651
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 98,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      },
+      "cost_in_usd_ticks": 0,
+      "extra_properties": {
+        "google": {
+          "traffic_type": "ON_DEMAND"
+        }
+      },
+      "num_sources_used": 0
+    }
+  },
+  "providerMetadata": {
+    "googleVertex": {
+      "acceptedPredictionTokens": 0,
+      "rejectedPredictionTokens": 0
+    },
+    "gateway": {
+      "routing": {
+        "originalModelId": "xai/grok-4.1-fast-reasoning",
+        "resolvedProvider": "vertex",
+        "fallbacksAvailable": [],
+        "planningReasoning": "System credentials planned for: vertex. Total execution order: vertex(system)",
+        "canonicalSlug": "xai/grok-4.1-fast-reasoning",
+        "finalProvider": "vertex",
+        "modelAttemptCount": 1,
+        "modelAttempts": [
+          {
+            "canonicalSlug": "xai/grok-4.1-fast-reasoning",
+            "success": true,
+            "providerAttemptCount": 1,
+            "providerAttempts": [
+              {
+                "provider": "vertex",
+                "credentialType": "system",
+                "success": true,
+                "startTime": 1783597051541,
+                "endTime": 1783597052986,
+                "statusCode": 200
+              }
+            ]
+          }
+        ],
+        "totalProviderAttemptCount": 1
+      },
+      "generationId": "gen_01KX3APBF96TQBDCNT0G0M4M84"
+    }
+  },
+  "warnings": []
+}


### PR DESCRIPTION
## Bug

xAI tool calls return `finishReason: "stop"` instead of `"tool-calls"`

## Reproduction

- Classified as a provider-specific AI `Gateway/xAI` finish-reason mapping report.
- Added runnable reproduction script at `examples/ai-functions/src/reproduction/issue-12218-gateway-xai-tool-finish-reason.ts`.
- Recorded the live Gateway response fixture at `packages/gateway/src/__fixtures__/issue-12218-gateway-xai-tool-finish-reason.json`.
- Live AI Gateway call to `xai/grok-4.1-fast-reasoning` produced a `getWeather` tool call with `finishReason: "tool-calls"` and `rawFinishReason: "tool_calls"`.
- Expected issue behavior was a tool call with `finishReason: "stop"`, but that behavior was not observed.

## Relevant Documentation

- https://vercel.com/changelog/grok-4-1-fast-models-now-available-on-vercel-ai-gateway
- https://vercel.com/docs/ai-gateway/models-and-providers
- https://vercel.com/ai-gateway/models/grok-4.1-fast-reasoning/providers
- https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://docs.x.ai/developers/tools/function-calling

## Related Issues

Could not reproduce #12218