### PR TITLE
reproduction: anthropic provider: toolChoice 'none' strips tools from request,

### DIFF
--- a/examples/ai-functions/src/reproduction/anthropic-tool-choice-none.ts
+++ b/examples/ai-functions/src/reproduction/anthropic-tool-choice-none.ts
@@ -1,0 +1,130 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type {
+  LanguageModelV4FunctionTool,
+  LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+const fixturePath =
+  '../../packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live.json';
+
+const prompt: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Search for climate change.',
+      },
+    ],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_01ReproToolChoiceNone0000000000',
+        toolName: 'search',
+        input: { query: 'climate change' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_01ReproToolChoiceNone0000000000',
+        toolName: 'search',
+        output: {
+          type: 'text',
+          value:
+            'Climate change results: global temperatures are rising and mitigation requires lowering greenhouse-gas emissions.',
+        },
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Now summarize what you found in one concise sentence.',
+      },
+    ],
+  },
+];
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: 'function',
+    name: 'search',
+    description: 'Search for information.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+  },
+];
+
+async function main() {
+  const requestBodies: unknown[] = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (url, options) => {
+      const parsedBody = await safeParseJSON({ text: String(options?.body) });
+      if (!parsedBody.success) {
+        throw parsedBody.error;
+      }
+      requestBodies.push(parsedBody.value);
+      return fetch(url, options);
+    },
+  });
+
+  const result = await anthropic('claude-sonnet-4-6').doGenerate({
+    prompt,
+    tools,
+    toolChoice: { type: 'none' },
+    maxOutputTokens: 64,
+  });
+
+  if (result.response == null) {
+    throw new Error('Expected an Anthropic response object.');
+  }
+
+  await mkdir('../../packages/anthropic/src/__fixtures__', { recursive: true });
+  await writeFile(
+    fixturePath,
+    `${JSON.stringify(result.response.body, null, 2)}\n`,
+  );
+
+  const requestBody = requestBodies[0] as Record<string, unknown>;
+  const responseBody = result.response.body as
+    | { content?: unknown }
+    | undefined;
+  console.log(
+    JSON.stringify(
+      {
+        model: requestBody.model,
+        sentTools: Array.isArray(requestBody.tools),
+        sentToolChoice: requestBody.tool_choice ?? null,
+        responseContent: responseBody?.content,
+        content: result.content,
+        finishReason: result.finishReason,
+        fixturePath,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-6",
+  "id": "msg_011CcrSQzgsq2uoQYtneZZyZ",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Climate change is causing global temperatures to rise, and addressing it requires reducing greenhouse gas emissions."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 112,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 21,
+    "service_tier": "standard",
+    "inference_geo": "global"
+  }
+}

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -28,6 +28,48 @@ const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
+const TOOL_CHOICE_NONE_WITH_TOOL_HISTORY_PROMPT: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Search for climate change.' }],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_01ReproToolChoiceNone0000000000',
+        toolName: 'search',
+        input: { query: 'climate change' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_01ReproToolChoiceNone0000000000',
+        toolName: 'search',
+        output: {
+          type: 'text',
+          value:
+            'Climate change results: global temperatures are rising and mitigation requires lowering greenhouse-gas emissions.',
+        },
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Now summarize what you found in one concise sentence.',
+      },
+    ],
+  },
+];
+
 const provider = createAnthropic({
   apiKey: 'test-api-key',
   generateId: mockId({ prefix: 'id' }),
@@ -63,6 +105,49 @@ describe('AnthropicLanguageModel', () => {
   }
 
   describe('doGenerate', () => {
+    it('should send tools and tool_choice none when tool history is present', async () => {
+      prepareJsonFixtureResponse('anthropic-tool-choice-none-live');
+
+      await provider('claude-sonnet-4-6').doGenerate({
+        prompt: TOOL_CHOICE_NONE_WITH_TOOL_HISTORY_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'search',
+            description: 'Search for information.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
+              },
+              required: ['query'],
+              additionalProperties: false,
+            },
+          },
+        ],
+        toolChoice: { type: 'none' },
+        maxOutputTokens: 64,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        tools: [
+          {
+            name: 'search',
+            description: 'Search for information.',
+            input_schema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
+              },
+              required: ['query'],
+              additionalProperties: false,
+            },
+          },
+        ],
+        tool_choice: { type: 'none' },
+      });
+    });
+
     describe('reasoning (thinking enabled)', () => {
       it('should pass thinking config; add budget tokens; clear out temperature, top_p, top_k; and return warnings', async () => {
         prepareJsonFixtureResponse('anthropic-text');


### PR DESCRIPTION
## Bug

anthropic provider: toolChoice 'none' strips tools from request, causing empty response with tool_use history

## Reproduction

- Classified as a provider-specific Anthropic request-construction issue.
- Anthropic documentation treats `tool_choice: { "type": "none" }` as a valid tool-choice mode and documents `tool_use`/`tool_result` message history.
- The issue's `claude-sonnet-4-20250514` model is retired on the Claude API as of June 15, 2026, so the live check used the documented replacement `claude-sonnet-4-6`.
- Live reproduction artifact `examples/ai-functions/src/reproduction/anthropic-tool-choice-none.ts` sent tool history with `toolChoice: { type: 'none' }`; the captured request had `sentTools: false` and `sentToolChoice: null` instead of sending `tools` and `tool_choice: { type: 'none' }`.
- Recorded the live Anthropic response fixture at `packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live.json`.
- Added failing provider unit test in `packages/anthropic/src/anthropic-language-model.test.ts`; it expects `tools` and `tool_choice: { type: 'none' }`, but the actual request omits both.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://platform.claude.com/docs/en/about-claude/model-deprecations

## Related Issues

Reproduces #12378