### PR TITLE
reproduction: anthropic provider: toolChoice 'none' strips tools from request,

### DIFF
--- a/examples/ai-functions/src/reproduction/anthropic-tool-choice-none-tool-history.ts
+++ b/examples/ai-functions/src/reproduction/anthropic-tool-choice-none-tool-history.ts
@@ -1,0 +1,125 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type {
+  LanguageModelV4Content,
+  LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
+
+const promptWithToolHistory: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Search for climate change' }],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_01_issue12378',
+        toolName: 'search',
+        input: { query: 'climate change' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_01_issue12378',
+        toolName: 'search',
+        output: {
+          type: 'text',
+          value:
+            'Climate change is a long-term shift in temperatures and weather patterns.',
+        },
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Now summarize what you found in one sentence.' },
+    ],
+  },
+];
+
+function getText(content: LanguageModelV4Content[]) {
+  return content
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('');
+}
+
+function hasProperty(value: unknown, property: string) {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    Object.prototype.hasOwnProperty.call(value, property)
+  );
+}
+
+async function main() {
+  const captured: {
+    requestBody?: unknown;
+    responseStatus?: number;
+    responseBodyText?: string;
+  } = {};
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      captured.requestBody =
+        typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body;
+
+      const response = await fetch(input, init);
+      captured.responseStatus = response.status;
+      captured.responseBodyText = await response.clone().text();
+      return response;
+    },
+  });
+
+  const result = await anthropic('claude-sonnet-4-6').doGenerate({
+    prompt: promptWithToolHistory,
+    maxOutputTokens: 64,
+    tools: [
+      {
+        type: 'function',
+        name: 'search',
+        description: 'Search for information',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    toolChoice: { type: 'none' },
+  });
+
+  const requestHasTools = hasProperty(captured.requestBody, 'tools');
+  const requestHasToolChoice = hasProperty(captured.requestBody, 'tool_choice');
+
+  console.log(
+    JSON.stringify(
+      {
+        requestHasTools,
+        requestHasToolChoice,
+        responseStatus: captured.responseStatus,
+        text: getText(result.content),
+        finishReason: result.finishReason,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!requestHasTools || !requestHasToolChoice) {
+    throw new Error(
+      'Reproduced issue #12378: toolChoice none removed tools/tool_choice from the Anthropic request.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-with-tool-history.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-with-tool-history.1.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-6",
+  "id": "msg_011CcrUZLSioSP1jmGttbfhe",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Based on the search results, climate change can be summarized as: **Climate change refers to the long-term shift in global temperatures and weather patterns over time.**"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 104,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 36,
+    "service_tier": "standard",
+    "inference_geo": "global"
+  }
+}

--- a/packages/anthropic/src/anthropic-tool-choice-none.issue-12378.test.ts
+++ b/packages/anthropic/src/anthropic-tool-choice-none.issue-12378.test.ts
@@ -1,0 +1,103 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const promptWithToolHistory: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Search for climate change' }],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_01_issue12378',
+        toolName: 'search',
+        input: { query: 'climate change' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_01_issue12378',
+        toolName: 'search',
+        output: {
+          type: 'text',
+          value:
+            'Climate change is a long-term shift in temperatures and weather patterns.',
+        },
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Now summarize what you found in one sentence.' },
+    ],
+  },
+];
+
+describe('issue #12378: toolChoice none with Anthropic tool history', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+
+  it('should keep tools and send tool_choice none', async () => {
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/anthropic-tool-choice-none-with-tool-history.1.json',
+          'utf8',
+        ),
+      ),
+    };
+
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+    })('claude-sonnet-4-6');
+
+    await model.doGenerate({
+      prompt: promptWithToolHistory,
+      maxOutputTokens: 64,
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          description: 'Search for information',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      ],
+      toolChoice: { type: 'none' },
+    });
+
+    await expect(server.calls[0].requestBodyJson).resolves.toMatchObject({
+      tools: [
+        {
+          name: 'search',
+          description: 'Search for information',
+          input_schema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      ],
+      tool_choice: { type: 'none' },
+    });
+  });
+});


### PR DESCRIPTION
## Bug

anthropic provider: toolChoice 'none' strips tools from request, causing empty response with tool_use history

## Reproduction

- `examples/ai-functions/src/reproduction/anthropic-tool-choice-none-tool-history.ts` reproduces the SDK request-shaping bug: with tool history and `toolChoice: { type: 'none' }`, the live Anthropic request had `requestHasTools: false` and `requestHasToolChoice: false`.
- `packages/anthropic/src/anthropic-tool-choice-none.issue-12378.test.ts` is a failing provider regression test that expects the request to keep the `tools` array and send `tool_choice: { type: 'none' }`.
- `packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-with-tool-history.1.json` records a real Anthropic `claude-sonnet-4-6` response used by the provider test fixture.
- The current live `claude-sonnet-4-6` response returned non-empty text, but the SDK still stripped the documented `tools` and `tool_choice` fields from the request.
- The exact issue model `claude-sonnet-4-20250514` returned a live Anthropic 404 `not_found_error`, so the runnable live reproduction uses current `claude-sonnet-4-6`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools?categoryid=2849204
- https://platform.claude.com/docs/en/api/messages/create
- https://platform.claude.com/docs/en/about-claude/models/overview

## Related Issues

Reproduces #12378