### PR TITLE
fix: @ai-sdk/workflow package.json declares unpublished entrypoint files

### DIFF
--- a/.changeset/workflow-entrypoints.md
+++ b/.changeset/workflow-entrypoints.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Fix package entrypoints so the published tarball contains the files declared for import, require, and types resolution.

--- a/examples/ai-functions/src/reproduction/workflow-require-entrypoint.ts
+++ b/examples/ai-functions/src/reproduction/workflow-require-entrypoint.ts
@@ -1,11 +1,16 @@
 import { spawn } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { parseJSON } from '@ai-sdk/provider-utils';
 
 const packageName = '@ai-sdk/workflow';
-const packageVersion = '1.0.17';
-const packageSpecifier = `${packageName}@${packageVersion}`;
 
 type CommandResult = {
   exitCode: number;
@@ -19,13 +24,18 @@ type NpmPackOutput = Array<{
 }>;
 
 type WorkflowPackageJson = {
+  name: string;
+  version: string;
+  type?: string;
   main: string;
+  module?: string;
   types: string;
   exports: {
     '.': {
       types: string;
       import: string;
-      require: string;
+      require?: string;
+      default?: string;
     };
   };
 };
@@ -89,15 +99,61 @@ async function runSuccessfulCommand(
   return result;
 }
 
+async function symlinkDependency({
+  dependencyName,
+  sourceNodeModulesDirectory,
+  targetNodeModulesDirectory,
+}: {
+  dependencyName: string;
+  sourceNodeModulesDirectory: string;
+  targetNodeModulesDirectory: string;
+}) {
+  const sourcePath = join(
+    sourceNodeModulesDirectory,
+    ...dependencyName.split('/'),
+  );
+  const targetPath = join(
+    targetNodeModulesDirectory,
+    ...dependencyName.split('/'),
+  );
+
+  await mkdir(dirname(targetPath), { recursive: true });
+  await symlink(
+    sourcePath,
+    targetPath,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+}
+
 async function main() {
+  const repositoryRoot = join(process.cwd(), '..', '..');
+  const workflowPackageSourceDirectory = join(
+    repositoryRoot,
+    'packages',
+    'workflow',
+  );
+  const workflowPackageNodeModulesDirectory = join(
+    workflowPackageSourceDirectory,
+    'node_modules',
+  );
   const tempDirectory = await mkdtemp(
     join(process.cwd(), '.tmp-workflow-require-entrypoint-'),
   );
 
   try {
+    await runSuccessfulCommand('pnpm', ['--filter', packageName, 'build'], {
+      cwd: repositoryRoot,
+    });
+
     const packResult = await runSuccessfulCommand(
       'npm',
-      ['pack', packageSpecifier, '--json', '--pack-destination', tempDirectory],
+      [
+        'pack',
+        workflowPackageSourceDirectory,
+        '--json',
+        '--pack-destination',
+        tempDirectory,
+      ],
       { cwd: tempDirectory },
     );
 
@@ -108,16 +164,16 @@ async function main() {
 
     if (packedPackage == null) {
       throw new Error(
-        `npm pack did not return package data for ${packageSpecifier}`,
+        `npm pack did not return package data for ${packageName}`,
       );
     }
 
     const packedFiles = packedPackage.files.map(file => file.path).sort();
     const tarballPath = join(tempDirectory, packedPackage.filename);
     const projectDirectory = join(tempDirectory, 'project');
+    const projectNodeModulesDirectory = join(projectDirectory, 'node_modules');
     const scopedPackagesDirectory = join(
-      projectDirectory,
-      'node_modules',
+      projectNodeModulesDirectory,
       '@ai-sdk',
     );
     const workflowPackageDirectory = join(scopedPackagesDirectory, 'workflow');
@@ -135,6 +191,23 @@ async function main() {
       { cwd: tempDirectory },
     );
 
+    await Promise.all(
+      [
+        '@ai-sdk/provider',
+        '@ai-sdk/provider-utils',
+        'ai',
+        'ajv',
+        'workflow',
+        'zod',
+      ].map(dependencyName =>
+        symlinkDependency({
+          dependencyName,
+          sourceNodeModulesDirectory: workflowPackageNodeModulesDirectory,
+          targetNodeModulesDirectory: projectNodeModulesDirectory,
+        }),
+      ),
+    );
+
     const packageJson = (await parseJSON({
       text: await readFile(
         join(workflowPackageDirectory, 'package.json'),
@@ -142,29 +215,36 @@ async function main() {
       ),
     })) as WorkflowPackageJson;
 
-    const hasImportTarget = packedFiles.includes('dist/index.mjs');
-    const hasImportTypesTarget = packedFiles.includes('dist/index.d.mts');
-    const hasRequireTarget = packedFiles.includes('dist/index.js');
+    const hasImportTarget = packedFiles.includes('dist/index.js');
     const hasTypesTarget = packedFiles.includes('dist/index.d.ts');
+    const hasStaleImportTarget = packedFiles.includes('dist/index.mjs');
+    const hasStaleTypesTarget = packedFiles.includes('dist/index.d.mts');
 
     console.log(
-      `Packed ${packageSpecifier} tarball: ${packedPackage.filename}`,
+      `Packed local ${packageJson.name}@${packageJson.version} tarball: ${packedPackage.filename}`,
     );
     console.log('Published files:');
     for (const file of packedFiles) {
       console.log(`- ${file}`);
     }
     console.log('Declared package entry points:');
+    console.log(`- type: ${packageJson.type}`);
     console.log(`- main: ${packageJson.main}`);
+    console.log(`- module: ${packageJson.module ?? '<absent>'}`);
     console.log(`- types: ${packageJson.types}`);
     console.log(`- exports["."].types: ${packageJson.exports['.'].types}`);
     console.log(`- exports["."].import: ${packageJson.exports['.'].import}`);
-    console.log(`- exports["."].require: ${packageJson.exports['.'].require}`);
+    console.log(
+      `- exports["."].require: ${packageJson.exports['.'].require ?? '<absent>'}`,
+    );
+    console.log(
+      `- exports["."].default: ${packageJson.exports['.'].default ?? '<absent>'}`,
+    );
     console.log('Entrypoint files present:');
-    console.log(`- dist/index.mjs: ${hasImportTarget}`);
-    console.log(`- dist/index.d.mts: ${hasImportTypesTarget}`);
-    console.log(`- dist/index.js: ${hasRequireTarget}`);
+    console.log(`- dist/index.js: ${hasImportTarget}`);
     console.log(`- dist/index.d.ts: ${hasTypesTarget}`);
+    console.log(`- dist/index.mjs: ${hasStaleImportTarget}`);
+    console.log(`- dist/index.d.mts: ${hasStaleTypesTarget}`);
 
     const importResolveResult = await runCommand(
       process.execPath,
@@ -185,8 +265,8 @@ async function main() {
     await writeFile(
       requireProbePath,
       [
-        `require('${packageName}');`,
-        `console.log('require("${packageName}") succeeded');`,
+        `const workflow = require('${packageName}');`,
+        `console.log(Object.keys(workflow).sort().join(','));`,
       ].join('\n'),
     );
 
@@ -201,9 +281,40 @@ async function main() {
     console.log(`- stdout: ${requireResult.stdout.trim()}`);
     console.log(`- stderr: ${requireResult.stderr.trim()}`);
 
-    if (!hasImportTarget || !hasImportTypesTarget) {
+    if (packageJson.type !== 'module') {
       throw new Error(
-        'Expected the published tarball to contain ESM import files, but one or more were missing.',
+        'Expected package.json to declare "type": "module" so tsup emits dist/index.js and dist/index.d.ts.',
+      );
+    }
+
+    if (packageJson.module != null) {
+      throw new Error(
+        'Expected package.json not to declare a stale "module" entrypoint.',
+      );
+    }
+
+    if (
+      packageJson.main !== './dist/index.js' ||
+      packageJson.types !== './dist/index.d.ts' ||
+      packageJson.exports['.'].types !== './dist/index.d.ts' ||
+      packageJson.exports['.'].import !== './dist/index.js' ||
+      packageJson.exports['.'].default !== './dist/index.js' ||
+      packageJson.exports['.'].require != null
+    ) {
+      throw new Error(
+        'Expected package.json to point all public entrypoints at the published ESM build files.',
+      );
+    }
+
+    if (!hasImportTarget || !hasTypesTarget) {
+      throw new Error(
+        'Expected the packed tarball to contain the declared JavaScript and TypeScript entrypoint files.',
+      );
+    }
+
+    if (hasStaleImportTarget || hasStaleTypesTarget) {
+      throw new Error(
+        'Expected the packed tarball not to contain stale .mjs or .d.mts entrypoint files.',
       );
     }
 
@@ -213,15 +324,9 @@ async function main() {
       );
     }
 
-    if (hasRequireTarget || hasTypesTarget) {
-      throw new Error(
-        'Expected the published tarball to be missing the declared CommonJS or TypeScript entrypoint files.',
-      );
-    }
-
     if (requireResult.exitCode !== 0) {
       throw new Error(
-        `Expected require("${packageName}") to succeed, but it failed because ${packageSpecifier} declares a CommonJS entrypoint that is not published.`,
+        `Expected require("${packageName}") to succeed from the packed package entrypoint.`,
       );
     }
   } finally {

--- a/examples/ai-functions/src/reproduction/workflow-require-entrypoint.ts
+++ b/examples/ai-functions/src/reproduction/workflow-require-entrypoint.ts
@@ -1,0 +1,232 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseJSON } from '@ai-sdk/provider-utils';
+
+const packageName = '@ai-sdk/workflow';
+const packageVersion = '1.0.17';
+const packageSpecifier = `${packageName}@${packageVersion}`;
+
+type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+type NpmPackOutput = Array<{
+  filename: string;
+  files: Array<{ path: string }>;
+}>;
+
+type WorkflowPackageJson = {
+  main: string;
+  types: string;
+  exports: {
+    '.': {
+      types: string;
+      import: string;
+      require: string;
+    };
+  };
+};
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+
+    child.on('close', exitCode => {
+      resolve({
+        exitCode: exitCode ?? -1,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+async function runSuccessfulCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<CommandResult> {
+  const result = await runCommand(command, args, options);
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      [
+        `Command failed: ${command} ${args.join(' ')}`,
+        `Exit code: ${result.exitCode}`,
+        `stdout:\n${result.stdout}`,
+        `stderr:\n${result.stderr}`,
+      ].join('\n'),
+    );
+  }
+
+  return result;
+}
+
+async function main() {
+  const tempDirectory = await mkdtemp(
+    join(process.cwd(), '.tmp-workflow-require-entrypoint-'),
+  );
+
+  try {
+    const packResult = await runSuccessfulCommand(
+      'npm',
+      ['pack', packageSpecifier, '--json', '--pack-destination', tempDirectory],
+      { cwd: tempDirectory },
+    );
+
+    const packOutput = (await parseJSON({
+      text: packResult.stdout,
+    })) as NpmPackOutput;
+    const packedPackage = packOutput[0];
+
+    if (packedPackage == null) {
+      throw new Error(
+        `npm pack did not return package data for ${packageSpecifier}`,
+      );
+    }
+
+    const packedFiles = packedPackage.files.map(file => file.path).sort();
+    const tarballPath = join(tempDirectory, packedPackage.filename);
+    const projectDirectory = join(tempDirectory, 'project');
+    const scopedPackagesDirectory = join(
+      projectDirectory,
+      'node_modules',
+      '@ai-sdk',
+    );
+    const workflowPackageDirectory = join(scopedPackagesDirectory, 'workflow');
+
+    await mkdir(workflowPackageDirectory, { recursive: true });
+    await runSuccessfulCommand(
+      'tar',
+      [
+        '-xzf',
+        tarballPath,
+        '--strip-components=1',
+        '-C',
+        workflowPackageDirectory,
+      ],
+      { cwd: tempDirectory },
+    );
+
+    const packageJson = (await parseJSON({
+      text: await readFile(
+        join(workflowPackageDirectory, 'package.json'),
+        'utf8',
+      ),
+    })) as WorkflowPackageJson;
+
+    const hasImportTarget = packedFiles.includes('dist/index.mjs');
+    const hasImportTypesTarget = packedFiles.includes('dist/index.d.mts');
+    const hasRequireTarget = packedFiles.includes('dist/index.js');
+    const hasTypesTarget = packedFiles.includes('dist/index.d.ts');
+
+    console.log(
+      `Packed ${packageSpecifier} tarball: ${packedPackage.filename}`,
+    );
+    console.log('Published files:');
+    for (const file of packedFiles) {
+      console.log(`- ${file}`);
+    }
+    console.log('Declared package entry points:');
+    console.log(`- main: ${packageJson.main}`);
+    console.log(`- types: ${packageJson.types}`);
+    console.log(`- exports["."].types: ${packageJson.exports['.'].types}`);
+    console.log(`- exports["."].import: ${packageJson.exports['.'].import}`);
+    console.log(`- exports["."].require: ${packageJson.exports['.'].require}`);
+    console.log('Entrypoint files present:');
+    console.log(`- dist/index.mjs: ${hasImportTarget}`);
+    console.log(`- dist/index.d.mts: ${hasImportTypesTarget}`);
+    console.log(`- dist/index.js: ${hasRequireTarget}`);
+    console.log(`- dist/index.d.ts: ${hasTypesTarget}`);
+
+    const importResolveResult = await runCommand(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `console.log(import.meta.resolve('${packageName}'))`,
+      ],
+      { cwd: projectDirectory },
+    );
+
+    console.log('ESM import resolution probe:');
+    console.log(`- exit code: ${importResolveResult.exitCode}`);
+    console.log(`- stdout: ${importResolveResult.stdout.trim()}`);
+    console.log(`- stderr: ${importResolveResult.stderr.trim()}`);
+
+    const requireProbePath = join(projectDirectory, 'require-probe.cjs');
+    await writeFile(
+      requireProbePath,
+      [
+        `require('${packageName}');`,
+        `console.log('require("${packageName}") succeeded');`,
+      ].join('\n'),
+    );
+
+    const requireResult = await runCommand(
+      process.execPath,
+      [requireProbePath],
+      { cwd: projectDirectory },
+    );
+
+    console.log('CommonJS require probe:');
+    console.log(`- exit code: ${requireResult.exitCode}`);
+    console.log(`- stdout: ${requireResult.stdout.trim()}`);
+    console.log(`- stderr: ${requireResult.stderr.trim()}`);
+
+    if (!hasImportTarget || !hasImportTypesTarget) {
+      throw new Error(
+        'Expected the published tarball to contain ESM import files, but one or more were missing.',
+      );
+    }
+
+    if (importResolveResult.exitCode !== 0) {
+      throw new Error(
+        'Expected import resolution to succeed through the published ESM entrypoint.',
+      );
+    }
+
+    if (hasRequireTarget || hasTypesTarget) {
+      throw new Error(
+        'Expected the published tarball to be missing the declared CommonJS or TypeScript entrypoint files.',
+      );
+    }
+
+    if (requireResult.exitCode !== 0) {
+      throw new Error(
+        `Expected require("${packageName}") to succeed, but it failed because ${packageSpecifier} declares a CommonJS entrypoint that is not published.`,
+      );
+    }
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.18",
   "description": "WorkflowAgent for building AI agents with AI SDK",
   "license": "Apache-2.0",
+  "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "source": "./src/index.ts",
   "files": [
@@ -33,8 +33,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "dependencies": {

--- a/packages/workflow/src/package-json.test.ts
+++ b/packages/workflow/src/package-json.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import { parseJSON } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+
+type WorkflowPackageJson = {
+  type?: string;
+  main?: string;
+  module?: string;
+  types?: string;
+  exports?: {
+    '.'?: {
+      types?: string;
+      import?: string;
+      require?: string;
+      default?: string;
+    };
+  };
+};
+
+describe('@ai-sdk/workflow package.json', () => {
+  it('points package entrypoints at the files produced by the ESM build', async () => {
+    const packageJson = (await parseJSON({
+      text: await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+    })) as WorkflowPackageJson;
+
+    expect(packageJson.type).toBe('module');
+    expect(packageJson.main).toBe('./dist/index.js');
+    expect(packageJson.types).toBe('./dist/index.d.ts');
+    expect(packageJson).not.toHaveProperty('module');
+
+    expect(packageJson.exports?.['.']).toEqual({
+      types: './dist/index.d.ts',
+      import: './dist/index.js',
+      default: './dist/index.js',
+    });
+  });
+});

--- a/packages/workflow/vitest.edge.config.js
+++ b/packages/workflow/vitest.edge.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/workflow/vitest.node.config.js
+++ b/packages/workflow/vitest.node.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Background

CommonJS consumers of @ai-sdk/workflow hit MODULE_NOT_FOUND because the npm package declared dist/index.js and dist/index.d.ts while only publishing .mjs/.d.mts files.

## Summary

Marked @ai-sdk/workflow as an ESM package and aligned main/types/exports to the generated dist/index.js and dist/index.d.ts files, removing stale module and require targets.

## Testing

Added a workflow package.json entrypoint regression test and updated the reproduction example to pack the local package and assert import, require, and type entrypoints.

## End-to-end Validation

- `examples/ai-functions/src/reproduction/workflow-require-entrypoint.ts`: ran `pnpm -C examples/ai-functions exec tsx src/reproduction/workflow-require-entrypoint.ts`; no live provider API was required, and the packed local tarball contained `dist/index.js`/`dist/index.d.ts` with ESM resolution and `require('@ai-sdk/workflow')` both succeeding.

## Related Issues

Fixes #16925

Co-authored-by: isimisi <91521821+isimisi@users.noreply.github.com>