### PR TITLE
reproduction: could not reproduce bug: forced anthropic tool call with empty schema

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11674.ts
+++ b/examples/ai-functions/src/reproduction/issue-11674.ts
@@ -1,0 +1,112 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText, tool } from 'ai';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+
+const fixturePath = path.resolve(
+  process.cwd(),
+  '../../packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt',
+);
+
+async function main() {
+  let executeCount = 0;
+
+  const result = streamText({
+    model: anthropic('claude-haiku-4-5'),
+    include: { rawChunks: true },
+    tools: {
+      sayHello: tool({
+        description: 'Say hello',
+        inputSchema: z.object({}),
+        execute: async ({}) => {
+          executeCount++;
+          return 'Hello!';
+        },
+      }),
+    },
+    toolChoice: {
+      type: 'tool',
+      toolName: 'sayHello',
+    },
+    prompt: 'Say hello!',
+  });
+
+  const parts: Array<{ type: string; [key: string]: unknown }> = [];
+  const rawChunks: unknown[] = [];
+
+  for await (const part of result.stream) {
+    parts.push(part as { type: string; [key: string]: unknown });
+
+    switch (part.type) {
+      case 'raw':
+        rawChunks.push(part.rawValue);
+        break;
+      case 'tool-call':
+      case 'tool-result':
+      case 'finish-step':
+      case 'finish':
+      case 'error':
+        console.log(JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  await fs.mkdir(path.dirname(fixturePath), { recursive: true });
+  await fs.writeFile(
+    fixturePath,
+    rawChunks.map(chunk => JSON.stringify(chunk)).join('\n') +
+      (rawChunks.length > 0 ? '\n' : ''),
+  );
+
+  const sayHelloToolCalls = parts.filter(
+    part => part.type === 'tool-call' && part.toolName === 'sayHello',
+  );
+  const sayHelloToolResults = parts.filter(
+    part => part.type === 'tool-result' && part.toolName === 'sayHello',
+  );
+  const finishStep = parts.find(part => part.type === 'finish-step');
+
+  const summary = {
+    executeCount,
+    fixturePath,
+    rawChunkCount: rawChunks.length,
+    sawSayHelloToolCall: sayHelloToolCalls.length > 0,
+    sawSayHelloToolResult: sayHelloToolResults.length > 0,
+    finishReason: finishStep?.finishReason,
+    rawFinishReason: finishStep?.rawFinishReason,
+    streamedPartTypes: parts.map(part => part.type),
+  };
+
+  console.log('issue-11674 summary:');
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (rawChunks.length === 0) {
+    throw new Error(
+      `Expected to record raw Anthropic stream chunks in ${fixturePath}, but none were emitted.`,
+    );
+  }
+
+  if (sayHelloToolCalls.length === 0) {
+    throw new Error(
+      'Expected streamText to emit a sayHello tool-call for the forced empty-schema tool, but no sayHello tool-call was emitted.',
+    );
+  }
+
+  if (executeCount === 0) {
+    throw new Error(
+      'Expected the forced empty-schema sayHello tool to execute, but execute() was not called.',
+    );
+  }
+
+  if (sayHelloToolResults.length === 0) {
+    throw new Error(
+      'Expected streamText to emit a sayHello tool-result after executing the forced empty-schema tool, but no sayHello tool-result was emitted.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt
@@ -1,0 +1,7 @@
+{"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_011CcrXqmNDQjbXjPV5qSHXs","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":666,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard","inference_geo":"not_available"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01TXcHNLeqmj1zzuK1HDecC4","name":"sayHello","input":{},"caller":{"type":"direct"}}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_stop","index":0}
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":666,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":16}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/anthropic-issue-11674.test.ts
+++ b/packages/anthropic/src/anthropic-issue-11674.test.ts
@@ -1,0 +1,114 @@
+import { type LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Say hello!' }] },
+];
+
+const provider = createAnthropic({
+  apiKey: 'test-api-key',
+});
+
+describe('Anthropic issue 11674', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+
+  function prepareChunksFixtureResponse(filename: string) {
+    const chunks = fs
+      .readFileSync(`src/__fixtures__/${filename}.chunks.txt`, 'utf8')
+      .split('\n')
+      .filter(line => line.length > 0)
+      .map(line => `data: ${line}\n\n`);
+    chunks.push('data: [DONE]\n\n');
+
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+  }
+
+  it('should support forced tools with empty parameters in streaming', async () => {
+    prepareChunksFixtureResponse(
+      'anthropic-issue-11674-empty-schema-forced-tool-call.1',
+    );
+
+    const result = await provider('claude-haiku-4-5').doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'sayHello',
+          description: 'Say hello',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      toolChoice: {
+        type: 'tool',
+        toolName: 'sayHello',
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      model: 'claude-haiku-4-5',
+      stream: true,
+      tool_choice: {
+        type: 'tool',
+        name: 'sayHello',
+      },
+      tools: [
+        expect.objectContaining({
+          name: 'sayHello',
+          input_schema: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        }),
+      ],
+    });
+
+    await expect(convertReadableStreamToArray(result.stream)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'tool-input-start',
+          id: expect.any(String),
+          toolName: 'sayHello',
+        }),
+        expect.objectContaining({
+          type: 'tool-input-end',
+          id: expect.any(String),
+        }),
+        expect.objectContaining({
+          type: 'tool-call',
+          toolCallId: expect.any(String),
+          toolName: 'sayHello',
+          input: '{}',
+        }),
+        expect.objectContaining({
+          type: 'finish',
+          finishReason: {
+            raw: 'tool_use',
+            unified: 'tool-calls',
+          },
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Bug

bug: forced anthropic tool call with empty schema and stream fails silently

## Reproduction

- Created live reproduction script at `examples/ai-functions/src/reproduction/issue-11674.ts` for Anthropic `claude-haiku-4-5` with forced `sayHello` and `inputSchema: z.object({})`.
- The live run emitted a `sayHello` `tool-call`, called `execute()` once, emitted a `tool-result` with `Hello!`, and finished with `finishReason: "tool-calls"` / `rawFinishReason: "tool_use"`.
- This differs from the expected issue behavior, where streaming finishes with `tool-calls` but returns no tool content and does not call `tool.execute()`.
- Recorded 7 raw Anthropic stream chunks in `packages/anthropic/src/__fixtures__/anthropic-issue-11674-empty-schema-forced-tool-call.1.chunks.txt`.
- Added provider fixture coverage in `packages/anthropic/src/anthropic-issue-11674.test.ts`; the fixture includes a `tool_use` content block with empty `{}` input for `sayHello`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools
- https://platform.claude.com/docs/en/build-with-claude/streaming
- https://platform.claude.com/docs/en/about-claude/models/overview

## Related Issues

Could not reproduce #11674