### PR TITLE
reproduction: @ai-sdk/replicate image model fails when sync-wait returns status:starting

### DIFF
--- a/examples/ai-functions/src/reproduction/replicate-image-sync-wait-output-null.ts
+++ b/examples/ai-functions/src/reproduction/replicate-image-sync-wait-output-null.ts
@@ -1,0 +1,126 @@
+import { createReplicate } from '@ai-sdk/replicate';
+import { APICallError, generateImage } from 'ai';
+
+const initialPrediction = {
+  id: 'sync-wait-starting-output-null',
+  model: 'black-forest-labs/flux-dev',
+  version: 'test-version',
+  input: {
+    prompt: 'A watercolor landscape at twilight',
+  },
+  logs: '',
+  output: null,
+  data_removed: false,
+  error: null,
+  status: 'starting',
+  created_at: '2026-07-09T00:00:00.000Z',
+  urls: {
+    cancel:
+      'https://api.replicate.com/v1/predictions/sync-wait-starting-output-null/cancel',
+    get: 'https://api.replicate.com/v1/predictions/sync-wait-starting-output-null',
+  },
+};
+
+const succeededPrediction = {
+  ...initialPrediction,
+  output: ['https://replicate.delivery/test/out-0.webp'],
+  status: 'succeeded',
+  completed_at: '2026-07-09T00:00:05.000Z',
+  metrics: {
+    predict_time: 5,
+  },
+};
+
+function getErrorName(error: unknown) {
+  return error instanceof Error ? error.name : undefined;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : undefined;
+}
+
+async function main() {
+  const requests: Array<{ method: string; url: string }> = [];
+
+  const replicate = createReplicate({
+    apiToken: 'test-api-token',
+    fetch: async (url, init) => {
+      const urlString = url.toString();
+      const method = init?.method ?? 'GET';
+
+      requests.push({ method, url: urlString });
+
+      if (
+        method === 'POST' &&
+        urlString ===
+          'https://api.replicate.com/v1/models/black-forest-labs/flux-dev/predictions'
+      ) {
+        return new Response(JSON.stringify(initialPrediction), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (method === 'GET' && urlString === initialPrediction.urls.get) {
+        return new Response(JSON.stringify(succeededPrediction), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (
+        method === 'GET' &&
+        urlString === 'https://replicate.delivery/test/out-0.webp'
+      ) {
+        return new Response(new Uint8Array(Buffer.from('test-image-binary')), {
+          status: 200,
+          headers: { 'Content-Type': 'image/webp' },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${urlString}`);
+    },
+  });
+
+  try {
+    const result = await generateImage({
+      model: replicate.image('black-forest-labs/flux-dev'),
+      prompt: 'A watercolor landscape at twilight',
+      size: '1024x1024',
+    });
+
+    if (requests.some(request => request.url === initialPrediction.urls.get)) {
+      console.log(
+        `Replicate image generation polled ${initialPrediction.urls.get} and returned ${result.images.length} image(s).`,
+      );
+      return;
+    }
+
+    throw new Error(
+      `Expected the image model to poll ${initialPrediction.urls.get}, but it did not. Requests: ${JSON.stringify(
+        requests,
+      )}`,
+    );
+  } catch (error) {
+    console.error('Expected generateImage to poll the prediction and succeed.');
+    console.error('Observed rejection:', {
+      name: getErrorName(error),
+      message: getErrorMessage(error),
+      isAPICallError: APICallError.isInstance(error),
+      statusCode: APICallError.isInstance(error) ? error.statusCode : undefined,
+      causeName: APICallError.isInstance(error)
+        ? getErrorName(error.cause)
+        : undefined,
+      causeMessage: APICallError.isInstance(error)
+        ? getErrorMessage(error.cause)
+        : undefined,
+      requests,
+    });
+    process.exitCode = 1;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/replicate/src/__fixtures__/image-sync-wait-starting-output-null.json
+++ b/packages/replicate/src/__fixtures__/image-sync-wait-starting-output-null.json
@@ -1,0 +1,45 @@
+{
+  "initialPrediction": {
+    "id": "sync-wait-starting-output-null",
+    "model": "black-forest-labs/flux-dev",
+    "version": "test-version",
+    "input": {
+      "prompt": "A watercolor landscape at twilight"
+    },
+    "logs": "",
+    "output": null,
+    "data_removed": false,
+    "error": null,
+    "status": "starting",
+    "created_at": "2026-07-09T00:00:00.000Z",
+    "urls": {
+      "cancel": "https://api.replicate.com/v1/predictions/sync-wait-starting-output-null/cancel",
+      "get": "https://api.replicate.com/v1/predictions/sync-wait-starting-output-null"
+    }
+  },
+  "succeededPrediction": {
+    "id": "sync-wait-starting-output-null",
+    "model": "black-forest-labs/flux-dev",
+    "version": "test-version",
+    "input": {
+      "prompt": "A watercolor landscape at twilight"
+    },
+    "logs": "",
+    "output": [
+      "https://replicate.delivery/test/out-0.webp"
+    ],
+    "data_removed": false,
+    "error": null,
+    "status": "succeeded",
+    "created_at": "2026-07-09T00:00:00.000Z",
+    "completed_at": "2026-07-09T00:00:05.000Z",
+    "metrics": {
+      "predict_time": 5
+    },
+    "urls": {
+      "cancel": "https://api.replicate.com/v1/predictions/sync-wait-starting-output-null/cancel",
+      "get": "https://api.replicate.com/v1/predictions/sync-wait-starting-output-null"
+    }
+  },
+  "imageBase64": "dGVzdC1pbWFnZS1iaW5hcnk="
+}

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -1,4 +1,5 @@
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { readFileSync } from 'node:fs';
 import { createReplicate } from './replicate-provider';
 import { ReplicateImageModel } from './replicate-image-model';
 import { describe, it, expect, vi } from 'vitest';
@@ -11,6 +12,26 @@ const prompt = 'The Loch Ness monster getting a manicure';
 
 const provider = createReplicate({ apiToken: 'test-api-token' });
 const model = provider.image('black-forest-labs/flux-schnell');
+
+type SyncWaitStartingFixture = {
+  initialPrediction: {
+    urls: {
+      get: string;
+    };
+  };
+  succeededPrediction: unknown;
+  imageBase64: string;
+};
+
+const syncWaitStartingFixture = JSON.parse(
+  readFileSync(
+    new URL(
+      './__fixtures__/image-sync-wait-starting-output-null.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+) as SyncWaitStartingFixture;
 
 describe('doGenerate', () => {
   const testDate = new Date(2024, 0, 1);
@@ -187,6 +208,88 @@ describe('doGenerate', () => {
     const requestBody = await server.calls[0].requestBodyJson;
     expect(requestBody.input.maxWaitTimeInSeconds).toBeUndefined();
     expect(requestBody.input.guidance_scale).toBe(7.5);
+  });
+
+  it('should poll when sync-wait returns an in-progress prediction with null output', async () => {
+    const requests: Array<{ method: string; url: string }> = [];
+
+    const model = createReplicate({
+      apiToken: 'test-api-token',
+      fetch: async (url, init) => {
+        const urlString = url.toString();
+        const method = init?.method ?? 'GET';
+
+        requests.push({ method, url: urlString });
+
+        if (
+          method === 'POST' &&
+          urlString ===
+            'https://api.replicate.com/v1/models/black-forest-labs/flux-dev/predictions'
+        ) {
+          return new Response(
+            JSON.stringify(syncWaitStartingFixture.initialPrediction),
+            {
+              status: 201,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+        }
+
+        if (
+          method === 'GET' &&
+          urlString === syncWaitStartingFixture.initialPrediction.urls.get
+        ) {
+          return new Response(
+            JSON.stringify(syncWaitStartingFixture.succeededPrediction),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+        }
+
+        if (
+          method === 'GET' &&
+          urlString === 'https://replicate.delivery/test/out-0.webp'
+        ) {
+          return new Response(
+            new Uint8Array(
+              Buffer.from(syncWaitStartingFixture.imageBase64, 'base64'),
+            ),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'image/webp' },
+            },
+          );
+        }
+
+        throw new Error(`Unexpected request: ${method} ${urlString}`);
+      },
+    }).image('black-forest-labs/flux-dev');
+
+    await expect(
+      model.doGenerate({
+        prompt: 'A watercolor landscape at twilight',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      }),
+    ).resolves.toMatchObject({
+      images: [
+        new Uint8Array(
+          Buffer.from(syncWaitStartingFixture.imageBase64, 'base64'),
+        ),
+      ],
+    });
+
+    expect(requests).toContainEqual({
+      method: 'GET',
+      url: syncWaitStartingFixture.initialPrediction.urls.get,
+    });
   });
 
   it('should extract the generated image from array response', async () => {


### PR DESCRIPTION
## Bug

@ai-sdk/replicate image model fails when sync-wait returns status:starting with output:null

## Reproduction

- Classified as provider-specific Replicate image-generation behavior; official Replicate docs describe `Prefer: wait` returning incomplete `starting`/`processing` predictions that should be fetched via `urls.get` until terminal.
- Added deterministic reproduction script at `examples/ai-functions/src/reproduction/replicate-image-sync-wait-output-null.ts`; it expects `generateImage` to poll a 201 `status: "starting"`, `output: null` prediction and return the mocked image, but it rejects with `AI_APICallError: Invalid JSON response`.
- Added provider fixture `packages/replicate/src/__fixtures__/image-sync-wait-starting-output-null.json` and failing provider test in `packages/replicate/src/replicate-image-model.test.ts`; the image model rejects on the initial successful POST before making any `GET` request to `urls.get`.
- Replicate live-service verification was skipped by policy; the reproduction uses a local response fixture shaped according to official Replicate prediction documentation.

## Relevant Documentation

- https://replicate.com/docs/topics/predictions/create-a-prediction
- https://replicate.com/docs/topics/predictions/lifecycle/

## Related Issues

Reproduces #16276