### PR TITLE
reproduction: could not reproduce OpenAI and Google provider cannot process URLs

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-7589-file-url-openai-google.ts
+++ b/examples/ai-functions/src/reproduction/issue-7589-file-url-openai-google.ts
@@ -1,0 +1,65 @@
+import { google } from '@ai-sdk/google';
+import { openai } from '@ai-sdk/openai';
+import { generateText, type ModelMessage } from 'ai';
+
+const pdfUrl = new URL(
+  'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+);
+
+const messages = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Read the attached PDF and reply with the exact short phrase printed in it.',
+      },
+      {
+        type: 'file',
+        data: pdfUrl,
+        mediaType: 'application/pdf',
+        filename: 'dummy.pdf',
+      },
+    ],
+  },
+] satisfies ModelMessage[];
+
+async function assertPdfUrlWorks({
+  providerName,
+  model,
+}: {
+  providerName: string;
+  model: Parameters<typeof generateText>[0]['model'];
+}) {
+  const result = await generateText({
+    model,
+    messages,
+    maxOutputTokens: 64,
+    temperature: 0,
+  });
+
+  console.log(`${providerName} response:`, JSON.stringify(result.text));
+
+  if (!/dummy/i.test(result.text)) {
+    throw new Error(
+      `${providerName} did not appear to read the PDF URL; expected "dummy" in response.`,
+    );
+  }
+}
+
+async function main() {
+  await assertPdfUrlWorks({
+    providerName: 'OpenAI',
+    model: openai('gpt-4.1-mini'),
+  });
+
+  await assertPdfUrlWorks({
+    providerName: 'Google',
+    model: google('gemini-2.5-flash'),
+  });
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

OpenAI and Google provider cannot process URLs

## Reproduction

- Created `examples/ai-functions/src/reproduction/issue-7589-file-url-openai-google.ts` to exercise a `FilePart` whose `data` is a PDF `URL` with OpenAI and Google.
- The live OpenAI `gpt-4.1-mini` call returned `"Dummy PDF file"` from the PDF URL instead of the reported OpenAI provider error.
- The live Google `gemini-2.5-flash` call returned `"Dummy PDF file"` from the PDF URL instead of the reported `empty/no-response` behavior.
- A narrowing check showed OpenAI `gpt-4o-mini` failed to read the same PDF from both URL data and byte data, so that model behavior was not URL-specific.
- `packages/google/src/google-language-model-options.ts` already defines `thinkingConfig.includeThoughts`, so the ancillary Google provider-options concern was not reproduced.

## Relevant Documentation

- https://ai-sdk.dev/docs/foundations/prompts
- https://ai-sdk.dev/docs/reference/ai-sdk-core/model-message
- https://developers.openai.com/api/reference/responses/create
- https://ai.google.dev/gemini-api/docs/file-input-methods
- https://ai.google.dev/api/generate-content

## Related Issues

Could not reproduce #7589