### PR TITLE
[v6.0] fix: Google provider serializes PDF tool result file data as text on the legacy path

### DIFF
--- a/.changeset/google-tool-result-file-data.md
+++ b/.changeset/google-tool-result-file-data.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Fix Google tool result conversion to send file data as inline data instead of JSON text on the legacy tool-result path.

--- a/examples/ai-functions/src/reproduction/issue-16072-google-pdf-tool-result.ts
+++ b/examples/ai-functions/src/reproduction/issue-16072-google-pdf-tool-result.ts
@@ -1,0 +1,113 @@
+import { createGoogle } from '@ai-sdk/google';
+import { generateText, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+
+const pdfBase64 =
+  'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCAyMDAgMjAwXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA1IDAgUiA+PiA+PiAvQ29udGVudHMgNCAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCA0MyA+PgpzdHJlYW0KQlQgL0YxIDEyIFRmIDcyIDEyMCBUZCAoSXNzdWUgMTYwNzIpIFRqIEVUCgplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCjAwMDAwMDAyNDEgMDAwMDAgbiAKMDAwMDAwMDMzNCAwMDAwMCBuIAp0cmFpbGVyCjw8IC9Sb290IDEgMCBSIC9TaXplIDYgPj4Kc3RhcnR4cmVmCjQwNAolJUVPRgo=';
+
+async function main() {
+  const calls: Array<{ url: string; requestBody: any; responseBody?: any }> =
+    [];
+  const google = createGoogle({
+    fetch: async (input, init) => {
+      const call: { url: string; requestBody: any; responseBody?: any } = {
+        url: String(input),
+        requestBody:
+          typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.responseBody = await response
+        .clone()
+        .json()
+        .catch(() => undefined);
+
+      return response;
+    },
+  });
+
+  await generateText({
+    model: google('gemini-2.5-flash-lite'),
+    maxOutputTokens: 64,
+    prompt:
+      'Call the catalogSearch tool, then answer briefly based on the tool result.',
+    tools: {
+      catalogSearch: tool({
+        description: 'Return catalog PDF metadata and document data.',
+        inputSchema: z.object({}),
+        execute: async () => ({ ok: true }),
+        toModelOutput: () => ({
+          type: 'content',
+          value: [
+            { type: 'text', text: 'metadata' },
+            {
+              type: 'file-data',
+              data: pdfBase64,
+              mediaType: 'application/pdf',
+            } as any,
+          ],
+        }),
+      }),
+    },
+    toolChoice: { type: 'tool', toolName: 'catalogSearch' },
+    stopWhen: isStepCount(2),
+  });
+
+  const secondRequest = calls[1]?.requestBody;
+  const secondResponse = calls[1]?.responseBody;
+  const toolResultParts =
+    secondRequest?.contents?.find(
+      (content: any) =>
+        content.role === 'user' &&
+        content.parts?.some((part: any) => part.functionResponse != null),
+    )?.parts ?? [];
+  const pdfTextPart = toolResultParts.find(
+    (part: any) =>
+      typeof part.text === 'string' && part.text.includes(pdfBase64),
+  );
+  const pdfInlineDataPart = toolResultParts.find(
+    (part: any) =>
+      part.inlineData?.mimeType === 'application/pdf' &&
+      part.inlineData?.data === pdfBase64,
+  );
+  const hasDocumentTokens =
+    secondResponse?.usageMetadata?.promptTokensDetails?.some(
+      (detail: any) => detail.modality === 'DOCUMENT',
+    ) === true;
+
+  const output = {
+    requestCount: calls.length,
+    observedToolResultParts: toolResultParts,
+    promptTokensDetails:
+      secondResponse?.usageMetadata?.promptTokensDetails ?? [],
+    hasPdfTextPart: pdfTextPart != null,
+    hasPdfInlineDataPart: pdfInlineDataPart != null,
+    hasDocumentTokens,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (pdfTextPart != null) {
+    throw new Error(
+      'Reproduced issue #16072: PDF file tool result was serialized as a JSON text part instead of file/document data.',
+    );
+  }
+
+  if (pdfInlineDataPart == null) {
+    throw new Error(
+      'Expected the PDF tool result to be sent as an inlineData part.',
+    );
+  }
+
+  if (!hasDocumentTokens) {
+    throw new Error(
+      'Expected the live Google response to report document tokens for the PDF tool result.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/ai-functions/src/reproduction/issue-16072-google-pdf-tool-result.ts
+++ b/examples/ai-functions/src/reproduction/issue-16072-google-pdf-tool-result.ts
@@ -1,5 +1,5 @@
-import { createGoogle } from '@ai-sdk/google';
-import { generateText, isStepCount, tool } from 'ai';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 
 const pdfBase64 =
@@ -8,7 +8,7 @@ const pdfBase64 =
 async function main() {
   const calls: Array<{ url: string; requestBody: any; responseBody?: any }> =
     [];
-  const google = createGoogle({
+  const google = createGoogleGenerativeAI({
     fetch: async (input, init) => {
       const call: { url: string; requestBody: any; responseBody?: any } = {
         url: String(input),
@@ -51,7 +51,7 @@ async function main() {
       }),
     },
     toolChoice: { type: 'tool', toolName: 'catalogSearch' },
-    stopWhen: isStepCount(2),
+    stopWhen: stepCountIs(2),
   });
 
   const secondRequest = calls[1]?.requestBody;

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -825,9 +825,64 @@ describe('tool messages', () => {
         text: 'Tool executed successfully and returned this image as a response',
       },
       {
+<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.test.ts
         text: '{"type":"file-data","data":"base64pdfdata","mediaType":"application/pdf","filename":"report.pdf"}',
+=======
+        inlineData: {
+          mimeType: 'application/pdf',
+          data: 'base64pdfdata',
+        },
+      },
+      {
+        text: 'Tool executed successfully and returned this file as a response',
+>>>>>>> 17d66c54c (fix: Google provider serializes PDF tool result file data as text on the legacy path (#16994)):packages/google/src/convert-to-google-messages.test.ts
       },
     ]);
+  });
+
+  it('issue #16072: should not serialize PDF file tool results as text on the non-Gemini-3 path', async () => {
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'catalogSearch',
+              toolCallId: 'testCallId',
+              output: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'metadata' },
+                  {
+                    type: 'file',
+                    data: { type: 'data', data: 'JVBERi0xLjQK' },
+                    mediaType: 'application/pdf',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      { supportsFunctionResponseParts: false },
+    );
+
+    const textParts = result.contents.flatMap(content =>
+      content.parts
+        .filter(part => 'text' in part)
+        .map(part => (part as { text: string }).text),
+    );
+
+    expect(textParts).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('JVBERi0xLjQK')]),
+    );
+    expect(result.contents[0].parts).toContainEqual({
+      inlineData: {
+        mimeType: 'application/pdf',
+        data: 'JVBERi0xLjQK',
+      },
+    });
   });
 
   it('should keep URL tool result parts on the legacy path', async () => {

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -825,9 +825,6 @@ describe('tool messages', () => {
         text: 'Tool executed successfully and returned this image as a response',
       },
       {
-<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.test.ts
-        text: '{"type":"file-data","data":"base64pdfdata","mediaType":"application/pdf","filename":"report.pdf"}',
-=======
         inlineData: {
           mimeType: 'application/pdf',
           data: 'base64pdfdata',
@@ -835,13 +832,12 @@ describe('tool messages', () => {
       },
       {
         text: 'Tool executed successfully and returned this file as a response',
->>>>>>> 17d66c54c (fix: Google provider serializes PDF tool result file data as text on the legacy path (#16994)):packages/google/src/convert-to-google-messages.test.ts
       },
     ]);
   });
 
   it('issue #16072: should not serialize PDF file tool results as text on the non-Gemini-3 path', async () => {
-    const result = convertToGoogleMessages(
+    const result = convertToGoogleGenerativeAIMessages(
       [
         {
           role: 'tool',
@@ -855,8 +851,8 @@ describe('tool messages', () => {
                 value: [
                   { type: 'text', text: 'metadata' },
                   {
-                    type: 'file',
-                    data: { type: 'data', data: 'JVBERi0xLjQK' },
+                    type: 'file-data',
+                    data: 'JVBERi0xLjQK',
                     mediaType: 'application/pdf',
                   },
                 ],

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -187,8 +187,10 @@ function appendLegacyToolResultParts(
           },
         });
         break;
-<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.ts
       case 'image-data':
+      case 'file-data': {
+        const topLevelMediaType = String(contentPart.mediaType).split('/')[0];
+
         parts.push(
           {
             inlineData: {
@@ -197,33 +199,14 @@ function appendLegacyToolResultParts(
             },
           },
           {
-            text: 'Tool executed successfully and returned this image as a response',
+            text:
+              `Tool executed successfully and returned this ` +
+              `${topLevelMediaType === 'image' ? 'image' : 'file'} ` +
+              `as a response`,
           },
         );
-=======
-      case 'file': {
-        if (contentPart.data.type === 'data') {
-          const topLevelMediaType = getTopLevelMediaType(contentPart.mediaType);
-
-          parts.push(
-            {
-              inlineData: {
-                mimeType: resolveFullMediaType({ part: contentPart }),
-                data: convertToBase64(contentPart.data.data),
-              },
-            },
-            {
-              text:
-                `Tool executed successfully and returned this ` +
-                `${topLevelMediaType === 'image' ? 'image' : 'file'} ` +
-                `as a response`,
-            },
-          );
-        } else {
-          parts.push({ text: JSON.stringify(contentPart) });
-        }
->>>>>>> 17d66c54c (fix: Google provider serializes PDF tool result file data as text on the legacy path (#16994)):packages/google/src/convert-to-google-messages.ts
         break;
+      }
       default:
         parts.push({ text: JSON.stringify(contentPart) });
         break;

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -187,6 +187,7 @@ function appendLegacyToolResultParts(
           },
         });
         break;
+<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.ts
       case 'image-data':
         parts.push(
           {
@@ -199,6 +200,29 @@ function appendLegacyToolResultParts(
             text: 'Tool executed successfully and returned this image as a response',
           },
         );
+=======
+      case 'file': {
+        if (contentPart.data.type === 'data') {
+          const topLevelMediaType = getTopLevelMediaType(contentPart.mediaType);
+
+          parts.push(
+            {
+              inlineData: {
+                mimeType: resolveFullMediaType({ part: contentPart }),
+                data: convertToBase64(contentPart.data.data),
+              },
+            },
+            {
+              text:
+                `Tool executed successfully and returned this ` +
+                `${topLevelMediaType === 'image' ? 'image' : 'file'} ` +
+                `as a response`,
+            },
+          );
+        } else {
+          parts.push({ text: JSON.stringify(contentPart) });
+        }
+>>>>>>> 17d66c54c (fix: Google provider serializes PDF tool result file data as text on the legacy path (#16994)):packages/google/src/convert-to-google-messages.ts
         break;
       default:
         parts.push({ text: JSON.stringify(contentPart) });

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -355,6 +355,9 @@ describe('doGenerate', () => {
   const TEST_URL_GEMINI_1_5_FLASH =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
+  const TEST_URL_GEMINI_2_5_FLASH_LITE =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent';
+
   const TEST_URL_GEMINI_3_PRO =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent';
 
@@ -364,6 +367,7 @@ describe('doGenerate', () => {
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
+    [TEST_URL_GEMINI_2_5_FLASH_LITE]: {},
     [TEST_URL_GEMINI_3_PRO]: {},
   });
 
@@ -415,7 +419,8 @@ describe('doGenerate', () => {
       | typeof TEST_URL_GEMINI_2_0_PRO
       | typeof TEST_URL_GEMINI_2_0_FLASH_EXP
       | typeof TEST_URL_GEMINI_1_0_PRO
-      | typeof TEST_URL_GEMINI_1_5_FLASH;
+      | typeof TEST_URL_GEMINI_1_5_FLASH
+      | typeof TEST_URL_GEMINI_2_5_FLASH_LITE;
   }) => {
     server.urls[url].response = {
       type: 'json-value',
@@ -472,8 +477,8 @@ describe('doGenerate', () => {
                 value: [
                   { type: 'text', text: 'metadata' },
                   {
-                    type: 'file',
-                    data: { type: 'data', data: 'JVBERi0xLjQK' },
+                    type: 'file-data',
+                    data: 'JVBERi0xLjQK',
                     mediaType: 'application/pdf',
                   },
                 ],

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -439,6 +439,83 @@ describe('doGenerate', () => {
     };
   };
 
+  it('should send PDF tool result data as inlineData for Gemini 2.5 legacy tool results', async () => {
+    server.urls[TEST_URL_GEMINI_2_5_FLASH_LITE].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'done' }],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = provider.chat('gemini-2.5-flash-lite');
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'catalogSearch',
+              toolCallId: 'testCallId',
+              output: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'metadata' },
+                  {
+                    type: 'file',
+                    data: { type: 'data', data: 'JVBERi0xLjQK' },
+                    mediaType: 'application/pdf',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    const parts = requestBody.contents[0].parts;
+    const textParts = parts
+      .filter((part: any) => part.text != null)
+      .map((part: any) => part.text);
+
+    expect(textParts).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('JVBERi0xLjQK')]),
+    );
+    expect(parts).toEqual([
+      {
+        functionResponse: {
+          id: 'testCallId',
+          name: 'catalogSearch',
+          response: {
+            name: 'catalogSearch',
+            content: 'metadata',
+          },
+        },
+      },
+      {
+        inlineData: {
+          mimeType: 'application/pdf',
+          data: 'JVBERi0xLjQK',
+        },
+      },
+      {
+        text: 'Tool executed successfully and returned this file as a response',
+      },
+    ]);
+  });
+
   describe('text', () => {
     beforeEach(() => {
       prepareJsonFixtureResponse('google-text');


### PR DESCRIPTION
## Background

Google tool-result file data for non-Gemini-3 models was being serialized as JSON text, causing PDF base64 to be counted as text tokens and triggering token-limit failures.

## Summary

Changed the Google legacy tool-result converter to send data-backed file parts as inlineData instead of JSON text, while preserving the existing success text marker.

## Testing

Updated Google prompt conversion coverage and added a Google language model regression test for Gemini 2.5 PDF tool result requests; added a patch changeset.

## End-to-end Validation

- Example: `examples/ai-functions/src/reproduction/issue-16072-google-pdf-tool-result.ts`; live API command: `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-16072-google-pdf-tool-result.ts`; observed outcome: exited 0, second request sent the PDF as `inlineData`, `hasPdfTextPart: false`, and Google reported DOCUMENT prompt tokens.

## Related Issues

Fixes #16072

Backport of #16994

Co-authored-by: Lqm1 <154405627+Lqm1@users.noreply.github.com>