### PR TITLE
reproduction: could not reproduce anthropic provider: toolChoice 'none' strips tools from request,

### DIFF
--- a/examples/ai-functions/src/reproduction/anthropic-tool-choice-none-tool-history.ts
+++ b/examples/ai-functions/src/reproduction/anthropic-tool-choice-none-tool-history.ts
@@ -1,0 +1,222 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type {
+  LanguageModelV4Content,
+  LanguageModelV4FunctionTool,
+  LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+function textFromContent(content: LanguageModelV4Content[]): string {
+  return content
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('');
+}
+
+async function bodyToJson(body: BodyInit | null | undefined): Promise<unknown> {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return JSON.parse(body);
+  }
+
+  return JSON.parse(await new Response(body).text());
+}
+
+function redactHeaders(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  const headerEntries: Array<[string, string]> = [];
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, name) => {
+      headerEntries.push([name, value]);
+    });
+  } else if (Array.isArray(headers)) {
+    headerEntries.push(...headers);
+  } else {
+    headerEntries.push(...Object.entries(headers ?? {}));
+  }
+
+  for (const [name, value] of headerEntries) {
+    const lowerName = name.toLowerCase();
+    result[lowerName] =
+      lowerName === 'x-api-key' || lowerName === 'authorization'
+        ? '<redacted>'
+        : value;
+  }
+
+  return result;
+}
+
+async function main() {
+  let capturedRequest:
+    | {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        body: unknown;
+      }
+    | undefined;
+  let capturedResponse:
+    | {
+        status: number;
+        body: unknown;
+      }
+    | undefined;
+
+  const provider = createAnthropic({
+    fetch: async (input, init) => {
+      capturedRequest = {
+        url: input instanceof Request ? input.url : input.toString(),
+        method:
+          init?.method ?? (input instanceof Request ? input.method : 'GET'),
+        headers: redactHeaders(init?.headers),
+        body: await bodyToJson(init?.body),
+      };
+
+      const response = await fetch(input, init);
+      const responseText = await response.clone().text();
+
+      capturedResponse = {
+        status: response.status,
+        body: responseText.length === 0 ? undefined : JSON.parse(responseText),
+      };
+
+      return response;
+    },
+  });
+
+  const searchTool: LanguageModelV4FunctionTool = {
+    type: 'function',
+    name: 'search',
+    description: 'Search for information.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+  };
+
+  const toolCallId = process.env.ANTHROPIC_REPRO_TOOL_CALL_ID ?? 'tc1';
+  const prompt: LanguageModelV4Prompt = [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Search for climate change information.' },
+      ],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId,
+          toolName: 'search',
+          input: { query: 'climate change' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId,
+          toolName: 'search',
+          output: {
+            type: 'text',
+            value:
+              'Climate change is driven by greenhouse gases and affects temperatures, weather patterns, and sea levels.',
+          },
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Now summarize what you found in one short sentence.',
+        },
+      ],
+    },
+  ];
+  const modelId = process.env.ANTHROPIC_REPRO_MODEL ?? 'claude-sonnet-4-6';
+  const model = provider(modelId);
+
+  const result = await model.doGenerate({
+    prompt,
+    tools: [searchTool],
+    toolChoice: { type: 'none' },
+    maxOutputTokens: 128,
+  });
+
+  const text = textFromContent(result.content);
+  const fixturePath = resolve(
+    process.cwd(),
+    '../../packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live-response.json',
+  );
+
+  await mkdir(dirname(fixturePath), { recursive: true });
+  await writeFile(
+    fixturePath,
+    `${JSON.stringify(
+      {
+        request: capturedRequest,
+        response: capturedResponse,
+        result: {
+          content: result.content,
+          finishReason: result.finishReason,
+          usage: result.usage,
+          warnings: result.warnings,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        requestHasTools:
+          capturedRequest != null &&
+          typeof capturedRequest.body === 'object' &&
+          capturedRequest.body != null &&
+          'tools' in capturedRequest.body,
+        requestHasToolChoice:
+          capturedRequest != null &&
+          typeof capturedRequest.body === 'object' &&
+          capturedRequest.body != null &&
+          'tool_choice' in capturedRequest.body,
+        responseStatus: capturedResponse?.status,
+        modelId,
+        content: result.content,
+        text,
+        finishReason: result.finishReason,
+        fixturePath,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (text.length === 0) {
+    throw new Error(
+      "Reproduced issue #12378: Anthropic returned empty text after tool_use/tool_result history when toolChoice is 'none'.",
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live-response.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live-response.json
@@ -1,0 +1,121 @@
+{
+  "request": {
+    "url": "https://api.anthropic.com/v1/messages",
+    "method": "POST",
+    "headers": {
+      "anthropic-beta": "structured-outputs-2025-11-13",
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+      "user-agent": "ai-sdk/anthropic/0.0.0-test ai-sdk/provider-utils/0.0.0-test runtime/node.js/22",
+      "x-api-key": "<redacted>"
+    },
+    "body": {
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 128,
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "Search for climate change information."
+            }
+          ]
+        },
+        {
+          "role": "assistant",
+          "content": [
+            {
+              "type": "tool_use",
+              "id": "tc1",
+              "name": "search",
+              "input": {
+                "query": "climate change"
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "tool_result",
+              "tool_use_id": "tc1",
+              "content": "Climate change is driven by greenhouse gases and affects temperatures, weather patterns, and sea levels."
+            },
+            {
+              "type": "text",
+              "text": "Now summarize what you found in one short sentence."
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "model": "claude-sonnet-4-6",
+      "id": "msg_011Ccremhn7ZBmUuuRYY9FXx",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "Climate change, driven by greenhouse gases, impacts global temperatures, weather patterns, and sea levels."
+        }
+      ],
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 111,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 22,
+        "service_tier": "standard",
+        "inference_geo": "global"
+      }
+    }
+  },
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Climate change, driven by greenhouse gases, impacts global temperatures, weather patterns, and sea levels."
+      }
+    ],
+    "finishReason": {
+      "unified": "stop",
+      "raw": "end_turn"
+    },
+    "usage": {
+      "inputTokens": {
+        "total": 111,
+        "noCache": 111,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "outputTokens": {
+        "total": 22
+      },
+      "raw": {
+        "input_tokens": 111,
+        "output_tokens": 22,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "service_tier": "standard",
+        "inference_geo": "global"
+      }
+    },
+    "warnings": []
+  }
+}

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -2,6 +2,7 @@ import {
   APICallError,
   NoSuchProviderReferenceError,
   LanguageModelV4,
+  type LanguageModelV4FunctionTool,
   type LanguageModelV4GenerateResult,
   type LanguageModelV4Prompt,
   type LanguageModelV4StreamPart,
@@ -63,6 +64,93 @@ describe('AnthropicLanguageModel', () => {
   }
 
   describe('doGenerate', () => {
+    it('issue #12378: does not reproduce empty content with live Claude Sonnet 4.6 fixture', async () => {
+      const fixture = JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/anthropic-tool-choice-none-live-response.json',
+          'utf8',
+        ),
+      );
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'json-value',
+        body: fixture.response.body,
+      };
+
+      const searchTool: LanguageModelV4FunctionTool = {
+        type: 'function',
+        name: 'search',
+        description: 'Search for information.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+          },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      };
+
+      const result = await provider('claude-sonnet-4-6').doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Search for climate change information.' },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'tc1',
+                toolName: 'search',
+                input: { query: 'climate change' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'tc1',
+                toolName: 'search',
+                output: {
+                  type: 'text',
+                  value:
+                    'Climate change is driven by greenhouse gases and affects temperatures, weather patterns, and sea levels.',
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Now summarize what you found in one short sentence.',
+              },
+            ],
+          },
+        ],
+        tools: [searchTool],
+        toolChoice: { type: 'none' },
+        maxOutputTokens: 128,
+      });
+
+      const text = result.content
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('');
+
+      expect(text).not.toBe('');
+      expect(result.finishReason).toStrictEqual({
+        unified: 'stop',
+        raw: 'end_turn',
+      });
+    });
+
     describe('reasoning (thinking enabled)', () => {
       it('should pass thinking config; add budget tokens; clear out temperature, top_p, top_k; and return warnings', async () => {
         prepareJsonFixtureResponse('anthropic-text');


### PR DESCRIPTION
## Bug

anthropic provider: toolChoice 'none' strips tools from request, causing empty response with tool_use history

## Reproduction

- Added runnable live-provider check at `examples/ai-functions/src/reproduction/anthropic-tool-choice-none-tool-history.ts` for the reported `toolChoice: { type: 'none' }` plus prior tool history scenario.
- The exact reported model `claude-sonnet-4-20250514` could not be checked because Anthropic returned HTTP 404 `not_found_error`; official docs list that model as retired on June 15, 2026.
- On the active replacement `claude-sonnet-4-6`, the request still omitted both `tools` and `tool_choice`, but Anthropic returned HTTP 200 with non-empty text and `finishReason` `stop`.
- The expected issue behavior was an empty `content: []` / empty text response, but the observed live replacement-model response was normal text.
- Recorded the live non-empty response fixture at `packages/anthropic/src/__fixtures__/anthropic-tool-choice-none-live-response.json` and added a fixture-backed package test in `packages/anthropic/src/anthropic-language-model.test.ts`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools?categoryid=2849204
- https://platform.claude.com/docs/en/about-claude/model-deprecations
- https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions

## Related Issues

Could not reproduce #12378