### PR TITLE
reproduction: could not reproduce OpenAI and Google provider cannot process URLs

### DIFF
--- a/examples/ai-core/src/reproduction/issue-7589-file-url-openai-google.ts
+++ b/examples/ai-core/src/reproduction/issue-7589-file-url-openai-google.ts
@@ -1,0 +1,118 @@
+import { google } from '@ai-sdk/google';
+import { openai } from '@ai-sdk/openai';
+import { generateText, type ModelMessage } from 'ai';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import 'dotenv/config';
+
+const pdfUrl =
+  'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf';
+
+const messages: ModelMessage[] = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Read the PDF. What exact words appear in the document? Answer concisely.',
+      },
+      {
+        type: 'file',
+        data: pdfUrl,
+        mediaType: 'application/pdf',
+        filename: 'dummy.pdf',
+      },
+    ],
+  },
+];
+
+type ProviderResult = {
+  provider: 'openai' | 'google';
+  model: string;
+  pdfUrl: string;
+  ok: boolean;
+  text?: string;
+  errorName?: string;
+  errorMessage?: string;
+};
+
+function hasReadDummyPdf(text: string | undefined): boolean {
+  const normalized = text?.toLowerCase() ?? '';
+  return normalized.includes('dummy') && normalized.includes('pdf');
+}
+
+async function runProvider(
+  provider: ProviderResult['provider'],
+  model: string,
+): Promise<ProviderResult> {
+  try {
+    const result = await generateText({
+      model: provider === 'openai' ? openai(model) : google(model),
+      messages,
+    });
+
+    return {
+      provider,
+      model,
+      pdfUrl,
+      ok: true,
+      text: result.text,
+    };
+  } catch (error) {
+    return {
+      provider,
+      model,
+      pdfUrl,
+      ok: false,
+      errorName: error instanceof Error ? error.name : typeof error,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function writeFixture(result: ProviderResult): Promise<void> {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(__dirname, '../../../..');
+  const fixtureDir = path.join(
+    repoRoot,
+    'packages',
+    result.provider,
+    'src',
+    '__fixtures__',
+  );
+  await mkdir(fixtureDir, { recursive: true });
+  await writeFile(
+    path.join(fixtureDir, 'issue-7589-file-url.json'),
+    `${JSON.stringify(result, null, 2)}\n`,
+  );
+}
+
+async function main() {
+  const results = await Promise.all([
+    runProvider('openai', 'gpt-4.1-mini'),
+    runProvider('google', 'gemini-2.5-flash'),
+  ]);
+
+  for (const result of results) {
+    await writeFixture(result);
+    console.log(JSON.stringify(result, null, 2));
+  }
+
+  const failures = results.filter(
+    result => !result.ok || !hasReadDummyPdf(result.text),
+  );
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Issue #7589 reproduced for ${failures
+        .map(result => `${result.provider}/${result.model}`)
+        .join(', ')}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/issue-7589-file-url.json
+++ b/packages/google/src/__fixtures__/issue-7589-file-url.json
@@ -1,0 +1,7 @@
+{
+  "provider": "google",
+  "model": "gemini-2.5-flash",
+  "pdfUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+  "ok": true,
+  "text": "The exact words that appear in the document are:\nDummy PDF file"
+}

--- a/packages/openai/src/__fixtures__/issue-7589-file-url.json
+++ b/packages/openai/src/__fixtures__/issue-7589-file-url.json
@@ -1,0 +1,7 @@
+{
+  "provider": "openai",
+  "model": "gpt-4.1-mini",
+  "pdfUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+  "ok": true,
+  "text": "The exact words in the document are: \"Dummy PDF file\"."
+}


### PR DESCRIPTION
## Bug

OpenAI and Google provider cannot process URLs

## Reproduction

- Created `examples/ai-core/src/reproduction/issue-7589-file-url-openai-google.ts` to exercise the issue's string URL `FilePart` shape with OpenAI and Google.
- The OpenAI `gpt-4.1-mini` live call read the URL PDF and returned text containing `Dummy PDF file` instead of the expected provider error.
- The Google `gemini-2.5-flash` live call read the URL PDF and returned text containing `Dummy PDF file` instead of the expected `empty/no-response` behavior.
- Recorded live response fixtures at `packages/openai/src/__fixtures__/issue-7589-file-url.json` and `packages/google/src/__fixtures__/issue-7589-file-url.json`.
- The ancillary Google option concern was not reproduced because `packages/google/src/google-generative-ai-options.ts` defines `thinkingConfig.includeThoughts`.

## Relevant Documentation

- https://ai-sdk.dev/docs/foundations/prompts
- https://ai-sdk.dev/docs/reference/ai-sdk-core/model-message
- https://developers.openai.com/api/reference/resources/responses/methods/create
- https://ai.google.dev/gemini-api/docs/file-input-methods
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/generate-content/thinking

## Related Issues

Could not reproduce #7589