### PR TITLE
reproduction: could not reproduce cachedInputTokens does not mapped

### DIFF
--- a/examples/ai-functions/src/reproduction/openai-cached-input-tokens-11178.ts
+++ b/examples/ai-functions/src/reproduction/openai-cached-input-tokens-11178.ts
@@ -1,0 +1,163 @@
+import {
+  createOpenAI,
+  type OpenAILanguageModelChatOptions,
+} from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { setTimeout } from 'node:timers/promises';
+
+type CapturedResponse = {
+  url: string;
+  status: number;
+  body: unknown;
+};
+
+const fixturePath =
+  '../../packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json';
+
+const cacheKey = `ai-sdk-issue-11178-${Date.now()}`;
+
+const longSystemPrompt = [
+  'You are a deterministic cache-mapping probe.',
+  'The following stable prefix is intentionally long so OpenAI prompt caching can apply.',
+  ...Array.from(
+    { length: 180 },
+    (_, index) =>
+      `Stable cache prefix sentence ${index}: maple river quartz lantern verifies cached prompt accounting.`,
+  ),
+].join('\n');
+
+function getRawCachedTokens(response: unknown): number | undefined {
+  if (response == null || typeof response !== 'object') {
+    return undefined;
+  }
+
+  const usage = 'usage' in response ? response.usage : undefined;
+  if (usage == null || typeof usage !== 'object') {
+    return undefined;
+  }
+
+  const promptTokensDetails =
+    'prompt_tokens_details' in usage ? usage.prompt_tokens_details : undefined;
+  if (promptTokensDetails == null || typeof promptTokensDetails !== 'object') {
+    return undefined;
+  }
+
+  const cachedTokens =
+    'cached_tokens' in promptTokensDetails
+      ? promptTokensDetails.cached_tokens
+      : undefined;
+
+  return typeof cachedTokens === 'number' ? cachedTokens : undefined;
+}
+
+async function main() {
+  const capturedResponses: CapturedResponse[] = [];
+
+  const openai = createOpenAI({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes('/chat/completions')) {
+        const responseClone = response.clone();
+        let body: unknown;
+        try {
+          body = await responseClone.json();
+        } catch {
+          body = await responseClone.text();
+        }
+
+        capturedResponses.push({
+          url,
+          status: response.status,
+          body,
+        });
+      }
+
+      return response;
+    },
+  });
+
+  async function createCompletion(label: string) {
+    const result = await generateText({
+      model: openai.chat('gpt-4o-mini'),
+      system: longSystemPrompt,
+      prompt: 'Reply with exactly: OK',
+      temperature: 0,
+      maxOutputTokens: 1,
+      providerOptions: {
+        openai: {
+          promptCacheKey: cacheKey,
+        } satisfies OpenAILanguageModelChatOptions,
+      },
+    });
+
+    console.log(
+      JSON.stringify(
+        {
+          label,
+          text: result.text,
+          usage: result.usage,
+          sdkCacheReadTokens: result.usage.inputTokenDetails.cacheReadTokens,
+        },
+        null,
+        2,
+      ),
+    );
+
+    return result;
+  }
+
+  await createCompletion('cache-warmup');
+  await setTimeout(1000);
+  const second = await createCompletion('cache-read');
+  const secondRawCachedTokens = getRawCachedTokens(capturedResponses[1]?.body);
+
+  await mkdir('../../packages/openai/src/chat/__fixtures__', {
+    recursive: true,
+  });
+  await writeFile(
+    fixturePath,
+    `${JSON.stringify(
+      {
+        issue: 11178,
+        model: 'gpt-4o-mini',
+        api: 'chat.completions',
+        promptCacheKey: cacheKey,
+        capturedResponses,
+        observedSdkUsage: second.usage,
+        observedRawCachedTokens: secondRawCachedTokens,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  console.log(`Wrote fixture to ${fixturePath}`);
+
+  const rawCachedTokens = secondRawCachedTokens ?? 0;
+  const sdkCacheReadTokens =
+    second.usage.inputTokenDetails.cacheReadTokens ?? 0;
+
+  if (rawCachedTokens <= 0) {
+    throw new Error(
+      `OpenAI did not report a cache hit on the second request; raw cached_tokens=${rawCachedTokens}`,
+    );
+  }
+
+  if (sdkCacheReadTokens !== rawCachedTokens) {
+    throw new Error(
+      `cached token mapping mismatch: raw prompt_tokens_details.cached_tokens=${rawCachedTokens}, SDK usage.inputTokenDetails.cacheReadTokens=${sdkCacheReadTokens}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json
+++ b/packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json
@@ -1,0 +1,102 @@
+{
+  "issue": 11178,
+  "model": "gpt-4o-mini",
+  "api": "chat.completions",
+  "promptCacheKey": "ai-sdk-issue-11178-1783609407156",
+  "capturedResponses": [
+    {
+      "url": "https://api.openai.com/v1/chat/completions",
+      "status": 200,
+      "body": {
+        "id": "chatcmpl-DzkZb8ThxzM15vy3nPxcsDOAddcfZ",
+        "object": "chat.completion",
+        "created": 1783609407,
+        "model": "gpt-4o-mini-2024-07-18",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "OK",
+              "refusal": null,
+              "annotations": []
+            },
+            "logprobs": null,
+            "finish_reason": "length"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 2920,
+          "completion_tokens": 1,
+          "total_tokens": 2921,
+          "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0
+          },
+          "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0
+          }
+        },
+        "service_tier": "default",
+        "system_fingerprint": "fp_956fb8d6db"
+      }
+    },
+    {
+      "url": "https://api.openai.com/v1/chat/completions",
+      "status": 200,
+      "body": {
+        "id": "chatcmpl-DzkZdUafUpWCXRPT4K66cOmNKR1At",
+        "object": "chat.completion",
+        "created": 1783609409,
+        "model": "gpt-4o-mini-2024-07-18",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "OK",
+              "refusal": null,
+              "annotations": []
+            },
+            "logprobs": null,
+            "finish_reason": "length"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 2920,
+          "completion_tokens": 1,
+          "total_tokens": 2921,
+          "prompt_tokens_details": {
+            "cached_tokens": 2816,
+            "audio_tokens": 0
+          },
+          "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0
+          }
+        },
+        "service_tier": "default",
+        "system_fingerprint": "fp_956fb8d6db"
+      }
+    }
+  ],
+  "observedSdkUsage": {
+    "inputTokens": 2920,
+    "inputTokenDetails": {
+      "noCacheTokens": 104,
+      "cacheReadTokens": 2816
+    },
+    "outputTokens": 1,
+    "outputTokenDetails": {
+      "textTokens": 1,
+      "reasoningTokens": 0
+    },
+    "totalTokens": 2921
+  },
+  "observedRawCachedTokens": 2816
+}

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -1424,6 +1424,38 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should map cached_tokens from the recorded issue 11178 chat completion fixture', async () => {
+    const fixture = JSON.parse(
+      fs.readFileSync(
+        'src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json',
+        'utf8',
+      ),
+    );
+    const response = fixture.capturedResponses[1].body;
+    const rawCachedTokens = response.usage.prompt_tokens_details.cached_tokens;
+
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: response,
+    };
+
+    const model = provider.chat('gpt-4o-mini');
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+    const rawUsage = result.usage.raw as {
+      prompt_tokens_details?: { cached_tokens?: number };
+    };
+
+    expect(rawCachedTokens).toBeGreaterThan(0);
+    expect(result.usage.inputTokens.cacheRead).toBe(rawCachedTokens);
+    expect(result.usage.inputTokens.noCache).toBe(
+      response.usage.prompt_tokens - rawCachedTokens,
+    );
+    expect(rawUsage.prompt_tokens_details?.cached_tokens).toBe(rawCachedTokens);
+  });
+
   it('should return accepted_prediction_tokens and rejected_prediction_tokens in completion_details_tokens', async () => {
     server.urls['https://api.openai.com/v1/chat/completions'].response = {
       type: 'json-value',


### PR DESCRIPTION
## Bug

cachedInputTokens does not mapped

## Reproduction

- `examples/ai-functions/src/reproduction/openai-cached-input-tokens-11178.ts` sends two live `generateText` calls through `openai.chat('gpt-4o-mini')` with a stable >1,024-token prompt and records the raw Chat Completions responses.
- OpenAI's second live response in `packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json` reported `usage.prompt_tokens_details.cached_tokens: 2816`.
- The SDK result for that same second call reported `usage.inputTokenDetails.cacheReadTokens: 2816`, matching the raw OpenAI cached-token value instead of returning 0.
- Added `packages/openai/src/chat/openai-chat-language-model.test.ts` fixture coverage confirming recorded `cached_tokens` maps to provider `inputTokens.cacheRead`.
- Current workspace versions are `ai` 7.0.18 and `@ai-sdk/openai` 4.0.9; current high-level usage exposes cached reads as `usage.inputTokenDetails.cacheReadTokens` rather than the older `usage.cachedInputTokens` field.

## Relevant Documentation

- https://openai.com/index/api-prompt-caching/
- https://platform.openai.com/docs/api-reference/chat/create

## Related Issues

Could not reproduce #11178