### PR TITLE
reproduction: could not reproduce cachedInputTokens does not mapped

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/openai": "workspace:*",
+    "ai": "workspace:*",
+    "dotenv": "16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/openai-cached-input-tokens-11178.ts
+++ b/examples/ai-functions/src/reproduction/openai-cached-input-tokens-11178.ts
@@ -1,0 +1,146 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+
+type ChatCompletionResponseBody = {
+  id?: string;
+  model?: string;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+      audio_tokens?: number;
+    };
+  };
+};
+
+type Usage = {
+  inputTokens: number | undefined;
+  outputTokens: number | undefined;
+  totalTokens: number | undefined;
+  reasoningTokens: number | undefined;
+  cachedInputTokens: number | undefined;
+};
+
+const fixturePath = path.resolve(
+  process.cwd(),
+  '../../packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json',
+);
+
+const staticSystemPrompt = [
+  'You are validating prompt caching token accounting for vercel/ai issue #11178.',
+  'Keep every shared prefix byte identical across requests.',
+  ...Array.from(
+    { length: 420 },
+    (_, index) =>
+      `Stable cache paragraph ${index.toString().padStart(3, '0')}: ` +
+      'This deterministic sentence exists only to make the prompt longer than the OpenAI prompt-cache threshold.',
+  ),
+].join('\n');
+
+function getRawCachedTokens(body: ChatCompletionResponseBody): number {
+  return body.usage?.prompt_tokens_details?.cached_tokens ?? 0;
+}
+
+async function runAttempt(attempt: number) {
+  const result = await generateText({
+    model: openai.chat('gpt-4o-mini'),
+    system: staticSystemPrompt,
+    prompt: 'Reply with exactly: ok',
+    temperature: 0,
+    maxOutputTokens: 8,
+    providerOptions: {
+      openai: {
+        promptCacheKey: 'vercel-ai-issue-11178-cached-input-tokens',
+      },
+    },
+  });
+
+  const rawResponseBody = result.response.body as ChatCompletionResponseBody;
+  const rawCachedTokens = getRawCachedTokens(rawResponseBody);
+  const sdkCachedInputTokens = result.usage.cachedInputTokens ?? 0;
+
+  console.log(
+    JSON.stringify(
+      {
+        attempt,
+        responseId: rawResponseBody.id,
+        rawCachedTokens,
+        sdkCachedInputTokens,
+        usage: result.usage,
+        providerMetadata: result.providerMetadata,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return {
+    attempt,
+    responseId: rawResponseBody.id,
+    model: rawResponseBody.model,
+    rawCachedTokens,
+    sdkCachedInputTokens,
+    sdkUsage: result.usage as Usage,
+    providerMetadata: result.providerMetadata,
+    rawResponseBody,
+  };
+}
+
+async function main() {
+  const attempts = [];
+
+  for (let attempt = 1; attempt <= 6; attempt++) {
+    attempts.push(await runAttempt(attempt));
+
+    if (attempts.at(-1)?.rawCachedTokens) {
+      break;
+    }
+
+    await setTimeout(1000);
+  }
+
+  await mkdir(path.dirname(fixturePath), { recursive: true });
+  await writeFile(
+    fixturePath,
+    `${JSON.stringify(
+      {
+        issue: '11178',
+        model: 'gpt-4o-mini',
+        description:
+          'Recorded live OpenAI Chat Completions responses for prompt cache usage mapping.',
+        attempts,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const cachedAttempt = attempts.find(attempt => attempt.rawCachedTokens > 0);
+  if (cachedAttempt == null) {
+    throw new Error(
+      `OpenAI did not report usage.prompt_tokens_details.cached_tokens > 0 after ${attempts.length} attempts; cached token mapping could not be evaluated.`,
+    );
+  }
+
+  if (cachedAttempt.sdkCachedInputTokens !== cachedAttempt.rawCachedTokens) {
+    throw new Error(
+      `Expected SDK usage.cachedInputTokens to equal raw OpenAI cached_tokens (${cachedAttempt.rawCachedTokens}), but received ${cachedAttempt.sdkCachedInputTokens}.`,
+    );
+  }
+
+  console.log(
+    `Mapped cached tokens successfully: raw cached_tokens=${cachedAttempt.rawCachedTokens}, SDK cachedInputTokens=${cachedAttempt.sdkCachedInputTokens}.`,
+  );
+  console.log(`Wrote fixture: ${fixturePath}`);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json
+++ b/packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json
@@ -1,0 +1,119 @@
+{
+  "issue": "11178",
+  "model": "gpt-4o-mini",
+  "description": "Recorded live OpenAI Chat Completions responses for prompt cache usage mapping.",
+  "attempts": [
+    {
+      "attempt": 1,
+      "responseId": "chatcmpl-Dzkk7Z94EQa81FigOK8zZPgxuirZX",
+      "model": "gpt-4o-mini-2024-07-18",
+      "rawCachedTokens": 0,
+      "sdkCachedInputTokens": 0,
+      "sdkUsage": {
+        "inputTokens": 10122,
+        "outputTokens": 1,
+        "totalTokens": 10123,
+        "reasoningTokens": 0,
+        "cachedInputTokens": 0
+      },
+      "providerMetadata": {
+        "openai": {
+          "acceptedPredictionTokens": 0,
+          "rejectedPredictionTokens": 0
+        }
+      },
+      "rawResponseBody": {
+        "id": "chatcmpl-Dzkk7Z94EQa81FigOK8zZPgxuirZX",
+        "object": "chat.completion",
+        "created": 1783610059,
+        "model": "gpt-4o-mini-2024-07-18",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "ok",
+              "refusal": null,
+              "annotations": []
+            },
+            "logprobs": null,
+            "finish_reason": "stop"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 10122,
+          "completion_tokens": 1,
+          "total_tokens": 10123,
+          "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0
+          },
+          "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0
+          }
+        },
+        "service_tier": "default",
+        "system_fingerprint": "fp_810e56f10f"
+      }
+    },
+    {
+      "attempt": 2,
+      "responseId": "chatcmpl-Dzkk95ZsXR00sJH1wE3qTGHxdGcrQ",
+      "model": "gpt-4o-mini-2024-07-18",
+      "rawCachedTokens": 9984,
+      "sdkCachedInputTokens": 9984,
+      "sdkUsage": {
+        "inputTokens": 10122,
+        "outputTokens": 1,
+        "totalTokens": 10123,
+        "reasoningTokens": 0,
+        "cachedInputTokens": 9984
+      },
+      "providerMetadata": {
+        "openai": {
+          "acceptedPredictionTokens": 0,
+          "rejectedPredictionTokens": 0
+        }
+      },
+      "rawResponseBody": {
+        "id": "chatcmpl-Dzkk95ZsXR00sJH1wE3qTGHxdGcrQ",
+        "object": "chat.completion",
+        "created": 1783610061,
+        "model": "gpt-4o-mini-2024-07-18",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "ok",
+              "refusal": null,
+              "annotations": []
+            },
+            "logprobs": null,
+            "finish_reason": "stop"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 10122,
+          "completion_tokens": 1,
+          "total_tokens": 10123,
+          "prompt_tokens_details": {
+            "cached_tokens": 9984,
+            "audio_tokens": 0
+          },
+          "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0
+          }
+        },
+        "service_tier": "default",
+        "system_fingerprint": "fp_810e56f10f"
+      }
+    }
+  ]
+}

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -1210,6 +1210,51 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should map cached_tokens from recorded live OpenAI response for issue #11178', async () => {
+    const fixture = JSON.parse(
+      fs.readFileSync(
+        'src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json',
+        'utf8',
+      ),
+    ) as {
+      attempts: Array<{
+        rawCachedTokens: number;
+        rawResponseBody: {
+          usage?: {
+            prompt_tokens?: number;
+            completion_tokens?: number;
+            total_tokens?: number;
+          };
+        };
+      }>;
+    };
+
+    const cachedAttempt = fixture.attempts.find(
+      attempt => attempt.rawCachedTokens > 0,
+    );
+
+    if (cachedAttempt == null) {
+      throw new Error('Recorded fixture does not contain a cache hit.');
+    }
+
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: cachedAttempt.rawResponseBody,
+    };
+
+    const result = await provider.chat('gpt-4o-mini').doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.usage).toStrictEqual({
+      inputTokens: cachedAttempt.rawResponseBody.usage?.prompt_tokens,
+      outputTokens: cachedAttempt.rawResponseBody.usage?.completion_tokens,
+      totalTokens: cachedAttempt.rawResponseBody.usage?.total_tokens,
+      reasoningTokens: 0,
+      cachedInputTokens: cachedAttempt.rawCachedTokens,
+    });
+  });
+
   it('should return accepted_prediction_tokens and rejected_prediction_tokens in completion_details_tokens', async () => {
     prepareJsonResponse({
       usage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,28 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../../packages/openai
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/ai-core:
     dependencies:
       '@ai-sdk/alibaba':


### PR DESCRIPTION
## Bug

cachedInputTokens does not mapped

## Reproduction

- `examples/ai-functions/src/reproduction/openai-cached-input-tokens-11178.ts` sends repeated live `generateText` calls through `openai.chat('gpt-4o-mini')` with a stable >1,024-token prompt.
- The reported issue behavior expected `usage.cachedInputTokens` to remain `0` when OpenAI returned a nonzero `usage.prompt_tokens_details.cached_tokens` value.
- The second live OpenAI response reported `usage.prompt_tokens_details.cached_tokens: 9984`, and the SDK result reported `usage.cachedInputTokens: 9984` for the same call.
- The recorded live response fixture is in `packages/openai/src/chat/__fixtures__/openai-chat-cached-input-tokens-11178.json`.
- Added fixture-backed provider coverage in `packages/openai/src/chat/openai-chat-language-model.test.ts` confirming recorded `cached_tokens` maps to `usage.cachedInputTokens`.
- `providerMetadata.openai` did not include cached-token metadata, but the primary user-visible usage field was mapped correctly.
- Current workspace versions are `ai` 5.0.210 and `@ai-sdk/openai` 2.0.110, so the older reported versions were not reproduced on this target worktree.

## Relevant Documentation

- https://developers.openai.com/api/docs/guides/prompt-caching
- https://platform.openai.com/docs/api-reference/chat/create

## Related Issues

Could not reproduce #11178