### PR TITLE
fix(workflow): forward stream response format

### DIFF
--- a/.changeset/four-parrots-flow.md
+++ b/.changeset/four-parrots-flow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Forward `WorkflowAgent.stream()` structured output response formats to workflow model calls.

--- a/packages/workflow/src/do-stream-step.test.ts
+++ b/packages/workflow/src/do-stream-step.test.ts
@@ -1,0 +1,64 @@
+import type {
+  LanguageModelV4CallOptions,
+  LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { describe, expect, it } from 'vitest';
+import { doStreamStep } from './do-stream-step.js';
+
+describe('doStreamStep', () => {
+  it('forwards responseFormat to the model call', async () => {
+    const responseFormat: LanguageModelV4CallOptions['responseFormat'] = {
+      type: 'json',
+      schema: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean' },
+        },
+        required: ['ok'],
+        additionalProperties: false,
+      },
+    };
+
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'text-start', id: '1' },
+          { type: 'text-delta', id: '1', delta: '{"ok":true}' },
+          { type: 'text-end', id: '1' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 1,
+                text: 1,
+                reasoning: undefined,
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'return json' }],
+      },
+    ];
+
+    await doStreamStep(prompt, model, undefined, undefined, {
+      responseFormat,
+    });
+
+    expect(model.doStreamCalls[0].responseFormat).toStrictEqual(responseFormat);
+  });
+});

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -125,6 +125,24 @@ export async function doStreamStep(
   const tools = serializedTools
     ? resolveSerializableTools(serializedTools)
     : undefined;
+  const output =
+    options?.responseFormat == null
+      ? undefined
+      : {
+          name: 'workflow-response-format',
+          responseFormat: Promise.resolve(options.responseFormat),
+          async parseCompleteOutput(): Promise<never> {
+            throw new Error(
+              'Workflow step output parsing is handled outside doStreamStep.',
+            );
+          },
+          async parsePartialOutput() {
+            return undefined;
+          },
+          createElementStreamTransform() {
+            return undefined;
+          },
+        };
 
   // streamModelCall handles: prompt standardization, tool preparation,
   // model.doStream(), retry logic, and stream part transformation
@@ -152,6 +170,7 @@ export async function doStreamStep(
     stopSequences: options?.stopSequences,
     seed: options?.seed,
     repairToolCall: options?.repairToolCall,
+    output,
   });
 
   // Consume the stream: capture data and write to writable in real-time


### PR DESCRIPTION
Summary
- forward the resolved `WorkflowAgent.stream()` response format into workflow model calls
- add a direct `doStreamStep` regression proving JSON response formats reach the mock model
- add a workflow package changeset

Tests
- `pnpm --filter @ai-sdk/provider build`
- `pnpm --filter @ai-sdk/provider-utils build`
- `pnpm --filter @ai-sdk/gateway build`
- `pnpm --filter ai build`
- `pnpm --dir packages/workflow test:node -- do-stream-step.test.ts`
- `pnpm --dir packages/workflow type-check`
- `pnpm --dir packages/workflow build`
- `pnpm exec oxfmt --check packages/workflow/src/do-stream-step.ts packages/workflow/src/do-stream-step.test.ts .changeset/four-parrots-flow.md`
- `pnpm exec oxlint packages/workflow/src/do-stream-step.ts packages/workflow/src/do-stream-step.test.ts`
- `git diff --check`

Refs #16565.