### PR TITLE
fix(google): omit Vertex function call ids

### DIFF
--- a/.changeset/vertex-tool-call-ids.md
+++ b/.changeset/vertex-tool-call-ids.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+Omit tool call and tool result IDs from Vertex Gemini function call request parts.

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -138,7 +138,6 @@ describe('thought signatures with vertex providerOptionsName', () => {
                   "args": {
                     "location": "London",
                   },
-                  "id": "call1",
                   "name": "getWeather",
                 },
                 "thoughtSignature": "sig3",
@@ -176,7 +175,6 @@ describe('thought signatures with vertex providerOptionsName', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
-        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
@@ -207,11 +205,120 @@ describe('thought signatures with vertex providerOptionsName', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
-        id: 'call1',
         name: 'getWeather',
         args: { location: 'London' },
       },
       thoughtSignature: 'vertex_sig',
+    });
+  });
+});
+
+describe('vertex function call ids', () => {
+  it('omits functionCall ids for Vertex requests', () => {
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call1',
+              toolName: 'getWeather',
+              input: { location: 'London' },
+            },
+          ],
+        },
+      ],
+      { providerOptionsNames: ['googleVertex', 'vertex'] },
+    );
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionCall: {
+        name: 'getWeather',
+        args: { location: 'London' },
+      },
+      thoughtSignature: undefined,
+    });
+  });
+
+  it('omits functionResponse ids for Vertex requests', () => {
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call1',
+              toolName: 'getWeather',
+              output: {
+                type: 'json',
+                value: { temperature: 72 },
+              },
+            },
+          ],
+        },
+      ],
+      { providerOptionsNames: ['googleVertex', 'vertex'] },
+    );
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionResponse: {
+        name: 'getWeather',
+        response: {
+          name: 'getWeather',
+          content: { temperature: 72 },
+        },
+      },
+    });
+  });
+
+  it('keeps functionCall and functionResponse ids for Google requests', () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call1',
+            toolName: 'getWeather',
+            input: { location: 'London' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call1',
+            toolName: 'getWeather',
+            output: {
+              type: 'json',
+              value: { temperature: 72 },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionCall: {
+        id: 'call1',
+        name: 'getWeather',
+        args: { location: 'London' },
+      },
+      thoughtSignature: undefined,
+    });
+    expect(result.contents[1].parts[0]).toEqual({
+      functionResponse: {
+        id: 'call1',
+        name: 'getWeather',
+        response: {
+          name: 'getWeather',
+          content: { temperature: 72 },
+        },
+      },
     });
   });
 });

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -76,6 +76,7 @@ function appendToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  includeToolCallId = true,
 ): void {
   const functionResponseParts: GoogleFunctionResponsePart[] = [];
   const responseTextParts: string[] = [];
@@ -118,7 +119,7 @@ function appendToolResultParts(
 
   parts.push({
     functionResponse: {
-      ...(toolCallId != null ? { id: toolCallId } : {}),
+      ...(includeToolCallId && toolCallId != null ? { id: toolCallId } : {}),
       name: toolName,
       response: {
         name: toolName,
@@ -147,13 +148,16 @@ function appendLegacyToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  includeToolCallId = true,
 ): void {
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
       case 'text':
         parts.push({
           functionResponse: {
-            ...(toolCallId != null ? { id: toolCallId } : {}),
+            ...(includeToolCallId && toolCallId != null
+              ? { id: toolCallId }
+              : {}),
             name: toolName,
             response: {
               name: toolName,
@@ -216,6 +220,7 @@ export function convertToGoogleMessages(
   const onWarning = options?.onWarning;
   const providerOptionsNames = options?.providerOptionsNames ?? ['google'];
   const isVertexLike = !providerOptionsNames.includes('google');
+  const includeFunctionCallIds = !isVertexLike;
   const supportsFunctionResponseParts =
     options?.supportsFunctionResponseParts ?? true;
 
@@ -481,7 +486,7 @@ export function convertToGoogleMessages(
 
                   return {
                     functionCall: {
-                      ...(part.toolCallId != null
+                      ...(includeFunctionCallIds && part.toolCallId != null
                         ? { id: part.toolCallId }
                         : {}),
                       name: part.toolName,
@@ -575,6 +580,7 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                includeFunctionCallIds,
               );
             } else {
               appendLegacyToolResultParts(
@@ -582,12 +588,15 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                includeFunctionCallIds,
               );
             }
           } else {
             parts.push({
               functionResponse: {
-                ...(part.toolCallId != null ? { id: part.toolCallId } : {}),
+                ...(includeFunctionCallIds && part.toolCallId != null
+                  ? { id: part.toolCallId }
+                  : {}),
                 name: part.toolName,
                 response: {
                   name: part.toolName,


### PR DESCRIPTION
## Summary
- omit ordinary Gemini `functionCall.id` and `functionResponse.id` fields when converting messages for Vertex-like providers
- keep the existing tool call/result IDs for the Google Gemini provider path
- add regression coverage for Vertex request conversion and Google-provider preservation

Fixes #15891.

## Tests
- `pnpm --filter @ai-sdk/google exec vitest run --config vitest.node.config.js src/convert-to-google-messages.test.ts` (57 passed)
- `pnpm --filter @ai-sdk/google test:node` (691 passed)
- `pnpm --filter @ai-sdk/google test:edge` (691 passed)
- `pnpm --filter @ai-sdk/google type-check`
- `pnpm exec oxfmt --check packages/google/src/convert-to-google-messages.ts packages/google/src/convert-to-google-messages.test.ts .changeset/vertex-tool-call-ids.md`
- `pnpm exec oxlint packages/google/src/convert-to-google-messages.ts packages/google/src/convert-to-google-messages.test.ts`
- `git diff --check`
- `pnpm changeset status --since origin/main`