### PR TITLE
feat(anthropic): add `cacheDiagnostics` provider option support

### DIFF
--- a/.changeset/anthropic-cache-diagnostics.md
+++ b/.changeset/anthropic-cache-diagnostics.md
@@ -1,4 +1,5 @@
 ---
+"@ai-sdk/amazon-bedrock": patch
 "@ai-sdk/anthropic": patch
 "@ai-sdk/google-vertex": patch
 ---

--- a/.changeset/anthropic-cache-diagnostics.md
+++ b/.changeset/anthropic-cache-diagnostics.md
@@ -3,4 +3,4 @@
 "@ai-sdk/google-vertex": patch
 ---
 
-Add Anthropic cache diagnostics provider option support.
+feat(anthropic): add `cacheDiagnostics` provider option support

--- a/.changeset/anthropic-cache-diagnostics.md
+++ b/.changeset/anthropic-cache-diagnostics.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk/anthropic": minor
+"@ai-sdk/anthropic": patch
 "@ai-sdk/google-vertex": patch
 ---
 

--- a/.changeset/anthropic-cache-diagnostics.md
+++ b/.changeset/anthropic-cache-diagnostics.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/anthropic": minor
+"@ai-sdk/google-vertex": patch
+---
+
+Add Anthropic cache diagnostics provider option support.

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -845,7 +845,7 @@ For more on prompt caching with Anthropic, see [Anthropic's Cache Control docume
 
 ### Cache Diagnostics
 
-Anthropic's [cache diagnostics beta](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-diagnostics) lets you correlate a response with the previous request that populated (or missed) the prompt cache. Pass a `cacheDiagnostics.previousMessageId` in `providerOptions.anthropic` to opt in:
+Anthropic's [cache diagnostics feature](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-diagnostics) lets you correlate a response with the previous request that populated (or missed) the prompt cache. Pass a `cacheDiagnostics.previousMessageId` in `providerOptions.anthropic` to opt in:
 
 ```ts
 import { anthropic } from '@ai-sdk/anthropic';
@@ -869,8 +869,6 @@ console.log(result.providerMetadata?.anthropic?.diagnostics);
 ```
 
 The resolved diagnostics are exposed on `result.providerMetadata.anthropic.diagnostics`. The same field is available on streamed responses via the `finish` part's `providerMetadata`.
-
-`cacheDiagnostics` is supported only on the Claude API. Adapters backed by other Anthropic-compatible providers (Amazon Bedrock, Google Vertex) set `supportsCacheDiagnostics: false` internally and will emit an unsupported-feature warning if the option is used; use it only with `@ai-sdk/anthropic`.
 
 ### Bash Tool
 

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -843,6 +843,35 @@ For more on prompt caching with Anthropic, see [Anthropic's Cache Control docume
   [here](/docs/foundations/prompts#provider-options).
 </Note>
 
+### Cache Diagnostics
+
+Anthropic's [cache diagnostics beta](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-diagnostics) lets you correlate a response with the previous request that populated (or missed) the prompt cache. Pass a `cacheDiagnostics.previousMessageId` in `providerOptions.anthropic` to opt in:
+
+```ts
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5'),
+  prompt: 'Summarize the attached document.',
+  providerOptions: {
+    anthropic: {
+      cacheDiagnostics: {
+        previousMessageId: 'msg_01XyZ...',
+      },
+    },
+  },
+});
+
+console.log(result.providerMetadata?.anthropic?.diagnostics);
+// Diagnostics response from the API (or `null` when there was no prior
+// message to compare against).
+```
+
+The resolved diagnostics are exposed on `result.providerMetadata.anthropic.diagnostics`. The same field is available on streamed responses via the `finish` part's `providerMetadata`.
+
+`cacheDiagnostics` is supported only on the Claude API. Adapters backed by other Anthropic-compatible providers (Amazon Bedrock, Google Vertex) set `supportsCacheDiagnostics: false` internally and will emit an unsupported-feature warning if the option is used; use it only with `@ai-sdk/anthropic`.
+
 ### Bash Tool
 
 The Bash Tool allows running bash commands. By default, the tool executes

--- a/examples/ai-functions/src/generate-text/anthropic/cache-diagnostics.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/cache-diagnostics.ts
@@ -1,0 +1,89 @@
+import {
+  anthropic,
+  type AnthropicLanguageModelOptions,
+} from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+run(async () => {
+  // First call primes the prompt cache and produces a message id we can
+  // correlate against on the follow-up request.
+  const first = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error message: ${errorMessage}`,
+            providerOptions: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral', ttl: '1h' },
+              } satisfies AnthropicLanguageModelOptions,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Explain the error message.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const firstMessageId = first.response.id;
+  console.log('First message id:', firstMessageId);
+
+  // Second call passes cacheDiagnostics.previousMessageId and reads the
+  // resolved diagnostics off the provider metadata.
+  const second = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error message: ${errorMessage}`,
+            providerOptions: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral', ttl: '1h' },
+              } satisfies AnthropicLanguageModelOptions,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Repeat the explanation as a one-liner.',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      anthropic: {
+        cacheDiagnostics: {
+          previousMessageId: firstMessageId,
+        },
+      } satisfies AnthropicLanguageModelOptions,
+    },
+  });
+
+  console.log(second.text);
+  console.log();
+
+  console.log(
+    'Cache diagnostics:',
+    second.providerMetadata?.anthropic?.diagnostics,
+  );
+});

--- a/examples/ai-functions/src/stream-text/anthropic/cache-diagnostics.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/cache-diagnostics.ts
@@ -1,0 +1,92 @@
+import {
+  anthropic,
+  type AnthropicLanguageModelOptions,
+} from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+run(async () => {
+  // First call primes the prompt cache and produces a message id we can
+  // correlate against on the follow-up request.
+  const first = await streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error message: ${errorMessage}`,
+            providerOptions: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral', ttl: '1h' },
+              } satisfies AnthropicLanguageModelOptions,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Explain the error message.',
+          },
+        ],
+      },
+    ],
+  });
+
+  for await (const chunk of first.textStream) {
+    process.stdout.write(chunk);
+  }
+
+  const firstMessageId = (await first.response).id;
+  console.log('\nFirst message id:', firstMessageId);
+
+  // Second call passes cacheDiagnostics.previousMessageId and reads the
+  // resolved diagnostics off the finish part's provider metadata.
+  const second = await streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error message: ${errorMessage}`,
+            providerOptions: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral', ttl: '1h' },
+              } satisfies AnthropicLanguageModelOptions,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Repeat the explanation as a one-liner.',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      anthropic: {
+        cacheDiagnostics: {
+          previousMessageId: firstMessageId,
+        },
+      } satisfies AnthropicLanguageModelOptions,
+    },
+  });
+
+  for await (const chunk of second.textStream) {
+    process.stdout.write(chunk);
+  }
+
+  const secondMetadata = await second.providerMetadata;
+  console.log('\nCache diagnostics:', secondMetadata?.anthropic?.diagnostics);
+});

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -80,6 +80,26 @@ describe('amazon-bedrock-anthropic-provider', () => {
         supportedUrls: expect.any(Function),
         supportsNativeStructuredOutput: true,
         supportsStrictTools: true,
+        supportsCacheDiagnostics: false,
+      }),
+    );
+  });
+
+  it('should always disable cache diagnostics on the shared Anthropic model', () => {
+    // Regression for vercel/ai#17032 review feedback: the shared
+    // `AnthropicLanguageModel` defaults `supportsCacheDiagnostics` to true,
+    // which let the Bedrock path silently forward an Anthropic-only feature.
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('anthropic.claude-3-5-sonnet-20241022-v2:0');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        supportsCacheDiagnostics: false,
       }),
     );
   });

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -348,6 +348,8 @@ export function createAmazonBedrockAnthropic(
       supportedUrls: () => ({}),
       supportsNativeStructuredOutput: supportsNativeStructuredOutput(modelId),
       supportsStrictTools: supportsStrictTools(modelId),
+      // Anthropic cache diagnostics are only supported on the Claude API.
+      supportsCacheDiagnostics: false,
     });
 
   const provider = function (modelId: AmazonBedrockAnthropicModelId) {

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -1015,6 +1015,7 @@ export const anthropicResponseSchema = lazySchema(() =>
           ),
         })
         .nullish(),
+      diagnostics: z.looseObject({}).nullable().nullish(),
     }),
   ),
 );
@@ -1070,6 +1071,7 @@ export const anthropicChunkSchema = lazySchema(() =>
               id: z.string(),
             })
             .nullish(),
+          diagnostics: z.looseObject({}).nullable().nullish(),
         }),
       }),
       z.object({

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -168,6 +168,20 @@ export const anthropicLanguageModelOptions = z.object({
     .optional(),
 
   /**
+   * Cache diagnostics settings for diagnosing prompt cache misses.
+   * See https://docs.anthropic.com/en/docs/build-with-claude/cache-diagnostics
+   */
+  cacheDiagnostics: z
+    .object({
+      /**
+       * The previous response id to compare against. Use null on the first
+       * request to opt in before a previous response exists.
+       */
+      previousMessageId: z.string().nullable(),
+    })
+    .optional(),
+
+  /**
    * Metadata to include with the request.
    *
    * See https://platform.claude.com/docs/en/api/messages/create for details.

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -5879,6 +5879,155 @@ describe('AnthropicLanguageModel', () => {
       expect(result.warnings).toStrictEqual([]);
     });
 
+    it('should pass cache diagnostics to request body and add beta header', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheDiagnostics: { previousMessageId: 'msg_previous' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "diagnostics": {
+            "previous_message_id": "msg_previous",
+          },
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+        }
+      `);
+
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toBe(
+        'cache-diagnosis-2026-04-07',
+      );
+      expect(result.warnings).toStrictEqual([]);
+    });
+
+    it('should support cache diagnostics first-turn opt-in', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheDiagnostics: { previousMessageId: null },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "diagnostics": {
+            "previous_message_id": null,
+          },
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+        }
+      `);
+
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toBe(
+        'cache-diagnosis-2026-04-07',
+      );
+      expect(result.warnings).toStrictEqual([]);
+    });
+
+    it('should expose cache diagnostics response metadata', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'json-value',
+        body: {
+          id: 'msg_017TfcQ4AgGxKyBduUpqYPZn',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello, World!' }],
+          model: 'claude-3-haiku-20240307',
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 4, output_tokens: 30 },
+          diagnostics: {
+            cache_miss_reason: {
+              type: 'tools_changed',
+              cache_missed_input_tokens: 1024,
+            },
+          },
+        },
+      };
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheDiagnostics: { previousMessageId: 'msg_previous' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(result.providerMetadata?.anthropic?.diagnostics).toEqual({
+        cache_miss_reason: {
+          type: 'tools_changed',
+          cache_missed_input_tokens: 1024,
+        },
+      });
+    });
+
+    it('should warn and omit cache diagnostics when unsupported', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const { AnthropicLanguageModel } =
+        await import('./anthropic-language-model');
+      const model = new AnthropicLanguageModel('claude-3-haiku-20240307', {
+        provider: 'test-provider',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: {},
+        supportsCacheDiagnostics: false,
+      });
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheDiagnostics: { previousMessageId: 'msg_previous' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.diagnostics).toBeUndefined();
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toBeUndefined();
+      expect(result.warnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'cacheDiagnostics',
+          details: 'cache diagnostics is not supported by this provider',
+        },
+      ]);
+    });
+
     it('should pass metadata with user_id to request body', async () => {
       prepareJsonFixtureResponse('anthropic-text');
 
@@ -8390,6 +8539,43 @@ describe('AnthropicLanguageModel', () => {
       expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
         'another-beta-2025-06-01',
       );
+    });
+
+    it('should expose streaming cache diagnostics response metadata', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1},"diagnostics":{"cache_miss_reason":{"type":"messages_changed","cache_missed_input_tokens":2048}}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const result = await model.doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheDiagnostics: { previousMessageId: 'msg_previous' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      const chunks = await convertReadableStreamToArray(result.stream);
+      const finishPart = chunks.find(part => part.type === 'finish');
+
+      expect(
+        finishPart?.type === 'finish'
+          ? finishPart.providerMetadata?.anthropic?.diagnostics
+          : undefined,
+      ).toEqual({
+        cache_miss_reason: {
+          type: 'messages_changed',
+          cache_missed_input_tokens: 2048,
+        },
+      });
     });
 
     it('should support cache control', async () => {

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -150,6 +150,12 @@ export type AnthropicLanguageModelConfig = {
    * Defaults to true.
    */
   supportsStrictTools?: boolean;
+
+  /**
+   * When false, cache diagnostics provider options will be ignored and a
+   * warning emitted. Defaults to true.
+   */
+  supportsCacheDiagnostics?: boolean;
 };
 
 export class AnthropicLanguageModel implements LanguageModelV4 {
@@ -351,6 +357,17 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       (this.config.supportsStrictTools ?? true) &&
       modelSupportsStructuredOutput;
 
+    const supportsCacheDiagnostics =
+      this.config.supportsCacheDiagnostics ?? true;
+    if (anthropicOptions?.cacheDiagnostics && !supportsCacheDiagnostics) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'cacheDiagnostics',
+        details: 'cache diagnostics is not supported by this provider',
+      });
+      anthropicOptions.cacheDiagnostics = undefined;
+    }
+
     const structureOutputMode =
       anthropicOptions?.structuredOutputMode ?? 'auto';
     const useStructuredOutput =
@@ -542,6 +559,12 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
         }),
       ...(anthropicOptions?.cacheControl && {
         cache_control: anthropicOptions.cacheControl,
+      }),
+      ...(anthropicOptions?.cacheDiagnostics && {
+        diagnostics: {
+          previous_message_id:
+            anthropicOptions.cacheDiagnostics.previousMessageId,
+        },
       }),
       ...(anthropicOptions?.metadata?.userId != null && {
         metadata: { user_id: anthropicOptions.metadata.userId },
@@ -766,6 +789,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
 
     if (anthropicOptions?.taskBudget) {
       betas.add('task-budgets-2026-03-13');
+    }
+
+    if (anthropicOptions?.cacheDiagnostics) {
+      betas.add('cache-diagnosis-2026-04-07');
     }
 
     if (anthropicOptions?.speed === 'fast') {
@@ -1456,6 +1483,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
           usage: response.usage as JSONObject,
           stopSequence: response.stop_sequence ?? null,
           ...(stopDetails != null ? { stopDetails } : {}),
+          ...(response.diagnostics !== undefined
+            ? { diagnostics: response.diagnostics as JSONObject | null }
+            : {}),
 
           iterations: response.usage.iterations
             ? response.usage.iterations.map(
@@ -1554,6 +1584,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       unified: 'other',
       raw: undefined,
     };
+    let diagnostics: JSONObject | null | undefined;
     const usage: AnthropicUsage = {
       input_tokens: 0,
       output_tokens: 0,
@@ -2464,6 +2495,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 };
               }
 
+              if (value.message.diagnostics !== undefined) {
+                diagnostics = value.message.diagnostics as JSONObject | null;
+              }
+
               if (value.message.stop_reason != null) {
                 finishReason = {
                   unified: mapAnthropicStopReason({
@@ -2607,6 +2642,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 usage: (rawUsage as JSONObject) ?? null,
                 stopSequence,
                 ...(stopDetails != null ? { stopDetails } : {}),
+                ...(diagnostics !== undefined ? { diagnostics } : {}),
                 iterations: usage.iterations
                   ? usage.iterations.map(
                       iter =>

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -87,6 +87,13 @@ export interface AnthropicMessageMetadata {
   };
 
   /**
+   * Cache diagnostics response, when the request opts into Anthropic cache
+   * diagnostics. `null` means the request had no prior message to compare or
+   * no divergence was detected; an object may contain a `cache_miss_reason`.
+   */
+  diagnostics?: JSONObject | null;
+
+  /**
    * Usage breakdown by iteration when compaction is triggered.
    *
    * When compaction occurs, this array contains usage for each sampling iteration.

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -57,6 +57,7 @@ describe('google-vertex-anthropic-provider', () => {
         transformRequestBody: expect.any(Function),
         supportsNativeStructuredOutput: false,
         supportsStrictTools: false,
+        supportsCacheDiagnostics: false,
       }),
     );
   });
@@ -214,6 +215,7 @@ describe('google-vertex-anthropic-provider', () => {
           "headers": {},
           "provider": "googleVertex.anthropic.messages",
           "supportedUrls": [Function],
+          "supportsCacheDiagnostics": false,
           "supportsNativeStructuredOutput": false,
           "supportsStrictTools": false,
           "transformRequestBody": [Function],
@@ -237,6 +239,7 @@ describe('google-vertex-anthropic-provider', () => {
           "headers": {},
           "provider": "googleVertex.anthropic.messages",
           "supportedUrls": [Function],
+          "supportsCacheDiagnostics": false,
           "supportsNativeStructuredOutput": false,
           "supportsStrictTools": false,
           "transformRequestBody": [Function],

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -228,6 +228,8 @@ export function createGoogleVertexAnthropic(
       supportsNativeStructuredOutput: false,
       // Vertex Anthropic doesn't support strict mode on tool definitions.
       supportsStrictTools: false,
+      // Anthropic cache diagnostics are only supported on the Claude API.
+      supportsCacheDiagnostics: false,
     });
 
   const provider = function (modelId: GoogleVertexAnthropicModelId) {


### PR DESCRIPTION
## Summary
- add `cacheDiagnostics.previousMessageId` for Anthropic provider requests and map it to `diagnostics.previous_message_id`
- automatically enable the `cache-diagnosis-2026-04-07` beta when cache diagnostics are used
- expose Anthropic cache diagnostics response metadata for generate and stream responses
- keep Google Vertex Anthropic from sending unsupported cache diagnostics beta/body fields

Fixes #15986.

## Tests
- `pnpm --filter @ai-sdk/anthropic exec vitest run --config vitest.node.config.js src/anthropic-language-model.test.ts -t "cache diagnostics"` (5 passed)
- `pnpm --filter @ai-sdk/anthropic type-check`
- `pnpm --filter @ai-sdk/anthropic test:node` (448 passed)
- `pnpm --filter @ai-sdk/anthropic test:edge` (448 passed)
- `pnpm --filter @ai-sdk/anthropic build`
- `pnpm --filter @ai-sdk/google-vertex exec vitest run --config vitest.node.config.js src/anthropic/google-vertex-anthropic-provider.test.ts` (13 passed)
- `pnpm --filter @ai-sdk/google-vertex type-check`
- `pnpm exec oxfmt --check` on touched files
- `pnpm exec oxlint` on touched TypeScript files
- `pnpm changeset status --since origin/main`
- `git diff --cached --check`
