### PR TITLE
fix(amazon-bedrock): serialize assistant tool results

### DIFF
--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1456,6 +1456,145 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should combine an inline assistant tool result with a following user message while preserving cache point order', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            input: { query: 'weather' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            output: { type: 'text', value: 'Sunny' },
+            providerOptions: {
+              bedrock: { cachePoint: { type: 'default', ttl: '5m' } },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'What about tomorrow?' }],
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+        },
+      },
+    ]);
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            toolUse: {
+              toolUseId: 'call-1',
+              name: 'search',
+              input: { query: 'weather' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'call-1',
+              content: [{ text: 'Sunny' }],
+            },
+          },
+          { cachePoint: { type: 'default', ttl: '5m' } },
+          { text: 'What about tomorrow?' },
+          { cachePoint: { type: 'default', ttl: '1h' } },
+        ],
+      },
+    ]);
+  });
+
+  it('should combine an inline assistant tool result with a following tool message', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            input: { query: 'weather' },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'forecast',
+            input: { location: 'home' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            output: { type: 'text', value: 'Sunny' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'forecast',
+            output: { type: 'text', value: 'Rain tomorrow' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            toolUse: {
+              toolUseId: 'call-1',
+              name: 'search',
+              input: { query: 'weather' },
+            },
+          },
+          {
+            toolUse: {
+              toolUseId: 'call-2',
+              name: 'forecast',
+              input: { location: 'home' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'call-1',
+              content: [{ text: 'Sunny' }],
+            },
+          },
+          {
+            toolResult: {
+              toolUseId: 'call-2',
+              content: [{ text: 'Rain tomorrow' }],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should preserve empty text blocks when reasoning blocks are present', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1333,6 +1333,129 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should place assistant tool results immediately after assistant tool use', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'User prompt here' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+            toolName: 'toolCall',
+            input: { query: 'toolCallInput' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+            toolName: 'toolCall',
+            output: { type: 'json', value: { success: true } },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'assistant response' }],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'User prompt here' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+                name: 'toolCall',
+                input: { query: 'toolCallInput' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'tooluse_XzLWc3v7S6S0mO3vpBh39Q',
+                content: [{ text: JSON.stringify({ success: true }) }],
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ text: 'assistant response' }],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should resume assistant content after inline assistant tool results', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            input: { query: 'weather' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            output: { type: 'text', value: 'Sunny' },
+          },
+          { type: 'text', text: 'It is sunny.' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'call-1',
+                name: 'search',
+                input: { query: 'weather' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'call-1',
+                content: [{ text: 'Sunny' }],
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ text: 'It is sunny.' }],
+        },
+      ],
+      system: [],
+    });
+  });
+
   it('should preserve empty text blocks when reasoning blocks are present', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -4,6 +4,7 @@ import {
   type JSONValue,
   type LanguageModelV4Message,
   type LanguageModelV4Prompt,
+  type LanguageModelV4ToolResultOutput,
   type SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import {
@@ -25,6 +26,7 @@ import {
   type AmazonBedrockImageMimeType,
   type AmazonBedrockMessages,
   type AmazonBedrockSystemMessages,
+  type AmazonBedrockToolResultBlock,
   type AmazonBedrockUserMessage,
 } from './amazon-bedrock-api-types';
 import { amazonBedrockFilePartProviderOptions } from './amazon-bedrock-chat-language-model-options';
@@ -225,98 +227,14 @@ export async function convertToAmazonBedrockChatMessages(
                 if (part.type === 'tool-approval-response') {
                   continue;
                 }
-                let toolResultContent;
-
-                const output = part.output;
-                switch (output.type) {
-                  case 'content': {
-                    toolResultContent = await Promise.all(
-                      output.value.map(async contentPart => {
-                        switch (contentPart.type) {
-                          case 'text':
-                            return { text: contentPart.text };
-                          case 'file': {
-                            if (contentPart.data.type !== 'data') {
-                              throw new UnsupportedFunctionalityError({
-                                functionality: `tool result file data of type "${contentPart.data.type}"`,
-                              });
-                            }
-
-                            const fullMediaType = resolveFullMediaType({
-                              part: contentPart,
-                            });
-
-                            if (
-                              getTopLevelMediaType(fullMediaType) !== 'image'
-                            ) {
-                              const enableCitations =
-                                await shouldEnableCitations(
-                                  contentPart.providerOptions,
-                                );
-
-                              return {
-                                document: {
-                                  format:
-                                    getAmazonBedrockDocumentFormat(
-                                      fullMediaType,
-                                    ),
-                                  name: contentPart.filename
-                                    ? stripFileExtension(contentPart.filename)
-                                    : generateDocumentName(),
-                                  source: {
-                                    bytes: convertToBase64(
-                                      contentPart.data.data,
-                                    ),
-                                  },
-                                  ...(enableCitations && {
-                                    citations: { enabled: true },
-                                  }),
-                                },
-                              };
-                            }
-
-                            return {
-                              image: {
-                                format:
-                                  getAmazonBedrockImageFormat(fullMediaType),
-                                source: {
-                                  bytes: convertToBase64(contentPart.data.data),
-                                },
-                              },
-                            };
-                          }
-                          default: {
-                            throw new UnsupportedFunctionalityError({
-                              functionality: `unsupported tool content part type: ${contentPart.type}`,
-                            });
-                          }
-                        }
-                      }),
-                    );
-                    break;
-                  }
-                  case 'text':
-                  case 'error-text':
-                    toolResultContent = [{ text: output.value }];
-                    break;
-                  case 'execution-denied':
-                    toolResultContent = [
-                      { text: output.reason ?? 'Tool call execution denied.' },
-                    ];
-                    break;
-                  case 'json':
-                  case 'error-json':
-                  default:
-                    toolResultContent = [
-                      { text: JSON.stringify(output.value) },
-                    ];
-                    break;
-                }
 
                 amazonBedrockContent.push({
                   toolResult: {
                     toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
-                    content: toolResultContent,
+                    content: await convertToolResultOutput(
+                      part.output,
+                      generateDocumentName,
+                    ),
                   },
                 });
                 pushCachePoint(amazonBedrockContent, part.providerOptions);
@@ -342,6 +260,24 @@ export async function convertToAmazonBedrockChatMessages(
         // combines multiple assistant messages in this block into a single message:
         const amazonBedrockContent: AmazonBedrockAssistantMessage['content'] =
           [];
+        let toolResultContent: AmazonBedrockUserMessage['content'] = [];
+
+        const flushAssistantContent = () => {
+          if (amazonBedrockContent.length > 0) {
+            messages.push({
+              role: 'assistant',
+              content: [...amazonBedrockContent],
+            });
+            amazonBedrockContent.length = 0;
+          }
+        };
+
+        const flushToolResultContent = () => {
+          if (toolResultContent.length > 0) {
+            messages.push({ role: 'user', content: toolResultContent });
+            toolResultContent = [];
+          }
+        };
 
         for (let j = 0; j < block.messages.length; j++) {
           const message = block.messages[j];
@@ -357,6 +293,8 @@ export async function convertToAmazonBedrockChatMessages(
 
             switch (part.type) {
               case 'text': {
+                flushToolResultContent();
+
                 // Skip empty text blocks unless reasoning blocks are present
                 if (!part.text.trim() && !hasReasoningBlocks) {
                   break;
@@ -378,6 +316,8 @@ export async function convertToAmazonBedrockChatMessages(
               }
 
               case 'reasoning': {
+                flushToolResultContent();
+
                 const reasoningMetadata =
                   (await parseProviderOptions({
                     provider: 'amazonBedrock',
@@ -418,6 +358,8 @@ export async function convertToAmazonBedrockChatMessages(
               }
 
               case 'tool-call': {
+                flushToolResultContent();
+
                 amazonBedrockContent.push({
                   toolUse: {
                     toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
@@ -427,14 +369,38 @@ export async function convertToAmazonBedrockChatMessages(
                 });
                 break;
               }
+
+              case 'tool-result': {
+                flushAssistantContent();
+
+                toolResultContent.push({
+                  toolResult: {
+                    toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
+                    content: await convertToolResultOutput(
+                      part.output,
+                      generateDocumentName,
+                    ),
+                  },
+                });
+                pushCachePoint(toolResultContent, part.providerOptions);
+                break;
+              }
             }
 
-            pushCachePoint(amazonBedrockContent, part.providerOptions);
+            if (part.type !== 'tool-result') {
+              pushCachePoint(amazonBedrockContent, part.providerOptions);
+            }
           }
-          pushCachePoint(amazonBedrockContent, message.providerOptions);
+          pushCachePoint(
+            toolResultContent.length > 0
+              ? toolResultContent
+              : amazonBedrockContent,
+            message.providerOptions,
+          );
         }
 
-        messages.push({ role: 'assistant', content: amazonBedrockContent });
+        flushAssistantContent();
+        flushToolResultContent();
 
         break;
       }
@@ -447,6 +413,79 @@ export async function convertToAmazonBedrockChatMessages(
   }
 
   return { system, messages };
+}
+
+async function convertToolResultOutput(
+  output: LanguageModelV4ToolResultOutput,
+  generateDocumentName: () => string,
+): Promise<AmazonBedrockToolResultBlock['toolResult']['content']> {
+  switch (output.type) {
+    case 'content': {
+      return Promise.all(
+        output.value.map(async contentPart => {
+          switch (contentPart.type) {
+            case 'text':
+              return { text: contentPart.text };
+            case 'file': {
+              if (contentPart.data.type !== 'data') {
+                throw new UnsupportedFunctionalityError({
+                  functionality: `tool result file data of type "${contentPart.data.type}"`,
+                });
+              }
+
+              const fullMediaType = resolveFullMediaType({
+                part: contentPart,
+              });
+
+              if (getTopLevelMediaType(fullMediaType) !== 'image') {
+                const enableCitations = await shouldEnableCitations(
+                  contentPart.providerOptions,
+                );
+
+                return {
+                  document: {
+                    format: getAmazonBedrockDocumentFormat(fullMediaType),
+                    name: contentPart.filename
+                      ? stripFileExtension(contentPart.filename)
+                      : generateDocumentName(),
+                    source: {
+                      bytes: convertToBase64(contentPart.data.data),
+                    },
+                    ...(enableCitations && {
+                      citations: { enabled: true },
+                    }),
+                  },
+                };
+              }
+
+              return {
+                image: {
+                  format: getAmazonBedrockImageFormat(fullMediaType),
+                  source: {
+                    bytes: convertToBase64(contentPart.data.data),
+                  },
+                },
+              };
+            }
+            default: {
+              throw new UnsupportedFunctionalityError({
+                functionality: `unsupported tool content part type: ${contentPart.type}`,
+              });
+            }
+          }
+        }),
+      );
+    }
+    case 'text':
+    case 'error-text':
+      return [{ text: output.value }];
+    case 'execution-denied':
+      return [{ text: output.reason ?? 'Tool call execution denied.' }];
+    case 'json':
+    case 'error-json':
+    default:
+      return [{ text: JSON.stringify(output.value) }];
+  }
 }
 
 // wrap invalid tool call input because Bedrock requires it to be an object

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -90,6 +90,18 @@ export async function convertToAmazonBedrockChatMessages(
   let system: AmazonBedrockSystemMessages = [];
   const messages: AmazonBedrockMessages = [];
 
+  const appendMessage = (
+    message: AmazonBedrockAssistantMessage | AmazonBedrockUserMessage,
+  ) => {
+    const previousMessage = messages.at(-1);
+
+    if (previousMessage?.role === message.role) {
+      previousMessage.content.push(...message.content);
+    } else {
+      messages.push(message);
+    }
+  };
+
   let documentCounter = 0;
   const generateDocumentName = () => `document-${++documentCounter}`;
 
@@ -251,7 +263,7 @@ export async function convertToAmazonBedrockChatMessages(
           pushCachePoint(amazonBedrockContent, providerOptions);
         }
 
-        messages.push({ role: 'user', content: amazonBedrockContent });
+        appendMessage({ role: 'user', content: amazonBedrockContent });
 
         break;
       }
@@ -264,7 +276,7 @@ export async function convertToAmazonBedrockChatMessages(
 
         const flushAssistantContent = () => {
           if (amazonBedrockContent.length > 0) {
-            messages.push({
+            appendMessage({
               role: 'assistant',
               content: [...amazonBedrockContent],
             });
@@ -274,7 +286,7 @@ export async function convertToAmazonBedrockChatMessages(
 
         const flushToolResultContent = () => {
           if (toolResultContent.length > 0) {
-            messages.push({ role: 'user', content: toolResultContent });
+            appendMessage({ role: 'user', content: toolResultContent });
             toolResultContent = [];
           }
         };


### PR DESCRIPTION
## Summary

- serialize `tool-result` parts that appear in assistant message content as immediate Bedrock user `toolResult` messages
- share the Bedrock tool-result conversion path with standalone tool messages
- add regression coverage for inline assistant tool results and resumed assistant text after tool results

Fixes #11216

## Tests

- `npx pnpm@10.33.4 exec oxfmt --check packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts`
- `npx pnpm@10.33.4 -C packages/amazon-bedrock exec vitest --config vitest.node.config.js --run src/convert-to-amazon-bedrock-chat-messages.test.ts`
- `npx pnpm@10.33.4 -C packages/amazon-bedrock type-check`
- `npx pnpm@10.33.4 -C packages/amazon-bedrock test`
- `npx pnpm@10.33.4 turbo build --filter=@ai-sdk/amazon-bedrock...`