### PR TITLE
[v5.0] feat(provider/openai): support GPT-5.6 reasoning and prompt caching controls

### DIFF
--- a/.changeset/openai-gpt-5-6-controls.md
+++ b/.changeset/openai-gpt-5-6-controls.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add GPT-5.6 reasoning and prompt cache controls

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -189,15 +189,19 @@ The following provider options are available:
 - **user** _string_
   A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. Defaults to `undefined`.
 
-- **reasoningEffort** _'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'_
+- **reasoningEffort** _'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'_
   Reasoning effort for reasoning models. Defaults to `medium`. If you use `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
 
 <Note>
-  The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
-  models. Also, the 'xhigh' type for `reasoningEffort` is only available for
-  OpenAI's GPT-5.1-Codex-Max model. Setting `reasoningEffort` to 'none' or
-  'xhigh' with unsupported models will result in an error.
+  Supported reasoning efforts vary by model. GPT-5.6 supports `'none'`, `'low'`,
+  `'medium'`, `'high'`, `'xhigh'`, and `'max'`.
 </Note>
+
+- **reasoningMode** _'standard' | 'pro'_
+  Controls how much model work GPT-5.6 performs before returning a final answer. `'standard'` is the default. Use `'pro'` for difficult tasks where quality matters more than latency and token usage.
+
+- **reasoningContext** _'auto' | 'current_turn' | 'all_turns'_
+  Controls which available reasoning items GPT-5.6 can reuse. `'auto'` uses the model default, `'current_turn'` excludes reasoning from earlier turns, and `'all_turns'` makes compatible earlier reasoning available. The effective context is returned as `providerMetadata.openai.reasoningContext`.
 
 - **reasoningSummary** _'auto' | 'detailed'_
   Controls whether the model returns its reasoning process. Set to `'auto'` for a condensed summary, `'detailed'` for more comprehensive reasoning. Defaults to `undefined` (no reasoning summaries). When enabled, reasoning summaries appear in the stream as events with type `'reasoning'` and in non-streaming responses within the `reasoning` field.
@@ -231,8 +235,11 @@ The following provider options are available:
 - **promptCacheKey** _string_
   A cache key for manual prompt caching control. Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
 
+- **promptCacheOptions** _object_
+  Configures prompt caching for GPT-5.6 and later models. `mode` can be `'implicit'` or `'explicit'`, and `ttl` currently only supports `'30m'`. In explicit mode, only content blocks marked with a prompt cache breakpoint are cached.
+
 - **promptCacheRetention** _'in_memory' | '24h'_
-  The retention policy for the prompt cache. Set to `'24h'` to enable extended prompt caching, which keeps cached prefixes active for up to 24 hours. Defaults to `'in_memory'` for standard prompt caching. Note: `'24h'` is currently only available for the 5.1 series of models.
+  The legacy retention policy for models before GPT-5.6. Set to `'24h'` to enable extended prompt caching on supported models. For GPT-5.6 and later models, use `promptCacheOptions.ttl` instead.
 
 - **safetyIdentifier** _string_
   A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies. The IDs should be a string that uniquely identifies each user.
@@ -240,11 +247,20 @@ The following provider options are available:
 The OpenAI responses provider also returns provider-specific metadata:
 
 ```ts
-const { providerMetadata } = await generateText({
+const { usage, providerMetadata } = await generateText({
   model: openai.responses('gpt-5'),
 });
 
-const openaiMetadata = providerMetadata?.openai;
+const openaiMetadata = providerMetadata?.openai as
+  | {
+      responseId?: string;
+      reasoningContext?: string;
+      usage?: { cacheWriteTokens?: number };
+    }
+  | undefined;
+console.log('Cache reads:', usage.cachedInputTokens);
+console.log('Reasoning tokens:', usage.reasoningTokens);
+console.log('Cache writes:', openaiMetadata?.usage?.cacheWriteTokens);
 ```
 
 The following OpenAI-specific metadata is returned:
@@ -252,11 +268,11 @@ The following OpenAI-specific metadata is returned:
 - **responseId** _string_
   The ID of the response. Can be used to continue a conversation.
 
-- **cachedPromptTokens** _number_
-  The number of prompt tokens that were a cache hit.
+- **reasoningContext** _string_
+  The effective persisted-reasoning context returned by GPT-5.6.
 
-- **reasoningTokens** _number_
-  The number of reasoning tokens that the model generated.
+- **usage.cacheWriteTokens** _number_
+  The number of input tokens written to the prompt cache.
 
 #### Reasoning Output
 
@@ -731,11 +747,13 @@ The following optional provider options are available for OpenAI chat models:
   A unique identifier representing your end-user, which can help OpenAI to
   monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
-- **reasoningEffort** _'minimal' | 'low' | 'medium' | 'high' | 'xhigh'_
+- **reasoningEffort** _'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'_
 
   Reasoning effort for reasoning models. Defaults to `medium`. If you use
   `providerOptions` to set the `reasoningEffort` option, this
   model setting will be ignored.
+
+  Supported reasoning efforts vary by model. GPT-5.6 supports `'none'`, `'low'`, `'medium'`, `'high'`, `'xhigh'`, and `'max'`.
 
 - **structuredOutputs** _boolean_
 
@@ -781,9 +799,13 @@ The following optional provider options are available for OpenAI chat models:
 
   A cache key for manual prompt caching control. Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
 
+- **promptCacheOptions** _object_
+
+  Configures prompt caching for GPT-5.6 and later models. `mode` can be `'implicit'` or `'explicit'`, and `ttl` currently only supports `'30m'`. In explicit mode, only content blocks marked with a prompt cache breakpoint are cached.
+
 - **promptCacheRetention** _'in_memory' | '24h'_
 
-  The retention policy for the prompt cache. Set to `'24h'` to enable extended prompt caching, which keeps cached prefixes active for up to 24 hours. Defaults to `'in_memory'` for standard prompt caching. Note: `'24h'` is currently only available for the 5.1 series of models.
+  The legacy retention policy for models before GPT-5.6. Set to `'24h'` to enable extended prompt caching on supported models. For GPT-5.6 and later models, use `promptCacheOptions.ttl` instead.
 
 - **safetyIdentifier** _string_
 
@@ -803,13 +825,13 @@ They support additional settings and response metadata:
 
   - the `reasoningEffort` option (or alternatively the `reasoningEffort` model setting), which determines the amount of reasoning the model performs.
 
-- You can use response `providerMetadata` to access the number of reasoning tokens that the model generated.
+- You can use response `usage.reasoningTokens` to access the number of reasoning tokens that the model generated.
 
 ```ts highlight="4,7-11,17"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { text, usage } = await generateText({
   model: openai.chat('gpt-5'),
   prompt: 'Invent a new holiday and describe its traditions.',
   providerOptions: {
@@ -822,7 +844,7 @@ const { text, usage, providerMetadata } = await generateText({
 console.log(text);
 console.log('Usage:', {
   ...usage,
-  reasoningTokens: providerMetadata?.openai?.reasoningTokens,
+  reasoningTokens: usage.reasoningTokens,
 });
 ```
 
@@ -1054,7 +1076,7 @@ const rejectedPredictionTokens = openaiMetadata?.rejectedPredictionTokens;
 
 #### Image Detail
 
-You can use the `openai` provider option to set the [image input detail](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#specify-image-input-detail-level) to `high`, `low`, or `auto`:
+You can use the `openai` provider option to set the [image input detail](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#specify-image-input-detail-level) to `high`, `low`, `original`, or `auto`:
 
 ```ts highlight="13-16"
 const result = await generateText({
@@ -1079,6 +1101,8 @@ const result = await generateText({
   ],
 });
 ```
+
+For GPT-5.6, `original` preserves the input dimensions without resizing to a patch budget or pixel-dimension limit. `auto` and an omitted detail setting use the same sizing behavior as `original`, which can increase input token usage for large images.
 
 <Note type="warning">
   Because the `UIMessage` type (used by AI SDK UI hooks like `useChat`) does not
@@ -1128,35 +1152,31 @@ including `gpt-4o` and `gpt-4o-mini`.
 
 - Prompt caching is automatically enabled for these models, when the prompt is 1024 tokens or longer. It does
   not need to be explicitly enabled.
-- You can use response `providerMetadata` to access the number of prompt tokens that were a cache hit.
-- Note that caching behavior is dependent on load on OpenAI's infrastructure. Prompt prefixes generally remain in the
-  cache following 5-10 minutes of inactivity before they are evicted, but during off-peak periods they may persist for up
-  to an hour.
+- Cache reads are reported in `usage.cachedInputTokens`.
+- For GPT-5.6 and later models, cache writes are reported in `providerMetadata.openai.usage.cacheWriteTokens`.
+- For GPT-5.6 and later models, `promptCacheOptions.ttl` sets a minimum cache lifetime of 30 minutes. Earlier models generally retain in-memory prefixes for 5-10 minutes of inactivity, up to one hour.
 
-```ts highlight="11"
+```ts
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { text, usage } = await generateText({
   model: openai.chat('gpt-4o-mini'),
-  prompt: `A 1024-token or longer prompt...`,
+  prompt: 'A 1024-token or longer prompt...',
 });
 
-console.log(`usage:`, {
-  ...usage,
-  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
-});
+console.log('Cache reads:', usage.cachedInputTokens);
 ```
 
 To improve cache hit rates, you can manually control caching using the `promptCacheKey` option:
 
-```ts highlight="7-11"
+```ts
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
-const { text, usage, providerMetadata } = await generateText({
+const { usage } = await generateText({
   model: openai.chat('gpt-5'),
-  prompt: `A 1024-token or longer prompt...`,
+  prompt: 'A 1024-token or longer prompt...',
   providerOptions: {
     openai: {
       promptCacheKey: 'my-custom-cache-key-123',
@@ -1164,33 +1184,74 @@ const { text, usage, providerMetadata } = await generateText({
   },
 });
 
-console.log(`usage:`, {
-  ...usage,
-  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
-});
+console.log('Cache reads:', usage.cachedInputTokens);
 ```
 
-For GPT-5.1 models, you can enable extended prompt caching that keeps cached prefixes active for up to 24 hours:
+GPT-5.6 and later models support explicit cache breakpoints on system messages and supported text, image, and file content blocks. Set a request-level cache key and mark the end of each reusable prefix with `promptCacheBreakpoint`:
 
-```ts highlight="7-12"
-import { openai } from '@ai-sdk/openai';
+```ts
+import {
+  openai,
+  type OpenAIResponsesProviderOptions,
+} from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
 const { text, usage, providerMetadata } = await generateText({
+  model: openai.responses('gpt-5.6'),
+  providerOptions: {
+    openai: {
+      promptCacheKey: 'tenant:acme:support-v1',
+      promptCacheOptions: { mode: 'explicit', ttl: '30m' },
+    } satisfies OpenAIResponsesProviderOptions,
+  },
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'A stable prefix of at least 1024 tokens...',
+          providerOptions: {
+            openai: {
+              promptCacheBreakpoint: { mode: 'explicit' },
+            },
+          },
+        },
+        { type: 'text', text: 'What should I do next?' },
+      ],
+    },
+  ],
+});
+
+const openaiMetadata = providerMetadata?.openai as
+  | { usage?: { cacheWriteTokens?: number } }
+  | undefined;
+console.log('Cache reads:', usage.cachedInputTokens);
+console.log('Cache writes:', openaiMetadata?.usage?.cacheWriteTokens);
+```
+
+In `'implicit'` mode, OpenAI places an automatic breakpoint on the latest message and also honors explicit breakpoints. In `'explicit'` mode, only marked content blocks are eligible for caching; a request without any explicit breakpoint does not use prompt caching.
+
+In AI SDK v5, a breakpoint on a tool-result part applies to the whole tool result. When the result contains multiple nested output parts, the OpenAI provider places the API breakpoint on the final nested part because the v5 provider interface does not carry provider options on each nested output item.
+
+For models before GPT-5.6 that support extended caching, you can keep cached prefixes active for up to 24 hours:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const { usage } = await generateText({
   model: openai.chat('gpt-5.1'),
-  prompt: `A 1024-token or longer prompt...`,
+  prompt: 'A 1024-token or longer prompt...',
   providerOptions: {
     openai: {
       promptCacheKey: 'my-custom-cache-key-123',
-      promptCacheRetention: '24h', // Extended caching for GPT-5.1
+      promptCacheRetention: '24h',
     },
   },
 });
 
-console.log(`usage:`, {
-  ...usage,
-  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
-});
+console.log('Cache reads:', usage.cachedInputTokens);
 ```
 
 #### Audio Input

--- a/examples/ai-core/src/generate-text/openai-cached-prompt-tokens.ts
+++ b/examples/ai-core/src/generate-text/openai-cached-prompt-tokens.ts
@@ -166,7 +166,7 @@ async function main() {
 
   console.log();
 
-  await setTimeout(1000); // wait for it to be cached?g
+  await setTimeout(1000); // wait for the cache write to become available
 
   start = performance.now();
   const {
@@ -179,7 +179,7 @@ async function main() {
   console.log(`Second pass text:`, text2);
   console.log(`Second pass usage:`, usage2);
   console.log(`Second pass provider metadata:`, providerMetadata2);
-  console.log(`First pass time: ${Math.floor(end - start)} ms`);
+  console.log(`Second pass time: ${Math.floor(end - start)} ms`);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-responses-prompt-cache-explicit.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-prompt-cache-explicit.ts
@@ -1,0 +1,59 @@
+import { openai, type OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { randomUUID } from 'node:crypto';
+import { setTimeout } from 'node:timers/promises';
+import { run } from '../lib/run';
+
+const stablePrefix =
+  'A support ticket must include the account ID, incident time, observed behavior, expected behavior, and attempted mitigations. '.repeat(
+    128,
+  );
+const promptCacheKey =
+  'ai-sdk:gpt-5.6:responses-explicit-cache:' + randomUUID();
+
+async function generateWithCachedPrefix(question: string) {
+  return generateText({
+    model: openai.responses('gpt-5.6'),
+    maxOutputTokens: 80,
+    allowSystemInMessages: true,
+    messages: [
+      {
+        role: 'system',
+        content: stablePrefix,
+        providerOptions: {
+          openai: {
+            promptCacheBreakpoint: { mode: 'explicit' },
+          },
+        },
+      },
+      { role: 'user', content: question },
+    ],
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'none',
+        promptCacheKey,
+        promptCacheOptions: { mode: 'explicit', ttl: '30m' },
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+}
+
+run(async () => {
+  const firstResult = await generateWithCachedPrefix(
+    'Summarize the required ticket fields.',
+  );
+  console.log('First response:', firstResult.text);
+
+  await setTimeout(1000);
+
+  const secondResult = await generateWithCachedPrefix(
+    'Which required field describes troubleshooting already performed?',
+  );
+  console.log('Second response:', secondResult.text);
+
+  const firstOpenAIMetadata = firstResult.providerMetadata?.openai as
+    | { usage?: { cacheWriteTokens?: number } }
+    | undefined;
+  console.log('Cache writes:', firstOpenAIMetadata?.usage?.cacheWriteTokens);
+  console.log('Cache reads:', secondResult.usage.cachedInputTokens);
+});

--- a/examples/ai-core/src/generate-text/openai-responses-reasoning-context.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-reasoning-context.ts
@@ -1,0 +1,51 @@
+import { openai, type OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+type ReasoningContextMetadata = {
+  responseId?: string;
+  reasoningContext?: string;
+};
+
+run(async () => {
+  const firstResult = await generateText({
+    model: openai.responses('gpt-5.6'),
+    prompt:
+      'Create a reversible three-step launch plan for a new API without interrupting existing clients.',
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'low',
+        reasoningContext: 'all_turns',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  const firstMetadata = firstResult.providerMetadata?.openai as
+    | ReasoningContextMetadata
+    | undefined;
+  if (!firstMetadata?.responseId) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+
+  console.log('First response:', firstResult.text);
+  console.log('Effective reasoning context:', firstMetadata.reasoningContext);
+
+  const secondResult = await generateText({
+    model: openai.responses('gpt-5.6'),
+    prompt:
+      'Revise step two to include a measurable rollback trigger without changing the other steps.',
+    providerOptions: {
+      openai: {
+        previousResponseId: firstMetadata.responseId,
+        reasoningEffort: 'low',
+        reasoningContext: 'all_turns',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  const secondMetadata = secondResult.providerMetadata?.openai as
+    | ReasoningContextMetadata
+    | undefined;
+  console.log('Second response:', secondResult.text);
+  console.log('Effective reasoning context:', secondMetadata?.reasoningContext);
+});

--- a/examples/ai-core/src/generate-text/openai-responses-reasoning-pro.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-reasoning-pro.ts
@@ -1,0 +1,23 @@
+import { openai, type OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { performance } from 'node:perf_hooks';
+import { run } from '../lib/run';
+
+run(async () => {
+  const start = performance.now();
+  const result = await generateText({
+    model: openai.responses('gpt-5.6'),
+    prompt:
+      'Review this deployment order for failure modes: migrate the database, deploy the application, then take a backup. Return the three most important risks and a corrected order.',
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'medium',
+        reasoningMode: 'pro',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  console.log(result.text);
+  console.log('Duration:', Math.round(performance.now() - start), 'ms');
+  console.log('Usage:', result.usage);
+});

--- a/examples/ai-core/src/stream-text/openai-cached-prompt-tokens.ts
+++ b/examples/ai-core/src/stream-text/openai-cached-prompt-tokens.ts
@@ -153,19 +153,27 @@ function createCompletion() {
   });
 }
 
-async function main() {
-  let start = performance.now();
-  let result = await createCompletion();
-  let end = performance.now();
-  console.log(`duration: ${Math.floor(end - start)} ms`);
+async function runCompletion(label: string) {
+  const start = performance.now();
+  const result = createCompletion();
 
-  let fullResponse = '';
-  process.stdout.write('\nAssistant: ');
+  process.stdout.write(`\n${label} response: `);
   for await (const delta of result.textStream) {
-    fullResponse += delta;
     process.stdout.write(delta);
   }
-  process.stdout.write('\n\n');
+  const end = performance.now();
+  process.stdout.write('\n');
+  console.log(`${label} usage:`, await result.usage);
+  console.log(`${label} duration: ${Math.floor(end - start)} ms`);
+}
+
+async function main() {
+  console.log(`PLEASE NOTE caching behavior is transparent and difficult to test.
+If you don't get a cache hit the first time, try several additional times.`);
+
+  await runCompletion('First pass');
+  await setTimeout(1000);
+  await runCompletion('Second pass');
 }
 
 main()

--- a/examples/ai-core/src/stream-text/openai-chat-prompt-cache-explicit.ts
+++ b/examples/ai-core/src/stream-text/openai-chat-prompt-cache-explicit.ts
@@ -1,0 +1,69 @@
+import { openai, type OpenAIChatLanguageModelOptions } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { randomUUID } from 'node:crypto';
+import { setTimeout } from 'node:timers/promises';
+import { run } from '../lib/run';
+
+const stablePrefix =
+  'A support ticket must include the account ID, incident time, observed behavior, expected behavior, and attempted mitigations. '.repeat(
+    128,
+  );
+const promptCacheKey = 'ai-sdk:gpt-5.6:chat-explicit-cache:' + randomUUID();
+
+async function streamWithCachedPrefix(label: string, question: string) {
+  const result = streamText({
+    model: openai.chat('gpt-5.6'),
+    maxOutputTokens: 80,
+    allowSystemInMessages: true,
+    messages: [
+      {
+        role: 'system',
+        content: stablePrefix,
+        providerOptions: {
+          openai: {
+            promptCacheBreakpoint: { mode: 'explicit' },
+          },
+        },
+      },
+      { role: 'user', content: question },
+    ],
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'none',
+        promptCacheKey,
+        promptCacheOptions: { mode: 'explicit', ttl: '30m' },
+      } satisfies OpenAIChatLanguageModelOptions,
+    },
+  });
+
+  process.stdout.write(label + ' response: ');
+  for await (const textDelta of result.textStream) {
+    process.stdout.write(textDelta);
+  }
+  console.log();
+
+  return {
+    usage: await result.usage,
+    providerMetadata: await result.providerMetadata,
+  };
+}
+
+run(async () => {
+  const firstResult = await streamWithCachedPrefix(
+    'First',
+    'Summarize the required ticket fields.',
+  );
+
+  await setTimeout(1000);
+
+  const secondResult = await streamWithCachedPrefix(
+    'Second',
+    'Which required field describes troubleshooting already performed?',
+  );
+
+  const firstOpenAIMetadata = firstResult.providerMetadata?.openai as
+    | { usage?: { cacheWriteTokens?: number } }
+    | undefined;
+  console.log('Cache writes:', firstOpenAIMetadata?.usage?.cacheWriteTokens);
+  console.log('Cache reads:', secondResult.usage.cachedInputTokens);
+});

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-context.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-context.ts
@@ -1,0 +1,58 @@
+import { openai, type OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+type ReasoningContextMetadata = {
+  responseId?: string;
+  reasoningContext?: string;
+};
+
+run(async () => {
+  const firstResult = streamText({
+    model: openai.responses('gpt-5.6'),
+    prompt:
+      'Create a reversible three-step launch plan for a new API without interrupting existing clients.',
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'low',
+        reasoningContext: 'all_turns',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  for await (const textDelta of firstResult.textStream) {
+    process.stdout.write(textDelta);
+  }
+  console.log();
+
+  const firstMetadata = (await firstResult.providerMetadata)?.openai as
+    | ReasoningContextMetadata
+    | undefined;
+  if (!firstMetadata?.responseId) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+  console.log('Effective reasoning context:', firstMetadata.reasoningContext);
+
+  const secondResult = streamText({
+    model: openai.responses('gpt-5.6'),
+    prompt:
+      'Revise step two to include a measurable rollback trigger without changing the other steps.',
+    providerOptions: {
+      openai: {
+        previousResponseId: firstMetadata.responseId,
+        reasoningEffort: 'low',
+        reasoningContext: 'all_turns',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  for await (const textDelta of secondResult.textStream) {
+    process.stdout.write(textDelta);
+  }
+  console.log();
+
+  const secondMetadata = (await secondResult.providerMetadata)?.openai as
+    | ReasoningContextMetadata
+    | undefined;
+  console.log('Effective reasoning context:', secondMetadata?.reasoningContext);
+});

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-pro.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-pro.ts
@@ -1,0 +1,27 @@
+import { openai, type OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { performance } from 'node:perf_hooks';
+import { run } from '../lib/run';
+
+run(async () => {
+  const start = performance.now();
+  const result = streamText({
+    model: openai.responses('gpt-5.6'),
+    prompt:
+      'Review this deployment order for failure modes: migrate the database, deploy the application, then take a backup. Return the three most important risks and a corrected order.',
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'medium',
+        reasoningMode: 'pro',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  for await (const textDelta of result.textStream) {
+    process.stdout.write(textDelta);
+  }
+
+  console.log();
+  console.log('Duration:', Math.round(performance.now() - start), 'ms');
+  console.log('Usage:', await result.usage);
+});

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -23,6 +23,33 @@ describe('system messages', () => {
     ]);
   });
 
+  it('should add a prompt cache breakpoint to a system message', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+          providerOptions: {
+            openai: { promptCacheBreakpoint: { mode: 'explicit' } },
+          },
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a helpful assistant.',
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should remove system messages when requested', async () => {
     const result = convertToOpenAIChatMessages({
       prompt: [{ role: 'system', content: 'You are a helpful assistant.' }],
@@ -45,6 +72,70 @@ describe('user messages', () => {
     });
 
     expect(result.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+  });
+
+  it('should add prompt cache breakpoints to supported content blocks', () => {
+    const promptCacheBreakpoint = { mode: 'explicit' } as const;
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello',
+              providerOptions: { openai: { promptCacheBreakpoint } },
+            },
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: new URL('https://example.com/image.png'),
+              providerOptions: { openai: { promptCacheBreakpoint } },
+            },
+            {
+              type: 'file',
+              mediaType: 'audio/wav',
+              data: 'AAECAw==',
+              providerOptions: { openai: { promptCacheBreakpoint } },
+            },
+            {
+              type: 'file',
+              mediaType: 'application/pdf',
+              data: 'file-pdf-123',
+              providerOptions: { openai: { promptCacheBreakpoint } },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            prompt_cache_breakpoint: promptCacheBreakpoint,
+          },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/image.png' },
+            prompt_cache_breakpoint: promptCacheBreakpoint,
+          },
+          {
+            type: 'input_audio',
+            input_audio: { data: 'AAECAw==', format: 'wav' },
+            prompt_cache_breakpoint: promptCacheBreakpoint,
+          },
+          {
+            type: 'file',
+            file: { file_id: 'file-pdf-123' },
+            prompt_cache_breakpoint: promptCacheBreakpoint,
+          },
+        ],
+      },
+    ]);
   });
 
   it('should convert messages with image parts', async () => {
@@ -424,6 +515,74 @@ describe('user messages', () => {
 });
 
 describe('tool calls', () => {
+  it('should add a prompt cache breakpoint to assistant text content', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'Cached assistant content',
+              providerOptions: {
+                openai: { promptCacheBreakpoint: { mode: 'explicit' } },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Cached assistant content',
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+        tool_calls: undefined,
+      },
+    ]);
+  });
+
+  it('should add a prompt cache breakpoint to tool text content', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'cached-tool',
+              toolName: 'cached-tool',
+              output: { type: 'text', value: 'Cached tool content' },
+              providerOptions: {
+                openai: { promptCacheBreakpoint: { mode: 'explicit' } },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'text',
+            text: 'Cached tool content',
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+        tool_call_id: 'cached-tool',
+      },
+    ]);
+  });
+
   it('should stringify arguments to tool calls', () => {
     const result = convertToOpenAIChatMessages({
       prompt: [

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -1,10 +1,21 @@
 import {
   type LanguageModelV2CallWarning,
   type LanguageModelV2Prompt,
+  type SharedV2ProviderOptions,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import type { OpenAIChatPrompt } from './openai-chat-prompt';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
+
+type OpenAIPromptCacheBreakpoint = { mode: 'explicit' };
+
+function getPromptCacheBreakpoint(
+  providerOptions: SharedV2ProviderOptions | undefined,
+): OpenAIPromptCacheBreakpoint | undefined {
+  return providerOptions?.openai?.promptCacheBreakpoint as
+    | OpenAIPromptCacheBreakpoint
+    | undefined;
+}
 
 export function convertToOpenAIChatMessages({
   prompt,
@@ -19,16 +30,44 @@ export function convertToOpenAIChatMessages({
   const messages: OpenAIChatPrompt = [];
   const warnings: Array<LanguageModelV2CallWarning> = [];
 
-  for (const { role, content } of prompt) {
+  for (const { role, content, providerOptions } of prompt) {
     switch (role) {
       case 'system': {
         switch (systemMessageMode) {
           case 'system': {
-            messages.push({ role: 'system', content });
+            const promptCacheBreakpoint =
+              getPromptCacheBreakpoint(providerOptions);
+            messages.push({
+              role: 'system',
+              content:
+                promptCacheBreakpoint == null
+                  ? content
+                  : [
+                      {
+                        type: 'text',
+                        text: content,
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ],
+            });
             break;
           }
           case 'developer': {
-            messages.push({ role: 'developer', content });
+            const promptCacheBreakpoint =
+              getPromptCacheBreakpoint(providerOptions);
+            messages.push({
+              role: 'developer',
+              content:
+                promptCacheBreakpoint == null
+                  ? content
+                  : [
+                      {
+                        type: 'text',
+                        text: content,
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ],
+            });
             break;
           }
           case 'remove': {
@@ -49,7 +88,11 @@ export function convertToOpenAIChatMessages({
       }
 
       case 'user': {
-        if (content.length === 1 && content[0].type === 'text') {
+        if (
+          content.length === 1 &&
+          content[0].type === 'text' &&
+          getPromptCacheBreakpoint(content[0].providerOptions) == null
+        ) {
           messages.push({ role: 'user', content: content[0].text });
           break;
         }
@@ -59,9 +102,21 @@ export function convertToOpenAIChatMessages({
           content: content.map((part, index) => {
             switch (part.type) {
               case 'text': {
-                return { type: 'text', text: part.text };
+                const promptCacheBreakpoint = getPromptCacheBreakpoint(
+                  part.providerOptions,
+                );
+                return {
+                  type: 'text',
+                  text: part.text,
+                  ...(promptCacheBreakpoint != null && {
+                    prompt_cache_breakpoint: promptCacheBreakpoint,
+                  }),
+                };
               }
               case 'file': {
+                const promptCacheBreakpoint = getPromptCacheBreakpoint(
+                  part.providerOptions,
+                );
                 if (part.mediaType.startsWith('image/')) {
                   const mediaType =
                     part.mediaType === 'image/*'
@@ -79,6 +134,9 @@ export function convertToOpenAIChatMessages({
                       // OpenAI specific extension: image detail
                       detail: part.providerOptions?.openai?.imageDetail,
                     },
+                    ...(promptCacheBreakpoint != null && {
+                      prompt_cache_breakpoint: promptCacheBreakpoint,
+                    }),
                   };
                 } else if (part.mediaType.startsWith('audio/')) {
                   if (part.data instanceof URL) {
@@ -95,6 +153,9 @@ export function convertToOpenAIChatMessages({
                           data: convertToBase64(part.data),
                           format: 'wav',
                         },
+                        ...(promptCacheBreakpoint != null && {
+                          prompt_cache_breakpoint: promptCacheBreakpoint,
+                        }),
                       };
                     }
                     case 'audio/mp3':
@@ -105,6 +166,9 @@ export function convertToOpenAIChatMessages({
                           data: convertToBase64(part.data),
                           format: 'mp3',
                         },
+                        ...(promptCacheBreakpoint != null && {
+                          prompt_cache_breakpoint: promptCacheBreakpoint,
+                        }),
                       };
                     }
 
@@ -131,6 +195,9 @@ export function convertToOpenAIChatMessages({
                             filename: part.filename ?? `part-${index}.pdf`,
                             file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
                           },
+                    ...(promptCacheBreakpoint != null && {
+                      prompt_cache_breakpoint: promptCacheBreakpoint,
+                    }),
                   };
                 } else {
                   throw new UnsupportedFunctionalityError({
@@ -147,6 +214,12 @@ export function convertToOpenAIChatMessages({
 
       case 'assistant': {
         let text = '';
+        const textParts: Array<{
+          type: 'text';
+          text: string;
+          prompt_cache_breakpoint?: OpenAIPromptCacheBreakpoint;
+        }> = [];
+        let hasPromptCacheBreakpoint = false;
         const toolCalls: Array<{
           id: string;
           type: 'function';
@@ -156,7 +229,18 @@ export function convertToOpenAIChatMessages({
         for (const part of content) {
           switch (part.type) {
             case 'text': {
+              const promptCacheBreakpoint = getPromptCacheBreakpoint(
+                part.providerOptions,
+              );
               text += part.text;
+              textParts.push({
+                type: 'text',
+                text: part.text,
+                ...(promptCacheBreakpoint != null && {
+                  prompt_cache_breakpoint: promptCacheBreakpoint,
+                }),
+              });
+              hasPromptCacheBreakpoint ||= promptCacheBreakpoint != null;
               break;
             }
             case 'tool-call': {
@@ -175,7 +259,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: hasPromptCacheBreakpoint ? textParts : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 
@@ -185,6 +269,9 @@ export function convertToOpenAIChatMessages({
       case 'tool': {
         for (const toolResponse of content) {
           const output = toolResponse.output;
+          const promptCacheBreakpoint = getPromptCacheBreakpoint(
+            toolResponse.providerOptions,
+          );
 
           let contentValue: string;
           switch (output.type) {
@@ -202,7 +289,16 @@ export function convertToOpenAIChatMessages({
           messages.push({
             role: 'tool',
             tool_call_id: toolResponse.toolCallId,
-            content: contentValue,
+            content:
+              promptCacheBreakpoint == null
+                ? contentValue
+                : [
+                    {
+                      type: 'text',
+                      text: contentValue,
+                      prompt_cache_breakpoint: promptCacheBreakpoint,
+                    },
+                  ],
           });
         }
         break;

--- a/packages/openai/src/chat/openai-chat-api.ts
+++ b/packages/openai/src/chat/openai-chat-api.ts
@@ -92,6 +92,7 @@ export const openaiChatResponseSchema = lazyValidator(() =>
           prompt_tokens_details: z
             .object({
               cached_tokens: z.number().nullish(),
+              cache_write_tokens: z.number().nullish(),
             })
             .nullish(),
           completion_tokens_details: z
@@ -180,6 +181,7 @@ export const openaiChatChunkSchema = lazyValidator(() =>
             prompt_tokens_details: z
               .object({
                 cached_tokens: z.number().nullish(),
+                cache_write_tokens: z.number().nullish(),
               })
               .nullish(),
             completion_tokens_details: z

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -195,6 +195,7 @@ describe('doGenerate', () => {
       };
       prompt_tokens_details?: {
         cached_tokens?: number;
+        cache_write_tokens?: number | null;
       };
     };
     finish_reason?: string;
@@ -295,6 +296,7 @@ describe('doGenerate', () => {
           "prediction": undefined,
           "presence_penalty": undefined,
           "prompt_cache_key": undefined,
+          "prompt_cache_options": undefined,
           "prompt_cache_retention": undefined,
           "reasoning_effort": undefined,
           "response_format": undefined,
@@ -540,6 +542,25 @@ describe('doGenerate', () => {
       model: 'gpt-5.1-codex-max',
       messages: [{ role: 'user', content: 'Hello' }],
       reasoning_effort: 'xhigh',
+    });
+  });
+
+  it('should pass reasoningEffort max setting', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const model = provider.chat('gpt-5.6');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: { reasoningEffort: 'max' },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-5.6',
+      messages: [{ role: 'user', content: 'Hello' }],
+      reasoning_effort: 'max',
     });
   });
 
@@ -1210,6 +1231,35 @@ describe('doGenerate', () => {
     `);
   });
 
+  it.each([
+    { cacheWriteTokens: 0, expectedUsage: { cacheWriteTokens: 0 } },
+    { cacheWriteTokens: null, expectedUsage: undefined },
+  ])(
+    'should expose cache write tokens $cacheWriteTokens in provider metadata',
+    async ({ cacheWriteTokens, expectedUsage }) => {
+      prepareJsonResponse({
+        usage: {
+          prompt_tokens: 15,
+          completion_tokens: 20,
+          total_tokens: 35,
+          prompt_tokens_details: {
+            cache_write_tokens: cacheWriteTokens,
+          },
+        },
+      });
+
+      const result = await provider.chat('gpt-5.6').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.providerMetadata).toStrictEqual({
+        openai: {
+          ...(expectedUsage != null && { usage: expectedUsage }),
+        },
+      });
+    },
+  );
+
   it('should return accepted_prediction_tokens and rejected_prediction_tokens in completion_details_tokens', async () => {
     prepareJsonResponse({
       usage: {
@@ -1454,6 +1504,31 @@ describe('doGenerate', () => {
       model: 'gpt-3.5-turbo',
       messages: [{ role: 'user', content: 'Hello' }],
       prompt_cache_key: 'test-cache-key-123',
+    });
+  });
+
+  it('should send promptCacheOptions extension value', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await provider.chat('gpt-5.6').doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          promptCacheOptions: {
+            mode: 'explicit',
+            ttl: '30m',
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-5.6',
+      messages: [{ role: 'user', content: 'Hello' }],
+      prompt_cache_options: {
+        mode: 'explicit',
+        ttl: '30m',
+      },
     });
   });
 
@@ -1745,6 +1820,7 @@ describe('doStream', () => {
       completion_tokens: number;
       prompt_tokens_details?: {
         cached_tokens?: number;
+        cache_write_tokens?: number | null;
       };
       completion_tokens_details?: {
         reasoning_tokens?: number;
@@ -2682,6 +2758,7 @@ describe('doStream', () => {
           "prediction": undefined,
           "presence_penalty": undefined,
           "prompt_cache_key": undefined,
+          "prompt_cache_options": undefined,
           "prompt_cache_retention": undefined,
           "reasoning_effort": undefined,
           "response_format": undefined,
@@ -2816,6 +2893,43 @@ describe('doStream', () => {
         }
       `);
   });
+
+  it.each([
+    { cacheWriteTokens: 0, expectedUsage: { cacheWriteTokens: 0 } },
+    { cacheWriteTokens: null, expectedUsage: undefined },
+  ])(
+    'should expose streaming cache write tokens $cacheWriteTokens in provider metadata',
+    async ({ cacheWriteTokens, expectedUsage }) => {
+      prepareStreamResponse({
+        content: [],
+        usage: {
+          prompt_tokens: 15,
+          completion_tokens: 20,
+          total_tokens: 35,
+          prompt_tokens_details: {
+            cache_write_tokens: cacheWriteTokens,
+          },
+        },
+      });
+
+      const { stream } = await provider.chat('gpt-5.6').doStream({
+        prompt: TEST_PROMPT,
+      });
+      const finish = (await convertReadableStreamToArray(stream)).at(-1);
+
+      expect(finish).toMatchObject({
+        type: 'finish',
+        providerMetadata: {
+          openai: {
+            ...(expectedUsage != null && { usage: expectedUsage }),
+          },
+        },
+      });
+      if (expectedUsage == null) {
+        expect(finish).not.toHaveProperty('providerMetadata.openai.usage');
+      }
+    },
+  );
 
   it('should return accepted_prediction_tokens and rejected_prediction_tokens in providerMetadata', async () => {
     prepareStreamResponse({

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -177,6 +177,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       reasoning_effort: openaiOptions.reasoningEffort,
       service_tier: openaiOptions.serviceTier,
       prompt_cache_key: openaiOptions.promptCacheKey,
+      prompt_cache_options: openaiOptions.promptCacheOptions,
       prompt_cache_retention: openaiOptions.promptCacheRetention,
       safety_identifier: openaiOptions.safetyIdentifier,
 
@@ -387,6 +388,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       providerMetadata.openai.rejectedPredictionTokens =
         completionTokenDetails?.rejected_prediction_tokens;
     }
+    if (promptTokenDetails?.cache_write_tokens != null) {
+      providerMetadata.openai.usage = {
+        cacheWriteTokens: promptTokenDetails.cache_write_tokens,
+      };
+    }
     if (choice.logprobs?.content != null) {
       providerMetadata.openai.logprobs = choice.logprobs.content;
     }
@@ -515,6 +521,14 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
                 undefined;
               usage.cachedInputTokens =
                 value.usage.prompt_tokens_details?.cached_tokens ?? undefined;
+              if (
+                value.usage.prompt_tokens_details?.cache_write_tokens != null
+              ) {
+                providerMetadata.openai.usage = {
+                  cacheWriteTokens:
+                    value.usage.prompt_tokens_details.cache_write_tokens,
+                };
+              }
 
               if (
                 value.usage.completion_tokens_details

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -100,7 +100,7 @@ export const openaiChatLanguageModelOptions = lazyValidator(() =>
        * Reasoning effort for reasoning models. Defaults to `medium`.
        */
       reasoningEffort: z
-        .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+        .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
         .optional(),
 
       /**
@@ -162,10 +162,24 @@ export const openaiChatLanguageModelOptions = lazyValidator(() =>
       promptCacheKey: z.string().optional(),
 
       /**
+       * Prompt cache behavior for GPT-5.6 and later models.
+       * `mode` controls whether OpenAI also places an implicit breakpoint.
+       * `ttl` sets the minimum cache lifetime and currently only supports 30 minutes.
+       */
+      promptCacheOptions: z
+        .object({
+          mode: z.enum(['implicit', 'explicit']).optional(),
+          ttl: z.literal('30m').optional(),
+        })
+        .optional(),
+
+      /**
        * The retention policy for the prompt cache.
        * - 'in_memory': Default. Standard prompt caching behavior.
        * - '24h': Extended prompt caching that keeps cached prefixes active for up to 24 hours.
-       *          Currently only available for 5.1 series models.
+       *          Available for models before GPT-5.6 that support extended caching.
+       *
+       * @deprecated For GPT-5.6 and later models, use `promptCacheOptions.ttl`.
        *
        * @default 'in_memory'
        */

--- a/packages/openai/src/chat/openai-chat-prompt.ts
+++ b/packages/openai/src/chat/openai-chat-prompt.ts
@@ -9,12 +9,12 @@ export type ChatCompletionMessage =
 
 export interface ChatCompletionSystemMessage {
   role: 'system';
-  content: string;
+  content: string | Array<ChatCompletionContentPartText>;
 }
 
 export interface ChatCompletionDeveloperMessage {
   role: 'developer';
-  content: string;
+  content: string | Array<ChatCompletionContentPartText>;
 }
 
 export interface ChatCompletionUserMessage {
@@ -31,26 +31,30 @@ export type ChatCompletionContentPart =
 export interface ChatCompletionContentPartText {
   type: 'text';
   text: string;
+  prompt_cache_breakpoint?: { mode: 'explicit' };
 }
 
 export interface ChatCompletionContentPartImage {
   type: 'image_url';
   image_url: { url: string };
+  prompt_cache_breakpoint?: { mode: 'explicit' };
 }
 
 export interface ChatCompletionContentPartInputAudio {
   type: 'input_audio';
   input_audio: { data: string; format: 'wav' | 'mp3' };
+  prompt_cache_breakpoint?: { mode: 'explicit' };
 }
 
 export interface ChatCompletionContentPartFile {
   type: 'file';
   file: { filename: string; file_data: string } | { file_id: string };
+  prompt_cache_breakpoint?: { mode: 'explicit' };
 }
 
 export interface ChatCompletionAssistantMessage {
   role: 'assistant';
-  content?: string | null;
+  content?: string | null | Array<ChatCompletionContentPartText>;
   tool_calls?: Array<ChatCompletionMessageToolCall>;
 }
 
@@ -65,6 +69,6 @@ export interface ChatCompletionMessageToolCall {
 
 export interface ChatCompletionToolMessage {
   role: 'tool';
-  content: string;
+  content: string | Array<ChatCompletionContentPartText>;
   tool_call_id: string;
 }

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -23,6 +23,35 @@ describe('convertToOpenAIResponsesInput', () => {
       expect(result.input).toEqual([{ role: 'developer', content: 'Hello' }]);
     });
 
+    it('should add a prompt cache breakpoint to a system message', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'system',
+            content: 'Hello',
+            providerOptions: {
+              openai: { promptCacheBreakpoint: { mode: 'explicit' } },
+            },
+          },
+        ],
+        systemMessageMode: 'developer',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'developer',
+          content: [
+            {
+              type: 'input_text',
+              text: 'Hello',
+              prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should remove system messages', async () => {
       const result = await convertToOpenAIResponsesInput({
         prompt: [{ role: 'system', content: 'Hello' }],
@@ -49,6 +78,63 @@ describe('convertToOpenAIResponsesInput', () => {
 
       expect(result.input).toEqual([
         { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ]);
+    });
+
+    it('should add prompt cache breakpoints to supported content blocks', async () => {
+      const promptCacheBreakpoint = { mode: 'explicit' } as const;
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+                providerOptions: { openai: { promptCacheBreakpoint } },
+              },
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: new URL('https://example.com/image.png'),
+                providerOptions: { openai: { promptCacheBreakpoint } },
+              },
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: 'file-pdf-123',
+                providerOptions: { openai: { promptCacheBreakpoint } },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        fileIdPrefixes: ['file-'],
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: 'Hello',
+              prompt_cache_breakpoint: promptCacheBreakpoint,
+            },
+            {
+              type: 'input_image',
+              image_url: 'https://example.com/image.png',
+              detail: undefined,
+              prompt_cache_breakpoint: promptCacheBreakpoint,
+            },
+            {
+              type: 'input_file',
+              file_id: 'file-pdf-123',
+              prompt_cache_breakpoint: promptCacheBreakpoint,
+            },
+          ],
+        },
       ]);
     });
 
@@ -1754,6 +1840,94 @@ describe('convertToOpenAIResponsesInput', () => {
   });
 
   describe('tool messages', () => {
+    it('should add a prompt cache breakpoint to a text tool result', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'search',
+                output: {
+                  type: 'text',
+                  value: 'Cached tool output',
+                },
+                providerOptions: {
+                  openai: { promptCacheBreakpoint: { mode: 'explicit' } },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: [
+            {
+              type: 'input_text',
+              text: 'Cached tool output',
+              prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should place a tool-result-level breakpoint on the final nested output part', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'search',
+                output: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'First part' },
+                    {
+                      type: 'media',
+                      mediaType: 'image/png',
+                      data: 'base64_data',
+                    },
+                  ],
+                },
+                providerOptions: {
+                  openai: { promptCacheBreakpoint: { mode: 'explicit' } },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: [
+            { type: 'input_text', text: 'First part' },
+            {
+              type: 'input_image',
+              image_url: 'data:image/png;base64,base64_data',
+              prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should convert single tool result part with json value', async () => {
       const result = await convertToOpenAIResponsesInput({
         prompt: [

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -2,6 +2,7 @@ import {
   type LanguageModelV2CallWarning,
   type LanguageModelV2Prompt,
   type LanguageModelV2ToolCallPart,
+  type SharedV2ProviderOptions,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
@@ -20,6 +21,16 @@ import type {
   OpenAIResponsesInput,
   OpenAIResponsesReasoning,
 } from './openai-responses-api';
+
+type OpenAIPromptCacheBreakpoint = { mode: 'explicit' };
+
+function getPromptCacheBreakpoint(
+  providerOptions: SharedV2ProviderOptions | undefined,
+): OpenAIPromptCacheBreakpoint | undefined {
+  return providerOptions?.openai?.promptCacheBreakpoint as
+    | OpenAIPromptCacheBreakpoint
+    | undefined;
+}
 
 /**
  * Check if a string is a file ID based on the given prefixes
@@ -49,16 +60,44 @@ export async function convertToOpenAIResponsesInput({
   let input: OpenAIResponsesInput = [];
   const warnings: Array<LanguageModelV2CallWarning> = [];
 
-  for (const { role, content } of prompt) {
+  for (const { role, content, providerOptions } of prompt) {
     switch (role) {
       case 'system': {
         switch (systemMessageMode) {
           case 'system': {
-            input.push({ role: 'system', content });
+            const promptCacheBreakpoint =
+              getPromptCacheBreakpoint(providerOptions);
+            input.push({
+              role: 'system',
+              content:
+                promptCacheBreakpoint == null
+                  ? content
+                  : [
+                      {
+                        type: 'input_text',
+                        text: content,
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ],
+            });
             break;
           }
           case 'developer': {
-            input.push({ role: 'developer', content });
+            const promptCacheBreakpoint =
+              getPromptCacheBreakpoint(providerOptions);
+            input.push({
+              role: 'developer',
+              content:
+                promptCacheBreakpoint == null
+                  ? content
+                  : [
+                      {
+                        type: 'input_text',
+                        text: content,
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ],
+            });
             break;
           }
           case 'remove': {
@@ -84,9 +123,21 @@ export async function convertToOpenAIResponsesInput({
           content: content.map((part, index) => {
             switch (part.type) {
               case 'text': {
-                return { type: 'input_text', text: part.text };
+                const promptCacheBreakpoint = getPromptCacheBreakpoint(
+                  part.providerOptions,
+                );
+                return {
+                  type: 'input_text',
+                  text: part.text,
+                  ...(promptCacheBreakpoint != null && {
+                    prompt_cache_breakpoint: promptCacheBreakpoint,
+                  }),
+                };
               }
               case 'file': {
+                const promptCacheBreakpoint = getPromptCacheBreakpoint(
+                  part.providerOptions,
+                );
                 if (part.mediaType.startsWith('image/')) {
                   const mediaType =
                     part.mediaType === 'image/*'
@@ -104,12 +155,18 @@ export async function convertToOpenAIResponsesInput({
                             image_url: `data:${mediaType};base64,${convertToBase64(part.data)}`,
                           }),
                     detail: part.providerOptions?.openai?.imageDetail,
+                    ...(promptCacheBreakpoint != null && {
+                      prompt_cache_breakpoint: promptCacheBreakpoint,
+                    }),
                   };
                 } else if (part.mediaType === 'application/pdf') {
                   if (part.data instanceof URL) {
                     return {
                       type: 'input_file',
                       file_url: part.data.toString(),
+                      ...(promptCacheBreakpoint != null && {
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      }),
                     };
                   }
                   return {
@@ -121,6 +178,9 @@ export async function convertToOpenAIResponsesInput({
                           filename: part.filename ?? `part-${index}.pdf`,
                           file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
                         }),
+                    ...(promptCacheBreakpoint != null && {
+                      prompt_cache_breakpoint: promptCacheBreakpoint,
+                    }),
                   };
                 } else {
                   throw new UnsupportedFunctionalityError({
@@ -309,6 +369,9 @@ export async function convertToOpenAIResponsesInput({
       case 'tool': {
         for (const part of content) {
           const output = part.output;
+          const promptCacheBreakpoint = getPromptCacheBreakpoint(
+            part.providerOptions,
+          );
 
           if (
             hasLocalShellTool &&
@@ -332,28 +395,61 @@ export async function convertToOpenAIResponsesInput({
           switch (output.type) {
             case 'text':
             case 'error-text':
-              contentValue = output.value;
+              contentValue =
+                promptCacheBreakpoint == null
+                  ? output.value
+                  : [
+                      {
+                        type: 'input_text',
+                        text: output.value,
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ];
               break;
             case 'json':
             case 'error-json':
-              contentValue = JSON.stringify(output.value);
+              contentValue =
+                promptCacheBreakpoint == null
+                  ? JSON.stringify(output.value)
+                  : [
+                      {
+                        type: 'input_text',
+                        text: JSON.stringify(output.value),
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ];
               break;
             case 'content':
-              contentValue = output.value.map(item => {
+              contentValue = output.value.map((item, index) => {
+                const isBreakpoint =
+                  promptCacheBreakpoint != null &&
+                  index === output.value.length - 1;
                 switch (item.type) {
                   case 'text': {
-                    return { type: 'input_text' as const, text: item.text };
+                    return {
+                      type: 'input_text' as const,
+                      text: item.text,
+                      ...(isBreakpoint && {
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      }),
+                    };
                   }
                   case 'media': {
                     return item.mediaType.startsWith('image/')
                       ? {
                           type: 'input_image' as const,
                           image_url: `data:${item.mediaType};base64,${item.data}`,
+                          ...(isBreakpoint && {
+                            prompt_cache_breakpoint: promptCacheBreakpoint,
+                          }),
                         }
                       : {
                           type: 'input_file' as const,
                           filename: 'data',
                           file_data: `data:${item.mediaType};base64,${item.data}`,
+                          ...(isBreakpoint && {
+                            prompt_cache_breakpoint: promptCacheBreakpoint,
+                          }),
                         };
                   }
                 }

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -36,18 +36,49 @@ export type OpenAIResponsesIncludeOptions =
 
 export type OpenAIResponsesSystemMessage = {
   role: 'system' | 'developer';
-  content: string;
+  content:
+    | string
+    | Array<{
+        type: 'input_text';
+        text: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }>;
 };
 
 export type OpenAIResponsesUserMessage = {
   role: 'user';
   content: Array<
-    | { type: 'input_text'; text: string }
-    | { type: 'input_image'; image_url: string }
-    | { type: 'input_image'; file_id: string }
-    | { type: 'input_file'; file_url: string }
-    | { type: 'input_file'; filename: string; file_data: string }
-    | { type: 'input_file'; file_id: string }
+    | {
+        type: 'input_text';
+        text: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }
+    | {
+        type: 'input_image';
+        image_url: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }
+    | {
+        type: 'input_image';
+        file_id: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }
+    | {
+        type: 'input_file';
+        file_url: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }
+    | {
+        type: 'input_file';
+        filename: string;
+        file_data: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }
+    | {
+        type: 'input_file';
+        file_id: string;
+        prompt_cache_breakpoint?: { mode: 'explicit' };
+      }
   >;
 };
 
@@ -72,9 +103,22 @@ export type OpenAIResponsesFunctionCallOutput = {
   output:
     | string
     | Array<
-        | { type: 'input_text'; text: string }
-        | { type: 'input_image'; image_url: string }
-        | { type: 'input_file'; filename: string; file_data: string }
+        | {
+            type: 'input_text';
+            text: string;
+            prompt_cache_breakpoint?: { mode: 'explicit' };
+          }
+        | {
+            type: 'input_image';
+            image_url: string;
+            prompt_cache_breakpoint?: { mode: 'explicit' };
+          }
+        | {
+            type: 'input_file';
+            filename: string;
+            file_data: string;
+            prompt_cache_breakpoint?: { mode: 'explicit' };
+          }
       >;
 };
 
@@ -261,6 +305,7 @@ export const openaiResponsesChunkSchema = lazyValidator(() =>
             input_tokens_details: z
               .object({
                 cached_tokens: z.number().nullish(),
+                cache_write_tokens: z.number().nullish(),
                 orchestration_input_tokens: z.number().nullish(),
                 orchestration_input_cached_tokens: z.number().nullish(),
               })
@@ -273,6 +318,11 @@ export const openaiResponsesChunkSchema = lazyValidator(() =>
               })
               .nullish(),
           }),
+          reasoning: z
+            .object({
+              context: z.string().nullish(),
+            })
+            .nullish(),
           service_tier: z.string().nullish(),
         }),
       }),
@@ -736,6 +786,11 @@ export const openaiResponsesResponseSchema = lazyValidator(() =>
         )
         .optional(),
       service_tier: z.string().nullish(),
+      reasoning: z
+        .object({
+          context: z.string().nullish(),
+        })
+        .nullish(),
       incomplete_details: z.object({ reason: z.string() }).nullish(),
       usage: z
         .object({
@@ -743,6 +798,7 @@ export const openaiResponsesResponseSchema = lazyValidator(() =>
           input_tokens_details: z
             .object({
               cached_tokens: z.number().nullish(),
+              cache_write_tokens: z.number().nullish(),
               orchestration_input_tokens: z.number().nullish(),
               orchestration_input_cached_tokens: z.number().nullish(),
             })

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -132,6 +132,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           reasoning: {
             effort: null,
             summary: null,
+            context: 'current_turn',
           },
           store: true,
           temperature: 1,
@@ -235,6 +236,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               input_tokens: 120,
               input_tokens_details: {
                 cached_tokens: 0,
+                cache_write_tokens: 0,
                 orchestration_input_tokens: 40,
                 orchestration_input_cached_tokens: 10,
               },
@@ -257,6 +259,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         // Sakana-style orchestration usage is surfaced via provider metadata so
         // downstream consumers (e.g. the AI Gateway) can bill it.
         expect(result.providerMetadata?.openai.usage).toStrictEqual({
+          cacheWriteTokens: 0,
           orchestrationInputTokens: 40,
           orchestrationInputCachedTokens: 10,
           orchestrationOutputTokens: 25,
@@ -339,6 +342,7 @@ describe('OpenAIResponsesLanguageModel', () => {
 
         expect(result.providerMetadata).toStrictEqual({
           openai: {
+            reasoningContext: 'current_turn',
             responseId: 'resp_67c97c0203188190a025beb4a75242bc',
           },
         });
@@ -897,6 +901,97 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send GPT-5.6 reasoning effort, mode, and context', async () => {
+        const { warnings } = await createModel('gpt-5.6').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningEffort: 'max',
+              reasoningMode: 'pro',
+              reasoningContext: 'all_turns',
+            } satisfies OpenAIResponsesProviderOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5.6',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+          reasoning: {
+            effort: 'max',
+            mode: 'pro',
+            context: 'all_turns',
+          },
+        });
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send reasoning mode without overriding the default effort', async () => {
+        const { warnings } = await createModel('gpt-5.6').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningMode: 'pro',
+              reasoningContext: 'auto',
+            } satisfies OpenAIResponsesProviderOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5.6',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+          reasoning: {
+            mode: 'pro',
+            context: 'auto',
+          },
+        });
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should warn about GPT-5.6 reasoning controls on non-reasoning models', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningMode: 'pro',
+              reasoningContext: 'all_turns',
+            } satisfies OpenAIResponsesProviderOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-4o',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+        });
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported-setting',
+            setting: 'reasoningMode',
+            details: 'reasoningMode is not supported for non-reasoning models',
+          },
+          {
+            type: 'unsupported-setting',
+            setting: 'reasoningContext',
+            details:
+              'reasoningContext is not supported for non-reasoning models',
+          },
+        ]);
+      });
+
       it.each(nonReasoningModelIds)(
         'should not send and warn about unsupported reasoningEffort and reasoningSummary provider options for %s',
         async modelId => {
@@ -1113,6 +1208,32 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt_cache_key: 'test-cache-key-123',
         });
 
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send promptCacheOptions provider option', async () => {
+        const { warnings } = await createModel('gpt-5.6').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              promptCacheOptions: {
+                mode: 'explicit',
+                ttl: '30m',
+              },
+            } satisfies OpenAIResponsesProviderOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5.6',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          prompt_cache_options: {
+            mode: 'explicit',
+            ttl: '30m',
+          },
+        });
         expect(warnings).toStrictEqual([]);
       });
 
@@ -3242,6 +3363,59 @@ describe('OpenAIResponsesLanguageModel', () => {
       const finishPart = parts.find(part => part.type === 'finish');
 
       expect(finishPart?.providerMetadata?.openai).not.toHaveProperty('usage');
+    });
+
+    it('should preserve zero cache writes and expose reasoning context', async () => {
+      const events = [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_gpt56',
+            created_at: 1783620000,
+            model: 'gpt-5.6',
+          },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            incomplete_details: null,
+            reasoning: { context: 'all_turns' },
+            usage: {
+              input_tokens: 100,
+              input_tokens_details: {
+                cached_tokens: 40,
+                cache_write_tokens: 0,
+              },
+              output_tokens: 20,
+              output_tokens_details: { reasoning_tokens: 5 },
+            },
+          },
+        },
+      ];
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: events.map(event => 'data:' + JSON.stringify(event) + '\n\n'),
+      };
+
+      const { stream } = await createModel('gpt-5.6').doStream({
+        prompt: TEST_PROMPT,
+      });
+      const finish = (await convertReadableStreamToArray(stream)).at(-1);
+
+      expect(finish).toMatchObject({
+        type: 'finish',
+        providerMetadata: {
+          openai: {
+            responseId: 'resp_gpt56',
+            reasoningContext: 'all_turns',
+            usage: { cacheWriteTokens: 0 },
+          },
+        },
+        usage: {
+          inputTokens: 100,
+          cachedInputTokens: 40,
+        },
+      });
     });
 
     it('should send finish reason for incomplete response', async () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -236,6 +236,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       service_tier: openaiOptions?.serviceTier,
       include,
       prompt_cache_key: openaiOptions?.promptCacheKey,
+      prompt_cache_options: openaiOptions?.promptCacheOptions,
       prompt_cache_retention: openaiOptions?.promptCacheRetention,
       safety_identifier: openaiOptions?.safetyIdentifier,
       top_logprobs: topLogprobs,
@@ -244,13 +245,21 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       // model-specific settings:
       ...(modelCapabilities.isReasoningModel &&
         (openaiOptions?.reasoningEffort != null ||
-          openaiOptions?.reasoningSummary != null) && {
+          openaiOptions?.reasoningSummary != null ||
+          openaiOptions?.reasoningMode != null ||
+          openaiOptions?.reasoningContext != null) && {
           reasoning: {
             ...(openaiOptions?.reasoningEffort != null && {
               effort: openaiOptions.reasoningEffort,
             }),
             ...(openaiOptions?.reasoningSummary != null && {
               summary: openaiOptions.reasoningSummary,
+            }),
+            ...(openaiOptions?.reasoningMode != null && {
+              mode: openaiOptions.reasoningMode,
+            }),
+            ...(openaiOptions?.reasoningContext != null && {
+              context: openaiOptions.reasoningContext,
             }),
           },
         }),
@@ -299,6 +308,22 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
           type: 'unsupported-setting',
           setting: 'reasoningSummary',
           details: 'reasoningSummary is not supported for non-reasoning models',
+        });
+      }
+
+      if (openaiOptions?.reasoningMode != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'reasoningMode',
+          details: 'reasoningMode is not supported for non-reasoning models',
+        });
+      }
+
+      if (openaiOptions?.reasoningContext != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'reasoningContext',
+          details: 'reasoningContext is not supported for non-reasoning models',
         });
       }
     }
@@ -686,11 +711,16 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       providerMetadata[providerKey].serviceTier = response.service_tier;
     }
 
+    if (response.reasoning?.context != null) {
+      providerMetadata[providerKey].reasoningContext =
+        response.reasoning.context;
+    }
+
     const usage = response.usage!; // defined when there is no error
 
-    const orchestrationUsage = getOrchestrationUsageMetadata(usage);
-    if (orchestrationUsage != null) {
-      providerMetadata[providerKey].usage = orchestrationUsage;
+    const responsesUsage = getResponsesUsageMetadata(usage);
+    if (responsesUsage != null) {
+      providerMetadata[providerKey].usage = responsesUsage;
     }
 
     return {
@@ -796,7 +826,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
     > = {};
 
     let serviceTier: string | undefined;
-    let orchestrationUsage: ResponsesUsageProviderMetadata | undefined;
+    let reasoningContext: string | undefined;
+    let responsesUsage: ResponsesUsageProviderMetadata | undefined;
 
     return {
       stream: response.pipeThrough(
@@ -1277,9 +1308,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               if (typeof value.response.service_tier === 'string') {
                 serviceTier = value.response.service_tier;
               }
-              orchestrationUsage = getOrchestrationUsageMetadata(
-                value.response.usage,
-              );
+              if (value.response.reasoning?.context != null) {
+                reasoningContext = value.response.reasoning.context;
+              }
+              responsesUsage = getResponsesUsageMetadata(value.response.usage);
             } else if (isResponseAnnotationAddedChunk(value)) {
               ongoingAnnotations.push(value.annotation);
               if (value.annotation.type === 'url_citation') {
@@ -1333,8 +1365,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               providerMetadata[providerKey].serviceTier = serviceTier;
             }
 
-            if (orchestrationUsage != null) {
-              providerMetadata[providerKey].usage = orchestrationUsage;
+            if (reasoningContext !== undefined) {
+              providerMetadata[providerKey].reasoningContext = reasoningContext;
+            }
+
+            if (responsesUsage != null) {
+              providerMetadata[providerKey].usage = responsesUsage;
             }
 
             controller.enqueue({
@@ -1452,14 +1488,14 @@ function mapWebSearchOutput(
 }
 
 /**
- * Extracts orchestration token usage details (e.g. Sakana-style orchestration)
- * from the Responses API usage so they can be surfaced via provider metadata.
- * Returns `undefined` when no orchestration usage is present.
+ * Extracts provider-specific usage details from the Responses API so they can
+ * be surfaced via provider metadata. Returns `undefined` when none are present.
  */
-function getOrchestrationUsageMetadata(
+function getResponsesUsageMetadata(
   usage:
     | {
         input_tokens_details?: {
+          cache_write_tokens?: number | null;
           orchestration_input_tokens?: number | null;
           orchestration_input_cached_tokens?: number | null;
         } | null;
@@ -1470,6 +1506,7 @@ function getOrchestrationUsageMetadata(
     | null
     | undefined,
 ): ResponsesUsageProviderMetadata | undefined {
+  const cacheWriteTokens = usage?.input_tokens_details?.cache_write_tokens;
   const orchestrationInputTokens =
     usage?.input_tokens_details?.orchestration_input_tokens;
   const orchestrationInputCachedTokens =
@@ -1478,6 +1515,7 @@ function getOrchestrationUsageMetadata(
     usage?.output_tokens_details?.orchestration_output_tokens;
 
   if (
+    cacheWriteTokens == null &&
     orchestrationInputTokens == null &&
     orchestrationInputCachedTokens == null &&
     orchestrationOutputTokens == null
@@ -1486,6 +1524,7 @@ function getOrchestrationUsageMetadata(
   }
 
   return {
+    ...(cacheWriteTokens != null && { cacheWriteTokens }),
     ...(orchestrationInputTokens != null && { orchestrationInputTokens }),
     ...(orchestrationInputCachedTokens != null && {
       orchestrationInputCachedTokens,

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -207,10 +207,24 @@ export const openaiResponsesProviderOptionsSchema = lazyValidator(() =>
       promptCacheKey: z.string().nullish(),
 
       /**
+       * Prompt cache behavior for GPT-5.6 and later models.
+       * `mode` controls whether OpenAI also places an implicit breakpoint.
+       * `ttl` sets the minimum cache lifetime and currently only supports 30 minutes.
+       */
+      promptCacheOptions: z
+        .object({
+          mode: z.enum(['implicit', 'explicit']).optional(),
+          ttl: z.literal('30m').optional(),
+        })
+        .optional(),
+
+      /**
        * The retention policy for the prompt cache.
        * - 'in_memory': Default. Standard prompt caching behavior.
        * - '24h': Extended prompt caching that keeps cached prefixes active for up to 24 hours.
-       *          Currently only available for 5.1 series models.
+       *          Available for models before GPT-5.6 that support extended caching.
+       *
+       * @deprecated For GPT-5.6 and later models, use `promptCacheOptions.ttl`.
        *
        * @default 'in_memory'
        */
@@ -219,14 +233,26 @@ export const openaiResponsesProviderOptionsSchema = lazyValidator(() =>
       /**
        * Reasoning effort for reasoning models. Defaults to `medium`. If you use
        * `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
-       * Valid values: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
-       *
-       * The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
-       * models. Also, the 'xhigh' type for `reasoningEffort` is only available for
-       * OpenAI's GPT-5.1-Codex-Max model. Setting `reasoningEffort` to 'none' or 'xhigh' with unsupported models will result in
-       * an error.
+       * GPT-5.6 supports 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'.
+       * Supported values vary by model.
        */
       reasoningEffort: z.string().nullish(),
+
+      /**
+       * Controls how much model work GPT-5.6 performs before returning a final answer.
+       * `standard` is the default. `pro` increases quality, latency, and token usage.
+       */
+      reasoningMode: z.enum(['standard', 'pro']).optional(),
+
+      /**
+       * Controls which available reasoning items GPT-5.6 can use.
+       * `auto` uses the model default, `current_turn` excludes reasoning from earlier
+       * turns, and `all_turns` makes compatible earlier reasoning available.
+       */
+      reasoningContext: z
+        .enum(['auto', 'current_turn', 'all_turns'])
+        .optional(),
+
       reasoningSummary: z.string().nullish(),
       safetyIdentifier: z.string().nullish(),
       serviceTier: z.enum(['auto', 'flex', 'priority', 'default']).nullish(),

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -15,15 +15,16 @@ export type ResponsesProviderMetadata = {
   responseId: string | null | undefined;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
+  reasoningContext?: string;
   /**
-   * Orchestration token usage details (e.g. Sakana-style orchestration) that
-   * the Responses API reports alongside the standard usage. Surfaced here so
-   * downstream consumers (e.g. the AI Gateway) can bill it.
+   * Provider-specific token usage details, including prompt cache writes and
+   * orchestration usage. Surfaced here so downstream consumers can bill it.
    */
   usage?: ResponsesUsageProviderMetadata;
 };
 
 export type ResponsesUsageProviderMetadata = {
+  cacheWriteTokens?: number;
   orchestrationInputTokens?: number;
   orchestrationInputCachedTokens?: number;
   orchestrationOutputTokens?: number;


### PR DESCRIPTION
## Summary

V5-native backport of #17028 to `release-v5.0`.

- add GPT-5.6 `max` reasoning effort support for Chat Completions
- add Responses API `reasoningMode` and `reasoningContext`, including the effective context in provider metadata
- support GPT-5.6 implicit and explicit prompt caching, 30-minute TTL, and explicit content breakpoints
- expose cache-write tokens for Chat and Responses
- backport the GPT-5.6 docs and examples to the v5 layout

The GPT-5.6 model prerequisite is already present through #17023.

### V5 adaptations

`LanguageModelV2Usage` has no cache-write or uncached-input bucket. This backport leaves that core v5 contract unchanged and exposes writes consistently as `providerMetadata.openai.usage.cacheWriteTokens`; cache reads remain at `usage.cachedInputTokens`. Consequently, the upstream no-cache subtraction is not applicable on v5.

V2 also has no provider options on nested tool-output items. A breakpoint on a v5 tool-result part therefore applies to the whole result; for multipart results, the provider places the OpenAI API breakpoint on the final nested output part.

## Test plan

- `pnpm test:node` in `packages/openai` — 15 files, 569 tests
- `pnpm test:edge` in `packages/openai` — 15 files, 569 tests
- targeted OpenAI suites — 4 files, 385 tests
- targeted Azure provider suite — 1 file, 48 tests
- `pnpm type-check` in `packages/openai`
- `pnpm type-check:full`
- `pnpm build` in `packages/openai`
- `pnpm check`

The release branch does not contain `tools/validate-properties-tables.mjs`; this change does not modify a PropertiesTable. Live GPT-5.6 examples were not run because no `OPENAI_API_KEY` was configured.

## Checklist

- [x] All commits are signed
- [x] Tests have been added / updated
- [x] Documentation has been added / updated
- [x] A patch changeset has been added
- [x] I have reviewed this pull request
