### PR TITLE
fix(workflow): align package.json entrypoints with published ESM-only build

### DIFF
--- a/.changeset/great-crabs-search.md
+++ b/.changeset/great-crabs-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+chore (devtools): remove leftover `module` field from package.json (dual CJS/ESM publishing was removed in AI SDK 7)

--- a/.changeset/tidy-donkeys-scream.md
+++ b/.changeset/tidy-donkeys-scream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+fix (workflow): mark package as ESM so the published files match the `main`, `types`, and `exports` entrypoints in package.json. Previously `require('@ai-sdk/workflow')` failed with `MODULE_NOT_FOUND` because the declared CommonJS entrypoints were never published.

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.3",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@ai-sdk/workflow",
   "version": "1.0.19",
+  "type": "module",
   "description": "WorkflowAgent for building AI agents with AI SDK",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "source": "./src/index.ts",
   "files": [
@@ -33,8 +33,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "dependencies": {

--- a/packages/workflow/vitest.edge.config.js
+++ b/packages/workflow/vitest.edge.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/workflow/vitest.node.config.js
+++ b/packages/workflow/vitest.node.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Background

Fixes #16925

`@ai-sdk/workflow` builds ESM only (`tsup` with `format: ['esm']`), but its `package.json` still had the pre-v7 dual CJS/ESM layout:

- `main` and `exports["."].require` pointed at `./dist/index.js` (a CJS bundle that is no longer built)
- `module` and `exports["."].import` pointed at `./dist/index.mjs`
- `types` pointed at `./dist/index.d.ts`, while the build emitted `./dist/index.d.mts`

Because the package was missing `"type": "module"`, tsup emitted the ESM bundle as `dist/index.mjs`/`dist/index.d.mts`, so the published tarball contained **none** of the files declared by `main`, `types`, or the `require` condition. `require('@ai-sdk/workflow')` failed with `MODULE_NOT_FOUND`; TypeScript consumers using node resolution could not find the types either.

## Summary

This PR removes the CJS leftovers from AI SDK 7's move to ESM-only publishing:

- **`packages/workflow/package.json`**: add `"type": "module"` and align entrypoints with the other AI SDK packages (`types`/`import`/`default` → `./dist/index.js` + `./dist/index.d.ts`, no `module` field, no `require` condition). With `"type": "module"`, tsup now emits `dist/index.js` and `dist/index.d.ts`, matching the declared entrypoints.
- **`packages/workflow/vitest.*.config.js`**: import `defineConfig` from `vitest/config` instead of `vite` (the repo-wide convention). Importing from `vite` broke config loading once the package became ESM, since `vite` is not a direct dependency.
- **`packages/devtools/package.json`**: remove the leftover `module` field (a dual-format publishing artifact; it pointed at the same file as `main`).

Other CJS references found during the sweep are intentional and left untouched: `@ai-sdk/codemod` (jscodeshift transforms must be CJS), `@ai-sdk/amazon-bedrock`'s `./mantle` subpath (still deliberately built with `format: ['cjs', 'esm']`, and the `.cjs` file is published), `@ai-sdk/rsc` (ESM-only via explicit `.mjs` files that are published), and the v7 migration guide's before/after `require()` examples.

## Verification

- `pnpm pack` + install into a temp project: `import('@ai-sdk/workflow')` and `require('@ai-sdk/workflow')` both resolve and expose `WorkflowAgent` (Node 24; `require(esm)` is supported on all Node versions ≥ 22 allowed by `engines`), and `dist/index.d.ts` exists at the declared path
- `pnpm test` in `packages/workflow` (155 tests, node + edge) ✅
- `pnpm turbo type-check --filter '@ai-sdk/workflow' --filter '@ai-sdk/devtools'` ✅
- `pnpm check` ✅

## Tasks

- [x] Tests have been added / updated (in case of bug fix / feature)
- [ ] Documentation has been added / updated (in case of new feature)
- [x] A _patch_ changeset for relevant packages has been added
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

`@ai-sdk/rsc` still uses the legacy layout (`main`/`module` pointing at `.mjs` files, no `"type": "module"`). It works because the `.mjs` files are published, but it could be modernized the same way in a follow-up.