### PR TITLE
fix(ai): flush compressed Node.js streams per chunk

### DIFF
--- a/.changeset/fresh-seals-stream.md
+++ b/.changeset/fresh-seals-stream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Flush compressed Node.js response chunks as they are piped so UI message and text streams remain incremental in Express and Next.js.

--- a/packages/ai/src/util/write-to-server-response.test.ts
+++ b/packages/ai/src/util/write-to-server-response.test.ts
@@ -43,6 +43,14 @@ describe('writeToServerResponse', () => {
 
     it('should respect backpressure and wait for drain event', async () => {
       const mockResponse = createBackpressureMockResponse();
+      const flushReceivers: unknown[] = [];
+      const writtenChunkCountsAtFlush: number[] = [];
+      Object.assign(mockResponse, {
+        flush(this: ServerResponse) {
+          flushReceivers.push(this);
+          writtenChunkCountsAtFlush.push(mockResponse.writtenChunks.length);
+        },
+      });
       let drainEventCount = 0;
       let readyToEnqueue: ((value: unknown) => void) | null = null;
 
@@ -76,6 +84,7 @@ describe('writeToServerResponse', () => {
       // Wait for first chunk to be written
       await vi.advanceTimersByTimeAsync(10);
       expect(mockResponse.writeCallCount).toBe(1);
+      expect(writtenChunkCountsAtFlush).toEqual([1]);
 
       // Enqueue second chunk - it should trigger write which returns false (backpressure)
       readyToEnqueue!(new TextEncoder().encode('chunk2'));
@@ -84,6 +93,7 @@ describe('writeToServerResponse', () => {
       // Second chunk write should have been called but returned false
       expect(mockResponse.writeCallCount).toBe(2);
       expect(mockResponse.writtenChunks.length).toBe(2);
+      expect(writtenChunkCountsAtFlush).toEqual([1, 2]);
 
       // Enqueue third chunk - it should NOT trigger write yet (still waiting for drain from chunk 2)
       readyToEnqueue!(new TextEncoder().encode('chunk3'));
@@ -91,11 +101,13 @@ describe('writeToServerResponse', () => {
 
       // Third chunk shouldn't be written yet (waiting for drain)
       expect(mockResponse.writeCallCount).toBe(2);
+      expect(writtenChunkCountsAtFlush).toEqual([1, 2]);
 
       // Simulate drain to allow third write
       mockResponse.simulateDrain();
       await vi.advanceTimersByTimeAsync(10);
       expect(mockResponse.writeCallCount).toBe(3);
+      expect(writtenChunkCountsAtFlush).toEqual([1, 2, 3]);
 
       // Close the stream
       readyToEnqueue!(null);
@@ -107,6 +119,11 @@ describe('writeToServerResponse', () => {
       expect(drainEventCount).toBeGreaterThanOrEqual(1);
       // Verify all chunks were eventually written
       expect(mockResponse.writtenChunks).toHaveLength(3);
+      expect(flushReceivers).toEqual([
+        mockResponse,
+        mockResponse,
+        mockResponse,
+      ]);
     });
   });
 

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -1,5 +1,9 @@
 import type { ServerResponse } from 'node:http';
 
+type FlushableServerResponse = ServerResponse & {
+  flush?: () => void;
+};
+
 /**
  * Writes the content of a stream to a server response.
  */
@@ -32,6 +36,11 @@ export function writeToServerResponse({
 
         // Respect backpressure: if write() returns false, wait for 'drain' event
         const canContinue = response.write(value);
+        const flush = (response as FlushableServerResponse).flush;
+        if (typeof flush === 'function') {
+          flush.call(response);
+        }
+
         if (!canContinue) {
           await new Promise<void>(resolve => {
             response.once('drain', resolve);


### PR DESCRIPTION
## Background

Express compression and Next.js 13 Pages Router can buffer AI SDK Node.js response streams until completion instead of delivering chunks incrementally. Both integrations expose an Express-style `response.flush()` hook for forcing partially compressed output to the client, but `writeToServerResponse` currently does not call it after writing chunks.

## Summary

- call an available Express-style `response.flush()` immediately after every streamed response write
- preserve the existing backpressure behavior and receiver binding
- cover write/flush ordering, receiver binding, and flushing before a backpressure wait
- add a patch changeset for the `ai` package
- supersede #17006 and #17007 with one shared fix that retains gzip

## Manual Verification

I used one script to exercise real Express 5.0.1 with `compression` 1.8.1 and a real Next.js 13.0.5 Pages API route. It requests gzip and fails if compression is disabled, the first event is delayed, or the events arrive together.

From the repository root, prepare a temporary environment:

```bash
repo=$PWD
tmp=$(mktemp -d)
trap 'rm -rf "$tmp"' EXIT

pnpm --filter 'ai...' build
printf '%s\n' '{"private":true,"type":"module"}' > "$tmp/package.json"
pnpm -C "$tmp" add --ignore-workspace --save-exact \
  compression@1.8.1 express@5.0.1 next@13.0.5 \
  react@18.2.0 react-dom@18.2.0
```

Save the following as `$tmp/verify.mjs`:

```js
import assert from 'node:assert/strict';
import { mkdir, rm, writeFile } from 'node:fs/promises';
import { createServer } from 'node:http';
import { dirname, join, resolve } from 'node:path';
import { setTimeout as sleep } from 'node:timers/promises';
import { fileURLToPath } from 'node:url';
import compression from 'compression';
import express from 'express';
import createNext from 'next';

const root = dirname(fileURLToPath(import.meta.url));
const aiDist = resolve(process.env.AI_DIST ?? '');
assert.ok(process.env.AI_DIST, 'Set AI_DIST to packages/ai/dist/index.js');
const { pipeUIMessageStreamToResponse } = await import(aiDist);
const host = '127.0.0.1';
const eventCount = 5;
const delayMs = 200;

function makeStream() {
  return new ReadableStream({
    async start(controller) {
      for (let i = 0; i < eventCount; i++) {
        if (i) await sleep(delayMs);
        controller.enqueue({ type: 'data-test', data: { i } });
      }
      controller.close();
    },
  });
}

function handler(_request, response) {
  pipeUIMessageStreamToResponse({ response, stream: makeStream() });
}

async function listen(server) {
  await new Promise(resolvePromise => server.listen(0, host, resolvePromise));
  return server.address().port;
}

async function close(server) {
  await new Promise((resolvePromise, reject) =>
    server.close(error => (error ? reject(error) : resolvePromise())),
  );
}

async function probe(url) {
  const startedAt = performance.now();
  const response = await fetch(url, {
    method: 'POST',
    headers: { Accept: 'text/event-stream', 'Accept-Encoding': 'gzip' },
  });
  assert.ok(response.body);
  const decoder = new TextDecoder();
  const eventTimes = [];
  let pending = '';
  const parseEvents = () => {
    for (let boundary; (boundary = pending.indexOf('\n\n')) !== -1; ) {
      const event = pending.slice(0, boundary);
      pending = pending.slice(boundary + 2);
      if (event.startsWith('data: ')) {
        eventTimes.push(Math.round(performance.now() - startedAt));
      }
    }
  };
  for await (const chunk of response.body) {
    pending += decoder.decode(chunk, { stream: true });
    parseEvents();
  }
  pending += decoder.decode();
  parseEvents();
  return {
    status: response.status,
    contentEncoding: response.headers.get('content-encoding'),
    eventCount: eventTimes.length,
    firstEventMs: eventTimes[0] ?? null,
    eventSpanMs:
      eventTimes.length < 2 ? 0 : eventTimes.at(-1) - eventTimes[0],
  };
}

async function probeExpress() {
  const app = express();
  app.use(compression({ threshold: 0 }));
  app.post('/stream', handler);
  const server = createServer(app);
  const port = await listen(server);
  try {
    return await probe(`http://${host}:${port}/stream`);
  } finally {
    await close(server);
  }
}

async function probeNext() {
  const appDir = join(root, 'next-app');
  await rm(appDir, { recursive: true, force: true });
  await mkdir(join(appDir, 'pages', 'api'), { recursive: true });
  await Promise.all([
    writeFile(
      join(appDir, 'package.json'),
      JSON.stringify({ private: true, type: 'module' }),
    ),
    writeFile(
      join(appDir, 'pages', 'index.js'),
      "export default function Home() { return 'ok' }\n",
    ),
    writeFile(
      join(appDir, 'pages', 'api', 'stream.js'),
      `import { pipeUIMessageStreamToResponse } from ${JSON.stringify(aiDist)};
const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
function makeStream() {
  return new ReadableStream({
    async start(controller) {
      for (let i = 0; i < ${eventCount}; i++) {
        if (i) await sleep(${delayMs});
        controller.enqueue({ type: 'data-test', data: { i } });
      }
      controller.close();
    },
  });
}
export default function handler(_request, response) {
  pipeUIMessageStreamToResponse({ response, stream: makeStream() });
}
`,
    ),
  ]);

  const nextApp = createNext({ dev: true, dir: appDir, hostname: host, port: 0 });
  await nextApp.prepare();
  const server = createServer(nextApp.getRequestHandler());
  const port = await listen(server);
  const baseUrl = `http://${host}:${port}`;
  try {
    const warm = await fetch(`${baseUrl}/api/stream`, {
      method: 'POST',
      headers: { 'Accept-Encoding': 'identity' },
    });
    await warm.arrayBuffer();
    return await probe(`${baseUrl}/api/stream`);
  } finally {
    await close(server);
    await nextApp.close();
  }
}

const results = {
  expressCompression: await probeExpress(),
  next13PagesRouter: await probeNext(),
};
console.log(JSON.stringify(results, null, 2));

const failures = [];
for (const [name, result] of Object.entries(results)) {
  if (result.status !== 200) failures.push(`${name}: status ${result.status}`);
  if (result.contentEncoding !== 'gzip') failures.push(`${name}: not gzip`);
  if (result.eventCount < eventCount) failures.push(`${name}: missing events`);
  if (result.firstEventMs === null || result.firstEventMs >= 500) {
    failures.push(`${name}: first event ${result.firstEventMs}ms (expected <500ms)`);
  }
  if (result.eventSpanMs < 400) {
    failures.push(`${name}: event span ${result.eventSpanMs}ms (expected >=400ms)`);
  }
}
if (failures.length) {
  console.error(`FAIL:\n${failures.join('\n')}`);
  process.exitCode = 1;
} else {
  console.log('PASS: Express and Next streamed incrementally while retaining gzip.');
}
```

Run it with:

```bash
NEXT_TELEMETRY_DISABLED=1 \
AI_DIST="$repo/packages/ai/dist/index.js" \
node "$tmp/verify.mjs"
```

At the test-only commit `9c0f6b504e`, both integrations retained gzip but buffered every event until the stream completed:

```json
{
  "expressCompression": {
    "status": 200,
    "contentEncoding": "gzip",
    "eventCount": 6,
    "firstEventMs": 827,
    "eventSpanMs": 0
  },
  "next13PagesRouter": {
    "status": 200,
    "contentEncoding": "gzip",
    "eventCount": 6,
    "firstEventMs": 844,
    "eventSpanMs": 0
  }
}
```

At the fix commit `a810277d26`, both integrations retained gzip and delivered the events incrementally:

```json
{
  "expressCompression": {
    "status": 200,
    "contentEncoding": "gzip",
    "eventCount": 6,
    "firstEventMs": 73,
    "eventSpanMs": 785
  },
  "next13PagesRouter": {
    "status": 200,
    "contentEncoding": "gzip",
    "eventCount": 6,
    "firstEventMs": 11,
    "eventSpanMs": 819
  }
}
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11917
Fixes #12233
Closes #17006
Closes #17007
