### PR TITLE
fix(ai): keep smoothed text ahead of tool execution

### DIFF
--- a/.changeset/smoothstream-tool-order.md
+++ b/.changeset/smoothstream-tool-order.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Wait for transformed stream output before executing client tools so `smoothStream` text is not overtaken by tool side effects.

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -51,6 +51,7 @@ export function executeToolsFromStream<
   onToolExecutionEnd,
   executeToolInTelemetryContext,
   runInTracingChannelSpan,
+  awaitBeforeToolExecution,
 }: {
   stream: ReadableStream<LanguageModelStreamPart<TOOLS>>;
   tools: TOOLS | undefined;
@@ -70,6 +71,7 @@ export function executeToolsFromStream<
   runInTracingChannelSpan?: NonNullable<
     TelemetryDispatcher['runInTracingChannelSpan']
   >;
+  awaitBeforeToolExecution?: () => Promise<void>;
 }): ReadableStream<ExecuteToolsStreamPart<TOOLS>> {
   const toolCallsToExecute: Array<TypedToolCall<TOOLS>> = [];
 
@@ -197,6 +199,10 @@ export function executeToolsFromStream<
           }
 
           case 'model-call-end': {
+            if (toolCallsToExecute.length > 0) {
+              await awaitBeforeToolExecution?.();
+            }
+
             await Promise.all(
               toolCallsToExecute.map(async toolCall => {
                 try {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -54,6 +54,7 @@ import {
 } from '../types/usage';
 import type { StepResult } from './step-result';
 import { isLoopFinished, isStepCount } from './stop-condition';
+import { smoothStream } from './smooth-stream';
 import { streamText } from './stream-text';
 import type { StreamTextResult, TextStreamPart } from './stream-text-result';
 import type {
@@ -17985,6 +17986,135 @@ describe('streamText', () => {
         expect(
           await convertAsyncIterableToArray(result.textStream),
         ).toStrictEqual(['HELLO', ', ', 'WORLD!']);
+      });
+
+      it('should emit smoothed text before executing the next tool call', async () => {
+        const firstStepText =
+          'I will help you replace Sunny with Rainy in hello.txt. First, let me read the file. ';
+        const secondStepText =
+          'Now I can see the file contents. I will replace Sunny with Rainy. Done!';
+
+        let modelCallCount = 0;
+        const events: Array<
+          | { type: 'text'; text: string; visibleText: string }
+          | { type: 'tool-execute' }
+        > = [];
+
+        const result = streamText({
+          model: new MockLanguageModelV4({
+            doStream: async () => {
+              modelCallCount++;
+
+              if (modelCallCount === 1) {
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'stream-start',
+                      warnings: [],
+                    },
+                    {
+                      type: 'response-metadata',
+                      id: 'id-1',
+                      modelId: 'mock-model-id',
+                      timestamp: new Date(0),
+                    },
+                    { type: 'text-start', id: 'text-1' },
+                    {
+                      type: 'text-delta',
+                      id: 'text-1',
+                      delta: firstStepText,
+                    },
+                    { type: 'text-end', id: 'text-1' },
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-1',
+                      toolName: 'readFile',
+                      input: '{"path":"hello.txt"}',
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool-calls',
+                      },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+              }
+
+              if (modelCallCount === 2) {
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'stream-start',
+                      warnings: [],
+                    },
+                    {
+                      type: 'response-metadata',
+                      id: 'id-2',
+                      modelId: 'mock-model-id',
+                      timestamp: new Date(0),
+                    },
+                    { type: 'text-start', id: 'text-2' },
+                    {
+                      type: 'text-delta',
+                      id: 'text-2',
+                      delta: secondStepText,
+                    },
+                    { type: 'text-end', id: 'text-2' },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+              }
+
+              throw new Error(`Unexpected model call ${modelCallCount}`);
+            },
+          }),
+          prompt: 'replace "Sunny" with "Rainy" in hello.txt',
+          tools: {
+            readFile: tool({
+              inputSchema: jsonSchema({
+                type: 'object',
+                properties: { path: { type: 'string' } },
+                required: ['path'],
+                additionalProperties: false,
+              }),
+              execute: async () => {
+                events.push({ type: 'tool-execute' });
+                return 'One\nSunny\nDay';
+              },
+            }),
+          },
+          stopWhen: isStepCount(2),
+          experimental_transform: smoothStream({
+            chunking: 'word',
+            delayInMs: 1,
+          }),
+        });
+
+        let visibleText = '';
+
+        for await (const text of result.textStream) {
+          visibleText += text;
+          events.push({ type: 'text', text, visibleText });
+        }
+
+        const toolExecuteIndex = events.findIndex(
+          event => event.type === 'tool-execute',
+        );
+        const firstStepCompleteIndex = events.findIndex(
+          event =>
+            event.type === 'text' && event.visibleText.includes(firstStepText),
+        );
+
+        expect(toolExecuteIndex).not.toBe(-1);
+        expect(firstStepCompleteIndex).not.toBe(-1);
+        expect(toolExecuteIndex).toBeGreaterThan(firstStepCompleteIndex);
       });
 
       it('result.text should be transformed', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1115,6 +1115,9 @@ class DefaultStreamTextResult<
       }
     > = createIdMap();
     let recordedNoOutputError: NoOutputGeneratedError | undefined;
+    let transformedOutputReadyForToolExecution:
+      | DelayedPromise<void>
+      | undefined;
 
     const eventProcessor = new TransformStream<
       EnrichedStreamPart<TOOLS, InferPartialOutput<OUTPUT>>,
@@ -1126,6 +1129,19 @@ class DefaultStreamTextResult<
         const { part } = chunk;
 
         await onChunk?.({ chunk: part });
+
+        // Client tools execute upstream of stream transforms. Wait until
+        // transformed assistant output reaches this boundary before running
+        // the next tool, so paced transforms cannot be overtaken by tool
+        // side effects such as console output.
+        if (
+          transformedOutputReadyForToolExecution?.isPending() &&
+          (part.type === 'text-end' ||
+            part.type === 'reasoning-end' ||
+            part.type === 'tool-call')
+        ) {
+          transformedOutputReadyForToolExecution.resolve();
+        }
 
         if (part.type === 'error') {
           const error = wrapGatewayError(part.error);
@@ -1737,6 +1753,11 @@ class DefaultStreamTextResult<
         currentStep: number;
         usage: LanguageModelUsage;
       }) {
+        const stepTransformedOutputReadyForToolExecution =
+          new DelayedPromise<void>();
+        transformedOutputReadyForToolExecution =
+          stepTransformedOutputReadyForToolExecution;
+
         // Set up step timeout if configured
         const stepTimeoutId = setAbortTimeout({
           abortController: stepAbortController,
@@ -1991,6 +2012,8 @@ class DefaultStreamTextResult<
 
             executeToolInTelemetryContext: telemetryDispatcher.executeTool,
             runInTracingChannelSpan: runInTracingChannelSpanInStep,
+            awaitBeforeToolExecution: () =>
+              stepTransformedOutputReadyForToolExecution.promise,
           });
 
           // Conditionally include request.body based on include settings.


### PR DESCRIPTION
## Summary

- wait for transformed assistant output to reach the stream boundary before executing client tools
- add regression coverage for `smoothStream` with a multi-step `streamText` tool call
- add a patch changeset for `ai`

Fixes #13199.

## Tests

- `npx --yes pnpm@10.33.4 install --frozen-lockfile`
- `npx --yes pnpm@10.33.4 --filter ai... build`
- `npx --yes pnpm@10.33.4 --dir packages/ai exec vitest --config vitest.node.config.js --run src/generate-text/stream-text.test.ts` (408 passed)
- `npx --yes pnpm@10.33.4 --dir packages/ai exec vitest --config vitest.node.config.js --run src/generate-text/stream-text.test.ts src/generate-text/smooth-stream.test.ts src/generate-text/execute-tools-from-stream.test.ts` (458 passed)
- `npx --yes pnpm@10.33.4 --dir packages/ai exec vitest --config vitest.edge.config.js --run src/generate-text/stream-text.test.ts src/generate-text/smooth-stream.test.ts src/generate-text/execute-tools-from-stream.test.ts` (458 passed)
- `npx --yes pnpm@10.33.4 --filter ai type-check`
- `npx --yes pnpm@10.33.4 exec oxfmt --check packages/ai/src/generate-text/execute-tools-from-stream.ts packages/ai/src/generate-text/stream-text.ts packages/ai/src/generate-text/stream-text.test.ts .changeset/smoothstream-tool-order.md`
- `npx --yes pnpm@10.33.4 exec oxlint packages/ai/src/generate-text/execute-tools-from-stream.ts packages/ai/src/generate-text/stream-text.ts packages/ai/src/generate-text/stream-text.test.ts`
- `git diff --check`