### PR TITLE
fix(ai): serialize tool output JSON values

### DIFF
--- a/.changeset/json-tool-output.md
+++ b/.changeset/json-tool-output.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+JSON serialize default tool outputs before storing them in model response messages.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -4727,6 +4727,100 @@ describe('generateText', () => {
         expect(result.responseMessages).toMatchSnapshot();
       });
 
+      it('result.responseMessages should JSON serialize object tool outputs', async () => {
+        const recordId = '507f1f77bcf86cd799439011';
+        let responseCount = 0;
+
+        class ObjectIdLike {
+          toJSON() {
+            return recordId;
+          }
+        }
+
+        const result = await generateText({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              switch (responseCount++) {
+                case 0:
+                  return {
+                    ...dummyResponseValues,
+                    content: [
+                      {
+                        type: 'tool-call',
+                        toolCallType: 'function',
+                        toolCallId: 'call-1',
+                        toolName: 'lookupRecord',
+                        input: '{}',
+                      },
+                    ],
+                    finishReason: { unified: 'tool-calls', raw: undefined },
+                  };
+                case 1:
+                  return {
+                    ...dummyResponseValues,
+                    content: [{ type: 'text', text: 'done' }],
+                    finishReason: { unified: 'stop', raw: 'stop' },
+                  };
+                default:
+                  throw new Error(
+                    `Unexpected response count: ${responseCount}`,
+                  );
+              }
+            },
+          }),
+          tools: {
+            lookupRecord: tool({
+              inputSchema: z.object({}),
+              execute: async () => ({ id: new ObjectIdLike() }),
+            }),
+          },
+          prompt: 'look up the record',
+          stopWhen: isStepCount(2),
+        });
+
+        expect(result.responseMessages).toEqual([
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'lookupRecord',
+                input: {},
+                providerExecuted: undefined,
+                providerOptions: undefined,
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'lookupRecord',
+                output: {
+                  type: 'json',
+                  value: {
+                    id: recordId,
+                  },
+                },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'done',
+                providerOptions: undefined,
+              },
+            ],
+          },
+        ]);
+      });
+
       it('result.totalUsage should sum token usage', () => {
         expect(result.totalUsage).toMatchInlineSnapshot(`
           {

--- a/packages/ai/src/prompt/create-tool-model-output.test.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.test.ts
@@ -279,6 +279,34 @@ describe('createToolModelOutput', () => {
       `);
     });
 
+    it('should JSON serialize object output', async () => {
+      class ObjectIdLike {
+        toJSON() {
+          return '507f1f77bcf86cd799439011';
+        }
+      }
+
+      const result = await createToolModelOutput({
+        toolCallId: '123',
+        input: {},
+        output: {
+          id: new ObjectIdLike(),
+          omitted: undefined,
+        },
+        tool: undefined,
+        errorMode: 'none',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "type": "json",
+          "value": {
+            "id": "507f1f77bcf86cd799439011",
+          },
+        }
+      `);
+    });
+
     it('should return json type for array output', async () => {
       const result = await createToolModelOutput({
         toolCallId: '123',

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -30,5 +30,10 @@ export async function createToolModelOutput({
 }
 
 function toJSONValue(value: unknown): JSONValue {
-  return value === undefined ? null : (value as JSONValue);
+  if (value === undefined) {
+    return null;
+  }
+
+  const serialized = JSON.stringify(value);
+  return serialized === undefined ? null : JSON.parse(serialized);
 }

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -1,5 +1,9 @@
 import { getErrorMessage, type JSONValue } from '@ai-sdk/provider';
-import type { Tool, ToolResultOutput } from '@ai-sdk/provider-utils';
+import {
+  parseJSON,
+  type Tool,
+  type ToolResultOutput,
+} from '@ai-sdk/provider-utils';
 
 export async function createToolModelOutput({
   toolCallId,
@@ -17,7 +21,7 @@ export async function createToolModelOutput({
   if (errorMode === 'text') {
     return { type: 'error-text', value: getErrorMessage(output) };
   } else if (errorMode === 'json') {
-    return { type: 'error-json', value: toJSONValue(output) };
+    return { type: 'error-json', value: await toJSONValue(output) };
   }
 
   if (tool?.toModelOutput) {
@@ -26,14 +30,16 @@ export async function createToolModelOutput({
 
   return typeof output === 'string'
     ? { type: 'text', value: output }
-    : { type: 'json', value: toJSONValue(output) };
+    : { type: 'json', value: await toJSONValue(output) };
 }
 
-function toJSONValue(value: unknown): JSONValue {
+async function toJSONValue(value: unknown): Promise<JSONValue> {
   if (value === undefined) {
     return null;
   }
 
   const serialized = JSON.stringify(value);
-  return serialized === undefined ? null : JSON.parse(serialized);
+  return serialized === undefined
+    ? null
+    : await parseJSON({ text: serialized });
 }


### PR DESCRIPTION
## Summary

- JSON serialize default non-string tool outputs before storing them as `json` model outputs
- keep explicit `tool.toModelOutput` behavior unchanged for custom model output serialization
- add regression coverage for ObjectId-like `toJSON` outputs in both `createToolModelOutput` and `generateText().responseMessages`

Fixes #12619.

## Tests

- `npx --yes pnpm@10.33.4 install --frozen-lockfile`
- `npx --yes pnpm@10.33.4 --filter ai... build`
- `npx --yes pnpm@10.33.4 --dir packages/ai exec vitest --config vitest.node.config.js --run src/prompt/create-tool-model-output.test.ts src/generate-text/generate-text.test.ts` (278 passed)
- `npx --yes pnpm@10.33.4 --dir packages/ai exec vitest --config vitest.edge.config.js --run src/prompt/create-tool-model-output.test.ts src/generate-text/generate-text.test.ts` (278 passed)
- `npx --yes pnpm@10.33.4 --filter ai type-check`
- `npx --yes pnpm@10.33.4 exec oxfmt --check packages/ai/src/prompt/create-tool-model-output.ts packages/ai/src/prompt/create-tool-model-output.test.ts packages/ai/src/generate-text/generate-text.test.ts .changeset/json-tool-output.md`
- `npx --yes pnpm@10.33.4 exec oxlint packages/ai/src/prompt/create-tool-model-output.ts packages/ai/src/prompt/create-tool-model-output.test.ts packages/ai/src/generate-text/generate-text.test.ts`
- `git diff --check`

The new `generateText` regression fails with the previous helper behavior because the ObjectId-like output becomes `id: {}` instead of the JSON string value.