### PR TITLE
fix(workflow): preserve reasoning across tool calls

### DIFF
--- a/.changeset/calm-tools-reason.md
+++ b/.changeset/calm-tools-reason.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Preserve reasoning content and provider metadata across WorkflowAgent tool-call turns.

--- a/packages/workflow/src/do-stream-step.test.ts
+++ b/packages/workflow/src/do-stream-step.test.ts
@@ -1,0 +1,293 @@
+import type { LanguageModelV4StreamPart } from '@ai-sdk/provider';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { describe, expect, it } from 'vitest';
+import { doStreamStep } from './do-stream-step.js';
+
+const finishPart: LanguageModelV4StreamPart = {
+  type: 'finish',
+  finishReason: { unified: 'stop', raw: 'stop' },
+  usage: {
+    inputTokens: {
+      total: 1,
+      noCache: 1,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: 1,
+      text: undefined,
+      reasoning: 1,
+    },
+  },
+};
+
+describe('doStreamStep', () => {
+  it('aggregates reasoning by id and keeps the latest provider metadata', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'reasoning-start',
+            id: 'reasoning-1',
+            providerMetadata: {
+              openai: { itemId: 'rs_initial' },
+            },
+          },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'first ',
+          },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'second',
+            providerMetadata: {
+              openai: { itemId: 'rs_delta' },
+            },
+          },
+          {
+            type: 'reasoning-end',
+            id: 'reasoning-1',
+            providerMetadata: {
+              openai: {
+                itemId: 'rs_final',
+                reasoningEncryptedContent: 'encrypted-final',
+              },
+            },
+          },
+          finishPart,
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      model,
+    );
+
+    expect(result.raw.reasoning).toEqual([
+      {
+        text: 'first second',
+        providerMetadata: {
+          openai: {
+            itemId: 'rs_final',
+            reasoningEncryptedContent: 'encrypted-final',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('retains ordered reasoning parts when encrypted reasoning has no deltas', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'reasoning-start',
+            id: 'reasoning-encrypted',
+            providerMetadata: {
+              openai: {
+                itemId: 'rs_encrypted',
+                reasoningEncryptedContent: 'encrypted-only',
+              },
+            },
+          },
+          { type: 'reasoning-end', id: 'reasoning-encrypted' },
+          { type: 'reasoning-start', id: 'reasoning-visible' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-visible',
+            delta: 'visible',
+          },
+          { type: 'reasoning-end', id: 'reasoning-visible' },
+          finishPart,
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      model,
+    );
+
+    expect(result.raw.reasoning).toEqual([
+      {
+        text: '',
+        providerMetadata: {
+          openai: {
+            itemId: 'rs_encrypted',
+            reasoningEncryptedContent: 'encrypted-only',
+          },
+        },
+      },
+      { text: 'visible' },
+    ]);
+  });
+
+  it('starts a new reasoning part when an id is reused after ending', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+          { type: 'stream-start', warnings: [] },
+          { type: 'reasoning-start', id: 'reused' },
+          {
+            type: 'reasoning-delta',
+            id: 'reused',
+            delta: 'first',
+          },
+          { type: 'reasoning-end', id: 'reused' },
+          {
+            type: 'reasoning-start',
+            id: 'reused',
+            providerMetadata: {
+              test: { sequence: 2 },
+            },
+          },
+          {
+            type: 'reasoning-delta',
+            id: 'reused',
+            delta: 'second',
+          },
+          { type: 'reasoning-end', id: 'reused' },
+          finishPart,
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      model,
+    );
+
+    expect(result.raw.reasoning).toEqual([
+      { text: 'first' },
+      {
+        text: 'second',
+        providerMetadata: { test: { sequence: 2 } },
+      },
+    ]);
+  });
+
+  it('keeps interleaved and orphan reasoning parts in first-seen order', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+          { type: 'stream-start', warnings: [] },
+          { type: 'reasoning-delta', id: 'first', delta: 'A' },
+          { type: 'reasoning-start', id: 'second' },
+          { type: 'reasoning-delta', id: 'second', delta: 'B' },
+          { type: 'reasoning-delta', id: 'first', delta: 'C' },
+          { type: 'reasoning-end', id: 'second' },
+          { type: 'reasoning-end', id: 'first' },
+          {
+            type: 'reasoning-end',
+            id: 'orphan-end',
+            providerMetadata: { test: { orphan: true } },
+          },
+          finishPart,
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      model,
+    );
+
+    expect(result.raw.reasoning).toEqual([
+      { text: 'AC' },
+      { text: 'B' },
+      {
+        text: '',
+        providerMetadata: { test: { orphan: true } },
+      },
+    ]);
+  });
+
+  it('records exact reasoning, reasoning-file, and tool-call order', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+          { type: 'stream-start', warnings: [] },
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'first',
+          },
+          { type: 'reasoning-end', id: 'reasoning-1' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'lookup',
+            input: '{"query":"first"}',
+          },
+          {
+            type: 'reasoning-file',
+            data: { type: 'data', data: 'c2lnbmVkLXRob3VnaHQ=' },
+            mediaType: 'application/octet-stream',
+            providerMetadata: {
+              google: { thoughtSignature: 'file-signature' },
+            },
+          },
+          { type: 'reasoning-start', id: 'reasoning-2' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-2',
+            delta: 'second',
+          },
+          { type: 'reasoning-end', id: 'reasoning-2' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'lookup',
+            input: '{"query":"second"}',
+          },
+          {
+            ...finishPart,
+            finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+          },
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      model,
+      undefined,
+      {
+        lookup: {
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      },
+    );
+
+    expect(result.raw.reasoning).toEqual([
+      { text: 'first' },
+      { text: 'second' },
+    ]);
+    expect(result.raw.reasoningFiles).toEqual([
+      {
+        data: 'c2lnbmVkLXRob3VnaHQ=',
+        mediaType: 'application/octet-stream',
+        providerMetadata: {
+          google: { thoughtSignature: 'file-signature' },
+        },
+      },
+    ]);
+    expect(result.raw.reasoningAndToolCallOrder).toEqual([
+      { type: 'reasoning', index: 0 },
+      { type: 'tool-call', index: 0 },
+      { type: 'reasoning-file', index: 0 },
+      { type: 'reasoning', index: 1 },
+      { type: 'tool-call', index: 1 },
+    ]);
+  });
+});

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -1,6 +1,7 @@
 import type {
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
+  SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import {
   experimental_streamLanguageModelCall as streamModelCall,
@@ -66,7 +67,7 @@ export interface ParsedToolCall {
   toolName: string;
   input: unknown;
   providerExecuted?: boolean;
-  providerMetadata?: Record<string, unknown>;
+  providerMetadata?: SharedV4ProviderMetadata;
   dynamic?: boolean;
   invalid?: boolean;
   error?: unknown;
@@ -79,7 +80,7 @@ export interface StreamFinish {
   finishReason: FinishReason;
   rawFinishReason: string | undefined;
   usage: LanguageModelUsage;
-  providerMetadata?: Record<string, unknown>;
+  providerMetadata?: SharedV4ProviderMetadata;
 }
 
 /**
@@ -94,7 +95,20 @@ export interface StreamFinish {
  */
 export interface DoStreamStepRawResult {
   text: string;
-  reasoning: Array<{ text: string }>;
+  reasoning: Array<{
+    text: string;
+    providerMetadata?: SharedV4ProviderMetadata;
+  }>;
+  reasoningFiles?: Array<{
+    data: string;
+    mediaType: string;
+    providerMetadata?: SharedV4ProviderMetadata;
+  }>;
+  reasoningAndToolCallOrder?: Array<
+    | { type: 'reasoning'; index: number }
+    | { type: 'reasoning-file'; index: number }
+    | { type: 'tool-call'; index: number }
+  >;
   responseMetadata?: { id?: string; timestamp?: Date; modelId?: string };
   warnings?: unknown[];
 }
@@ -164,7 +178,32 @@ export async function doStreamStep(
 
   // Minimal aggregation — only what buildStepResult needs outside the step.
   let text = '';
-  const reasoningParts: Array<{ text: string }> = [];
+  const reasoningAndToolCallOrder: NonNullable<
+    DoStreamStepRawResult['reasoningAndToolCallOrder']
+  > = [];
+  const reasoningParts: Array<{
+    text: string;
+    providerMetadata?: SharedV4ProviderMetadata;
+  }> = [];
+  const reasoningFiles: NonNullable<DoStreamStepRawResult['reasoningFiles']> =
+    [];
+  const reasoningPartIndexes = new Map<string, number>();
+  const upsertReasoningPart = (
+    id: string,
+    providerMetadata?: SharedV4ProviderMetadata,
+  ) => {
+    let partIndex = reasoningPartIndexes.get(id);
+    if (partIndex == null) {
+      partIndex = reasoningParts.push({ text: '' }) - 1;
+      reasoningPartIndexes.set(id, partIndex);
+      reasoningAndToolCallOrder.push({ type: 'reasoning', index: partIndex });
+    }
+    const reasoningPart = reasoningParts[partIndex];
+    if (providerMetadata != null) {
+      reasoningPart.providerMetadata = providerMetadata;
+    }
+    return reasoningPart;
+  };
   let responseMetadata:
     | { id?: string; timestamp?: Date; modelId?: string }
     | undefined;
@@ -179,25 +218,50 @@ export async function doStreamStep(
         case 'text-delta':
           text += part.text;
           break;
-        case 'reasoning-delta':
-          reasoningParts.push({ text: part.text });
+        case 'reasoning-start':
+          upsertReasoningPart(part.id, part.providerMetadata);
           break;
+        case 'reasoning-delta': {
+          const reasoningPart = upsertReasoningPart(
+            part.id,
+            part.providerMetadata,
+          );
+          reasoningPart.text += part.text;
+          break;
+        }
+        case 'reasoning-end': {
+          upsertReasoningPart(part.id, part.providerMetadata);
+          reasoningPartIndexes.delete(part.id);
+          break;
+        }
+        case 'reasoning-file': {
+          const index =
+            reasoningFiles.push({
+              data: part.file.base64,
+              mediaType: part.file.mediaType,
+              ...(part.providerMetadata != null
+                ? { providerMetadata: part.providerMetadata }
+                : {}),
+            }) - 1;
+          reasoningAndToolCallOrder.push({ type: 'reasoning-file', index });
+          break;
+        }
         case 'tool-call': {
           // parseToolCall adds dynamic/invalid/error at runtime
           const toolCallPart = part as typeof part & Partial<ParsedToolCall>;
-          toolCalls.push({
-            type: 'tool-call',
-            toolCallId: toolCallPart.toolCallId,
-            toolName: toolCallPart.toolName,
-            input: toolCallPart.input,
-            providerExecuted: toolCallPart.providerExecuted,
-            providerMetadata: toolCallPart.providerMetadata as
-              | Record<string, unknown>
-              | undefined,
-            dynamic: toolCallPart.dynamic,
-            invalid: toolCallPart.invalid,
-            error: toolCallPart.error,
-          });
+          const index =
+            toolCalls.push({
+              type: 'tool-call',
+              toolCallId: toolCallPart.toolCallId,
+              toolName: toolCallPart.toolName,
+              input: toolCallPart.input,
+              providerExecuted: toolCallPart.providerExecuted,
+              providerMetadata: toolCallPart.providerMetadata,
+              dynamic: toolCallPart.dynamic,
+              invalid: toolCallPart.invalid,
+              error: toolCallPart.error,
+            }) - 1;
+          reasoningAndToolCallOrder.push({ type: 'tool-call', index });
           break;
         }
         case 'tool-result':
@@ -229,9 +293,7 @@ export async function doStreamStep(
             finishReason: part.finishReason,
             rawFinishReason: part.rawFinishReason,
             usage: part.usage,
-            providerMetadata: part.providerMetadata as
-              | Record<string, unknown>
-              | undefined,
+            providerMetadata: part.providerMetadata,
           };
           break;
         case 'model-call-start':
@@ -257,6 +319,8 @@ export async function doStreamStep(
     raw: {
       text,
       reasoning: reasoningParts,
+      reasoningFiles,
+      reasoningAndToolCallOrder,
       responseMetadata,
       warnings,
     },

--- a/packages/workflow/src/reasoning-preservation.test.ts
+++ b/packages/workflow/src/reasoning-preservation.test.ts
@@ -1,0 +1,246 @@
+import type {
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
+  LanguageModelV4ToolResultPart,
+} from '@ai-sdk/provider';
+import { tool, type ToolSet } from 'ai';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { streamTextIterator } from './stream-text-iterator.js';
+
+function finishPart(
+  finishReason: 'stop' | 'tool-calls',
+): LanguageModelV4StreamPart {
+  return {
+    type: 'finish',
+    finishReason: {
+      unified: finishReason,
+      raw: finishReason === 'tool-calls' ? 'tool_calls' : 'stop',
+    },
+    usage: {
+      inputTokens: {
+        total: 1,
+        noCache: 1,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 1,
+        text: undefined,
+        reasoning: 1,
+      },
+    },
+  };
+}
+
+describe('WorkflowAgent reasoning preservation', () => {
+  it('carries reasoning and provider metadata into the next model turn', async () => {
+    let callCount = 0;
+    let secondTurnPrompt: LanguageModelV4Prompt | undefined;
+    const model = new MockLanguageModelV4({
+      doStream: async options => {
+        if (callCount++ === 0) {
+          return {
+            stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'reasoning-start',
+                id: 'reasoning-1',
+                providerMetadata: {
+                  openai: {
+                    itemId: 'rs_reasoning_item',
+                    reasoningEncryptedContent: 'encrypted-reasoning',
+                  },
+                },
+              },
+              { type: 'reasoning-end', id: 'reasoning-1' },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'lookup',
+                input: '{"query":"weather"}',
+                providerMetadata: {
+                  openai: { itemId: 'fc_requires_reasoning' },
+                },
+              },
+              finishPart('tool-calls'),
+            ]),
+          };
+        }
+
+        secondTurnPrompt = options.prompt;
+        return {
+          stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+            { type: 'stream-start', warnings: [] },
+            finishPart('stop'),
+          ]),
+        };
+      },
+    });
+    const tools = {
+      lookup: tool({
+        description: 'Look up information',
+        inputSchema: z.object({ query: z.string() }),
+      }),
+    } satisfies ToolSet;
+
+    const iterator = streamTextIterator({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      tools,
+      model,
+    });
+
+    const firstTurn = await iterator.next();
+    expect(firstTurn.done).toBe(false);
+    const toolResults: LanguageModelV4ToolResultPart[] = [
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        output: { type: 'json', value: { ok: true } },
+      },
+    ];
+    await iterator.next(toolResults);
+
+    const assistantMessage = secondTurnPrompt?.find(
+      message => message.role === 'assistant',
+    );
+    expect(assistantMessage?.content).toEqual([
+      {
+        type: 'reasoning',
+        text: '',
+        providerOptions: {
+          openai: {
+            itemId: 'rs_reasoning_item',
+            reasoningEncryptedContent: 'encrypted-reasoning',
+          },
+        },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        input: { query: 'weather' },
+        providerOptions: {
+          openai: { itemId: 'fc_requires_reasoning' },
+        },
+      },
+    ]);
+  });
+
+  it('preserves interleaved reasoning files and tool calls end to end', async () => {
+    let callCount = 0;
+    let secondTurnPrompt: LanguageModelV4Prompt | undefined;
+    const model = new MockLanguageModelV4({
+      doStream: async options => {
+        if (callCount++ === 0) {
+          return {
+            stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+              { type: 'stream-start', warnings: [] },
+              { type: 'reasoning-start', id: 'reasoning-1' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'first',
+              },
+              { type: 'reasoning-end', id: 'reasoning-1' },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'lookup',
+                input: '{"query":"first"}',
+              },
+              {
+                type: 'reasoning-file',
+                data: { type: 'data', data: 'c2lnbmVkLXRob3VnaHQ=' },
+                mediaType: 'application/octet-stream',
+                providerMetadata: {
+                  google: { thoughtSignature: 'file-signature' },
+                },
+              },
+              { type: 'reasoning-start', id: 'reasoning-2' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-2',
+                delta: 'second',
+              },
+              { type: 'reasoning-end', id: 'reasoning-2' },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-2',
+                toolName: 'lookup',
+                input: '{"query":"second"}',
+              },
+              finishPart('tool-calls'),
+            ]),
+          };
+        }
+
+        secondTurnPrompt = options.prompt;
+        return {
+          stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+            { type: 'stream-start', warnings: [] },
+            finishPart('stop'),
+          ]),
+        };
+      },
+    });
+    const tools = {
+      lookup: tool({
+        description: 'Look up information',
+        inputSchema: z.object({ query: z.string() }),
+      }),
+    } satisfies ToolSet;
+
+    const iterator = streamTextIterator({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      tools,
+      model,
+    });
+
+    await iterator.next();
+    await iterator.next([
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        output: { type: 'json', value: { ok: true } },
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'call-2',
+        toolName: 'lookup',
+        output: { type: 'json', value: { ok: true } },
+      },
+    ]);
+
+    const assistantMessage = secondTurnPrompt?.find(
+      message => message.role === 'assistant',
+    );
+    expect(assistantMessage?.content).toEqual([
+      { type: 'reasoning', text: 'first' },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        input: { query: 'first' },
+      },
+      {
+        type: 'reasoning-file',
+        data: { type: 'data', data: 'c2lnbmVkLXRob3VnaHQ=' },
+        mediaType: 'application/octet-stream',
+        providerOptions: {
+          google: { thoughtSignature: 'file-signature' },
+        },
+      },
+      { type: 'reasoning', text: 'second' },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-2',
+        toolName: 'lookup',
+        input: { query: 'second' },
+      },
+    ]);
+  });
+});

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -618,13 +618,13 @@ describe('streamTextIterator', () => {
       expect(toolWithoutMeta?.providerOptions).toBeUndefined();
     });
 
-    it('should strip OpenAI itemId from providerMetadata to avoid reasoning item errors', async () => {
+    it('should pass OpenAI itemId through as opaque provider metadata', async () => {
       const mockWritable = createMockWritable();
       const mockModel = vi.fn();
 
       let capturedPrompt: LanguageModelV4Prompt | undefined;
 
-      // OpenAI Responses API returns itemId which requires reasoning items we don't preserve
+      // OpenAI Responses API returns itemId references to preceding reasoning items.
       const toolCallWithOpenAIMetadata: LanguageModelV4ToolCall = {
         type: 'tool-call',
         toolCallId: 'call-1',
@@ -684,18 +684,21 @@ describe('streamTextIterator', () => {
         part => part.type === 'tool-call',
       );
 
-      // itemId should be stripped, leaving no providerOptions
       expect(toolCallPart).toBeDefined();
-      expect(toolCallPart.providerOptions).toBeUndefined();
+      expect(toolCallPart.providerOptions).toEqual({
+        openai: {
+          itemId: 'fc_0402bf2d292dd7ed00697a35fb10e0819ab0098545c4d0d7f5',
+        },
+      });
     });
 
-    it('should preserve other OpenAI metadata while stripping itemId', async () => {
+    it('should preserve all OpenAI metadata fields', async () => {
       const mockWritable = createMockWritable();
       const mockModel = vi.fn();
 
       let capturedPrompt: LanguageModelV4Prompt | undefined;
 
-      // OpenAI metadata with both itemId (should be stripped) and other fields (should be preserved)
+      // OpenAI metadata with an item reference and an additional provider field.
       const toolCallWithMixedOpenAIMetadata: LanguageModelV4ToolCall = {
         type: 'tool-call',
         toolCallId: 'call-1',
@@ -756,22 +759,22 @@ describe('streamTextIterator', () => {
         part => part.type === 'tool-call',
       );
 
-      // itemId should be stripped, but other fields preserved
       expect(toolCallPart).toBeDefined();
       expect(toolCallPart.providerOptions).toEqual({
         openai: {
+          itemId: 'fc_0402bf2d292dd7ed00697a35fb10e0819ab0098545c4d0d7f5',
           someOtherField: 'should-be-preserved',
         },
       });
     });
 
-    it('should preserve Gemini metadata while stripping OpenAI itemId in mixed provider metadata', async () => {
+    it('should preserve mixed Gemini and OpenAI metadata', async () => {
       const mockWritable = createMockWritable();
       const mockModel = vi.fn();
 
       let capturedPrompt: LanguageModelV4Prompt | undefined;
 
-      // Mixed provider metadata - Gemini should be fully preserved, OpenAI itemId stripped
+      // Mixed provider metadata must survive without provider-specific filtering.
       const toolCallWithMixedProviders: LanguageModelV4ToolCall = {
         type: 'tool-call',
         toolCallId: 'call-1',
@@ -782,7 +785,7 @@ describe('streamTextIterator', () => {
             thoughtSignature: 'sig_gemini_preserved',
           },
           openai: {
-            itemId: 'fc_should_be_stripped',
+            itemId: 'fc_preserved',
           },
         },
       };
@@ -834,13 +837,333 @@ describe('streamTextIterator', () => {
         part => part.type === 'tool-call',
       );
 
-      // Gemini metadata should be preserved, OpenAI itemId stripped
       expect(toolCallPart).toBeDefined();
       expect(toolCallPart.providerOptions).toEqual({
         google: {
           thoughtSignature: 'sig_gemini_preserved',
         },
+        openai: {
+          itemId: 'fc_preserved',
+        },
       });
+    });
+  });
+
+  describe('reasoning content preservation', () => {
+    it('should include reasoning before tool calls with provider options intact', async () => {
+      let capturedPrompt: LanguageModelV4Prompt | undefined;
+
+      const toolCall: ParsedToolCall = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        input: { query: 'weather' },
+        providerExecuted: true,
+        providerMetadata: {
+          openai: { itemId: 'fc_requires_reasoning' },
+        },
+      };
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce(
+          createMockDoStreamStepResult({
+            toolCalls: [toolCall],
+            finishReason: 'tool-calls',
+            finishRaw: 'tool_calls',
+            rawOverrides: {
+              reasoning: [
+                {
+                  text: 'I should look this up.',
+                  providerMetadata: {
+                    openai: {
+                      itemId: 'rs_reasoning_item',
+                      reasoningEncryptedContent: 'encrypted-reasoning',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        )
+        .mockImplementationOnce(async prompt => {
+          capturedPrompt = prompt;
+          return createMockDoStreamStepResult();
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          lookup: {
+            description: 'Look up information',
+            execute: async () => ({ ok: true }),
+          },
+        } as unknown as ToolSet,
+        writable: createMockWritable(),
+        model: vi.fn() as any,
+      });
+
+      const firstResult = await iterator.next();
+      const firstValue = firstResult.value as StreamTextIteratorYieldValue;
+      expect(firstValue.step?.content[0]).toEqual({
+        type: 'reasoning',
+        text: 'I should look this up.',
+        providerMetadata: {
+          openai: {
+            itemId: 'rs_reasoning_item',
+            reasoningEncryptedContent: 'encrypted-reasoning',
+          },
+        },
+      });
+      expect(firstValue.step?.reasoning[0]).toEqual({
+        type: 'reasoning',
+        text: 'I should look this up.',
+        providerOptions: {
+          openai: {
+            itemId: 'rs_reasoning_item',
+            reasoningEncryptedContent: 'encrypted-reasoning',
+          },
+        },
+      });
+      await iterator.next([
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          output: { type: 'json', value: { ok: true } },
+        },
+      ]);
+
+      const assistantMessage = capturedPrompt?.find(
+        message => message.role === 'assistant',
+      );
+      expect(assistantMessage?.content).toEqual([
+        {
+          type: 'reasoning',
+          text: 'I should look this up.',
+          providerOptions: {
+            openai: {
+              itemId: 'rs_reasoning_item',
+              reasoningEncryptedContent: 'encrypted-reasoning',
+            },
+          },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          input: { query: 'weather' },
+          providerExecuted: true,
+          providerOptions: {
+            openai: { itemId: 'fc_requires_reasoning' },
+          },
+        },
+      ]);
+    });
+
+    it('should retain metadata-only reasoning parts', async () => {
+      let capturedPrompt: LanguageModelV4Prompt | undefined;
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce(
+          createMockDoStreamStepResult({
+            toolCalls: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'lookup',
+                input: {},
+              },
+            ],
+            finishReason: 'tool-calls',
+            rawOverrides: {
+              reasoning: [
+                {
+                  text: '',
+                  providerMetadata: {
+                    openai: {
+                      itemId: 'rs_encrypted',
+                      reasoningEncryptedContent: 'encrypted-only',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        )
+        .mockImplementationOnce(async prompt => {
+          capturedPrompt = prompt;
+          return createMockDoStreamStepResult();
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          lookup: { description: 'Look up information' },
+        } as unknown as ToolSet,
+        writable: createMockWritable(),
+        model: vi.fn() as any,
+      });
+
+      await iterator.next();
+      await iterator.next([
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          output: { type: 'json', value: { ok: true } },
+        },
+      ]);
+
+      const assistantMessage = capturedPrompt?.find(
+        message => message.role === 'assistant',
+      );
+      expect(assistantMessage?.content[0]).toEqual({
+        type: 'reasoning',
+        text: '',
+        providerOptions: {
+          openai: {
+            itemId: 'rs_encrypted',
+            reasoningEncryptedContent: 'encrypted-only',
+          },
+        },
+      });
+    });
+
+    it('should preserve interleaved reasoning files and tool calls', async () => {
+      let capturedPrompt: LanguageModelV4Prompt | undefined;
+      const toolCalls: ParsedToolCall[] = [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          input: { query: 'first' },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'lookup',
+          input: { query: 'second' },
+        },
+      ];
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce(
+          createMockDoStreamStepResult({
+            toolCalls,
+            finishReason: 'tool-calls',
+            finishRaw: 'tool_calls',
+            rawOverrides: {
+              reasoning: [{ text: 'first' }, { text: 'second' }],
+              reasoningFiles: [
+                {
+                  data: 'c2lnbmVkLXRob3VnaHQ=',
+                  mediaType: 'application/octet-stream',
+                  providerMetadata: {
+                    google: { thoughtSignature: 'file-signature' },
+                  },
+                },
+              ],
+              reasoningAndToolCallOrder: [
+                { type: 'reasoning', index: 0 },
+                { type: 'tool-call', index: 0 },
+                { type: 'reasoning-file', index: 0 },
+                { type: 'reasoning', index: 1 },
+                { type: 'tool-call', index: 1 },
+              ],
+            },
+          }),
+        )
+        .mockImplementationOnce(async prompt => {
+          capturedPrompt = prompt;
+          return createMockDoStreamStepResult();
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          lookup: { description: 'Look up information' },
+        } as unknown as ToolSet,
+        writable: createMockWritable(),
+        model: vi.fn() as any,
+      });
+
+      const firstResult = await iterator.next();
+      const firstValue = firstResult.value as StreamTextIteratorYieldValue;
+      expect(firstValue.step?.content.map(part => part.type)).toEqual([
+        'reasoning',
+        'tool-call',
+        'reasoning-file',
+        'reasoning',
+        'tool-call',
+      ]);
+      const reasoningFile = firstValue.step?.content.find(
+        part => part.type === 'reasoning-file',
+      );
+      expect(reasoningFile).toMatchObject({
+        type: 'reasoning-file',
+        providerMetadata: {
+          google: { thoughtSignature: 'file-signature' },
+        },
+      });
+      if (reasoningFile?.type !== 'reasoning-file') {
+        throw new Error('Expected reasoning-file content');
+      }
+      expect(reasoningFile.file.base64).toBe('c2lnbmVkLXRob3VnaHQ=');
+      expect(firstValue.step?.reasoning).toEqual([
+        { type: 'reasoning', text: 'first' },
+        {
+          type: 'reasoning-file',
+          data: 'c2lnbmVkLXRob3VnaHQ=',
+          mediaType: 'application/octet-stream',
+          providerOptions: {
+            google: { thoughtSignature: 'file-signature' },
+          },
+        },
+        { type: 'reasoning', text: 'second' },
+      ]);
+
+      await iterator.next([
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          output: { type: 'json', value: { ok: true } },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-2',
+          toolName: 'lookup',
+          output: { type: 'json', value: { ok: true } },
+        },
+      ]);
+
+      const assistantMessage = capturedPrompt?.find(
+        message => message.role === 'assistant',
+      );
+      expect(assistantMessage?.content).toEqual([
+        { type: 'reasoning', text: 'first' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          input: { query: 'first' },
+        },
+        {
+          type: 'reasoning-file',
+          data: { type: 'data', data: 'c2lnbmVkLXRob3VnaHQ=' },
+          mediaType: 'application/octet-stream',
+          providerOptions: {
+            google: { thoughtSignature: 'file-signature' },
+          },
+        },
+        { type: 'reasoning', text: 'second' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'lookup',
+          input: { query: 'second' },
+        },
+      ]);
     });
   });
 

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -7,6 +7,7 @@ import type {
 import type { Context } from '@ai-sdk/provider-utils';
 import {
   experimental_filterActiveTools as filterActiveTools,
+  DefaultGeneratedFile,
   type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   type Experimental_SandboxSession as SandboxSession,
   type Instructions,
@@ -70,6 +71,12 @@ function mergePrepareStepGenerationSettings(
 
   return { ...current, ...definedOverrides };
 }
+
+type WorkflowStepContentPart = StepResult<ToolSet, any>['content'][number];
+type WorkflowReasoningContentPart = Extract<
+  WorkflowStepContentPart,
+  { type: 'reasoning' | 'reasoning-file' }
+>;
 
 /**
  * The value yielded by the stream text iterator when tool calls are requested.
@@ -363,37 +370,12 @@ export async function* streamTextIterator({
       if (finishReason === 'tool-calls') {
         lastStepWasToolCalls = true;
 
-        const textContent = step.content.filter(
-          item => item.type === 'text',
-        ) as Array<{ type: 'text'; text: string }>;
-
-        // Add assistant message with text and tool calls to the conversation
-        // Note: providerMetadata from the tool call is mapped to providerOptions
-        // in the prompt format, following the AI SDK convention. This is critical
-        // for providers like Gemini that require thoughtSignature to be preserved
-        // across multi-turn tool calls. Some fields are sanitized before mapping.
+        // Preserve reasoning alongside tool calls. Their provider metadata can
+        // contain references that are only valid when both parts are carried
+        // into the next provider request together.
         conversationPrompt.push({
           role: 'assistant',
-          content: [
-            ...textContent,
-            ...toolCalls.map(toolCall => {
-              const sanitizedMetadata = sanitizeProviderMetadataForToolCall(
-                toolCall.providerMetadata,
-              );
-              return {
-                type: 'tool-call' as const,
-                toolCallId: toolCall.toolCallId,
-                toolName: toolCall.toolName,
-                input: toolCall.input,
-                ...(sanitizedMetadata != null
-                  ? {
-                      providerOptions:
-                        sanitizedMetadata as SharedV4ProviderOptions,
-                    }
-                  : {}),
-              };
-            }),
-          ],
+          content: buildAssistantPromptContent(raw, toolCalls),
         });
 
         // Yield the tool calls along with the current conversation messages
@@ -522,17 +504,94 @@ function buildStepResult(
   },
 ): StepResult<ToolSet, any> {
   const { text, reasoning: reasoningParts, responseMetadata, warnings } = raw;
-  const reasoningText = reasoningParts.map(r => r.text).join('') || undefined;
+  const reasoningText =
+    reasoningParts.map(part => part.text).join('') || undefined;
 
-  const validToolCalls = toolCalls
-    .filter(tc => !tc.invalid)
-    .map(tc => ({
-      type: 'tool-call' as const,
-      toolCallId: tc.toolCallId,
-      toolName: tc.toolName,
-      input: tc.input,
-      ...(tc.dynamic ? { dynamic: true as const } : {}),
-    }));
+  const reasoningContentByIndex = reasoningParts.map(part => ({
+    type: 'reasoning' as const,
+    text: part.text,
+    ...(part.providerMetadata != null
+      ? { providerMetadata: part.providerMetadata }
+      : {}),
+  }));
+  const reasoningFileContentByIndex = (raw.reasoningFiles ?? []).map(part => ({
+    type: 'reasoning-file' as const,
+    file: new DefaultGeneratedFile({
+      data: part.data,
+      mediaType: part.mediaType,
+    }),
+    ...(part.providerMetadata != null
+      ? { providerMetadata: part.providerMetadata }
+      : {}),
+  }));
+
+  const toolCallContentByIndex = toolCalls.map(toolCall =>
+    toolCall.invalid
+      ? undefined
+      : ({
+          type: 'tool-call' as const,
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+          input: toolCall.input,
+          ...(toolCall.dynamic ? { dynamic: true as const } : {}),
+        } as const),
+  );
+  const validToolCalls = toolCallContentByIndex.filter(
+    (
+      toolCall,
+    ): toolCall is NonNullable<(typeof toolCallContentByIndex)[number]> =>
+      toolCall != null,
+  );
+
+  const contentOrder = getReasoningAndToolCallOrder(raw, toolCalls);
+  const orderedGeneratedContent: WorkflowStepContentPart[] = [];
+  for (const part of contentOrder) {
+    switch (part.type) {
+      case 'reasoning': {
+        const reasoningPart = reasoningContentByIndex[part.index];
+        if (reasoningPart != null) {
+          orderedGeneratedContent.push(reasoningPart);
+        }
+        break;
+      }
+      case 'reasoning-file': {
+        const reasoningFile = reasoningFileContentByIndex[part.index];
+        if (reasoningFile != null) {
+          orderedGeneratedContent.push(reasoningFile);
+        }
+        break;
+      }
+      case 'tool-call': {
+        const toolCall = toolCallContentByIndex[part.index];
+        if (toolCall != null) {
+          orderedGeneratedContent.push(toolCall);
+        }
+        break;
+      }
+    }
+  }
+  const reasoningContent = orderedGeneratedContent.filter(
+    (part): part is WorkflowReasoningContentPart =>
+      part.type === 'reasoning' || part.type === 'reasoning-file',
+  );
+  const reasoning = reasoningContent.map(part =>
+    part.type === 'reasoning'
+      ? {
+          type: 'reasoning' as const,
+          text: part.text,
+          ...(part.providerMetadata != null
+            ? { providerOptions: part.providerMetadata }
+            : {}),
+        }
+      : {
+          type: 'reasoning-file' as const,
+          data: part.file.base64,
+          mediaType: part.file.mediaType,
+          ...(part.providerMetadata != null
+            ? { providerOptions: part.providerMetadata }
+            : {}),
+        },
+  );
 
   return {
     callId: 'workflow-agent',
@@ -547,13 +606,10 @@ function buildStepResult(
     toolsContext: opts.toolsContext ?? {},
     content: [
       ...(text ? [{ type: 'text' as const, text }] : []),
-      ...validToolCalls,
+      ...orderedGeneratedContent,
     ],
     text,
-    reasoning: reasoningParts.map(r => ({
-      type: 'reasoning' as const,
-      text: r.text,
-    })),
+    reasoning,
     reasoningText,
     files: [],
     sources: [],
@@ -606,38 +662,86 @@ function buildStepResult(
   } as StepResult<ToolSet, any>;
 }
 
-/**
- * Strip OpenAI's itemId from providerMetadata (requires reasoning items we don't preserve).
- * Preserves all other provider metadata (e.g., Gemini's thoughtSignature).
- */
-function sanitizeProviderMetadataForToolCall(
-  metadata: unknown,
-): Record<string, unknown> | undefined {
-  if (metadata == null) return undefined;
+function getReasoningAndToolCallOrder(
+  raw: DoStreamStepRawResult,
+  toolCalls: ParsedToolCall[],
+): NonNullable<DoStreamStepRawResult['reasoningAndToolCallOrder']> {
+  return (
+    raw.reasoningAndToolCallOrder ?? [
+      ...raw.reasoning.map((_, index) => ({
+        type: 'reasoning' as const,
+        index,
+      })),
+      ...(raw.reasoningFiles ?? []).map((_, index) => ({
+        type: 'reasoning-file' as const,
+        index,
+      })),
+      ...toolCalls.map((_, index) => ({
+        type: 'tool-call' as const,
+        index,
+      })),
+    ]
+  );
+}
 
-  const meta = metadata as Record<string, unknown>;
+function buildAssistantPromptContent(
+  raw: DoStreamStepRawResult,
+  toolCalls: ParsedToolCall[],
+): Extract<LanguageModelV4Prompt[number], { role: 'assistant' }>['content'] {
+  const content: Extract<
+    LanguageModelV4Prompt[number],
+    { role: 'assistant' }
+  >['content'] = [];
 
-  // Check if OpenAI metadata exists and needs sanitization
-  if ('openai' in meta && meta.openai != null) {
-    const { openai, ...restProviders } = meta;
-    const openaiMeta = openai as Record<string, unknown>;
-
-    // Remove itemId from OpenAI metadata - it requires reasoning items we don't preserve
-    const { itemId: _itemId, ...restOpenai } = openaiMeta;
-
-    // Reconstruct metadata without itemId
-    const hasOtherOpenaiFields = Object.keys(restOpenai).length > 0;
-    const hasOtherProviders = Object.keys(restProviders).length > 0;
-
-    if (hasOtherOpenaiFields && hasOtherProviders) {
-      return { ...restProviders, openai: restOpenai };
-    } else if (hasOtherOpenaiFields) {
-      return { openai: restOpenai };
-    } else if (hasOtherProviders) {
-      return restProviders;
+  for (const part of getReasoningAndToolCallOrder(raw, toolCalls)) {
+    switch (part.type) {
+      case 'reasoning': {
+        const reasoningPart = raw.reasoning[part.index];
+        if (reasoningPart != null) {
+          content.push({
+            type: 'reasoning',
+            text: reasoningPart.text,
+            ...(reasoningPart.providerMetadata != null
+              ? { providerOptions: reasoningPart.providerMetadata }
+              : {}),
+          });
+        }
+        break;
+      }
+      case 'reasoning-file': {
+        const reasoningFile = raw.reasoningFiles?.[part.index];
+        if (reasoningFile != null) {
+          content.push({
+            type: 'reasoning-file',
+            data: { type: 'data', data: reasoningFile.data },
+            mediaType: reasoningFile.mediaType,
+            ...(reasoningFile.providerMetadata != null
+              ? { providerOptions: reasoningFile.providerMetadata }
+              : {}),
+          });
+        }
+        break;
+      }
+      case 'tool-call': {
+        const toolCall = toolCalls[part.index];
+        if (toolCall != null) {
+          content.push({
+            type: 'tool-call',
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            input: toolCall.input,
+            ...(toolCall.providerExecuted != null
+              ? { providerExecuted: toolCall.providerExecuted }
+              : {}),
+            ...(toolCall.providerMetadata != null
+              ? { providerOptions: toolCall.providerMetadata }
+              : {}),
+          });
+        }
+        break;
+      }
     }
-    return undefined;
   }
 
-  return meta;
+  return content;
 }


### PR DESCRIPTION
## Background

`WorkflowAgent` currently carries tool calls into the next model turn without the reasoning items that preceded them. Provider metadata on those tool calls can reference the missing reasoning items, so the implementation strips OpenAI `itemId` values as a provider-specific workaround.

This change preserves the reasoning content and metadata instead, allowing providers to receive the complete assistant turn without hardcoded metadata filtering.

## Summary

- aggregate reasoning across its start/delta/end lifecycle, including metadata-only encrypted reasoning
- preserve first-seen block order across textual reasoning, reasoning files, and tool calls with a small serializable index ledger
- reconstruct both `StepResult` and the next assistant prompt with reasoning-file data, media type, and provider metadata intact
- remove the OpenAI-specific `itemId` sanitizer now that referenced reasoning items are retained
- add focused, composed, Node, and Edge coverage for metadata, reused IDs, orphan parts, interleaving, reasoning files, and legacy raw-result fallback

## Manual Verification

I inspected the captured second-turn V4 prompt for the maintainer's reproduction scenario and confirmed that the reasoning item immediately precedes its dependent tool call, with provider options preserved on both parts. I repeated the scenario with two interleaved reasoning blocks, a metadata-bearing reasoning file, and two tool calls; the next prompt retained the exact first-seen block order and the file's data, media type, and signature metadata.

Local live-provider verification was not run because no provider credential is configured. The workflow integration harness also fails before user code with the same 19 run-start event errors on this branch and a clean `origin/main`; package-level Node and Edge suites, typecheck, and build are green.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14293.

Related implementation: vercel/workflow#1444.
