### PR TITLE
Fix Google Interactions dropping `text/*` file parts

### DIFF
--- a/.changeset/eighty-toes-hide.md
+++ b/.changeset/eighty-toes-hide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+Fix Google Interactions dropping `text/*` file parts referenced via the Files API. These media types are now mapped to `document` content blocks instead of being removed with a warning.

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -783,6 +783,129 @@ describe('convertToGoogleInteractionsInput', () => {
         ]
       `);
     });
+
+    it('maps a reference text/plain file part to a document block with the resolved Files API URI', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'summarize this text document' },
+            {
+              type: 'file',
+              mediaType: 'text/plain',
+              data: {
+                type: 'reference',
+                reference: {
+                  google:
+                    'https://generativelanguage.googleapis.com/v1beta/files/text-abc',
+                },
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "summarize this text document",
+                  "type": "text",
+                },
+                {
+                  "mime_type": "text/plain",
+                  "type": "document",
+                  "uri": "https://generativelanguage.googleapis.com/v1beta/files/text-abc",
+                },
+              ],
+              "type": "user_input",
+            },
+          ],
+          "systemInstruction": undefined,
+          "warnings": [],
+        }
+      `);
+    });
+
+    it('maps a url text/plain file part to a document block with `uri` (URL passthrough)', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'text/markdown',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/notes.md'),
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "input": [
+            {
+              "content": [
+                {
+                  "mime_type": "text/markdown",
+                  "type": "document",
+                  "uri": "https://example.com/notes.md",
+                },
+              ],
+              "type": "user_input",
+            },
+          ],
+          "systemInstruction": undefined,
+          "warnings": [],
+        }
+      `);
+    });
+
+    it('maps a binary text/plain data file part to a document block', () => {
+      const bytes = new Uint8Array([104, 105]);
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'text/plain',
+              data: { type: 'data', data: bytes },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "input": [
+            {
+              "content": [
+                {
+                  "data": "aGk=",
+                  "mime_type": "text/plain",
+                  "type": "document",
+                },
+              ],
+              "type": "user_input",
+            },
+          ],
+          "systemInstruction": undefined,
+          "warnings": [],
+        }
+      `);
+    });
   });
 
   describe('assistant tool-call parts', () => {

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -263,6 +263,7 @@ function convertFilePartToContent({
       kind = 'video';
       break;
     case 'application':
+    case 'text':
       kind = 'document';
       break;
     default:


### PR DESCRIPTION
These media types are now mapped to `document` content blocks instead of being removed with a warning. Add some tests as well.

Closes #17040

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

`text/*` files are being dropped even though Google Interactions API lists them as being supported.

## Summary

Add `text` as a valid format and map it to document type

## Manual Verification

Uploaded a text/plain file to the Google Files API and referenced it via providerReference in a google.interactions('gemini-3.5-flash') call with text 'Summarize this text document.'. 
Before the fix the file part was dropped with an unsupported file media type "text/plain" warning. 
After the fix result.warnings is empty and the model returns an accurate summary of the document, confirming the text file was sent as a document block and read by the model.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features) (bug fix no documentation needed)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
