### PR TITLE
fix(google): support text/* media types as document parts in interactions file parts

### DIFF
--- a/.changeset/tender-pans-tan.md
+++ b/.changeset/tender-pans-tan.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): support text/\* media types as document parts in interactions file parts

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -485,6 +485,81 @@ describe('convertToGoogleInteractionsInput', () => {
     });
   });
 
+  describe('text file parts', () => {
+    it('maps a text/plain reference part to a document block with the resolved Files API URI', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Summarize this text document' },
+            {
+              type: 'file',
+              mediaType: 'text/plain',
+              data: {
+                type: 'reference',
+                reference: {
+                  google:
+                    'https://generativelanguage.googleapis.com/v1beta/files/txt-abc',
+                },
+              },
+            },
+          ],
+        },
+      ];
+      const result = convertToGoogleInteractionsInput({ prompt });
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Summarize this text document",
+                  "type": "text",
+                },
+                {
+                  "mime_type": "text/plain",
+                  "type": "document",
+                  "uri": "https://generativelanguage.googleapis.com/v1beta/files/txt-abc",
+                },
+              ],
+              "type": "user_input",
+            },
+          ],
+          "systemInstruction": undefined,
+          "warnings": [],
+        }
+      `);
+    });
+    it('emits a warning and drops unsupported non-text/* media types', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'font/woff2',
+              data: {
+                type: 'reference',
+                reference: {
+                  google:
+                    'https://generativelanguage.googleapis.com/v1beta/files/font-xyz',
+                },
+              },
+            },
+          ],
+        },
+      ];
+      const result = convertToGoogleInteractionsInput({ prompt });
+      expect(result.warnings).toEqual([
+        {
+          type: 'other',
+          message:
+            'google.interactions: unsupported file media type "font/woff2"; part dropped.',
+        },
+      ]);
+    });
+  });
+
   describe('video file parts', () => {
     it('passes a YouTube URL through as a video block with `uri`', () => {
       const prompt: LanguageModelV4Prompt = [

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -265,6 +265,9 @@ function convertFilePartToContent({
     case 'application':
       kind = 'document';
       break;
+    case 'text':
+      kind = 'document';
+      break;
     default:
       kind = undefined;
   }


### PR DESCRIPTION
## Background:

Google's Interactions API supports text/* files (text/plain, text/html, text/css, text/xml, text/csv, text/rtf, text/javascript) uploaded via the Files API and referenced with a ProviderReference. However, the SDK incorrectly dropped these file parts with a warning: `google.interactions: unsupported file media type "text/plain"; part dropped.`

## Summary:

Added `case 'text': kind = 'document'; break;` to the media type switch in `convertFilePartToContent` in `convert-to-google-interactions-input.ts`. This follows the same pattern as `case 'application'` and mirrors the existing `supportedExternalUrlMediaTypes` list in `google-provider.ts` which already includes all text/* subtypes.

## Manual Verification:

All 690 existing tests pass. Added 2 new tests covering text/plain ProviderReference parts mapping correctly to document blocks, and confirming unsupported types (e.g. font/woff2) still emit warnings and are dropped.

## Related Issues:

Fixes #17040