### PR TITLE
Update openai-compatible-image-model.ts

### DIFF
--- a/packages/openai-compatible/src/image/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.ts
@@ -173,7 +173,6 @@ export class OpenAICompatibleImageModel implements ImageModelV4 {
         n,
         size,
         ...args,
-        response_format: 'b64_json',
       },
       failedResponseHandler: createJsonErrorResponseHandler(
         this.config.errorStructure ?? defaultOpenAICompatibleErrorStructure,


### PR DESCRIPTION
## Background

The OpenAI-compatible image model always included `response_format: "b64_json"` in image generation requests by default. While this works for the OpenAI Images API, some OpenAI-compatible providers either do not support this parameter or use provider-specific alternatives (for example, `extra_body.response_format` or `return_base64`).

As a result, image generation requests fail on those providers because the unsupported parameter is always sent.

## Summary

* Removed the default `response_format: "b64_json"` from the OpenAI-compatible image model.
* Image generation requests no longer include `response_format` unless it is explicitly provided.
* This improves compatibility with OpenAI-compatible providers that implement the Images API differently or rely on custom request parameters.

## Manual Verification

* Verified that image generation requests no longer include `response_format: "b64_json"` by default.
* Confirmed that providers which previously rejected the parameter can now receive requests without the unsupported field.
* Verified that explicitly providing a `response_format` still includes the parameter in the request as expected.

## Checklist

* [ ] All commits are signed (PRs with unsigned commits cannot be merged)
* [ ] Tests have been added / updated (for bug fixes / features)
* [ ] Documentation has been added / updated (for bug fixes / features)
* [ ] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
* [x] I have reviewed this pull request (self-review)

## Future Work

Consider allowing providers to define their own default image response format or request-specific parameters through provider configuration, avoiding provider-specific forks while maintaining compatibility.

## Related Issues

Fixes the compatibility issue where OpenAI-compatible providers reject image generation requests because `response_format: "b64_json"` is sent by default.