### PR TITLE
[v6.0] fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo

### DIFF
--- a/.changeset/chatty-pandas-compare.md
+++ b/.changeset/chatty-pandas-compare.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Align React development dependencies with React 18 so workspace-linked examples do not bundle duplicate React copies.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,12 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "jsdom": "^24.0.0",
     "msw": "2.6.4",
+<<<<<<< HEAD
     "react-dom": "^18 || ^19",
+=======
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
     "zod": "3.25.76"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,12 +51,8 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "jsdom": "^24.0.0",
     "msw": "2.6.4",
-<<<<<<< HEAD
-    "react-dom": "^18 || ^19",
-=======
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
     "zod": "3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2754,12 +2754,18 @@ importers:
       ai:
         specifier: workspace:*
         version: link:../ai
+<<<<<<< HEAD
       react:
         specifier: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
         version: 19.2.4
       swr:
         specifier: ^2.2.5
         version: 2.4.1(react@19.2.4)
+=======
+      swr:
+        specifier: ^2.4.1
+        version: 2.4.1(react@18.3.1)
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
       throttleit:
         specifier: 2.1.0
         version: 2.1.0
@@ -2771,8 +2777,13 @@ importers:
         specifier: ^6.6.3
         version: 6.9.1
       '@testing-library/react':
+<<<<<<< HEAD
         specifier: ^16.0.1
         version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+=======
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -2793,10 +2804,20 @@ importers:
         version: 24.1.3
       msw:
         specifier: 2.6.4
+<<<<<<< HEAD
         version: 2.6.4(@types/node@20.17.24)(typescript@5.8.3)
       react-dom:
         specifier: ^18 || ^19
         version: 19.2.4(react@19.2.4)
+=======
+        version: 2.6.4(@types/node@22.19.19)(typescript@5.8.3)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
       tsup:
         specifier: ^7.2.0
         version: 7.2.0(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.3))(typescript@5.8.3)
@@ -29245,6 +29266,7 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+<<<<<<< HEAD
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -29256,6 +29278,9 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@testing-library/svelte-core@1.0.0(svelte@5.53.6)':
+=======
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.7)':
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
     dependencies:
       svelte: 5.53.6
 
@@ -39695,11 +39720,19 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
+<<<<<<< HEAD
   swr@2.4.1(react@19.2.4):
     dependencies:
       dequal: 2.0.3
       react: 19.2.4
       use-sync-external-store: 1.6.0(react@19.2.4)
+=======
+  swr@2.4.1(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
 
   swrv@1.1.0(vue@3.5.13(typescript@5.8.3)):
     dependencies:
@@ -40804,9 +40837,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+<<<<<<< HEAD
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+=======
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+>>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
 
   utif@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2754,18 +2754,9 @@ importers:
       ai:
         specifier: workspace:*
         version: link:../ai
-<<<<<<< HEAD
-      react:
-        specifier: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-        version: 19.2.4
       swr:
         specifier: ^2.2.5
-        version: 2.4.1(react@19.2.4)
-=======
-      swr:
-        specifier: ^2.4.1
         version: 2.4.1(react@18.3.1)
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
       throttleit:
         specifier: 2.1.0
         version: 2.1.0
@@ -2777,13 +2768,8 @@ importers:
         specifier: ^6.6.3
         version: 6.9.1
       '@testing-library/react':
-<<<<<<< HEAD
         specifier: ^16.0.1
-        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-=======
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -2804,20 +2790,13 @@ importers:
         version: 24.1.3
       msw:
         specifier: 2.6.4
-<<<<<<< HEAD
         version: 2.6.4(@types/node@20.17.24)(typescript@5.8.3)
-      react-dom:
-        specifier: ^18 || ^19
-        version: 19.2.4(react@19.2.4)
-=======
-        version: 2.6.4(@types/node@22.19.19)(typescript@5.8.3)
       react:
         specifier: ^18.3.1
         version: 18.3.1
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
       tsup:
         specifier: ^7.2.0
         version: 7.2.0(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.3))(typescript@5.8.3)
@@ -29266,21 +29245,7 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-<<<<<<< HEAD
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@testing-library/dom': 10.4.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
-
   '@testing-library/svelte-core@1.0.0(svelte@5.53.6)':
-=======
-  '@testing-library/svelte-core@1.0.0(svelte@5.55.7)':
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
     dependencies:
       svelte: 5.53.6
 
@@ -39720,19 +39685,11 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-<<<<<<< HEAD
-  swr@2.4.1(react@19.2.4):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.4
-      use-sync-external-store: 1.6.0(react@19.2.4)
-=======
   swr@2.4.1(react@18.3.1):
     dependencies:
       dequal: 2.0.3
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
 
   swrv@1.1.0(vue@3.5.13(typescript@5.8.3)):
     dependencies:
@@ -40837,15 +40794,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-<<<<<<< HEAD
-  use-sync-external-store@1.6.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-=======
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
->>>>>>> d26bf9988 (fix: Prevent duplicate React crashes in next-openai-pages when run from the monorepo (#16918))
 
   utif@2.0.1:
     dependencies:


### PR DESCRIPTION
## Background

Running `examples/next-openai-pages` inside the monorepo with workspace-linked `@ai-sdk/react` could bundle React 19 from `packages/react` alongside the example app's React 18, causing the Pages Router `/basics/stream-object` page to crash at `useId` during client rendering.

## Summary

No runtime production source code changed. The PR aligns `@ai-sdk/react` development React and React DOM resolution to React 18.3.1, updates the lockfile, and adds a patch changeset.

## Testing

No regression test remains after review. Validation covers dependency resolution with `pnpm -C examples/next-openai-pages why react --depth 5`, browser loading of `/basics/stream-object`, and full `pnpm test`, `pnpm check`, `pnpm type-check`, and `pnpm konsistent:check` runs.

## End-to-end Validation

- `examples/next-openai-pages` `/basics/stream-object`: ran `NEXT_TELEMETRY_DISABLED=1 pnpm -C examples/next-openai-pages exec next dev -p 3100` and opened the page with Playwright; observed HTTP 200, the Generate UI rendered, and no `useId` or invalid-hook-call errors. Live provider API was not invoked because this regression occurs during client hydration before any provider request.

## Related Issues

Fixes #16890

Backport of #16918

Co-authored-by: gr2m <39992+gr2m@users.noreply.github.com>
Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>