### PR TITLE
docs: update provider package skill for ESM-only package configuration

### DIFF
--- a/skills/add-provider-package/SKILL.md
+++ b/skills/add-provider-package/SKILL.md
@@ -60,6 +60,7 @@ Set up your `package.json` with:
 
 - `"name": "@ai-sdk/<provider>"`
 - `"version": "0.0.0"` (initial version, will be updated by changeset)
+- `"type": "module"`
 - `"license": "Apache-2.0"`
 - `"sideEffects": false`
 - Dependencies on `@ai-sdk/provider` and `@ai-sdk/provider-utils` (use `workspace:*`)
@@ -67,16 +68,19 @@ Set up your `package.json` with:
 - `"engines": { "node": ">=22" }`
 - Peer dependency on `zod` (both v3 and v4): `"zod": "^3.25.76 || ^4.1.8"`
 
-Example exports configuration:
+Example package entry point configuration:
 
 ```json
 {
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   }
 }


### PR DESCRIPTION
## Background

The provider-package skill showed dual-module exports using an ESM .mjs import and CommonJS require entry. Current provider manifests declare "type": "module", export ./dist/index.js through import/default, and tsup builds ESM only.

## Summary

Updated the add-provider-package skill to require "type": "module" and show the current main, types, import, and default entry points without a CommonJS export.

## Testing

Focused formatting, documentation validation, JSON parsing, stale-entry scanning, and package-manifest alignment checks all passed.

## Related Issues

Fixes #17059

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>