### PR TITLE
docs: expand Open Responses provider setup and usage guidance

### DIFF
--- a/content/providers/01-ai-sdk-providers/06-open-responses.mdx
+++ b/content/providers/01-ai-sdk-providers/06-open-responses.mdx
@@ -5,7 +5,15 @@ description: Learn how to use the Open Responses provider for the AI SDK.
 
 # Open Responses Provider
 
-The [Open Responses](https://www.openresponses.org/) provider contains language model support for Open Responses compatible APIs.
+The [Open Responses](https://www.openresponses.org/) provider connects AI SDK
+Core to language model servers that implement an Open Responses-compatible
+`POST` endpoint. Open Responses is an open specification based on the OpenAI
+Responses API.
+
+Use `@ai-sdk/open-responses` for third-party or self-hosted endpoints that
+implement this protocol, such as LM Studio. If you call OpenAI directly and
+need OpenAI-specific provider options or built-in tools, use the
+[`@ai-sdk/openai` provider](/providers/ai-sdk-providers/openai) instead.
 
 ## Setup
 
@@ -21,7 +29,7 @@ Create an Open Responses provider instance using `createOpenResponses`:
 import { createOpenResponses } from '@ai-sdk/open-responses';
 
 const openResponses = createOpenResponses({
-  name: 'aProvider',
+  name: 'lmstudio',
   url: 'http://localhost:1234/v1/responses',
 });
 ```
@@ -30,17 +38,19 @@ The `name` and `url` options are required:
 
 - **name** _string_
 
-  Provider name. Used as the key for provider options and metadata.
+  Provider name. Used in the model's provider identifier and as the key for
+  provider options.
 
 - **url** _string_
 
-  URL for the Open Responses API POST endpoint.
+  Full URL for the Open Responses API `POST` endpoint. Pass the endpoint URL,
+  such as `http://localhost:1234/v1/responses`, not only its base URL.
 
 You can use the following optional settings to customize the Open Responses provider instance:
 
 - **apiKey** _string_
 
-  API key that is being sent using the `Authorization` header.
+  API key that is sent as a bearer token in the `Authorization` header.
 
 - **headers** _Record&lt;string,string&gt;_
 
@@ -51,36 +61,178 @@ You can use the following optional settings to customize the Open Responses prov
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
   Defaults to the global `fetch` function.
 
+### Endpoint Examples
+
+For a local LM Studio server that does not require authentication:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+
+const lmstudio = createOpenResponses({
+  name: 'lmstudio',
+  url: 'http://localhost:1234/v1/responses',
+});
+```
+
+For the OpenAI Responses API:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+
+const openAIResponses = createOpenResponses({
+  name: 'openai',
+  url: 'https://api.openai.com/v1/responses',
+  apiKey: process.env.OPENAI_API_KEY,
+});
+```
+
+You can use the same setup with another compatible service by changing the
+`name`, `url`, authentication, and model ID.
+
 ## Language Models
 
 The Open Responses provider instance is a function that you can invoke to create a language model:
 
 ```ts
-const model = openResponses('mistralai/ministral-3-14b-reasoning');
+const model = openResponses('your-model-id');
 ```
+
+The model ID is passed to the endpoint unchanged.
 
 You can use Open Responses models with the `generateText` and `streamText` functions,
 and they support structured data generation with [`Output`](/docs/reference/ai-sdk-core/output)
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
-### Example
+### Generate Text
 
 ```ts
 import { createOpenResponses } from '@ai-sdk/open-responses';
 import { generateText } from 'ai';
 
 const openResponses = createOpenResponses({
-  name: 'aProvider',
+  name: 'lmstudio',
   url: 'http://localhost:1234/v1/responses',
 });
 
 const { text } = await generateText({
-  model: openResponses('mistralai/ministral-3-14b-reasoning'),
+  model: openResponses('your-model-id'),
   prompt: 'Invent a new holiday and describe its traditions.',
 });
+
+console.log(text);
 ```
 
-## Notes
+### Stream Text
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { streamText } from 'ai';
+
+const openResponses = createOpenResponses({
+  name: 'lmstudio',
+  url: 'http://localhost:1234/v1/responses',
+});
+
+const result = streamText({
+  model: openResponses('your-model-id'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+## Reasoning and Provider Options
+
+Use the top-level [`reasoning`](/docs/ai-sdk-core/reasoning) setting to control
+reasoning effort. The provider maps supported values to the Open Responses
+`reasoning.effort` field.
+
+The provider also supports `reasoningSummary` through `providerOptions`. The
+provider option key must match the `name` passed to `createOpenResponses`:
+
+```ts
+import {
+  createOpenResponses,
+  type OpenResponsesLanguageModelOptions,
+} from '@ai-sdk/open-responses';
+import { generateText } from 'ai';
+
+const lmstudio = createOpenResponses({
+  name: 'lmstudio',
+  url: 'http://localhost:1234/v1/responses',
+});
+
+const { text, reasoningText } = await generateText({
+  model: lmstudio('your-reasoning-model-id'),
+  reasoning: 'high',
+  providerOptions: {
+    lmstudio: {
+      reasoningSummary: 'detailed',
+    } satisfies OpenResponsesLanguageModelOptions,
+  },
+  prompt: 'Explain why the sky appears blue.',
+});
+
+console.log(reasoningText);
+console.log(text);
+```
+
+`reasoningSummary` accepts `'auto'`, `'concise'`, or `'detailed'`. Reasoning
+support and accepted values depend on the endpoint and model.
+
+## File Inputs
+
+The provider supports image and non-image file inputs in user messages. Images
+are sent as `input_image` parts, while other media types, such as PDFs, are
+sent as `input_file` parts.
+
+You can provide a file as inline data:
+
+```ts
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import { readFileSync } from 'node:fs';
+import { generateText } from 'ai';
+
+const openResponses = createOpenResponses({
+  name: 'lmstudio',
+  url: 'http://localhost:1234/v1/responses',
+});
+
+const { text } = await generateText({
+  model: openResponses('your-file-capable-model-id'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Summarize this document.',
+        },
+        {
+          type: 'file',
+          data: readFileSync('./document.pdf'),
+          mediaType: 'application/pdf',
+          filename: 'document.pdf',
+        },
+      ],
+    },
+  ],
+});
+
+console.log(text);
+```
+
+You can also set `data` to a `URL`. The endpoint and model must support the
+file's media type. Provider file references, such as OpenAI file IDs, and
+file data in `{ type: 'text', text: '...' }` format are not supported by this
+provider.
+
+## Limitations
 
 - Stop sequences, `topK`, and `seed` are not supported and are ignored with warnings.
-- Image inputs are supported for user messages with `file` parts using image media types.
+- The provider supports language models only. It does not provide embedding or
+  image generation models.
+- AI SDK function tools are supported. Provider-specific built-in tools and
+  options require a dedicated provider implementation.


### PR DESCRIPTION
## Background

The provider page only covered basic setup and generateText usage. Implementation, public types, tests, examples, and official Open Responses and LM Studio documentation confirm support for full POST endpoint configuration, streaming, reasoning summaries, function tools, and image/PDF file inputs.

## Summary

Expanded the Open Responses provider documentation with use-case guidance, complete endpoint examples, generateText and streamText quickstarts, reasoning options, file inputs, and implementation-backed limitations.

## Testing

Documentation validation, formatting, repository lint checks, full type checking, and all 70 Open Responses Node tests passed.

## Related Issues

Fixes #15931

Co-authored-by: cameronjoyner <3481451+cameronjoyner@users.noreply.github.com>