### PR TITLE
reproduction: could not reproduce @ai-sdk/xai responses stream drops final text fragments in

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-13836-xai-responses-missing-tail.ts
+++ b/examples/ai-functions/src/reproduction/issue-13836-xai-responses-missing-tail.ts
@@ -1,0 +1,118 @@
+import { xai } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import fs from 'node:fs';
+
+const fixturePath =
+  '../../packages/xai/src/responses/__fixtures__/issue-13836-xai-responses-missing-tail.chunks.txt';
+const marker = 'END_OK_9981';
+
+const prompt = `Return only the requested content, with no introduction or conclusion.
+
+1. Write a numbered list from 1 to 120.
+2. Each line must be exactly: <N>. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu
+3. Then write a JavaScript code block with 80 numbered comment lines: // 1 through // 80
+4. End after the code block with the exact line: ${marker}`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null;
+}
+
+function getCompletedMessageText(rawChunks: unknown[]): string | undefined {
+  let completedText: string | undefined;
+
+  for (const rawChunk of rawChunks) {
+    if (
+      !isRecord(rawChunk) ||
+      rawChunk.type !== 'response.output_item.done' ||
+      !isRecord(rawChunk.item) ||
+      rawChunk.item.type !== 'message' ||
+      !Array.isArray(rawChunk.item.content)
+    ) {
+      continue;
+    }
+
+    for (const contentPart of rawChunk.item.content) {
+      if (
+        isRecord(contentPart) &&
+        contentPart.type === 'output_text' &&
+        typeof contentPart.text === 'string'
+      ) {
+        completedText = (completedText ?? '') + contentPart.text;
+      }
+    }
+  }
+
+  return completedText;
+}
+
+async function main() {
+  const result = streamText({
+    model: xai.responses('grok-4-1-fast-non-reasoning'),
+    maxOutputTokens: 6000,
+    temperature: 0,
+    prompt,
+    include: {
+      rawChunks: true,
+    },
+  });
+
+  const rawChunks: unknown[] = [];
+  let streamedText = '';
+  let finishReason: string | undefined;
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'raw') {
+      rawChunks.push(part.rawValue);
+    } else if (part.type === 'text-delta') {
+      streamedText += part.text;
+    } else if (part.type === 'finish') {
+      finishReason = part.finishReason;
+    }
+  }
+
+  fs.writeFileSync(
+    fixturePath,
+    `${rawChunks.map(chunk => JSON.stringify(chunk)).join('\n')}\n`,
+  );
+
+  const completedText = getCompletedMessageText(rawChunks);
+  const output = {
+    model: 'grok-4-1-fast-non-reasoning',
+    finishReason,
+    streamedLength: streamedText.length,
+    completedLength: completedText?.length,
+    streamedHasMarker: streamedText.includes(marker),
+    completedHasMarker: completedText?.includes(marker),
+    streamMatchesCompletedItem: streamedText === completedText,
+    missingSuffix:
+      completedText != null && completedText.startsWith(streamedText)
+        ? completedText.slice(streamedText.length)
+        : undefined,
+    fixturePath,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (completedText == null) {
+    throw new Error(
+      'The live xAI stream did not contain a completed message item to compare against.',
+    );
+  }
+
+  if (!completedText.includes(marker)) {
+    throw new Error(
+      `The live provider output did not include ${marker}, so this run cannot test whether the adapter dropped that final text.`,
+    );
+  }
+
+  if (streamedText !== completedText || !streamedText.includes(marker)) {
+    throw new Error(
+      `Reproduced issue #13836: the SDK stream omitted text present in the completed xAI message (missing ${completedText.length - streamedText.length} characters).`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/xai/src/responses/__fixtures__/issue-13836-xai-responses-missing-tail.chunks.txt
+++ b/packages/xai/src/responses/__fixtures__/issue-13836-xai-responses-missing-tail.chunks.txt
@@ -1,0 +1,2137 @@
+{"sequence_number":0,"type":"response.created","response":{"created_at":1783693897,"completed_at":null,"id":"68f32c62-42e7-9c29-8f31-5cd4514897c0","max_output_tokens":6000,"model":"grok-4.3","object":"response","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":0.949999988079071,"usage":null,"user":null,"incomplete_details":null,"status":"in_progress","store":true,"metadata":{"system_fingerprint":"fp_eb3c003fc66c14ed"},"background":false,"service_tier":"default","truncation":"disabled","top_logprobs":0,"presence_penalty":0,"frequency_penalty":0,"prompt_cache_key":null,"max_tool_calls":null,"safety_identifier":null,"error":null,"instructions":null}}
+{"sequence_number":1,"type":"response.in_progress","response":{"created_at":1783693897,"completed_at":null,"id":"68f32c62-42e7-9c29-8f31-5cd4514897c0","max_output_tokens":6000,"model":"grok-4.3","object":"response","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":0.949999988079071,"usage":null,"user":null,"incomplete_details":null,"status":"in_progress","store":true,"metadata":{"system_fingerprint":"fp_eb3c003fc66c14ed"},"background":false,"service_tier":"default","truncation":"disabled","top_logprobs":0,"presence_penalty":0,"frequency_penalty":0,"prompt_cache_key":null,"max_tool_calls":null,"safety_identifier":null,"error":null,"instructions":null}}
+{"sequence_number":2,"type":"response.output_item.added","item":{"content":[],"id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","role":"assistant","type":"message","status":"in_progress"},"output_index":0}
+{"sequence_number":3,"type":"response.content_part.added","content_index":0,"item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"part":{"type":"output_text","text":"","logprobs":[],"annotations":[]}}
+{"sequence_number":4,"type":"response.output_text.delta","content_index":0,"delta":"1","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":5,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":6,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":7,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":8,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":9,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":10,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":11,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":12,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":13,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":14,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":15,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":16,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":17,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":18,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":19,"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":20,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":21,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":22,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":23,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":24,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":25,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":26,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":27,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":28,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":29,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":30,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":31,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":32,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":33,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":34,"type":"response.output_text.delta","content_index":0,"delta":"3","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":35,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":36,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":37,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":38,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":39,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":40,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":41,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":42,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":43,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":44,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":45,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":46,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":47,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":48,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":49,"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":50,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":51,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":52,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":53,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":54,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":55,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":56,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":57,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":58,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":59,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":60,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":61,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":62,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":63,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":64,"type":"response.output_text.delta","content_index":0,"delta":"5","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":65,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":66,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":67,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":68,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":69,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":70,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":71,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":72,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":73,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":74,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":75,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":76,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":77,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":78,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":79,"type":"response.output_text.delta","content_index":0,"delta":"6","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":80,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":81,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":82,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":83,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":84,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":85,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":86,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":87,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":88,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":89,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":90,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":91,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":92,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":93,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":94,"type":"response.output_text.delta","content_index":0,"delta":"7","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":95,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":96,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":97,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":98,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":99,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":100,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":101,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":102,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":103,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":104,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":105,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":106,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":107,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":108,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":109,"type":"response.output_text.delta","content_index":0,"delta":"8","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":110,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":111,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":112,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":113,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":114,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":115,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":116,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":117,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":118,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":119,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":120,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":121,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":122,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":123,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":124,"type":"response.output_text.delta","content_index":0,"delta":"9","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":125,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":126,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":127,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":128,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":129,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":130,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":131,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":132,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":133,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":134,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":135,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":136,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":137,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":138,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":139,"type":"response.output_text.delta","content_index":0,"delta":"10","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":140,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":141,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":142,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":143,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":144,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":145,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":146,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":147,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":148,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":149,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":150,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":151,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":152,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":153,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":154,"type":"response.output_text.delta","content_index":0,"delta":"11","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":155,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":156,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":157,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":158,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":159,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":160,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":161,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":162,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":163,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":164,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":165,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":166,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":167,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":168,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":169,"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":170,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":171,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":172,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":173,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":174,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":175,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":176,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":177,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":178,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":179,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":180,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":181,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":182,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":183,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":184,"type":"response.output_text.delta","content_index":0,"delta":"13","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":185,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":186,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":187,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":188,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":189,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":190,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":191,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":192,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":193,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":194,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":195,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":196,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":197,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":198,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":199,"type":"response.output_text.delta","content_index":0,"delta":"14","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":200,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":201,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":202,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":203,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":204,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":205,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":206,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":207,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":208,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":209,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":210,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":211,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":212,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":213,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":214,"type":"response.output_text.delta","content_index":0,"delta":"15","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":215,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":216,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":217,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":218,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":219,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":220,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":221,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":222,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":223,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":224,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":225,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":226,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":227,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":228,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":229,"type":"response.output_text.delta","content_index":0,"delta":"16","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":230,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":231,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":232,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":233,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":234,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":235,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":236,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":237,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":238,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":239,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":240,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":241,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":242,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":243,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":244,"type":"response.output_text.delta","content_index":0,"delta":"17","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":245,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":246,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":247,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":248,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":249,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":250,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":251,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":252,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":253,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":254,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":255,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":256,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":257,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":258,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":259,"type":"response.output_text.delta","content_index":0,"delta":"18","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":260,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":261,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":262,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":263,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":264,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":265,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":266,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":267,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":268,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":269,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":270,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":271,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":272,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":273,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":274,"type":"response.output_text.delta","content_index":0,"delta":"19","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":275,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":276,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":277,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":278,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":279,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":280,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":281,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":282,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":283,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":284,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":285,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":286,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":287,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":288,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":289,"type":"response.output_text.delta","content_index":0,"delta":"20","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":290,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":291,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":292,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":293,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":294,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":295,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":296,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":297,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":298,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":299,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":300,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":301,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":302,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":303,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":304,"type":"response.output_text.delta","content_index":0,"delta":"21","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":305,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":306,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":307,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":308,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":309,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":310,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":311,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":312,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":313,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":314,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":315,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":316,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":317,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":318,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":319,"type":"response.output_text.delta","content_index":0,"delta":"22","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":320,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":321,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":322,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":323,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":324,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":325,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":326,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":327,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":328,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":329,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":330,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":331,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":332,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":333,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":334,"type":"response.output_text.delta","content_index":0,"delta":"23","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":335,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":336,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":337,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":338,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":339,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":340,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":341,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":342,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":343,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":344,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":345,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":346,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":347,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":348,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":349,"type":"response.output_text.delta","content_index":0,"delta":"24","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":350,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":351,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":352,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":353,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":354,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":355,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":356,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":357,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":358,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":359,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":360,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":361,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":362,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":363,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":364,"type":"response.output_text.delta","content_index":0,"delta":"25","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":365,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":366,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":367,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":368,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":369,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":370,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":371,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":372,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":373,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":374,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":375,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":376,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":377,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":378,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":379,"type":"response.output_text.delta","content_index":0,"delta":"26","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":380,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":381,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":382,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":383,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":384,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":385,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":386,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":387,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":388,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":389,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":390,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":391,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":392,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":393,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":394,"type":"response.output_text.delta","content_index":0,"delta":"27","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":395,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":396,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":397,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":398,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":399,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":400,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":401,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":402,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":403,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":404,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":405,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":406,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":407,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":408,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":409,"type":"response.output_text.delta","content_index":0,"delta":"28","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":410,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":411,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":412,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":413,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":414,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":415,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":416,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":417,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":418,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":419,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":420,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":421,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":422,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":423,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":424,"type":"response.output_text.delta","content_index":0,"delta":"29","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":425,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":426,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":427,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":428,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":429,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":430,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":431,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":432,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":433,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":434,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":435,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":436,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":437,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":438,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":439,"type":"response.output_text.delta","content_index":0,"delta":"30","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":440,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":441,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":442,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":443,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":444,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":445,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":446,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":447,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":448,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":449,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":450,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":451,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":452,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":453,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":454,"type":"response.output_text.delta","content_index":0,"delta":"31","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":455,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":456,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":457,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":458,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":459,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":460,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":461,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":462,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":463,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":464,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":465,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":466,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":467,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":468,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":469,"type":"response.output_text.delta","content_index":0,"delta":"32","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":470,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":471,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":472,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":473,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":474,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":475,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":476,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":477,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":478,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":479,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":480,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":481,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":482,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":483,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":484,"type":"response.output_text.delta","content_index":0,"delta":"33","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":485,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":486,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":487,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":488,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":489,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":490,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":491,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":492,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":493,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":494,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":495,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":496,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":497,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":498,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":499,"type":"response.output_text.delta","content_index":0,"delta":"34","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":500,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":501,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":502,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":503,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":504,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":505,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":506,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":507,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":508,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":509,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":510,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":511,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":512,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":513,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":514,"type":"response.output_text.delta","content_index":0,"delta":"35","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":515,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":516,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":517,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":518,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":519,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":520,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":521,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":522,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":523,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":524,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":525,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":526,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":527,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":528,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":529,"type":"response.output_text.delta","content_index":0,"delta":"36","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":530,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":531,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":532,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":533,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":534,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":535,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":536,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":537,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":538,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":539,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":540,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":541,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":542,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":543,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":544,"type":"response.output_text.delta","content_index":0,"delta":"37","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":545,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":546,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":547,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":548,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":549,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":550,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":551,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":552,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":553,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":554,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":555,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":556,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":557,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":558,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":559,"type":"response.output_text.delta","content_index":0,"delta":"38","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":560,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":561,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":562,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":563,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":564,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":565,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":566,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":567,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":568,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":569,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":570,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":571,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":572,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":573,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":574,"type":"response.output_text.delta","content_index":0,"delta":"39","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":575,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":576,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":577,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":578,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":579,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":580,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":581,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":582,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":583,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":584,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":585,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":586,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":587,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":588,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":589,"type":"response.output_text.delta","content_index":0,"delta":"40","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":590,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":591,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":592,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":593,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":594,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":595,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":596,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":597,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":598,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":599,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":600,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":601,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":602,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":603,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":604,"type":"response.output_text.delta","content_index":0,"delta":"41","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":605,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":606,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":607,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":608,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":609,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":610,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":611,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":612,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":613,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":614,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":615,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":616,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":617,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":618,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":619,"type":"response.output_text.delta","content_index":0,"delta":"42","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":620,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":621,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":622,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":623,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":624,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":625,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":626,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":627,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":628,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":629,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":630,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":631,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":632,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":633,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":634,"type":"response.output_text.delta","content_index":0,"delta":"43","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":635,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":636,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":637,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":638,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":639,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":640,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":641,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":642,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":643,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":644,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":645,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":646,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":647,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":648,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":649,"type":"response.output_text.delta","content_index":0,"delta":"44","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":650,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":651,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":652,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":653,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":654,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":655,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":656,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":657,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":658,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":659,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":660,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":661,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":662,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":663,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":664,"type":"response.output_text.delta","content_index":0,"delta":"45","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":665,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":666,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":667,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":668,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":669,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":670,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":671,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":672,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":673,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":674,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":675,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":676,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":677,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":678,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":679,"type":"response.output_text.delta","content_index":0,"delta":"46","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":680,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":681,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":682,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":683,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":684,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":685,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":686,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":687,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":688,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":689,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":690,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":691,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":692,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":693,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":694,"type":"response.output_text.delta","content_index":0,"delta":"47","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":695,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":696,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":697,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":698,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":699,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":700,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":701,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":702,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":703,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":704,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":705,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":706,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":707,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":708,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":709,"type":"response.output_text.delta","content_index":0,"delta":"48","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":710,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":711,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":712,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":713,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":714,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":715,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":716,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":717,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":718,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":719,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":720,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":721,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":722,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":723,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":724,"type":"response.output_text.delta","content_index":0,"delta":"49","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":725,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":726,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":727,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":728,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":729,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":730,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":731,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":732,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":733,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":734,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":735,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":736,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":737,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":738,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":739,"type":"response.output_text.delta","content_index":0,"delta":"50","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":740,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":741,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":742,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":743,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":744,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":745,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":746,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":747,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":748,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":749,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":750,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":751,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":752,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":753,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":754,"type":"response.output_text.delta","content_index":0,"delta":"51","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":755,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":756,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":757,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":758,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":759,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":760,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":761,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":762,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":763,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":764,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":765,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":766,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":767,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":768,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":769,"type":"response.output_text.delta","content_index":0,"delta":"52","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":770,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":771,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":772,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":773,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":774,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":775,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":776,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":777,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":778,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":779,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":780,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":781,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":782,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":783,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":784,"type":"response.output_text.delta","content_index":0,"delta":"53","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":785,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":786,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":787,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":788,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":789,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":790,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":791,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":792,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":793,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":794,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":795,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":796,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":797,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":798,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":799,"type":"response.output_text.delta","content_index":0,"delta":"54","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":800,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":801,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":802,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":803,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":804,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":805,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":806,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":807,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":808,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":809,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":810,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":811,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":812,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":813,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":814,"type":"response.output_text.delta","content_index":0,"delta":"55","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":815,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":816,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":817,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":818,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":819,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":820,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":821,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":822,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":823,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":824,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":825,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":826,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":827,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":828,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":829,"type":"response.output_text.delta","content_index":0,"delta":"56","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":830,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":831,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":832,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":833,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":834,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":835,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":836,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":837,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":838,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":839,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":840,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":841,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":842,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":843,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":844,"type":"response.output_text.delta","content_index":0,"delta":"57","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":845,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":846,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":847,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":848,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":849,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":850,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":851,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":852,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":853,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":854,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":855,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":856,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":857,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":858,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":859,"type":"response.output_text.delta","content_index":0,"delta":"58","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":860,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":861,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":862,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":863,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":864,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":865,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":866,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":867,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":868,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":869,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":870,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":871,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":872,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":873,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":874,"type":"response.output_text.delta","content_index":0,"delta":"59","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":875,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":876,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":877,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":878,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":879,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":880,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":881,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":882,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":883,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":884,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":885,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":886,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":887,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":888,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":889,"type":"response.output_text.delta","content_index":0,"delta":"60","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":890,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":891,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":892,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":893,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":894,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":895,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":896,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":897,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":898,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":899,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":900,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":901,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":902,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":903,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":904,"type":"response.output_text.delta","content_index":0,"delta":"61","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":905,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":906,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":907,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":908,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":909,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":910,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":911,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":912,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":913,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":914,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":915,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":916,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":917,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":918,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":919,"type":"response.output_text.delta","content_index":0,"delta":"62","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":920,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":921,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":922,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":923,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":924,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":925,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":926,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":927,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":928,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":929,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":930,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":931,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":932,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":933,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":934,"type":"response.output_text.delta","content_index":0,"delta":"63","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":935,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":936,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":937,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":938,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":939,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":940,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":941,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":942,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":943,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":944,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":945,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":946,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":947,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":948,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":949,"type":"response.output_text.delta","content_index":0,"delta":"64","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":950,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":951,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":952,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":953,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":954,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":955,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":956,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":957,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":958,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":959,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":960,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":961,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":962,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":963,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":964,"type":"response.output_text.delta","content_index":0,"delta":"65","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":965,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":966,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":967,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":968,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":969,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":970,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":971,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":972,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":973,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":974,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":975,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":976,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":977,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":978,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":979,"type":"response.output_text.delta","content_index":0,"delta":"66","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":980,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":981,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":982,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":983,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":984,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":985,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":986,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":987,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":988,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":989,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":990,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":991,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":992,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":993,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":994,"type":"response.output_text.delta","content_index":0,"delta":"67","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":995,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":996,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":997,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":998,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":999,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1000,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1001,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1002,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1003,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1004,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1005,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1006,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1007,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1008,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1009,"type":"response.output_text.delta","content_index":0,"delta":"68","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1010,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1011,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1012,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1013,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1014,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1015,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1016,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1017,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1018,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1019,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1020,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1021,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1022,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1023,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1024,"type":"response.output_text.delta","content_index":0,"delta":"69","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1025,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1026,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1027,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1028,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1029,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1030,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1031,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1032,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1033,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1034,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1035,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1036,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1037,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1038,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1039,"type":"response.output_text.delta","content_index":0,"delta":"70","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1040,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1041,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1042,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1043,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1044,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1045,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1046,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1047,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1048,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1049,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1050,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1051,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1052,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1053,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1054,"type":"response.output_text.delta","content_index":0,"delta":"71","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1055,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1056,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1057,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1058,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1059,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1060,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1061,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1062,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1063,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1064,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1065,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1066,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1067,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1068,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1069,"type":"response.output_text.delta","content_index":0,"delta":"72","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1070,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1071,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1072,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1073,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1074,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1075,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1076,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1077,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1078,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1079,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1080,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1081,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1082,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1083,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1084,"type":"response.output_text.delta","content_index":0,"delta":"73","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1085,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1086,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1087,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1088,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1089,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1090,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1091,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1092,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1093,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1094,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1095,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1096,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1097,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1098,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1099,"type":"response.output_text.delta","content_index":0,"delta":"74","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1100,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1101,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1102,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1103,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1104,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1105,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1106,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1107,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1108,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1109,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1110,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1111,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1112,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1113,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1114,"type":"response.output_text.delta","content_index":0,"delta":"75","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1115,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1116,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1117,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1118,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1119,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1120,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1121,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1122,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1123,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1124,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1125,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1126,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1127,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1128,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1129,"type":"response.output_text.delta","content_index":0,"delta":"76","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1130,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1131,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1132,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1133,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1134,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1135,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1136,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1137,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1138,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1139,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1140,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1141,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1142,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1143,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1144,"type":"response.output_text.delta","content_index":0,"delta":"77","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1145,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1146,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1147,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1148,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1149,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1150,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1151,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1152,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1153,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1154,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1155,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1156,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1157,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1158,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1159,"type":"response.output_text.delta","content_index":0,"delta":"78","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1160,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1161,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1162,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1163,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1164,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1165,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1166,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1167,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1168,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1169,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1170,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1171,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1172,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1173,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1174,"type":"response.output_text.delta","content_index":0,"delta":"79","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1175,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1176,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1177,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1178,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1179,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1180,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1181,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1182,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1183,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1184,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1185,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1186,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1187,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1188,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1189,"type":"response.output_text.delta","content_index":0,"delta":"80","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1190,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1191,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1192,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1193,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1194,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1195,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1196,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1197,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1198,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1199,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1200,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1201,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1202,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1203,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1204,"type":"response.output_text.delta","content_index":0,"delta":"81","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1205,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1206,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1207,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1208,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1209,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1210,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1211,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1212,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1213,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1214,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1215,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1216,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1217,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1218,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1219,"type":"response.output_text.delta","content_index":0,"delta":"82","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1220,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1221,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1222,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1223,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1224,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1225,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1226,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1227,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1228,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1229,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1230,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1231,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1232,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1233,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1234,"type":"response.output_text.delta","content_index":0,"delta":"83","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1235,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1236,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1237,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1238,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1239,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1240,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1241,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1242,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1243,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1244,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1245,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1246,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1247,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1248,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1249,"type":"response.output_text.delta","content_index":0,"delta":"84","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1250,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1251,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1252,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1253,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1254,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1255,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1256,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1257,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1258,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1259,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1260,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1261,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1262,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1263,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1264,"type":"response.output_text.delta","content_index":0,"delta":"85","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1265,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1266,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1267,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1268,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1269,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1270,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1271,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1272,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1273,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1274,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1275,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1276,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1277,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1278,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1279,"type":"response.output_text.delta","content_index":0,"delta":"86","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1280,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1281,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1282,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1283,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1284,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1285,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1286,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1287,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1288,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1289,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1290,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1291,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1292,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1293,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1294,"type":"response.output_text.delta","content_index":0,"delta":"87","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1295,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1296,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1297,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1298,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1299,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1300,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1301,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1302,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1303,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1304,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1305,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1306,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1307,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1308,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1309,"type":"response.output_text.delta","content_index":0,"delta":"88","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1310,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1311,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1312,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1313,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1314,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1315,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1316,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1317,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1318,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1319,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1320,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1321,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1322,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1323,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1324,"type":"response.output_text.delta","content_index":0,"delta":"89","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1325,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1326,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1327,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1328,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1329,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1330,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1331,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1332,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1333,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1334,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1335,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1336,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1337,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1338,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1339,"type":"response.output_text.delta","content_index":0,"delta":"90","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1340,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1341,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1342,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1343,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1344,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1345,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1346,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1347,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1348,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1349,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1350,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1351,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1352,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1353,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1354,"type":"response.output_text.delta","content_index":0,"delta":"91","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1355,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1356,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1357,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1358,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1359,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1360,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1361,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1362,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1363,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1364,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1365,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1366,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1367,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1368,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1369,"type":"response.output_text.delta","content_index":0,"delta":"92","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1370,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1371,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1372,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1373,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1374,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1375,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1376,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1377,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1378,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1379,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1380,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1381,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1382,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1383,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1384,"type":"response.output_text.delta","content_index":0,"delta":"93","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1385,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1386,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1387,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1388,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1389,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1390,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1391,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1392,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1393,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1394,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1395,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1396,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1397,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1398,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1399,"type":"response.output_text.delta","content_index":0,"delta":"94","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1400,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1401,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1402,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1403,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1404,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1405,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1406,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1407,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1408,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1409,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1410,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1411,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1412,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1413,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1414,"type":"response.output_text.delta","content_index":0,"delta":"95","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1415,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1416,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1417,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1418,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1419,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1420,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1421,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1422,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1423,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1424,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1425,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1426,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1427,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1428,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1429,"type":"response.output_text.delta","content_index":0,"delta":"96","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1430,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1431,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1432,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1433,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1434,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1435,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1436,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1437,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1438,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1439,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1440,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1441,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1442,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1443,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1444,"type":"response.output_text.delta","content_index":0,"delta":"97","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1445,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1446,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1447,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1448,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1449,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1450,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1451,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1452,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1453,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1454,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1455,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1456,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1457,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1458,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1459,"type":"response.output_text.delta","content_index":0,"delta":"98","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1460,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1461,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1462,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1463,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1464,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1465,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1466,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1467,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1468,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1469,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1470,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1471,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1472,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1473,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1474,"type":"response.output_text.delta","content_index":0,"delta":"99","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1475,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1476,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1477,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1478,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1479,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1480,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1481,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1482,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1483,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1484,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1485,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1486,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1487,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1488,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1489,"type":"response.output_text.delta","content_index":0,"delta":"100","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1490,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1491,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1492,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1493,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1494,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1495,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1496,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1497,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1498,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1499,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1500,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1501,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1502,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1503,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1504,"type":"response.output_text.delta","content_index":0,"delta":"101","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1505,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1506,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1507,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1508,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1509,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1510,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1511,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1512,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1513,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1514,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1515,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1516,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1517,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1518,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1519,"type":"response.output_text.delta","content_index":0,"delta":"102","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1520,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1521,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1522,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1523,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1524,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1525,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1526,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1527,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1528,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1529,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1530,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1531,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1532,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1533,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1534,"type":"response.output_text.delta","content_index":0,"delta":"103","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1535,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1536,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1537,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1538,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1539,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1540,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1541,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1542,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1543,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1544,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1545,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1546,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1547,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1548,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1549,"type":"response.output_text.delta","content_index":0,"delta":"104","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1550,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1551,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1552,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1553,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1554,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1555,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1556,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1557,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1558,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1559,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1560,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1561,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1562,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1563,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1564,"type":"response.output_text.delta","content_index":0,"delta":"105","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1565,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1566,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1567,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1568,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1569,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1570,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1571,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1572,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1573,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1574,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1575,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1576,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1577,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1578,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1579,"type":"response.output_text.delta","content_index":0,"delta":"106","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1580,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1581,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1582,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1583,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1584,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1585,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1586,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1587,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1588,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1589,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1590,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1591,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1592,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1593,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1594,"type":"response.output_text.delta","content_index":0,"delta":"107","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1595,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1596,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1597,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1598,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1599,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1600,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1601,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1602,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1603,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1604,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1605,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1606,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1607,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1608,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1609,"type":"response.output_text.delta","content_index":0,"delta":"108","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1610,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1611,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1612,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1613,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1614,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1615,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1616,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1617,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1618,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1619,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1620,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1621,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1622,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1623,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1624,"type":"response.output_text.delta","content_index":0,"delta":"109","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1625,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1626,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1627,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1628,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1629,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1630,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1631,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1632,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1633,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1634,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1635,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1636,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1637,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1638,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1639,"type":"response.output_text.delta","content_index":0,"delta":"110","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1640,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1641,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1642,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1643,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1644,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1645,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1646,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1647,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1648,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1649,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1650,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1651,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1652,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1653,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1654,"type":"response.output_text.delta","content_index":0,"delta":"111","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1655,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1656,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1657,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1658,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1659,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1660,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1661,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1662,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1663,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1664,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1665,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1666,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1667,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1668,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1669,"type":"response.output_text.delta","content_index":0,"delta":"112","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1670,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1671,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1672,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1673,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1674,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1675,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1676,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1677,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1678,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1679,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1680,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1681,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1682,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1683,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1684,"type":"response.output_text.delta","content_index":0,"delta":"113","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1685,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1686,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1687,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1688,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1689,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1690,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1691,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1692,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1693,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1694,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1695,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1696,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1697,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1698,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1699,"type":"response.output_text.delta","content_index":0,"delta":"114","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1700,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1701,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1702,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1703,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1704,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1705,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1706,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1707,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1708,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1709,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1710,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1711,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1712,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1713,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1714,"type":"response.output_text.delta","content_index":0,"delta":"115","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1715,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1716,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1717,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1718,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1719,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1720,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1721,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1722,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1723,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1724,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1725,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1726,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1727,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1728,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1729,"type":"response.output_text.delta","content_index":0,"delta":"116","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1730,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1731,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1732,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1733,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1734,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1735,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1736,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1737,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1738,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1739,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1740,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1741,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1742,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1743,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1744,"type":"response.output_text.delta","content_index":0,"delta":"117","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1745,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1746,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1747,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1748,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1749,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1750,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1751,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1752,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1753,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1754,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1755,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1756,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1757,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1758,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1759,"type":"response.output_text.delta","content_index":0,"delta":"118","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1760,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1761,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1762,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1763,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1764,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1765,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1766,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1767,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1768,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1769,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1770,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1771,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1772,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1773,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1774,"type":"response.output_text.delta","content_index":0,"delta":"119","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1775,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1776,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1777,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1778,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1779,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1780,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1781,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1782,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1783,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1784,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1785,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1786,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1787,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1788,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1789,"type":"response.output_text.delta","content_index":0,"delta":"120","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1790,"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1791,"type":"response.output_text.delta","content_index":0,"delta":" alfa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1792,"type":"response.output_text.delta","content_index":0,"delta":" beta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1793,"type":"response.output_text.delta","content_index":0,"delta":" gama","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1794,"type":"response.output_text.delta","content_index":0,"delta":" delta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1795,"type":"response.output_text.delta","content_index":0,"delta":" epsilon","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1796,"type":"response.output_text.delta","content_index":0,"delta":" zeta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1797,"type":"response.output_text.delta","content_index":0,"delta":" eta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1798,"type":"response.output_text.delta","content_index":0,"delta":" theta","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1799,"type":"response.output_text.delta","content_index":0,"delta":" iota","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1800,"type":"response.output_text.delta","content_index":0,"delta":" kappa","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1801,"type":"response.output_text.delta","content_index":0,"delta":" lambda","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1802,"type":"response.output_text.delta","content_index":0,"delta":" mu","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1803,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1804,"type":"response.output_text.delta","content_index":0,"delta":"```","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1805,"type":"response.output_text.delta","content_index":0,"delta":"javascript","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1806,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1807,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1808,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1809,"type":"response.output_text.delta","content_index":0,"delta":"1","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1810,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1811,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1812,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1813,"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1814,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1815,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1816,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1817,"type":"response.output_text.delta","content_index":0,"delta":"3","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1818,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1819,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1820,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1821,"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1822,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1823,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1824,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1825,"type":"response.output_text.delta","content_index":0,"delta":"5","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1826,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1827,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1828,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1829,"type":"response.output_text.delta","content_index":0,"delta":"6","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1830,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1831,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1832,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1833,"type":"response.output_text.delta","content_index":0,"delta":"7","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1834,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1835,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1836,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1837,"type":"response.output_text.delta","content_index":0,"delta":"8","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1838,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1839,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1840,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1841,"type":"response.output_text.delta","content_index":0,"delta":"9","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1842,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1843,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1844,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1845,"type":"response.output_text.delta","content_index":0,"delta":"10","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1846,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1847,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1848,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1849,"type":"response.output_text.delta","content_index":0,"delta":"11","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1850,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1851,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1852,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1853,"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1854,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1855,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1856,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1857,"type":"response.output_text.delta","content_index":0,"delta":"13","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1858,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1859,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1860,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1861,"type":"response.output_text.delta","content_index":0,"delta":"14","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1862,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1863,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1864,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1865,"type":"response.output_text.delta","content_index":0,"delta":"15","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1866,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1867,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1868,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1869,"type":"response.output_text.delta","content_index":0,"delta":"16","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1870,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1871,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1872,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1873,"type":"response.output_text.delta","content_index":0,"delta":"17","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1874,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1875,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1876,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1877,"type":"response.output_text.delta","content_index":0,"delta":"18","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1878,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1879,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1880,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1881,"type":"response.output_text.delta","content_index":0,"delta":"19","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1882,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1883,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1884,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1885,"type":"response.output_text.delta","content_index":0,"delta":"20","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1886,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1887,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1888,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1889,"type":"response.output_text.delta","content_index":0,"delta":"21","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1890,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1891,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1892,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1893,"type":"response.output_text.delta","content_index":0,"delta":"22","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1894,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1895,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1896,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1897,"type":"response.output_text.delta","content_index":0,"delta":"23","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1898,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1899,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1900,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1901,"type":"response.output_text.delta","content_index":0,"delta":"24","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1902,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1903,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1904,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1905,"type":"response.output_text.delta","content_index":0,"delta":"25","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1906,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1907,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1908,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1909,"type":"response.output_text.delta","content_index":0,"delta":"26","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1910,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1911,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1912,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1913,"type":"response.output_text.delta","content_index":0,"delta":"27","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1914,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1915,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1916,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1917,"type":"response.output_text.delta","content_index":0,"delta":"28","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1918,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1919,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1920,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1921,"type":"response.output_text.delta","content_index":0,"delta":"29","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1922,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1923,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1924,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1925,"type":"response.output_text.delta","content_index":0,"delta":"30","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1926,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1927,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1928,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1929,"type":"response.output_text.delta","content_index":0,"delta":"31","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1930,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1931,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1932,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1933,"type":"response.output_text.delta","content_index":0,"delta":"32","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1934,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1935,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1936,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1937,"type":"response.output_text.delta","content_index":0,"delta":"33","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1938,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1939,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1940,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1941,"type":"response.output_text.delta","content_index":0,"delta":"34","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1942,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1943,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1944,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1945,"type":"response.output_text.delta","content_index":0,"delta":"35","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1946,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1947,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1948,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1949,"type":"response.output_text.delta","content_index":0,"delta":"36","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1950,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1951,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1952,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1953,"type":"response.output_text.delta","content_index":0,"delta":"37","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1954,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1955,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1956,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1957,"type":"response.output_text.delta","content_index":0,"delta":"38","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1958,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1959,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1960,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1961,"type":"response.output_text.delta","content_index":0,"delta":"39","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1962,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1963,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1964,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1965,"type":"response.output_text.delta","content_index":0,"delta":"40","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1966,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1967,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1968,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1969,"type":"response.output_text.delta","content_index":0,"delta":"41","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1970,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1971,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1972,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1973,"type":"response.output_text.delta","content_index":0,"delta":"42","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1974,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1975,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1976,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1977,"type":"response.output_text.delta","content_index":0,"delta":"43","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1978,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1979,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1980,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1981,"type":"response.output_text.delta","content_index":0,"delta":"44","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1982,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1983,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1984,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1985,"type":"response.output_text.delta","content_index":0,"delta":"45","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1986,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1987,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1988,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1989,"type":"response.output_text.delta","content_index":0,"delta":"46","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1990,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1991,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1992,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1993,"type":"response.output_text.delta","content_index":0,"delta":"47","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1994,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1995,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1996,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1997,"type":"response.output_text.delta","content_index":0,"delta":"48","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1998,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":1999,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2000,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2001,"type":"response.output_text.delta","content_index":0,"delta":"49","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2002,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2003,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2004,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2005,"type":"response.output_text.delta","content_index":0,"delta":"50","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2006,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2007,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2008,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2009,"type":"response.output_text.delta","content_index":0,"delta":"51","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2010,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2011,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2012,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2013,"type":"response.output_text.delta","content_index":0,"delta":"52","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2014,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2015,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2016,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2017,"type":"response.output_text.delta","content_index":0,"delta":"53","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2018,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2019,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2020,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2021,"type":"response.output_text.delta","content_index":0,"delta":"54","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2022,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2023,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2024,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2025,"type":"response.output_text.delta","content_index":0,"delta":"55","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2026,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2027,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2028,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2029,"type":"response.output_text.delta","content_index":0,"delta":"56","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2030,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2031,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2032,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2033,"type":"response.output_text.delta","content_index":0,"delta":"57","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2034,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2035,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2036,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2037,"type":"response.output_text.delta","content_index":0,"delta":"58","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2038,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2039,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2040,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2041,"type":"response.output_text.delta","content_index":0,"delta":"59","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2042,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2043,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2044,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2045,"type":"response.output_text.delta","content_index":0,"delta":"60","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2046,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2047,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2048,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2049,"type":"response.output_text.delta","content_index":0,"delta":"61","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2050,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2051,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2052,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2053,"type":"response.output_text.delta","content_index":0,"delta":"62","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2054,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2055,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2056,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2057,"type":"response.output_text.delta","content_index":0,"delta":"63","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2058,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2059,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2060,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2061,"type":"response.output_text.delta","content_index":0,"delta":"64","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2062,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2063,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2064,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2065,"type":"response.output_text.delta","content_index":0,"delta":"65","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2066,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2067,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2068,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2069,"type":"response.output_text.delta","content_index":0,"delta":"66","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2070,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2071,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2072,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2073,"type":"response.output_text.delta","content_index":0,"delta":"67","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2074,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2075,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2076,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2077,"type":"response.output_text.delta","content_index":0,"delta":"68","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2078,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2079,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2080,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2081,"type":"response.output_text.delta","content_index":0,"delta":"69","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2082,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2083,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2084,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2085,"type":"response.output_text.delta","content_index":0,"delta":"70","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2086,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2087,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2088,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2089,"type":"response.output_text.delta","content_index":0,"delta":"71","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2090,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2091,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2092,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2093,"type":"response.output_text.delta","content_index":0,"delta":"72","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2094,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2095,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2096,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2097,"type":"response.output_text.delta","content_index":0,"delta":"73","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2098,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2099,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2100,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2101,"type":"response.output_text.delta","content_index":0,"delta":"74","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2102,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2103,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2104,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2105,"type":"response.output_text.delta","content_index":0,"delta":"75","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2106,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2107,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2108,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2109,"type":"response.output_text.delta","content_index":0,"delta":"76","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2110,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2111,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2112,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2113,"type":"response.output_text.delta","content_index":0,"delta":"77","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2114,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2115,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2116,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2117,"type":"response.output_text.delta","content_index":0,"delta":"78","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2118,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2119,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2120,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2121,"type":"response.output_text.delta","content_index":0,"delta":"79","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2122,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2123,"type":"response.output_text.delta","content_index":0,"delta":"//","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2124,"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2125,"type":"response.output_text.delta","content_index":0,"delta":"80","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2126,"type":"response.output_text.delta","content_index":0,"delta":"\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2127,"type":"response.output_text.delta","content_index":0,"delta":"```\n","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2128,"type":"response.output_text.delta","content_index":0,"delta":"END","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2129,"type":"response.output_text.delta","content_index":0,"delta":"_OK","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2130,"type":"response.output_text.delta","content_index":0,"delta":"_","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2131,"type":"response.output_text.delta","content_index":0,"delta":"998","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2132,"type":"response.output_text.delta","content_index":0,"delta":"1","item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"logprobs":[]}
+{"sequence_number":2133,"type":"response.output_text.done","content_index":0,"item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"text":"1. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n2. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n3. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n4. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n5. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n6. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n7. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n8. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n9. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n10. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n11. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n12. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n13. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n14. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n15. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n16. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n17. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n18. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n19. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n20. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n21. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n22. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n23. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n24. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n25. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n26. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n27. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n28. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n29. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n30. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n31. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n32. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n33. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n34. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n35. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n36. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n37. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n38. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n39. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n40. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n41. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n42. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n43. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n44. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n45. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n46. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n47. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n48. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n49. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n50. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n51. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n52. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n53. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n54. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n55. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n56. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n57. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n58. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n59. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n60. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n61. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n62. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n63. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n64. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n65. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n66. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n67. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n68. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n69. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n70. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n71. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n72. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n73. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n74. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n75. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n76. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n77. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n78. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n79. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n80. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n81. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n82. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n83. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n84. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n85. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n86. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n87. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n88. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n89. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n90. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n91. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n92. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n93. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n94. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n95. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n96. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n97. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n98. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n99. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n100. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n101. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n102. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n103. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n104. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n105. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n106. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n107. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n108. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n109. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n110. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n111. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n112. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n113. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n114. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n115. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n116. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n117. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n118. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n119. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n120. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n```javascript\n// 1\n// 2\n// 3\n// 4\n// 5\n// 6\n// 7\n// 8\n// 9\n// 10\n// 11\n// 12\n// 13\n// 14\n// 15\n// 16\n// 17\n// 18\n// 19\n// 20\n// 21\n// 22\n// 23\n// 24\n// 25\n// 26\n// 27\n// 28\n// 29\n// 30\n// 31\n// 32\n// 33\n// 34\n// 35\n// 36\n// 37\n// 38\n// 39\n// 40\n// 41\n// 42\n// 43\n// 44\n// 45\n// 46\n// 47\n// 48\n// 49\n// 50\n// 51\n// 52\n// 53\n// 54\n// 55\n// 56\n// 57\n// 58\n// 59\n// 60\n// 61\n// 62\n// 63\n// 64\n// 65\n// 66\n// 67\n// 68\n// 69\n// 70\n// 71\n// 72\n// 73\n// 74\n// 75\n// 76\n// 77\n// 78\n// 79\n// 80\n```\nEND_OK_9981","logprobs":[]}
+{"sequence_number":2134,"type":"response.content_part.done","content_index":0,"item_id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","output_index":0,"part":{"type":"output_text","text":"1. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n2. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n3. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n4. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n5. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n6. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n7. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n8. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n9. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n10. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n11. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n12. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n13. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n14. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n15. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n16. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n17. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n18. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n19. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n20. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n21. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n22. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n23. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n24. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n25. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n26. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n27. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n28. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n29. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n30. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n31. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n32. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n33. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n34. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n35. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n36. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n37. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n38. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n39. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n40. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n41. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n42. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n43. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n44. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n45. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n46. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n47. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n48. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n49. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n50. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n51. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n52. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n53. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n54. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n55. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n56. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n57. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n58. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n59. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n60. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n61. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n62. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n63. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n64. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n65. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n66. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n67. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n68. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n69. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n70. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n71. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n72. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n73. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n74. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n75. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n76. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n77. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n78. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n79. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n80. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n81. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n82. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n83. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n84. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n85. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n86. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n87. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n88. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n89. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n90. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n91. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n92. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n93. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n94. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n95. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n96. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n97. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n98. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n99. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n100. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n101. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n102. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n103. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n104. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n105. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n106. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n107. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n108. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n109. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n110. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n111. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n112. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n113. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n114. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n115. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n116. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n117. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n118. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n119. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n120. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n```javascript\n// 1\n// 2\n// 3\n// 4\n// 5\n// 6\n// 7\n// 8\n// 9\n// 10\n// 11\n// 12\n// 13\n// 14\n// 15\n// 16\n// 17\n// 18\n// 19\n// 20\n// 21\n// 22\n// 23\n// 24\n// 25\n// 26\n// 27\n// 28\n// 29\n// 30\n// 31\n// 32\n// 33\n// 34\n// 35\n// 36\n// 37\n// 38\n// 39\n// 40\n// 41\n// 42\n// 43\n// 44\n// 45\n// 46\n// 47\n// 48\n// 49\n// 50\n// 51\n// 52\n// 53\n// 54\n// 55\n// 56\n// 57\n// 58\n// 59\n// 60\n// 61\n// 62\n// 63\n// 64\n// 65\n// 66\n// 67\n// 68\n// 69\n// 70\n// 71\n// 72\n// 73\n// 74\n// 75\n// 76\n// 77\n// 78\n// 79\n// 80\n```\nEND_OK_9981","logprobs":[],"annotations":[]}}
+{"sequence_number":2135,"type":"response.output_item.done","item":{"content":[{"type":"output_text","text":"1. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n2. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n3. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n4. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n5. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n6. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n7. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n8. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n9. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n10. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n11. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n12. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n13. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n14. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n15. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n16. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n17. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n18. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n19. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n20. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n21. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n22. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n23. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n24. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n25. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n26. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n27. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n28. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n29. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n30. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n31. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n32. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n33. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n34. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n35. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n36. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n37. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n38. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n39. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n40. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n41. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n42. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n43. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n44. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n45. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n46. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n47. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n48. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n49. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n50. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n51. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n52. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n53. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n54. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n55. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n56. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n57. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n58. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n59. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n60. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n61. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n62. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n63. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n64. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n65. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n66. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n67. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n68. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n69. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n70. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n71. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n72. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n73. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n74. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n75. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n76. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n77. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n78. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n79. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n80. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n81. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n82. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n83. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n84. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n85. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n86. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n87. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n88. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n89. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n90. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n91. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n92. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n93. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n94. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n95. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n96. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n97. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n98. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n99. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n100. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n101. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n102. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n103. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n104. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n105. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n106. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n107. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n108. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n109. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n110. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n111. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n112. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n113. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n114. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n115. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n116. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n117. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n118. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n119. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n120. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n```javascript\n// 1\n// 2\n// 3\n// 4\n// 5\n// 6\n// 7\n// 8\n// 9\n// 10\n// 11\n// 12\n// 13\n// 14\n// 15\n// 16\n// 17\n// 18\n// 19\n// 20\n// 21\n// 22\n// 23\n// 24\n// 25\n// 26\n// 27\n// 28\n// 29\n// 30\n// 31\n// 32\n// 33\n// 34\n// 35\n// 36\n// 37\n// 38\n// 39\n// 40\n// 41\n// 42\n// 43\n// 44\n// 45\n// 46\n// 47\n// 48\n// 49\n// 50\n// 51\n// 52\n// 53\n// 54\n// 55\n// 56\n// 57\n// 58\n// 59\n// 60\n// 61\n// 62\n// 63\n// 64\n// 65\n// 66\n// 67\n// 68\n// 69\n// 70\n// 71\n// 72\n// 73\n// 74\n// 75\n// 76\n// 77\n// 78\n// 79\n// 80\n```\nEND_OK_9981","logprobs":[],"annotations":[]}],"id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","role":"assistant","type":"message","status":"completed"},"output_index":0}
+{"sequence_number":2136,"type":"response.completed","response":{"created_at":1783693897,"completed_at":1783693913,"id":"68f32c62-42e7-9c29-8f31-5cd4514897c0","max_output_tokens":6000,"model":"grok-4.3","object":"response","output":[{"content":[{"type":"output_text","text":"1. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n2. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n3. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n4. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n5. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n6. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n7. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n8. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n9. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n10. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n11. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n12. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n13. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n14. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n15. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n16. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n17. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n18. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n19. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n20. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n21. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n22. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n23. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n24. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n25. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n26. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n27. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n28. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n29. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n30. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n31. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n32. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n33. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n34. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n35. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n36. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n37. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n38. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n39. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n40. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n41. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n42. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n43. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n44. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n45. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n46. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n47. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n48. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n49. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n50. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n51. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n52. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n53. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n54. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n55. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n56. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n57. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n58. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n59. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n60. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n61. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n62. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n63. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n64. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n65. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n66. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n67. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n68. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n69. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n70. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n71. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n72. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n73. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n74. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n75. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n76. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n77. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n78. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n79. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n80. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n81. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n82. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n83. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n84. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n85. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n86. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n87. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n88. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n89. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n90. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n91. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n92. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n93. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n94. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n95. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n96. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n97. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n98. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n99. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n100. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n101. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n102. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n103. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n104. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n105. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n106. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n107. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n108. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n109. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n110. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n111. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n112. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n113. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n114. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n115. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n116. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n117. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n118. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n119. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n120. alfa beta gama delta epsilon zeta eta theta iota kappa lambda mu\n```javascript\n// 1\n// 2\n// 3\n// 4\n// 5\n// 6\n// 7\n// 8\n// 9\n// 10\n// 11\n// 12\n// 13\n// 14\n// 15\n// 16\n// 17\n// 18\n// 19\n// 20\n// 21\n// 22\n// 23\n// 24\n// 25\n// 26\n// 27\n// 28\n// 29\n// 30\n// 31\n// 32\n// 33\n// 34\n// 35\n// 36\n// 37\n// 38\n// 39\n// 40\n// 41\n// 42\n// 43\n// 44\n// 45\n// 46\n// 47\n// 48\n// 49\n// 50\n// 51\n// 52\n// 53\n// 54\n// 55\n// 56\n// 57\n// 58\n// 59\n// 60\n// 61\n// 62\n// 63\n// 64\n// 65\n// 66\n// 67\n// 68\n// 69\n// 70\n// 71\n// 72\n// 73\n// 74\n// 75\n// 76\n// 77\n// 78\n// 79\n// 80\n```\nEND_OK_9981","logprobs":[],"annotations":[]}],"id":"msg_68f32c62-42e7-9c29-8f31-5cd4514897c0","role":"assistant","type":"message","status":"completed"}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":0.949999988079071,"usage":{"input_tokens":273,"input_tokens_details":{"cached_tokens":128},"output_tokens":2129,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2402,"num_sources_used":0,"num_server_side_tools_used":0,"cost_in_usd_ticks":55293500,"context_details":{"input_tokens":273,"output_tokens":2129}},"user":null,"incomplete_details":null,"status":"completed","store":true,"metadata":{"system_fingerprint":"fp_eb3c003fc66c14ed"},"background":false,"service_tier":"default","truncation":"disabled","top_logprobs":0,"presence_penalty":0,"frequency_penalty":0,"prompt_cache_key":null,"max_tool_calls":null,"safety_identifier":null,"error":null,"instructions":null}}


### PR DESCRIPTION
## Bug

@ai-sdk/xai responses stream drops final text fragments in doStream when content block already exists

## Reproduction

- The primary reported failure could not be reproduced in two live runs using the exact `grok-4-1-fast-non-reasoning` Responses path and long-output prompt.
- Both runs returned `finishReason: stop`, 8,792 streamed characters, and the final `END_OK_9981` marker.
- The streamed text exactly matched the completed `response.output_item.done` text; the reported truncation or missing suffix did not occur.
- The recorded fixture contains 2,129 text-delta events whose concatenated text exactly matches the completed message: `packages/xai/src/responses/__fixtures__/issue-13836-xai-responses-missing-tail.chunks.txt`.
- A runnable live reproduction remains at `examples/ai-functions/src/reproduction/issue-13836-xai-responses-missing-tail.ts`; it would fail if the SDK stream omitted text present in the completed provider message.

## Relevant Documentation

- https://docs.x.ai/developers/rest-api-reference/inference/chat
- https://docs.x.ai/developers/tools/overview
- https://docs.x.ai/developers/migration/may-15-retirement

## Related Issues

Could not reproduce #13836