### PR TITLE
fix(openai): do not send both Authorization header and subprotocol api key on the transcription WebSocket

### DIFF
--- a/.changeset/openai-realtime-ws-dual-auth.md
+++ b/.changeset/openai-realtime-ws-dual-auth.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Fix streaming transcription over header-capable WebSocket implementations: the realtime WebSocket handshake sent the api key in both the `openai-insecure-api-key` subprotocol and the `Authorization` header, which OpenAI rejects ("You must only send one of protocol api key and Authorization header"). The Authorization header is now stripped when the subprotocol carries the key.

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -560,6 +560,14 @@ describe('doStream', () => {
       'realtime',
       'openai-insecure-api-key.test-api-key',
     ]);
+    // regression: the api key rides the subprotocol, so the Authorization
+    // header must be stripped (OpenAI rejects handshakes that send both).
+    expect(Object.keys(ws.options?.headers ?? {})).not.toContain(
+      'Authorization',
+    );
+    expect(Object.keys(ws.options?.headers ?? {})).not.toContain(
+      'authorization',
+    );
 
     ws.open();
     await flush();
@@ -648,6 +656,84 @@ describe('doStream', () => {
       }),
     );
 
+    ws.message({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item-1',
+      transcript: 'Hello',
+    });
+    await expect(partsPromise).resolves.toBeDefined();
+  });
+
+  it('should strip only the Authorization header and pass other headers to the WebSocket constructor', async () => {
+    MockWebSocket.instances = [];
+    const model = new OpenAITranscriptionModel('gpt-realtime-whisper', {
+      provider: 'test-provider',
+      url: ({ path }) => `https://api.openai.com/v1${path}`,
+      headers: () => ({
+        Authorization: 'Bearer test-api-key',
+        'OpenAI-Organization': 'test-organization',
+        'Custom-Header': 'custom-value',
+      }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    expect(ws.protocols).toEqual([
+      'realtime',
+      'openai-insecure-api-key.test-api-key',
+    ]);
+    expect(ws.options?.headers).toMatchObject({
+      'OpenAI-Organization': 'test-organization',
+      'Custom-Header': 'custom-value',
+    });
+    expect(Object.keys(ws.options?.headers ?? {})).not.toContain(
+      'Authorization',
+    );
+    expect(Object.keys(ws.options?.headers ?? {})).not.toContain(
+      'authorization',
+    );
+
+    ws.open();
+    await flush();
+    ws.message({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item-1',
+      transcript: 'Hello',
+    });
+    await expect(partsPromise).resolves.toBeDefined();
+  });
+
+  it('should use only the realtime protocol and pass headers unchanged when there is no Authorization header', async () => {
+    MockWebSocket.instances = [];
+    const model = new OpenAITranscriptionModel('gpt-realtime-whisper', {
+      provider: 'test-provider',
+      url: ({ path }) => `https://api.openai.com/v1${path}`,
+      headers: () => ({ 'Custom-Header': 'custom-value' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    expect(ws.protocols).toEqual(['realtime']);
+    expect(ws.options?.headers).toMatchObject({
+      'Custom-Header': 'custom-value',
+    });
+
+    ws.open();
+    await flush();
     ws.message({
       type: 'conversation.item.input_audio_transcription.completed',
       item_id: 'item-1',

--- a/packages/openai/src/transcription/openai-transcription-model.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.ts
@@ -391,11 +391,10 @@ function createOpenAIRealtimeTranscriptionStream({
   return new ReadableStream({
     start: controller => {
       const WebSocketConstructor = getWebSocketConstructor(webSocket);
-      const ws = new WebSocketConstructor(
-        url,
-        getOpenAIRealtimeProtocols(headers),
-        { headers },
-      );
+      const connection = getOpenAIRealtimeConnection(headers);
+      const ws = new WebSocketConstructor(url, connection.protocols, {
+        headers: connection.headers,
+      });
       let audioReader:
         | ReadableStreamDefaultReader<Uint8Array | string>
         | undefined;
@@ -564,15 +563,36 @@ function buildOpenAIRealtimeTranscriptionSession({
   };
 }
 
-function getOpenAIRealtimeProtocols(
+// When an Authorization bearer token is present, it is moved into the
+// `openai-insecure-api-key.<token>` subprotocol so that native `WebSocket`
+// implementations (which ignore the `headers` option) can authenticate.
+// The Authorization header must then be stripped: header-capable
+// implementations (e.g. `ws`) would otherwise send both auth channels and
+// OpenAI rejects the handshake ("You must only send one of protocol api key
+// and Authorization header").
+function getOpenAIRealtimeConnection(
   headers: Record<string, string | undefined>,
-): string[] {
+): {
+  protocols: string[];
+  headers: Record<string, string | undefined>;
+} {
   const authorization = headers.Authorization ?? headers.authorization;
   const token = authorization?.startsWith('Bearer ')
     ? authorization.slice('Bearer '.length)
     : undefined;
 
-  return token == null
-    ? ['realtime']
-    : ['realtime', `openai-insecure-api-key.${token}`];
+  if (token == null) {
+    return { protocols: ['realtime'], headers };
+  }
+
+  const {
+    Authorization: _authorization,
+    authorization: _authorizationLowercase,
+    ...headersWithoutAuthorization
+  } = headers;
+
+  return {
+    protocols: ['realtime', `openai-insecure-api-key.${token}`],
+    headers: headersWithoutAuthorization,
+  };
 }


### PR DESCRIPTION
## Background

Found while testing gateway streaming transcription (#16776 / vercel/ai-gateway#2509) end-to-end: `openai/gpt-realtime-whisper` through the gateway failed on every connect, and a direct repro against the live OpenAI API fails the handshake with:

> You must only send one of protocol api key and Authorization header.

`createOpenAIRealtimeTranscriptionStream` reuses the provider's HTTP header record for the WebSocket connect: the Bearer token is derived into the `openai-insecure-api-key.<token>` subprotocol (so native `WebSocket`, which ignores the headers option, can authenticate), but the full record — `Authorization` still inside — is also passed to the constructor. Native implementations silently drop it, so this was invisible until a header-capable implementation like `ws` is used (which server-side callers such as the AI Gateway must, because xAI's STT WebSocket is header-auth-only). `ws` faithfully forwards the header, OpenAI receives both auth channels, and rejects.

## Summary

- `packages/openai/src/transcription/openai-transcription-model.ts`: `getOpenAIRealtimeProtocols(headers)` → `getOpenAIRealtimeConnection(headers)` returning `{ protocols, headers }`. When the Bearer token rides the subprotocol, `Authorization`/`authorization` are stripped from the constructor headers; other headers still pass through. No token → both untouched. The subprotocol scheme itself is unchanged.
- Regression tests: constructor headers must not contain Authorization when the subprotocol carries the key (fails without the fix); non-auth custom headers still reach the constructor; no-Authorization case passes headers through unchanged.

## Verification

- `packages/openai`: 761/761 tests pass.
- Live against OpenAI with `webSocket: ws`: previously failed instantly with the dual-auth rejection; with the fix, `gpt-realtime-whisper` streams deltas and finishes with the correct transcript.

Side-finding (not addressed here): OpenAI realtime transcription rejects `inputAudioFormat.rate < 24000` mid-session ("Expected a value >= 24000").