### PR TITLE
fix(xai): only emit transcript-final on speech_final and reconstruct empty finish text

### DIFF
--- a/.changeset/xai-stt-final-parts.md
+++ b/.changeset/xai-stt-final-parts.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Fix streaming transcription stream parts against the live xAI STT API: `transcript-final` was emitted for every `is_final: true` event, but xAI re-sends the finalized text with `speech_final: false` before the `speech_final: true` event (duplicating finals) and also finalizes *fragments* whose text the eventual `speech_final` event merges and re-punctuates (later-revised finals). `transcript-final` is now only emitted on `speech_final: true`; finalized fragments surface as `transcript-partial`. Additionally, xAI's `transcript.done` event arrives with an empty `text`, which produced an empty `finish.text` and made `experimental_streamTranscribe` throw `NoTranscriptGeneratedError` despite a full transcript having streamed — the finish text now falls back to the accumulated finalized utterances (plus any trailing unfinalized text).

--- a/packages/xai/src/xai-transcription-model.test.ts
+++ b/packages/xai/src/xai-transcription-model.test.ts
@@ -415,6 +415,223 @@ describe('doStream', () => {
     expect(result.response).toEqual({ timestamp: testDate, modelId: '' });
   });
 
+  // xAI re-sends a finalized utterance twice — `is_final: true` with
+  // `speech_final: false`, then the identical text with `speech_final: true` —
+  // and its `transcript.done` event carries an empty `text` (observed against
+  // the live API). Only `speech_final` marks a completed utterance.
+  it('should emit one transcript-final per utterance and reconstruct the finish text when transcript.done is empty', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    ws.message({ type: 'transcript.created' });
+    await flush();
+
+    ws.message({
+      type: 'transcript.partial',
+      text: 'Hello wor',
+      is_final: false,
+      speech_final: false,
+      start: 0,
+      duration: 0.8,
+    });
+    ws.message({
+      type: 'transcript.partial',
+      text: 'Hello world.',
+      is_final: true,
+      speech_final: false,
+      start: 0,
+      duration: 1,
+    });
+    ws.message({
+      type: 'transcript.partial',
+      text: 'Hello world.',
+      is_final: true,
+      speech_final: true,
+      start: 0,
+      duration: 1,
+    });
+    ws.message({ type: 'transcript.done', text: '', duration: 1 });
+
+    const parts = await partsPromise;
+    expect(parts.filter(part => part.type === 'transcript-final')).toEqual([
+      {
+        type: 'transcript-final',
+        id: undefined,
+        text: 'Hello world.',
+        startSecond: 0,
+        endSecond: 1,
+        channelIndex: undefined,
+      },
+    ]);
+    // The speech_final:false re-send surfaces as a (revisable) partial.
+    expect(
+      parts.filter(part => part.type === 'transcript-partial'),
+    ).toHaveLength(2);
+    expect(parts.at(-1)).toEqual({
+      type: 'finish',
+      text: 'Hello world.',
+      segments: [],
+      language: undefined,
+      durationInSeconds: 1,
+    });
+  });
+
+  // Live mic sessions show `is_final` *fragments* whose text the eventual
+  // `speech_final` event merges and re-punctuates — fragment text is still
+  // revisable and must not be emitted as transcript-final.
+  it('should treat is_final fragments as partials and use the speech_final text for finish', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    ws.message({ type: 'transcript.created' });
+    await flush();
+
+    ws.message({
+      type: 'transcript.partial',
+      text: 'No',
+      is_final: true,
+      speech_final: false,
+      start: 0,
+      duration: 0.5,
+    });
+    ws.message({
+      type: 'transcript.partial',
+      text: ", I'm not",
+      is_final: true,
+      speech_final: false,
+      start: 0.5,
+      duration: 0.7,
+    });
+    ws.message({
+      type: 'transcript.partial',
+      text: "No, I'm not.",
+      is_final: true,
+      speech_final: true,
+      start: 0,
+      duration: 1.2,
+    });
+    ws.message({ type: 'transcript.done', text: '', duration: 1.2 });
+
+    const parts = await partsPromise;
+    expect(parts.map(part => part.type)).toEqual([
+      'stream-start',
+      'transcript-partial',
+      'transcript-partial',
+      'transcript-final',
+      'finish',
+    ]);
+    expect(parts.at(-1)).toMatchObject({ text: "No, I'm not." });
+  });
+
+  it('should fall back to the latest pending text when no speech_final arrived before transcript.done', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    ws.message({ type: 'transcript.created' });
+    await flush();
+
+    ws.message({
+      type: 'transcript.partial',
+      text: 'Hello wor',
+      is_final: false,
+      speech_final: false,
+    });
+    ws.message({
+      type: 'transcript.partial',
+      text: 'Hello world',
+      is_final: true,
+      speech_final: false,
+    });
+    ws.message({ type: 'transcript.done', text: '', duration: 1 });
+
+    const parts = await partsPromise;
+    expect(parts.at(-1)).toMatchObject({ type: 'finish', text: 'Hello world' });
+  });
+
+  it('should join finalized utterances per channel when transcript.done is empty', async () => {
+    MockWebSocket.instances = [];
+    const model = new XaiTranscriptionModel('', {
+      provider: 'xai.transcription',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      webSocket: MockWebSocket,
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+
+    ws.message({ type: 'transcript.created' });
+    await flush();
+
+    ws.message({
+      type: 'transcript.partial',
+      text: 'First utterance.',
+      is_final: true,
+      speech_final: true,
+      start: 0,
+      duration: 1,
+    });
+    ws.message({
+      type: 'transcript.partial',
+      text: 'Second utterance.',
+      is_final: true,
+      speech_final: true,
+      start: 1,
+      duration: 1,
+    });
+    ws.message({ type: 'transcript.done', text: '', duration: 2 });
+
+    const parts = await partsPromise;
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      text: 'First utterance. Second utterance.',
+    });
+  });
+
   it('should error the stream with the server message on error events', async () => {
     MockWebSocket.instances = [];
     const model = new XaiTranscriptionModel('', {

--- a/packages/xai/src/xai-transcription-model.ts
+++ b/packages/xai/src/xai-transcription-model.ts
@@ -276,6 +276,12 @@ function createXaiStreamingTranscriptionStream({
       const WebSocketConstructor = getWebSocketConstructor(webSocket);
       const ws = new WebSocketConstructor(url, undefined, { headers });
       const doneTexts = new Map<number, string>();
+      // Finalized utterances per channel (`speech_final` events), plus the
+      // latest still-revisable text per channel: xAI's `transcript.done`
+      // arrives with an empty `text`, so the finish text is reconstructed
+      // from these when that happens.
+      const finalizedTexts = new Map<number, string[]>();
+      const pendingTexts = new Map<number, string>();
       let doneDuration: number | undefined;
       let audioReader:
         | ReadableStreamDefaultReader<Uint8Array | string>
@@ -363,8 +369,23 @@ function createXaiStreamingTranscriptionStream({
 
               case 'transcript.partial': {
                 const id = channelId(raw.channel_index);
-                const timing = timingFromXaiEvent(raw);
-                if (raw.is_final) {
+                const channelIndex = raw.channel_index ?? 0;
+                // Only `speech_final` marks a completed utterance. xAI also
+                // sends `is_final: true` for finalized *fragments* whose text
+                // the eventual `speech_final` event merges and re-punctuates
+                // (and it re-sends that final text once with
+                // `speech_final: false` first) — treating those as finals
+                // produced duplicated and later-revised `transcript-final`
+                // parts, so they surface as partials instead.
+                if (raw.is_final && raw.speech_final) {
+                  const timing = timingFromXaiEvent(raw);
+                  if (raw.text) {
+                    finalizedTexts.set(channelIndex, [
+                      ...(finalizedTexts.get(channelIndex) ?? []),
+                      raw.text,
+                    ]);
+                  }
+                  pendingTexts.delete(channelIndex);
                   controller.enqueue({
                     type: 'transcript-final',
                     id,
@@ -373,6 +394,7 @@ function createXaiStreamingTranscriptionStream({
                     channelIndex: raw.channel_index,
                   });
                 } else {
+                  pendingTexts.set(channelIndex, raw.text ?? '');
                   controller.enqueue({
                     type: 'transcript-partial',
                     id,
@@ -387,7 +409,17 @@ function createXaiStreamingTranscriptionStream({
 
               case 'transcript.done': {
                 const channelIndex = raw.channel_index ?? 0;
-                doneTexts.set(channelIndex, raw.text ?? '');
+                // xAI sends `transcript.done` with an empty `text`; fall back
+                // to the finalized utterances (plus any trailing text that
+                // never got a `speech_final`) so `finish.text` carries the
+                // transcript.
+                const accumulated = [
+                  ...(finalizedTexts.get(channelIndex) ?? []),
+                  ...(pendingTexts.get(channelIndex)
+                    ? [pendingTexts.get(channelIndex) as string]
+                    : []),
+                ].join(' ');
+                doneTexts.set(channelIndex, raw.text || accumulated);
                 doneDuration = raw.duration ?? doneDuration;
                 maybeFinish();
                 break;


### PR DESCRIPTION
## Background

Found while testing gateway streaming transcription (#16776 / vercel/ai-gateway#2509) end-to-end against the live xAI STT API, with raw upstream events captured via `includeRawChunks`:

1. **Duplicated finals**: xAI sends a finalized utterance twice — `transcript.partial` with `is_final: true, speech_final: false`, then the identical text with `speech_final: true`. Emitting `transcript-final` for every `is_final: true` (the previous behavior) duplicates every utterance.
2. **Revised finals**: live mic sessions show `is_final: true` *fragments* (e.g. `"No"`, `", I'm not"`) whose text the eventual `speech_final` event merges and re-punctuates (`"No, I'm not."`) — so `is_final && !speech_final` text is still revisable, which is partial semantics, not final.
3. **Empty finish**: xAI's `transcript.done` arrives with `text: ""`. `finish.text` was built solely from it, so `finish` went out empty and `experimental_streamTranscribe` threw `AI_NoTranscriptGeneratedError` despite a full transcript having streamed.

## Summary

- `packages/xai/src/xai-transcription-model.ts`:
  - `transcript-final` is now only emitted on `is_final && speech_final`; finalized fragments (and the `speech_final: false` re-send) surface as `transcript-partial`.
  - `finish.text` falls back to the accumulated finalized utterances per channel (joined with spaces, plus any trailing text that never got a `speech_final`) when `transcript.done.text` is empty. A non-empty `done.text` still wins.
- 4 regression tests modeled on the captured live sequences (duplicate re-send, fragment merge, no-speech_final trailing text, multi-utterance join).

## Verification

`packages/xai`: 396/396 tests pass. End-to-end validation happens through the gateway preview (vercel/ai-gateway#2509) on the next snapshot.

Note the intentional semantic change beyond the dedupe: consumers previously saw `is_final` fragments as `transcript-final`; they are now `transcript-partial` because the live API later revises that text. Finals should never be superseded.