### PR TITLE
reproduction: could not reproduce The SDK should include output-error results as toolresult

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
@@ -1,0 +1,147 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+type AnthropicContentBlock = {
+  type?: string;
+  id?: string;
+  tool_use_id?: string;
+  content?: {
+    type?: string;
+    error_code?: string;
+  };
+};
+
+type AnthropicMessage = {
+  role?: string;
+  content?: AnthropicContentBlock[];
+};
+
+type AnthropicRequest = {
+  messages?: AnthropicMessage[];
+};
+
+type AnthropicResponse = {
+  content?: AnthropicContentBlock[];
+};
+
+type CapturedCall = {
+  request?: AnthropicRequest;
+  response?: AnthropicResponse;
+  status?: number;
+};
+
+async function main() {
+  const calls: CapturedCall[] = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const call: CapturedCall = {
+        request:
+          typeof init?.body === 'string'
+            ? (JSON.parse(init.body) as AnthropicRequest)
+            : undefined,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.status = response.status;
+      call.response = (await response
+        .clone()
+        .json()
+        .catch(() => undefined)) as AnthropicResponse | undefined;
+
+      return response;
+    },
+  });
+
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    maxOutputTokens: 512,
+    prompt: [
+      'Follow these steps in order:',
+      '1. Use web_fetch on https://httpbin.org/status/500.',
+      '2. Regardless of whether web_fetch succeeds, call display_products once.',
+      '3. After display_products returns, answer with exactly DONE.',
+      'Do not skip either tool call.',
+    ].join('\n'),
+    tools: {
+      web_fetch: anthropic.tools.webFetch_20250910({
+        maxUses: 1,
+      }),
+      display_products: tool({
+        description:
+          'Record that product display was attempted after the web fetch.',
+        inputSchema: z.object({}),
+        execute: async () => ({ displayed: true }),
+      }),
+    },
+    stopWhen: stepCountIs(4),
+  });
+
+  const errorResult = calls
+    .flatMap(call => call.response?.content ?? [])
+    .find(
+      block =>
+        block.type === 'web_fetch_tool_result' &&
+        block.content?.type === 'web_fetch_tool_result_error',
+    );
+
+  if (errorResult?.tool_use_id == null) {
+    throw new Error(
+      'The live response did not exercise a web_fetch_tool_result_error, so issue #10819 could not be evaluated.',
+    );
+  }
+
+  const continuationRequest = calls
+    .slice(1)
+    .map(call => call.request)
+    .find(request =>
+      request?.messages?.some(
+        message =>
+          message.role === 'assistant' &&
+          message.content?.some(
+            block =>
+              block.type === 'web_fetch_tool_result' &&
+              block.tool_use_id === errorResult.tool_use_id &&
+              block.content?.type === 'web_fetch_tool_result_error',
+          ),
+      ),
+    );
+
+  const output = {
+    requestCount: calls.length,
+    responseStatuses: calls.map(call => call.status),
+    webFetchToolUseId: errorResult.tool_use_id,
+    webFetchErrorCode: errorResult.content?.error_code,
+    continuationIncludedErrorResult: continuationRequest != null,
+    stepCount: result.steps.length,
+    finalText: result.text,
+    responses: calls.map(call => call.response),
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (continuationRequest == null) {
+    throw new Error(
+      'Reproduced issue #10819: the continuation request omitted the errored web_fetch_tool_result block.',
+    );
+  }
+
+  if (calls.some(call => call.status != null && call.status >= 400)) {
+    throw new Error(
+      'Reproduced issue #10819: Anthropic rejected a multi-step continuation request after the web fetch error.',
+    );
+  }
+
+  if (result.steps.length < 2 || result.text.trim() !== 'DONE') {
+    throw new Error(
+      'The multi-step continuation did not complete after the web fetch error.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json
@@ -1,0 +1,63 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CctdGxFqq9wd9BWwXvDgY",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "I'll follow these steps in order."
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01M4mXhDsUwdg47obxPH4ZAQ",
+      "name": "web_fetch",
+      "input": {
+        "url": "https://httpbin.org/status/500"
+      }
+    },
+    {
+      "type": "web_fetch_tool_result",
+      "tool_use_id": "srvtoolu_01M4mXhDsUwdg47obxPH4ZAQ",
+      "content": {
+        "type": "web_fetch_tool_result_error",
+        "error_code": "url_not_accessible"
+      },
+      "caller": {
+        "type": "direct"
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now I'll call display_products as instructed:"
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01M48QRiAhRAtxKfsCrc831L",
+      "name": "display_products",
+      "input": {},
+      "caller": {
+        "type": "direct"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 2448,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 119,
+    "service_tier": "standard",
+    "inference_geo": "not_available",
+    "server_tool_use": {
+      "web_search_requests": 0,
+      "web_fetch_requests": 1
+    }
+  }
+}

--- a/packages/anthropic/src/issue-10819.test.ts
+++ b/packages/anthropic/src/issue-10819.test.ts
@@ -1,0 +1,78 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+it('preserves a provider-executed web fetch error before a client tool call', async () => {
+  server.urls['https://api.anthropic.com/v1/messages'].response = {
+    type: 'json-value',
+    body: JSON.parse(
+      fs.readFileSync(
+        'src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json',
+        'utf8',
+      ),
+    ),
+  };
+
+  const provider = createAnthropic({ apiKey: 'test-api-key' });
+  const result = await provider('claude-sonnet-4-5-20250929').doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run both tools.' }],
+      },
+    ],
+    tools: [
+      {
+        type: 'provider',
+        id: 'anthropic.web_fetch_20250910',
+        name: 'web_fetch',
+        args: { maxUses: 1 },
+      },
+      {
+        type: 'function',
+        name: 'display_products',
+        description: 'Record that product display was attempted.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+    ],
+  });
+
+  expect(result.content).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: 'tool-call',
+        toolCallId: 'srvtoolu_01M4mXhDsUwdg47obxPH4ZAQ',
+        toolName: 'web_fetch',
+        providerExecuted: true,
+      }),
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'srvtoolu_01M4mXhDsUwdg47obxPH4ZAQ',
+        toolName: 'web_fetch',
+        result: {
+          type: 'web_fetch_tool_result_error',
+          errorCode: 'url_not_accessible',
+        },
+        isError: true,
+      }),
+      expect.objectContaining({
+        type: 'tool-call',
+        toolCallId: 'toolu_01M48QRiAhRAtxKfsCrc831L',
+        toolName: 'display_products',
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
## Bug

The SDK should include output-error results as tool_result blocks

## Reproduction

- The exact reported model `claude-sonnet-4-5-20250929` returned a `url_not_accessible` web-fetch error followed by a client tool call; both continuation requests returned HTTP 200 and the final output was `DONE`.
- The continuation request included the matching errored `web_fetch_tool_result`; the expected Anthropic 400 error for a missing result did not occur.
- Runnable live reproduction: `examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts`.
- The live response fixture and provider regression test are stored at `packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json` and `packages/anthropic/src/issue-10819.test.ts`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls

## Related Issues

Could not reproduce #10819