### PR TITLE
docs: explain how to set up, configure, run, and test the Next.js example locally

### DIFF
--- a/examples/next/.env.local.example
+++ b/examples/next/.env.local.example
@@ -1,9 +1,8 @@
-VERCEL_API_KEY=""
-VERCEL_OIDC_TOKEN=""
+# Required for AI Gateway authentication when running locally.
+AI_GATEWAY_API_KEY=""
 
-# If you choose to use external files for attachments, you will need to configure a Vercel Blob Store.
-# Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
-BLOB_READ_WRITE_TOKEN=xxxxxxx
+# Alternatively, authenticate with a Vercel OIDC token.
+# VERCEL_OIDC_TOKEN=""
 
-# Required for resumable streams. You can create a Redis store here: https://vercel.com/marketplace/redis
-REDIS_URL=xxxxxx
+# Required for resumable streams. The Redis server must support pub/sub.
+REDIS_URL=""

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -1,1 +1,54 @@
-A minimal example to test persistence, SSR, and stream resume.
+# Next.js Chat Example
+
+A minimal Next.js chat application for testing message persistence, server-side
+rendering (SSR), and resumable streams.
+
+## Prerequisites
+
+- Node.js 22, 24, or 26
+- pnpm 10 or later
+- An [AI Gateway API key](https://vercel.com/ai-gateway)
+- A Redis database with pub/sub support for resumable streams
+
+## Setup
+
+From the repository root, install dependencies and build the workspace
+packages:
+
+```bash
+pnpm install
+pnpm build
+```
+
+Copy the example environment file:
+
+```bash
+cp examples/next/.env.local.example examples/next/.env.local
+```
+
+Then set these values in `examples/next/.env.local`:
+
+- `AI_GATEWAY_API_KEY`: authenticates requests to the AI Gateway. A
+  `VERCEL_OIDC_TOKEN` can be used instead.
+- `REDIS_URL`: connects `resumable-stream` to Redis.
+
+## Run locally
+
+```bash
+cd examples/next
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Test the example
+
+Send a message to create a chat. The example stores chat data as JSON files in
+`examples/next/.chats` so that reloading a chat URL renders its saved messages
+on the server.
+
+To test stream resumption, request a long response and reload the page while it
+is still streaming. The client reconnects to the active stream through Redis.
+
+The file-based chat store is for local demonstration only and is not suitable
+for production use.


### PR DESCRIPTION
## Background

The README contained only a one-line description. Repository code confirms that the example uses AI Gateway authentication, Redis-backed resumable streams, file-based chat persistence, and Next.js on localhost:3000. Official authentication documentation confirms AI_GATEWAY_API_KEY and VERCEL_OIDC_TOKEN support. 

## Summary

Expanded the README with prerequisites, workspace installation and build steps, environment setup, run instructions, the local URL, feature-testing guidance, and the file-store limitation. Corrected the environment template to use AI_GATEWAY_API_KEY, optional VERCEL_OIDC_TOKEN, and REDIS_URL while removing unused Blob configuration.

## Testing

Formatting, linting, documentation validation, full type checking, the example production build, and a local development-server smoke test all passed.

## Related Issues

Fixes #15563

Co-authored-by: shujanislam <92726082+shujanislam@users.noreply.github.com>