### PR TITLE
reproduction: could not reproduce Unable to use Zod v4 in AI SDK

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10014-zod-v4-generate-object.ts
+++ b/examples/ai-functions/src/reproduction/issue-10014-zod-v4-generate-object.ts
@@ -1,0 +1,105 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+async function main() {
+  const directory = await mkdtemp(join(tmpdir(), 'ai-issue-10014-'));
+
+  try {
+    await writeFile(
+      join(directory, 'package.json'),
+      JSON.stringify(
+        {
+          private: true,
+          type: 'module',
+          dependencies: {
+            '@openrouter/ai-sdk-provider': '1.1.0',
+            ai: '5.0.86',
+            zod: '4.1.12',
+          },
+          devDependencies: {
+            '@types/json-schema': '7.0.15',
+            '@types/node': '22.20.1',
+            typescript: '5.9.3',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await writeFile(
+      join(directory, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            noEmit: true,
+            skipLibCheck: false,
+            strict: true,
+            target: 'ES2022',
+          },
+          include: ['index.ts'],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await writeFile(
+      join(directory, 'index.ts'),
+      `import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const openrouter = createOpenRouter({ apiKey: 'not-used-by-typecheck' });
+
+void generateObject({
+  model: openrouter('openai/gpt-4o-mini'),
+  schema: z.object({
+    pretranslatedPhrase: z.string().describe('The phrase before translation'),
+    translatedPhrase: z.string().describe('The phrase after translation'),
+    sourceLanguage: z.string(),
+    targetLanguage: z.string(),
+  }),
+  prompt: 'Translate hello to French.',
+});
+`,
+    );
+
+    await execFileAsync(
+      'pnpm',
+      [
+        'install',
+        '--ignore-workspace',
+        '--frozen-lockfile=false',
+        '--reporter=silent',
+      ],
+      {
+        cwd: directory,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+
+    await execFileAsync('pnpm', ['exec', 'tsc', '--pretty', 'false'], {
+      cwd: directory,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    console.log(
+      'Could not reproduce: generateObject accepts a Zod 4.1.12 object schema with ai 5.0.86 and @openrouter/ai-sdk-provider 1.1.0.',
+    );
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Unable to use Zod v4 in AI SDK

## Reproduction

- A clean installation of `ai@5.0.86`, `zod@4.1.12`, and `@openrouter/ai-sdk-provider@1.1.0` accepted the Zod object schema without the reported TS2322 error.
- The reported diagnostic appeared only when forcing AI SDK to resolve Zod 3 types while the application used Zod 4, consistent with a stale or mixed dependency installation.
- The runnable reproduction at `examples/ai-functions/src/reproduction/issue-10014-zod-v4-generate-object.ts` observed successful compilation, whereas the issue expected `generateObject` to reject the schema.

## Relevant Documentation

- https://ai-sdk.dev/v5/docs/migration-guides/migration-guide-5-0
- https://v5.ai-sdk.dev/docs/reference/ai-sdk-core/generate-object
- https://ai-sdk.dev/docs/troubleshooting/typescript-performance-zod

## Related Issues

Could not reproduce #10014