### PR TITLE
reproduction: could not reproduce Incorrect import of useSWR as default export causes

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-8644-swr-default-import.ts
+++ b/examples/ai-functions/src/reproduction/issue-8644-swr-default-import.ts
@@ -1,0 +1,125 @@
+import { spawn } from 'node:child_process';
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+async function run(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<{ exitCode: number; output: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      ...options,
+      env: {
+        ...process.env,
+        NEXT_TELEMETRY_DISABLED: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+
+    child.stdout.on('data', chunk => {
+      output += chunk;
+    });
+    child.stderr.on('data', chunk => {
+      output += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', exitCode => {
+      resolve({ exitCode: exitCode ?? 1, output });
+    });
+  });
+}
+
+async function main() {
+  const repositoryRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../..',
+  );
+  const fixtureDirectory = path.join(
+    repositoryRoot,
+    '.tmp',
+    'issue-8644-next-app',
+  );
+  const nextExampleDirectory = path.join(
+    repositoryRoot,
+    'examples',
+    'ai-e2e-next',
+  );
+
+  await rm(fixtureDirectory, { recursive: true, force: true });
+  await mkdir(path.join(fixtureDirectory, 'app'), { recursive: true });
+
+  try {
+    await Promise.all([
+      writeFile(
+        path.join(fixtureDirectory, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'issue-8644-reproduction',
+            private: true,
+          },
+          null,
+          2,
+        ),
+      ),
+      writeFile(
+        path.join(fixtureDirectory, 'app', 'layout.tsx'),
+        [
+          'export default function RootLayout({',
+          '  children,',
+          '}: Readonly<{ children: React.ReactNode }>) {',
+          '  return <html><body>{children}</body></html>;',
+          '}',
+          '',
+        ].join('\n'),
+      ),
+      writeFile(
+        path.join(fixtureDirectory, 'app', 'page.tsx'),
+        [
+          "'use client';",
+          '',
+          "import { useCompletion } from '@ai-sdk/react';",
+          '',
+          'export default function Page() {',
+          '  const { completion } = useCompletion();',
+          '  return <main>{completion}</main>;',
+          '}',
+          '',
+        ].join('\n'),
+      ),
+      symlink(
+        path.join(nextExampleDirectory, 'node_modules'),
+        path.join(fixtureDirectory, 'node_modules'),
+        'dir',
+      ),
+    ]);
+
+    const nextBinary = path.join(
+      nextExampleDirectory,
+      'node_modules',
+      '.bin',
+      'next',
+    );
+    const result = await run(nextBinary, ['build'], {
+      cwd: fixtureDirectory,
+    });
+
+    console.log(result.output);
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Expected the Next.js client component to build without an SWR import error, but next build exited with code ${result.exitCode}.`,
+      );
+    }
+  } finally {
+    await rm(fixtureDirectory, { recursive: true, force: true });
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Incorrect import of useSWR as default export causes runtime error

## Reproduction

- `examples/ai-functions/src/reproduction/issue-8644-swr-default-import.ts` builds a minimal Next.js 15.5.18 Client Component using `useCompletion` from `@ai-sdk/react` 4.0.21 with SWR 2.4.1; the build succeeds without the reported import error.
- SWR 2.4.1 exports `useSWR` as its default export and does not provide a named `useSWR` export, matching the official SWR documentation; the proposed named import is unsupported.
- Without `'use client'`, Next.js instead reports that React hooks cannot be used in a Server Component; this is not an SWR default-export failure.
- The issue provides no exact package versions or source component, so the current workspace versions were used as the available substitute scenario.

## Relevant Documentation

- https://swr.vercel.app/docs/getting-started
- https://nextjs.org/docs/app/getting-started/server-and-client-components
- https://nextjs.org/docs/messages/react-client-hook-in-server-component

## Related Issues

Could not reproduce #8644