### PR TITLE
fix: Anthropic multi-step requests omit provider-executed web-fetch error results

### DIFF
--- a/.changeset/tidy-web-fetch-errors.md
+++ b/.changeset/tidy-web-fetch-errors.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Serialize provider-executed web fetch errors in multi-step requests.

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "scripts": {
+    "type-check": "tsc --build"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
@@ -1,0 +1,180 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+type AnthropicContentBlock = {
+  type?: string;
+  id?: string;
+  tool_use_id?: string;
+  content?: {
+    type?: string;
+    error_code?: string;
+  };
+};
+
+type AnthropicMessage = {
+  role?: string;
+  content?: AnthropicContentBlock[];
+};
+
+type AnthropicRequest = {
+  messages?: AnthropicMessage[];
+};
+
+type AnthropicResponse = {
+  content?: AnthropicContentBlock[];
+};
+
+type CapturedCall = {
+  request?: AnthropicRequest;
+  response?: AnthropicResponse;
+  status?: number;
+};
+
+async function main() {
+  const calls: CapturedCall[] = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const call: CapturedCall = {
+        request:
+          typeof init?.body === 'string'
+            ? (JSON.parse(init.body) as AnthropicRequest)
+            : undefined,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.status = response.status;
+      call.response = (await response
+        .clone()
+        .json()
+        .catch(() => undefined)) as AnthropicResponse | undefined;
+
+      return response;
+    },
+  });
+
+  let result:
+    | {
+        steps: readonly unknown[];
+        text: string;
+      }
+    | undefined;
+  let generationError: unknown;
+
+  try {
+    result = await generateText({
+      model: anthropic('claude-sonnet-4-5-20250929'),
+      maxOutputTokens: 512,
+      temperature: 0,
+      prompt: [
+        'Follow these steps in order:',
+        '1. Use web_fetch on https://httpbin.org/status/500.',
+        '2. Wait until web_fetch has returned its result. Do not call tools in parallel.',
+        '3. Regardless of whether web_fetch succeeds, call display_products once.',
+        '4. After display_products returns, answer with exactly DONE.',
+        'Do not skip either tool call.',
+      ].join('\n'),
+      tools: {
+        web_fetch: anthropic.tools.webFetch_20250910({
+          maxUses: 1,
+        }),
+        display_products: tool({
+          description:
+            'Record that product display was attempted after the web fetch.',
+          inputSchema: z.object({}),
+          execute: async () => ({ displayed: true }),
+        }),
+      },
+      stopWhen: stepCountIs(4),
+    });
+  } catch (error) {
+    generationError = error;
+  }
+
+  const errorResult = calls
+    .flatMap(call => call.response?.content ?? [])
+    .find(
+      block =>
+        block.type === 'web_fetch_tool_result' &&
+        block.content?.type === 'web_fetch_tool_result_error',
+    );
+
+  if (errorResult?.tool_use_id == null) {
+    throw new Error(
+      'The live response did not exercise a web_fetch_tool_result_error, so issue #10819 could not be evaluated.',
+    );
+  }
+
+  const continuationRequest = calls
+    .slice(1)
+    .map(call => call.request)
+    .find(request =>
+      request?.messages?.some(
+        message =>
+          message.role === 'assistant' &&
+          message.content?.some(
+            block =>
+              block.type === 'web_fetch_tool_result' &&
+              block.tool_use_id === errorResult.tool_use_id &&
+              block.content?.type === 'web_fetch_tool_result_error',
+          ),
+      ),
+    );
+
+  const output = {
+    requestCount: calls.length,
+    responseStatuses: calls.map(call => call.status),
+    webFetchToolUseId: errorResult.tool_use_id,
+    webFetchErrorCode: errorResult.content?.error_code,
+    continuationIncludedErrorResult: continuationRequest != null,
+    stepCount: result?.steps.length,
+    finalText: result?.text,
+    generationError:
+      generationError instanceof Error
+        ? {
+            name: generationError.name,
+            message: generationError.message,
+          }
+        : generationError,
+    requests: calls.map(call => call.request),
+    responses: calls.map(call => call.response),
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (generationError != null) {
+    throw new Error(
+      'Reproduced issue #10819: multi-step generation failed after the web fetch error.',
+      { cause: generationError },
+    );
+  }
+
+  if (continuationRequest == null) {
+    throw new Error(
+      'Reproduced issue #10819: the continuation request omitted the errored web_fetch_tool_result block.',
+    );
+  }
+
+  if (calls.some(call => call.status != null && call.status >= 400)) {
+    throw new Error(
+      'Reproduced issue #10819: Anthropic rejected a multi-step continuation request after the web fetch error.',
+    );
+  }
+
+  if (
+    result == null ||
+    result.steps.length < 2 ||
+    result.text.trim() !== 'DONE'
+  ) {
+    throw new Error(
+      'The multi-step continuation did not complete after the web fetch error.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
@@ -166,7 +166,7 @@ async function main() {
   if (
     result == null ||
     result.steps.length < 2 ||
-    result.text.trim() !== 'DONE'
+    !result.text.trim().endsWith('DONE')
   ) {
     throw new Error(
       'The multi-step continuation did not complete after the web fetch error.',

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "target": "es2022",
+    "lib": [
+      "es2022",
+      "dom"
+    ],
+    "module": "esnext",
+    "types": [
+      "node"
+    ],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "./build",
+    "skipLibCheck": true,
+    "composite": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../packages/ai"
+    },
+    {
+      "path": "../../packages/anthropic"
+    }
+  ]
+}

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -44,6 +44,7 @@
     "@ai-sdk/test-server": "workspace:*",
     "@types/node": "20.17.24",
     "@vercel/ai-tsconfig": "workspace:*",
+    "ai": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
     "zod": "3.25.76"

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json
@@ -1,0 +1,63 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CctfvNz9QmqUaXih7hdQk",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "I'll follow these steps in order.\n\nStep 1: Calling web_fetch on the specified URL."
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01YLvnKz3B4whrw1vbfoMEbn",
+      "name": "web_fetch",
+      "input": {
+        "url": "https://httpbin.org/status/500"
+      }
+    },
+    {
+      "type": "web_fetch_tool_result",
+      "tool_use_id": "srvtoolu_01YLvnKz3B4whrw1vbfoMEbn",
+      "content": {
+        "type": "web_fetch_tool_result_error",
+        "error_code": "url_not_accessible"
+      },
+      "caller": {
+        "type": "direct"
+      }
+    },
+    {
+      "type": "text",
+      "text": "Step 2: web_fetch has returned (with an error, but it has completed).\n\nStep 3: Now calling display_products."
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01B9ZVZqCqy4BtWhv5z4ihmW",
+      "name": "display_products",
+      "input": {},
+      "caller": {
+        "type": "direct"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 2503,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 153,
+    "service_tier": "standard",
+    "inference_geo": "not_available",
+    "server_tool_use": {
+      "web_search_requests": 0,
+      "web_fetch_requests": 1
+    }
+  }
+}

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json
@@ -1,0 +1,42 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011Cctfw4PUmLoWuBZxAD3tS",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "web_fetch_tool_result",
+      "tool_use_id": "srvtoolu_01YLvnKz3B4whrw1vbfoMEbn",
+      "content": {
+        "type": "web_fetch_tool_result_error",
+        "error_code": "url_not_accessible"
+      },
+      "caller": {
+        "type": "direct"
+      }
+    },
+    {
+      "type": "text",
+      "text": "Step 4: display_products has returned.\n\nDONE"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 1431,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 16,
+    "service_tier": "standard",
+    "inference_geo": "not_available",
+    "server_tool_use": {
+      "web_search_requests": 0,
+      "web_fetch_requests": 1
+    }
+  }
+}

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json
@@ -5,17 +5,6 @@
   "role": "assistant",
   "content": [
     {
-      "type": "web_fetch_tool_result",
-      "tool_use_id": "srvtoolu_01YLvnKz3B4whrw1vbfoMEbn",
-      "content": {
-        "type": "web_fetch_tool_result_error",
-        "error_code": "url_not_accessible"
-      },
-      "caller": {
-        "type": "direct"
-      }
-    },
-    {
       "type": "text",
       "text": "Step 4: display_products has returned.\n\nDONE"
     }
@@ -33,10 +22,6 @@
     },
     "output_tokens": 16,
     "service_tier": "standard",
-    "inference_geo": "not_available",
-    "server_tool_use": {
-      "web_search_requests": 0,
-      "web_fetch_requests": 1
-    }
+    "inference_geo": "not_available"
   }
 }

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -256,19 +256,24 @@ export interface AnthropicBashCodeExecutionToolResultContent {
 export interface AnthropicWebFetchToolResultContent {
   type: 'web_fetch_tool_result';
   tool_use_id: string;
-  content: {
-    type: 'web_fetch_result';
-    url: string;
-    retrieved_at: string | null;
-    content: {
-      type: 'document';
-      title: string | null;
-      citations?: { enabled: boolean };
-      source:
-        | { type: 'base64'; media_type: 'application/pdf'; data: string }
-        | { type: 'text'; media_type: 'text/plain'; data: string };
-    };
-  };
+  content:
+    | {
+        type: 'web_fetch_result';
+        url: string;
+        retrieved_at: string | null;
+        content: {
+          type: 'document';
+          title: string | null;
+          citations?: { enabled: boolean };
+          source:
+            | { type: 'base64'; media_type: 'application/pdf'; data: string }
+            | { type: 'text'; media_type: 'text/plain'; data: string };
+        };
+      }
+    | {
+        type: 'web_fetch_tool_result_error';
+        error_code: string;
+      };
   cache_control: AnthropicCacheControl | undefined;
 }
 

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1104,6 +1104,77 @@ describe('assistant messages', () => {
     expect(warnings).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should convert anthropic web_fetch tool call with error result', async () => {
+    const warnings: LanguageModelV2CallWarning[] = [];
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'srvtoolu_016yTvwN6L1sDdjdPUzPbZRV',
+              toolName: 'web_fetch',
+              input: {
+                url: 'https://httpbin.org/status/500',
+              },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'srvtoolu_016yTvwN6L1sDdjdPUzPbZRV',
+              toolName: 'web_fetch',
+              output: {
+                type: 'error-json',
+                value: {
+                  type: 'web_fetch_tool_result_error',
+                  errorCode: 'url_not_accessible',
+                },
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "betas": Set {},
+        "prompt": {
+          "messages": [
+            {
+              "content": [
+                {
+                  "cache_control": undefined,
+                  "id": "srvtoolu_016yTvwN6L1sDdjdPUzPbZRV",
+                  "input": {
+                    "url": "https://httpbin.org/status/500",
+                  },
+                  "name": "web_fetch",
+                  "type": "server_tool_use",
+                },
+                {
+                  "cache_control": undefined,
+                  "content": {
+                    "error_code": "url_not_accessible",
+                    "type": "web_fetch_tool_result_error",
+                  },
+                  "tool_use_id": "srvtoolu_016yTvwN6L1sDdjdPUzPbZRV",
+                  "type": "web_fetch_tool_result",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "system": undefined,
+        },
+      }
+    `);
+    expect(warnings).toMatchInlineSnapshot(`[]`);
+  });
+
   describe('code_execution 20250522', () => {
     it('should convert anthropic code_execution tool call and result parts', async () => {
       const warnings: LanguageModelV2CallWarning[] = [];

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -9,6 +9,7 @@ import {
 import {
   convertToBase64,
   parseProviderOptions,
+  safeParseJSON,
   validateTypes,
 } from '@ai-sdk/provider-utils';
 import {
@@ -600,6 +601,35 @@ export async function convertToAnthropicMessagesPrompt({
                 if (part.toolName === 'web_fetch') {
                   const output = part.output;
 
+                  if (output.type === 'error-json') {
+                    const parsedOutput =
+                      typeof output.value === 'string'
+                        ? await safeParseJSON({ text: output.value })
+                        : { success: true as const, value: output.value };
+                    const errorValue = parsedOutput.success
+                      ? parsedOutput.value
+                      : undefined;
+                    const errorCode =
+                      errorValue != null &&
+                      typeof errorValue === 'object' &&
+                      'errorCode' in errorValue &&
+                      typeof errorValue.errorCode === 'string'
+                        ? errorValue.errorCode
+                        : 'unavailable';
+
+                    anthropicContent.push({
+                      type: 'web_fetch_tool_result',
+                      tool_use_id: part.toolCallId,
+                      content: {
+                        type: 'web_fetch_tool_result_error',
+                        error_code: errorCode,
+                      },
+                      cache_control: cacheControl,
+                    });
+
+                    break;
+                  }
+
                   if (output.type !== 'json') {
                     warnings.push({
                       type: 'other',
@@ -629,7 +659,10 @@ export async function convertToAnthropicMessagesPrompt({
                           type: webFetchOutput.content.source.type,
                           media_type: webFetchOutput.content.source.mediaType,
                           data: webFetchOutput.content.source.data,
-                        } as AnthropicWebFetchToolResultContent['content']['content']['source'],
+                        } as Extract<
+                          AnthropicWebFetchToolResultContent['content'],
+                          { type: 'web_fetch_result' }
+                        >['content']['source'],
                       },
                     },
                     cache_control: cacheControl,

--- a/packages/anthropic/src/issue-10819.test.ts
+++ b/packages/anthropic/src/issue-10819.test.ts
@@ -1,0 +1,68 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { generateText, stepCountIs, tool } from 'ai';
+import fs from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+it('continues after a provider-executed web fetch error before a client tool call', async () => {
+  server.urls['https://api.anthropic.com/v1/messages'].response = [1, 2].map(
+    fixtureNumber => ({
+      type: 'json-value' as const,
+      body: JSON.parse(
+        fs.readFileSync(
+          `src/__fixtures__/anthropic-issue-10819-web-fetch-error.${fixtureNumber}.json`,
+          'utf8',
+        ),
+      ),
+    }),
+  );
+
+  const anthropic = createAnthropic({ apiKey: 'test-api-key' });
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    maxOutputTokens: 512,
+    prompt: 'Run web_fetch and then display_products.',
+    tools: {
+      web_fetch: anthropic.tools.webFetch_20250910({
+        maxUses: 1,
+      }),
+      display_products: tool({
+        description:
+          'Record that product display was attempted after the web fetch.',
+        inputSchema: z.object({}),
+        execute: async () => ({ displayed: true }),
+      }),
+    },
+    stopWhen: stepCountIs(4),
+  });
+
+  expect(result.text.trim()).toBe('DONE');
+
+  const continuationRequest = await server.calls[1].requestBodyJson;
+  expect(continuationRequest.messages).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'web_fetch_tool_result',
+            tool_use_id: 'srvtoolu_01YLvnKz3B4whrw1vbfoMEbn',
+            content: {
+              type: 'web_fetch_tool_result_error',
+              error_code: 'url_not_accessible',
+            },
+          }),
+        ]),
+      }),
+    ]),
+  );
+});

--- a/packages/anthropic/src/issue-10819.test.ts
+++ b/packages/anthropic/src/issue-10819.test.ts
@@ -45,7 +45,7 @@ it('continues after a provider-executed web fetch error before a client tool cal
     stopWhen: stepCountIs(4),
   });
 
-  expect(result.text.trim()).toBe('DONE');
+  expect(result.text.trim()).toMatch(/DONE$/);
 
   const continuationRequest = await server.calls[1].requestBodyJson;
   expect(continuationRequest.messages).toEqual(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -1452,6 +1474,9 @@ importers:
       '@vercel/ai-tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
+      ai:
+        specifier: workspace:*
+        version: link:../ai
       tsup:
         specifier: ^8
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
@@ -19630,7 +19655,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19644,13 +19669,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19658,22 +19683,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19683,7 +19708,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19713,7 +19738,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24963,7 +24988,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29439,7 +29464,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30208,7 +30233,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30305,7 +30330,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33789,7 +33814,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33817,7 +33842,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34896,7 +34921,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36436,7 +36461,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37393,7 +37418,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37830,7 +37855,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -40029,7 +40054,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Background

Anthropic web-fetch errors were omitted from continuation requests, causing successful multi-step generations to fail with a tool-call-not-found error.

## Summary

Updated Anthropic prompt serialization and types to emit provider-executed web-fetch errors as web_fetch_tool_result error blocks with the original error code.

## Testing

Added serializer coverage and updated the fixture-based multi-step regression test to verify the errored web-fetch result is included and generation completes.

## End-to-end Validation

- `issue-10819-anthropic-web-fetch-error.ts`: ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-10819-anthropic-web-fetch-error.ts`; both Anthropic requests returned HTTP 200, the continuation included the `url_not_accessible` result, and generation completed in two steps ending with `DONE`.

## Related Issues

Fixes #10819

Co-authored-by: emilankerwiik <54847581+emilankerwiik@users.noreply.github.com>