### PR TITLE
fix(harness): fix harness tool approval regression

### DIFF
--- a/.changeset/cuddly-eagles-hide.md
+++ b/.changeset/cuddly-eagles-hide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+fix(harness): fix harness tool approval regression

--- a/packages/harness/src/bridge/index.test.ts
+++ b/packages/harness/src/bridge/index.test.ts
@@ -274,6 +274,74 @@ describe('runBridge', () => {
     expect(ack).toMatchObject({ type: 'bridge-interrupted', ok: true });
   });
 
+  it('preserves a turn waiting for a host tool result when interrupted', async () => {
+    let interrupted = false;
+    const handle = await startBridge(async (_start, turn) => {
+      turn.onInterrupt(() => {
+        interrupted = true;
+      });
+      turn.emit({ type: 'tool-call', toolCallId: 'tool-1' });
+      const result = await turn.requestToolResult('tool-1');
+      turn.emit({ type: 'text-delta', delta: String(result.output) });
+      turn.emit({ type: 'finish' });
+    });
+    const client = await connect(handle.port);
+    await client.waitFor(f => f.type === 'bridge-hello');
+    client.send({ type: 'start' });
+    await client.waitFor(f => f.type === 'tool-call');
+
+    client.send({ type: 'interrupt' });
+    const ack = await client.waitFor(f => f.type === 'bridge-interrupted');
+    expect(interrupted).toBe(false);
+    expect(ack).toMatchObject({ type: 'bridge-interrupted', ok: true });
+
+    client.send({
+      type: 'tool-result',
+      toolCallId: 'tool-1',
+      output: 'sunny',
+    });
+    await client.waitFor(f => f.type === 'finish');
+    expect(client.frames).toContainEqual(
+      expect.objectContaining({ type: 'text-delta', delta: 'sunny' }),
+    );
+  });
+
+  it('preserves a turn waiting for host approval when interrupted', async () => {
+    let interrupted = false;
+    const handle = await startBridge(async (_start, turn) => {
+      turn.onInterrupt(() => {
+        interrupted = true;
+      });
+      turn.emit({
+        type: 'tool-approval-request',
+        approvalId: 'approval-1',
+        toolCallId: 'tool-1',
+      });
+      const response = await turn.requestToolApproval('approval-1');
+      turn.emit({ type: 'text-delta', delta: String(response.approved) });
+      turn.emit({ type: 'finish' });
+    });
+    const client = await connect(handle.port);
+    await client.waitFor(f => f.type === 'bridge-hello');
+    client.send({ type: 'start' });
+    await client.waitFor(f => f.type === 'tool-approval-request');
+
+    client.send({ type: 'interrupt' });
+    const ack = await client.waitFor(f => f.type === 'bridge-interrupted');
+    expect(interrupted).toBe(false);
+    expect(ack).toMatchObject({ type: 'bridge-interrupted', ok: true });
+
+    client.send({
+      type: 'tool-approval-response',
+      approvalId: 'approval-1',
+      approved: true,
+    });
+    await client.waitFor(f => f.type === 'finish');
+    expect(client.frames).toContainEqual(
+      expect.objectContaining({ type: 'text-delta', delta: 'true' }),
+    );
+  });
+
   it('clears the log per turn but keeps seq monotonic across turns', async () => {
     let turnNo = 0;
     const handle = await startBridge(async (_start, turn) => {

--- a/packages/harness/src/bridge/index.ts
+++ b/packages/harness/src/bridge/index.ts
@@ -616,10 +616,22 @@ export async function runBridge<TStart extends { type: 'start' }>(
         return;
       case 'interrupt':
         try {
-          if (currentInterruptHandler) {
-            await currentInterruptHandler();
-          } else {
-            turnAbort?.abort();
+          /*
+           * A bridge waiting for a host tool result or approval is already
+           * paused at a resumable boundary. Interrupting the native runtime at
+           * that point terminates the operation that owns the pending request,
+           * so a later host process cannot satisfy it. Active turns without
+           * pending host input are interrupted before suspension as usual.
+           */
+          if (
+            pendingToolResults.size === 0 &&
+            pendingToolApprovals.size === 0
+          ) {
+            if (currentInterruptHandler) {
+              await currentInterruptHandler();
+            } else {
+              turnAbort?.abort();
+            }
           }
           sendControl({ type: 'bridge-interrupted', ok: true });
         } catch (err) {


### PR DESCRIPTION
## Background

#17026 added a formal `interrupt()` call in each harness when suspending an in-flight turn. However, that inadvertently broke cross-request tool approvals: They would suspend the harness bridge by interrupting the native runtime, terminating the operation waiting for host input and replaying an error on continuation.

## Summary

Treat pending host tool results and approvals as resumable pause boundaries while preserving interruption for actively executing turns.

- Acknowledge bridge interrupts without aborting operations already waiting for host input.
- Continue interrupting active turns normally, preserving step-based stopping support.
- Add regression coverage for both pending tool results and approval responses.

All implemented in the central harness layer, so that the individual harness adapters don't have to worry about it.

## Manual Verification

Use any of the `examples/harness-e2e-next` harness examples for `weather-approval`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
