### PR TITLE
fix(provider/cohere): emit citations as source parts when streaming

### DIFF
--- a/.changeset/cohere-streaming-citations.md
+++ b/.changeset/cohere-streaming-citations.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cohere': patch
+---
+
+Emit citations as source parts when streaming, matching the existing non-streaming behavior.

--- a/packages/cohere/src/__fixtures__/cohere-citations.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-citations.chunks.txt
@@ -1,0 +1,8 @@
+{"id":"68475c80-574b-4c65-98a4-e81cebab5dce","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+{"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"The key benefits are "}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"automation of tasks."}}}}
+{"type":"content-end","index":0}
+{"type":"citation-start","index":0,"delta":{"message":{"citations":{"start":21,"end":40,"text":"automation of tasks","sources":[{"type":"document","id":"doc:0","document":{"id":"doc:0","text":"AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction","title":"benefits.txt"}}],"type":"TEXT_CONTENT"}}}}
+{"type":"citation-end","index":0}
+{"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"billed_units":{"input_tokens":39,"output_tokens":27},"tokens":{"input_tokens":1683,"output_tokens":62}}}}

--- a/packages/cohere/src/__snapshots__/cohere-chat-language-model.test.ts.snap
+++ b/packages/cohere/src/__snapshots__/cohere-chat-language-model.test.ts.snap
@@ -562,6 +562,87 @@ exports[`doGenerate > tool call > should extract tool calls 1`] = `
 }
 `;
 
+exports[`doStream > citations > should stream citations as source parts 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "68475c80-574b-4c65-98a4-e81cebab5dce",
+    "type": "response-metadata",
+  },
+  {
+    "id": "0",
+    "type": "text-start",
+  },
+  {
+    "delta": "The key benefits are ",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "automation of tasks.",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "id": "0",
+    "type": "text-end",
+  },
+  {
+    "id": "test-citation-id",
+    "mediaType": "text/plain",
+    "providerMetadata": {
+      "cohere": {
+        "citationType": "TEXT_CONTENT",
+        "end": 40,
+        "sources": [
+          {
+            "document": {
+              "id": "doc:0",
+              "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+              "title": "benefits.txt",
+            },
+            "id": "doc:0",
+            "type": "document",
+          },
+        ],
+        "start": 21,
+        "text": "automation of tasks",
+      },
+    },
+    "sourceType": "document",
+    "title": "benefits.txt",
+    "type": "source",
+  },
+  {
+    "finishReason": {
+      "raw": "COMPLETE",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": undefined,
+        "cacheWrite": undefined,
+        "noCache": 1683,
+        "total": 1683,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 62,
+        "total": 62,
+      },
+      "raw": {
+        "input_tokens": 1683,
+        "output_tokens": 62,
+      },
+    },
+  },
+]
+`;
+
 exports[`doStream > empty tool call > should handle empty tool call arguments 1`] = `
 [
   {

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -808,6 +808,71 @@ describe('doStream', () => {
     });
   });
 
+  describe('citations', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('cohere-citations');
+    });
+
+    it('should stream citations as source parts', async () => {
+      const mockGenerateId = vi.fn().mockReturnValue('test-citation-id');
+      const testProvider = createCohere({
+        apiKey: 'test-api-key',
+        generateId: mockGenerateId,
+      });
+
+      const { stream } = await testProvider('command-r-plus').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
+    });
+
+    it('should emit the same source parts as doGenerate', async () => {
+      const mockGenerateId = vi.fn().mockReturnValue('test-citation-id');
+      const testProvider = createCohere({
+        apiKey: 'test-api-key',
+        generateId: mockGenerateId,
+      });
+
+      const { stream } = await testProvider('command-r-plus').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(parts.filter(part => part.type === 'source')).toEqual([
+        {
+          type: 'source',
+          sourceType: 'document',
+          id: 'test-citation-id',
+          mediaType: 'text/plain',
+          title: 'benefits.txt',
+          providerMetadata: {
+            cohere: {
+              start: 21,
+              end: 40,
+              text: 'automation of tasks',
+              sources: [
+                {
+                  type: 'document',
+                  id: 'doc:0',
+                  document: {
+                    id: 'doc:0',
+                    text: 'AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction',
+                    title: 'benefits.txt',
+                  },
+                },
+              ],
+              citationType: 'TEXT_CONTENT',
+            },
+          },
+        },
+      ]);
+    });
+  });
+
   describe('tool call', () => {
     beforeEach(() => {
       prepareChunksFixtureResponse('cohere-tool-call');

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -278,6 +278,8 @@ export class CohereChatLanguageModel implements LanguageModelV4 {
 
     let isActiveReasoning = false;
 
+    const generateId = this.config.generateId;
+
     return {
       stream: response.pipeThrough(
         new TransformStream<
@@ -422,6 +424,31 @@ export class CohereChatLanguageModel implements LanguageModelV4 {
                   pendingToolCall.hasFinished = true;
                   pendingToolCall = null;
                 }
+                return;
+              }
+
+              case 'citation-start': {
+                const citation = value.delta?.message?.citations;
+
+                if (citation != null) {
+                  controller.enqueue({
+                    type: 'source',
+                    sourceType: 'document',
+                    id: generateId(),
+                    mediaType: 'text/plain',
+                    title: citation.sources?.[0]?.document?.title || 'Document',
+                    providerMetadata: {
+                      cohere: {
+                        start: citation.start ?? null,
+                        end: citation.end ?? null,
+                        text: citation.text ?? null,
+                        sources: citation.sources ?? [],
+                        ...(citation.type && { citationType: citation.type }),
+                      },
+                    },
+                  });
+                }
+
                 return;
               }
 
@@ -574,6 +601,38 @@ const cohereChatResponseSchema = z.object({
 const cohereChatChunkSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('citation-start'),
+    index: z.number().nullish(),
+    delta: z
+      .object({
+        message: z
+          .object({
+            citations: z
+              .object({
+                start: z.number().nullish(),
+                end: z.number().nullish(),
+                text: z.string().nullish(),
+                sources: z
+                  .array(
+                    z.object({
+                      type: z.string().optional(),
+                      id: z.string().optional(),
+                      document: z
+                        .object({
+                          id: z.string().optional(),
+                          text: z.string().optional(),
+                          title: z.string().optional(),
+                        })
+                        .nullish(),
+                    }),
+                  )
+                  .nullish(),
+                type: z.string().optional(),
+              })
+              .nullish(),
+          })
+          .nullish(),
+      })
+      .nullish(),
   }),
   z.object({
     type: z.literal('citation-end'),


### PR DESCRIPTION
## Background

`doGenerate` emits every Cohere citation as a `source` content part, but `doStream` drops them all. The streaming chunk schema declares `citation-start` / `citation-end` event types but captures only `{ type }` — the `delta.message.citations` payload is discarded at parse time — and the stream transform has no case for either event, so they fall through to the `default: return` branch.

The result: a RAG call with `documents` returns the full source/citation list via `generateText`, but the identical call via `streamText` yields zero `source` parts, with no error or warning.

## Summary

- The `citation-start` chunk schema now captures the citation payload (`start`, `end`, `text`, `sources`, `type`), using defensive `nullish()` fields.
- The stream transform emits a `source` part for each `citation-start` event with the same shape and `providerMetadata` as the existing non-streaming path (`sourceType: 'document'`, `id` from `config.generateId`, title from the first source document, and `cohere.start/end/text/sources/citationType` metadata).
- `citation-end` remains a no-op; a citation is complete when it starts, matching how `doGenerate` maps the final `citations` array.
- Added a streaming citations fixture (`cohere-citations.chunks.txt`) modeled on the v2 API event shapes, a snapshot test, and an explicit test asserting the emitted `source` part matches what `doGenerate` produces for the same citation.

## Manual Verification

Ran the two new tests against the unmodified transform: both fail there (no `source` parts are emitted). With this change, the full `@ai-sdk/cohere` suite passes (`pnpm test`: node + edge, 77 tests each) plus `pnpm type-check`; `oxlint`/`oxfmt` clean on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

None
