### PR TITLE
fix(provider/huggingface): base64-encode binary image data in responses messages

### DIFF
--- a/.changeset/huggingface-image-binary-data.md
+++ b/.changeset/huggingface-image-binary-data.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/huggingface': patch
+---
+
+Base64-encode binary image file data instead of stringifying the bytes, so images passed as Uint8Array produce valid data URLs.

--- a/packages/huggingface/src/responses/convert-to-huggingface-responses-messages.ts
+++ b/packages/huggingface/src/responses/convert-to-huggingface-responses-messages.ts
@@ -4,6 +4,7 @@ import {
   type LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
 import {
+  convertToBase64,
   getTopLevelMediaType,
   resolveFullMediaType,
 } from '@ai-sdk/provider-utils';
@@ -54,7 +55,7 @@ export async function convertToHuggingFaceResponsesMessages({
                         image_url:
                           part.data.type === 'url'
                             ? part.data.url.toString()
-                            : `data:${resolveFullMediaType({ part })};base64,${part.data.data}`,
+                            : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
                       };
                     } else {
                       throw new UnsupportedFunctionalityError({

--- a/packages/huggingface/src/responses/huggingface-responses-language-model.test.ts
+++ b/packages/huggingface/src/responses/huggingface-responses-language-model.test.ts
@@ -757,6 +757,33 @@ describe('HuggingFaceResponsesLanguageModel', () => {
       `);
     });
 
+    it('should base64-encode binary image data', async () => {
+      await createModel('deepseek-ai/DeepSeek-V3-0324').doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What do you see?' },
+              {
+                type: 'file',
+                mediaType: 'image/jpeg',
+                data: {
+                  type: 'data' as const,
+                  data: new Uint8Array([1, 2, 3, 4]),
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.input[0].content[1]).toEqual({
+        type: 'input_image',
+        image_url: 'data:image/jpeg;base64,AQIDBA==',
+      });
+    });
+
     it('should throw for file parts with provider references', async () => {
       await expect(
         createModel('Qwen/Qwen2.5-VL-32B-Instruct').doGenerate({


### PR DESCRIPTION
## Background

`convertToHuggingFaceResponsesMessages` builds image data URLs by interpolating the file part's data directly:

```ts
`data:${resolveFullMediaType({ part })};base64,${part.data.data}`
```

`part.data.data` is typed `Uint8Array | string`. When the caller passes binary data (a `Buffer`/`Uint8Array`, which is also what the SDK produces when it downloads an image URL for the model), the template literal stringifies the bytes as comma-joined numbers, producing a corrupt payload like `data:image/jpeg;base64,137,80,78,71,...`. Every other converter in the repo (openai, groq, mistral, xai, cohere, alibaba, openai-compatible, perplexity) wraps this value in `convertToBase64`; this converter was the only one interpolating the raw value. The existing test only covered an already-base64 string, which is why it passed.

## Summary

- Use `convertToBase64(part.data.data)` when building the `input_image` data URL, so both `string` and `Uint8Array` inputs produce a valid base64 data URL.
- Added a regression test passing `new Uint8Array([1, 2, 3, 4])` and asserting the request contains `data:image/jpeg;base64,AQIDBA==`.

## Manual Verification

Ran the new test against the unmodified converter: it fails there with `"data:image/jpeg;base64,1,2,3,4"` as the actual value. With this change, the full `@ai-sdk/huggingface` suite passes (`pnpm test`: node + edge) plus `pnpm type-check`; `oxlint`/`oxfmt` clean on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

None
