### PR TITLE
fix(provider/elevenlabs): send a single diarize field so it can be disabled

### DIFF
--- a/.changeset/elevenlabs-duplicate-diarize.md
+++ b/.changeset/elevenlabs-duplicate-diarize.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': patch
+---
+
+Send a single `diarize` form field instead of duplicate contradictory values, so `diarize: false` can actually disable diarization.

--- a/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
@@ -9,7 +9,7 @@ export const elevenLabsTranscriptionModelOptionsSchema = z.object({
     .enum(['none', 'word', 'character'])
     .nullish()
     .default('word'),
-  diarize: z.boolean().nullish().default(false),
+  diarize: z.boolean().nullish(),
   fileFormat: z.enum(['pcm_s16le_16', 'other']).nullish().default('other'),
 });
 

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -117,6 +117,64 @@ describe('doGenerate', () => {
         }
       `);
     });
+
+    describe('diarize', () => {
+      function createFormDataCapturingProvider() {
+        const captured: { formData?: FormData } = {};
+
+        const capturingProvider = createElevenLabs({
+          apiKey: 'test-api-key',
+          fetch: async (input, init) => {
+            captured.formData = init?.body as FormData;
+            return fetch(input, init);
+          },
+        });
+
+        return { capturingProvider, captured };
+      }
+
+      it('should send diarize as true by default', async () => {
+        const { capturingProvider, captured } =
+          createFormDataCapturingProvider();
+
+        await capturingProvider.transcription('scribe_v1').doGenerate({
+          audio: audioData,
+          mediaType: 'audio/wav',
+        });
+
+        expect(captured.formData?.getAll('diarize')).toEqual(['true']);
+      });
+
+      it('should send a single diarize field when diarize is disabled', async () => {
+        const { capturingProvider, captured } =
+          createFormDataCapturingProvider();
+
+        await capturingProvider.transcription('scribe_v1').doGenerate({
+          audio: audioData,
+          mediaType: 'audio/wav',
+          providerOptions: {
+            elevenlabs: { diarize: false },
+          },
+        });
+
+        expect(captured.formData?.getAll('diarize')).toEqual(['false']);
+      });
+
+      it('should keep the diarize default when other options are set', async () => {
+        const { capturingProvider, captured } =
+          createFormDataCapturingProvider();
+
+        await capturingProvider.transcription('scribe_v1').doGenerate({
+          audio: audioData,
+          mediaType: 'audio/wav',
+          providerOptions: {
+            elevenlabs: { languageCode: 'en' },
+          },
+        });
+
+        expect(captured.formData?.getAll('diarize')).toEqual(['true']);
+      });
+    });
   });
 
   describe('response headers', () => {

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -77,7 +77,7 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
       new File([blob], 'audio', { type: mediaType }),
       `audio.${fileExtension}`,
     );
-    formData.append('diarize', 'true');
+    formData.append('diarize', String(elevenlabsOptions?.diarize ?? true));
 
     // Add provider-specific options
     if (elevenlabsOptions) {
@@ -89,10 +89,6 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
           elevenlabsOptions.timestampsGranularity ?? undefined,
         file_format: elevenlabsOptions.fileFormat ?? undefined,
       };
-
-      if (typeof elevenlabsOptions.diarize === 'boolean') {
-        formData.append('diarize', String(elevenlabsOptions.diarize));
-      }
 
       for (const key in transcriptionModelOptions) {
         const value =


### PR DESCRIPTION
## Background

The ElevenLabs transcription model appends `diarize` to the multipart body twice. `getArgs` unconditionally appends `diarize=true`, and then — because the options schema declares `diarize: z.boolean().nullish().default(false)` — any use of `providerOptions.elevenlabs` (even just `languageCode`) produces a concrete boolean that gets appended as a second `diarize` field.

Consequences:

- `providerOptions: { elevenlabs: { languageCode: 'en' } }` sends the contradictory pair `diarize=true` **and** `diarize=false`.
- `diarize: false` sends `diarize=true` followed by `diarize=false`, so whether diarization is actually disabled depends on which duplicate the server reads — the option cannot reliably turn diarization off.
- The schema default (`false`) also contradicts both the hardcoded `true` and the documented behavior (the provider docs state `diarize` "Defaults to `true`").

## Summary

- Send `diarize` exactly once: `String(elevenlabsOptions?.diarize ?? true)`, preserving the existing (and documented) default of `true`.
- Removed the schema's `.default(false)` so an unset option stays unset instead of silently injecting a conflicting value.
- Added three regression tests that capture the outgoing `FormData` via a custom `fetch` and assert `getAll('diarize')` — default (`['true']`), explicit `diarize: false` (`['false']`), and other options without `diarize` (`['true']`). The existing collapsed-multipart assertions can't catch this because duplicate fields collapse to the last value.

## Manual Verification

Ran the new tests against the unmodified code: the `diarize: false` test fails with `['true', 'false']` and the other-options test fails with `['true', 'false']`. With this change, the full `@ai-sdk/elevenlabs` suite passes (`pnpm test`: node + edge, 18 tests each) plus `pnpm type-check`; `oxlint`/`oxfmt` clean on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

None
