### PR TITLE
fix(provider/togetherai): warn on unsupported aspectRatio instead of supported size

### DIFF
--- a/.changeset/togetherai-aspect-ratio-warning.md
+++ b/.changeset/togetherai-aspect-ratio-warning.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/togetherai': patch
+---
+
+Warn on the unsupported `aspectRatio` image option instead of warning when the supported `size` option is used.

--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -198,7 +198,7 @@ describe('doGenerate', () => {
         files: undefined,
         mask: undefined,
         n: 1,
-        size: '1024x1024',
+        size: undefined,
         aspectRatio: '1:1',
         seed: 123,
         providerOptions: {},
@@ -213,6 +213,23 @@ describe('doGenerate', () => {
           },
         ]
       `);
+    });
+
+    it('should not return a warning when only size is provided', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: undefined,
+        seed: 123,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toEqual([]);
     });
   });
 

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -56,6 +56,7 @@ export class TogetherAIImageModel implements ImageModelV4 {
     prompt,
     n,
     size,
+    aspectRatio,
     seed,
     providerOptions,
     headers,
@@ -75,7 +76,7 @@ export class TogetherAIImageModel implements ImageModelV4 {
       );
     }
 
-    if (size != null) {
+    if (aspectRatio != null) {
       warnings.push({
         type: 'unsupported',
         feature: 'aspectRatio',


### PR DESCRIPTION
## Background

The Together AI image model's unsupported-option guard checks the wrong variable:

```ts
if (size != null) {
  warnings.push({
    type: 'unsupported',
    feature: 'aspectRatio',
    details: 'This model does not support the `aspectRatio` option. Use `size` instead.',
  });
}
```

`size` is the option the model *does* support (it is split into `width`/`height` further down), while `aspectRatio` was never even destructured from the call options. So a user passing only `size` (correct usage) gets a warning telling them `aspectRatio` is unsupported and to "use `size` instead" — which they already did — while a user passing only `aspectRatio` gets no warning at all and the option is silently ignored.

The existing warning test masked this because it passed both `size` and `aspectRatio` together, and the plain size test never asserted on `warnings`.

## Summary

- Destructure `aspectRatio` in `doGenerate` and trigger the warning on `aspectRatio != null`, matching the warning's own wording and the behavior of sibling image models.
- Tightened the existing warning test to pass only `aspectRatio` (as its name says), and added a test asserting that `size` alone produces no warnings.

## Manual Verification

Ran the two tests against the unmodified code: both fail there (aspectRatio-only produces no warning; size-only produces the bogus warning). With this change, the full `@ai-sdk/togetherai` suite passes (`pnpm test`: node + edge, 42 tests each) plus `pnpm type-check`; `oxlint`/`oxfmt` clean on the changed files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

None
