### PR TITLE
perf(ai): speed up streamed string tool input

### DIFF
--- a/.changeset/faster-tool-streams.md
+++ b/.changeset/faster-tool-streams.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Improve streamed tool input performance for large progressive string arguments.

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -3073,6 +3073,313 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  it('should preserve progressive top-level string tool input', async () => {
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-start',
+        toolCallId: 'tool-call-string',
+        toolName: 'test-tool',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-string',
+        inputTextDelta: '{"payload":"a',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-string',
+        inputTextDelta: 'bc',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-string',
+        inputTextDelta: '\\n',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-string',
+        inputTextDelta: 'def',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-string',
+        inputTextDelta: '"}',
+      },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-call-string',
+        toolName: 'test-tool',
+        input: { payload: 'abc\ndef' },
+      },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    const inputs = writeCalls.flatMap(({ message }) => {
+      const part = message.parts.find(
+        part =>
+          'toolCallId' in part &&
+          part.toolCallId === 'tool-call-string' &&
+          'input' in part,
+      );
+      return part == null ? [] : [(part as { input: unknown }).input];
+    });
+    expect(inputs).toEqual([
+      undefined,
+      { payload: 'a' },
+      { payload: 'abc' },
+      { payload: 'abc\n' },
+      { payload: 'abc\ndef' },
+      { payload: 'abc\ndef' },
+      { payload: 'abc\ndef' },
+    ]);
+    expect(
+      state!.partialToolCalls['tool-call-string'].streamingString,
+    ).toBeUndefined();
+  });
+
+  it('should replace progressive dynamic tool input objects', async () => {
+    const inputReferences: unknown[] = [];
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-start',
+        toolCallId: 'tool-call-dynamic',
+        toolName: 'test-tool',
+        dynamic: true,
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-dynamic',
+        inputTextDelta: '{"payload":"a',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-dynamic',
+        inputTextDelta: 'bc',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-dynamic',
+        inputTextDelta: 'def',
+      },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        runUpdateMessageJob: async job => {
+          await job({
+            state: state!,
+            write: () => {
+              const part = state!.message.parts.find(
+                part =>
+                  part.type === 'dynamic-tool' &&
+                  part.toolCallId === 'tool-call-dynamic',
+              );
+              if (
+                part != null &&
+                'state' in part &&
+                part.state === 'input-streaming' &&
+                'input' in part &&
+                part.input != null
+              ) {
+                inputReferences.push(part.input);
+              }
+            },
+          });
+        },
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    expect(inputReferences).toEqual([
+      { payload: 'a' },
+      { payload: 'abc' },
+      { payload: 'abcdef' },
+    ]);
+    expect(inputReferences[0]).not.toBe(inputReferences[1]);
+    expect(inputReferences[1]).not.toBe(inputReferences[2]);
+  });
+
+  it('should not fast-path __proto__ tool input', async () => {
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-start',
+        toolCallId: 'tool-call-proto',
+        toolName: 'test-tool',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-proto',
+        inputTextDelta: '{"__proto__":"safe',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-proto',
+        inputTextDelta: ' value',
+      },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    const part = state!.message.parts.find(
+      part => 'toolCallId' in part && part.toolCallId === 'tool-call-proto',
+    );
+    expect(
+      part != null && 'input' in part ? part.input : undefined,
+    ).toBeUndefined();
+    expect(
+      state!.partialToolCalls['tool-call-proto'].streamingString,
+    ).toBeUndefined();
+  });
+
+  it('should stop appending after trailing tool input', async () => {
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-start',
+        toolCallId: 'tool-call-trailing',
+        toolName: 'test-tool',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-trailing',
+        inputTextDelta: '{"payload":"a',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-trailing',
+        inputTextDelta: '"}"x',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-trailing',
+        inputTextDelta: 'y',
+      },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-call-trailing',
+        toolName: 'test-tool',
+        input: { payload: 'a' },
+      },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    const inputs = writeCalls.flatMap(({ message }) => {
+      const part = message.parts.find(
+        part =>
+          'toolCallId' in part &&
+          part.toolCallId === 'tool-call-trailing' &&
+          'input' in part,
+      );
+      return part == null ? [] : [(part as { input: unknown }).input];
+    });
+    expect(inputs).toEqual([
+      undefined,
+      { payload: 'a' },
+      { payload: 'a' },
+      { payload: 'a' },
+      { payload: 'a' },
+    ]);
+  });
+
+  it('should clear streaming string state after tool input error', async () => {
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-start',
+        toolCallId: 'tool-call-error',
+        toolName: 'test-tool',
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'tool-call-error',
+        inputTextDelta: '{"payload":"cached',
+      },
+      {
+        type: 'tool-input-error',
+        toolCallId: 'tool-call-error',
+        toolName: 'test-tool',
+        input: '{"payload":"cached',
+        errorText: 'Invalid tool input',
+      },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    expect(
+      state!.partialToolCalls['tool-call-error'].streamingString,
+    ).toBeUndefined();
+  });
+
   describe('tool call streaming', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -31,6 +31,17 @@ import {
   type UIMessage,
   type UIMessagePart,
 } from './ui-messages';
+
+function isPlainStringDelta(delta: string): boolean {
+  for (let index = 0; index < delta.length; index++) {
+    const code = delta.charCodeAt(index);
+    if (code === 0x22 || code === 0x5c || code <= 0x1f) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   message: UI_MESSAGE;
   activeTextParts: Record<string, TextUIPart>;
@@ -44,6 +55,10 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
       dynamic?: boolean;
       title?: string;
       toolMetadata?: JSONObject;
+      streamingString?: {
+        key: string;
+        value: string;
+      };
     }
   >;
   finishReason?: FinishReason;
@@ -592,11 +607,49 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 });
               }
 
-              partialToolCall.text += chunk.inputTextDelta;
+              const delta = chunk.inputTextDelta;
+              partialToolCall.text += delta;
 
-              const { value: partialArgs } = await parsePartialJson(
-                partialToolCall.text,
-              );
+              let partialArgs: unknown;
+              if (
+                partialToolCall.streamingString != null &&
+                isPlainStringDelta(delta)
+              ) {
+                partialToolCall.streamingString.value += delta;
+                partialArgs = {
+                  [partialToolCall.streamingString.key]:
+                    partialToolCall.streamingString.value,
+                };
+              } else {
+                const { value } = await parsePartialJson(partialToolCall.text);
+                partialArgs = value;
+
+                const match = partialToolCall.text.match(
+                  /^\s*\{\s*"([^"\\]*)"\s*:\s*"([^"\\]*)$/,
+                );
+                const partialObject =
+                  typeof partialArgs === 'object' &&
+                  partialArgs !== null &&
+                  !Array.isArray(partialArgs)
+                    ? (partialArgs as JSONObject)
+                    : undefined;
+
+                if (
+                  match != null &&
+                  isPlainStringDelta(match[1]) &&
+                  isPlainStringDelta(match[2]) &&
+                  partialObject != null &&
+                  Object.keys(partialObject).length === 1 &&
+                  partialObject[match[1]] === match[2]
+                ) {
+                  partialToolCall.streamingString = {
+                    key: match[1],
+                    value: match[2],
+                  };
+                } else {
+                  partialToolCall.streamingString = undefined;
+                }
+              }
 
               if (partialToolCall.dynamic) {
                 updateDynamicToolPart({
@@ -623,6 +676,11 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-available': {
+              const partialToolCall = state.partialToolCalls[chunk.toolCallId];
+              if (partialToolCall != null) {
+                partialToolCall.streamingString = undefined;
+              }
+
               if (chunk.dynamic) {
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
@@ -662,6 +720,11 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-error': {
+              const partialToolCall = state.partialToolCalls[chunk.toolCallId];
+              if (partialToolCall != null) {
+                partialToolCall.streamingString = undefined;
+              }
+
               // When a part already exists for this toolCallId (e.g. from
               // tool-input-start), honour its type so we update in place
               // instead of creating a duplicate with a mismatched type.


### PR DESCRIPTION
## Background

Each `tool-input-delta` currently reparses the complete accumulated JSON prefix. For a large tool argument streamed as one progressive string, that repeats work on every chunk and makes the partial-JSON parsing path scale quadratically. This is one of the remaining partial-JSON parsing sites discussed in #15670.

## Summary

- retain the parsed key and value for the exact case of one top-level, unclosed, unescaped string property
- build a new input object for every delta so update/reference semantics stay unchanged
- fall back to the general partial JSON parser for quotes, escapes, control characters, nested structures, trailing input, and other shapes
- clear the transient fast-path state when input becomes available or errors
- add regression coverage for progressive updates, dynamic tools, replacement-object semantics, escaped and nested JSON, trailing junk, `__proto__`, and terminal cleanup
- add a patch changeset for `ai`

## Performance

Using the same strict harness on current `main` (`7d9f2cfad3`) and this branch, with 4,000 one-character deltas:

| | Current main | This PR |
|---|---:|---:|
| median processing time | 13,646.641 ms | 63.495 ms |
| 2N/N scaling ratio | 3.872 | 1.643 |
| log-log slope | 1.979 | 0.711 |

That is a 99.53% reduction, or about 215x, for this scoped partial-JSON processing workload. This is not an end-to-end UI or request latency claim.

The incremental parsing direction was identified through [autoresearch with Weco](https://dashboard.weco.ai/share/iz2dKvSGQ0RVNnRkBaIH3s75xp4SwO4G). The final implementation was rebuilt on current main, typed, reduced, and hardened against counterexamples.

## Verification

- `process-ui-message-stream.test.ts`: 108 passed
- `pnpm --filter ai type-check`
- `pnpm build:packages`: 70/70 packages passed
- `oxfmt --check` and `oxlint`
- strict evaluator: all 11 correctness gates passed
- compatibility check with #17025: after retaining both adjacent state fields, 111 tests and type-check passed

Related to #15670.
