### PR TITLE
fix (provider/groq): surface prompt cache reads in usage

### DIFF
--- a/.changeset/groq-cache-read-usage.md
+++ b/.changeset/groq-cache-read-usage.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix (provider/groq): surface prompt cache reads in usage
+
+`convertGroqUsage` accepted `prompt_tokens_details.cached_tokens` but never read it, so cache hits were reported as `cacheRead: undefined` and the entire prompt was counted as `noCache`. Groq's implicit prompt caching now surfaces as `usage.cachedInputTokens` (mapped to `cacheRead`, subtracted from `noCache`). Groq has no cache-creation charge, so `cacheWrite` remains undefined.

--- a/examples/ai-functions/src/generate-text/groq/prompt-caching.ts
+++ b/examples/ai-functions/src/generate-text/groq/prompt-caching.ts
@@ -1,0 +1,30 @@
+import { groq } from '@ai-sdk/groq';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+const MODEL = 'qwen/qwen3-32b'; // 'openai/gpt-oss-120b';
+
+const REFERENCE = (
+  'The quick brown fox jumps over the lazy dog. ' +
+  'Implicit prompt caching reuses a shared prompt prefix across requests. '
+).repeat(1200);
+
+run(async () => {
+  console.log(`Model: ${MODEL} — 5 identical runs (caching is best-effort)\n`);
+
+  for (let i = 1; i <= 5; i++) {
+    const result = await generateText({
+      model: groq(MODEL),
+      system: `Reference context follows.\n\n${REFERENCE}`,
+      prompt:
+        'In one short sentence, what does the reference context describe?',
+    });
+
+    const usage = result.usage;
+    const cached = usage.inputTokenDetails.cacheReadTokens ?? 0;
+    console.log(
+      `run ${i}: inputTokens=${usage.inputTokens} cachedInputTokens=${cached} ` +
+        `${cached > 0 ? '← cache hit' : ''}`,
+    );
+  }
+});

--- a/examples/ai-functions/src/generate-text/groq/prompt-caching.ts
+++ b/examples/ai-functions/src/generate-text/groq/prompt-caching.ts
@@ -2,7 +2,7 @@ import { groq } from '@ai-sdk/groq';
 import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
-const MODEL = 'qwen/qwen3-32b'; // 'openai/gpt-oss-120b';
+const MODEL = 'openai/gpt-oss-120b';
 
 const REFERENCE = (
   'The quick brown fox jumps over the lazy dog. ' +

--- a/examples/ai-functions/src/stream-text/groq/prompt-caching.ts
+++ b/examples/ai-functions/src/stream-text/groq/prompt-caching.ts
@@ -2,7 +2,7 @@ import { groq } from '@ai-sdk/groq';
 import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
-const MODEL = 'qwen/qwen3-32b'; // 'openai/gpt-oss-120b';
+const MODEL = 'openai/gpt-oss-120b';
 
 const REFERENCE = (
   'The quick brown fox jumps over the lazy dog. ' +

--- a/examples/ai-functions/src/stream-text/groq/prompt-caching.ts
+++ b/examples/ai-functions/src/stream-text/groq/prompt-caching.ts
@@ -1,0 +1,32 @@
+import { groq } from '@ai-sdk/groq';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+const MODEL = 'qwen/qwen3-32b'; // 'openai/gpt-oss-120b';
+
+const REFERENCE = (
+  'The quick brown fox jumps over the lazy dog. ' +
+  'Implicit prompt caching reuses a shared prompt prefix across requests. '
+).repeat(1200);
+
+run(async () => {
+  console.log(`Model: ${MODEL} — 5 identical runs (caching is best-effort)\n`);
+
+  for (let i = 1; i <= 5; i++) {
+    const result = streamText({
+      model: groq(MODEL),
+      system: `Reference context follows.\n\n${REFERENCE}`,
+      prompt:
+        'In one short sentence, what does the reference context describe?',
+    });
+
+    result.consumeStream();
+
+    const usage = await result.usage;
+    const cached = usage.inputTokenDetails.cacheReadTokens ?? 0;
+    console.log(
+      `run ${i}: inputTokens=${usage.inputTokens} cachedInputTokens=${cached} ` +
+        `${cached > 0 ? '← cache hit' : ''}`,
+    );
+  }
+});

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -216,6 +216,71 @@ describe('convertGroqUsage', () => {
     });
   });
 
+  it('should map cached_tokens to cacheRead and subtract from noCache', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 4641,
+      completion_tokens: 1817,
+      prompt_tokens_details: {
+        cached_tokens: 4608,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 4641,
+        noCache: 33, // 4641 - 4608
+        cacheRead: 4608,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 1817,
+        text: 1817,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 4641,
+        completion_tokens: 1817,
+        prompt_tokens_details: {
+          cached_tokens: 4608,
+        },
+      },
+    });
+  });
+
+  it('should treat zero cached_tokens as a cache miss (cacheRead 0)', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+      },
+    });
+
+    expect(result.inputTokens).toStrictEqual({
+      total: 20,
+      noCache: 20,
+      cacheRead: 0,
+      cacheWrite: undefined,
+    });
+  });
+
+  it('should leave cacheRead undefined when cached_tokens is null', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+      prompt_tokens_details: {
+        cached_tokens: null,
+      },
+    });
+
+    expect(result.inputTokens).toStrictEqual({
+      total: 20,
+      noCache: 20,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    });
+  });
+
   it('should handle missing prompt_tokens and completion_tokens', () => {
     const result = convertGroqUsage({});
 

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -47,11 +47,18 @@ export function convertGroqUsage(
       ? completionTokens - reasoningTokens
       : completionTokens;
 
+  // Groq reports prompt-cache hits (implicit caching, 50% discount) in
+  // prompt_tokens_details.cached_tokens. Groq has no cache-creation charge, so
+  // there is no cacheWrite. cached_tokens is a subset of prompt_tokens.
+  const cacheReadTokens =
+    usage.prompt_tokens_details?.cached_tokens ?? undefined;
+
   return {
     inputTokens: {
       total: promptTokens,
-      noCache: promptTokens,
-      cacheRead: undefined,
+      noCache:
+        cacheReadTokens != null ? promptTokens - cacheReadTokens : promptTokens,
+      cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },
     outputTokens: {

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -39,6 +39,8 @@ export function convertGroqUsage(
   }
 
   const promptTokens = usage.prompt_tokens ?? 0;
+  const cacheReadTokens =
+    usage.prompt_tokens_details?.cached_tokens ?? undefined;
   const completionTokens = usage.completion_tokens ?? 0;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? undefined;
@@ -46,12 +48,6 @@ export function convertGroqUsage(
     reasoningTokens != null
       ? completionTokens - reasoningTokens
       : completionTokens;
-
-  // Groq reports prompt-cache hits (implicit caching, 50% discount) in
-  // prompt_tokens_details.cached_tokens. Groq has no cache-creation charge, so
-  // there is no cacheWrite. cached_tokens is a subset of prompt_tokens.
-  const cacheReadTokens =
-    usage.prompt_tokens_details?.cached_tokens ?? undefined;
 
   return {
     inputTokens: {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -286,9 +286,9 @@ describe('doGenerate', () => {
     expect(usage).toMatchInlineSnapshot(`
       {
         "inputTokens": {
-          "cacheRead": undefined,
+          "cacheRead": 15,
           "cacheWrite": undefined,
-          "noCache": 20,
+          "noCache": 5,
           "total": 20,
         },
         "outputTokens": {


### PR DESCRIPTION
## Background

Groq supports implicit prompt caching (automatic, 50% discount on cached input tokens) and returns cache hits in `usage.prompt_tokens_details.cached_tokens`. The `@ai-sdk/groq` response schema already parses that field, but `convertGroqUsage` never read it.

## Problem

`convertGroqUsage` declared `prompt_tokens_details.cached_tokens` in its input type but dropped it — it hardcoded `cacheRead: undefined` and counted the entire prompt as `noCache`. So every Groq request reported zero cache reads regardless of whether Groq actually served tokens from cache, and downstream consumers couldn't observe (or price) the discount.

## Fix

Map `cached_tokens` → `cacheRead`, and subtract it from `noCache`. Groq has no separate cache-creation charge, so `cacheWrite` stays `undefined`.

```ts
const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? undefined;
// inputTokens:
noCache: cacheReadTokens != null ? promptTokens - cacheReadTokens : promptTokens,
cacheRead: cacheReadTokens,
cacheWrite: undefined,
```

Verified against Groq's REST API: the gpt-oss models (and others) do return `cached_tokens > 0` on warm requests; caching is best-effort, so hits are non-deterministic.

## Changes

- `convert-groq-usage.ts` — surface `cached_tokens` as `cacheRead`
- `convert-groq-usage.test.ts` — unit tests (cached→cacheRead, zero, null)
- `groq-chat-language-model.test.ts` — update the affected inline usage snapshot
- Examples: `stream-text/groq/prompt-caching.ts` and `generate-text/groq/prompt-caching.ts`
- Changeset (patch)

Refs SHAPER-24.