### PR TITLE
fix(amazon-bedrock): parse exception frame error as object in Anthropic SSE shim

### DIFF
--- a/.changeset/large-clouds-sell.md
+++ b/.changeset/large-clouds-sell.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): parse Bedrock exception frames as structured error objects in Anthropic SSE shim

--- a/packages/amazon-bedrock/src/amazon-bedrock-event-stream-decoder.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-event-stream-decoder.ts
@@ -4,6 +4,7 @@ import { toUtf8, fromUtf8 } from '@smithy/util-utf8';
 export interface DecodedEvent {
   messageType: string;
   eventType: string;
+  exceptionType?: string;
   data: string;
 }
 
@@ -46,9 +47,14 @@ export function createAmazonBedrockEventStreamDecoder<T>(
             const messageType = decoded.headers[':message-type']
               ?.value as string;
             const eventType = decoded.headers[':event-type']?.value as string;
+            const exceptionType = decoded.headers[':exception-type']
+              ?.value as string;
             const data = textDecoder.decode(decoded.body);
 
-            await processEvent({ messageType, eventType, data }, controller);
+            await processEvent(
+              { messageType, eventType, exceptionType, data },
+              controller,
+            );
           } catch {
             break;
           }

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
@@ -148,7 +148,70 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     const text = new TextDecoder().decode(value);
 
     expect(text).toBe(
-      `data: ${JSON.stringify({ type: 'error', error: errorData })}\n\n`,
+      `data: ${JSON.stringify({ type: 'error', error: { type: 'ThrottlingException', message: 'Rate limit exceeded' } })}\n\n`,
+    );
+  });
+
+  it('should fall back to a generic error type when :exception-type header is missing', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+    const errorData = JSON.stringify({ message: 'Something went wrong' });
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+      },
+      body: fromUtf8(errorData),
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    expect(text).toBe(
+      `data: ${JSON.stringify({ type: 'error', error: { type: 'error', message: 'Something went wrong' } })}\n\n`,
+    );
+  });
+
+  it('should fall back to the raw exception body when it is not valid JSON', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+    const errorData = 'not valid json';
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+        ':exception-type': { type: 'string', value: 'ThrottlingException' },
+      },
+      body: fromUtf8(errorData),
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    expect(text).toBe(
+      `data: ${JSON.stringify({ type: 'error', error: { type: 'ThrottlingException', message: errorData } })}\n\n`,
     );
   });
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -93,9 +93,18 @@ function transformAmazonBedrockEventStreamToSSE(
           controller.enqueue(textEncoder.encode('data: [DONE]\n\n'));
         }
       } else if (event.messageType === 'exception') {
+        const parsed = await safeParseJSON({
+          text: event.data,
+          schema: amazonBedrockErrorSchema,
+        });
+        const message =
+          parsed.success && parsed.value.message
+            ? parsed.value.message
+            : event.data;
+        const exceptionType = event.exceptionType ?? 'error';
         controller.enqueue(
           textEncoder.encode(
-            `data: ${JSON.stringify({ type: 'error', error: event.data })}\n\n`,
+            `data: ${JSON.stringify({ type: 'error', error: { type: exceptionType, message } })}\n\n`,
           ),
         );
       }


### PR DESCRIPTION
## Background:

When Bedrock delivers an exception frame mid-stream (e.g. internalServerException, ThrottlingException), the SSE shim was forwarding `error` as a raw JSON string instead of an object. This caused the Anthropic chunk schema to throw `AI_TypeValidationError: expected object, received string` at path `["error"]`, burying the actual Bedrock message and preventing retry logic from engaging.

## Summary:

- Added `exceptionType` field to `DecodedEvent` interface, extracted from the `:exception-type` header
- Updated the exception branch in `amazon-bedrock-anthropic-fetch.ts` to parse `event.data`, extract the message, and wrap it as `{ type: exceptionType, message }` — matching the existing non-streaming error path pattern
- Updated the existing exception test to assert correct structured behavior

## Manual Verification:

Used the self-contained reproduction script from #17124 (fake fetch, no AWS account needed) — the stream now correctly emits a structured error part instead of throwing AI_TypeValidationError. 406/406 tests passing.

## Related Issues:

Fixes #17124
