### PR TITLE
fix: stop dropping repeated multipart fields, and send elevenlabs diarize once

### DIFF
--- a/.changeset/tidy-jars-shake.md
+++ b/.changeset/tidy-jars-shake.md
@@ -1,0 +1,16 @@
+---
+'@ai-sdk/elevenlabs': patch
+'@ai-sdk/test-server': patch
+---
+
+fix (provider/elevenlabs): don't send `diarize` twice when it is set explicitly
+
+The model always appended a default `diarize=true`, then appended the caller's value on top,
+so the request carried the field twice and an explicit `diarize: false` was left for the server
+to disambiguate. It now overwrites the default instead.
+
+fix (test-server): keep repeated multipart fields instead of dropping all but the last
+
+`requestBodyMultipart` overwrote entries on each key, so a repeated field (how multipart
+encodes an array, e.g. OpenAI's `timestamp_granularities[]`) collapsed to its final value and
+could not be asserted on. Repeated keys now collect into an array; single keys are unchanged.

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -91,7 +91,10 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
       };
 
       if (typeof elevenlabsOptions.diarize === 'boolean') {
-        formData.append('diarize', String(elevenlabsOptions.diarize));
+        // `set`, not `append`: a default `diarize=true` is written above, and appending would
+        // send the field twice (`diarize=true` *and* `diarize=false`), leaving it to the server
+        // to pick — so an explicit `diarize: false` could be silently ignored.
+        formData.set('diarize', String(elevenlabsOptions.diarize));
       }
 
       for (const key in transcriptionModelOptions) {

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -242,6 +242,30 @@ describe('doGenerate', () => {
     `);
   });
 
+  // Regression for #6561: several granularities must go out as repeated
+  // `timestamp_granularities[]` fields, which is what the OpenAI API expects. The original bug
+  // stringified the array into a single `"word,segment"` value; a single-element test cannot
+  // catch that coming back, since the broken and the correct encoding look identical with one
+  // item.
+  it('should send each `timestampGranularities` value as a repeated field', async () => {
+    prepareJsonFixtureResponse('openai-transcription');
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        openai: {
+          timestampGranularities: ['word', 'segment'],
+        },
+      },
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!['timestamp_granularities[]']).toEqual(['word', 'segment']);
+    // and not a single comma-joined string, which is how the bug manifested
+    expect(body!['timestamp_granularities[]']).not.toBe('word,segment');
+  });
+
   it('should not set pass response_format to "verbose_json" when model is "gpt-4o-transcribe"', async () => {
     prepareJsonFixtureResponse('openai-transcription');
 

--- a/packages/test-server/src/create-test-server.ts
+++ b/packages/test-server/src/create-test-server.ts
@@ -69,7 +69,22 @@ class TestServerCall {
       ? this.request!.formData().then(formData => {
           const entries: Record<string, any> = {};
           formData.forEach((value, key) => {
-            entries[key] = value;
+            // A multipart body may repeat a key to express an array (e.g. OpenAI's
+            // `timestamp_granularities[]=word` + `timestamp_granularities[]=segment`).
+            // Overwriting on each hit dropped every value but the last, which made repeated
+            // fields impossible to assert on. Collect them instead: a key seen once stays a
+            // scalar (existing assertions are unaffected), a key seen more than once becomes
+            // an array in encounter order.
+            if (key in entries) {
+              const existing = entries[key];
+              if (Array.isArray(existing)) {
+                existing.push(value);
+              } else {
+                entries[key] = [existing, value];
+              }
+            } else {
+              entries[key] = value;
+            }
           });
           return entries;
         })

--- a/packages/xai/src/xai-transcription-model.test.ts
+++ b/packages/xai/src/xai-transcription-model.test.ts
@@ -127,7 +127,10 @@ describe('doGenerate', () => {
       multichannel: 'true',
       channels: '2',
       diarize: 'true',
-      keyterm: 'Grok',
+      // xAI takes multiple keyterms as repeated `keyterm` fields, and the model appends one per
+      // entry. This read `'Grok'` only because the multipart test helper used to overwrite
+      // repeated keys, dropping every value but the last — the request always carried both.
+      keyterm: ['AI SDK', 'Grok'],
       filler_words: 'true',
     });
   });


### PR DESCRIPTION
### What

Multipart encodes an array by **repeating a key**: OpenAI wants `timestamp_granularities[]=word` + `timestamp_granularities[]=segment`, xAI wants one `keyterm` field per term.

`requestBodyMultipart` in `@ai-sdk/test-server` overwrote entries as it walked the form data:

```ts
formData.forEach((value, key) => {
  entries[key] = value; // repeated key -> every value but the last is lost
});
```

So a repeated field collapsed to its final value and **no test could assert on one at all**. Repeated keys now collect into an array; a key seen once stays a scalar, so existing assertions are untouched.

### What that was hiding

Two real problems surfaced the moment the helper stopped discarding data:

**1. `@ai-sdk/elevenlabs` sent `diarize` twice.** The model appends a default `diarize=true`, then appends the caller's value on top. An explicit `diarize: false` therefore went out as `diarize=true` **and** `diarize=false`, leaving the server to disambiguate — the user's choice could be silently ignored. Changed to `set`, so the caller overwrites the default.

**2. The xAI transcription test asserted the wrong thing.** It expected `keyterm: 'Grok'` for an input of `['AI SDK', 'Grok']`. The request always carried both terms; the helper was dropping one. The expectation now matches what is actually sent — no production change needed there, the model was already correct.

### Regression test for #6561

The reported bug (`timestamp_granularities` stringified into `"word,segment"`) is **already fixed on main** — the array is appended per item. But nothing covered it: the existing test passes a *single* granularity, and with one element the broken and the correct encoding are indistinguishable. A future refactor could reintroduce it with every test still green.

Added a test that passes two granularities and asserts they go out as repeated fields.

Verified by mutation: restoring the old `formData.append(key, String(value))` makes the new test fail, so it genuinely locks the behaviour.

### Verification

All 8 packages that use `requestBodyMultipart` pass:

| package | tests |
|---|---|
| anthropic | 443 ✅ |
| cartesia | 32 ✅ |
| deepgram | 25 ✅ |
| elevenlabs | 15 ✅ |
| groq | 98 ✅ |
| openai | 773 ✅ |
| revai | 6 ✅ |
| xai | 392 ✅ |

Patch changeset included for the two published packages that change behaviour.

Closes #6561.