### PR TITLE
fix: WorkflowAgent drops assistant text between tool-call steps

### DIFF
--- a/.changeset/tidy-tools-remember.md
+++ b/.changeset/tidy-tools-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Preserve assistant text in the conversation prompt when a WorkflowAgent step also calls tools.

--- a/examples/ai-functions/src/reproduction/issue-17123-workflow-agent-tool-call-text.ts
+++ b/examples/ai-functions/src/reproduction/issue-17123-workflow-agent-tool-call-text.ts
@@ -1,93 +1,15 @@
+import { anthropic } from '@ai-sdk/anthropic';
 import { tool, type ModelMessage } from 'ai';
-import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
 import { z } from 'zod/v4';
 import { WorkflowAgent } from '../../../../packages/workflow/dist/index.js';
 
-const narration = 'Found the root cause — implementing the fix now.';
-
-const usage = {
-  inputTokens: {
-    total: 3,
-    noCache: 3,
-    cacheRead: undefined,
-    cacheWrite: undefined,
-  },
-  outputTokens: {
-    total: 10,
-    text: 10,
-    reasoning: undefined,
-  },
-};
+const narration = 'ISSUE-17123-NARRATION';
 
 async function main() {
-  let callCount = 0;
   let secondStepMessages: ModelMessage[] | undefined;
 
-  const model = new MockLanguageModelV4({
-    doStream: async () => {
-      if (callCount++ === 0) {
-        return {
-          stream: convertArrayToReadableStream([
-            { type: 'stream-start' as const, warnings: [] },
-            {
-              type: 'response-metadata' as const,
-              id: 'response-1',
-              modelId: 'mock-model',
-              timestamp: new Date(0),
-            },
-            { type: 'text-start' as const, id: 'text-1' },
-            {
-              type: 'text-delta' as const,
-              id: 'text-1',
-              delta: narration,
-            },
-            { type: 'text-end' as const, id: 'text-1' },
-            {
-              type: 'tool-call' as const,
-              toolCallId: 'call-1',
-              toolName: 'applyFix',
-              input: '{}',
-            },
-            {
-              type: 'finish' as const,
-              finishReason: {
-                unified: 'tool-calls' as const,
-                raw: 'tool_calls',
-              },
-              usage,
-            },
-          ]),
-        };
-      }
-
-      return {
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start' as const, warnings: [] },
-          {
-            type: 'response-metadata' as const,
-            id: 'response-2',
-            modelId: 'mock-model',
-            timestamp: new Date(0),
-          },
-          { type: 'text-start' as const, id: 'text-2' },
-          {
-            type: 'text-delta' as const,
-            id: 'text-2',
-            delta: 'Done.',
-          },
-          { type: 'text-end' as const, id: 'text-2' },
-          {
-            type: 'finish' as const,
-            finishReason: { unified: 'stop' as const, raw: 'stop' },
-            usage,
-          },
-        ]),
-      };
-    },
-  });
-
   const agent = new WorkflowAgent({
-    model,
+    model: anthropic('claude-haiku-4-5'),
     tools: {
       applyFix: tool({
         description: 'Apply the selected fix.',
@@ -98,13 +20,19 @@ async function main() {
     prepareStep: ({ stepNumber, messages }) => {
       if (stepNumber === 1) {
         secondStepMessages = messages as ModelMessage[];
+        return { toolChoice: 'none' };
       }
       return {};
     },
   });
 
   const result = await agent.stream({
-    messages: [{ role: 'user', content: 'Find and fix the bug.' }],
+    messages: [
+      {
+        role: 'user',
+        content: `Write exactly "${narration}" as visible text, then call the applyFix tool in the same response. Do not write any other text before the tool call.`,
+      },
+    ],
     writable: new WritableStream(),
   });
 
@@ -137,7 +65,9 @@ async function main() {
   );
 
   if (!narrationWasGenerated) {
-    throw new Error('The mock model did not generate the expected narration.');
+    throw new Error(
+      'The live model did not generate the expected narration before the tool call.',
+    );
   }
 
   if (!narrationWasCarriedForward) {

--- a/examples/ai-functions/src/reproduction/issue-17123-workflow-agent-tool-call-text.ts
+++ b/examples/ai-functions/src/reproduction/issue-17123-workflow-agent-tool-call-text.ts
@@ -1,0 +1,153 @@
+import { tool, type ModelMessage } from 'ai';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { z } from 'zod/v4';
+import { WorkflowAgent } from '../../../../packages/workflow/dist/index.js';
+
+const narration = 'Found the root cause — implementing the fix now.';
+
+const usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+async function main() {
+  let callCount = 0;
+  let secondStepMessages: ModelMessage[] | undefined;
+
+  const model = new MockLanguageModelV4({
+    doStream: async () => {
+      if (callCount++ === 0) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'response-metadata' as const,
+              id: 'response-1',
+              modelId: 'mock-model',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start' as const, id: 'text-1' },
+            {
+              type: 'text-delta' as const,
+              id: 'text-1',
+              delta: narration,
+            },
+            { type: 'text-end' as const, id: 'text-1' },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-1',
+              toolName: 'applyFix',
+              input: '{}',
+            },
+            {
+              type: 'finish' as const,
+              finishReason: {
+                unified: 'tool-calls' as const,
+                raw: 'tool_calls',
+              },
+              usage,
+            },
+          ]),
+        };
+      }
+
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          {
+            type: 'response-metadata' as const,
+            id: 'response-2',
+            modelId: 'mock-model',
+            timestamp: new Date(0),
+          },
+          { type: 'text-start' as const, id: 'text-2' },
+          {
+            type: 'text-delta' as const,
+            id: 'text-2',
+            delta: 'Done.',
+          },
+          { type: 'text-end' as const, id: 'text-2' },
+          {
+            type: 'finish' as const,
+            finishReason: { unified: 'stop' as const, raw: 'stop' },
+            usage,
+          },
+        ]),
+      };
+    },
+  });
+
+  const agent = new WorkflowAgent({
+    model,
+    tools: {
+      applyFix: tool({
+        description: 'Apply the selected fix.',
+        inputSchema: z.object({}),
+        execute: async () => ({ applied: true }),
+      }),
+    },
+    prepareStep: ({ stepNumber, messages }) => {
+      if (stepNumber === 1) {
+        secondStepMessages = messages as ModelMessage[];
+      }
+      return {};
+    },
+  });
+
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: 'Find and fix the bug.' }],
+    writable: new WritableStream(),
+  });
+
+  const firstStep = result.steps[0];
+  const priorAssistantMessage = secondStepMessages?.find(
+    message => message.role === 'assistant',
+  );
+  const priorAssistantContent = Array.isArray(priorAssistantMessage?.content)
+    ? priorAssistantMessage.content
+    : [];
+  const narrationWasGenerated = firstStep?.content.some(
+    part => part.type === 'text' && part.text === narration,
+  );
+  const narrationWasCarriedForward = priorAssistantContent.some(
+    part => part.type === 'text' && part.text === narration,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        firstStepFinishReason: firstStep?.finishReason,
+        firstStepContent: firstStep?.content,
+        secondStepAssistantContent: priorAssistantContent,
+        narrationWasGenerated,
+        narrationWasCarriedForward,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!narrationWasGenerated) {
+    throw new Error('The mock model did not generate the expected narration.');
+  }
+
+  if (!narrationWasCarriedForward) {
+    throw new Error(
+      'Reproduced issue #17123: WorkflowAgent dropped assistant text from the prompt after a tool-calls finish.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/workflow/src/issue-17123.test.ts
+++ b/packages/workflow/src/issue-17123.test.ts
@@ -118,8 +118,16 @@ it('preserves assistant text in the next prompt after a tool-calls finish', asyn
     message => message.role === 'assistant',
   );
 
-  expect(priorAssistantMessage?.content).toContainEqual({
-    type: 'text',
-    text: narration,
-  });
+  expect(priorAssistantMessage?.content).toEqual([
+    {
+      type: 'text',
+      text: narration,
+    },
+    {
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'applyFix',
+      input: {},
+    },
+  ]);
 });

--- a/packages/workflow/src/issue-17123.test.ts
+++ b/packages/workflow/src/issue-17123.test.ts
@@ -1,0 +1,125 @@
+import { tool, type ModelMessage } from 'ai';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { WorkflowAgent } from './workflow-agent.js';
+
+const narration = 'Found the root cause — implementing the fix now.';
+
+const usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+it('preserves assistant text in the next prompt after a tool-calls finish', async () => {
+  let callCount = 0;
+  let secondStepMessages: ModelMessage[] | undefined;
+
+  const model = new MockLanguageModelV4({
+    doStream: async () => {
+      if (callCount++ === 0) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'response-metadata' as const,
+              id: 'response-1',
+              modelId: 'mock-model',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start' as const, id: 'text-1' },
+            {
+              type: 'text-delta' as const,
+              id: 'text-1',
+              delta: narration,
+            },
+            { type: 'text-end' as const, id: 'text-1' },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-1',
+              toolName: 'applyFix',
+              input: '{}',
+            },
+            {
+              type: 'finish' as const,
+              finishReason: {
+                unified: 'tool-calls' as const,
+                raw: 'tool_calls',
+              },
+              usage,
+            },
+          ]),
+        };
+      }
+
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          {
+            type: 'response-metadata' as const,
+            id: 'response-2',
+            modelId: 'mock-model',
+            timestamp: new Date(0),
+          },
+          { type: 'text-start' as const, id: 'text-2' },
+          {
+            type: 'text-delta' as const,
+            id: 'text-2',
+            delta: 'Done.',
+          },
+          { type: 'text-end' as const, id: 'text-2' },
+          {
+            type: 'finish' as const,
+            finishReason: { unified: 'stop' as const, raw: 'stop' },
+            usage,
+          },
+        ]),
+      };
+    },
+  });
+
+  const agent = new WorkflowAgent({
+    model,
+    tools: {
+      applyFix: tool({
+        description: 'Apply the selected fix.',
+        inputSchema: z.object({}),
+        execute: async () => ({ applied: true }),
+      }),
+    },
+    prepareStep: ({ stepNumber, messages }) => {
+      if (stepNumber === 1) {
+        secondStepMessages = messages as ModelMessage[];
+      }
+      return {};
+    },
+  });
+
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: 'Find and fix the bug.' }],
+    writable: new WritableStream(),
+  });
+
+  expect(result.steps[0].content).toContainEqual({
+    type: 'text',
+    text: narration,
+  });
+
+  const priorAssistantMessage = secondStepMessages?.find(
+    message => message.role === 'assistant',
+  );
+
+  expect(priorAssistantMessage?.content).toContainEqual({
+    type: 'text',
+    text: narration,
+  });
+});

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -1,6 +1,8 @@
 import type {
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
+  LanguageModelV4TextPart,
+  LanguageModelV4ToolCallPart,
   LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
 import type { Context } from '@ai-sdk/provider-utils';
@@ -391,27 +393,34 @@ export async function* streamTextIterator({
       if (finishReason === 'tool-calls') {
         lastStepWasToolCalls = true;
 
-        // Add assistant message with tool calls to the conversation
+        const textContent = step.content.filter(
+          item => item.type === 'text',
+        ) as LanguageModelV4TextPart[];
+
+        // Add assistant message with text and tool calls to the conversation
         // Note: providerMetadata from the tool call is mapped to providerOptions
         // in the prompt format, following the AI SDK convention. This is critical
         // for providers like Gemini that require thoughtSignature to be preserved
         // across multi-turn tool calls. Some fields are sanitized before mapping.
         conversationPrompt.push({
           role: 'assistant',
-          content: toolCalls.map(toolCall => {
-            const sanitizedMetadata = sanitizeProviderMetadataForToolCall(
-              toolCall.providerMetadata,
-            );
-            return {
-              type: 'tool-call',
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.toolName,
-              input: toolCall.input,
-              ...(sanitizedMetadata != null
-                ? { providerOptions: sanitizedMetadata }
-                : {}),
-            };
-          }) as typeof toolCalls,
+          content: [
+            ...textContent,
+            ...(toolCalls.map(toolCall => {
+              const sanitizedMetadata = sanitizeProviderMetadataForToolCall(
+                toolCall.providerMetadata,
+              );
+              return {
+                type: 'tool-call',
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                input: toolCall.input,
+                ...(sanitizedMetadata != null
+                  ? { providerOptions: sanitizedMetadata }
+                  : {}),
+              };
+            }) as LanguageModelV4ToolCallPart[]),
+          ],
         });
 
         // Yield the tool calls along with the current conversation messages
@@ -444,7 +453,7 @@ export async function* streamTextIterator({
         // Add assistant message with text content to the conversation
         const textContent = step.content.filter(
           item => item.type === 'text',
-        ) as Array<{ type: 'text'; text: string }>;
+        ) as LanguageModelV4TextPart[];
 
         if (textContent.length > 0) {
           conversationPrompt.push({


### PR DESCRIPTION
## Background

WorkflowAgent discarded narration emitted alongside tool calls, leaving subsequent model steps with incomplete conversation context.

## Summary

WorkflowAgent now carries assistant text parts forward alongside tool-call parts in the conversation prompt.

## Testing

Added regression coverage asserting that the next step receives both the prior narration and tool call.

## End-to-end Validation

- `issue-17123-workflow-agent-tool-call-text.ts`: ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17123-workflow-agent-tool-call-text.ts` against Anthropic; the live model generated narration and a tool call, and the next-step prompt retained both.

## Related Issues

Fixes #17123

Co-authored-by: devontivona <1065495+devontivona@users.noreply.github.com>