### PR TITLE
fix(ai): remove orphaned reasoning parts in pruneMessages

### DIFF
--- a/.changeset/pruneMessages-orphaned-reasoning.md
+++ b/.changeset/pruneMessages-orphaned-reasoning.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `pruneMessages` leaving orphaned reasoning parts. When pruning tool calls removed the only non-reasoning content from an assistant message, the message was left containing only reasoning/thinking blocks. Providers such as Anthropic reject these messages because a well-formed assistant message must contain at least one non-reasoning content block. With `emptyMessages: 'remove'` (the default), assistant messages that only contain reasoning parts after pruning are now removed together with truly empty messages.

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -408,15 +408,6 @@ describe('pruneMessages', () => {
             {
               "content": [
                 {
-                  "text": "I need to get the weather in Tokyo and Busan.",
-                  "type": "reasoning",
-                },
-              ],
-              "role": "assistant",
-            },
-            {
-              "content": [
-                {
                   "text": "I have got the weather in Tokyo and Busan.",
                   "type": "reasoning",
                 },
@@ -909,6 +900,131 @@ describe('pruneMessages', () => {
           ]
         `);
       });
+    });
+  });
+
+  describe('orphaned reasoning parts (issue #13430)', () => {
+    const reasoningToolCallFixture: ModelMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Are there any errors?' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Let me check for errors...',
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'checkSandboxErrors',
+            input: '{}',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'checkSandboxErrors',
+            output: { type: 'text', value: 'no errors' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Everything looks good.' }],
+      },
+    ];
+
+    it('should remove assistant messages left with only reasoning parts after pruning tool calls', () => {
+      const result = pruneMessages({
+        messages: reasoningToolCallFixture,
+        toolCalls: 'all',
+      });
+
+      // The assistant message that only had a reasoning part and a (pruned)
+      // tool call must be dropped, otherwise providers like Anthropic reject
+      // the conversation because the message has no non-reasoning content.
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Are there any errors?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "Everything looks good.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+
+      const hasReasoningOnlyAssistantMessage = result.some(
+        message =>
+          message.role === 'assistant' &&
+          typeof message.content !== 'string' &&
+          message.content.length > 0 &&
+          message.content.every(part => part.type === 'reasoning'),
+      );
+      expect(hasReasoningOnlyAssistantMessage).toBe(false);
+    });
+
+    it('should keep reasoning-only assistant messages when emptyMessages is "keep"', () => {
+      const result = pruneMessages({
+        messages: reasoningToolCallFixture,
+        toolCalls: 'all',
+        emptyMessages: 'keep',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Are there any errors?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "Let me check for errors...",
+                "type": "reasoning",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [],
+            "role": "tool",
+          },
+          {
+            "content": [
+              {
+                "text": "Everything looks good.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
     });
   });
 });

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -189,7 +189,26 @@ export function pruneMessages({
   }
 
   if (emptyMessages === 'remove') {
-    messages = messages.filter(message => message.content.length > 0);
+    messages = messages.filter(message => {
+      if (message.content.length === 0) {
+        return false;
+      }
+
+      // Treat assistant messages that only contain reasoning parts as empty.
+      // Pruning tool calls can leave a preceding reasoning/thinking block as
+      // the sole content of an assistant message. Such messages are invalid
+      // for providers like Anthropic, which require at least one non-reasoning
+      // content block, so they are removed together with truly empty messages.
+      if (
+        message.role === 'assistant' &&
+        typeof message.content !== 'string' &&
+        message.content.every(part => part.type === 'reasoning')
+      ) {
+        return false;
+      }
+
+      return true;
+    });
   }
 
   return messages;


### PR DESCRIPTION
## Problem
`pruneMessages` removes tool-call parts but leaves the preceding reasoning/thinking block, producing assistant messages that contain only reasoning parts. Anthropic (and the gateway) reject these as malformed ("no non-reasoning content block") (#13430).

## Fix
Extend the default `emptyMessages: 'remove'` filter so an assistant message whose remaining content is entirely reasoning parts is treated as empty and removed — matching the reporter's expected behavior. With `emptyMessages: 'keep'` such messages are still retained.

## Testing
Added two tests in `packages/ai/src/generate-text/prune-messages.test.ts` (red before, green after) and updated one pre-existing snapshot that had been encoding the buggy reasoning-only message. Changeset included.

Closes #13430
