### PR TITLE
reproduction: could not reproduce GPT 5.2 with gateway stuck

### DIFF
--- a/examples/ai-functions/src/reproduction/gateway-gpt-5-2-stuck.ts
+++ b/examples/ai-functions/src/reproduction/gateway-gpt-5-2-stuck.ts
@@ -1,0 +1,98 @@
+import { createGateway } from '@ai-sdk/gateway';
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { streamText } from 'ai';
+
+const fixturePath = fileURLToPath(
+  new URL(
+    '../../../../packages/gateway/src/__fixtures__/openai-gpt-5.2-stream.sse.txt',
+    import.meta.url,
+  ),
+);
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let result = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return result + decoder.decode();
+    }
+    result += decoder.decode(value, { stream: true });
+  }
+}
+
+async function main() {
+  let recordedResponse: Promise<string> | undefined;
+
+  const gateway = createGateway({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      if (response.body == null) {
+        return response;
+      }
+
+      const [sdkBody, fixtureBody] = response.body.tee();
+      recordedResponse = readStream(fixtureBody);
+
+      return new Response(sdkBody, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    },
+  });
+
+  const result = streamText({
+    model: gateway('openai/gpt-5.2'),
+    prompt: 'Reply with exactly: stream completed',
+    maxOutputTokens: 20,
+    timeout: {
+      totalMs: 90_000,
+      chunkMs: 30_000,
+    },
+  });
+
+  let text = '';
+  const eventTypes: string[] = [];
+
+  for await (const part of result.fullStream) {
+    eventTypes.push(part.type);
+    if (part.type === 'text-delta') {
+      text += part.text;
+    }
+  }
+
+  assert.ok(recordedResponse, 'Expected to record the Gateway response');
+  const responseBody = await recordedResponse;
+  await mkdir(dirname(fixturePath), { recursive: true });
+  await writeFile(fixturePath, responseBody);
+
+  assert.ok(text.length > 0, 'Expected the stream to produce text');
+  assert.ok(
+    eventTypes.includes('finish'),
+    'Expected the stream to emit a finish event instead of getting stuck',
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        eventTypes,
+        finishReason: await result.finishReason,
+        text,
+        usage: await result.usage,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/gateway/src/__fixtures__/openai-gpt-5.2-stream.sse.txt
+++ b/packages/gateway/src/__fixtures__/openai-gpt-5.2-stream.sse.txt
@@ -1,0 +1,16 @@
+data: {"type":"stream-start","warnings":[]}
+
+data: {"type":"response-metadata","id":"resp_04def9ac25d44674016a54a9559bf081928d5b862fdbc6aa74","timestamp":"2026-07-13T09:01:09.000Z","modelId":"gpt-5.2-2025-12-11"}
+
+data: {"type":"text-start","id":"msg_04def9ac25d44674016a54a95601508192891e3102eddb9659","providerMetadata":{"openai":{"itemId":"msg_04def9ac25d44674016a54a95601508192891e3102eddb9659"}}}
+
+data: {"type":"text-delta","id":"msg_04def9ac25d44674016a54a95601508192891e3102eddb9659","delta":"stream"}
+
+data: {"type":"text-delta","id":"msg_04def9ac25d44674016a54a95601508192891e3102eddb9659","delta":" completed"}
+
+data: {"type":"text-end","id":"msg_04def9ac25d44674016a54a95601508192891e3102eddb9659","providerMetadata":{"openai":{"itemId":"msg_04def9ac25d44674016a54a95601508192891e3102eddb9659"}}}
+
+data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":12,"noCache":12,"cacheRead":0,"cacheWrite":0},"outputTokens":{"total":6,"text":6,"reasoning":0},"raw":{"input_tokens":12,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens":6,"output_tokens_details":{"reasoning_tokens":0}}},"providerMetadata":{"openai":{"responseId":"resp_04def9ac25d44674016a54a9559bf081928d5b862fdbc6aa74","serviceTier":"default","reasoningContext":"current_turn"},"gateway":{"routing":{"originalModelId":"openai/gpt-5.2","resolvedProvider":"openai","fallbacksAvailable":["azure"],"planningReasoning":"System credentials planned for: openai, azure. Total execution order: openai(system) → azure(system)","canonicalSlug":"openai/gpt-5.2","finalProvider":"openai","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"openai/gpt-5.2","success":true,"providerAttemptCount":1,"providerAttempts":[{"provider":"openai","credentialType":"system","success":true,"startTime":1783933269520,"endTime":1783933270243,"providerRequestId":"req_7828c4ef2c35498f93dee693c7f85b1b","statusCode":200,"providerResponseId":"resp_04def9ac25d44674016a54a9559bf081928d5b862fdbc6aa74"}]}],"totalProviderAttemptCount":1},"cost":"0.000105","marketCost":"0.000105","surchargeCost":"0","gatewayCost":"0.000105","inferenceCost":"0.000105","inputInferenceCost":"0.000021","outputInferenceCost":"0.000084","generationId":"gen_01KXDBAX3SJ3PR9R3TZ1S3F9ZB"}}}
+
+DONE
+

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -4,6 +4,7 @@ import type {
 } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
 import { GatewayLanguageModel } from './gateway-language-model';
 import type { GatewayConfig } from './gateway-config';
 import {
@@ -650,6 +651,36 @@ describe('GatewayLanguageModel', () => {
           },
         ]
       `);
+    });
+
+    it('should complete the recorded GPT-5.2 Gateway stream', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: fs
+          .readFileSync(
+            new URL(
+              './__fixtures__/openai-gpt-5.2-stream.sse.txt',
+              import.meta.url,
+            ),
+            'utf8',
+          )
+          .split(/(?<=\n\n)/),
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(
+        parts
+          .filter(part => part.type === 'text-delta')
+          .map(part => part.delta)
+          .join(''),
+      ).toBe('stream completed');
+      expect(parts.at(-1)?.type).toBe('finish');
     });
 
     it('should pass streaming headers', async () => {


### PR DESCRIPTION
## Bug

GPT 5.2 with gateway stuck

## Reproduction

- The reported user-visible failure was not observed: `openai/gpt-5.2` produced `stream completed`, emitted a final `finish` event, and returned finish reason `stop` instead of remaining stuck.
- An isolated check with AI SDK `6.0.218` and `@ai-sdk/gateway` `3.0.142`, the latest AI SDK 6 versions available when the issue was filed, also completed normally.
- Runnable reproduction `examples/ai-functions/src/reproduction/gateway-gpt-5-2-stuck.ts` asserts that the live stream produces text and terminates within bounded time.
- The live Gateway response was recorded at `packages/gateway/src/__fixtures__/openai-gpt-5.2-stream.sse.txt` and contains text deltas, a `finish` event, and stream termination.
- `packages/gateway/src/gateway-language-model.test.ts` replays the recorded response and confirms that the Gateway stream closes successfully.
- The report does not provide an exact AI SDK 6 patch version, prompt, application code, or request options beyond the model and Gateway combination.

## Relevant Documentation

- https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway
- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://vercel.com/changelog/gpt-5-2-models-now-available-on-vercel-ai-gateway

## Related Issues

Could not reproduce #11480