### PR TITLE
reproduction: could not reproduce The SDK should include output-error results as toolresult

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
@@ -1,0 +1,174 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+type AnthropicContentBlock = {
+  type?: string;
+  id?: string;
+  tool_use_id?: string;
+  content?: {
+    type?: string;
+    error_code?: string;
+  };
+};
+
+type AnthropicMessage = {
+  role?: string;
+  content?: AnthropicContentBlock[];
+};
+
+type AnthropicRequest = {
+  messages?: AnthropicMessage[];
+};
+
+type AnthropicResponse = {
+  content?: AnthropicContentBlock[];
+};
+
+type CapturedCall = {
+  request?: AnthropicRequest;
+  response?: AnthropicResponse;
+  status?: number;
+};
+
+async function main() {
+  const calls: CapturedCall[] = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const call: CapturedCall = {
+        request:
+          typeof init?.body === 'string'
+            ? (JSON.parse(init.body) as AnthropicRequest)
+            : undefined,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.status = response.status;
+      call.response = (await response
+        .clone()
+        .json()
+        .catch(() => undefined)) as AnthropicResponse | undefined;
+
+      return response;
+    },
+  });
+
+  let result:
+    | {
+        steps: readonly unknown[];
+        text: string;
+      }
+    | undefined;
+  let generationError: unknown;
+
+  try {
+    result = await generateText({
+      model: anthropic('claude-sonnet-4-5-20250929'),
+      maxOutputTokens: 512,
+      temperature: 0,
+      prompt: [
+        'Follow these steps in order:',
+        '1. Use web_fetch on https://httpbin.org/status/500.',
+        '2. Wait until web_fetch has returned its result. Do not call tools in parallel.',
+        '3. Regardless of whether web_fetch succeeds, call display_products once.',
+        '4. After display_products returns, answer with exactly DONE.',
+        'Do not skip either tool call.',
+      ].join('\n'),
+      tools: {
+        web_fetch: anthropic.tools.webFetch_20250910({
+          maxUses: 1,
+        }),
+        display_products: tool({
+          description:
+            'Record that product display was attempted after the web fetch.',
+          inputSchema: z.object({}),
+          execute: async () => ({ displayed: true }),
+        }),
+      },
+      stopWhen: stepCountIs(4),
+    });
+  } catch (error) {
+    generationError = error;
+  }
+
+  const errorResult = calls
+    .flatMap(call => call.response?.content ?? [])
+    .find(
+      block =>
+        block.type === 'web_fetch_tool_result' &&
+        block.content?.type === 'web_fetch_tool_result_error',
+    );
+
+  if (errorResult?.tool_use_id == null) {
+    throw new Error(
+      'The live response did not exercise a web_fetch_tool_result_error, so issue #10819 could not be evaluated.',
+    );
+  }
+
+  const continuationRequest = calls
+    .slice(1)
+    .map(call => call.request)
+    .find(request =>
+      request?.messages?.some(
+        message =>
+          message.role === 'assistant' &&
+          message.content?.some(
+            block =>
+              block.type === 'web_fetch_tool_result' &&
+              block.tool_use_id === errorResult.tool_use_id &&
+              block.content?.type === 'web_fetch_tool_result_error',
+          ),
+      ),
+    );
+
+  const output = {
+    requestCount: calls.length,
+    responseStatuses: calls.map(call => call.status),
+    webFetchToolUseId: errorResult.tool_use_id,
+    webFetchErrorCode: errorResult.content?.error_code,
+    continuationIncludedErrorResult: continuationRequest != null,
+    stepCount: result?.steps.length,
+    finalText: result?.text,
+    generationError:
+      generationError instanceof Error
+        ? {
+            name: generationError.name,
+            message: generationError.message,
+          }
+        : generationError,
+    requests: calls.map(call => call.request),
+    responses: calls.map(call => call.response),
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (generationError != null) {
+    throw new Error(
+      'Reproduced issue #10819: multi-step generation failed after the web fetch error.',
+      { cause: generationError },
+    );
+  }
+
+  if (calls.some(call => call.status != null && call.status >= 400)) {
+    throw new Error(
+      'Reproduced issue #10819: Anthropic rejected a multi-step continuation request after the web fetch error.',
+    );
+  }
+
+  if (
+    result == null ||
+    result.steps.length < 2 ||
+    !result.text.trim().endsWith('DONE')
+  ) {
+    throw new Error(
+      'Reproduced issue #10819: the multi-step continuation did not expose the expected final text after the web fetch error.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json
@@ -1,0 +1,63 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011Ccyqj7VcMJ93CF6YHFbVX",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "I'll follow these steps in order.\n\nStep 1: Calling web_fetch on https://httpbin.org/status/500"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01LBuJngKXBYNJ628yrPBaix",
+      "name": "web_fetch",
+      "input": {
+        "url": "https://httpbin.org/status/500"
+      }
+    },
+    {
+      "type": "web_fetch_tool_result",
+      "tool_use_id": "srvtoolu_01LBuJngKXBYNJ628yrPBaix",
+      "content": {
+        "type": "web_fetch_tool_result_error",
+        "error_code": "unavailable"
+      },
+      "caller": {
+        "type": "direct"
+      }
+    },
+    {
+      "type": "text",
+      "text": "Step 2: web_fetch has returned (with an error, but it has returned).\n\nStep 3: Now calling display_products as instructed."
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01JUMqLeawQF1cBiXAJybo94",
+      "name": "display_products",
+      "input": {},
+      "caller": {
+        "type": "direct"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 2502,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 162,
+    "service_tier": "standard",
+    "inference_geo": "not_available",
+    "server_tool_use": {
+      "web_search_requests": 0,
+      "web_fetch_requests": 1
+    }
+  }
+}

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CcyqkoN15DSNGciJSvVMa",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Step 4: display_products has returned.\n\nDONE"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 1402,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 16,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/issue-10819.test.ts
+++ b/packages/anthropic/src/issue-10819.test.ts
@@ -1,0 +1,78 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+it('preserves a provider-executed web fetch error before a client tool call', async () => {
+  server.urls['https://api.anthropic.com/v1/messages'].response = {
+    type: 'json-value',
+    body: JSON.parse(
+      fs.readFileSync(
+        'src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json',
+        'utf8',
+      ),
+    ),
+  };
+
+  const provider = createAnthropic({ apiKey: 'test-api-key' });
+  const result = await provider('claude-sonnet-4-5-20250929').doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run both tools.' }],
+      },
+    ],
+    tools: [
+      {
+        type: 'provider',
+        id: 'anthropic.web_fetch_20250910',
+        name: 'web_fetch',
+        args: { maxUses: 1 },
+      },
+      {
+        type: 'function',
+        name: 'display_products',
+        description: 'Record that product display was attempted.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+    ],
+  });
+
+  expect(result.content).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: 'tool-call',
+        toolCallId: 'srvtoolu_01LBuJngKXBYNJ628yrPBaix',
+        toolName: 'web_fetch',
+        providerExecuted: true,
+      }),
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'srvtoolu_01LBuJngKXBYNJ628yrPBaix',
+        toolName: 'web_fetch',
+        result: {
+          type: 'web_fetch_tool_result_error',
+          errorCode: 'unavailable',
+        },
+        isError: true,
+      }),
+      expect.objectContaining({
+        type: 'tool-call',
+        toolCallId: 'toolu_01JUMqLeawQF1cBiXAJybo94',
+        toolName: 'display_products',
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
## Bug

The SDK should include output-error results as tool_result blocks

## Reproduction

- The exact model `claude-sonnet-4-5-20250929` returned a provider-executed web-fetch error followed by the client `display_products` tool call; both Anthropic requests returned HTTP 200.
- The continuation request included the matching errored `web_fetch_tool_result`, and generation completed two steps with final text ending in `DONE`; the expected omission and resulting generation failure did not occur.
- Runnable live reproduction: `examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts`.
- Live response fixtures are recorded at `packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.json` and `packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.json`.
- The fixture-based provider regression test is `packages/anthropic/src/issue-10819.test.ts`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls

## Related Issues

Could not reproduce #10819