### PR TITLE
fix: client-denied tool approvals never transition to output-denied

### DIFF
--- a/.changeset/fuzzy-dodos-deny.md
+++ b/.changeset/fuzzy-dodos-deny.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix UI tool parts remaining in approval-responded after a user denies tool execution

--- a/examples/ai-functions/src/reproduction/issue-17136-denied-tool-approval-state.ts
+++ b/examples/ai-functions/src/reproduction/issue-17136-denied-tool-approval-state.ts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import {
+  AbstractChat,
+  type ChatInit,
+  type ChatState,
+  type ChatStatus,
+  DirectChatTransport,
+  type InferAgentUIMessage,
+  ToolLoopAgent,
+  tool,
+  type UIMessage,
+} from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod';
+
+class InMemoryChatState<
+  UI_MESSAGE extends UIMessage,
+> implements ChatState<UI_MESSAGE> {
+  status: ChatStatus = 'ready';
+  error: Error | undefined;
+  messages: UI_MESSAGE[] = [];
+
+  pushMessage = (message: UI_MESSAGE) => {
+    this.messages.push(message);
+  };
+
+  popMessage = () => {
+    this.messages.pop();
+  };
+
+  replaceMessage = (index: number, message: UI_MESSAGE) => {
+    this.messages[index] = message;
+  };
+
+  snapshot = <T>(value: T): T => structuredClone(value);
+}
+
+class TestChat<UI_MESSAGE extends UIMessage> extends AbstractChat<UI_MESSAGE> {
+  constructor(init: ChatInit<UI_MESSAGE>) {
+    super({ ...init, state: new InMemoryChatState<UI_MESSAGE>() });
+  }
+}
+
+function usage() {
+  return {
+    inputTokens: {
+      total: 1,
+      noCache: 1,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: 1,
+      text: 1,
+      reasoning: undefined,
+    },
+  };
+}
+
+async function main() {
+  let modelSawExecutionDenied = false;
+
+  const model = new MockLanguageModelV4({
+    doStream: async ({ prompt }) => {
+      modelSawExecutionDenied =
+        JSON.stringify(prompt).includes('execution-denied');
+
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          ...(modelSawExecutionDenied
+            ? [
+                { type: 'text-start' as const, id: 'text-1' },
+                {
+                  type: 'text-delta' as const,
+                  id: 'text-1',
+                  delta: 'Understood, I will not delete the file.',
+                },
+                { type: 'text-end' as const, id: 'text-1' },
+                {
+                  type: 'finish' as const,
+                  finishReason: { unified: 'stop' as const, raw: 'stop' },
+                  usage: usage(),
+                },
+              ]
+            : [
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'delete_file',
+                  input: JSON.stringify({ path: '/tmp/x' }),
+                },
+                {
+                  type: 'finish' as const,
+                  finishReason: {
+                    unified: 'tool-calls' as const,
+                    raw: 'tool-calls',
+                  },
+                  usage: usage(),
+                },
+              ]),
+        ]),
+      };
+    },
+  });
+
+  const agent = new ToolLoopAgent({
+    model,
+    tools: {
+      delete_file: tool({
+        description: 'Delete a file.',
+        inputSchema: z.object({ path: z.string() }),
+        execute: async ({ path }) => `deleted ${path}`,
+      }),
+    },
+    toolApproval: { delete_file: 'user-approval' },
+  });
+
+  const chat = new TestChat<InferAgentUIMessage<typeof agent>>({
+    transport: new DirectChatTransport({ agent }),
+  });
+
+  await chat.sendMessage({ text: 'Please delete /tmp/x.' });
+
+  const toolPart = chat.messages
+    .at(-1)
+    ?.parts.find(part => part.type === 'tool-delete_file');
+
+  assert.ok(toolPart?.type === 'tool-delete_file');
+  assert.equal(toolPart.state, 'approval-requested');
+  assert.ok(toolPart.approval != null);
+
+  await chat.addToolApprovalResponse({
+    id: toolPart.approval.id,
+    approved: false,
+    reason: 'user declined',
+  });
+
+  const respondedToolPart = chat.messages
+    .at(-1)
+    ?.parts.find(part => part.type === 'tool-delete_file');
+
+  assert.ok(respondedToolPart?.type === 'tool-delete_file');
+  assert.equal(respondedToolPart.state, 'approval-responded');
+
+  await chat.sendMessage();
+
+  const finalToolPart = chat.messages
+    .flatMap(message => message.parts)
+    .find(part => part.type === 'tool-delete_file');
+  const assistantText = chat.messages
+    .filter(message => message.role === 'assistant')
+    .flatMap(message => message.parts)
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('');
+
+  console.log(
+    JSON.stringify(
+      {
+        modelSawExecutionDenied,
+        finalToolState:
+          finalToolPart?.type === 'tool-delete_file'
+            ? finalToolPart.state
+            : undefined,
+        assistantText,
+        expectedFinalToolState: 'output-denied',
+      },
+      null,
+      2,
+    ),
+  );
+
+  assert.equal(modelSawExecutionDenied, true);
+  assert.ok(finalToolPart?.type === 'tool-delete_file');
+  assert.equal(
+    finalToolPart.state,
+    'output-denied',
+    'A client-denied tool approval should reach the output-denied terminal UI state.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/ai/src/generate-text/collect-tool-approvals.test.ts
+++ b/packages/ai/src/generate-text/collect-tool-approvals.test.ts
@@ -219,7 +219,7 @@ describe('collectToolApprovals', () => {
     `);
   });
 
-  it('should return processed approval with denied response and tool result', () => {
+  it('should return denied approval with an execution-denied tool result', () => {
     const result = collectToolApprovals({
       messages: [
         {
@@ -261,7 +261,30 @@ describe('collectToolApprovals', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "approvedToolApprovals": [],
-        "deniedToolApprovals": [],
+        "deniedToolApprovals": [
+          {
+            "approvalRequest": {
+              "approvalId": "approval-id-1",
+              "toolCallId": "call-1",
+              "type": "tool-approval-request",
+            },
+            "approvalResponse": {
+              "approvalId": "approval-id-1",
+              "approved": false,
+              "reason": "test-reason",
+              "type": "tool-approval-response",
+            },
+            "hasToolResult": true,
+            "toolCall": {
+              "input": {
+                "value": "test-input",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ],
       }
     `);
   });
@@ -580,6 +603,27 @@ describe('collectToolApprovals', () => {
                 "value": "test-input-4",
               },
               "toolCallId": "call-approval-4",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+          {
+            "approvalRequest": {
+              "approvalId": "approval-id-6",
+              "toolCallId": "call-approval-6",
+              "type": "tool-approval-request",
+            },
+            "approvalResponse": {
+              "approvalId": "approval-id-6",
+              "approved": false,
+              "type": "tool-approval-response",
+            },
+            "hasToolResult": true,
+            "toolCall": {
+              "input": {
+                "value": "test-input-6",
+              },
+              "toolCallId": "call-approval-6",
               "toolName": "tool1",
               "type": "tool-call",
             },

--- a/packages/ai/src/generate-text/collect-tool-approvals.ts
+++ b/packages/ai/src/generate-text/collect-tool-approvals.ts
@@ -13,6 +13,9 @@ export type CollectedToolApprovals<TOOLS extends ToolSet> = {
   approvalRequest: ToolApprovalRequest;
   approvalResponse: ToolApprovalResponse;
   toolCall: TypedToolCall<TOOLS>;
+  // The existing result must be preserved while the denial is collected so
+  // streamText can emit tool-output-denied without adding a duplicate result.
+  hasToolResult?: true;
 };
 
 /**
@@ -100,7 +103,21 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
       });
     }
 
-    if (toolResults[approvalRequest.toolCallId] != null) {
+    const toolResult = toolResults[approvalRequest.toolCallId];
+
+    // Execution-denied results can be synthesized while converting a denied
+    // UI tool part. Collect the denial so the UI stream can reach its terminal
+    // state, but continue skipping approvals with any other completed result.
+    if (
+      toolResult != null &&
+      !(
+        approvalResponse.approved === false &&
+        typeof toolResult.output === 'object' &&
+        toolResult.output != null &&
+        'type' in toolResult.output &&
+        toolResult.output.type === 'execution-denied'
+      )
+    ) {
       continue;
     }
 
@@ -116,6 +133,7 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
       approvalRequest,
       approvalResponse,
       toolCall,
+      ...(toolResult != null ? { hasToolResult: true as const } : {}),
     };
 
     if (approvalResponse.approved) {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -679,7 +679,9 @@ export async function generateText<
       });
 
       const deniedToolApprovals = [
-        ...collectedDeniedToolApprovals,
+        ...collectedDeniedToolApprovals.filter(
+          toolApproval => toolApproval.hasToolResult !== true,
+        ),
         ...revalidationDeniedToolApprovals,
       ];
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1691,7 +1691,12 @@ class DefaultStreamTextResult<
           );
 
           // Local tool results (approved + denied) are sent as tool results:
-          if (toolOutputs.length > 0 || localDeniedToolApprovals.length > 0) {
+          if (
+            toolOutputs.length > 0 ||
+            localDeniedToolApprovals.some(
+              toolApproval => toolApproval.hasToolResult !== true,
+            )
+          ) {
             const localToolContent: ToolContent = [];
 
             // add regular tool results for approved tool calls:
@@ -1715,6 +1720,10 @@ class DefaultStreamTextResult<
 
             // add execution denied tool results for denied local tool approvals:
             for (const toolApproval of localDeniedToolApprovals) {
+              if (toolApproval.hasToolResult === true) {
+                continue;
+              }
+
               localToolContent.push({
                 type: 'tool-result' as const,
                 toolCallId: toolApproval.toolCall.toolCallId,


### PR DESCRIPTION
## Background

Client-denied tool approvals remained in approval-responded, preventing UIs from rendering the documented output-denied terminal state.

## Summary

Collects denials that already have synthetic execution-denied results so streamText emits tool-output-denied, while avoiding duplicate tool results in streaming and non-streaming generation.

## Testing

Updated collectToolApprovals regression coverage for synthetic execution-denied results, including mixed approval scenarios.

## End-to-end Validation

- Example `issue-17136-denied-tool-approval-state.ts`; command `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17136-denied-tool-approval-state.ts`; observed the model receive `execution-denied`, respond normally, and the tool reach `output-denied`. Live API command/outcome: not applicable because this provider-independent core UI transition is validated deterministically with `MockLanguageModelV4`.

## Related Issues

Fixes #17136

Co-authored-by: Shanik1 <64074694+Shanik1@users.noreply.github.com>