### PR TITLE
fix(provider/groq): report cached token usage

### DIFF
--- a/.changeset/calm-tools-cache.md
+++ b/.changeset/calm-tools-cache.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix(provider/groq): report cached input token usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ We greatly appreciate your pull requests. Here are the steps to submit them:
 1. **Create a New Branch**: Initiate your changes in a fresh branch. It's recommended to name the branch in a manner that signifies the changes you're implementing.
 2. **Add a patch changeset**: If you update any packages, add a **patch** changeset to your branch by running `pnpm changeset` in the workspace root.
    - **Please do not use minor or major changesets**, we'll let you know when you need to use a different changeset type than patch.
-   - Changesets should always be created when any API or behaivor is changed. We also recommend it for large refactors, just in case an uncaught regression is introduced.
+   - Changesets should always be created when any API or behavior is changed. We also recommend it for large refactors, just in case an uncaught regression is introduced.
    - You don't need to create changesets for docs or any of the `examples/*` packages, as they are not released. But, if you change a `README.md`, create a changeset so that the package's documentation on npm's website is updated.
 
 3. **Add a codemod**: If the change introduces a deprecation or a breaking change, add a codemod if possible. See [how to contribute codemods](contributing/codemods.md)

--- a/content/docs/03-ai-sdk-core/26-reasoning.mdx
+++ b/content/docs/03-ai-sdk-core/26-reasoning.mdx
@@ -13,7 +13,7 @@ Many language models support an internal "reasoning" phase (sometimes also calle
 import { generateText } from 'ai';
 
 const { text, reasoning, reasoningText } = await generateText({
-  model: 'anthropic/claude-sonnet-4.6,
+  model: 'anthropic/claude-sonnet-4.6',
   reasoning: 'medium',
   prompt: 'How many people will live in the world in 2040?',
 });

--- a/examples/ai-e2e-next/README.md
+++ b/examples/ai-e2e-next/README.md
@@ -6,7 +6,7 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai&env=OPENAI_API_KEY&project-name=ai-sdk-next-openai&repository-name=ai-sdk-next-openai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fai-e2e-next&env=OPENAI_API_KEY&project-name=ai-sdk-next-openai&repository-name=ai-sdk-next-openai)
 
 ## How to use
 

--- a/examples/next-google-vertex/README.md
+++ b/examples/next-google-vertex/README.md
@@ -6,14 +6,14 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-google-vertex-edge&env=GOOGLE_VERTEX_API_KEY&project-name=ai-sdk-vertex-edge&repository-name=ai-sdk-vertex-edge)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-google-vertex&env=GOOGLE_VERTEX_API_KEY&project-name=ai-sdk-vertex-edge&repository-name=ai-sdk-vertex-edge)
 
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-google-vertex-edge next-vertex-edge-app
+npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-google-vertex next-vertex-edge-app
 ```
 
 To run the example locally you need to:

--- a/examples/next-openai-upstash-rate-limits/README.md
+++ b/examples/next-openai-upstash-rate-limits/README.md
@@ -8,22 +8,22 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai-rate-limits&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chat-openai&repository-name=vercel-ai-chat-openai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai-upstash-rate-limits&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chat-openai&repository-name=vercel-ai-chat-openai)
 
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-upstash-rate-limits-app
 ```
 
 ```bash
-yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-upstash-rate-limits-app
 ```
 
 ```bash
-pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-upstash-rate-limits-app
 ```
 
 To run the example locally you need to:

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -65,6 +65,37 @@ describe('convertGroqUsage', () => {
     });
   });
 
+  it('should extract cached input tokens', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 5,
+      prompt_tokens_details: {
+        cached_tokens: 15,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 5,
+        cacheRead: 15,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 5,
+        text: 5,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 5,
+        prompt_tokens_details: {
+          cached_tokens: 15,
+        },
+      },
+    });
+  });
+
   it('should extract reasoning tokens from completion_tokens_details', () => {
     const result = convertGroqUsage({
       prompt_tokens: 79,

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -40,6 +40,8 @@ export function convertGroqUsage(
 
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
+  const cacheReadTokens =
+    usage.prompt_tokens_details?.cached_tokens ?? undefined;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? undefined;
   const textTokens =
@@ -50,8 +52,8 @@ export function convertGroqUsage(
   return {
     inputTokens: {
       total: promptTokens,
-      noCache: promptTokens,
-      cacheRead: undefined,
+      noCache: promptTokens - (cacheReadTokens ?? 0),
+      cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },
     outputTokens: {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -286,9 +286,9 @@ describe('doGenerate', () => {
     expect(usage).toMatchInlineSnapshot(`
       {
         "inputTokens": {
-          "cacheRead": undefined,
+          "cacheRead": 15,
           "cacheWrite": undefined,
-          "noCache": 20,
+          "noCache": 5,
           "total": 20,
         },
         "outputTokens": {


### PR DESCRIPTION
## Background

Groq reports cached prompt tokens in `prompt_tokens_details.cached_tokens`, but the usage converter discarded that value. As a result, cached tokens were reported as non-cached input tokens and `cacheRead` remained undefined.

## Summary

- Map Groq cached prompt tokens to `inputTokens.cacheRead`.
- Subtract cached tokens from `inputTokens.noCache`.
- Add converter-level regression coverage and update the existing model-level usage snapshot.
- Add a patch changeset for `@ai-sdk/groq`.

## Manual Verification

No live Groq request was made because no provider credentials were used. The behavior was verified against the existing mocked Groq response path, and the following automated checks passed:

- `pnpm test` in `packages/groq` (96 Node and 96 Edge tests)
- `pnpm type-check:full`
- `pnpm check`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)