### PR TITLE
reproduction: could not reproduce providerOptions not applied when using parts in messages

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts
+++ b/examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts
@@ -1,0 +1,107 @@
+import {
+  anthropic,
+  type AnthropicLanguageModelOptions,
+} from '@ai-sdk/anthropic';
+import { streamText, type ModelMessage } from 'ai';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+
+type AnthropicUsage = {
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+};
+
+const modelId = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6';
+
+async function runRequest(messages: ModelMessage[]) {
+  const result = streamText({
+    model: anthropic(modelId),
+    messages,
+    maxOutputTokens: 2,
+    include: {
+      rawChunks: true,
+      requestBody: true,
+    },
+  });
+
+  const rawChunks: unknown[] = [];
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'raw') {
+      rawChunks.push(part.rawValue);
+    }
+  }
+
+  const finalStep = await result.finalStep;
+  const usage = finalStep.providerMetadata?.anthropic?.usage as
+    | AnthropicUsage
+    | undefined;
+
+  return {
+    requestBody: finalStep.request.body,
+    rawChunks,
+    usage,
+  };
+}
+
+async function main() {
+  const runId = randomUUID();
+  const longText = Array.from(
+    { length: 400 },
+    (_, index) =>
+      `Cache reproduction ${runId}, line ${index}: message-level provider options must apply to structured text content.`,
+  ).join('\n');
+
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: longText }],
+      providerOptions: {
+        anthropic: {
+          cacheControl: {
+            type: 'ephemeral',
+          },
+        } satisfies AnthropicLanguageModelOptions,
+      },
+    },
+  ];
+
+  const first = await runRequest(messages);
+  const second = await runRequest(messages);
+
+  console.log(
+    JSON.stringify(
+      {
+        model: modelId,
+        first,
+        second,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const requestMessages = (
+    first.requestBody as {
+      messages?: Array<{
+        content?: Array<{ cache_control?: { type?: string } }>;
+      }>;
+    }
+  ).messages;
+
+  assert.equal(
+    requestMessages?.[0]?.content?.at(-1)?.cache_control?.type,
+    'ephemeral',
+    'Expected message-level providerOptions to add cache_control to the structured content block.',
+  );
+  assert.ok(
+    (first.usage?.cache_creation_input_tokens ?? 0) > 0,
+    'Expected the first request to create an Anthropic prompt cache entry.',
+  );
+  assert.ok(
+    (second.usage?.cache_read_input_tokens ?? 0) > 0,
+    'Expected the second request to read the Anthropic prompt from cache.',
+  );
+}
+
+main();

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt
@@ -1,0 +1,8 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_011Ccz2c95Sp6i2BkaQAwoDm","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":17603,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" error"}}
+{"type":"content_block_stop","index":0}
+{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":17603,"output_tokens":2}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt
@@ -1,0 +1,8 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_011Ccz2bzXzEeVqZZ7G1bwor","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":17603,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":17603,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" see"}}
+{"type":"content_block_stop","index":0}
+{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":17603,"cache_read_input_tokens":0,"output_tokens":2}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/anthropic-issue-5942.test.ts
+++ b/packages/anthropic/src/anthropic-issue-5942.test.ts
@@ -1,0 +1,95 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import {
+  convertReadableStreamToArray,
+  mockId,
+} from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+describe('issue #5942', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+  const provider = createAnthropic({
+    apiKey: 'test-api-key',
+    generateId: mockId({ prefix: 'id' }),
+  });
+
+  function prepareChunksFixtureResponse(filename: string) {
+    const chunks = fs
+      .readFileSync(`src/__fixtures__/${filename}.chunks.txt`, 'utf8')
+      .split('\n')
+      .map(line => `data: ${line}\n\n`);
+    chunks.push('data: [DONE]\n\n');
+
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+  }
+
+  it('applies message cache control to structured content and exposes live cache usage', async () => {
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'recorded long prompt' }],
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral' },
+          },
+        },
+      },
+    ];
+    const model = provider('claude-sonnet-4-6');
+
+    prepareChunksFixtureResponse('anthropic-issue-5942-cache-write');
+    const firstResult = await model.doStream({ prompt, maxOutputTokens: 2 });
+    const firstParts = await convertReadableStreamToArray(firstResult.stream);
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'recorded long prompt',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(firstParts.find(part => part.type === 'finish')).toMatchObject({
+      providerMetadata: {
+        anthropic: {
+          usage: {
+            cache_creation_input_tokens: 17603,
+            cache_read_input_tokens: 0,
+          },
+        },
+      },
+    });
+
+    prepareChunksFixtureResponse('anthropic-issue-5942-cache-read');
+    const secondResult = await model.doStream({ prompt, maxOutputTokens: 2 });
+    const secondParts = await convertReadableStreamToArray(secondResult.stream);
+
+    expect(secondParts.find(part => part.type === 'finish')).toMatchObject({
+      providerMetadata: {
+        anthropic: {
+          usage: {
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 17603,
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Bug

providerOptions not applied when using parts in messages

## Reproduction

- The reported user-visible failure is Anthropic prompt caching remaining unused for structured messages, causing avoidable input-token cost and latency.
- `examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts` used the current documented structured-message equivalent and observed `cache_control: { type: "ephemeral" }`, 17,203 cache-write tokens on the first request, and 17,203 cache-read tokens on the second; the expected `0/0` failure did not occur.
- The original `parts` request shape is now represented as structured `content` in `ModelMessage`; current `UIMessage` objects must be converted before use with `streamText` and do not directly support message-level `providerOptions`.
- The exact reported model, `claude-3-7-sonnet-20250219`, was retired on February 19, 2026, and the narrowing request returned HTTP 404, preventing an exact-model rerun.
- Recorded live responses are in `packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt` and `packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt`; `packages/anthropic/src/anthropic-issue-5942.test.ts` validates request forwarding and cache metadata.

## Relevant Documentation

- https://ai-sdk.dev/docs/foundations/prompts
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching
- https://platform.claude.com/docs/en/about-claude/model-deprecations

## Related Issues

Could not reproduce #5942