### PR TITLE
fix: prevent smoothStream tool execution from overtaking assistant text

### DIFF
--- a/.changeset/slow-tools-wait.md
+++ b/.changeset/slow-tools-wait.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Ensure `smoothStream` emits preceding assistant text before executing tool calls.

--- a/.changeset/slow-tools-wait.md
+++ b/.changeset/slow-tools-wait.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-Ensure `smoothStream` emits preceding assistant text before executing tool calls.
+Ensure `smoothStream` emits all assistant text from a model call before executing its local tools.

--- a/examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts
+++ b/examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts
@@ -8,7 +8,7 @@ async function main() {
   let textObservedWhenToolExecuted: string | undefined;
 
   const result = streamText({
-    model: openai('gpt-5-mini'),
+    model: openai('gpt-4o'),
     prompt:
       'You must complete these actions in order: ' +
       '(1) output exactly "I will read hello.txt now. " including the trailing space, ' +

--- a/examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts
+++ b/examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts
@@ -1,0 +1,121 @@
+import { smoothStream, tool, ToolLoopAgent } from 'ai';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod/v4';
+
+const usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 1,
+    text: 1,
+    reasoning: undefined,
+  },
+};
+
+async function main() {
+  const useSmoothStream = !process.argv.includes('--without-smooth-stream');
+  const textBeforeTool =
+    'I will help replace Sunny with Rainy. First, let me read the file. ';
+  let streamedText = '';
+  let textObservedWhenToolExecuted: string | undefined;
+
+  const model = new MockLanguageModelV4({
+    doStream: [
+      {
+        stream: convertArrayToReadableStream([
+          { type: 'text-start', id: 'text-1' },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: textBeforeTool,
+          },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'tool-call',
+            toolCallId: 'tool-call-1',
+            toolName: 'readFile',
+            input: JSON.stringify({ path: 'hello.txt' }),
+          },
+          {
+            type: 'finish',
+            finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+            usage,
+          },
+        ]),
+      },
+      {
+        stream: convertArrayToReadableStream([
+          { type: 'text-start', id: 'text-2' },
+          {
+            type: 'text-delta',
+            id: 'text-2',
+            delta: 'The file contains Sunny.',
+          },
+          { type: 'text-end', id: 'text-2' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage,
+          },
+        ]),
+      },
+    ],
+  });
+
+  const agent = new ToolLoopAgent({
+    model,
+    tools: {
+      readFile: tool({
+        inputSchema: z.object({ path: z.string() }),
+        execute: async () => {
+          textObservedWhenToolExecuted = streamedText;
+          return 'Sunny';
+        },
+      }),
+    },
+  });
+
+  const result = await agent.stream({
+    prompt: 'Replace Sunny with Rainy in hello.txt',
+    experimental_transform: useSmoothStream
+      ? smoothStream({
+          delayInMs: 50,
+          chunking: 'word',
+        })
+      : undefined,
+  });
+
+  for await (const text of result.textStream) {
+    streamedText += text;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        useSmoothStream,
+        expectedTextBeforeTool: textBeforeTool,
+        textObservedWhenToolExecuted,
+        finalStreamedText: streamedText,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (textObservedWhenToolExecuted !== textBeforeTool) {
+    throw new Error(
+      useSmoothStream
+        ? 'Issue #13199 reproduced: the tool executed before smoothStream emitted all preceding assistant text.'
+        : 'Unexpected baseline failure: the tool executed before all preceding assistant text was emitted without smoothStream.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts
+++ b/examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts
@@ -1,75 +1,21 @@
-import { smoothStream, tool, ToolLoopAgent } from 'ai';
-import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import { openai } from '@ai-sdk/openai';
+import { smoothStream, streamText, tool } from 'ai';
 import { z } from 'zod/v4';
 
-const usage = {
-  inputTokens: {
-    total: 1,
-    noCache: 1,
-    cacheRead: undefined,
-    cacheWrite: undefined,
-  },
-  outputTokens: {
-    total: 1,
-    text: 1,
-    reasoning: undefined,
-  },
-};
-
 async function main() {
-  const useSmoothStream = !process.argv.includes('--without-smooth-stream');
-  const textBeforeTool =
-    'I will help replace Sunny with Rainy. First, let me read the file. ';
+  let completeTextBeforeTool: string | undefined;
   let streamedText = '';
   let textObservedWhenToolExecuted: string | undefined;
 
-  const model = new MockLanguageModelV4({
-    doStream: [
-      {
-        stream: convertArrayToReadableStream([
-          { type: 'text-start', id: 'text-1' },
-          {
-            type: 'text-delta',
-            id: 'text-1',
-            delta: textBeforeTool,
-          },
-          { type: 'text-end', id: 'text-1' },
-          {
-            type: 'tool-call',
-            toolCallId: 'tool-call-1',
-            toolName: 'readFile',
-            input: JSON.stringify({ path: 'hello.txt' }),
-          },
-          {
-            type: 'finish',
-            finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
-            usage,
-          },
-        ]),
-      },
-      {
-        stream: convertArrayToReadableStream([
-          { type: 'text-start', id: 'text-2' },
-          {
-            type: 'text-delta',
-            id: 'text-2',
-            delta: 'The file contains Sunny.',
-          },
-          { type: 'text-end', id: 'text-2' },
-          {
-            type: 'finish',
-            finishReason: { unified: 'stop', raw: 'stop' },
-            usage,
-          },
-        ]),
-      },
-    ],
-  });
-
-  const agent = new ToolLoopAgent({
-    model,
+  const result = streamText({
+    model: openai('gpt-5-mini'),
+    prompt:
+      'You must complete these actions in order: ' +
+      '(1) output exactly "I will read hello.txt now. " including the trailing space, ' +
+      '(2) call the readFile tool with path "hello.txt".',
     tools: {
       readFile: tool({
+        description: 'Read a file.',
         inputSchema: z.object({ path: z.string() }),
         execute: async () => {
           textObservedWhenToolExecuted = streamedText;
@@ -77,16 +23,16 @@ async function main() {
         },
       }),
     },
-  });
-
-  const result = await agent.stream({
-    prompt: 'Replace Sunny with Rainy in hello.txt',
-    experimental_transform: useSmoothStream
-      ? smoothStream({
-          delayInMs: 50,
-          chunking: 'word',
-        })
-      : undefined,
+    experimental_transform: smoothStream({
+      delayInMs: 50,
+      chunking: 'word',
+    }),
+    onLanguageModelCallEnd: event => {
+      completeTextBeforeTool = event.content
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('');
+    },
   });
 
   for await (const text of result.textStream) {
@@ -96,8 +42,7 @@ async function main() {
   console.log(
     JSON.stringify(
       {
-        useSmoothStream,
-        expectedTextBeforeTool: textBeforeTool,
+        completeTextBeforeTool,
         textObservedWhenToolExecuted,
         finalStreamedText: streamedText,
       },
@@ -106,11 +51,13 @@ async function main() {
     ),
   );
 
-  if (textObservedWhenToolExecuted !== textBeforeTool) {
+  if (completeTextBeforeTool == null || completeTextBeforeTool.length === 0) {
+    throw new Error('The model did not emit text before the tool call.');
+  }
+
+  if (textObservedWhenToolExecuted !== completeTextBeforeTool) {
     throw new Error(
-      useSmoothStream
-        ? 'Issue #13199 reproduced: the tool executed before smoothStream emitted all preceding assistant text.'
-        : 'Unexpected baseline failure: the tool executed before all preceding assistant text was emitted without smoothStream.',
+      'The tool executed before smoothStream emitted all preceding assistant text.',
     );
   }
 }

--- a/packages/ai/src/generate-text/execute-tools-from-stream.test.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.test.ts
@@ -84,6 +84,7 @@ describe('executeToolsFromStream', () => {
         },
         finishChunk,
       ]);
+    const waitForToolExecution = vi.fn(async () => {});
 
     const transformedStream = executeToolsFromStream({
       stream: inputStream,
@@ -95,6 +96,7 @@ describe('executeToolsFromStream', () => {
       abortSignal: undefined,
       toolsContext: {},
       runtimeContext: {},
+      waitForToolExecution,
     });
 
     expect(await convertReadableStreamToArray(transformedStream))
@@ -153,6 +155,7 @@ describe('executeToolsFromStream', () => {
           },
         ]
       `);
+    expect(waitForToolExecution).toHaveBeenCalledOnce();
   });
 
   it('should handle sync tool execution', async () => {
@@ -307,6 +310,7 @@ describe('executeToolsFromStream', () => {
     };
 
     let toolExecuted = false;
+    const waitForToolExecution = vi.fn(async () => {});
 
     const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
       convertArrayToReadableStream([
@@ -338,11 +342,13 @@ describe('executeToolsFromStream', () => {
       timeout: undefined,
       toolsContext: {},
       runtimeContext: {},
+      waitForToolExecution,
     });
 
     await convertReadableStreamToArray(transformedStream);
 
     expect(toolExecuted).toBe(false);
+    expect(waitForToolExecution).not.toHaveBeenCalled();
   });
 
   it('should emit approval request and approved response before executing auto-approved tools', async () => {
@@ -885,6 +891,7 @@ describe('executeToolsFromStream', () => {
       const toolExecutionStartEvents: ToolExecutionStartEvent<typeof tools>[] =
         [];
       const toolExecutionEndEvents: ToolExecutionEndEvent<typeof tools>[] = [];
+      const waitForToolExecution = vi.fn(async () => {});
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -913,12 +920,14 @@ describe('executeToolsFromStream', () => {
         onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
+        waitForToolExecution,
       });
 
       await convertReadableStreamToArray(transformedStream);
 
       expect(toolExecutionStartEvents).toMatchInlineSnapshot(`[]`);
       expect(toolExecutionEndEvents).toMatchInlineSnapshot(`[]`);
+      expect(waitForToolExecution).not.toHaveBeenCalled();
     });
 
     it('should call callbacks for each tool in a multi-tool stream', async () => {

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -51,6 +51,7 @@ export function executeToolsFromStream<
   onToolExecutionEnd,
   executeToolInTelemetryContext,
   runInTracingChannelSpan,
+  waitForToolExecution,
 }: {
   stream: ReadableStream<LanguageModelStreamPart<TOOLS>>;
   tools: TOOLS | undefined;
@@ -70,6 +71,7 @@ export function executeToolsFromStream<
   runInTracingChannelSpan?: NonNullable<
     TelemetryDispatcher['runInTracingChannelSpan']
   >;
+  waitForToolExecution?: () => Promise<void>;
 }): ReadableStream<ExecuteToolsStreamPart<TOOLS>> {
   const toolCallsToExecute: Array<TypedToolCall<TOOLS>> = [];
 
@@ -197,6 +199,10 @@ export function executeToolsFromStream<
           }
 
           case 'model-call-end': {
+            if (toolCallsToExecute.length > 0) {
+              await waitForToolExecution?.();
+            }
+
             await Promise.all(
               toolCallsToExecute.map(async toolCall => {
                 try {

--- a/packages/ai/src/generate-text/smooth-stream-tool-order.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream-tool-order.test.ts
@@ -1,0 +1,79 @@
+import { tool } from '@ai-sdk/provider-utils';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { smoothStream } from './smooth-stream';
+import { streamText } from './stream-text';
+
+const usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 1,
+    text: 1,
+    reasoning: undefined,
+  },
+};
+
+describe('smoothStream tool ordering', () => {
+  it('should emit preceding text before executing a tool call', async () => {
+    const textBeforeTool =
+      'I will help replace Sunny with Rainy. First, let me read the file. ';
+    let streamedText = '';
+    let textObservedWhenToolExecuted: string | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            {
+              type: 'text-delta',
+              id: '1',
+              delta: textBeforeTool,
+            },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'readFile',
+              input: JSON.stringify({ path: 'hello.txt' }),
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+              usage,
+            },
+          ]),
+        }),
+      }),
+      tools: {
+        readFile: tool({
+          inputSchema: z.object({ path: z.string() }),
+          execute: async () => {
+            textObservedWhenToolExecuted = streamedText;
+            return 'Sunny';
+          },
+        }),
+      },
+      experimental_transform: smoothStream({
+        chunking: 'word',
+        _internal: {
+          delay: () => new Promise(resolve => setTimeout(resolve, 0)),
+        },
+      }),
+      prompt: 'Replace Sunny with Rainy in hello.txt',
+    });
+
+    for await (const text of result.textStream) {
+      streamedText += text;
+    }
+
+    expect(textObservedWhenToolExecuted).toBe(textBeforeTool);
+  });
+});

--- a/packages/ai/src/generate-text/smooth-stream-tool-order.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream-tool-order.test.ts
@@ -5,6 +5,7 @@ import { z } from 'zod/v4';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import { smoothStream } from './smooth-stream';
 import { streamText } from './stream-text';
+import type { TextStreamPart } from './stream-text-result';
 
 const usage = {
   inputTokens: {
@@ -75,5 +76,240 @@ describe('smoothStream tool ordering', () => {
     }
 
     expect(textObservedWhenToolExecuted).toBe(textBeforeTool);
+  });
+
+  it('should emit all model-call text before executing tools', async () => {
+    let streamedText = '';
+    let textObservedWhenToolExecuted: string | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'before tool ' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'readFile',
+              input: JSON.stringify({ path: 'hello.txt' }),
+            },
+            { type: 'text-start', id: '2' },
+            { type: 'text-delta', id: '2', delta: 'after tool ' },
+            { type: 'text-end', id: '2' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+              usage,
+            },
+          ]),
+        }),
+      }),
+      tools: {
+        readFile: tool({
+          inputSchema: z.object({ path: z.string() }),
+          execute: async () => {
+            textObservedWhenToolExecuted = streamedText;
+            return 'Sunny';
+          },
+        }),
+      },
+      experimental_transform: smoothStream({
+        chunking: 'word',
+        _internal: {
+          delay: () => new Promise(resolve => setTimeout(resolve, 0)),
+        },
+      }),
+      prompt: 'Read hello.txt',
+    });
+
+    for await (const text of result.textStream) {
+      streamedText += text;
+    }
+
+    expect(textObservedWhenToolExecuted).toBe('before tool after tool ');
+  });
+
+  it('should emit intervening text before executing multiple tools', async () => {
+    let streamedText = '';
+    const textObservedWhenToolsExecuted: string[] = [];
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'before first ' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'readFile',
+              input: JSON.stringify({ path: 'hello.txt' }),
+            },
+            { type: 'text-start', id: '2' },
+            { type: 'text-delta', id: '2', delta: 'between tools ' },
+            { type: 'text-end', id: '2' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-2',
+              toolName: 'readFile',
+              input: JSON.stringify({ path: 'world.txt' }),
+            },
+            { type: 'text-start', id: '3' },
+            { type: 'text-delta', id: '3', delta: 'after second ' },
+            { type: 'text-end', id: '3' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+              usage,
+            },
+          ]),
+        }),
+      }),
+      tools: {
+        readFile: tool({
+          inputSchema: z.object({ path: z.string() }),
+          execute: async () => {
+            textObservedWhenToolsExecuted.push(streamedText);
+            return 'contents';
+          },
+        }),
+      },
+      experimental_transform: smoothStream({
+        chunking: 'word',
+        _internal: {
+          delay: () => new Promise(resolve => setTimeout(resolve, 0)),
+        },
+      }),
+      prompt: 'Read both files',
+    });
+
+    for await (const text of result.textStream) {
+      streamedText += text;
+    }
+
+    expect(textObservedWhenToolsExecuted).toStrictEqual([
+      'before first between tools after second ',
+      'before first between tools after second ',
+    ]);
+  });
+
+  it('should not depend on a tool-call chunk surviving later transforms', async () => {
+    let toolExecuted = false;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'before tool ' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'readFile',
+              input: JSON.stringify({ path: 'hello.txt' }),
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+              usage,
+            },
+          ]),
+        }),
+      }),
+      tools: {
+        readFile: tool({
+          inputSchema: z.object({ path: z.string() }),
+          execute: async () => {
+            toolExecuted = true;
+            return 'Sunny';
+          },
+        }),
+      },
+      experimental_transform: [
+        smoothStream({
+          chunking: 'word',
+          _internal: {
+            delay: () => new Promise(resolve => setTimeout(resolve, 0)),
+          },
+        }),
+        () =>
+          new TransformStream<TextStreamPart<any>, TextStreamPart<any>>({
+            transform(chunk, controller) {
+              if (chunk.type !== 'tool-call') {
+                controller.enqueue(chunk);
+              }
+            },
+          }),
+      ],
+      prompt: 'Read hello.txt',
+    });
+
+    const streamedText = await Promise.race([
+      (async () => {
+        let text = '';
+        for await (const chunk of result.textStream) {
+          text += chunk;
+        }
+        return text;
+      })(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('stream timed out')), 500),
+      ),
+    ]);
+
+    expect(streamedText).toBe('before tool ');
+    expect(toolExecuted).toBe(true);
+  });
+
+  it('should preserve ordering when delayInMs is null', async () => {
+    let streamedText = '';
+    let textObservedWhenToolExecuted: string | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'before tool ' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'readFile',
+              input: JSON.stringify({ path: 'hello.txt' }),
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+              usage,
+            },
+          ]),
+        }),
+      }),
+      tools: {
+        readFile: tool({
+          inputSchema: z.object({ path: z.string() }),
+          execute: async () => {
+            textObservedWhenToolExecuted = streamedText;
+            return 'Sunny';
+          },
+        }),
+      },
+      experimental_transform: smoothStream({
+        delayInMs: null,
+        chunking: 'word',
+      }),
+      prompt: 'Read hello.txt',
+    });
+
+    for await (const text of result.textStream) {
+      streamedText += text;
+    }
+
+    expect(textObservedWhenToolExecuted).toBe('before tool ');
   });
 });

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -4,19 +4,25 @@ import {
   type SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import type { TextStreamPart } from './stream-text-result';
+import {
+  completeToolExecutionBarrierChunks,
+  releaseToolExecutionBarriersForChunk,
+} from './tool-execution-barrier';
 
 const CHUNKING_REGEXPS = {
   word: /\S+\s+/m,
   line: /\n+/m,
 };
 
-const smoothStreamTransforms = new WeakSet<object>();
+const smoothStreamTransforms = new WeakMap<object, symbol>();
 
 /**
  * Internal marker used to coordinate tool execution with smoothed output.
  */
-export function isSmoothStreamTransform(transform: object): boolean {
-  return smoothStreamTransforms.has(transform);
+export function getSmoothStreamTransformId(
+  transform: object,
+): symbol | undefined {
+  return smoothStreamTransforms.get(transform);
 }
 
 /**
@@ -52,6 +58,7 @@ export function smoothStream<TOOLS extends ToolSet>({
 } = {}): (options: {
   tools: TOOLS;
 }) => TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>> {
+  const smoothStreamId = Symbol('smoothStream');
   let detectChunk: ChunkDetector;
 
   // Check if chunking is an Intl.Segmenter (duck-typing for segment method)
@@ -119,58 +126,90 @@ export function smoothStream<TOOLS extends ToolSet>({
     let id = '';
     let type: 'text-delta' | 'reasoning-delta' | undefined = undefined;
     let providerMetadata: SharedV4ProviderMetadata | undefined = undefined;
+    let bufferedInputChunks: object[] = [];
+    let lastOutputChunk: object | undefined;
+
+    function completeBufferedInputChunks() {
+      completeToolExecutionBarrierChunks({
+        inputChunks: bufferedInputChunks,
+        outputChunk: lastOutputChunk,
+        smoothStreamId,
+      });
+      bufferedInputChunks = [];
+      lastOutputChunk = undefined;
+    }
 
     function flushBuffer(
       controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
     ) {
       if (buffer.length > 0 && type !== undefined) {
-        controller.enqueue({
+        const outputChunk = {
           type,
           text: buffer,
           id,
           ...(providerMetadata != null ? { providerMetadata } : {}),
-        });
+        } as TextStreamPart<TOOLS>;
+        controller.enqueue(outputChunk);
+        lastOutputChunk = outputChunk;
         buffer = '';
         providerMetadata = undefined;
       }
+
+      completeBufferedInputChunks();
     }
 
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async transform(chunk, controller) {
-        // Handle non-smoothable chunks: flush buffer and pass through
-        if (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') {
-          flushBuffer(controller);
-          controller.enqueue(chunk);
-          return;
-        }
+        try {
+          // Handle non-smoothable chunks: flush buffer and pass through
+          if (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') {
+            flushBuffer(controller);
+            controller.enqueue(chunk);
+            return;
+          }
 
-        // Flush buffer when type or id changes
-        if ((chunk.type !== type || chunk.id !== id) && buffer.length > 0) {
-          flushBuffer(controller);
-        }
+          // Flush buffer when type or id changes
+          if ((chunk.type !== type || chunk.id !== id) && buffer.length > 0) {
+            flushBuffer(controller);
+          }
 
-        buffer += chunk.text;
-        id = chunk.id;
-        type = chunk.type;
+          bufferedInputChunks.push(chunk);
+          buffer += chunk.text;
+          id = chunk.id;
+          type = chunk.type;
 
-        // Preserve providerMetadata (e.g., Anthropic thinking signatures)
-        if (chunk.providerMetadata != null) {
-          providerMetadata = chunk.providerMetadata;
-        }
+          // Preserve providerMetadata (e.g., Anthropic thinking signatures)
+          if (chunk.providerMetadata != null) {
+            providerMetadata = chunk.providerMetadata;
+          }
 
-        let match;
+          let match;
 
-        while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
-          buffer = buffer.slice(match.length);
+          while ((match = detectChunk(buffer)) != null) {
+            const outputChunk = { type, text: match, id };
+            controller.enqueue(outputChunk);
+            lastOutputChunk = outputChunk;
+            buffer = buffer.slice(match.length);
 
-          await delay(delayInMs);
+            await delay(delayInMs);
+          }
+
+          if (buffer.length === 0) {
+            completeBufferedInputChunks();
+          }
+        } catch (error) {
+          for (const bufferedChunk of bufferedInputChunks) {
+            releaseToolExecutionBarriersForChunk(bufferedChunk);
+          }
+          bufferedInputChunks = [];
+          releaseToolExecutionBarriersForChunk(chunk);
+          throw error;
         }
       },
     });
   };
 
-  smoothStreamTransforms.add(transform);
+  smoothStreamTransforms.set(transform, smoothStreamId);
 
   return transform;
 }

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -10,6 +10,15 @@ const CHUNKING_REGEXPS = {
   line: /\n+/m,
 };
 
+const smoothStreamTransforms = new WeakSet<object>();
+
+/**
+ * Internal marker used to coordinate tool execution with smoothed output.
+ */
+export function isSmoothStreamTransform(transform: object): boolean {
+  return smoothStreamTransforms.has(transform);
+}
+
 /**
  * Detects the first chunk in a buffer.
  *
@@ -105,7 +114,7 @@ export function smoothStream<TOOLS extends ToolSet>({
     };
   }
 
-  return () => {
+  const transform = () => {
     let buffer = '';
     let id = '';
     let type: 'text-delta' | 'reasoning-delta' | undefined = undefined;
@@ -160,4 +169,8 @@ export function smoothStream<TOOLS extends ToolSet>({
       },
     });
   };
+
+  smoothStreamTransforms.add(transform);
+
+  return transform;
 }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -72,7 +72,6 @@ import {
 import type { Callback } from '../util/callback';
 import { consumeStream } from '../util/consume-stream';
 import { createIdMap } from '../util/create-id-map';
-import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { createStitchableStream } from '../util/create-stitchable-stream';
 import type { DownloadFunction } from '../util/download/download-function';
 import { getOwn } from '../util/get-own';
@@ -126,7 +125,7 @@ import {
   isStopConditionMet,
   type StopCondition,
 } from './stop-condition';
-import { isSmoothStreamTransform } from './smooth-stream';
+import { getSmoothStreamTransformId } from './smooth-stream';
 import { streamLanguageModelCall } from './stream-language-model-call';
 import type {
   ConsumeStreamOptions,
@@ -146,6 +145,10 @@ import type { ToolInputRefinement } from './tool-input-refinement';
 import type { ToolOrder } from './tool-order';
 import type { ToolOutput } from './tool-output';
 import type { StaticToolOutputDenied } from './tool-output-denied';
+import {
+  createToolExecutionBarrier,
+  type ToolExecutionBarrier,
+} from './tool-execution-barrier';
 import type { ToolsContextParameter } from './tools-context-parameter';
 import { validateApprovedToolApprovals } from './validate-tool-approvals';
 
@@ -1443,49 +1446,18 @@ class DefaultStreamTextResult<
 
     // smoothStream can otherwise delay visible text while upstream tool
     // execution continues and overtakes it.
-    const delayToolExecution = transforms.some(isSmoothStreamTransform);
-    let availableToolExecutionBarriers = 0;
-    let toolExecutionBarriersReleased = false;
-    const pendingToolExecutionBarriers: Array<
-      ReturnType<typeof createResolvablePromise<void>>
-    > = [];
-
-    function waitForToolExecution() {
-      if (toolExecutionBarriersReleased) {
-        return Promise.resolve();
-      }
-
-      if (availableToolExecutionBarriers > 0) {
-        availableToolExecutionBarriers--;
-        return Promise.resolve();
-      }
-
-      const barrier = createResolvablePromise<void>();
-      pendingToolExecutionBarriers.push(barrier);
-      return barrier.promise;
-    }
-
-    function notifyToolCallEmitted() {
-      const barrier = pendingToolExecutionBarriers.shift();
-
-      if (barrier != null) {
-        barrier.resolve();
-      } else {
-        availableToolExecutionBarriers++;
-      }
-    }
+    const smoothStreamId = transforms
+      .map(getSmoothStreamTransformId)
+      .filter((id): id is symbol => id != null)
+      .at(-1);
+    const activeToolExecutionBarriers = new Set<ToolExecutionBarrier>();
 
     function releaseToolExecutionBarriers() {
-      toolExecutionBarriersReleased = true;
-
-      for (const barrier of pendingToolExecutionBarriers.splice(0)) {
-        barrier.resolve();
+      for (const barrier of activeToolExecutionBarriers) {
+        barrier.release();
       }
+      activeToolExecutionBarriers.clear();
     }
-
-    abortSignal?.addEventListener('abort', releaseToolExecutionBarriers, {
-      once: true,
-    });
 
     // resilient stream that handles abort signals and errors:
     const reader = stitchableStream.stream.getReader();
@@ -1498,6 +1470,7 @@ class DefaultStreamTextResult<
       async pull(controller) {
         // abort handling:
         async function abort() {
+          releaseToolExecutionBarriers();
           await notify({
             event: {
               callId,
@@ -1544,6 +1517,7 @@ class DefaultStreamTextResult<
       },
 
       cancel(reason) {
+        releaseToolExecutionBarriers();
         return stitchableStream.stream.cancel(reason);
       },
     });
@@ -1571,30 +1545,6 @@ class DefaultStreamTextResult<
             stitchableStream.terminate();
             isRunning = false;
             releaseToolExecutionBarriers();
-          },
-        }),
-      );
-    }
-
-    if (delayToolExecution) {
-      let hasEmittedToolCallForStep = false;
-
-      // Release tool execution only after the transformed tool call reaches
-      // the output stream, which guarantees preceding smoothed text was emitted.
-      stream = stream.pipeThrough(
-        new TransformStream({
-          transform(chunk, controller) {
-            controller.enqueue(chunk);
-
-            if (chunk.type === 'start-step') {
-              hasEmittedToolCallForStep = false;
-            } else if (
-              chunk.type === 'tool-call' &&
-              !hasEmittedToolCallForStep
-            ) {
-              hasEmittedToolCallForStep = true;
-              notifyToolCallEmitted();
-            }
           },
         }),
       );
@@ -2045,6 +1995,17 @@ class DefaultStreamTextResult<
                     telemetryDispatcher.runInTracingChannelSpan!(options),
                   );
 
+          let toolExecutionBarrier: ToolExecutionBarrier | undefined;
+          if (smoothStreamId != null) {
+            toolExecutionBarrier = createToolExecutionBarrier({
+              smoothStreamId,
+              onSettled() {
+                activeToolExecutionBarriers.delete(toolExecutionBarrier!);
+              },
+            });
+            activeToolExecutionBarriers.add(toolExecutionBarrier);
+          }
+
           const streamWithToolResults = executeToolsFromStream({
             stream: streamAfterToolCallbackInvocation,
             tools,
@@ -2072,9 +2033,10 @@ class DefaultStreamTextResult<
 
             executeToolInTelemetryContext: telemetryDispatcher.executeTool,
             runInTracingChannelSpan: runInTracingChannelSpanInStep,
-            waitForToolExecution: delayToolExecution
-              ? waitForToolExecution
-              : undefined,
+            waitForToolExecution:
+              toolExecutionBarrier == null
+                ? undefined
+                : () => toolExecutionBarrier.wait(abortSignal),
           });
 
           // Conditionally include request.body based on include settings.
@@ -2171,12 +2133,19 @@ class DefaultStreamTextResult<
                     case 'tool-input-end':
                     case 'tool-input-delta':
                     case 'tool-approval-request': {
+                      if (
+                        chunk.type === 'reasoning-delta' &&
+                        chunk.text.length > 0
+                      ) {
+                        toolExecutionBarrier?.register(chunk);
+                      }
                       controller.enqueue(chunk);
                       break;
                     }
 
                     case 'text-delta': {
                       if (chunk.text.length > 0) {
+                        toolExecutionBarrier?.register(chunk);
                         controller.enqueue(chunk);
                       }
                       break;
@@ -2226,6 +2195,7 @@ class DefaultStreamTextResult<
                     }
 
                     case 'model-call-end': {
+                      toolExecutionBarrier?.seal();
                       hasReceivedTerminalChunk = true;
 
                       // Note: tool executions might not be finished yet when the finish event is emitted.
@@ -2240,6 +2210,7 @@ class DefaultStreamTextResult<
                     }
 
                     case 'error': {
+                      toolExecutionBarrier?.release();
                       hasReceivedTerminalChunk = true;
                       controller.enqueue(chunk);
                       stepFinishReason = 'error';

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -72,6 +72,7 @@ import {
 import type { Callback } from '../util/callback';
 import { consumeStream } from '../util/consume-stream';
 import { createIdMap } from '../util/create-id-map';
+import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { createStitchableStream } from '../util/create-stitchable-stream';
 import type { DownloadFunction } from '../util/download/download-function';
 import { getOwn } from '../util/get-own';
@@ -125,6 +126,7 @@ import {
   isStopConditionMet,
   type StopCondition,
 } from './stop-condition';
+import { isSmoothStreamTransform } from './smooth-stream';
 import { streamLanguageModelCall } from './stream-language-model-call';
 import type {
   ConsumeStreamOptions,
@@ -1439,6 +1441,52 @@ class DefaultStreamTextResult<
     this.addStream = stitchableStream.addStream;
     this.closeStream = stitchableStream.close;
 
+    // smoothStream can otherwise delay visible text while upstream tool
+    // execution continues and overtakes it.
+    const delayToolExecution = transforms.some(isSmoothStreamTransform);
+    let availableToolExecutionBarriers = 0;
+    let toolExecutionBarriersReleased = false;
+    const pendingToolExecutionBarriers: Array<
+      ReturnType<typeof createResolvablePromise<void>>
+    > = [];
+
+    function waitForToolExecution() {
+      if (toolExecutionBarriersReleased) {
+        return Promise.resolve();
+      }
+
+      if (availableToolExecutionBarriers > 0) {
+        availableToolExecutionBarriers--;
+        return Promise.resolve();
+      }
+
+      const barrier = createResolvablePromise<void>();
+      pendingToolExecutionBarriers.push(barrier);
+      return barrier.promise;
+    }
+
+    function notifyToolCallEmitted() {
+      const barrier = pendingToolExecutionBarriers.shift();
+
+      if (barrier != null) {
+        barrier.resolve();
+      } else {
+        availableToolExecutionBarriers++;
+      }
+    }
+
+    function releaseToolExecutionBarriers() {
+      toolExecutionBarriersReleased = true;
+
+      for (const barrier of pendingToolExecutionBarriers.splice(0)) {
+        barrier.resolve();
+      }
+    }
+
+    abortSignal?.addEventListener('abort', releaseToolExecutionBarriers, {
+      once: true,
+    });
+
     // resilient stream that handles abort signals and errors:
     const reader = stitchableStream.stream.getReader();
     let stream = new ReadableStream<TextStreamPart<TOOLS>>({
@@ -1522,6 +1570,31 @@ class DefaultStreamTextResult<
           stopStream() {
             stitchableStream.terminate();
             isRunning = false;
+            releaseToolExecutionBarriers();
+          },
+        }),
+      );
+    }
+
+    if (delayToolExecution) {
+      let hasEmittedToolCallForStep = false;
+
+      // Release tool execution only after the transformed tool call reaches
+      // the output stream, which guarantees preceding smoothed text was emitted.
+      stream = stream.pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            controller.enqueue(chunk);
+
+            if (chunk.type === 'start-step') {
+              hasEmittedToolCallForStep = false;
+            } else if (
+              chunk.type === 'tool-call' &&
+              !hasEmittedToolCallForStep
+            ) {
+              hasEmittedToolCallForStep = true;
+              notifyToolCallEmitted();
+            }
           },
         }),
       );
@@ -1999,6 +2072,9 @@ class DefaultStreamTextResult<
 
             executeToolInTelemetryContext: telemetryDispatcher.executeTool,
             runInTracingChannelSpan: runInTracingChannelSpanInStep,
+            waitForToolExecution: delayToolExecution
+              ? waitForToolExecution
+              : undefined,
           });
 
           // Conditionally include request.body based on include settings.

--- a/packages/ai/src/generate-text/tool-execution-barrier.test.ts
+++ b/packages/ai/src/generate-text/tool-execution-barrier.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createToolExecutionBarrier } from './tool-execution-barrier';
+
+describe('tool execution barrier', () => {
+  it('does not share completion state between model calls', async () => {
+    const firstBarrier = createToolExecutionBarrier({
+      smoothStreamId: Symbol('smoothStream'),
+    });
+    const secondBarrier = createToolExecutionBarrier({
+      smoothStreamId: Symbol('smoothStream'),
+    });
+    let secondBarrierSettled = false;
+
+    firstBarrier.seal();
+    secondBarrier.register({});
+    secondBarrier.seal();
+
+    await firstBarrier.wait();
+    void secondBarrier.wait().then(() => {
+      secondBarrierSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(secondBarrierSettled).toBe(false);
+
+    secondBarrier.release();
+    await secondBarrier.wait();
+  });
+
+  it('removes its abort listener after an aborted wait', async () => {
+    const abortController = new AbortController();
+    const addEventListener = vi.spyOn(
+      abortController.signal,
+      'addEventListener',
+    );
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      'removeEventListener',
+    );
+    const barrier = createToolExecutionBarrier({
+      smoothStreamId: Symbol('smoothStream'),
+    });
+
+    barrier.register({});
+    barrier.seal();
+
+    const wait = barrier.wait(abortController.signal);
+    abortController.abort();
+    await wait;
+
+    expect(addEventListener).toHaveBeenCalledOnce();
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/ai/src/generate-text/tool-execution-barrier.ts
+++ b/packages/ai/src/generate-text/tool-execution-barrier.ts
@@ -1,0 +1,163 @@
+type ToolExecutionBarrierRegistration = {
+  barrier: ToolExecutionBarrier;
+  key: object;
+  smoothStreamId: symbol;
+};
+
+const registrationsByChunk = new WeakMap<
+  object,
+  ToolExecutionBarrierRegistration[]
+>();
+
+type InternalToolExecutionBarrier = {
+  register(chunk: object): void;
+  seal(): void;
+  wait(abortSignal?: AbortSignal): Promise<void>;
+  release(): void;
+  process(key: object): void;
+};
+
+export type ToolExecutionBarrier = Omit<
+  InternalToolExecutionBarrier,
+  'process'
+>;
+
+export function createToolExecutionBarrier({
+  smoothStreamId,
+  onSettled,
+}: {
+  smoothStreamId: symbol;
+  onSettled?: () => void;
+}): ToolExecutionBarrier {
+  const pendingChunks = new Set<object>();
+  let isSealed = false;
+  let isSettled = false;
+  let resolve!: () => void;
+  const promise = new Promise<void>(resolveParam => {
+    resolve = resolveParam;
+  });
+
+  function settle() {
+    if (isSettled || !isSealed || pendingChunks.size > 0) {
+      return;
+    }
+
+    isSettled = true;
+    resolve();
+    onSettled?.();
+  }
+
+  const barrier: InternalToolExecutionBarrier = {
+    register(chunk) {
+      if (isSettled) {
+        return;
+      }
+
+      pendingChunks.add(chunk);
+
+      const registrations = registrationsByChunk.get(chunk) ?? [];
+      registrations.push({
+        barrier,
+        key: chunk,
+        smoothStreamId,
+      });
+      registrationsByChunk.set(chunk, registrations);
+    },
+
+    seal() {
+      isSealed = true;
+      settle();
+    },
+
+    async wait(abortSignal) {
+      if (abortSignal?.aborted || isSettled) {
+        return;
+      }
+
+      if (abortSignal == null) {
+        await promise;
+        return;
+      }
+
+      let onAbort!: () => void;
+      const abortPromise = new Promise<void>(resolveAbort => {
+        onAbort = () => {
+          barrier.release();
+          resolveAbort();
+        };
+        abortSignal.addEventListener('abort', onAbort, { once: true });
+      });
+
+      try {
+        await Promise.race([promise, abortPromise]);
+      } finally {
+        abortSignal.removeEventListener('abort', onAbort);
+      }
+    },
+
+    release() {
+      if (isSettled) {
+        return;
+      }
+
+      pendingChunks.clear();
+      isSealed = true;
+      settle();
+    },
+
+    process(key) {
+      pendingChunks.delete(key);
+      settle();
+    },
+  };
+
+  return barrier;
+}
+
+export function completeToolExecutionBarrierChunks({
+  inputChunks,
+  outputChunk,
+  smoothStreamId,
+}: {
+  inputChunks: object[];
+  outputChunk: object | undefined;
+  smoothStreamId: symbol;
+}) {
+  for (const inputChunk of inputChunks) {
+    const registrations = registrationsByChunk.get(inputChunk);
+
+    if (registrations == null) {
+      continue;
+    }
+
+    registrationsByChunk.delete(inputChunk);
+
+    for (const registration of registrations) {
+      if (registration.smoothStreamId === smoothStreamId) {
+        (registration.barrier as InternalToolExecutionBarrier).process(
+          registration.key,
+        );
+      } else if (outputChunk != null) {
+        const outputRegistrations = registrationsByChunk.get(outputChunk) ?? [];
+        outputRegistrations.push(registration);
+        registrationsByChunk.set(outputChunk, outputRegistrations);
+      } else {
+        registration.barrier.release();
+      }
+    }
+  }
+}
+
+export function releaseToolExecutionBarriersForChunk(chunk: object) {
+  const registrations = registrationsByChunk.get(chunk);
+
+  if (registrations == null) {
+    return;
+  }
+
+  registrationsByChunk.delete(chunk);
+
+  for (const registration of registrations) {
+    registration.barrier.release();
+  }
+}


### PR DESCRIPTION
## Background

smoothStream delays transformed assistant text while upstream local tool execution can continue, causing tool side effects such as console output to appear before the model call's assistant text has been emitted.

## Summary

Added model-call-scoped coordination between smoothStream and local tool execution. Executable local tools now wait until all text and reasoning from their model call has passed through the final smoothStream transform. Barrier state is isolated per model call, propagates across composed smoothStream transforms, does not depend on tool-call chunks surviving later transforms, and is released on abort, cancellation, transform errors, or stream termination.

## Testing

Added a runnable OpenAI reproduction and integration regressions covering preceding and trailing text, multiple tools with intervening text, filtered tool-call chunks, and delayInMs null. Added unit coverage for isolated model-call barriers, abort-listener cleanup, and ensuring only executable local tools wait. Focused smoothStream and tool-execution suites passed with 57 tests, followed by successful full repository test, check, type-check, and consistency runs.

## End-to-end Validation

- `examples/ai-functions/src/reproduction/issue-13199-smooth-stream-tool-order.ts` — ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-13199-smooth-stream-tool-order.ts` against OpenAI; the text observed at tool execution exactly matched the complete final streamed assistant text.

## Related Issues

Fixes #13199

Co-authored-by: mindplay-dk <103348+mindplay-dk@users.noreply.github.com>
Co-authored-by: vercel[bot] <35613825+vercel[bot]@users.noreply.github.com>
Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>