### PR TITLE
reproduction: could not reproduce providerOptions not applied when using parts in messages

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts
+++ b/examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts
@@ -1,0 +1,175 @@
+import {
+  createAnthropic,
+  type AnthropicLanguageModelOptions,
+} from '@ai-sdk/anthropic';
+import { APICallError, streamText } from 'ai';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+
+const fixtureDirectory = new URL(
+  '../../../../packages/anthropic/src/__fixtures__/',
+  import.meta.url,
+);
+
+const cacheableText = [
+  'This is stable reference material used to verify Anthropic prompt caching.',
+  'Keep it unchanged between requests.',
+  `Reproduction run: ${randomUUID()}.`,
+  ...Array.from(
+    { length: 1_000 },
+    (_, index) =>
+      `Reference item ${index}: structured messages must preserve message-level provider options.`,
+  ),
+  'Reply with only OK.',
+].join('\n');
+
+type CapturedCall = {
+  requestBody: unknown;
+  responseText: Promise<string>;
+};
+
+function toChunksFixture(responseText: string): string {
+  return responseText
+    .split('\n')
+    .filter(line => line.startsWith('data: '))
+    .map(line => line.slice('data: '.length))
+    .filter(line => line !== '[DONE]')
+    .join('\n');
+}
+
+async function main() {
+  const calls: CapturedCall[] = [];
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      calls.push({
+        requestBody:
+          typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+        responseText: response.clone().text(),
+      });
+      return response;
+    },
+  });
+
+  async function runCacheRequest() {
+    const result = streamText({
+      model: anthropic('claude-sonnet-4-6'),
+      maxOutputTokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: cacheableText }],
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral' },
+            } satisfies AnthropicLanguageModelOptions,
+          },
+        },
+      ],
+    });
+
+    await result.text;
+
+    return {
+      request: await result.request,
+      usage: await result.usage,
+      providerMetadata: (await result.providerMetadata)?.anthropic,
+    };
+  }
+
+  const first = await runCacheRequest();
+  const second = await runCacheRequest();
+
+  await fs.writeFile(
+    new URL('anthropic-issue-5942-cache-write.chunks.txt', fixtureDirectory),
+    `${toChunksFixture(await calls[0].responseText)}\n`,
+  );
+  await fs.writeFile(
+    new URL('anthropic-issue-5942-cache-read.chunks.txt', fixtureDirectory),
+    `${toChunksFixture(await calls[1].responseText)}\n`,
+  );
+
+  let exactModelError: { statusCode?: number; message: string } | undefined;
+  try {
+    const exactModelResult = streamText({
+      model: anthropic('claude-3-7-sonnet-20250219'),
+      maxOutputTokens: 8,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: cacheableText }],
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral' },
+            } satisfies AnthropicLanguageModelOptions,
+          },
+        },
+      ],
+      onError({ error }) {
+        exactModelError = APICallError.isInstance(error)
+          ? { statusCode: error.statusCode, message: error.message }
+          : {
+              message: error instanceof Error ? error.message : String(error),
+            };
+      },
+    });
+    await exactModelResult.text;
+  } catch (error) {
+    exactModelError ??= {
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const requestBody = calls[0].requestBody as {
+    messages?: Array<{
+      content?: Array<{ cache_control?: { type?: string } }>;
+    }>;
+  };
+  const forwardedCacheControl =
+    requestBody.messages?.[0]?.content?.at(-1)?.cache_control;
+  const cacheCreationInputTokens =
+    first.usage.inputTokenDetails.cacheWriteTokens ?? 0;
+  const cacheReadInputTokens =
+    second.usage.inputTokenDetails.cacheReadTokens ?? 0;
+
+  console.log(
+    JSON.stringify(
+      {
+        forwardedCacheControl,
+        firstUsage: first.usage,
+        secondUsage: second.usage,
+        firstProviderMetadata: first.providerMetadata,
+        secondProviderMetadata: second.providerMetadata,
+        firstRequestBodyHasCacheControl: JSON.stringify(
+          first.request.body,
+        ).includes('"cache_control"'),
+        exactModelError,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (forwardedCacheControl?.type !== 'ephemeral') {
+    throw new Error(
+      'Reproduced issue #5942: message-level cacheControl was not forwarded for structured content.',
+    );
+  }
+
+  if (cacheCreationInputTokens === 0) {
+    throw new Error(
+      'Reproduced issue #5942: Anthropic did not create a cache entry for structured content.',
+    );
+  }
+
+  if (cacheReadInputTokens === 0) {
+    throw new Error(
+      'Reproduced issue #5942: Anthropic did not read the cache entry on the repeated request.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt
@@ -1,0 +1,8 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_011CczASF5zsVRivqefHgFnT","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":16060,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}} }
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}             }
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}           }
+{"type":"content_block_stop","index":0  }
+{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":16060,"output_tokens":5}         }
+{"type":"message_stop"         }

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt
@@ -1,0 +1,8 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_011CczAS1JHS2jFCg2cPCPP4","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":16060,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":16060,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}           }
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}        }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}  }
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}           }
+{"type":"content_block_stop","index":0            }
+{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":16060,"cache_read_input_tokens":0,"output_tokens":5}           }
+{"type":"message_stop"    }

--- a/packages/anthropic/src/anthropic-issue-5942.test.ts
+++ b/packages/anthropic/src/anthropic-issue-5942.test.ts
@@ -1,0 +1,124 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import type { AnthropicLanguageModelOptions } from './anthropic-messages-options';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+const provider = createAnthropic({
+  apiKey: 'test-api-key',
+});
+
+const prompt: LanguageModelV3Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Long cached structured content' }],
+    providerOptions: {
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+      } satisfies AnthropicLanguageModelOptions,
+    },
+  },
+];
+
+function prepareChunksFixtureResponse(filename: string) {
+  const chunks = fs
+    .readFileSync(`src/__fixtures__/${filename}.chunks.txt`, 'utf8')
+    .trim()
+    .split('\n')
+    .map(line => `data: ${line}\n\n`);
+
+  server.urls['https://api.anthropic.com/v1/messages'].response = {
+    type: 'stream-chunks',
+    chunks,
+  };
+}
+
+async function streamFixture(filename: string) {
+  prepareChunksFixtureResponse(filename);
+
+  const { stream } = await provider('claude-sonnet-4-6').doStream({
+    prompt,
+    maxOutputTokens: 8,
+  });
+
+  return convertReadableStreamToArray(stream);
+}
+
+it('forwards message-level cache control for structured content and exposes live cache usage', async () => {
+  const cacheWriteStream = await streamFixture(
+    'anthropic-issue-5942-cache-write',
+  );
+
+  expect(await server.calls[0].requestBodyJson).toMatchObject({
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Long cached structured content',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(cacheWriteStream.at(-1)).toMatchObject({
+    type: 'finish',
+    usage: {
+      inputTokens: {
+        cacheRead: 0,
+      },
+    },
+    providerMetadata: {
+      anthropic: {
+        usage: {
+          cache_read_input_tokens: 0,
+        },
+      },
+    },
+  });
+  const cacheWriteFinish = cacheWriteStream.find(
+    part => part.type === 'finish',
+  );
+  expect(cacheWriteFinish?.usage.inputTokens.cacheWrite).toBeGreaterThan(0);
+  expect(cacheWriteFinish?.providerMetadata?.anthropic?.usage).toMatchObject({
+    cache_creation_input_tokens: cacheWriteFinish?.usage.inputTokens.cacheWrite,
+  });
+
+  const cacheReadStream = await streamFixture(
+    'anthropic-issue-5942-cache-read',
+  );
+
+  expect(cacheReadStream.at(-1)).toMatchObject({
+    type: 'finish',
+    usage: {
+      inputTokens: {
+        cacheWrite: 0,
+      },
+    },
+    providerMetadata: {
+      anthropic: {
+        usage: {
+          cache_creation_input_tokens: 0,
+        },
+      },
+    },
+  });
+  const cacheReadFinish = cacheReadStream.find(part => part.type === 'finish');
+  expect(cacheReadFinish?.usage.inputTokens.cacheRead).toBeGreaterThan(0);
+  expect(cacheReadFinish?.providerMetadata?.anthropic?.usage).toMatchObject({
+    cache_read_input_tokens: cacheReadFinish?.usage.inputTokens.cacheRead,
+  });
+});


### PR DESCRIPTION
## Bug

providerOptions not applied when using parts in messages

## Reproduction

- The reported user-visible impact is lost Anthropic prompt caching for structured messages, increasing input-token cost and latency.
- `examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts` forwarded `cache_control: { type: "ephemeral" }`, wrote 16,060 cache tokens, and read 16,060 tokens on the repeated request; the expected `0/0` failure did not occur.
- The current documented structured `ModelMessage` shape uses an array in `content`; `UIMessage.parts` does not directly support message-level `providerOptions` and must be converted first.
- The exact reported model, `claude-3-7-sonnet-20250219`, was retired on February 19, 2026, and the narrowing request returned HTTP 404.
- Live response fixtures were recorded in `packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt` and `packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt`.
- `packages/anthropic/src/anthropic-issue-5942.test.ts` verifies request forwarding and `cache-write/cache-read` metadata using the recorded fixtures.

## Relevant Documentation

- https://ai-sdk.dev/docs/foundations/prompts
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching
- https://platform.claude.com/docs/en/about-claude/model-deprecations

## Related Issues

Could not reproduce #5942