### PR TITLE
reproduction: could not reproduce providerOptions not applied when using parts in messages

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts
+++ b/examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts
@@ -1,0 +1,273 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { streamText, type ModelMessage } from 'ai';
+import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const modelId = 'claude-sonnet-4-6';
+const exactReportedModelId = 'claude-3-7-sonnet-20250219';
+const fixtureDirectory = path.resolve(
+  process.cwd(),
+  '../../packages/anthropic/src/__fixtures__',
+);
+
+const longText = Array.from(
+  { length: 600 },
+  (_, index) =>
+    `Cacheable reference paragraph ${index}: provider options on structured message content must reach Anthropic without being dropped. Keep this paragraph unchanged between requests.`,
+).join('\n');
+const runId = randomUUID();
+
+const messages: ModelMessage[] = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: `${longText}\n\nReproduction run: ${runId}\nReturn only the word OK.`,
+      },
+    ],
+    providerOptions: {
+      anthropic: {
+        cacheControl: {
+          type: 'ephemeral',
+        },
+      },
+    },
+  },
+];
+
+type CallObservation = {
+  cacheControl: unknown;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  fixturePath?: string;
+  modelId: string;
+};
+
+function extractNumber(value: unknown): number {
+  return typeof value === 'number' ? value : 0;
+}
+
+function extractCacheControl(requestBody: unknown): unknown {
+  if (
+    requestBody == null ||
+    typeof requestBody !== 'object' ||
+    !('messages' in requestBody) ||
+    !Array.isArray(requestBody.messages)
+  ) {
+    return undefined;
+  }
+
+  const firstMessage = requestBody.messages[0];
+  if (
+    firstMessage == null ||
+    typeof firstMessage !== 'object' ||
+    !('content' in firstMessage) ||
+    !Array.isArray(firstMessage.content)
+  ) {
+    return undefined;
+  }
+
+  const lastPart = firstMessage.content.at(-1);
+  return lastPart != null &&
+    typeof lastPart === 'object' &&
+    'cache_control' in lastPart
+    ? lastPart.cache_control
+    : undefined;
+}
+
+async function writeChunksFixture({
+  fixtureName,
+  responseText,
+}: {
+  fixtureName: string;
+  responseText: string;
+}): Promise<string> {
+  const fixturePath = path.join(fixtureDirectory, `${fixtureName}.chunks.txt`);
+  const fixtureLines = responseText
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('data: '))
+    .map(line => line.slice('data: '.length))
+    .filter(line => line.length > 0 && line !== '[DONE]');
+
+  await mkdir(fixtureDirectory, { recursive: true });
+  await writeFile(fixturePath, `${fixtureLines.join('\n')}\n`);
+
+  return fixturePath;
+}
+
+async function callAnthropic({
+  fixtureName,
+  model,
+}: {
+  fixtureName?: string;
+  model: string;
+}): Promise<CallObservation> {
+  let responseTextPromise: Promise<string> | undefined;
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      responseTextPromise = response.clone().text();
+      return response;
+    },
+  });
+
+  const result = streamText({
+    model: anthropic(model),
+    messages,
+    maxOutputTokens: 1,
+  });
+
+  await result.text;
+
+  const request = await result.request;
+  const requestBody =
+    typeof request.body === 'string' ? JSON.parse(request.body) : request.body;
+  const providerMetadata = await result.providerMetadata;
+  const usage = await result.usage;
+  const anthropicMetadata = providerMetadata?.anthropic as
+    | Record<string, unknown>
+    | undefined;
+  const rawUsage = anthropicMetadata?.usage as
+    | Record<string, unknown>
+    | undefined;
+
+  let fixturePath: string | undefined;
+  if (fixtureName != null && responseTextPromise != null) {
+    fixturePath = await writeChunksFixture({
+      fixtureName,
+      responseText: await responseTextPromise,
+    });
+  }
+
+  return {
+    cacheControl: extractCacheControl(requestBody),
+    cacheCreationInputTokens: extractNumber(
+      anthropicMetadata?.cacheCreationInputTokens ??
+        rawUsage?.cache_creation_input_tokens,
+    ),
+    cacheReadInputTokens: extractNumber(
+      usage.cachedInputTokens ?? rawUsage?.cache_read_input_tokens,
+    ),
+    fixturePath,
+    modelId: model,
+  };
+}
+
+async function checkExactReportedModel(): Promise<
+  | { modelId: string; result: 'available' }
+  | { error: { message: string; statusCode?: number }; modelId: string }
+> {
+  try {
+    const result = await createAnthropic()(exactReportedModelId).doStream({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: `${longText}\n\nReproduction run: ${runId}\nReturn only the word OK.`,
+            },
+          ],
+          providerOptions: {
+            anthropic: {
+              cacheControl: {
+                type: 'ephemeral',
+              },
+            },
+          },
+        },
+      ],
+      maxOutputTokens: 1,
+    });
+
+    await result.stream.pipeTo(new WritableStream());
+
+    return {
+      modelId: exactReportedModelId,
+      result: 'available',
+    };
+  } catch (error) {
+    return {
+      error: getErrorDetails(error),
+      modelId: exactReportedModelId,
+    };
+  }
+}
+
+function getErrorDetails(error: unknown): {
+  message: string;
+  statusCode?: number;
+} {
+  if (error == null || typeof error !== 'object') {
+    return { message: String(error) };
+  }
+
+  return {
+    message:
+      'message' in error && typeof error.message === 'string'
+        ? error.message
+        : String(error),
+    statusCode:
+      'statusCode' in error && typeof error.statusCode === 'number'
+        ? error.statusCode
+        : undefined,
+  };
+}
+
+async function main(): Promise<void> {
+  const first = await callAnthropic({
+    fixtureName: 'anthropic-issue-5942-cache-write',
+    model: modelId,
+  });
+  const second = await callAnthropic({
+    fixtureName: 'anthropic-issue-5942-cache-read',
+    model: modelId,
+  });
+
+  if (
+    JSON.stringify(first.cacheControl) !==
+      JSON.stringify({ type: 'ephemeral' }) ||
+    JSON.stringify(second.cacheControl) !==
+      JSON.stringify({ type: 'ephemeral' })
+  ) {
+    throw new Error(
+      `Issue #5942 reproduced: cache_control was not forwarded for structured message content: ${JSON.stringify(
+        { first: first.cacheControl, second: second.cacheControl },
+      )}`,
+    );
+  }
+
+  if (first.cacheCreationInputTokens <= 0) {
+    throw new Error(
+      `Issue #5942 reproduced: the first request created ${first.cacheCreationInputTokens} cached tokens.`,
+    );
+  }
+
+  if (second.cacheReadInputTokens <= 0) {
+    throw new Error(
+      `Issue #5942 reproduced: the repeated request read ${second.cacheReadInputTokens} cached tokens.`,
+    );
+  }
+
+  const exactModel = await checkExactReportedModel();
+
+  console.log(
+    JSON.stringify(
+      {
+        exactModel,
+        first,
+        second,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt
@@ -1,0 +1,7 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_011CczBWmS717HsNJwaC9mWM","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":18639,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}         }
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}        }
+{"type":"content_block_stop","index":0      }
+{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":18639,"output_tokens":1}     }
+{"type":"message_stop"    }

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt
@@ -1,0 +1,7 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_011CczBWezemuqo5xUfertVi","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":18639,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":18639,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}              }
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}             }
+{"type":"content_block_stop","index":0      }
+{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":18639,"cache_read_input_tokens":0,"output_tokens":1}           }
+{"type":"message_stop"           }

--- a/packages/anthropic/src/anthropic-issue-5942.test.ts
+++ b/packages/anthropic/src/anthropic-issue-5942.test.ts
@@ -1,0 +1,87 @@
+import type {
+  LanguageModelV2Prompt,
+  LanguageModelV2StreamPart,
+} from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Recorded cache-control reproduction.' }],
+    providerOptions: {
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+      },
+    },
+  },
+];
+
+describe('issue #5942 structured message cache control', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+  const model = createAnthropic({
+    apiKey: 'test-api-key',
+  })('claude-sonnet-4-6');
+
+  async function replayFixture(
+    fixtureName: string,
+  ): Promise<LanguageModelV2StreamPart> {
+    const chunks = fs
+      .readFileSync(`src/__fixtures__/${fixtureName}.chunks.txt`, 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => `data: ${line}\n\n`);
+
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+
+    const callIndex = server.calls.length;
+    const result = await model.doStream({
+      prompt,
+      maxOutputTokens: 1,
+    });
+    const streamParts = await convertReadableStreamToArray(result.stream);
+    const requestBody = await server.calls[callIndex].requestBodyJson;
+
+    expect(requestBody.messages[0].content[0].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+
+    const finish = streamParts.find(part => part.type === 'finish');
+    expect(finish).toBeDefined();
+
+    return finish!;
+  }
+
+  it('forwards cache control and maps cache-write metadata', async () => {
+    const finish = await replayFixture('anthropic-issue-5942-cache-write');
+
+    expect(finish.type).toBe('finish');
+    if (finish.type !== 'finish') {
+      return;
+    }
+
+    expect(
+      finish.providerMetadata?.anthropic.cacheCreationInputTokens,
+    ).toBeGreaterThan(0);
+    expect(finish.usage.cachedInputTokens ?? 0).toBe(0);
+  });
+
+  it('forwards cache control and maps cache-read metadata', async () => {
+    const finish = await replayFixture('anthropic-issue-5942-cache-read');
+
+    expect(finish.type).toBe('finish');
+    if (finish.type !== 'finish') {
+      return;
+    }
+
+    expect(finish.usage.cachedInputTokens).toBeGreaterThan(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,25 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19630,7 +19649,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19644,13 +19663,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19658,22 +19677,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19683,7 +19702,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19713,7 +19732,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24963,7 +24982,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -27396,7 +27415,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -29439,7 +29458,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30208,7 +30227,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30305,7 +30324,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33789,7 +33808,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33817,7 +33836,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34896,7 +34915,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36436,7 +36455,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -36840,7 +36859,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:
@@ -37393,7 +37412,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37830,7 +37849,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -38497,6 +38516,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -38699,7 +38727,7 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   ts-node@10.9.2(@types/node@20.17.24)(typescript@5.4.5):
     dependencies:
@@ -40029,12 +40057,44 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Bug

providerOptions not applied when using parts in messages

## Reproduction

- The reported user-visible impact is lost Anthropic prompt caching for structured messages, increasing input-token cost and latency.
- `examples/ai-functions/src/reproduction/issue-5942-anthropic-parts-cache-control.ts` forwarded `cache_control: { type: "ephemeral" }`, created 18,639 cache tokens, and read 18,639 tokens on the repeated request; the expected `0/0` failure did not occur.
- The exact reported model, `claude-3-7-sonnet-20250219`, was retired on February 19, 2026, and the narrowing request returned HTTP 404, preventing an exact-model rerun.
- The current documented structured `ModelMessage` shape uses an array in `content`; `UIMessage.parts` must be converted before use and does not directly support message-level `providerOptions`.
- Live response fixtures are recorded in `packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-write.chunks.txt` and `packages/anthropic/src/__fixtures__/anthropic-issue-5942-cache-read.chunks.txt`.
- `packages/anthropic/src/anthropic-issue-5942.test.ts` validates request forwarding and `cache-write/cache-read` metadata against the recorded responses.

## Relevant Documentation

- https://ai-sdk.dev/docs/foundations/prompts
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching
- https://platform.claude.com/docs/en/about-claude/model-deprecations

## Related Issues

Could not reproduce #5942