### PR TITLE
fix: tool-call-only assistant messages serialize with empty-string content instead of null

### DIFF
--- a/.changeset/silly-tools-call.md
+++ b/.changeset/silly-tools-call.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): send null content for tool-only assistant messages

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/openai": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts
+++ b/examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, tool } from 'ai';
 import { z } from 'zod';
 
 type OpenAIMessage = {
@@ -15,142 +15,70 @@ type OpenAIChatRequest = {
   messages?: OpenAIMessage[];
 };
 
-function createChatCompletion({
-  content,
-  finishReason,
-  toolCall,
-}: {
-  content: string;
-  finishReason: 'stop' | 'tool_calls';
-  toolCall?: {
-    id: string;
-    name: string;
-    arguments: string;
-  };
-}) {
-  return {
-    id: `chatcmpl-reproduction-${toolCall?.id ?? 'final'}`,
-    object: 'chat.completion',
-    created: 1_750_000_000,
-    model: 'qwen3-coder:latest',
-    choices: [
-      {
-        index: 0,
-        message: {
-          role: 'assistant',
-          content,
-          ...(toolCall == null
-            ? {}
-            : {
-                tool_calls: [
-                  {
-                    id: toolCall.id,
-                    type: 'function',
-                    function: {
-                      name: toolCall.name,
-                      arguments: toolCall.arguments,
-                    },
-                  },
-                ],
-              }),
-        },
-        finish_reason: finishReason,
-      },
-    ],
-    usage: {
-      prompt_tokens: 10,
-      completion_tokens: 5,
-      total_tokens: 15,
-    },
-  };
-}
-
 async function main() {
   const requests: OpenAIChatRequest[] = [];
-  const responses = [
-    createChatCompletion({
-      content: '',
-      finishReason: 'tool_calls',
-      toolCall: {
-        id: 'call_lookup',
-        name: 'lookup',
-        arguments: '{"path":"demo.txt"}',
-      },
-    }),
-    createChatCompletion({
-      content: '',
-      finishReason: 'tool_calls',
-      toolCall: {
-        id: 'call_write_file',
-        name: 'write_file',
-        arguments: '{"path":"demo.txt","content":"hello"}',
-      },
-    }),
-    createChatCompletion({
-      content: 'File created.',
-      finishReason: 'stop',
-    }),
-  ];
-
   const openai = createOpenAI({
-    baseURL: 'http://localhost:11434/v1',
-    apiKey: 'ollama',
-    fetch: async (_url, options) => {
-      if (typeof options?.body !== 'string') {
-        throw new Error('Expected the OpenAI request body to be JSON text.');
+    fetch: async (url, options) => {
+      if (typeof options?.body === 'string') {
+        requests.push(JSON.parse(options.body) as OpenAIChatRequest);
       }
 
-      requests.push(JSON.parse(options.body) as OpenAIChatRequest);
-
-      const response = responses[requests.length - 1];
-      if (response == null) {
-        throw new Error('The SDK made more than three requests.');
-      }
-
-      return new Response(JSON.stringify(response), {
-        headers: { 'content-type': 'application/json' },
-      });
+      return fetch(url, options);
     },
   });
 
   const result = await generateText({
-    model: openai.chat('qwen3-coder:latest'),
-    prompt: 'Check whether demo.txt exists, then create it.',
+    model: openai.chat('gpt-4o'),
+    messages: [
+      {
+        role: 'user',
+        content: 'Check whether demo.txt exists.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call_lookup',
+            toolName: 'lookup',
+            input: { path: 'demo.txt' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_lookup',
+            toolName: 'lookup',
+            output: {
+              type: 'json',
+              value: { path: 'demo.txt', exists: false },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'The lookup is complete. Reply exactly: File created.',
+      },
+    ],
     tools: {
       lookup: tool({
+        description: 'Check whether a file exists.',
         inputSchema: z.object({ path: z.string() }),
-        execute: async ({ path }) => ({ path, exists: false }),
-      }),
-      write_file: tool({
-        inputSchema: z.object({
-          path: z.string(),
-          content: z.string(),
-        }),
-        execute: async ({ path, content }) => ({
-          path,
-          bytesWritten: content.length,
-        }),
       }),
     },
-    stopWhen: stepCountIs(3),
+    toolChoice: 'none',
+    temperature: 0,
   });
 
-  const toolCallOnlyAssistantMessages = new Map<string, OpenAIMessage>();
-
-  for (const request of requests.slice(1)) {
-    for (const message of request.messages ?? []) {
-      const toolCallId = message.tool_calls?.[0]?.id;
-      if (message.role === 'assistant' && toolCallId != null) {
-        toolCallOnlyAssistantMessages.set(toolCallId, message);
-      }
-    }
-  }
-
-  const observed = [...toolCallOnlyAssistantMessages.values()].map(message => ({
-    content: message.content,
-    toolCallId: message.tool_calls?.[0]?.id,
-    toolName: message.tool_calls?.[0]?.function?.name,
-  }));
+  const assistantToolCallMessage = requests[0]?.messages?.find(
+    message =>
+      message.role === 'assistant' &&
+      message.tool_calls?.[0]?.id === 'call_lookup',
+  );
 
   console.log(
     JSON.stringify(
@@ -158,18 +86,18 @@ async function main() {
         requestCount: requests.length,
         finalText: result.text,
         expectedAssistantToolCallContent: null,
-        observedAssistantToolCallMessages: observed,
-        reproducesIssue12389: observed.some(message => message.content === ''),
+        observedAssistantToolCallContent: assistantToolCallMessage?.content,
+        observedToolName:
+          assistantToolCallMessage?.tool_calls?.[0]?.function?.name,
       },
       null,
       2,
     ),
   );
 
-  const invalidMessage = observed.find(message => message.content !== null);
-  if (invalidMessage != null) {
+  if (assistantToolCallMessage?.content !== null) {
     throw new Error(
-      `Expected tool-call-only assistant content to be null, received ${JSON.stringify(invalidMessage.content)}.`,
+      `Expected tool-call-only assistant content to be null, received ${JSON.stringify(assistantToolCallMessage?.content)}.`,
     );
   }
 }

--- a/examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts
+++ b/examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts
@@ -1,0 +1,180 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+type OpenAIMessage = {
+  role?: string;
+  content?: unknown;
+  tool_calls?: Array<{
+    id?: string;
+    function?: { name?: string };
+  }>;
+};
+
+type OpenAIChatRequest = {
+  messages?: OpenAIMessage[];
+};
+
+function createChatCompletion({
+  content,
+  finishReason,
+  toolCall,
+}: {
+  content: string;
+  finishReason: 'stop' | 'tool_calls';
+  toolCall?: {
+    id: string;
+    name: string;
+    arguments: string;
+  };
+}) {
+  return {
+    id: `chatcmpl-reproduction-${toolCall?.id ?? 'final'}`,
+    object: 'chat.completion',
+    created: 1_750_000_000,
+    model: 'qwen3-coder:latest',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content,
+          ...(toolCall == null
+            ? {}
+            : {
+                tool_calls: [
+                  {
+                    id: toolCall.id,
+                    type: 'function',
+                    function: {
+                      name: toolCall.name,
+                      arguments: toolCall.arguments,
+                    },
+                  },
+                ],
+              }),
+        },
+        finish_reason: finishReason,
+      },
+    ],
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    },
+  };
+}
+
+async function main() {
+  const requests: OpenAIChatRequest[] = [];
+  const responses = [
+    createChatCompletion({
+      content: '',
+      finishReason: 'tool_calls',
+      toolCall: {
+        id: 'call_lookup',
+        name: 'lookup',
+        arguments: '{"path":"demo.txt"}',
+      },
+    }),
+    createChatCompletion({
+      content: '',
+      finishReason: 'tool_calls',
+      toolCall: {
+        id: 'call_write_file',
+        name: 'write_file',
+        arguments: '{"path":"demo.txt","content":"hello"}',
+      },
+    }),
+    createChatCompletion({
+      content: 'File created.',
+      finishReason: 'stop',
+    }),
+  ];
+
+  const openai = createOpenAI({
+    baseURL: 'http://localhost:11434/v1',
+    apiKey: 'ollama',
+    fetch: async (_url, options) => {
+      if (typeof options?.body !== 'string') {
+        throw new Error('Expected the OpenAI request body to be JSON text.');
+      }
+
+      requests.push(JSON.parse(options.body) as OpenAIChatRequest);
+
+      const response = responses[requests.length - 1];
+      if (response == null) {
+        throw new Error('The SDK made more than three requests.');
+      }
+
+      return new Response(JSON.stringify(response), {
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  const result = await generateText({
+    model: openai.chat('qwen3-coder:latest'),
+    prompt: 'Check whether demo.txt exists, then create it.',
+    tools: {
+      lookup: tool({
+        inputSchema: z.object({ path: z.string() }),
+        execute: async ({ path }) => ({ path, exists: false }),
+      }),
+      write_file: tool({
+        inputSchema: z.object({
+          path: z.string(),
+          content: z.string(),
+        }),
+        execute: async ({ path, content }) => ({
+          path,
+          bytesWritten: content.length,
+        }),
+      }),
+    },
+    stopWhen: stepCountIs(3),
+  });
+
+  const toolCallOnlyAssistantMessages = new Map<string, OpenAIMessage>();
+
+  for (const request of requests.slice(1)) {
+    for (const message of request.messages ?? []) {
+      const toolCallId = message.tool_calls?.[0]?.id;
+      if (message.role === 'assistant' && toolCallId != null) {
+        toolCallOnlyAssistantMessages.set(toolCallId, message);
+      }
+    }
+  }
+
+  const observed = [...toolCallOnlyAssistantMessages.values()].map(message => ({
+    content: message.content,
+    toolCallId: message.tool_calls?.[0]?.id,
+    toolName: message.tool_calls?.[0]?.function?.name,
+  }));
+
+  console.log(
+    JSON.stringify(
+      {
+        requestCount: requests.length,
+        finalText: result.text,
+        expectedAssistantToolCallContent: null,
+        observedAssistantToolCallMessages: observed,
+        reproducesIssue12389: observed.some(message => message.content === ''),
+      },
+      null,
+      2,
+    ),
+  );
+
+  const invalidMessage = observed.find(message => message.content !== null);
+  if (invalidMessage != null) {
+    throw new Error(
+      `Expected tool-call-only assistant content to be null, received ${JSON.stringify(invalidMessage.content)}.`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -583,7 +583,7 @@ describe('tool calls', () => {
     ]);
   });
 
-  it('should stringify arguments to tool calls', () => {
+  it('should stringify arguments and use null content for tool-only assistant messages', () => {
     const result = convertToOpenAIChatMessages({
       prompt: [
         {
@@ -614,7 +614,7 @@ describe('tool calls', () => {
     expect(result.messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -259,7 +259,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: hasPromptCacheBreakpoint ? textParts : text,
+          content: hasPromptCacheBreakpoint ? textParts : text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../../packages/openai
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':


### PR DESCRIPTION
## Background

Tool-call-only assistant messages used empty-string content, which could break subsequent structured tool calls with OpenAI-compatible providers.

## Summary

Changed OpenAI chat message conversion to serialize empty assistant text content as null.

## Testing

Updated converter regression coverage to assert null content for tool-call-only assistant messages.

## End-to-end Validation

- `issue-12389-openai-tool-call-content.ts`: ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12389-openai-tool-call-content.ts` against the live OpenAI API; the request contained `content: null` and returned `File created.`.

## Related Issues

Fixes #12389

Co-authored-by: lbijeau <2281680+lbijeau@users.noreply.github.com>