### PR TITLE
feat(ai): wrap embedMany in tracing channel context

### DIFF
--- a/.changeset/hungry-balloons-appear.md
+++ b/.changeset/hungry-balloons-appear.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): wrap embedMany in tracing channel context

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -171,236 +171,248 @@ export async function embedMany({
     telemetry,
   });
 
-  await notify({
-    event: {
-      callId,
-      operationId: 'ai.embedMany',
-      provider: model.provider,
-      modelId: model.modelId,
-      value: values,
-      maxRetries,
-      headers: headersWithUserAgent,
-      providerOptions,
-    },
-    callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
-  });
+  const runInTracingChannelSpan =
+    telemetryDispatcher.runInTracingChannelSpan ??
+    (async <T>({ execute }: { execute: () => PromiseLike<T> }) =>
+      await execute());
 
-  try {
-    const [maxEmbeddingsPerCall, supportsParallelCalls] = await Promise.all([
-      model.maxEmbeddingsPerCall,
-      model.supportsParallelCalls,
-    ]);
+  const startEvent = {
+    callId,
+    operationId: 'ai.embedMany',
+    provider: model.provider,
+    modelId: model.modelId,
+    value: values,
+    maxRetries,
+    headers: headersWithUserAgent,
+    providerOptions,
+  };
 
-    if (maxEmbeddingsPerCall == null || maxEmbeddingsPerCall === Infinity) {
-      const { embeddings, usage, warnings, response, providerMetadata } =
-        await retry(async () => {
-          const embedCallId = generateCallId();
+  return await runInTracingChannelSpan({
+    type: 'embedMany',
+    event: startEvent,
+    execute: async () => {
+      await notify({
+        event: startEvent,
+        callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
+      });
+
+      try {
+        const [maxEmbeddingsPerCall, supportsParallelCalls] = await Promise.all(
+          [model.maxEmbeddingsPerCall, model.supportsParallelCalls],
+        );
+
+        if (maxEmbeddingsPerCall == null || maxEmbeddingsPerCall === Infinity) {
+          const { embeddings, usage, warnings, response, providerMetadata } =
+            await retry(async () => {
+              const embedCallId = generateCallId();
+
+              await notify({
+                event: {
+                  callId,
+                  embedCallId,
+                  operationId: 'ai.embedMany.doEmbed',
+                  provider: model.provider,
+                  modelId: model.modelId,
+                  values,
+                },
+                callbacks: [telemetryDispatcher.onEmbedStart],
+              });
+
+              const modelResponse = await model.doEmbed({
+                values,
+                abortSignal,
+                headers: headersWithUserAgent,
+                providerOptions,
+              });
+
+              const embeddings = modelResponse.embeddings;
+              const usage = modelResponse.usage ?? { tokens: NaN };
+
+              await notify({
+                event: {
+                  callId,
+                  embedCallId,
+                  operationId: 'ai.embedMany.doEmbed',
+                  provider: model.provider,
+                  modelId: model.modelId,
+                  values,
+                  embeddings,
+                  usage,
+                },
+                callbacks: [telemetryDispatcher.onEmbedEnd],
+              });
+
+              return {
+                embeddings,
+                usage,
+                warnings: modelResponse.warnings ?? [],
+                providerMetadata: modelResponse.providerMetadata,
+                response: modelResponse.response,
+              };
+            });
+
+          logWarnings({
+            warnings,
+            provider: model.provider,
+            model: model.modelId,
+          });
 
           await notify({
             event: {
               callId,
-              embedCallId,
-              operationId: 'ai.embedMany.doEmbed',
+              operationId: 'ai.embedMany',
               provider: model.provider,
               modelId: model.modelId,
-              values,
-            },
-            callbacks: [telemetryDispatcher.onEmbedStart],
-          });
-
-          const modelResponse = await model.doEmbed({
-            values,
-            abortSignal,
-            headers: headersWithUserAgent,
-            providerOptions,
-          });
-
-          const embeddings = modelResponse.embeddings;
-          const usage = modelResponse.usage ?? { tokens: NaN };
-
-          await notify({
-            event: {
-              callId,
-              embedCallId,
-              operationId: 'ai.embedMany.doEmbed',
-              provider: model.provider,
-              modelId: model.modelId,
-              values,
-              embeddings,
+              value: values,
+              embedding: embeddings,
               usage,
+              warnings,
+              providerMetadata,
+              response: [response],
             },
-            callbacks: [telemetryDispatcher.onEmbedEnd],
+            callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
           });
 
-          return {
+          return new DefaultEmbedManyResult({
+            values,
             embeddings,
             usage,
-            warnings: modelResponse.warnings ?? [],
-            providerMetadata: modelResponse.providerMetadata,
-            response: modelResponse.response,
-          };
-        });
-
-      logWarnings({
-        warnings,
-        provider: model.provider,
-        model: model.modelId,
-      });
-
-      await notify({
-        event: {
-          callId,
-          operationId: 'ai.embedMany',
-          provider: model.provider,
-          modelId: model.modelId,
-          value: values,
-          embedding: embeddings,
-          usage,
-          warnings,
-          providerMetadata,
-          response: [response],
-        },
-        callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
-      });
-
-      return new DefaultEmbedManyResult({
-        values,
-        embeddings,
-        usage,
-        warnings,
-        providerMetadata,
-        responses: [response],
-      });
-    }
-
-    const valueChunks = splitArray(values, maxEmbeddingsPerCall);
-
-    const embeddings: Array<Embedding> = [];
-    const warnings: Array<Warning> = [];
-    const responses: Array<
-      | {
-          headers?: Record<string, string>;
-          body?: unknown;
-        }
-      | undefined
-    > = [];
-    let tokens = 0;
-    let providerMetadata: ProviderMetadata | undefined;
-
-    const parallelChunks = splitArray(
-      valueChunks,
-      supportsParallelCalls ? maxParallelCalls : 1,
-    );
-
-    for (const parallelChunk of parallelChunks) {
-      const results = await Promise.all(
-        parallelChunk.map(chunk => {
-          return retry(async () => {
-            const embedCallId = generateCallId();
-
-            await notify({
-              event: {
-                callId,
-                embedCallId,
-                operationId: 'ai.embedMany.doEmbed',
-                provider: model.provider,
-                modelId: model.modelId,
-                values: chunk,
-              },
-              callbacks: [telemetryDispatcher.onEmbedStart],
-            });
-
-            const modelResponse = await model.doEmbed({
-              values: chunk,
-              abortSignal,
-              headers: headersWithUserAgent,
-              providerOptions,
-            });
-
-            const chunkEmbeddings = modelResponse.embeddings;
-            const usage = modelResponse.usage ?? { tokens: NaN };
-
-            await notify({
-              event: {
-                callId,
-                embedCallId,
-                operationId: 'ai.embedMany.doEmbed',
-                provider: model.provider,
-                modelId: model.modelId,
-                values: chunk,
-                embeddings: chunkEmbeddings,
-                usage,
-              },
-              callbacks: [telemetryDispatcher.onEmbedEnd],
-            });
-
-            return {
-              embeddings: chunkEmbeddings,
-              usage,
-              warnings: modelResponse.warnings ?? [],
-              providerMetadata: modelResponse.providerMetadata,
-              response: modelResponse.response,
-            };
+            warnings,
+            providerMetadata,
+            responses: [response],
           });
-        }),
-      );
+        }
 
-      for (const result of results) {
-        embeddings.push(...result.embeddings);
-        warnings.push(...result.warnings);
-        responses.push(result.response);
-        tokens += result.usage.tokens;
-        if (result.providerMetadata) {
-          if (!providerMetadata) {
-            providerMetadata = { ...result.providerMetadata };
-          } else {
-            for (const [providerName, metadata] of Object.entries(
-              result.providerMetadata,
-            )) {
-              providerMetadata[providerName] = {
-                ...(providerMetadata[providerName] ?? {}),
-                ...metadata,
-              };
+        const valueChunks = splitArray(values, maxEmbeddingsPerCall);
+
+        const embeddings: Array<Embedding> = [];
+        const warnings: Array<Warning> = [];
+        const responses: Array<
+          | {
+              headers?: Record<string, string>;
+              body?: unknown;
+            }
+          | undefined
+        > = [];
+        let tokens = 0;
+        let providerMetadata: ProviderMetadata | undefined;
+
+        const parallelChunks = splitArray(
+          valueChunks,
+          supportsParallelCalls ? maxParallelCalls : 1,
+        );
+
+        for (const parallelChunk of parallelChunks) {
+          const results = await Promise.all(
+            parallelChunk.map(chunk => {
+              return retry(async () => {
+                const embedCallId = generateCallId();
+
+                await notify({
+                  event: {
+                    callId,
+                    embedCallId,
+                    operationId: 'ai.embedMany.doEmbed',
+                    provider: model.provider,
+                    modelId: model.modelId,
+                    values: chunk,
+                  },
+                  callbacks: [telemetryDispatcher.onEmbedStart],
+                });
+
+                const modelResponse = await model.doEmbed({
+                  values: chunk,
+                  abortSignal,
+                  headers: headersWithUserAgent,
+                  providerOptions,
+                });
+
+                const chunkEmbeddings = modelResponse.embeddings;
+                const usage = modelResponse.usage ?? { tokens: NaN };
+
+                await notify({
+                  event: {
+                    callId,
+                    embedCallId,
+                    operationId: 'ai.embedMany.doEmbed',
+                    provider: model.provider,
+                    modelId: model.modelId,
+                    values: chunk,
+                    embeddings: chunkEmbeddings,
+                    usage,
+                  },
+                  callbacks: [telemetryDispatcher.onEmbedEnd],
+                });
+
+                return {
+                  embeddings: chunkEmbeddings,
+                  usage,
+                  warnings: modelResponse.warnings ?? [],
+                  providerMetadata: modelResponse.providerMetadata,
+                  response: modelResponse.response,
+                };
+              });
+            }),
+          );
+
+          for (const result of results) {
+            embeddings.push(...result.embeddings);
+            warnings.push(...result.warnings);
+            responses.push(result.response);
+            tokens += result.usage.tokens;
+            if (result.providerMetadata) {
+              if (!providerMetadata) {
+                providerMetadata = { ...result.providerMetadata };
+              } else {
+                for (const [providerName, metadata] of Object.entries(
+                  result.providerMetadata,
+                )) {
+                  providerMetadata[providerName] = {
+                    ...(providerMetadata[providerName] ?? {}),
+                    ...metadata,
+                  };
+                }
+              }
             }
           }
         }
+
+        logWarnings({
+          warnings,
+          provider: model.provider,
+          model: model.modelId,
+        });
+
+        await notify({
+          event: {
+            callId,
+            operationId: 'ai.embedMany',
+            provider: model.provider,
+            modelId: model.modelId,
+            value: values,
+            embedding: embeddings,
+            usage: { tokens },
+            warnings,
+            providerMetadata,
+            response: responses,
+          },
+          callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
+        });
+
+        return new DefaultEmbedManyResult({
+          values,
+          embeddings,
+          usage: { tokens },
+          warnings,
+          providerMetadata: providerMetadata,
+          responses,
+        });
+      } catch (error) {
+        await telemetryDispatcher.onError?.({ callId, error });
+        throw error;
       }
-    }
-
-    logWarnings({
-      warnings,
-      provider: model.provider,
-      model: model.modelId,
-    });
-
-    await notify({
-      event: {
-        callId,
-        operationId: 'ai.embedMany',
-        provider: model.provider,
-        modelId: model.modelId,
-        value: values,
-        embedding: embeddings,
-        usage: { tokens },
-        warnings,
-        providerMetadata,
-        response: responses,
-      },
-      callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
-    });
-
-    return new DefaultEmbedManyResult({
-      values,
-      embeddings,
-      usage: { tokens },
-      warnings,
-      providerMetadata: providerMetadata,
-      responses,
-    });
-  } catch (error) {
-    await telemetryDispatcher.onError?.({ callId, error });
-    throw error;
-  }
+    },
+  });
 }
 
 class DefaultEmbedManyResult implements EmbedManyResult {

--- a/packages/ai/src/telemetry/tracing-channel.test.ts
+++ b/packages/ai/src/telemetry/tracing-channel.test.ts
@@ -5,6 +5,7 @@ import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { embed } from '../embed/embed';
+import { embedMany } from '../embed/embed-many';
 import { generateText } from '../generate-text';
 import { streamText } from '../generate-text/stream-text';
 import { isStepCount } from '../generate-text/stop-condition';
@@ -583,6 +584,36 @@ describe.runIf(isNodeRuntime())('telemetry tracing channel publisher', () => {
     `);
   });
 
+  it('traces the current embedMany lifecycle sequence', async () => {
+    const sequence = await collectTracingChannelEventSequence(async () => {
+      await embedMany({
+        model: new MockEmbeddingModelV4({
+          maxEmbeddingsPerCall: 2,
+          doEmbed: async ({ values }) => ({
+            embeddings: values.map(() => [0.1, 0.2, 0.3]),
+            usage: { tokens: 10 },
+            warnings: [],
+          }),
+        }),
+        values: [
+          'sunny day at the beach',
+          'rainy day in the city',
+          'cloudy day in the mountains',
+        ],
+        telemetry: {
+          functionId: 'tracing-channel-embed-many-test',
+        },
+      });
+    });
+
+    expect(sequence).toMatchInlineSnapshot(`
+      [
+        "bindStart embedMany",
+        "asyncEnd embedMany",
+      ]
+    `);
+  });
+
   it('traces the current rerank lifecycle sequence', async () => {
     const sequence = await collectTracingChannelEventSequence(async () => {
       await rerank({
@@ -639,6 +670,47 @@ describe.runIf(isNodeRuntime())('telemetry tracing channel publisher', () => {
       embedding: [0.1, 0.2, 0.3],
       usage: { tokens: 10 },
       warnings: [],
+    });
+  });
+
+  it('publishes the embedMany result on asyncEnd', async () => {
+    const messages = await collectTracingChannelAsyncEndMessages(async () => {
+      await embedMany({
+        model: new MockEmbeddingModelV4({
+          maxEmbeddingsPerCall: 2,
+          doEmbed: async ({ values }) => ({
+            embeddings: values.map(() => [0.1, 0.2, 0.3]),
+            usage: { tokens: 10 },
+            warnings: [],
+          }),
+        }),
+        values: [
+          'sunny day at the beach',
+          'rainy day in the city',
+          'cloudy day in the mountains',
+        ],
+        telemetry: {
+          functionId: 'tracing-channel-embed-many-result-test',
+        },
+      });
+    });
+
+    const embedManyMessage = messages.find(
+      message => message.type === 'embedMany',
+    );
+
+    expect(embedManyMessage?.result).toMatchObject({
+      values: [
+        'sunny day at the beach',
+        'rainy day in the city',
+        'cloudy day in the mountains',
+      ],
+      embeddings: [
+        [0.1, 0.2, 0.3],
+        [0.1, 0.2, 0.3],
+        [0.1, 0.2, 0.3],
+      ],
+      usage: { tokens: 20 },
     });
   });
 

--- a/packages/ai/src/telemetry/tracing-channel.ts
+++ b/packages/ai/src/telemetry/tracing-channel.ts
@@ -7,6 +7,7 @@ export type TelemetryTracingEventType =
   | 'languageModelCall'
   | 'executeTool'
   | 'embed'
+  | 'embedMany'
   | 'rerank';
 
 export type TelemetryTracingChannelMessage<EVENT = unknown> = {


### PR DESCRIPTION
## Background

embedMany did not use `runInTracingChannelSpan` at all so no tracing channel span was created for it, even though it fires the regular telemetry callbacks.

## Summary

embedMany body wrapped in runInTracingChannelSpan + tests added

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #17154