### PR TITLE
fix: reject empty OpenAI, Anthropic, and Replicate base URLs with a helpful error

### DIFF
--- a/.changeset/tidy-ravens-check.md
+++ b/.changeset/tidy-ravens-check.md
@@ -5,4 +5,5 @@
 '@ai-sdk/replicate': patch
 ---
 
-Reject empty provider base URLs with a helpful AI SDK invalid argument error.
+Reject empty OpenAI, Anthropic, and Replicate base URLs with a helpful AI SDK
+invalid argument error.

--- a/.changeset/tidy-ravens-check.md
+++ b/.changeset/tidy-ravens-check.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/replicate': patch
+---
+
+Reject empty provider base URLs with a helpful AI SDK invalid argument error.

--- a/examples/ai-functions/src/reproduction/issue-17156-empty-base-url.ts
+++ b/examples/ai-functions/src/reproduction/issue-17156-empty-base-url.ts
@@ -121,15 +121,6 @@ async function main() {
   });
 
   const primaryResults = [explicitOpenAI, environmentOpenAI];
-  const output = {
-    expected:
-      'OpenAI provider creation rejects an empty baseURL with a helpful AI SDK error mentioning the invalid base URL.',
-    primaryResults,
-    secondaryOtherProviderCheck: explicitAnthropic,
-  };
-
-  console.log(JSON.stringify(output, null, 2));
-
   const primaryFailures = primaryResults.filter(
     result => !isHelpfulBaseURLError(result),
   );
@@ -144,6 +135,28 @@ async function main() {
         .join('; ')}`,
     );
   }
+
+  if (!isHelpfulBaseURLError(explicitAnthropic)) {
+    throw new Error(
+      `Other provider check failed: ${explicitAnthropic.scenario} failed during ${explicitAnthropic.failurePhase} with ${explicitAnthropic.error?.name}: ${explicitAnthropic.error?.message}`,
+    );
+  }
+
+  const liveResult = await generateText({
+    model: createOpenAI()('gpt-4o-mini'),
+    prompt: 'Reply with exactly: empty base URL validation works',
+    maxOutputTokens: 20,
+  });
+
+  const output = {
+    expected:
+      'OpenAI provider creation rejects an empty baseURL with a helpful AI SDK error mentioning the invalid base URL.',
+    primaryResults,
+    secondaryOtherProviderCheck: explicitAnthropic,
+    liveOpenAIResponse: liveResult.text,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
 }
 
 main().catch(error => {

--- a/examples/ai-functions/src/reproduction/issue-17156-empty-base-url.ts
+++ b/examples/ai-functions/src/reproduction/issue-17156-empty-base-url.ts
@@ -1,0 +1,152 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { AISDKError, type LanguageModelV4 } from '@ai-sdk/provider';
+import { generateText } from 'ai';
+
+type ErrorDetails = {
+  name: string;
+  message: string;
+  isAISDKError: boolean;
+  cause?: {
+    name: string;
+    message: string;
+  };
+};
+
+type ScenarioResult = {
+  scenario: string;
+  failurePhase: 'factory' | 'request' | 'none';
+  error?: ErrorDetails;
+};
+
+function getErrorDetails(error: unknown): ErrorDetails {
+  const cause =
+    error instanceof Error && error.cause instanceof Error
+      ? {
+          name: error.cause.name,
+          message: error.cause.message,
+        }
+      : undefined;
+
+  return {
+    name: error instanceof Error ? error.name : typeof error,
+    message: error instanceof Error ? error.message : String(error),
+    isAISDKError: AISDKError.isInstance(error),
+    cause,
+  };
+}
+
+async function runScenario({
+  scenario,
+  createModel,
+}: {
+  scenario: string;
+  createModel: () => LanguageModelV4;
+}): Promise<ScenarioResult> {
+  let model: LanguageModelV4;
+
+  try {
+    model = createModel();
+  } catch (error) {
+    return {
+      scenario,
+      failurePhase: 'factory',
+      error: getErrorDetails(error),
+    };
+  }
+
+  try {
+    await generateText({
+      model,
+      prompt: 'Hello',
+      maxRetries: 0,
+    });
+
+    return { scenario, failurePhase: 'none' };
+  } catch (error) {
+    return {
+      scenario,
+      failurePhase: 'request',
+      error: getErrorDetails(error),
+    };
+  }
+}
+
+function isHelpfulBaseURLError(result: ScenarioResult): boolean {
+  return (
+    result.failurePhase === 'factory' &&
+    result.error?.isAISDKError === true &&
+    /base.?url/i.test(result.error.message) &&
+    /(empty|non-empty|invalid|required)/i.test(result.error.message)
+  );
+}
+
+async function main() {
+  const explicitOpenAI = await runScenario({
+    scenario: 'createOpenAI({ baseURL: "" })',
+    createModel: () =>
+      createOpenAI({
+        baseURL: '',
+        apiKey: 'test-api-key',
+      })('gpt-4o-mini'),
+  });
+
+  const originalOpenAIBaseURL = process.env.OPENAI_BASE_URL;
+  let environmentOpenAI: ScenarioResult;
+
+  try {
+    process.env.OPENAI_BASE_URL = '';
+    environmentOpenAI = await runScenario({
+      scenario: 'OPENAI_BASE_URL=""',
+      createModel: () =>
+        createOpenAI({
+          apiKey: 'test-api-key',
+        })('gpt-4o-mini'),
+    });
+  } finally {
+    if (originalOpenAIBaseURL == null) {
+      delete process.env.OPENAI_BASE_URL;
+    } else {
+      process.env.OPENAI_BASE_URL = originalOpenAIBaseURL;
+    }
+  }
+
+  const explicitAnthropic = await runScenario({
+    scenario: 'createAnthropic({ baseURL: "" })',
+    createModel: () =>
+      createAnthropic({
+        baseURL: '',
+        apiKey: 'test-api-key',
+      })('claude-sonnet-4-20250514'),
+  });
+
+  const primaryResults = [explicitOpenAI, environmentOpenAI];
+  const output = {
+    expected:
+      'OpenAI provider creation rejects an empty baseURL with a helpful AI SDK error mentioning the invalid base URL.',
+    primaryResults,
+    secondaryOtherProviderCheck: explicitAnthropic,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  const primaryFailures = primaryResults.filter(
+    result => !isHelpfulBaseURLError(result),
+  );
+
+  if (primaryFailures.length > 0) {
+    throw new Error(
+      `Reproduced issue #17156: ${primaryFailures
+        .map(
+          result =>
+            `${result.scenario} failed during ${result.failurePhase} with ${result.error?.name}: ${result.error?.message}`,
+        )
+        .join('; ')}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import {
+  InvalidArgumentError,
+  type LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
 import { createAnthropic } from './anthropic-provider';
 
 vi.mock('./version', () => ({
@@ -135,6 +138,24 @@ describe('createAnthropic', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [requestUrl] = fetchMock.mock.calls[0]!;
       expect(requestUrl).toBe('https://option.anthropic.example/v1/messages');
+    });
+
+    it('rejects an empty baseURL option during provider creation', () => {
+      try {
+        createAnthropic({
+          apiKey: 'test-api-key',
+          baseURL: '',
+        });
+      } catch (error) {
+        expect(InvalidArgumentError.isInstance(error)).toBe(true);
+        expect(error).toMatchObject({
+          argument: 'baseURL',
+          message: 'baseURL must be a non-empty string.',
+        });
+        return;
+      }
+
+      throw new Error('Expected createAnthropic to reject an empty base URL.');
     });
   });
 });

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -10,6 +10,7 @@ import {
   generateId,
   loadApiKey,
   loadOptionalSetting,
+  validateBaseURL,
   withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
@@ -25,7 +26,9 @@ const ANTHROPIC_API_URL = 'https://api.anthropic.com';
 const ANTHROPIC_API_VERSIONED_URL = `${ANTHROPIC_API_URL}/v1`;
 
 function normalizeBaseURL(baseURL: string | undefined): string | undefined {
-  const baseURLWithoutTrailingSlash = withoutTrailingSlash(baseURL);
+  const baseURLWithoutTrailingSlash = withoutTrailingSlash(
+    validateBaseURL(baseURL),
+  );
 
   return baseURLWithoutTrailingSlash === ANTHROPIC_API_URL
     ? ANTHROPIC_API_VERSIONED_URL

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createGoogleVertexMaas } from './google-vertex-maas-provider';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
 
 // Mock the imported modules
 vi.mock('@ai-sdk/openai-compatible', () => ({
@@ -17,21 +18,22 @@ vi.mock('@ai-sdk/openai-compatible', () => ({
   }),
 }));
 
-vi.mock('@ai-sdk/provider-utils', () => ({
-  loadSetting: vi.fn().mockImplementation(({ settingValue }) => {
-    if (settingValue === undefined) {
-      throw new Error('Setting is missing');
-    }
-    return settingValue;
-  }),
-  loadOptionalSetting: vi
-    .fn()
-    .mockImplementation(({ settingValue }) => settingValue),
-  withoutTrailingSlash: vi.fn().mockImplementation(url => {
-    if (!url) return '';
-    return url?.endsWith('/') ? url.slice(0, -1) : url;
-  }),
-}));
+vi.mock('@ai-sdk/provider-utils', async importOriginal => {
+  const actual = await importOriginal<typeof ProviderUtilsModule>();
+
+  return {
+    ...actual,
+    loadSetting: vi.fn().mockImplementation(({ settingValue }) => {
+      if (settingValue === undefined) {
+        throw new Error('Setting is missing');
+      }
+      return settingValue;
+    }),
+    loadOptionalSetting: vi
+      .fn()
+      .mockImplementation(({ settingValue }) => settingValue),
+  };
+});
 
 describe('google-vertex-maas-provider', () => {
   beforeEach(() => {

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider.test.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider.test.ts
@@ -1,5 +1,6 @@
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createGoogleVertexXai } from './google-vertex-xai-provider';
 
@@ -13,21 +14,22 @@ vi.mock('@ai-sdk/openai-compatible', () => ({
   }),
 }));
 
-vi.mock('@ai-sdk/provider-utils', () => ({
-  loadSetting: vi.fn().mockImplementation(({ settingValue }) => {
-    if (settingValue === undefined) {
-      throw new Error('Setting is missing');
-    }
-    return settingValue;
-  }),
-  loadOptionalSetting: vi
-    .fn()
-    .mockImplementation(({ settingValue }) => settingValue),
-  withoutTrailingSlash: vi.fn().mockImplementation(url => {
-    if (!url) return '';
-    return url?.endsWith('/') ? url.slice(0, -1) : url;
-  }),
-}));
+vi.mock('@ai-sdk/provider-utils', async importOriginal => {
+  const actual = await importOriginal<typeof ProviderUtilsModule>();
+
+  return {
+    ...actual,
+    loadSetting: vi.fn().mockImplementation(({ settingValue }) => {
+      if (settingValue === undefined) {
+        throw new Error('Setting is missing');
+      }
+      return settingValue;
+    }),
+    loadOptionalSetting: vi
+      .fn()
+      .mockImplementation(({ settingValue }) => settingValue),
+  };
+});
 
 describe('google-vertex-xai-provider', () => {
   beforeEach(() => {
@@ -64,6 +66,23 @@ describe('google-vertex-xai-provider', () => {
           "transformRequestBody": [Function],
         }
       `);
+  });
+
+  it('should construct the default base URL when baseURL is an empty string', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+      baseURL: '',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    expect(vi.mocked(createOpenAICompatible)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi',
+      }),
+    );
   });
 
   it('should create a provider with correct base URL for regional location', () => {

--- a/packages/openai/src/openai-provider.test.ts
+++ b/packages/openai/src/openai-provider.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InvalidArgumentError } from '@ai-sdk/provider';
 import { createOpenAI } from './openai-provider';
 
 vi.mock('./version', () => ({
@@ -93,6 +94,38 @@ describe('createOpenAI', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const call = fetchMock.mock.calls[0]!;
       expect(call[0]).toBe('https://option.openai.example/v1/embeddings');
+    });
+
+    it('rejects an empty baseURL option during provider creation', () => {
+      expect(() =>
+        createOpenAI({
+          apiKey: 'test-api-key',
+          baseURL: '',
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          name: 'AI_InvalidArgumentError',
+          argument: 'baseURL',
+          message: 'baseURL must be a non-empty string.',
+        }),
+      );
+    });
+
+    it('rejects an empty OPENAI_BASE_URL during provider creation', () => {
+      process.env.OPENAI_BASE_URL = '';
+
+      try {
+        createOpenAI({ apiKey: 'test-api-key' });
+      } catch (error) {
+        expect(InvalidArgumentError.isInstance(error)).toBe(true);
+        expect(error).toMatchObject({
+          argument: 'baseURL',
+          message: 'baseURL must be a non-empty string.',
+        });
+        return;
+      }
+
+      throw new Error('Expected createOpenAI to reject an empty base URL.');
     });
 
     it('uses the Responses API for the default language model', async () => {

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -13,6 +13,7 @@ import type {
 import {
   loadApiKey,
   loadOptionalSetting,
+  validateBaseURL,
   withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
@@ -175,10 +176,12 @@ export function createOpenAI(
 ): OpenAIProvider {
   const baseURL =
     withoutTrailingSlash(
-      loadOptionalSetting({
-        settingValue: options.baseURL,
-        environmentVariableName: 'OPENAI_BASE_URL',
-      }),
+      validateBaseURL(
+        loadOptionalSetting({
+          settingValue: options.baseURL,
+          environmentVariableName: 'OPENAI_BASE_URL',
+        }),
+      ),
     ) ?? 'https://api.openai.com/v1';
 
   const providerName = options.name ?? 'openai';

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -92,6 +92,7 @@ export {
 } from './streaming-tool-call-tracker';
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
+export { validateBaseURL } from './validate-base-url';
 export { validateDownloadUrl } from './validate-download-url';
 export * from './validate-types';
 export { VERSION } from './version';

--- a/packages/provider-utils/src/validate-base-url.test.ts
+++ b/packages/provider-utils/src/validate-base-url.test.ts
@@ -1,0 +1,34 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { validateBaseURL } from './validate-base-url';
+
+describe('validateBaseURL', () => {
+  it('returns a valid baseURL', () => {
+    expect(validateBaseURL('https://example.com/')).toBe(
+      'https://example.com/',
+    );
+  });
+
+  it('returns undefined when the baseURL is undefined', () => {
+    expect(validateBaseURL(undefined)).toBeUndefined();
+  });
+
+  it.each(['', '   '])(
+    'throws an InvalidArgumentError for an empty baseURL',
+    baseURL => {
+      expect(() => validateBaseURL(baseURL)).toThrow(
+        expect.objectContaining({
+          name: 'AI_InvalidArgumentError',
+          argument: 'baseURL',
+          message: 'baseURL must be a non-empty string.',
+        }),
+      );
+
+      try {
+        validateBaseURL(baseURL);
+      } catch (error) {
+        expect(InvalidArgumentError.isInstance(error)).toBe(true);
+      }
+    },
+  );
+});

--- a/packages/provider-utils/src/validate-base-url.ts
+++ b/packages/provider-utils/src/validate-base-url.ts
@@ -1,0 +1,12 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
+
+export function validateBaseURL(baseURL: string | undefined) {
+  if (baseURL?.trim() === '') {
+    throw new InvalidArgumentError({
+      argument: 'baseURL',
+      message: 'baseURL must be a non-empty string.',
+    });
+  }
+
+  return baseURL;
+}

--- a/packages/provider-utils/src/without-trailing-slash.test.ts
+++ b/packages/provider-utils/src/without-trailing-slash.test.ts
@@ -1,0 +1,34 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { withoutTrailingSlash } from './without-trailing-slash';
+
+describe('withoutTrailingSlash', () => {
+  it('removes a trailing slash', () => {
+    expect(withoutTrailingSlash('https://example.com/')).toBe(
+      'https://example.com',
+    );
+  });
+
+  it('returns undefined when the URL is undefined', () => {
+    expect(withoutTrailingSlash(undefined)).toBeUndefined();
+  });
+
+  it.each(['', '   '])(
+    'throws an InvalidArgumentError for an empty baseURL',
+    baseURL => {
+      expect(() => withoutTrailingSlash(baseURL)).toThrow(
+        expect.objectContaining({
+          name: 'AI_InvalidArgumentError',
+          argument: 'baseURL',
+          message: 'baseURL must be a non-empty string.',
+        }),
+      );
+
+      try {
+        withoutTrailingSlash(baseURL);
+      } catch (error) {
+        expect(InvalidArgumentError.isInstance(error)).toBe(true);
+      }
+    },
+  );
+});

--- a/packages/provider-utils/src/without-trailing-slash.test.ts
+++ b/packages/provider-utils/src/without-trailing-slash.test.ts
@@ -1,4 +1,3 @@
-import { InvalidArgumentError } from '@ai-sdk/provider';
 import { describe, expect, it } from 'vitest';
 import { withoutTrailingSlash } from './without-trailing-slash';
 
@@ -13,22 +12,7 @@ describe('withoutTrailingSlash', () => {
     expect(withoutTrailingSlash(undefined)).toBeUndefined();
   });
 
-  it.each(['', '   '])(
-    'throws an InvalidArgumentError for an empty baseURL',
-    baseURL => {
-      expect(() => withoutTrailingSlash(baseURL)).toThrow(
-        expect.objectContaining({
-          name: 'AI_InvalidArgumentError',
-          argument: 'baseURL',
-          message: 'baseURL must be a non-empty string.',
-        }),
-      );
-
-      try {
-        withoutTrailingSlash(baseURL);
-      } catch (error) {
-        expect(InvalidArgumentError.isInstance(error)).toBe(true);
-      }
-    },
-  );
+  it('preserves an empty string', () => {
+    expect(withoutTrailingSlash('')).toBe('');
+  });
 });

--- a/packages/provider-utils/src/without-trailing-slash.ts
+++ b/packages/provider-utils/src/without-trailing-slash.ts
@@ -1,3 +1,12 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
+
 export function withoutTrailingSlash(url: string | undefined) {
+  if (url?.trim() === '') {
+    throw new InvalidArgumentError({
+      argument: 'baseURL',
+      message: 'baseURL must be a non-empty string.',
+    });
+  }
+
   return url?.replace(/\/$/, '');
 }

--- a/packages/provider-utils/src/without-trailing-slash.ts
+++ b/packages/provider-utils/src/without-trailing-slash.ts
@@ -1,12 +1,3 @@
-import { InvalidArgumentError } from '@ai-sdk/provider';
-
 export function withoutTrailingSlash(url: string | undefined) {
-  if (url?.trim() === '') {
-    throw new InvalidArgumentError({
-      argument: 'baseURL',
-      message: 'baseURL must be a non-empty string.',
-    });
-  }
-
   return url?.replace(/\/$/, '');
 }

--- a/packages/replicate/src/replicate-provider.test.ts
+++ b/packages/replicate/src/replicate-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { InvalidArgumentError } from '@ai-sdk/provider';
 import { createReplicate } from './replicate-provider';
 import { ReplicateImageModel } from './replicate-image-model';
 import { ReplicateVideoModel } from './replicate-video-model';
@@ -19,6 +20,24 @@ describe('createReplicate', () => {
       baseURL: 'https://custom.replicate.com',
     });
     expect(provider.image).toBeDefined();
+  });
+
+  it('rejects an empty baseURL during provider creation', () => {
+    try {
+      createReplicate({
+        apiToken: 'test-token',
+        baseURL: '',
+      });
+    } catch (error) {
+      expect(InvalidArgumentError.isInstance(error)).toBe(true);
+      expect(error).toMatchObject({
+        argument: 'baseURL',
+        message: 'baseURL must be a non-empty string.',
+      });
+      return;
+    }
+
+    throw new Error('Expected createReplicate to reject an empty base URL.');
   });
 
   it('creates an image model instance', () => {

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   loadApiKey,
+  validateBaseURL,
   withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
@@ -74,7 +75,8 @@ export function createReplicate(
   options: ReplicateProviderSettings = {},
 ): ReplicateProvider {
   const baseURL =
-    withoutTrailingSlash(options.baseURL) ?? 'https://api.replicate.com/v1';
+    withoutTrailingSlash(validateBaseURL(options.baseURL)) ??
+    'https://api.replicate.com/v1';
 
   const getHeaders = () =>
     withUserAgentSuffix(

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   loadApiKey,
+  withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
@@ -72,6 +73,9 @@ export interface ReplicateProvider extends ProviderV4 {
 export function createReplicate(
   options: ReplicateProviderSettings = {},
 ): ReplicateProvider {
+  const baseURL =
+    withoutTrailingSlash(options.baseURL) ?? 'https://api.replicate.com/v1';
+
   const getHeaders = () =>
     withUserAgentSuffix(
       {
@@ -88,7 +92,7 @@ export function createReplicate(
   const createImageModel = (modelId: ReplicateImageModelId) =>
     new ReplicateImageModel(modelId, {
       provider: 'replicate',
-      baseURL: options.baseURL ?? 'https://api.replicate.com/v1',
+      baseURL,
       headers: getHeaders(),
       fetch: options.fetch,
     });
@@ -96,7 +100,7 @@ export function createReplicate(
   const createVideoModel = (modelId: ReplicateVideoModelId) =>
     new ReplicateVideoModel(modelId, {
       provider: 'replicate.video',
-      baseURL: options.baseURL ?? 'https://api.replicate.com/v1',
+      baseURL,
       headers: getHeaders,
       fetch: options.fetch,
     });


### PR DESCRIPTION
## Background

Empty base URL configuration previously allowed provider creation and later produced opaque request-time URL parsing errors, including when OPENAI_BASE_URL was empty.

## Summary

Added a shared validateBaseURL helper that throws InvalidArgumentError for empty or whitespace-only values and applied it during OpenAI, Anthropic, and Replicate provider creation without changing the semantics of withoutTrailingSlash or Google Vertex default URL construction.

## Testing

Added utility tests for validation and URL normalization, provider regressions for explicit OpenAI, OPENAI_BASE_URL, Anthropic, and Replicate configurations, and Google Vertex xAI and MaaS coverage using the real shared URL utility for omitted and empty defaults.

## End-to-end Validation

- `issue-17156-empty-base-url.ts` — ran `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17156-empty-base-url.ts`; all invalid configurations produced helpful factory-time AI SDK errors and the live OpenAI call returned the expected text.

## Related Issues

Fixes #17156

Co-authored-by: gr2m <39992+gr2m@users.noreply.github.com>