### PR TITLE
fix(provider-utils): exempt the developer-configured origin from URL validation

### DIFF
--- a/.changeset/hard-donkeys-hunt.md
+++ b/.changeset/hard-donkeys-hunt.md
@@ -22,4 +22,6 @@ fix(provider-utils): validate provider-response URLs in `getFromApi` and make th
 
 A new optional `credentialedOrigin` withholds caller headers unless the URL is same-origin with it, so the API key is not sent to a response-supplied host on a different origin.
 
+A new optional `trustedOrigin` exempts URLs (and redirect hops) that are same-origin with the developer-configured provider endpoint from target validation, so self-hosted and localhost deployments whose response URLs point back at the configured host keep working; all other hops are still validated.
+
 Also closes range gaps in `validateDownloadUrl` (IPv4 `224.0.0.0/4` multicast, IPv6 `2001:db8::/32` documentation). This guard performs string/literal checks only and does not resolve DNS; hostnames that resolve to private addresses and DNS rebinding remain out of scope and must be constrained at the network layer (or by injecting a Node `fetch` that pins the resolved IP at connect time) for server deployments handling untrusted URLs. See `contributing/secure-url-handling.md`.

--- a/content/docs/06-advanced/11-secure-url-fetching.mdx
+++ b/content/docs/06-advanced/11-secure-url-fetching.mdx
@@ -35,6 +35,13 @@ When the SDK fetches a URL taken from a provider response, it:
 
 A blocked URL surfaces as a `DownloadError`.
 
+## Self-hosted and local endpoints
+
+URLs that are same-origin with the provider endpoint **you configured** (e.g. a
+custom `baseURL` pointing at a self-hosted or `localhost` deployment) are
+exempt from these checks — they target exactly the host you told the SDK to
+talk to. Any redirect off that origin is still validated.
+
 ## Limitation: DNS resolution and DNS rebinding
 
 The built-in guard inspects the URL **as a string**. It deliberately does

--- a/contributing/secure-url-handling.md
+++ b/contributing/secure-url-handling.md
@@ -25,6 +25,30 @@ body?**
 > If the host, or anything beyond a path segment, comes from a response body →
 > `validateUrl: true`.
 
+## Self-hosted deployments: `trustedOrigin`
+
+A response URL often points back at the developer-configured endpoint itself
+(a polling URL on the API host, a download URL on a self-hosted server). When
+that endpoint is private — a localhost Replicate-compatible cog server, an
+internal fal deployment — `validateUrl: true` would reject exactly the host the
+developer configured. Pass `trustedOrigin` with the configured base URL so
+hops that are same-origin with it skip target validation; every other hop is
+still validated:
+
+```ts
+await getFromApi({
+  url: pollUrl, // from the response body
+  validateUrl: true,
+  trustedOrigin: this.config.baseURL,
+  // …
+});
+```
+
+This is safe because a URL same-origin with the configured endpoint is exactly
+what a config-derived `validateUrl: false` request would fetch anyway.
+`trustedOrigin` must always be a developer-configured value — never derive it
+from response data.
+
 ## Credentials
 
 When an untrusted URL may legitimately carry the API key on its first hop (e.g.
@@ -36,6 +60,7 @@ await getFromApi({
   url: pollUrl, // from the response body
   validateUrl: true,
   credentialedOrigin: this.config.baseURL,
+  trustedOrigin: this.config.baseURL,
   headers: authHeaders,
   successfulResponseHandler,
   failedResponseHandler,

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -238,6 +238,7 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       url: imageUrl,
       // imageUrl comes from the provider response body; validate it.
       validateUrl: true,
+      trustedOrigin: this.config.baseURL,
       // Only send credentials if the response-supplied URL points back at the
       // provider; the image is typically delivered from a CDN, so the API key
       // must not travel to a foreign host.
@@ -324,6 +325,7 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
         url: url.toString(),
         // The polling URL comes from the provider response; validate it.
         validateUrl: true,
+        trustedOrigin: this.config.baseURL,
         // Only send credentials when it stays on a trusted provider host.
         headers: isTrustedUrl(url.toString(), this.config.baseURL)
           ? headers

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -252,6 +252,7 @@ export class FalImageModel implements ImageModelV4 {
       url,
       // url is a generated-image URL from the provider response; validate it.
       validateUrl: true,
+      trustedOrigin: this.config.baseURL,
       // No specific headers should be needed for this request as it's a
       // generated image provided by fal.ai.
       abortSignal,

--- a/packages/fal/src/fal-speech-model.ts
+++ b/packages/fal/src/fal-speech-model.ts
@@ -101,15 +101,17 @@ export class FalSpeechModel implements SpeechModelV4 {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { requestBody, warnings } = await this.getArgs(options);
 
+    const requestUrl = this.config.url({
+      path: `https://fal.run/${this.modelId}`,
+      modelId: this.modelId,
+    });
+
     const {
       value: json,
       responseHeaders,
       rawValue,
     } = await postJsonToApi({
-      url: this.config.url({
-        path: `https://fal.run/${this.modelId}`,
-        modelId: this.modelId,
-      }),
+      url: requestUrl,
       headers: combineHeaders(this.config.headers?.(), options.headers),
       body: requestBody,
       failedResponseHandler: falFailedResponseHandler,
@@ -125,6 +127,7 @@ export class FalSpeechModel implements SpeechModelV4 {
       url: audioUrl,
       // audioUrl comes from the provider response body; validate it.
       validateUrl: true,
+      trustedOrigin: requestUrl,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),
       abortSignal: options.abortSignal,

--- a/packages/fal/src/fal-video-model.ts
+++ b/packages/fal/src/fal-video-model.ts
@@ -159,6 +159,7 @@ export class FalVideoModel implements Experimental_VideoModelV4 {
             // statusUrl comes from the queue response body.
             validateUrl: true,
             credentialedOrigin: submitUrl,
+            trustedOrigin: submitUrl,
             headers: combineHeaders(this.config.headers?.(), options.headers),
             failedResponseHandler: async ({
               response,

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -303,6 +303,7 @@ export class FireworksImageModel implements ImageModelV4 {
       // imageUrl comes from the provider response body.
       validateUrl: true,
       credentialedOrigin: this.config.baseURL,
+      trustedOrigin: this.config.baseURL,
       headers,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -276,6 +276,7 @@ export class GladiaTranscriptionModel implements TranscriptionModelV4 {
         // resultUrl comes from the provider response body.
         validateUrl: true,
         credentialedOrigin: apiOrigin,
+        trustedOrigin: apiOrigin,
         headers: combineHeaders(this.config.headers?.(), options.headers),
         failedResponseHandler: gladiaFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(

--- a/packages/luma/src/luma-image-model.ts
+++ b/packages/luma/src/luma-image-model.ts
@@ -348,6 +348,7 @@ export class LumaImageModel implements ImageModelV4 {
       url,
       // url is a generated-image URL from the provider response; validate it.
       validateUrl: true,
+      trustedOrigin: this.config.baseURL,
       // No specific headers should be needed for this request as it's a
       // generated image provided by Luma.
       abortSignal,

--- a/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
@@ -188,6 +188,39 @@ describe('fetchWithValidatedRedirects', () => {
     });
   });
 
+  it('skips validation for hops same-origin with trustedOrigin', async () => {
+    // A self-hosted deployment: the configured origin is private, and its
+    // response URLs (and same-origin redirects) point back at it.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('http://localhost:5000/final'))
+      .mockResolvedValueOnce(okResponse());
+
+    const response = await fetchWithValidatedRedirects({
+      url: 'http://localhost:5000/predictions/123',
+      trustedOrigin: 'http://localhost:5000',
+      fetch: fetchMock,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('validates hops on other origins even when trustedOrigin is set', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('http://169.254.169.254/'));
+
+    await expect(
+      fetchWithValidatedRedirects({
+        url: 'http://localhost:5000/predictions/123',
+        trustedOrigin: 'http://localhost:5000',
+        fetch: fetchMock,
+      }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('uses the injected fetch instead of the global one', async () => {
     globalThis.fetch = vi.fn();
     const injected = vi.fn().mockResolvedValueOnce(okResponse());

--- a/packages/provider-utils/src/fetch-with-validated-redirects.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.ts
@@ -29,6 +29,13 @@ const MAX_DOWNLOAD_REDIRECTS = 10;
  * cloud-metadata). On any other runtime we cannot validate the hop, so we fail
  * closed rather than follow it blindly and bypass the guard.
  *
+ * A hop that is same-origin with `trustedOrigin` (the developer-configured
+ * provider endpoint) skips target validation: that origin is exactly what an
+ * unvalidated, config-derived request would fetch anyway, and validating it
+ * would break legitimate self-hosted / localhost deployments whose response
+ * URLs point back at the configured host. Hops on any other origin are always
+ * validated.
+ *
  * The returned response is the final (non-redirect) response. The caller is
  * responsible for checking `response.ok` and reading the body.
  *
@@ -49,12 +56,18 @@ export async function fetchWithValidatedRedirects({
   abortSignal,
   maxRedirects = MAX_DOWNLOAD_REDIRECTS,
   fetch = globalThis.fetch,
+  trustedOrigin,
 }: {
   url: string;
   headers?: HeadersInit;
   abortSignal?: AbortSignal;
   maxRedirects?: number;
   fetch?: FetchFunction;
+  /**
+   * A developer-configured origin (e.g. the provider's `baseURL`) whose hops
+   * skip target validation. Must never be derived from response data.
+   */
+  trustedOrigin?: string;
 }): Promise<Response> {
   // Left undefined when no headers are provided (bare request); otherwise
   // sanitized once and mutated in place across hops (cross-origin drop below).
@@ -72,7 +85,14 @@ export async function fetchWithValidatedRedirects({
   let currentUrl = url;
   // The bound also acts as a backstop against an unterminated redirect chain.
   for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
-    validateDownloadUrl(currentUrl);
+    // The developer-configured origin is trusted by definition; validating it
+    // would reject legitimate self-hosted / localhost deployments.
+    if (
+      trustedOrigin === undefined ||
+      !isSameOrigin(currentUrl, trustedOrigin)
+    ) {
+      validateDownloadUrl(currentUrl);
+    }
 
     const response = await fetch(currentUrl, perHopInit('manual'));
 

--- a/packages/provider-utils/src/get-from-api.test.ts
+++ b/packages/provider-utils/src/get-from-api.test.ts
@@ -325,6 +325,39 @@ describe('getFromApi', () => {
       expect(secondHopHeaders.get('authorization')).toBeNull();
     });
 
+    it('fetches a private URL when it is same-origin with trustedOrigin (self-hosted deployments)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(okJson());
+
+      const result = await getFromApi({
+        url: 'http://localhost:5000/predictions/123',
+        validateUrl: true,
+        trustedOrigin: 'http://localhost:5000',
+        successfulResponseHandler:
+          createJsonResponseHandler(mockResponseSchema),
+        failedResponseHandler: createStatusCodeErrorResponseHandler(),
+        fetch: mockFetch,
+      });
+
+      expect(result.value).toEqual(mockSuccessResponse);
+    });
+
+    it('still rejects a private URL on a different origin than trustedOrigin', async () => {
+      const mockFetch = vi.fn();
+
+      await expect(
+        getFromApi({
+          url: 'http://169.254.169.254/latest/meta-data/',
+          validateUrl: true,
+          trustedOrigin: 'http://localhost:5000',
+          successfulResponseHandler:
+            createJsonResponseHandler(mockResponseSchema),
+          failedResponseHandler: createStatusCodeErrorResponseHandler(),
+          fetch: mockFetch,
+        }),
+      ).rejects.toThrow(DownloadError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('does not validate the URL when validateUrl is false', async () => {
       const mockFetch = vi.fn().mockResolvedValue(okJson());
 

--- a/packages/provider-utils/src/get-from-api.ts
+++ b/packages/provider-utils/src/get-from-api.ts
@@ -22,6 +22,7 @@ export const getFromApi = async <T>({
   fetch = getOriginalFetch(),
   validateUrl,
   credentialedOrigin,
+  trustedOrigin,
 }: {
   url: string;
   headers?: Record<string, string | undefined>;
@@ -48,6 +49,17 @@ export const getFromApi = async <T>({
    * {@link fetchWithValidatedRedirects}).
    */
   credentialedOrigin?: string;
+  /**
+   * A developer-configured origin (e.g. the provider's `baseURL`) that is
+   * exempt from URL validation when `validateUrl` is `true`. A response URL
+   * (or redirect hop) that is same-origin with it is fetched without target
+   * validation — it points at exactly the host a config-derived
+   * `validateUrl: false` request would fetch anyway, so blocking it would
+   * only break legitimate self-hosted / localhost deployments whose response
+   * URLs point back at the configured host. Hops on any other origin are
+   * still validated. Must never be derived from response data.
+   */
+  trustedOrigin?: string;
 }) => {
   try {
     // Withhold caller headers when the URL is not same-origin with the origin
@@ -69,6 +81,7 @@ export const getFromApi = async <T>({
           headers: requestHeaders,
           abortSignal,
           fetch,
+          trustedOrigin,
         })
       : await fetch(url, {
           method: 'GET',

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -199,6 +199,7 @@ export class ReplicateImageModel implements ImageModelV4 {
           url,
           // url is an output image URL from the provider response; validate it.
           validateUrl: true,
+          trustedOrigin: this.config.baseURL,
           successfulResponseHandler: createBinaryResponseHandler(),
           failedResponseHandler: replicateFailedResponseHandler,
           abortSignal,

--- a/packages/replicate/src/replicate-video-model.ts
+++ b/packages/replicate/src/replicate-video-model.ts
@@ -223,6 +223,7 @@ export class ReplicateVideoModel implements Experimental_VideoModelV4 {
           // pollUrl comes from the provider response body.
           validateUrl: true,
           credentialedOrigin: this.config.baseURL,
+          trustedOrigin: this.config.baseURL,
           headers: await resolve(this.config.headers),
           successfulResponseHandler: createJsonResponseHandler(
             replicatePredictionSchema,

--- a/packages/xai/src/xai-image-model.ts
+++ b/packages/xai/src/xai-image-model.ts
@@ -203,6 +203,7 @@ export class XaiImageModel implements ImageModelV4 {
       url,
       // url is a generated-image URL from the provider response; validate it.
       validateUrl: true,
+      trustedOrigin: this.config.baseURL,
       abortSignal,
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),


### PR DESCRIPTION
## What this does

Follow-up to the review of #16971. `validateUrl: true` is hard-coded at the response-URL call sites, with no escape hatch — but response URLs routinely point back at the endpoint the developer configured. A self-hosted deployment breaks: `createReplicate({ baseURL: 'http://localhost:5000' })` against a local cog server returns `urls.get = http://localhost:5000/…` in the response body, and polling now throws `DownloadError` before the injected `fetch` is ever consulted. The base PR's own contributing doc gives this exact rationale for `validateUrl: false` ("validating it would break legitimate self-hosted / localhost base URLs") — the same reasoning applies to response URLs that point back at the configured host.

This adds an optional `trustedOrigin` to `getFromApi` and `fetchWithValidatedRedirects`: a hop that is same-origin with it skips target validation; **every other hop is still validated**. It is safe because a URL same-origin with the configured endpoint is exactly what a config-derived `validateUrl: false` request would fetch anyway. It must always be a developer-configured value, never response data (documented on the option and in `contributing/secure-url-handling.md`).

## Changes

- `fetchWithValidatedRedirects` / `getFromApi`: new optional `trustedOrigin`; per-hop same-origin exemption (fails closed on invalid URLs via `isSameOrigin`)
- Wired `trustedOrigin` (the configured `baseURL` / request origin) at all 11 `validateUrl: true` call sites (fal ×3, luma, gladia, fireworks, xai, black-forest-labs ×2, replicate ×2); `fal-speech` hoists its request URL into a variable to reuse it
- Tests: private same-origin URL fetched, private foreign URL still rejected, redirect hops on other origins still validated
- Docs: `contributing/secure-url-handling.md` section, user-facing note in `content/docs/06-advanced/11-secure-url-fetching.mdx`, changeset paragraph