### PR TITLE
fix(provider-utils): pass each redirect hop an independent header snapshot

### DIFF
--- a/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
@@ -188,6 +188,27 @@ describe('fetchWithValidatedRedirects', () => {
     });
   });
 
+  it('passes each hop an independent header snapshot (later hops must not mutate earlier ones)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('https://other.example.net/a'))
+      .mockResolvedValueOnce(okResponse());
+
+    await fetchWithValidatedRedirects({
+      url: 'https://example.com/file',
+      headers: { authorization: 'Bearer secret' },
+      fetch: fetchMock,
+    });
+
+    const firstHop = fetchMock.mock.calls[0][1].headers as Headers;
+    const secondHop = fetchMock.mock.calls[1][1].headers as Headers;
+    expect(firstHop).not.toBe(secondHop);
+    // The cross-origin credential drop on the second hop must not be visible
+    // in the header set the first hop was issued with.
+    expect(firstHop.get('authorization')).toBe('Bearer secret');
+    expect(secondHop.get('authorization')).toBeNull();
+  });
+
   it('uses the injected fetch instead of the global one', async () => {
     globalThis.fetch = vi.fn();
     const injected = vi.fn().mockResolvedValueOnce(okResponse());

--- a/packages/provider-utils/src/fetch-with-validated-redirects.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.ts
@@ -64,7 +64,10 @@ export async function fetchWithValidatedRedirects({
   const perHopInit = (redirect: RequestRedirect): RequestInit => {
     const init: RequestInit = { signal: abortSignal, redirect };
     if (currentHeaders !== undefined) {
-      init.headers = currentHeaders;
+      // Snapshot per hop: the platform fetch reads headers synchronously, but
+      // an injected fetch may defer, and a later cross-origin drop must not
+      // mutate what an earlier hop observes.
+      init.headers = new Headers(currentHeaders);
     }
     return init;
   };


### PR DESCRIPTION
## What this does

Follow-up to the review of #16971. `fetchWithValidatedRedirects` passed the same mutable `Headers` instance to every hop's `fetch` call and mutated it in place for the cross-origin credential drop. Real `fetch` implementations snapshot headers synchronously at call time, so observable behavior was correct — but:

- an **injected custom fetch** (a supported option) that defers reading `init.headers` could observe post-mutation state, i.e. a first-hop request whose credentials appear already dropped or vice versa;
- in tests, `mock.calls[0][1].headers` and `mock.calls[1][1].headers` were the same object, so any future assertion on an earlier hop's headers would silently check later-hop state.

Each hop now gets its own `new Headers(currentHeaders)` snapshot. Includes a regression test asserting the hops receive distinct objects and that the cross-origin drop is not retroactively visible on the first hop.