### PR TITLE
reproduction: could not reproduce @ai-sdk/amazon-bedrock: Output.object + tools intermittently fails with AINoObjectGeneratedError

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-16662-bedrock-output-tools.ts
+++ b/examples/ai-functions/src/reproduction/issue-16662-bedrock-output-tools.ts
@@ -1,0 +1,251 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import type { LanguageModelV4 } from '@ai-sdk/provider';
+import {
+  generateText,
+  isStepCount,
+  NoObjectGeneratedError,
+  Output,
+  tool,
+} from 'ai';
+import 'dotenv/config';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const modelId = 'us.anthropic.claude-opus-4-8';
+const region = 'us-east-1';
+const batchRuns = Number.parseInt(process.env.BATCH_RUNS ?? '12', 10);
+const requestMode = process.env.ISSUE_16662_REQUEST_MODE ?? 'legacy-json-tool';
+const fixturePath = fileURLToPath(
+  new URL(
+    '../../../../packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json',
+    import.meta.url,
+  ),
+);
+
+type RecordedCall = {
+  requestBody: string | null;
+  responseBody: string;
+  status: number;
+};
+
+function asLegacyJsonToolModel(model: LanguageModelV4): LanguageModelV4 {
+  return {
+    specificationVersion: 'v4',
+    provider: `${model.provider}.issue-16662-legacy-json-tool`,
+    modelId: model.modelId,
+    supportedUrls: model.supportedUrls,
+    doStream: options => model.doStream(options),
+    async doGenerate(options) {
+      const responseFormat = options.responseFormat;
+
+      if (responseFormat?.type !== 'json' || responseFormat.schema == null) {
+        return model.doGenerate(options);
+      }
+
+      const result = await model.doGenerate({
+        ...options,
+        responseFormat: undefined,
+        tools: [
+          ...(options.tools ?? []),
+          {
+            type: 'function',
+            name: 'json',
+            description: 'Respond with a JSON object.',
+            inputSchema: responseFormat.schema,
+          },
+        ],
+        toolChoice: { type: 'required' },
+      });
+
+      let isJsonResponseFromTool = false;
+      const content = result.content.flatMap(part => {
+        if (part.type !== 'tool-call' || part.toolName !== 'json') {
+          return [part];
+        }
+
+        isJsonResponseFromTool = true;
+        return [{ type: 'text' as const, text: part.input }];
+      });
+
+      return {
+        ...result,
+        content,
+        finishReason: isJsonResponseFromTool
+          ? { unified: 'stop', raw: result.finishReason.raw }
+          : result.finishReason,
+      };
+    },
+  };
+}
+
+async function main() {
+  if (!Number.isInteger(batchRuns) || batchRuns < 1) {
+    throw new Error(`BATCH_RUNS must be a positive integer, got ${batchRuns}.`);
+  }
+
+  const callsByRun: RecordedCall[][] = Array.from(
+    { length: batchRuns },
+    () => [],
+  );
+  let activeRun = 0;
+
+  const bedrock = createAmazonBedrock({
+    region,
+    fetch: async (input, init) => {
+      const response = await globalThis.fetch(input, init);
+      callsByRun[activeRun].push({
+        requestBody:
+          typeof init?.body === 'string'
+            ? init.body
+            : input instanceof Request
+              ? await input.clone().text()
+              : null,
+        responseBody: await response.clone().text(),
+        status: response.status,
+      });
+      return response;
+    },
+  });
+
+  const failures: Array<{
+    run: number;
+    message: string;
+    text: string | undefined;
+  }> = [];
+  const summaries: Array<{
+    run: number;
+    output: unknown;
+    steps: number;
+    toolNames: string[];
+  }> = [];
+  const model =
+    requestMode === 'legacy-json-tool'
+      ? asLegacyJsonToolModel(bedrock(modelId))
+      : bedrock(modelId);
+
+  for (let run = 0; run < batchRuns; run++) {
+    activeRun = run;
+
+    try {
+      const result = await generateText({
+        model,
+        maxOutputTokens: 400,
+        stopWhen: isStepCount(15),
+        output: Output.object({
+          schema: z.object({
+            decision: z.enum(['approve', 'deny']),
+            accountTier: z.string(),
+            policyLimit: z.number(),
+          }),
+        }),
+        tools: {
+          lookupAccount: tool({
+            description: 'Look up the account tier for an account ID.',
+            inputSchema: z.object({ accountId: z.string() }),
+            execute: async () => ({ accountTier: 'gold' }),
+          }),
+          lookupPolicy: tool({
+            description: 'Look up the numeric limit for a policy ID.',
+            inputSchema: z.object({ policyId: z.string() }),
+            execute: async () => ({ policyLimit: 100 }),
+          }),
+        },
+        prompt:
+          'You must call lookupAccount with accountId "acct-16662" and lookupPolicy with policyId "policy-16662" before answering. Approve when the account tier is gold and the policy limit is at least 100. Return the requested structured output.',
+      });
+
+      const toolNames = result.steps.flatMap(step =>
+        step.toolCalls.map(call => call.toolName),
+      );
+
+      if (
+        !toolNames.includes('lookupAccount') ||
+        !toolNames.includes('lookupPolicy')
+      ) {
+        throw new Error(
+          `Run ${run + 1} did not call both tools: ${toolNames.join(', ')}`,
+        );
+      }
+
+      summaries.push({
+        run: run + 1,
+        output: result.output,
+        steps: result.steps.length,
+        toolNames,
+      });
+      console.log(
+        `run ${run + 1}/${batchRuns}: success (${result.steps.length} steps)`,
+      );
+    } catch (error) {
+      if (!NoObjectGeneratedError.isInstance(error)) {
+        throw error;
+      }
+
+      failures.push({
+        run: run + 1,
+        message: error.message,
+        text: error.text,
+      });
+      console.error(`run ${run + 1}/${batchRuns}: ${error.message}`);
+    }
+  }
+
+  if (process.env.RECORD_FIXTURE === '1') {
+    await mkdir(
+      new URL(
+        '../../../../packages/amazon-bedrock/src/__fixtures__/',
+        import.meta.url,
+      ),
+      {
+        recursive: true,
+      },
+    );
+    await writeFile(
+      fixturePath,
+      `${JSON.stringify(
+        {
+          issue: 16662,
+          modelId,
+          region,
+          requestMode,
+          capturedRuns: callsByRun.slice(0, 1),
+          failures,
+          representativeSummaries: summaries.slice(0, 3),
+          batchSummary: {
+            batchRuns,
+            failures: failures.length,
+            successes: summaries.length,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`recorded ${fixturePath}`);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        batchRuns,
+        failures: failures.length,
+        requestMode,
+        successes: summaries.length,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Reproduced issue #16662 in ${failures.length}/${batchRuns} runs.`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json
@@ -1,0 +1,41 @@
+{
+  "issue": 16662,
+  "modelId": "us.anthropic.claude-opus-4-8",
+  "region": "us-east-1",
+  "requestMode": "legacy-json-tool",
+  "capturedRuns": [
+    [
+      {
+        "requestBody": "{\"system\":[],\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"You must call lookupAccount with accountId \\\"acct-16662\\\" and lookupPolicy with policyId \\\"policy-16662\\\" before answering. Approve when the account tier is gold and the policy limit is at least 100. Return the requested structured output.\"}]}],\"additionalModelResponseFieldPaths\":[\"/delta/stop_sequence\"],\"inferenceConfig\":{\"maxTokens\":400},\"toolConfig\":{\"tools\":[{\"toolSpec\":{\"name\":\"lookupAccount\",\"description\":\"Look up the account tier for an account ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"accountId\":{\"type\":\"string\"}},\"required\":[\"accountId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"lookupPolicy\",\"description\":\"Look up the numeric limit for a policy ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"policyId\":{\"type\":\"string\"}},\"required\":[\"policyId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"json\",\"description\":\"Respond with a JSON object.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\",\"enum\":[\"approve\",\"deny\"]},\"accountTier\":{\"type\":\"string\"},\"policyLimit\":{\"type\":\"number\"}},\"required\":[\"decision\",\"accountTier\",\"policyLimit\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}}],\"toolChoice\":{\"any\":{}}}}",
+        "responseBody": "{\"metrics\":{\"latencyMs\":9225},\"output\":{\"message\":{\"content\":[{\"toolUse\":{\"input\":{\"accountId\":\"acct-16662\"},\"name\":\"lookupAccount\",\"toolUseId\":\"tooluse_SmVJFSHPFQ5njlvJw7XpNw\",\"type\":\"tool_use\"}},{\"toolUse\":{\"input\":{\"policyId\":\"policy-16662\"},\"name\":\"lookupPolicy\",\"toolUseId\":\"tooluse_7mavsT1KaUuvaB8QjaqzAm\",\"type\":\"tool_use\"}}],\"role\":\"assistant\"}},\"stopReason\":\"tool_use\",\"usage\":{\"cacheReadInputTokenCount\":0,\"cacheReadInputTokens\":0,\"inputTokens\":888,\"outputTokens\":100,\"serverToolUsage\":{},\"totalTokens\":988}}",
+        "status": 200
+      },
+      {
+        "requestBody": "{\"system\":[],\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"You must call lookupAccount with accountId \\\"acct-16662\\\" and lookupPolicy with policyId \\\"policy-16662\\\" before answering. Approve when the account tier is gold and the policy limit is at least 100. Return the requested structured output.\"}]},{\"role\":\"assistant\",\"content\":[{\"toolUse\":{\"toolUseId\":\"tooluse_SmVJFSHPFQ5njlvJw7XpNw\",\"name\":\"lookupAccount\",\"input\":{\"accountId\":\"acct-16662\"}}},{\"toolUse\":{\"toolUseId\":\"tooluse_7mavsT1KaUuvaB8QjaqzAm\",\"name\":\"lookupPolicy\",\"input\":{\"policyId\":\"policy-16662\"}}}]},{\"role\":\"user\",\"content\":[{\"toolResult\":{\"toolUseId\":\"tooluse_SmVJFSHPFQ5njlvJw7XpNw\",\"content\":[{\"text\":\"{\\\"accountTier\\\":\\\"gold\\\"}\"}]}},{\"toolResult\":{\"toolUseId\":\"tooluse_7mavsT1KaUuvaB8QjaqzAm\",\"content\":[{\"text\":\"{\\\"policyLimit\\\":100}\"}]}}]}],\"additionalModelResponseFieldPaths\":[\"/delta/stop_sequence\"],\"inferenceConfig\":{\"maxTokens\":400},\"toolConfig\":{\"tools\":[{\"toolSpec\":{\"name\":\"lookupAccount\",\"description\":\"Look up the account tier for an account ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"accountId\":{\"type\":\"string\"}},\"required\":[\"accountId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"lookupPolicy\",\"description\":\"Look up the numeric limit for a policy ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"policyId\":{\"type\":\"string\"}},\"required\":[\"policyId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"json\",\"description\":\"Respond with a JSON object.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\",\"enum\":[\"approve\",\"deny\"]},\"accountTier\":{\"type\":\"string\"},\"policyLimit\":{\"type\":\"number\"}},\"required\":[\"decision\",\"accountTier\",\"policyLimit\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}}],\"toolChoice\":{\"any\":{}}}}",
+        "responseBody": "{\"metrics\":{\"latencyMs\":3599},\"output\":{\"message\":{\"content\":[{\"toolUse\":{\"input\":{\"decision\":\"approve\",\"accountTier\":\"gold\",\"policyLimit\":100},\"name\":\"json\",\"toolUseId\":\"tooluse_MWRpvAQg0Mx1Qu28ih5oGg\",\"type\":\"tool_use\"}}],\"role\":\"assistant\"}},\"stopReason\":\"tool_use\",\"usage\":{\"cacheReadInputTokenCount\":0,\"cacheReadInputTokens\":0,\"inputTokens\":1083,\"outputTokens\":87,\"serverToolUsage\":{},\"totalTokens\":1170}}",
+        "status": 200
+      }
+    ]
+  ],
+  "failures": [],
+  "representativeSummaries": [
+    {
+      "run": 1,
+      "output": {
+        "decision": "approve",
+        "accountTier": "gold",
+        "policyLimit": 100
+      },
+      "steps": 2,
+      "toolNames": [
+        "lookupAccount",
+        "lookupPolicy"
+      ]
+    }
+  ],
+  "batchSummary": {
+    "batchRuns": 1,
+    "failures": 0,
+    "successes": 1
+  }
+}


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: Output.object() + tools intermittently fails with AI_NoObjectGeneratedError on Claude Opus 4.7/4.8 after the strict fix (#16237)

## Reproduction

- The primary failure could not be reproduced: 30 live runs using the reported `ai@6.0.201`, `@ai-sdk/amazon-bedrock@4.0.120`, model, region, tools, and forced JSON-tool request shape produced valid structured objects in two steps with zero `AI_NoObjectGeneratedError` failures.
- `examples/ai-functions/src/reproduction/issue-16662-bedrock-output-tools.ts` is a runnable batch reproduction; the expected issue behavior is a post-tool `AI_NoObjectGeneratedError`, while observed runs successfully called both tools and returned schema-valid output.
- `packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json` records a live run where Opus 4.8 called both lookup tools and then the synthetic `json` tool without an empty or plain-text terminal response.
- The unmodified current worktree follows a different path and receives HTTP 400 `output_config.format: Extra inputs are not permitted`, so it does not reach the reported intermittent `AI_NoObjectGeneratedError` path.
- AWS documents Bedrock `{ "any": {} }` tool choice as requiring at least one tool call with no text generation, contrary to reported shape A.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_AnyToolChoice.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_SpecificToolChoice.html

## Related Issues

Could not reproduce #16662