### PR TITLE
reproduction: could not reproduce @ai-sdk/amazon-bedrock: Output.object + tools intermittently fails with AINoObjectGeneratedError

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-16662-bedrock-output-tools.ts
+++ b/examples/ai-functions/src/reproduction/issue-16662-bedrock-output-tools.ts
@@ -1,0 +1,196 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  generateText,
+  NoObjectGeneratedError,
+  Output,
+  stepCountIs,
+  tool,
+} from 'ai';
+import 'dotenv/config';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const modelId = 'us.anthropic.claude-opus-4-8';
+const region = 'us-east-1';
+const batchRuns = Number.parseInt(process.env.BATCH_RUNS ?? '12', 10);
+const fixturePath = fileURLToPath(
+  new URL(
+    '../../../../packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json',
+    import.meta.url,
+  ),
+);
+
+type RecordedCall = {
+  requestBody: string | null;
+  responseBody: string;
+  status: number;
+};
+
+async function main() {
+  if (!Number.isInteger(batchRuns) || batchRuns < 1) {
+    throw new Error(`BATCH_RUNS must be a positive integer, got ${batchRuns}.`);
+  }
+
+  const callsByRun: RecordedCall[][] = Array.from(
+    { length: batchRuns },
+    () => [],
+  );
+  let activeRun = 0;
+
+  const bedrock = createAmazonBedrock({
+    region,
+    fetch: async (input, init) => {
+      const response = await globalThis.fetch(input, init);
+      callsByRun[activeRun].push({
+        requestBody:
+          typeof init?.body === 'string'
+            ? init.body
+            : input instanceof Request
+              ? await input.clone().text()
+              : null,
+        responseBody: await response.clone().text(),
+        status: response.status,
+      });
+      return response;
+    },
+  });
+
+  const failures: Array<{
+    run: number;
+    message: string;
+    text: string | undefined;
+  }> = [];
+  const summaries: Array<{
+    run: number;
+    output: unknown;
+    steps: number;
+    toolNames: string[];
+  }> = [];
+
+  for (let run = 0; run < batchRuns; run++) {
+    activeRun = run;
+
+    try {
+      const result = await generateText({
+        model: bedrock(modelId),
+        maxOutputTokens: 400,
+        stopWhen: stepCountIs(15),
+        output: Output.object({
+          schema: z.object({
+            decision: z.enum(['approve', 'deny']),
+            accountTier: z.string(),
+            policyLimit: z.number(),
+          }),
+        }),
+        tools: {
+          lookupAccount: tool({
+            description: 'Look up the account tier for an account ID.',
+            inputSchema: z.object({ accountId: z.string() }),
+            execute: async () => ({ accountTier: 'gold' }),
+          }),
+          lookupPolicy: tool({
+            description: 'Look up the numeric limit for a policy ID.',
+            inputSchema: z.object({ policyId: z.string() }),
+            execute: async () => ({ policyLimit: 100 }),
+          }),
+        },
+        prompt:
+          'You must call lookupAccount with accountId "acct-16662" and lookupPolicy with policyId "policy-16662" before answering. Approve when the account tier is gold and the policy limit is at least 100. Return the requested structured output.',
+      });
+
+      const toolNames = result.steps.flatMap(step =>
+        step.toolCalls.map(call => call.toolName),
+      );
+
+      if (
+        !toolNames.includes('lookupAccount') ||
+        !toolNames.includes('lookupPolicy')
+      ) {
+        throw new Error(
+          `Run ${run + 1} did not call both tools: ${toolNames.join(', ')}`,
+        );
+      }
+
+      summaries.push({
+        run: run + 1,
+        output: result.output,
+        steps: result.steps.length,
+        toolNames,
+      });
+      console.log(
+        `run ${run + 1}/${batchRuns}: success (${result.steps.length} steps)`,
+      );
+    } catch (error) {
+      if (!NoObjectGeneratedError.isInstance(error)) {
+        throw error;
+      }
+
+      failures.push({
+        run: run + 1,
+        message: error.message,
+        text: error.text,
+      });
+      console.error(`run ${run + 1}/${batchRuns}: ${error.message}`);
+    }
+  }
+
+  if (process.env.RECORD_FIXTURE === '1') {
+    await mkdir(
+      new URL(
+        '../../../../packages/amazon-bedrock/src/__fixtures__/',
+        import.meta.url,
+      ),
+      {
+        recursive: true,
+      },
+    );
+    await writeFile(
+      fixturePath,
+      `${JSON.stringify(
+        {
+          issue: 16662,
+          modelId,
+          region,
+          capturedRuns:
+            failures.length > 0
+              ? failures.slice(0, 1).map(failure => callsByRun[failure.run - 1])
+              : callsByRun.slice(0, 1),
+          failures,
+          representativeSummaries: summaries.slice(0, 3),
+          batchSummary: {
+            batchRuns,
+            failures: failures.length,
+            successes: summaries.length,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`recorded ${fixturePath}`);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        batchRuns,
+        failures: failures.length,
+        successes: summaries.length,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Reproduced issue #16662 in ${failures.length}/${batchRuns} runs.`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json
@@ -1,0 +1,66 @@
+{
+  "issue": 16662,
+  "modelId": "us.anthropic.claude-opus-4-8",
+  "region": "us-east-1",
+  "capturedRuns": [
+    [
+      {
+        "requestBody": "{\"system\":[],\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"You must call lookupAccount with accountId \\\"acct-16662\\\" and lookupPolicy with policyId \\\"policy-16662\\\" before answering. Approve when the account tier is gold and the policy limit is at least 100. Return the requested structured output.\"}]}],\"additionalModelResponseFieldPaths\":[\"/delta/stop_sequence\"],\"inferenceConfig\":{\"maxTokens\":400},\"toolConfig\":{\"tools\":[{\"toolSpec\":{\"name\":\"lookupAccount\",\"description\":\"Look up the account tier for an account ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"accountId\":{\"type\":\"string\"}},\"required\":[\"accountId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"lookupPolicy\",\"description\":\"Look up the numeric limit for a policy ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"policyId\":{\"type\":\"string\"}},\"required\":[\"policyId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"json\",\"description\":\"Respond with a JSON object.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\",\"enum\":[\"approve\",\"deny\"]},\"accountTier\":{\"type\":\"string\"},\"policyLimit\":{\"type\":\"number\"}},\"required\":[\"decision\",\"accountTier\",\"policyLimit\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}}],\"toolChoice\":{\"any\":{}}}}",
+        "responseBody": "{\"metrics\":{\"latencyMs\":1807},\"output\":{\"message\":{\"content\":[{\"toolUse\":{\"input\":{\"accountId\":\"acct-16662\"},\"name\":\"lookupAccount\",\"toolUseId\":\"tooluse_g0PvGHEYOr5K6FSQk7YmJY\",\"type\":\"tool_use\"}},{\"toolUse\":{\"input\":{\"policyId\":\"policy-16662\"},\"name\":\"lookupPolicy\",\"toolUseId\":\"tooluse_ZCBnqPwTeJiRFEhVEz442G\",\"type\":\"tool_use\"}}],\"role\":\"assistant\"}},\"stopReason\":\"tool_use\",\"usage\":{\"cacheReadInputTokenCount\":0,\"cacheReadInputTokens\":0,\"inputTokens\":888,\"outputTokens\":100,\"serverToolUsage\":{},\"totalTokens\":988}}",
+        "status": 200
+      },
+      {
+        "requestBody": "{\"system\":[],\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"You must call lookupAccount with accountId \\\"acct-16662\\\" and lookupPolicy with policyId \\\"policy-16662\\\" before answering. Approve when the account tier is gold and the policy limit is at least 100. Return the requested structured output.\"}]},{\"role\":\"assistant\",\"content\":[{\"toolUse\":{\"toolUseId\":\"tooluse_g0PvGHEYOr5K6FSQk7YmJY\",\"name\":\"lookupAccount\",\"input\":{\"accountId\":\"acct-16662\"}}},{\"toolUse\":{\"toolUseId\":\"tooluse_ZCBnqPwTeJiRFEhVEz442G\",\"name\":\"lookupPolicy\",\"input\":{\"policyId\":\"policy-16662\"}}}]},{\"role\":\"user\",\"content\":[{\"toolResult\":{\"toolUseId\":\"tooluse_g0PvGHEYOr5K6FSQk7YmJY\",\"content\":[{\"text\":\"{\\\"accountTier\\\":\\\"gold\\\"}\"}]}},{\"toolResult\":{\"toolUseId\":\"tooluse_ZCBnqPwTeJiRFEhVEz442G\",\"content\":[{\"text\":\"{\\\"policyLimit\\\":100}\"}]}}]}],\"additionalModelResponseFieldPaths\":[\"/delta/stop_sequence\"],\"inferenceConfig\":{\"maxTokens\":400},\"toolConfig\":{\"tools\":[{\"toolSpec\":{\"name\":\"lookupAccount\",\"description\":\"Look up the account tier for an account ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"accountId\":{\"type\":\"string\"}},\"required\":[\"accountId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"lookupPolicy\",\"description\":\"Look up the numeric limit for a policy ID.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"policyId\":{\"type\":\"string\"}},\"required\":[\"policyId\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}},{\"toolSpec\":{\"name\":\"json\",\"description\":\"Respond with a JSON object.\",\"inputSchema\":{\"json\":{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\",\"enum\":[\"approve\",\"deny\"]},\"accountTier\":{\"type\":\"string\"},\"policyLimit\":{\"type\":\"number\"}},\"required\":[\"decision\",\"accountTier\",\"policyLimit\"],\"additionalProperties\":false,\"$schema\":\"http://json-schema.org/draft-07/schema#\"}}}}],\"toolChoice\":{\"any\":{}}}}",
+        "responseBody": "{\"metrics\":{\"latencyMs\":3571},\"output\":{\"message\":{\"content\":[{\"toolUse\":{\"input\":{\"decision\":\"approve\",\"accountTier\":\"gold\",\"policyLimit\":100},\"name\":\"json\",\"toolUseId\":\"tooluse_XXnjLHuzNOyXidGjslVRf3\",\"type\":\"tool_use\"}}],\"role\":\"assistant\"}},\"stopReason\":\"tool_use\",\"usage\":{\"cacheReadInputTokenCount\":0,\"cacheReadInputTokens\":0,\"inputTokens\":1083,\"outputTokens\":87,\"serverToolUsage\":{},\"totalTokens\":1170}}",
+        "status": 200
+      }
+    ]
+  ],
+  "failures": [],
+  "representativeSummaries": [
+    {
+      "run": 1,
+      "output": {
+        "decision": "approve",
+        "accountTier": "gold",
+        "policyLimit": 100
+      },
+      "steps": 2,
+      "toolNames": [
+        "lookupAccount",
+        "lookupPolicy"
+      ]
+    },
+    {
+      "run": 2,
+      "output": {
+        "decision": "approve",
+        "accountTier": "gold",
+        "policyLimit": 100
+      },
+      "steps": 2,
+      "toolNames": [
+        "lookupAccount",
+        "lookupPolicy"
+      ]
+    },
+    {
+      "run": 3,
+      "output": {
+        "decision": "approve",
+        "accountTier": "gold",
+        "policyLimit": 100
+      },
+      "steps": 2,
+      "toolNames": [
+        "lookupAccount",
+        "lookupPolicy"
+      ]
+    }
+  ],
+  "batchSummary": {
+    "batchRuns": 30,
+    "failures": 0,
+    "successes": 30
+  }
+}

--- a/packages/amazon-bedrock/src/issue-16662.test.ts
+++ b/packages/amazon-bedrock/src/issue-16662.test.ts
@@ -1,0 +1,157 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+type Issue16662Fixture = {
+  capturedRuns: Array<
+    Array<{
+      requestBody: string | null;
+      responseBody: string;
+      status: number;
+    }>
+  >;
+};
+
+const fixture = JSON.parse(
+  fs.readFileSync('src/__fixtures__/issue-16662-live.json', 'utf8'),
+) as Issue16662Fixture;
+
+describe('issue #16662 live fixture', () => {
+  it('returns the post-tool json tool call as structured-output text', async () => {
+    const recordedCall = fixture.capturedRuns[0][1];
+    let requestBody: any;
+
+    const model = new BedrockChatLanguageModel('us.anthropic.claude-opus-4-8', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {},
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(init?.body as string);
+        return new Response(recordedCall.responseBody, {
+          status: recordedCall.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+      generateId: () => 'test-id',
+    });
+
+    const prompt: LanguageModelV3Prompt = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Use both lookup tools and return structured output.',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'account-call',
+            toolName: 'lookupAccount',
+            input: { accountId: 'acct-16662' },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'policy-call',
+            toolName: 'lookupPolicy',
+            input: { policyId: 'policy-16662' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'account-call',
+            toolName: 'lookupAccount',
+            output: {
+              type: 'text',
+              value: '{"accountTier":"gold"}',
+            },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'policy-call',
+            toolName: 'lookupPolicy',
+            output: {
+              type: 'text',
+              value: '{"policyLimit":100}',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await model.doGenerate({
+      prompt,
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            decision: { type: 'string', enum: ['approve', 'deny'] },
+            accountTier: { type: 'string' },
+            policyLimit: { type: 'number' },
+          },
+          required: ['decision', 'accountTier', 'policyLimit'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          type: 'function',
+          name: 'lookupAccount',
+          description: 'Look up the account tier for an account ID.',
+          inputSchema: {
+            type: 'object',
+            properties: { accountId: { type: 'string' } },
+            required: ['accountId'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+        {
+          type: 'function',
+          name: 'lookupPolicy',
+          description: 'Look up the numeric limit for a policy ID.',
+          inputSchema: {
+            type: 'object',
+            properties: { policyId: { type: 'string' } },
+            required: ['policyId'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ],
+    });
+
+    expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+    expect(
+      requestBody.toolConfig.tools.map(
+        (tool: { toolSpec: { name: string } }) => tool.toolSpec.name,
+      ),
+    ).toEqual(['lookupAccount', 'lookupPolicy', 'json']);
+    expect(
+      requestBody.toolConfig.tools.every(
+        (tool: { toolSpec: { strict?: boolean } }) =>
+          tool.toolSpec.strict == null,
+      ),
+    ).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: '{"decision":"approve","accountTier":"gold","policyLimit":100}',
+      },
+    ]);
+    expect(result.finishReason).toEqual({
+      unified: 'stop',
+      raw: 'tool_use',
+    });
+    expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: Output.object() + tools intermittently fails with AI_NoObjectGeneratedError on Claude Opus 4.7/4.8 after the strict fix (#16237)

## Reproduction

- The primary failure could not be reproduced: 30 live runs against `us.anthropic.claude-opus-4-8` completed both tool calls and returned schema-valid objects in two steps, with zero `AI_NoObjectGeneratedError` failures.
- `examples/ai-functions/src/reproduction/issue-16662-bedrock-output-tools.ts` is the runnable batch reproduction; the expected issue behavior is a post-tool structured-output failure, while all observed runs succeeded.
- `packages/amazon-bedrock/src/__fixtures__/issue-16662-live.json` records a live run where the post-tool response called the synthetic `json` tool rather than returning empty or plain-text output.
- `packages/amazon-bedrock/src/issue-16662.test.ts` replays the live response and confirms the provider converts the `json` tool call into valid structured-output text with a `stop` finish reason.
- The relevant Bedrock provider implementation is unchanged between `@ai-sdk/amazon-bedrock@4.0.120` and the tested workspace version; AWS also documents `{ "any": {} }` as requiring a tool call with no text generation.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_AnyToolChoice.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_SpecificToolChoice.html

## Related Issues

Could not reproduce #16662