### PR TITLE
feat: support ordered OpenAI additional tools after normal tool results

### DIFF
--- a/.changeset/tidy-tools-appear.md
+++ b/.changeset/tidy-tools-appear.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+feat(provider/openai): support ordered additional tools after function results and execute dynamically loaded tools in streamText

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1168,6 +1168,78 @@ In client mode, the flow spans two steps:
 
 For more details, see the [OpenAI Tool Search documentation](https://platform.openai.com/docs/guides/tools-tool-search).
 
+##### Load Tools After a Normal Tool Result
+
+When a normal function tool discovers additional functions, attach
+`providerOptions.openai.additionalTools` to its `tool-result` part. The OpenAI
+Responses adapter keeps the ordinary `function_call_output` and emits an
+`additional_tools` input item immediately after it:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool, type ModelMessage } from 'ai';
+import { z } from 'zod';
+
+const messages: ModelMessage[] = [
+  // Earlier user message and connection_search tool call...
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'call_connection_search',
+        toolName: 'connection_search',
+        output: {
+          type: 'json',
+          value: [{ connection: 'linear', tool: 'list_issues' }],
+        },
+        providerOptions: {
+          openai: {
+            additionalTools: [
+              {
+                type: 'function',
+                name: 'linear__list_issues',
+                description: 'List Linear issues',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    team: { type: 'string' },
+                  },
+                  required: ['team'],
+                  additionalProperties: false,
+                },
+                strict: true,
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+];
+
+await generateText({
+  model: openai.responses('gpt-5.4'),
+  messages,
+  tools: {
+    connection_search: tool({
+      inputSchema: z.object({ query: z.string() }),
+    }),
+    linear__list_issues: tool({
+      inputSchema: z.object({ team: z.string() }),
+      execute: async ({ team }) => ({ team, issues: [] }),
+    }),
+  },
+  activeTools: ['connection_search'],
+});
+```
+
+Keep the discovered tools in the full `tools` map so the AI SDK can validate
+and execute later calls, while omitting them from `activeTools` prevents them
+from being duplicated in the request-level tools list. Replaying the same
+messages preserves the `additional_tools` item's original position. This works
+with both `generateText` and `streamText`.
+
 #### Custom Tool
 
 The OpenAI Responses API supports

--- a/examples/ai-functions/src/reproduction/issue-17155-openai-additional-tools.ts
+++ b/examples/ai-functions/src/reproduction/issue-17155-openai-additional-tools.ts
@@ -1,0 +1,243 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import {
+  generateText,
+  streamText,
+  tool,
+  type ModelMessage,
+  type ToolSet,
+} from 'ai';
+import { z } from 'zod';
+
+type CapturedRequest = {
+  input?: Array<Record<string, unknown>>;
+  tools?: Array<Record<string, unknown>>;
+  stream?: boolean;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+
+const openai = createOpenAI({
+  fetch: async (input, init) => {
+    if (typeof init?.body === 'string') {
+      capturedRequests.push(JSON.parse(init.body) as CapturedRequest);
+    }
+    return fetch(input, init);
+  },
+});
+
+function createMessages(): ModelMessage[] {
+  return [
+    {
+      role: 'user',
+      content:
+        'Use the discovered get_weather function to get the weather in Chicago.',
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call_connection_search',
+          toolName: 'connection_search',
+          input: { query: 'weather' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_connection_search',
+          toolName: 'connection_search',
+          output: {
+            type: 'json',
+            value: [
+              {
+                connection: 'weather',
+                description: 'Weather data',
+                tool: 'get_weather',
+                qualifiedName: 'get_weather',
+                needsAuthorization: false,
+              },
+            ],
+          },
+          providerOptions: {
+            openai: {
+              additionalTools: [
+                {
+                  type: 'function',
+                  name: 'get_weather',
+                  description: 'Get the weather for a location.',
+                  parameters: {
+                    type: 'object',
+                    properties: {
+                      location: { type: 'string' },
+                    },
+                    required: ['location'],
+                    additionalProperties: false,
+                  },
+                  strict: true,
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ];
+}
+
+function createTools(onWeatherExecute: () => void) {
+  return {
+    connection_search: tool({
+      description: 'Find connection tools.',
+      inputSchema: z.object({ query: z.string() }),
+      execute: async ({ query }) => ({ query }),
+    }),
+    get_weather: tool({
+      description: 'Get the weather for a location.',
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => {
+        onWeatherExecute();
+        return { location, temperature: 72, condition: 'Sunny' };
+      },
+    }),
+  } satisfies ToolSet;
+}
+
+function validateRequest(
+  request: CapturedRequest | undefined,
+  stream: boolean,
+) {
+  if (request == null) {
+    throw new Error(
+      `Missing ${stream ? 'streamText' : 'generateText'} request.`,
+    );
+  }
+
+  const relevantInput = request.input?.filter(item =>
+    ['function_call', 'function_call_output', 'additional_tools'].includes(
+      String(item.type),
+    ),
+  );
+
+  if (
+    relevantInput?.[0]?.type !== 'function_call' ||
+    relevantInput[1]?.type !== 'function_call_output' ||
+    relevantInput[2]?.type !== 'additional_tools'
+  ) {
+    throw new Error(
+      `Expected function_call, function_call_output, and additional_tools in order: ${JSON.stringify(relevantInput)}`,
+    );
+  }
+
+  const additionalTools = relevantInput[2] as {
+    role?: string;
+    tools?: Array<{ name?: string }>;
+  };
+  if (
+    additionalTools.role !== 'developer' ||
+    additionalTools.tools?.[0]?.name !== 'get_weather'
+  ) {
+    throw new Error(
+      `Expected get_weather in a developer additional_tools item: ${JSON.stringify(additionalTools)}`,
+    );
+  }
+
+  if (request.tools?.some(tool => tool.name === 'get_weather')) {
+    throw new Error(
+      'get_weather was duplicated in the request-level tools list.',
+    );
+  }
+
+  if (
+    (stream && request.stream !== true) ||
+    (!stream && request.stream === true)
+  ) {
+    throw new Error(`Unexpected stream value: ${String(request.stream)}`);
+  }
+}
+
+async function main() {
+  let generateExecutions = 0;
+  const generateResult = await generateText({
+    model: openai.responses('gpt-5.4'),
+    messages: createMessages(),
+    tools: createTools(() => {
+      generateExecutions++;
+    }),
+    activeTools: [],
+    toolChoice: 'required',
+  });
+
+  validateRequest(capturedRequests[0], false);
+
+  if (
+    generateExecutions !== 1 ||
+    generateResult.toolResults[0]?.toolName !== 'get_weather'
+  ) {
+    throw new Error('generateText did not execute the discovered tool.');
+  }
+
+  let streamExecutions = 0;
+  const streamResult = streamText({
+    model: openai.responses('gpt-5.4'),
+    messages: createMessages(),
+    tools: createTools(() => {
+      streamExecutions++;
+    }),
+    activeTools: [],
+    toolChoice: 'required',
+  });
+  const streamToolCalls = await streamResult.toolCalls;
+  const streamToolResults = await streamResult.toolResults;
+
+  validateRequest(capturedRequests[1], true);
+
+  if (
+    streamExecutions !== 1 ||
+    streamToolResults[0]?.toolName !== 'get_weather'
+  ) {
+    throw new Error(
+      `streamText did not execute the discovered tool: ${JSON.stringify({
+        streamExecutions,
+        streamToolCalls,
+        streamToolResults,
+      })}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        generateText: {
+          toolName: generateResult.toolResults[0]?.toolName,
+          output: generateResult.toolResults[0]?.output,
+        },
+        streamText: {
+          toolName: streamToolResults[0]?.toolName,
+          output: streamToolResults[0]?.output,
+        },
+        requestInputOrder: capturedRequests.map(request =>
+          request.input
+            ?.filter(item =>
+              [
+                'function_call',
+                'function_call_output',
+                'additional_tools',
+              ].includes(String(item.type)),
+            )
+            .map(item => item.type),
+        ),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -220,6 +220,7 @@ export async function streamLanguageModelCall<
     generateId = originalGenerateId,
     generateCallId = originalGenerateCallId,
     now = originalNow,
+    preparedTools,
   } = {},
   onStart,
   onLanguageModelCallStart,
@@ -253,6 +254,9 @@ export async function streamLanguageModelCall<
     generateId?: IdGenerator;
     generateCallId?: IdGenerator;
     now?: () => number;
+    preparedTools?: {
+      tools: Awaited<ReturnType<typeof prepareTools>>;
+    };
   };
   onLanguageModelCallStart?: Arrayable<OnLanguageModelCallStartCallback>;
   onLanguageModelCallEnd?: Arrayable<OnLanguageModelCallEndCallback<TOOLS>>;
@@ -305,12 +309,15 @@ export async function streamLanguageModelCall<
     provider: resolvedModel.provider.split('.')[0],
   });
 
-  const stepTools = await prepareTools({
-    tools,
-    toolOrder,
-    toolsContext,
-    experimental_sandbox: sandbox,
-  });
+  const stepTools =
+    preparedTools == null
+      ? await prepareTools({
+          tools,
+          toolOrder,
+          toolsContext,
+          experimental_sandbox: sandbox,
+        })
+      : preparedTools.tools;
 
   const stepToolChoice = prepareToolChoice({
     toolChoice,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -29230,6 +29230,56 @@ describe('streamText', () => {
       expect(events).toEqual(['first', 'second']);
     });
   });
+
+  describe('active tools with dynamically loaded tools', () => {
+    it('should validate and execute calls against the full tools map', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async ({ tools }) => {
+            expect(tools?.map(tool => tool.name)).toEqual(['tool1']);
+
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool2',
+                  input: '{"value":"test"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => 'result1',
+          },
+          tool2: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result2`,
+          },
+        },
+        prompt: 'test-input',
+        activeTools: ['tool1'],
+      });
+
+      await expect(result.toolResults).resolves.toMatchObject([
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'tool2',
+          input: { value: 'test' },
+          output: 'test-result2',
+        },
+      ]);
+    });
+  });
 });
 
 async function expectUndefinedUnhandledRejections({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1883,7 +1883,7 @@ class DefaultStreamTextResult<
             retry(async () =>
               streamLanguageModelCall({
                 model: prepareStepResult?.model ?? model,
-                tools: stepActiveTools,
+                tools,
                 toolOrder: stepToolOrder,
                 toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
                 instructions: stepInstructions,
@@ -1942,6 +1942,7 @@ class DefaultStreamTextResult<
                 },
                 _internal: {
                   now,
+                  preparedTools: { tools: stepTools },
                 },
                 ...callSettings,
               }),

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 import type { ToolNameMapping } from '../../../provider-utils/src/create-tool-name-mapping';
 import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-input';
 import { describe, it, expect } from 'vitest';
@@ -5557,6 +5558,140 @@ describe('convertToOpenAIResponsesInput', () => {
           },
         ]
       `);
+    });
+
+    it('should emit additional tools immediately after a normal tool result', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_search',
+                toolName: 'connection_search',
+                output: {
+                  type: 'json',
+                  value: {
+                    connection: 'linear',
+                    qualifiedName: 'linear__list_issues',
+                  },
+                },
+                providerOptions: {
+                  openai: {
+                    additionalTools: [
+                      {
+                        type: 'function',
+                        name: 'linear__list_issues',
+                        description: 'List Linear issues',
+                        parameters: { type: 'object' },
+                        strict: true,
+                      },
+                    ],
+                  },
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_other',
+                toolName: 'other_tool',
+                output: {
+                  type: 'text',
+                  value: 'other result',
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_search',
+          output:
+            '{"connection":"linear","qualifiedName":"linear__list_issues"}',
+        },
+        {
+          type: 'additional_tools',
+          role: 'developer',
+          tools: [
+            {
+              type: 'function',
+              name: 'linear__list_issues',
+              description: 'List Linear issues',
+              parameters: { type: 'object' },
+              strict: true,
+            },
+          ],
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_other',
+          output: 'other result',
+        },
+      ]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should preserve additional tool placement when messages are replayed', async () => {
+      const prompt = [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_search',
+              toolName: 'connection_search',
+              output: {
+                type: 'json',
+                value: [{ connection: 'linear' }],
+              },
+              providerOptions: {
+                openai: {
+                  additionalTools: [
+                    {
+                      type: 'function',
+                      name: 'linear__list_issues',
+                      parameters: { type: 'object' },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Continue.' }],
+        },
+      ] satisfies LanguageModelV4Prompt;
+
+      const firstConversion = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+      const replayedConversion = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(replayedConversion.input).toEqual(firstConversion.input);
+      expect(
+        replayedConversion.input.map(item =>
+          'type' in item ? item.type : undefined,
+        ),
+      ).toEqual(['function_call_output', 'additional_tools', undefined]);
     });
   });
 });

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -27,9 +27,11 @@ import {
 } from '../tool/local-shell';
 import { shellInputSchema, shellOutputSchema } from '../tool/shell';
 import type {
+  OpenAIResponsesAdditionalTools,
   OpenAIResponsesCompactionItem,
   OpenAIResponsesCustomToolCallOutput,
   OpenAIResponsesFunctionCallOutput,
+  OpenAIResponsesFunctionTool,
   OpenAIResponsesInput,
   OpenAIResponsesReasoning,
 } from './openai-responses-api';
@@ -1082,6 +1084,20 @@ export async function convertToOpenAIResponsesInput({
             call_id: part.toolCallId,
             output: contentValue,
           });
+
+          const toolResultProviderOptions = await parseProviderOptions({
+            provider: providerOptionsName,
+            providerOptions: part.providerOptions,
+            schema: openaiResponsesToolResultProviderOptionsSchema,
+          });
+
+          if (toolResultProviderOptions?.additionalTools != null) {
+            input.push({
+              type: 'additional_tools',
+              role: 'developer',
+              tools: toolResultProviderOptions.additionalTools,
+            } satisfies OpenAIResponsesAdditionalTools);
+          }
         }
 
         break;
@@ -1123,6 +1139,20 @@ export async function convertToOpenAIResponsesInput({
 const openaiResponsesReasoningProviderOptionsSchema = z.object({
   itemId: z.string().nullish(),
   reasoningEncryptedContent: z.string().nullish(),
+});
+
+const openaiResponsesFunctionToolSchema: z.ZodType<OpenAIResponsesFunctionTool> =
+  z.object({
+    type: z.literal('function'),
+    name: z.string(),
+    description: z.string().optional(),
+    parameters: z.record(z.string(), z.unknown()),
+    strict: z.boolean().optional(),
+    defer_loading: z.boolean().optional(),
+  }) as z.ZodType<OpenAIResponsesFunctionTool>;
+
+const openaiResponsesToolResultProviderOptionsSchema = z.object({
+  additionalTools: z.array(openaiResponsesFunctionToolSchema).min(1).optional(),
 });
 
 export type OpenAIResponsesReasoningProviderOptions = z.infer<

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -25,6 +25,7 @@ export type OpenAIResponsesInputItem =
   | OpenAIResponsesAssistantMessage
   | OpenAIResponsesFunctionCall
   | OpenAIResponsesFunctionCallOutput
+  | OpenAIResponsesAdditionalTools
   | OpenAIResponsesCustomToolCall
   | OpenAIResponsesCustomToolCallOutput
   | OpenAIResponsesMcpApprovalResponse
@@ -163,6 +164,12 @@ export type OpenAIResponsesFunctionCallOutput = {
             prompt_cache_breakpoint?: { mode: 'explicit' };
           }
       >;
+};
+
+export type OpenAIResponsesAdditionalTools = {
+  type: 'additional_tools';
+  role: 'developer';
+  tools: Array<OpenAIResponsesFunctionTool>;
 };
 
 export type OpenAIResponsesCustomToolCall = {


### PR DESCRIPTION
## Background

Applications need to preserve a normal tool result while loading newly discovered OpenAI function tools at that exact history position, enabling prompt caching and local execution without duplicating tools in the request-level list.

## Summary

Added OpenAI Responses serialization for providerOptions.openai.additionalTools immediately after function_call_output, preserved replay ordering, enabled streamText validation and execution against the full tools map, and added documentation and patch changesets for @ai-sdk/openai and ai.

## Testing

Added converter tests for sibling additional_tools serialization and replay stability, plus a streamText regression test proving inactive dynamically loaded tools remain locally validated and executable.

## End-to-end Validation

- Ran the issue #17155 reproduction against the live OpenAI gpt-5.4 API; generateText and streamText both sent function_call_output followed by additional_tools, omitted get_weather from request-level tools, and invoked its local executor successfully.

## Related Issues

Fixes #17155

Co-authored-by: ruiconti <1834568+ruiconti@users.noreply.github.com>