### PR TITLE
feat(ai): group orphaned tool calls after tool approvals under parent span

### DIFF
--- a/.changeset/happy-doors-design.md
+++ b/.changeset/happy-doors-design.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/devtools": patch
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+feat(ai): group orphaned tool calls after tool approvals under parent span

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1589,6 +1589,19 @@ class DefaultStreamTextResult<
       // Re-enter the streamText tracing context after stream setup returns.
       const runInStreamTextTracingChannelContext = <T>(execute: () => T): T =>
         streamTextTracingChannelContext?.run(execute) ?? execute();
+      const runInTracingChannelSpanInStreamText =
+        telemetryDispatcher.runInTracingChannelSpan == null
+          ? undefined
+          : <T>(
+              options: Parameters<
+                NonNullable<TelemetryDispatcher['runInTracingChannelSpan']>
+              >[0] & {
+                execute: () => PromiseLike<T>;
+              },
+            ) =>
+              runInStreamTextTracingChannelContext(() =>
+                telemetryDispatcher.runInTracingChannelSpan!(options),
+              );
 
       await notify({
         event: startEvent,
@@ -1676,8 +1689,7 @@ class DefaultStreamTextResult<
                   telemetryDispatcher.onToolExecutionEnd,
                 ),
                 executeToolInTelemetryContext: telemetryDispatcher.executeTool,
-                runInTracingChannelSpan:
-                  telemetryDispatcher.runInTracingChannelSpan,
+                runInTracingChannelSpan: runInTracingChannelSpanInStreamText,
                 onPreliminaryToolResult: result => {
                   toolExecutionStepStreamController?.enqueue(result);
                 },

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,2 +1,5 @@
 export { devToolsMiddleware } from './middleware.js';
-export { DevToolsTelemetry } from './integration.js';
+export {
+  DevToolsTelemetry,
+  type DevToolsTelemetryOptions,
+} from './integration.js';

--- a/packages/devtools/src/integration.test.ts
+++ b/packages/devtools/src/integration.test.ts
@@ -4,12 +4,14 @@ import { DevToolsTelemetry } from './integration.js';
 
 const mockCreateRun = vi.fn();
 const mockCreateStep = vi.fn();
+const mockGetStepsForRun = vi.fn();
 const mockUpdateStepResult = vi.fn();
 const mockNotifyServerAsync = vi.fn();
 
 vi.mock('./db.js', () => ({
   createRun: (...args: unknown[]) => mockCreateRun(...args),
   createStep: (...args: unknown[]) => mockCreateStep(...args),
+  getStepsForRun: (...args: unknown[]) => mockGetStepsForRun(...args),
   updateStepResult: (...args: unknown[]) => mockUpdateStepResult(...args),
   notifyServerAsync: (...args: unknown[]) => mockNotifyServerAsync(...args),
 }));
@@ -230,6 +232,35 @@ describe('DevToolsTelemetry', () => {
           "fromProvider": true,
         }
       `);
+    });
+
+    it('groups resumed calls under a shared run id', async () => {
+      mockGetStepsForRun.mockResolvedValueOnce([]).mockResolvedValueOnce([{}]);
+      const integration = DevToolsTelemetry({
+        runId: 'tool-approval-run',
+      }) as unknown as TestIntegration;
+
+      await integration.onStart!(
+        makeStartEvent({ operationId: 'ai.streamText' }),
+      );
+      await integration.onStepStart!(makeStepStartEvent());
+      await integration.onEnd!({ callId: 'call-1' });
+
+      await integration.onStart!(
+        makeStartEvent({
+          callId: 'call-2',
+          operationId: 'ai.streamText',
+        }),
+      );
+      await integration.onStepStart!(makeStepStartEvent({ callId: 'call-2' }));
+
+      expect(mockCreateRun.mock.calls.map(([runId]) => runId)).toEqual([
+        'tool-approval-run',
+        'tool-approval-run',
+      ]);
+      expect(
+        mockCreateStep.mock.calls.map(([step]) => step.step_number),
+      ).toEqual([1, 2]);
     });
   });
 

--- a/packages/devtools/src/integration.ts
+++ b/packages/devtools/src/integration.ts
@@ -11,6 +11,7 @@ import type {
 import {
   createRun,
   createStep,
+  getStepsForRun,
   updateStepResult,
   notifyServerAsync,
 } from './db.js';
@@ -28,6 +29,15 @@ interface CallState {
   functionId: string | undefined;
   settings: Record<string, unknown>;
   stepStates: Map<number, StepState>;
+  stepNumberOffset: number;
+}
+
+export interface DevToolsTelemetryOptions {
+  /**
+   * Identifier used to group multiple AI SDK calls into one DevTools run.
+   * Reuse the same value when resuming an interrupted interaction.
+   */
+  runId?: string;
 }
 
 const activeSteps = new Map<string, StepState>();
@@ -99,7 +109,9 @@ function getOperationType(operationId: string): OperationType {
  * Telemetry is enabled by default — no need to set `telemetry`
  * unless you want to configure `functionId`, `recordInputs`, or `recordOutputs`.
  */
-export function DevToolsTelemetry(): Telemetry {
+export function DevToolsTelemetry(
+  options: DevToolsTelemetryOptions = {},
+): Telemetry {
   if (process.env.NODE_ENV === 'production') {
     throw new Error(
       '@ai-sdk/devtools should not be used in production. ' +
@@ -179,6 +191,7 @@ export function DevToolsTelemetry(): Telemetry {
         seed: event.seed,
       },
       stepStates: new Map(),
+      stepNumberOffset: 0,
     };
     callStates.set(callId, state);
     return state;
@@ -211,6 +224,11 @@ export function DevToolsTelemetry(): Telemetry {
         startEvent,
       );
 
+      if (options.runId != null) {
+        state.runId = options.runId;
+        state.stepNumberOffset = (await getStepsForRun(options.runId)).length;
+      }
+
       await createRun(state.runId, parentInfo, state.functionId);
     },
 
@@ -238,7 +256,7 @@ export function DevToolsTelemetry(): Telemetry {
       await createStep({
         id: stepId,
         run_id: state.runId,
-        step_number: stepNumber + 1,
+        step_number: state.stepNumberOffset + stepNumber + 1,
         type: state.operationType,
         model_id: stepStartEvent.modelId,
         provider: stepStartEvent.provider ?? null,
@@ -288,7 +306,7 @@ export function DevToolsTelemetry(): Telemetry {
       await createStep({
         id: stepId,
         run_id: state.runId,
-        step_number: stepStartEvent.stepNumber + 1,
+        step_number: state.stepNumberOffset + stepStartEvent.stepNumber + 1,
         type: state.operationType,
         model_id: stepStartEvent.modelId,
         provider: stepStartEvent.provider ?? null,

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -903,6 +903,16 @@ describe('OpenTelemetry', () => {
       expect(mock.mock.calls[2][2]).toBe(mock.mock.calls[3][2]);
     });
 
+    it('parents execute_tool under the root span before a step starts', () => {
+      integration.onStart!(makeOnStartEvent());
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+
+      const mock = tracer.startSpan as ReturnType<typeof vi.fn>;
+      const toolParentContext = mock.mock.calls[1][2];
+
+      expect(trace.getSpan(toolParentContext)).toBe(tracer.spans[0]);
+    });
+
     it('sets gen_ai.tool.call.result on success', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -776,7 +776,8 @@ export class OpenTelemetry implements Telemetry {
 
   onToolExecutionStart(event: ToolExecutionStartEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
-    if (!state?.stepContext) return;
+    const parentContext = state?.stepContext ?? state?.rootContext;
+    if (!state || !parentContext) return;
 
     const { telemetry } = state;
     const { toolCall } = event;
@@ -804,9 +805,9 @@ export class OpenTelemetry implements Telemetry {
         }),
         kind: SpanKind.INTERNAL,
       },
-      state.stepContext,
+      parentContext,
     );
-    const toolContext = trace.setSpan(state.stepContext, toolSpan);
+    const toolContext = trace.setSpan(parentContext, toolSpan);
 
     state.toolSpans.set(toolCall.toolCallId, {
       span: toolSpan,


### PR DESCRIPTION
## Background

for HITL model calls (tool approvals), both OTel and tracing channel left the tool call as an orphaned span. it'd be nice if it was nested under the same parent span.

## Summary

- resumed approved tools now fall back to the operation root context when no step context exists, creating `execute_tool` under the resumed trace
- a shared `runId` lets both HITL calls appear as one multi-step run when using the `@ai-sdk/devtools`

## Manual Verification

verified by running the following code (and viewing under the devtools viewer)

<details>
<summary>code:</summary>

```ts
import { DevToolsTelemetry } from '@ai-sdk/devtools';
import { openai } from '@ai-sdk/openai';
import { OpenTelemetry } from '@ai-sdk/otel';
import { NodeSDK } from '@opentelemetry/sdk-node';
import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
import {
  isStepCount,
  registerTelemetry,
  streamText,
  type ModelMessage,
} from 'ai';
import * as readline from 'node:readline/promises';
import { z } from 'zod/v4';
import { printFullStream } from '../../lib/print-full-stream';
import { run } from '../../lib/run';

const sdk = new NodeSDK({
  traceExporter: new ConsoleSpanExporter(),
});

sdk.start();
registerTelemetry(
  new OpenTelemetry(),
  DevToolsTelemetry({
    runId: `stream-text-tool-approval-${crypto.randomUUID()}`,
  }),
);

const terminal = readline.createInterface({
  input: process.stdin,
  output: process.stdout,
});

const weatherTool = {
  description: 'Get the weather in a location',
  inputSchema: z.object({
    location: z.string().describe('The location to get the weather for'),
  }),
  execute: async ({ location }: { location: string }) => ({
    location,
    temperature: 72,
    condition: 'sunny',
  }),
};

run(async () => {
  try {
    const messages: ModelMessage[] = [
      {
        role: 'user',
        content: 'What is the weather in San Francisco?',
      },
    ];

    const approvalRequest = streamText({
      model: openai('gpt-5.4-mini'),
      messages,
      tools: { weather: weatherTool },
      toolApproval: { weather: 'user-approval' },
      stopWhen: isStepCount(5),
      telemetry: {
        functionId: 'stream-text-tool-approval-request-devtools',
      },
    });

    let approvalId: string | undefined;

    for await (const part of approvalRequest.stream) {
      if (part.type === 'text-delta') {
        process.stdout.write(part.text);
      } else if (part.type === 'tool-approval-request') {
        approvalId = part.approvalId;
        console.log(
          `\nApproval requested for ${part.toolCall.toolName}:`,
          part.toolCall.input,
        );
      }
    }

    messages.push(...(await approvalRequest.response).messages);

    if (approvalId == null) {
      throw new Error('The model did not request tool approval.');
    }

    const answer = await terminal.question('\nApprove the tool call? (y/n) ');
    messages.push({
      role: 'tool',
      content: [
        {
          type: 'tool-approval-response',
          approvalId,
          approved:
            answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes',
        },
      ],
    });

    const approvedExecution = streamText({
      model: openai('gpt-5.4-mini'),
      messages,
      tools: { weather: weatherTool },
      toolApproval: { weather: 'user-approval' },
      stopWhen: isStepCount(5),
      telemetry: {
        functionId: 'stream-text-tool-approval-resume-devtools',
      },
    });

    await printFullStream({ result: approvedExecution });
  } finally {
    terminal.close();
    await sdk.shutdown();
  }
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)