### PR TITLE
fix(provider/amazon-bedrock): translate eager_input_streaming into the fine-grained-tool-streaming beta for Anthropic models

### DIFF
--- a/.changeset/bedrock-eager-input-streaming.md
+++ b/.changeset/bedrock-eager-input-streaming.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): translate eager_input_streaming into the fine-grained-tool-streaming beta for Anthropic models

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -496,6 +496,121 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(transformedBody?.anthropic_beta).toBeUndefined();
   });
 
+  it('should translate eager_input_streaming on tools into the fine-grained-tool-streaming beta', () => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          {
+            name: 'get_weather',
+            input_schema: { type: 'object', properties: {} },
+            eager_input_streaming: true,
+          },
+          {
+            name: 'get_time',
+            input_schema: { type: 'object', properties: {} },
+          },
+        ],
+      },
+      new Set(),
+    );
+
+    expect(transformedBody?.tools).toEqual([
+      { name: 'get_weather', input_schema: { type: 'object', properties: {} } },
+      { name: 'get_time', input_schema: { type: 'object', properties: {} } },
+    ]);
+    expect(transformedBody?.anthropic_beta).toEqual([
+      'fine-grained-tool-streaming-2025-05-14',
+    ]);
+  });
+
+  it('should not add the fine-grained-tool-streaming beta when no tool has eager_input_streaming', () => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          {
+            name: 'get_weather',
+            input_schema: { type: 'object', properties: {} },
+          },
+        ],
+      },
+      new Set(),
+    );
+
+    expect(transformedBody?.anthropic_beta).toBeUndefined();
+  });
+
+  it('should strip eager_input_streaming from tools that also get version remapped', () => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          {
+            name: 'get_weather',
+            input_schema: { type: 'object', properties: {} },
+            eager_input_streaming: true,
+          },
+          { type: 'bash_20241022', name: 'bash' },
+        ],
+      },
+      new Set(),
+    );
+
+    expect(transformedBody?.tools).toEqual([
+      { name: 'get_weather', input_schema: { type: 'object', properties: {} } },
+      { type: 'bash_20250124', name: 'bash' },
+    ]);
+    expect(transformedBody?.anthropic_beta).toEqual(
+      expect.arrayContaining([
+        'fine-grained-tool-streaming-2025-05-14',
+        'computer-use-2025-01-24',
+      ]),
+    );
+  });
+
   it('should not support URL sources to force base64 conversion', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -280,41 +280,52 @@ export function createAmazonBedrockAnthropic(
             : undefined;
 
         const requiredBetas = new Set<string>(betas);
-        const transformedTools = tools?.map((tool: Record<string, unknown>) => {
-          const toolType = tool.type as string | undefined;
-
-          if (toolType && toolType in BEDROCK_TOOL_VERSION_MAP) {
-            const newType =
-              BEDROCK_TOOL_VERSION_MAP[
-                toolType as keyof typeof BEDROCK_TOOL_VERSION_MAP
-              ];
-            if (newType in BEDROCK_TOOL_BETA_MAP) {
-              requiredBetas.add(BEDROCK_TOOL_BETA_MAP[newType]);
+        const transformedTools = tools?.map(
+          (rawTool: Record<string, unknown>) => {
+            // Bedrock rejects the per-tool eager_input_streaming field even when
+            // the fine-grained-tool-streaming beta is declared, but the beta alone
+            // enables the same behavior, so translate the field into the beta
+            const { eager_input_streaming: eagerInputStreaming, ...tool } =
+              rawTool;
+            if (eagerInputStreaming === true) {
+              requiredBetas.add('fine-grained-tool-streaming-2025-05-14');
             }
-            const newName =
-              newType in BEDROCK_TOOL_NAME_MAP
-                ? BEDROCK_TOOL_NAME_MAP[newType]
-                : tool.name;
-            return {
-              ...tool,
-              type: newType,
-              name: newName,
-            };
-          }
 
-          if (toolType && toolType in BEDROCK_TOOL_BETA_MAP) {
-            requiredBetas.add(BEDROCK_TOOL_BETA_MAP[toolType]);
-          }
+            const toolType = tool.type as string | undefined;
 
-          if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
-            return {
-              ...tool,
-              name: BEDROCK_TOOL_NAME_MAP[toolType],
-            };
-          }
+            if (toolType && toolType in BEDROCK_TOOL_VERSION_MAP) {
+              const newType =
+                BEDROCK_TOOL_VERSION_MAP[
+                  toolType as keyof typeof BEDROCK_TOOL_VERSION_MAP
+                ];
+              if (newType in BEDROCK_TOOL_BETA_MAP) {
+                requiredBetas.add(BEDROCK_TOOL_BETA_MAP[newType]);
+              }
+              const newName =
+                newType in BEDROCK_TOOL_NAME_MAP
+                  ? BEDROCK_TOOL_NAME_MAP[newType]
+                  : tool.name;
+              return {
+                ...tool,
+                type: newType,
+                name: newName,
+              };
+            }
 
-          return tool;
-        });
+            if (toolType && toolType in BEDROCK_TOOL_BETA_MAP) {
+              requiredBetas.add(BEDROCK_TOOL_BETA_MAP[toolType]);
+            }
+
+            if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
+              return {
+                ...tool,
+                name: BEDROCK_TOOL_NAME_MAP[toolType],
+              };
+            }
+
+            return tool;
+          },
+        );
 
         return {
           ...rest,


### PR DESCRIPTION
## Background

Since #14542, the Anthropic prompt builder emits a per-tool `eager_input_streaming: true` field on streaming requests with function tools (instead of the legacy `fine-grained-tool-streaming-2025-05-14` beta header, which is obsolete on the direct Anthropic API).

Bedrock's InvokeModel API strictly validates the Anthropic-native request body and does not recognize the field, so every streaming request with function tools against `@ai-sdk/amazon-bedrock/anthropic` currently fails with:

```
tools.0.custom.eager_input_streaming: Extra inputs are not permitted
```

Reported in the community: https://community.vercel.com/t/ai-gateway-aws-bedrock-fails-with-400-error-tools-0-custom-eager-input-streaming/38552

## Behavior verified against Bedrock InvokeModel

Probed live with `us.anthropic.claude-haiku-4-5-20251001-v1:0` (streaming, one function tool):

| request shape | result |
| --- | --- |
| bare `eager_input_streaming` field (current SDK output) | 400 |
| field + `fine-grained-tool-streaming-2025-05-14` in `anthropic_beta` | 400 — Bedrock rejects the field even with the beta declared |
| beta only, no field (pre-#14542 shape) | 200, tool input deltas stream |
| neither | 200 |

Bedrock still gates fine-grained tool streaming behind the beta and never accepts the per-tool field, so the field must be translated rather than passed through.

## Fix

In the `transformRequestBody` hook of the Bedrock Anthropic provider (which already rewrites tool versions and moves betas into the `anthropic_beta` body field), strip `eager_input_streaming` from each tool and add `fine-grained-tool-streaming-2025-05-14` to `anthropic_beta` when any tool had it set. This restores the request shape that worked before #14542 and preserves fine-grained tool streaming behavior on Bedrock.

## Verification

Unit tests: field is stripped and translated into the beta, no beta is added when no tool opts in, and the translation composes with the existing tool version remapping. Full `@ai-sdk/amazon-bedrock` suite passes (409 node + 409 edge), `pnpm check` and `pnpm type-check:full` pass.

Empirical AI SDK runs against live Bedrock (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) through the patched provider, asserting on both the observed behavior and the captured outbound request bodies (no `eager_input_streaming` on any tool, beta present exactly when expected):

| scenario | result |
| --- | --- |
| `streamText` + function tools, defaults (the currently broken shape) | ✅ tool call streamed with input deltas, beta present |
| `streamText` multi-step tool round trip (`stopWhen: stepCountIs(3)`, tool_result history in second request) | ✅ 2 steps, final text, both requests clean |
| `generateText` + tools (non-streaming) | ✅ works, no beta added |
| `streamText` + `toolStreaming: false` | ✅ works, no beta added |
| explicit per-tool `eagerInputStreaming: true` with request-level `toolStreaming: false` | ✅ field translated to beta |
| `streamObject` with `structuredOutputMode: 'jsonTool'` (injected json response tool also carries the field) | ✅ valid object streamed, beta present |

Before the fix, the same `streamText` + tools call through this provider failed with the 400 above.