### PR TITLE
fix(ai): streamTranscribe result promises resolve without consuming fullStream

### DIFF
--- a/.changeset/stream-transcribe-consume-on-access.md
+++ b/.changeset/stream-transcribe-consume-on-access.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+`experimental_streamTranscribe` result promises now resolve without consuming `fullStream`: accessing any result promise consumes the stream internally. Previously `await result.text` alone deadlocked on transform backpressure. Because live transcription streams can be unbounded, `fullStream` is explicitly single-consumer (no replay buffering): access it once, before any result promise, when both stream parts and final results are needed.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -71,6 +71,12 @@ for await (const part of result.fullStream) {
 console.log(await result.text);
 ```
 
+`fullStream` is a single-consumer live stream and can only be accessed once.
+When you need both stream parts and final results, access `fullStream` first and
+await the result promises while or after consuming it. Accessing a result
+promise first consumes the stream internally, so `fullStream` is no longer
+available. This avoids retaining an unbounded replay buffer for live audio.
+
 To access the final transcript metadata:
 
 ```ts

--- a/content/docs/07-reference/01-ai-sdk-core/11-stream-transcribe.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/11-stream-transcribe.mdx
@@ -99,7 +99,7 @@ console.log(await result.text);
       name: 'fullStream',
       type: 'AsyncIterableStream<TranscriptionStreamPart>',
       description:
-        'A stream of transcription parts: `transcript-delta`, `transcript-partial`, `transcript-final`, `raw`, and `error`.',
+        'A single-consumer live stream of transcription parts: `transcript-delta`, `transcript-partial`, `transcript-final`, `raw`, and `error`. Access it once, before any result promise, when both stream parts and final results are needed. Accessing a result promise first consumes the stream internally and makes `fullStream` unavailable.',
     },
     {
       name: 'text',

--- a/packages/ai/src/transcribe/stream-transcribe-result.ts
+++ b/packages/ai/src/transcribe/stream-transcribe-result.ts
@@ -81,6 +81,11 @@ export interface StreamTranscriptionResult {
 
   /**
    * Full stream of transcription parts.
+   *
+   * This is a single-consumer live stream and can only be accessed once.
+   * Access it before any result promise when both stream parts and final
+   * results are needed; accessing a result promise first consumes the stream
+   * internally and makes `fullStream` unavailable.
    */
   readonly fullStream: AsyncIterableStream<TranscriptionStreamPart>;
 }

--- a/packages/ai/src/transcribe/stream-transcribe.test.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.test.ts
@@ -359,4 +359,147 @@ describe('experimental_streamTranscribe', () => {
       expect(observedSignal?.aborted).toBe(true);
     });
   });
+
+  it('should resolve the result promises without consuming fullStream', async () => {
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () =>
+          createStreamResponse([
+            { type: 'stream-start', warnings: [] },
+            { type: 'transcript-delta', id: 'item-1', delta: 'Hello' },
+            {
+              type: 'finish',
+              text: 'Hello',
+              segments: [{ text: 'Hello', startSecond: 0, endSecond: 1 }],
+              language: 'en',
+              durationInSeconds: 1,
+            },
+          ]),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    // no fullStream access: accessing a promise consumes the stream
+    expect(await result.text).toBe('Hello');
+    expect(await result.segments).toEqual([
+      { text: 'Hello', startSecond: 0, endSecond: 1 },
+    ]);
+    expect(await result.warnings).toEqual([]);
+  });
+
+  it('should reject the result promises without consuming fullStream when no transcript is produced', async () => {
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () =>
+          createStreamResponse([{ type: 'stream-start', warnings: [] }]),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    await expect(result.text).rejects.toThrow('No transcript generated.');
+  });
+
+  it('should reject fullStream access after a result promise claimed the stream', async () => {
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () =>
+          createStreamResponse([
+            { type: 'stream-start', warnings: [] },
+            { type: 'transcript-delta', id: 'item-1', delta: 'Hello' },
+            { type: 'finish', text: 'Hello', segments: [] },
+          ]),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    expect(await result.text).toBe('Hello');
+    expect(() => result.fullStream).toThrow(
+      'fullStream cannot be accessed after a result promise.',
+    );
+  });
+
+  it('should support iterating fullStream before awaiting promises', async () => {
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () =>
+          createStreamResponse([
+            { type: 'stream-start', warnings: [] },
+            { type: 'transcript-delta', id: 'item-1', delta: 'Hello' },
+            { type: 'finish', text: 'Hello', segments: [] },
+          ]),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    const parts = await convertAsyncIterableToArray(result.fullStream);
+    expect(parts).toEqual([
+      { type: 'transcript-delta', id: 'item-1', delta: 'Hello' },
+    ]);
+    expect(await result.text).toBe('Hello');
+  });
+
+  it('should resolve a result promise while fullStream is actively consumed', async () => {
+    let modelController!: ReadableStreamDefaultController<TranscriptionModelV4StreamPart>;
+    const modelStream = new ReadableStream<TranscriptionModelV4StreamPart>({
+      start(controller) {
+        modelController = controller;
+      },
+    });
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () => ({ stream: modelStream }),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+    const reader = result.fullStream.getReader();
+
+    modelController.enqueue({ type: 'stream-start', warnings: [] });
+    modelController.enqueue({
+      type: 'transcript-delta',
+      id: 'item-1',
+      delta: 'Hello',
+    });
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { type: 'transcript-delta', id: 'item-1', delta: 'Hello' },
+    });
+
+    // Keep consuming fullStream while awaiting the result promise.
+    const streamDone = reader.read();
+    const text = result.text;
+    modelController.enqueue({ type: 'finish', text: 'Hello', segments: [] });
+    modelController.close();
+    expect(await text).toBe('Hello');
+    await expect(streamDone).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('should reject a second fullStream access', async () => {
+    const result = streamTranscribe({
+      model: new MockTranscriptionModelV4({
+        doStream: async () =>
+          createStreamResponse([
+            { type: 'stream-start', warnings: [] },
+            { type: 'finish', text: 'Hello', segments: [] },
+          ]),
+      }),
+      audio,
+      inputAudioFormat,
+    });
+
+    const fullStream = result.fullStream;
+    const textAssertion = expect(result.text).rejects.toThrow();
+    expect(() => result.fullStream).toThrow(
+      'fullStream can only be accessed once.',
+    );
+    await fullStream.cancel();
+    await textAssertion;
+  });
 });

--- a/packages/ai/src/transcribe/stream-transcribe.ts
+++ b/packages/ai/src/transcribe/stream-transcribe.ts
@@ -285,34 +285,73 @@ export function streamTranscribe({
     });
   });
 
+  // Transcription streams can be unbounded (live microphone + raw chunks), so
+  // unlike streamText we cannot retain an unread tee branch for replay. The
+  // output stream has one owner: either fullStream, or the first result promise
+  // getter which claims and drains it internally.
+  let streamOwner: 'unclaimed' | 'full-stream' | 'result-promises' =
+    'unclaimed';
+
+  function consumeStream() {
+    if (streamOwner === 'full-stream' || streamOwner === 'result-promises') {
+      return;
+    }
+    streamOwner = 'result-promises';
+    const reader = transform.readable.getReader();
+    void (async () => {
+      while (!(await reader.read()).done) {
+        // drain; results surface via the promises
+      }
+    })().catch(() => {
+      // stream errors reject the promises via the pipe handler above
+    });
+  }
+
+  function getFullStream() {
+    if (streamOwner !== 'unclaimed') {
+      throw new Error(
+        streamOwner === 'full-stream'
+          ? 'fullStream can only be accessed once.'
+          : 'fullStream cannot be accessed after a result promise.',
+      );
+    }
+    streamOwner = 'full-stream';
+    // Direct ownership preserves backpressure and cancellation: cancelling
+    // this stream reaches Transformer.cancel and aborts the model pipe.
+    return asAsyncIterableStream(transform.readable);
+  }
+
   return {
     get text() {
+      consumeStream();
       return textPromise.promise;
     },
     get segments() {
+      consumeStream();
       return segmentsPromise.promise;
     },
     get language() {
+      consumeStream();
       return languagePromise.promise;
     },
     get durationInSeconds() {
+      consumeStream();
       return durationInSecondsPromise.promise;
     },
     get warnings() {
+      consumeStream();
       return warningsPromise.promise;
     },
     get responses() {
+      consumeStream();
       return responsesPromise.promise;
     },
     get providerMetadata() {
+      consumeStream();
       return providerMetadataPromise.promise;
     },
-    // `transform.readable` is fresh and exclusively owned here, so attach the
-    // async iterator in place rather than piping through another transform.
-    // The extra transform (as `createAsyncIterableStream` would add) chains two
-    // transforms fed by the active model pipe below and surfaces a spurious
-    // unhandled `undefined` rejection when the consumer cancels early on
-    // Node.js 26.
-    fullStream: asAsyncIterableStream(transform.readable),
+    get fullStream() {
+      return getFullStream();
+    },
   };
 }


### PR DESCRIPTION
## Background

Follow-up to the streaming transcription stack (#17093/#17094/#17095), found during live gateway testing: `await result.text` on `experimental_streamTranscribe` **deadlocks silently** unless `fullStream` is consumed. The result promises only settle when parts transit the internal TransformStream, and with no `fullStream` reader the transform backpressures after ~one part, so the `finish` part never arrives.

This deviates from the contract `streamText` establishes explicitly (stream-text.ts: *"when any of the promises are accessed, the stream is consumed so it resolves without needing to consume the stream separately"*) — and for transcription, `await result.text` is the primary simple-mode usage (mic in → transcript out).

## Summary

- Accessing any result promise (`text`, `segments`, `language`, `durationInSeconds`, `warnings`, `responses`, `providerMetadata`) claims and drains the output stream internally.
- Live transcription streams can be unbounded, so `fullStream` is explicitly single-consumer (no replay tee or retained history): access it once, before any result promise, when both stream parts and final results are needed. Late/second access fails clearly.
- Direct ownership preserves normal backpressure and cancellation: cancelling `fullStream` still aborts the model pipe with a defined reason (the Node 26 spurious-rejection guard).
- No public `consumeStream()` added — the getters make it unnecessary and the experimental surface stays minimal.

## Verification

- Tests cover promise-only success/rejection, promise-first ownership, fullStream-first ownership, active iteration + concurrent result promise, second-access rejection, and cancellation cleanup.
- Full `packages/ai` suite: 2959 passed, node + edge, zero unhandled errors.
- Live: the exact `await result.text`-only script that hung against the AI Gateway preview now completes with the correct transcript.
