### PR TITLE
fix(harness-claude-code): add ToolSearch to claude code builtin tools

### DIFF
--- a/.changeset/proud-phones-collect.md
+++ b/.changeset/proud-phones-collect.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-claude-code": patch
+---
+
+fix(harness-claude-code): add ToolSearch to claude code builtin tools

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -86,6 +86,7 @@ const PUBLIC_TO_NATIVE: Readonly<Record<string, string>> = {
   ExitWorktree: 'ExitWorktree',
   AskUserQuestion: 'AskUserQuestion',
   Skill: 'Skill',
+  ToolSearch: 'ToolSearch',
 };
 
 const PUBLIC_TOOL_NAMES = Object.keys(PUBLIC_TO_NATIVE);
@@ -116,6 +117,7 @@ const NATIVE_TOOL_KINDS: Readonly<
   ExitPlanMode: 'edit',
   Skill: 'edit',
   AskUserQuestion: 'readonly',
+  ToolSearch: 'readonly',
   Bash: 'bash',
   Monitor: 'bash',
 };

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -203,6 +203,7 @@ describe('createClaudeCode adapter', () => {
       'ExitWorktree',
       'AskUserQuestion',
       'Skill',
+      'ToolSearch',
     ]);
     expect(harness.builtinTools.read.nativeName).toBe('Read');
     expect(harness.builtinTools.read.commonName).toBe('read');

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -374,6 +374,14 @@ const CLAUDE_CODE_BUILTIN_TOOLS = {
       args: z.string().optional(),
     }),
   }),
+  ToolSearch: tool({
+    description:
+      'Search deferred MCP / catalog tools so the model can load them on demand',
+    inputSchema: z.object({
+      query: z.string(),
+      max_results: z.number().optional(),
+    }),
+  }),
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
 /*


### PR DESCRIPTION
## Background

reported in https://github.com/vercel/ai/issues/16694

claude code’s native `ToolSearch` tool (used for deferred MCP tool loading) wasn’t listed in `CLAUDE_CODE_BUILTIN_TOOLS` so when the CLI called it, harness validation treated it as an unknown tool and returned `NoSuchToolError`

## Summary

declare `ToolSearch` as a claude code builtin

## Manual Verification

verified by running the script in https://github.com/vercel/ai/pull/16698 before and after the fix

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #16694