### PR TITLE
docs(ai): explain post-approval revalidation

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -329,6 +329,10 @@ export async function POST(req: Request) {
 
 In this example, only payments over $1000 require approval. Smaller amounts execute automatically.
 
+### Revalidate Mutable State
+
+Approval confirms the tool input shown to the user; it does not freeze external state. Before an approved tool performs a side effect using mutable data, fetch the current authoritative values and compare every security-relevant field, such as the amount, recipient, asset, and network, with the values the user approved. If anything changed, stop and request approval again. Use an idempotency key for the side-effect request so retries cannot duplicate the action.
+
 ### Handling Denial
 
 When a user denies a tool execution, the model receives the denial and can respond accordingly. To prevent the model from retrying the same tool call, add an instruction:


### PR DESCRIPTION
## Background

Tool approval confirms the intent shown to a user, but external terms can change before execution. The human-in-the-loop cookbook did not call out this boundary.

## Summary

- explain that approved tools should re-fetch and compare security-relevant external values before side effects
- recommend aborting on changed terms and using an idempotency key for retries
- keep the guidance framework-neutral and dependency-free

Checks: `pnpm exec ultracite check content/cookbook/01-next/75-human-in-the-loop.mdx`, `pnpm validate:docs`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)