### PR TITLE
[v6.0] fix: Effect Standard Schema classes fail as message metadata validators

### DIFF
--- a/.changeset/funny-schemas-smile.md
+++ b/.changeset/funny-schemas-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Accept callable Standard Schema validators that do not provide JSON Schema conversion.

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -13,6 +13,29 @@ describe('asSchema', () => {
       additionalProperties: false,
     });
   });
+
+  it('should validate with callable standard schemas', async () => {
+    class CallableStandardSchema {
+      static readonly '~standard' = {
+        version: 1 as const,
+        vendor: 'effect',
+        validate: (value: unknown) =>
+          typeof value === 'object' &&
+          value !== null &&
+          'model' in value &&
+          typeof value.model === 'string'
+            ? { value: { model: value.model } }
+            : { issues: [{ message: 'model must be a string' }] },
+      };
+    }
+
+    const schema = asSchema(CallableStandardSchema);
+
+    await expect(schema.validate?.({ model: 'test-model' })).resolves.toEqual({
+      success: true,
+      value: { model: 'test-model' },
+    });
+  });
 });
 
 describe('zodSchema', () => {

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -69,7 +69,13 @@ export type ZodSchema<SCHEMA = any> =
   | z3.Schema<SCHEMA, z3.ZodTypeDef, any>
   | z4.core.$ZodType<SCHEMA, any>;
 
-export type StandardSchema<SCHEMA = any> = StandardSchemaV1<unknown, SCHEMA> &
+export type StandardSchema<SCHEMA = any> = StandardSchemaV1<unknown, SCHEMA> & {
+  readonly '~standard': StandardSchemaV1.Props<unknown, SCHEMA> & {
+    readonly jsonSchema?: StandardJSONSchemaV1.Converter;
+  };
+};
+
+type StandardSchemaWithJsonSchema<SCHEMA = any> = StandardSchema<SCHEMA> &
   StandardJSONSchemaV1<unknown, SCHEMA>;
 
 export type FlexibleSchema<SCHEMA = any> =
@@ -154,12 +160,19 @@ function standardSchema<OBJECT>(
   standardSchema: StandardSchema<OBJECT>,
 ): Schema<OBJECT> {
   return jsonSchema(
-    () =>
-      addAdditionalPropertiesToJsonSchema(
+    () => {
+      if (!hasStandardJsonSchema(standardSchema)) {
+        throw new Error(
+          `Standard schema vendor '${standardSchema['~standard'].vendor}' does not support JSON Schema conversion.`,
+        );
+      }
+
+      return addAdditionalPropertiesToJsonSchema(
         standardSchema['~standard'].jsonSchema.input({
           target: 'draft-07',
         }) as JSONSchema7,
-      ),
+      );
+    },
     {
       validate: async value => {
         const result = await standardSchema['~standard'].validate(value);
@@ -175,6 +188,12 @@ function standardSchema<OBJECT>(
       },
     },
   );
+}
+
+function hasStandardJsonSchema<OBJECT>(
+  schema: StandardSchema<OBJECT>,
+): schema is StandardSchemaWithJsonSchema<OBJECT> {
+  return schema['~standard'].jsonSchema != null;
 }
 
 export function zod3Schema<OBJECT>(


### PR DESCRIPTION
## Background

Effect Standard Schema validators are callable classes, causing valid message metadata schemas to be rejected or invoked as constructors instead of validators.

## Summary

Allowed Standard Schema validators without JSON Schema conversion and guarded JSON Schema access when conversion is requested.

## Testing

Added regression coverage proving callable Standard Schema classes validate metadata successfully.

## End-to-end Validation

- `cd examples/ai-functions && pnpm tsx src/reproduction/issue-9934-effect-message-metadata-schema.ts` completed successfully with Effect 3.18.4; the chat remained ready and retained `{ model: 'test-model' }` metadata.

## Related Issues

Fixes #9934

Backport of #17191

Co-authored-by: wormsan <6257388+wormsan@users.noreply.github.com>