### PR TITLE
reproduction: could not reproduce Refactor: use FlexibleSchema instead of z3/z4 schema types

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-8573.ts
+++ b/examples/ai-functions/src/reproduction/issue-8573.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { generateObject, tool } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from '../../../../node_modules/.pnpm/zod@4.1.11/node_modules/zod/index.js';
+
+async function main() {
+  const objectSchema = z.object({ content: z.string() });
+  const inputSchema = z.object({ name: z.string() });
+
+  const greetingTool = tool({
+    inputSchema,
+    execute: async ({ name }) => `Hello, ${name}!`,
+  });
+
+  assert.equal(greetingTool.inputSchema, inputSchema);
+
+  const result = await generateObject({
+    model: new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: '{"content":"Hello, world!"}' }],
+        finishReason: { raw: undefined, unified: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 1,
+            noCache: 1,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 1,
+            text: 1,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      }),
+    }),
+    schema: objectSchema,
+    prompt: 'Return a greeting.',
+  });
+
+  assert.deepEqual(result.object, { content: 'Hello, world!' });
+  console.log(
+    'Zod 4.1.11 schemas were accepted by tool() and generateObject().',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Refactor: use `FlexibleSchema` instead of z3/z4 schema types

## Reproduction

- The current checkout already uses `FlexibleSchema` constraints in `generateObject`, `streamObject`, and the React, Vue, and Svelte object APIs; the reported explicit Zod `3/Zod` 4 union is absent.
- Reproduction artifact `examples/ai-functions/src/reproduction/issue-8573.ts` uses an independently installed Zod 4.1.11 schema with both `tool()` and `generateObject()`.
- The artifact compiled and generated the expected validated object, so the reported TypeScript schema incompatibility did not occur.
- Exact Zod 4.1.8 was unavailable in the prepared checkout; Zod 4.1.11, which satisfies the current `^4.1.8` peer range, was tested instead.

## Related Issues

Could not reproduce #8573