### PR TITLE
reproduction: could not reproduce web search tool name does not respect key

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-8190-openai-web-search-tool-name.ts
+++ b/examples/ai-functions/src/reproduction/issue-8190-openai-web-search-tool-name.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+async function main() {
+  let requestBody: unknown;
+
+  const openai = createOpenAI({
+    fetch: async (input, init) => {
+      if (
+        String(input).endsWith('/responses') &&
+        typeof init?.body === 'string'
+      ) {
+        requestBody = JSON.parse(init.body);
+      }
+
+      return fetch(input, init);
+    },
+  });
+
+  const result = await generateText({
+    model: openai.responses('gpt-5-mini'),
+    prompt: 'Search the web for the current weather in Tokyo and summarize it.',
+    tools: {
+      webSearch: openai.tools.webSearchPreview({}),
+    },
+    toolChoice: {
+      type: 'tool',
+      toolName: 'webSearch',
+    },
+    providerOptions: {
+      openai: {
+        store: false,
+        include: ['reasoning.encrypted_content'],
+      },
+    },
+  });
+
+  const toolCallNames = result.toolCalls.map(toolCall => toolCall.toolName);
+  const toolResultNames = result.toolResults.map(
+    toolResult => toolResult.toolName,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        requestBody,
+        toolCallNames,
+        toolResultNames,
+        text: result.text,
+      },
+      null,
+      2,
+    ),
+  );
+
+  assert.ok(
+    toolCallNames.length > 0,
+    'OpenAI did not call the web search tool.',
+  );
+  assert.ok(
+    toolResultNames.length > 0,
+    'OpenAI did not return a web search tool result.',
+  );
+  assert.deepEqual(
+    toolCallNames,
+    toolCallNames.map(() => 'webSearch'),
+    'Issue #8190 reproduced: tool calls use web_search_preview instead of the tools object key webSearch.',
+  );
+  assert.deepEqual(
+    toolResultNames,
+    toolResultNames.map(() => 'webSearch'),
+    'Issue #8190 reproduced: tool results use web_search_preview instead of the tools object key webSearch.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

web search tool name does not respect key in tools object

## Reproduction

- The reported behavior would expose `web_search_preview` instead of the application-defined `webSearch`, breaking logic keyed by the configured tool name.
- The live `gpt-5-mini` Responses API call sent OpenAI's required `web_search_preview` type, but both AI SDK tool calls and tool results correctly used `webSearch`; the reported mismatch did not occur.
- The runnable reproduction at `examples/ai-functions/src/reproduction/issue-8190-openai-web-search-tool-name.ts` asserts that the tools object key is preserved and passed.
- `packages/ai/CHANGELOG.md` and `packages/openai/CHANGELOG.md` record change `954c356`, allowing custom names for provider-defined tools, in versions newer than those reported.
- The prepared workspace uses `ai@7.0.26` and `@ai-sdk/openai@4.0.13`; the historical `ai@5.0.18` and `@ai-sdk/openai@2.0.16` combination was not rerun.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/providers/ai-sdk-providers/openai
- https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal/delta?lang=curl

## Related Issues

Could not reproduce #8190