### PR TITLE
reproduction: could not reproduce Incorrect property name: responseSchema should be responsejsonschema for

### DIFF
--- a/examples/ai-functions/src/reproduction/google-response-schema-7689.ts
+++ b/examples/ai-functions/src/reproduction/google-response-schema-7689.ts
@@ -1,0 +1,63 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText, Output } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  let requestBody: unknown;
+  let responseBody: unknown;
+  let responseStatus: number | undefined;
+
+  const google = createGoogleGenerativeAI({
+    fetch: async (input, init) => {
+      requestBody =
+        typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body;
+
+      const response = await fetch(input, init);
+      responseStatus = response.status;
+
+      const responseText = await response.clone().text();
+      try {
+        responseBody = JSON.parse(responseText);
+      } catch {
+        responseBody = responseText;
+      }
+
+      return response;
+    },
+  });
+
+  const result = await generateText({
+    model: google('gemini-2.5-flash'),
+    output: Output.object({
+      schema: z.object({
+        location: z.string(),
+      }),
+    }),
+    prompt: 'Return the location "Paris".',
+  });
+
+  if (result.output.location !== 'Paris') {
+    throw new Error(
+      `Expected the structured output location to be "Paris", received ${JSON.stringify(result.output)}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        requestBody,
+        responseStatus,
+        responseBody,
+        output: result.output,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/google-response-schema-7689.json
+++ b/packages/google/src/__fixtures__/google-response-schema-7689.json
@@ -1,0 +1,31 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{\"location\": \"Paris\"}"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 7,
+    "candidatesTokenCount": 6,
+    "totalTokenCount": 49,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 7
+      }
+    ],
+    "thoughtsTokenCount": 36,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "nyxWarWeK6bnxN8Psp-UQQ"
+}

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -395,7 +395,8 @@ describe('doGenerate', () => {
         | typeof TEST_URL_GEMINI_2_0_PRO
         | typeof TEST_URL_GEMINI_2_0_FLASH_EXP
         | typeof TEST_URL_GEMINI_1_0_PRO
-        | typeof TEST_URL_GEMINI_1_5_FLASH;
+        | typeof TEST_URL_GEMINI_1_5_FLASH
+        | typeof TEST_URL_GEMINI_2_5_FLASH;
     } = {},
   ) {
     server.urls[url].response = {
@@ -1213,6 +1214,46 @@ describe('doGenerate', () => {
         },
       }
     `);
+  });
+
+  it('should accept lowercase JSON Schema types in responseSchema (issue #7689)', async () => {
+    prepareJsonFixtureResponse('google-response-schema-7689', {
+      url: TEST_URL_GEMINI_2_5_FLASH,
+    });
+
+    const result = await provider.languageModel('gemini-2.5-flash').doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+          required: ['location'],
+        },
+      },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Return the location "Paris".' }],
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: 'object',
+          properties: {
+            location: { type: 'string' },
+          },
+          required: ['location'],
+        },
+      },
+    });
+    expect(result.content).toContainEqual({
+      type: 'text',
+      text: '{"location": "Paris"}',
+    });
   });
 
   it('should pass specification with responseFormat and structuredOutputs = true (default)', async () => {


### PR DESCRIPTION
## Bug

Incorrect property name: `responseSchema` should be `response_json_schema` for Google providers

## Reproduction

- The reported primary failure was an HTTP 400 when structured output sends lowercase JSON Schema types through `generationConfig.responseSchema`.
- The live reproduction in `examples/ai-functions/src/reproduction/google-response-schema-7689.ts` sent `responseSchema` with lowercase `object` and `string` types to Gemini 2.5 Flash and received HTTP 200 with `{"location":"Paris"}`.
- The checkout uses `@ai-sdk/google` 4.0.14 rather than the reported 2.0.0, but it retains the reported `responseSchema` request shape.
- The live response was recorded in `packages/google/src/__fixtures__/google-response-schema-7689.json`, with a fixture-backed provider test added to `packages/google/src/google-language-model.test.ts`.
- Google's API reference documents `responseSchema` as a valid OpenAPI-subset field and `responseJsonSchema` as an alternative for JSON Schema.

## Relevant Documentation

- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/structured-output?lang=rest

## Related Issues

Could not reproduce #7689