### PR TITLE
reproduction: could not reproduce Incorrect property name: responseSchema should be responsejsonschema for

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/google-response-schema-7689.ts
+++ b/examples/ai-functions/src/reproduction/google-response-schema-7689.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { createGoogleGenerativeAI } from '../../../../packages/google/dist/index.mjs';
+import {
+  generateObject,
+  jsonSchema,
+} from '../../../../packages/ai/dist/index.mjs';
+
+let requestBody: unknown;
+let responseStatus: number | undefined;
+let responseBody: unknown;
+
+const google = createGoogleGenerativeAI({
+  fetch: async (url, init) => {
+    requestBody = JSON.parse(String(init?.body));
+
+    const response = await fetch(url, init);
+    responseStatus = response.status;
+    responseBody = await response
+      .clone()
+      .json()
+      .catch(async () => await response.clone().text());
+
+    return response;
+  },
+});
+
+async function main() {
+  const result = await generateObject({
+    model: google('gemini-2.5-flash'),
+    schema: jsonSchema<{ location: string }>({
+      type: 'object',
+      properties: {
+        location: { type: 'string' },
+      },
+      required: ['location'],
+      additionalProperties: false,
+    }),
+    prompt: 'Return the location Paris.',
+  });
+
+  const generationConfig = (
+    requestBody as {
+      generationConfig?: {
+        responseSchema?: {
+          type?: string;
+          properties?: { location?: { type?: string } };
+        };
+      };
+    }
+  ).generationConfig;
+
+  assert.equal(generationConfig?.responseSchema?.type, 'object');
+  assert.equal(
+    generationConfig.responseSchema.properties?.location?.type,
+    'string',
+  );
+  assert.equal(
+    responseStatus,
+    200,
+    `Expected Google to accept responseSchema with lowercase JSON Schema types, received ${responseStatus}: ${JSON.stringify(responseBody)}`,
+  );
+  assert.equal(typeof result.object.location, 'string');
+
+  console.log(
+    JSON.stringify(
+      {
+        requestBody,
+        responseStatus,
+        responseBody,
+        object: result.object,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/google-response-schema-7689.json
+++ b/packages/google/src/__fixtures__/google-response-schema-7689.json
@@ -1,0 +1,31 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{\"location\":\"Paris\"}"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 6,
+    "candidatesTokenCount": 5,
+    "totalTokenCount": 51,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 6
+      }
+    ],
+    "thoughtsTokenCount": 40,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "0C9WatDANYSd28oPhM6D8QM"
+}

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -9,6 +9,7 @@ import {
   getGroundingMetadataSchema,
   getUrlContextMetadataSchema,
 } from './google-generative-ai-language-model';
+import fs from 'node:fs';
 
 import type {
   GoogleGenerativeAIGroundingMetadata,
@@ -354,6 +355,9 @@ describe('doGenerate', () => {
   const TEST_URL_GEMINI_2_0_FLASH_EXP =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent';
 
+  const TEST_URL_GEMINI_2_5_FLASH =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+
   const TEST_URL_GEMINI_1_0_PRO =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.0-pro:generateContent';
 
@@ -364,6 +368,7 @@ describe('doGenerate', () => {
     [TEST_URL_GEMINI_PRO]: {},
     [TEST_URL_GEMINI_2_0_PRO]: {},
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
+    [TEST_URL_GEMINI_2_5_FLASH]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
   });
@@ -391,6 +396,7 @@ describe('doGenerate', () => {
       | typeof TEST_URL_GEMINI_PRO
       | typeof TEST_URL_GEMINI_2_0_PRO
       | typeof TEST_URL_GEMINI_2_0_FLASH_EXP
+      | typeof TEST_URL_GEMINI_2_5_FLASH
       | typeof TEST_URL_GEMINI_1_0_PRO
       | typeof TEST_URL_GEMINI_1_5_FLASH;
   }) => {
@@ -943,6 +949,63 @@ describe('doGenerate', () => {
         },
       },
     });
+  });
+
+  it('accepts responseSchema with lowercase JSON Schema types (issue #7689)', async () => {
+    server.urls[TEST_URL_GEMINI_2_5_FLASH].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/google-response-schema-7689.json',
+          'utf8',
+        ),
+      ),
+    };
+
+    const result = await provider.languageModel('gemini-2.5-flash').doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+          required: ['location'],
+          additionalProperties: false,
+        },
+      },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Return the location Paris.' }],
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'Return the location Paris.' }],
+        },
+      ],
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseSchema: {
+          required: ['location'],
+          type: 'object',
+          properties: {
+            location: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    });
+    expect(result.content).toContainEqual({
+      type: 'text',
+      text: '{"location":"Paris"}',
+      providerMetadata: undefined,
+    });
+    expect(result.finishReason).toBe('stop');
   });
 
   it('should pass specification with responseFormat and structuredOutputs = true (default)', async () => {


### PR DESCRIPTION
## Bug

Incorrect property name: `responseSchema` should be `response_json_schema` for Google providers

## Reproduction

- Live reproduction at `examples/ai-functions/src/reproduction/google-response-schema-7689.ts` used `@ai-sdk/google` 2.0.79 and sent `generationConfig.responseSchema` with lowercase `object` and `string` types to Gemini 2.5 Flash.
- Gemini returned HTTP 200 with `{"location":"Paris"}` instead of the reported HTTP 400, so the primary failure did not occur.
- The live response was recorded in `packages/google/src/__fixtures__/google-response-schema-7689.json` and replayed by a provider test in `packages/google/src/google-generative-ai-language-model.test.ts`.
- `examples/ai-functions/package.json` was added because this checkout lacked that workspace, making the required reproduction command runnable.
- Google's GenerateContent reference documents `responseSchema` as valid and `responseJsonSchema` as an alternative JSON Schema field.

## Relevant Documentation

- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/structured-output?lang=rest

## Related Issues

Could not reproduce #7689