### PR TITLE
reproduction: onFinish callback for streamText is missing tool information

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-8578-stream-text-on-finish-tool-information.ts
+++ b/examples/ai-functions/src/reproduction/issue-8578-stream-text-on-finish-tool-information.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import type {
+  LanguageModelV2,
+  LanguageModelV2StreamPart,
+} from '@ai-sdk/provider';
+import { dynamicTool, stepCountIs, streamText } from 'ai';
+import { z } from 'zod';
+
+const toolCallId = 'call-list-my-issues';
+
+function convertArrayToReadableStream<T>(values: T[]): ReadableStream<T> {
+  return new ReadableStream({
+    start(controller) {
+      for (const value of values) {
+        controller.enqueue(value);
+      }
+      controller.close();
+    },
+  });
+}
+
+async function main() {
+  let responseCount = 0;
+  let observed:
+    | {
+        dynamicToolCallIds: string[];
+        dynamicToolResultIds: string[];
+        finalStepToolCallIds: string[];
+        finalStepToolResultIds: string[];
+        stepCount: number;
+        stepToolCallIds: string[];
+        stepToolResultIds: string[];
+        text: string;
+        toolCallIds: string[];
+        toolResultIds: string[];
+      }
+    | undefined;
+
+  const model: LanguageModelV2 = {
+    specificationVersion: 'v2',
+    provider: 'issue-8578-reproduction',
+    modelId: 'deterministic-tool-loop',
+    supportedUrls: {},
+    doGenerate: async () => {
+      throw new Error('doGenerate is not used by this reproduction');
+    },
+    doStream: async () => {
+      switch (responseCount++) {
+        case 0:
+          return {
+            stream: convertArrayToReadableStream<LanguageModelV2StreamPart>([
+              {
+                type: 'tool-call',
+                toolCallId,
+                toolName: 'list_my_issues',
+                input: JSON.stringify({
+                  limit: 5,
+                  orderBy: 'updatedAt',
+                }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 5,
+                  totalTokens: 15,
+                },
+              },
+            ]),
+          };
+        case 1:
+          return {
+            stream: convertArrayToReadableStream<LanguageModelV2StreamPart>([
+              { type: 'text-start', id: 'text-1' },
+              {
+                type: 'text-delta',
+                id: 'text-1',
+                delta: 'Here are your 5 latest Linear issues.',
+              },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: {
+                  inputTokens: 20,
+                  outputTokens: 10,
+                  totalTokens: 30,
+                },
+              },
+            ]),
+          };
+        default:
+          throw new Error(`Unexpected model response ${responseCount}`);
+      }
+    },
+  };
+
+  const result = streamText({
+    model,
+    prompt: 'Fetch my latest Linear issues.',
+    tools: {
+      list_my_issues: dynamicTool({
+        inputSchema: z.object({
+          limit: z.number(),
+          orderBy: z.string(),
+        }),
+        execute: async () => ({
+          issues: [{ id: 'ISSUE-1', title: 'Example issue' }],
+        }),
+      }),
+    },
+    stopWhen: stepCountIs(10),
+    onFinish: finishResult => {
+      const finalStep = finishResult.steps.at(-1);
+
+      observed = {
+        dynamicToolCallIds: finishResult.dynamicToolCalls.map(
+          toolCall => toolCall.toolCallId,
+        ),
+        dynamicToolResultIds: finishResult.dynamicToolResults.map(
+          toolResult => toolResult.toolCallId,
+        ),
+        finalStepToolCallIds:
+          finalStep?.toolCalls.map(toolCall => toolCall.toolCallId) ?? [],
+        finalStepToolResultIds:
+          finalStep?.toolResults.map(toolResult => toolResult.toolCallId) ?? [],
+        stepCount: finishResult.steps.length,
+        stepToolCallIds: finishResult.steps.flatMap(step =>
+          step.toolCalls.map(toolCall => toolCall.toolCallId),
+        ),
+        stepToolResultIds: finishResult.steps.flatMap(step =>
+          step.toolResults.map(toolResult => toolResult.toolCallId),
+        ),
+        text: finishResult.text,
+        toolCallIds: finishResult.toolCalls.map(
+          toolCall => toolCall.toolCallId,
+        ),
+        toolResultIds: finishResult.toolResults.map(
+          toolResult => toolResult.toolCallId,
+        ),
+      };
+    },
+  });
+
+  await result.consumeStream();
+
+  assert.ok(observed, 'onFinish should have been called');
+  assert.equal(responseCount, 2);
+  assert.equal(observed.stepCount, 2);
+  assert.equal(observed.text, 'Here are your 5 latest Linear issues.');
+  assert.deepEqual(observed.stepToolCallIds, [toolCallId]);
+  assert.deepEqual(observed.stepToolResultIds, [toolCallId]);
+  assert.deepEqual(observed.finalStepToolCallIds, []);
+  assert.deepEqual(observed.finalStepToolResultIds, []);
+
+  console.log(JSON.stringify(observed, null, 2));
+
+  assert.deepEqual(
+    {
+      dynamicToolCallIds: observed.dynamicToolCallIds,
+      dynamicToolResultIds: observed.dynamicToolResultIds,
+      toolCallIds: observed.toolCallIds,
+      toolResultIds: observed.toolResultIds,
+    },
+    {
+      dynamicToolCallIds: [toolCallId],
+      dynamicToolResultIds: [toolCallId],
+      toolCallIds: [toolCallId],
+      toolResultIds: [toolCallId],
+    },
+    'onFinish should expose tool calls and results executed in earlier steps',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../../packages/provider
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -27396,7 +27418,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -36840,7 +36862,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:
@@ -38497,6 +38519,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -40035,6 +40066,38 @@ snapshots:
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Bug

onFinish callback for streamText is missing tool information

## Reproduction

- Added runnable reproduction at `examples/ai-functions/src/reproduction/issue-8578-stream-text-on-finish-tool-information.ts` against AI SDK 5.0.212.
- A two-step dynamic tool flow executed `call-list-my-issues` and produced its result in the first step, followed by a text-only final step.
- `onFinish.steps` contained the tool call and result, while top-level `toolCalls`, `dynamicToolCalls`, `toolResults`, and `dynamicToolResults` were all empty.
- The expected issue behavior was observed: the dedicated top-level `onFinish` fields omitted tool information executed during an earlier step.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling

## Related Issues

Reproduces #8578