### PR TITLE
feat: support smoothing streamed tool inputs with configurable chunking and per-tool controls

### DIFF
--- a/.changeset/smooth-tools-smile.md
+++ b/.changeset/smooth-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add opt-in tool input smoothing to `smoothStream`

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -553,7 +553,8 @@ If you e.g. have a transformation that changes all text to uppercase, the `onEnd
 #### Smoothing streams
 
 The AI SDK Core provides a [`smoothStream` function](/docs/reference/ai-sdk-core/smooth-stream) that
-can be used to smooth out text and reasoning streaming.
+can be used to smooth out text and reasoning streaming. Tool input smoothing can
+be enabled separately with the `toolInputSmoothing` option.
 
 ```tsx highlight="6"
 import { smoothStream, streamText } from 'ai';
@@ -562,6 +563,17 @@ const result = streamText({
   model,
   prompt,
   experimental_transform: smoothStream(),
+});
+```
+
+```tsx highlight="6-8"
+const result = streamText({
+  model,
+  prompt,
+  tools,
+  experimental_transform: smoothStream({
+    toolInputSmoothing: {},
+  }),
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -1,6 +1,6 @@
 ---
 title: smoothStream
-description: Stream transformer for smoothing text and reasoning output
+description: Stream transformer for smoothing text, reasoning, and tool input output
 ---
 
 # `smoothStream()`
@@ -8,7 +8,8 @@ description: Stream transformer for smoothing text and reasoning output
 `smoothStream` is a utility function that creates a TransformStream
 for the `streamText` `transform` option
 to smooth out text and reasoning streaming by buffering and releasing complete chunks with configurable delays.
-This creates a more natural reading experience when streaming text and reasoning responses.
+It can also opt in to smoothing streamed tool inputs.
+This creates a more natural experience when displaying streaming model output.
 
 ```ts highlight={"6-9"}
 import { smoothStream, streamText } from 'ai';
@@ -47,8 +48,57 @@ const result = streamText({
       description:
         'Controls how text and reasoning content is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom callback or RegExp pattern for custom chunking.',
     },
+    {
+      name: 'toolInputSmoothing',
+      type: '{ chunking?: "character" | RegExp | ChunkDetector; include?: string[]; exclude?: string[] }',
+      isOptional: true,
+      description:
+        'Opts in to smoothing tool input deltas. Tool inputs are streamed character by character by default. Use include to smooth only selected tools and exclude to opt individual tools out.',
+    },
   ]}
 />
+
+### Smoothing tool inputs
+
+Tool input smoothing is disabled by default. Enable it with `toolInputSmoothing`.
+The default character chunking works with partial JSON, including input that is
+not valid JSON until the tool call is complete.
+
+```ts highlight={"10-13"}
+import { smoothStream, streamText } from 'ai';
+
+const result = streamText({
+  model,
+  prompt: 'Check the weather in London.',
+  tools: {
+    weather,
+    uploadFile,
+  },
+  experimental_transform: smoothStream({
+    toolInputSmoothing: {
+      exclude: ['uploadFile'],
+    },
+  }),
+});
+```
+
+You can provide a regular expression or custom chunk detector when
+character-by-character streaming is too fine-grained:
+
+```ts
+smoothStream({
+  toolInputSmoothing: {
+    chunking: /[:,}\]]/,
+  },
+});
+```
+
+<Note>
+  Smoothing can only subdivide tool input deltas after the provider sends them.
+  It cannot make a provider start streaming tool input earlier. Delaying many
+  small tool input chunks can also delay tool execution, so adjust `delayInMs`
+  or the tool input chunking strategy for large inputs.
+</Note>
 
 #### Word chunking caveats with non-latin languages
 
@@ -139,7 +189,7 @@ smoothStream({
 
 Returns a `TransformStream` that:
 
-- Buffers incoming text and reasoning chunks
+- Buffers incoming text, reasoning, and enabled tool input chunks
 - Releases content when the chunking pattern is encountered
 - Adds configurable delays between chunks for smooth output
-- Passes through non-text/reasoning chunks (like tool calls, step-finish events) immediately
+- Passes through other chunks (like tool calls and step-finish events) immediately

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -203,7 +203,7 @@ It also contains the following helper functions:
     },
     {
       title: 'smoothStream()',
-      description: 'Smooths text and reasoning streaming output.',
+      description: 'Smooths text, reasoning, and tool input streaming output.',
       href: '/docs/reference/ai-sdk-core/smooth-stream',
     },
     {

--- a/examples/ai-functions/src/stream-text/anthropic/smooth-tool-input.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/smooth-tool-input.ts
@@ -1,0 +1,49 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { smoothStream, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-6'),
+    prompt:
+      'Use the weather tool to check the weather in London, United Kingdom.',
+    tools: {
+      weather: tool({
+        description: 'Get the weather for a location.',
+        inputSchema: z.object({
+          city: z.string(),
+          country: z.string(),
+        }),
+        execute: async input => ({
+          ...input,
+          temperature: 18,
+          condition: 'partly cloudy',
+        }),
+      }),
+    },
+    toolChoice: { type: 'tool', toolName: 'weather' },
+    experimental_transform: smoothStream({
+      delayInMs: 5,
+      toolInputSmoothing: {},
+    }),
+  });
+
+  const toolInputDeltas: string[] = [];
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'tool-input-delta') {
+      toolInputDeltas.push(part.delta);
+      process.stdout.write(part.delta);
+    }
+  }
+
+  console.log();
+
+  if (
+    toolInputDeltas.length === 0 ||
+    toolInputDeltas.some(delta => [...delta].length !== 1)
+  ) {
+    throw new Error('Expected character-by-character tool input deltas.');
+  }
+});

--- a/packages/ai/src/generate-text/smooth-stream-tool-input.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream-tool-input.test.ts
@@ -1,0 +1,247 @@
+import type { ToolSet } from '@ai-sdk/provider-utils';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, vi } from 'vitest';
+import { smoothStream } from './smooth-stream';
+import type { TextStreamPart } from './stream-text-result';
+
+async function consumeStream(
+  stream: ReadableStream<TextStreamPart<ToolSet>>,
+): Promise<TextStreamPart<ToolSet>[]> {
+  const events: TextStreamPart<ToolSet>[] = [];
+  const reader = stream.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    events.push(value);
+  }
+
+  return events;
+}
+
+function createStream(
+  chunks: TextStreamPart<ToolSet>[],
+  options: Parameters<typeof smoothStream>[0],
+) {
+  return convertArrayToReadableStream(chunks).pipeThrough(
+    smoothStream({
+      ...options,
+      _internal: {
+        delay: options?._internal?.delay,
+      },
+    })({ tools: {} }),
+  );
+}
+
+describe('smoothStream tool input smoothing', () => {
+  it.each([null, 'word', new Intl.Segmenter('en')])(
+    'rejects invalid tool input chunking: %s',
+    chunking => {
+      expect(() =>
+        smoothStream({
+          toolInputSmoothing: {
+            chunking: chunking as any,
+          },
+        }),
+      ).toThrowError();
+    },
+  );
+
+  it('smooths tool input character by character when enabled', async () => {
+    const delay = vi.fn(async () => {});
+
+    const events = await consumeStream(
+      createStream(
+        [
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          {
+            type: 'tool-input-delta',
+            id: 'call-1',
+            delta: '{"city":"London 🌧️"}',
+            providerMetadata: { testProvider: { signature: 'test' } },
+          },
+          { type: 'tool-input-end', id: 'call-1' },
+        ],
+        {
+          delayInMs: 5,
+          toolInputSmoothing: {},
+          _internal: { delay },
+        },
+      ),
+    );
+
+    expect(events).toEqual([
+      { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+      ...[...'{"city":"London 🌧️"}'].map((delta, index, input) => ({
+        type: 'tool-input-delta' as const,
+        id: 'call-1',
+        delta,
+        ...(index === input.length - 1
+          ? {
+              providerMetadata: {
+                testProvider: { signature: 'test' },
+              },
+            }
+          : {}),
+      })),
+      { type: 'tool-input-end', id: 'call-1' },
+    ]);
+    expect(delay).toHaveBeenCalledTimes([...'{"city":"London 🌧️"}'].length);
+    expect(delay).toHaveBeenCalledWith(5);
+  });
+
+  it('preserves malformed partial JSON with custom chunking', async () => {
+    const events = await consumeStream(
+      createStream(
+        [
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city":' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '"Lon' },
+          { type: 'tool-input-delta', id: 'call-1', delta: 'don"' },
+          { type: 'tool-input-end', id: 'call-1' },
+        ],
+        {
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /[:,]/,
+          },
+        },
+      ),
+    );
+
+    expect(events).toEqual([
+      { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '{"city":' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '"London"' },
+      { type: 'tool-input-end', id: 'call-1' },
+    ]);
+    expect(
+      events
+        .filter(event => event.type === 'tool-input-delta')
+        .map(event => event.delta)
+        .join(''),
+    ).toBe('{"city":"London"');
+  });
+
+  it('supports including and excluding individual tools', async () => {
+    const events = await consumeStream(
+      createStream(
+        [
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"}' },
+          { type: 'tool-input-end', id: 'call-1' },
+          { type: 'tool-input-start', id: 'call-2', toolName: 'upload' },
+          { type: 'tool-input-delta', id: 'call-2', delta: '{"data":"abc"}' },
+          { type: 'tool-input-end', id: 'call-2' },
+          { type: 'tool-input-start', id: 'call-3', toolName: 'search' },
+          { type: 'tool-input-delta', id: 'call-3', delta: '{"query":"AI"}' },
+          { type: 'tool-input-end', id: 'call-3' },
+        ],
+        {
+          delayInMs: null,
+          toolInputSmoothing: {
+            include: ['weather', 'upload'],
+            exclude: ['upload'],
+          },
+        },
+      ),
+    );
+
+    expect(events.filter(event => event.type === 'tool-input-delta')).toEqual([
+      ...[...'{"city":"Rome"}'].map(delta => ({
+        type: 'tool-input-delta',
+        id: 'call-1',
+        delta,
+      })),
+      { type: 'tool-input-delta', id: 'call-2', delta: '{"data":"abc"}' },
+      { type: 'tool-input-delta', id: 'call-3', delta: '{"query":"AI"}' },
+    ]);
+  });
+
+  it('preserves ordering for interleaved parallel tool calls', async () => {
+    const events = await consumeStream(
+      createStream(
+        [
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-start', id: 'call-2', toolName: 'search' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city"' },
+          { type: 'tool-input-delta', id: 'call-2', delta: '{"query"' },
+          { type: 'tool-input-delta', id: 'call-1', delta: ':"Rome"}' },
+          { type: 'tool-input-end', id: 'call-1' },
+          { type: 'tool-input-delta', id: 'call-2', delta: ':"AI"}' },
+          { type: 'tool-input-end', id: 'call-2' },
+        ],
+        {
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /:/,
+          },
+        },
+      ),
+    );
+
+    expect(events).toEqual([
+      { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+      { type: 'tool-input-start', id: 'call-2', toolName: 'search' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '{"city"' },
+      { type: 'tool-input-delta', id: 'call-2', delta: '{"query"' },
+      { type: 'tool-input-delta', id: 'call-1', delta: ':' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '"Rome"}' },
+      { type: 'tool-input-end', id: 'call-1' },
+      { type: 'tool-input-delta', id: 'call-2', delta: ':' },
+      { type: 'tool-input-delta', id: 'call-2', delta: '"AI"}' },
+      { type: 'tool-input-end', id: 'call-2' },
+    ]);
+  });
+
+  it.each([
+    { type: 'error' as const, error: new Error('test') },
+    { type: 'abort' as const, reason: 'test' },
+  ])('flushes pending tool input before $type chunks', async finalChunk => {
+    const events = await consumeStream(
+      createStream(
+        [
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+          finalChunk,
+        ],
+        {
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /,missing,/,
+          },
+        },
+      ),
+    );
+
+    expect(events).toEqual([
+      { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+      finalChunk,
+    ]);
+  });
+
+  it('flushes pending tool input when the stream closes', async () => {
+    const events = await consumeStream(
+      createStream(
+        [
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+        ],
+        {
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /,missing,/,
+          },
+        },
+      ),
+    );
+
+    expect(events).toEqual([
+      { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+    ]);
+  });
+});

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -10,6 +10,8 @@ const CHUNKING_REGEXPS = {
   line: /\n+/m,
 };
 
+type TextChunking = 'word' | 'line' | RegExp | ChunkDetector | Intl.Segmenter;
+
 /**
  * Detects the first chunk in a buffer.
  *
@@ -19,32 +21,15 @@ const CHUNKING_REGEXPS = {
  */
 export type ChunkDetector = (buffer: string) => string | undefined | null;
 
-/**
- * Smooths text and reasoning streaming output.
- *
- * @param delayInMs - The delay in milliseconds between each chunk. Defaults to 10ms. Can be set to `null` to skip the delay.
- * @param chunking - Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, provide a custom RegExp pattern for custom chunking, provide an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom ChunkDetector function.
- *
- * @returns A transform stream that smooths text streaming output.
- */
-export function smoothStream<TOOLS extends ToolSet>({
-  delayInMs = 10,
-  chunking = 'word',
-  _internal: { delay = originalDelay } = {},
+function createChunkDetector({
+  chunking,
+  argument,
+  validChunkingDescription,
 }: {
-  delayInMs?: number | null;
-  chunking?: 'word' | 'line' | RegExp | ChunkDetector | Intl.Segmenter;
-  /**
-   * Internal. For test use only. May change without notice.
-   */
-  _internal?: {
-    delay?: (delayInMs: number | null) => Promise<void>;
-  };
-} = {}): (options: {
-  tools: TOOLS;
-}) => TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>> {
-  let detectChunk: ChunkDetector;
-
+  chunking: TextChunking;
+  argument: string;
+  validChunkingDescription: string;
+}): ChunkDetector {
   // Check if chunking is an Intl.Segmenter (duck-typing for segment method)
   if (
     chunking != null &&
@@ -53,14 +38,16 @@ export function smoothStream<TOOLS extends ToolSet>({
     typeof chunking.segment === 'function'
   ) {
     const segmenter = chunking as Intl.Segmenter;
-    detectChunk = (buffer: string) => {
+    return (buffer: string) => {
       if (buffer.length === 0) return null;
       const iterator = segmenter.segment(buffer)[Symbol.iterator]();
       const first = iterator.next().value;
       return first?.segment || null;
     };
-  } else if (typeof chunking === 'function') {
-    detectChunk = buffer => {
+  }
+
+  if (typeof chunking === 'function') {
+    return buffer => {
       const match = chunking(buffer);
 
       if (match == null) {
@@ -79,37 +66,121 @@ export function smoothStream<TOOLS extends ToolSet>({
 
       return match;
     };
-  } else {
-    const chunkingRegex =
-      typeof chunking === 'string'
-        ? CHUNKING_REGEXPS[chunking]
-        : chunking instanceof RegExp
-          ? chunking
-          : undefined;
+  }
 
-    if (chunkingRegex == null) {
-      throw new InvalidArgumentError({
-        argument: 'chunking',
-        message: `Chunking must be "word", "line", a RegExp, an Intl.Segmenter, or a ChunkDetector function. Received: ${chunking}`,
-      });
+  const chunkingRegex =
+    typeof chunking === 'string'
+      ? CHUNKING_REGEXPS[chunking]
+      : chunking instanceof RegExp
+        ? chunking
+        : undefined;
+
+  if (chunkingRegex == null) {
+    throw new InvalidArgumentError({
+      argument,
+      message: `Chunking must be ${validChunkingDescription}. Received: ${chunking}`,
+    });
+  }
+
+  return buffer => {
+    const match = chunkingRegex.exec(buffer);
+
+    if (!match) {
+      return null;
     }
 
-    detectChunk = buffer => {
-      const match = chunkingRegex.exec(buffer);
+    return buffer.slice(0, match.index) + match[0];
+  };
+}
 
-      if (!match) {
-        return null;
-      }
+/**
+ * Smooths text, reasoning, and optionally tool input streaming output.
+ *
+ * @param delayInMs - The delay in milliseconds between each chunk. Defaults to 10ms. Can be set to `null` to skip the delay.
+ * @param chunking - Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, provide a custom RegExp pattern for custom chunking, provide an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom ChunkDetector function.
+ * @param toolInputSmoothing - Opt-in configuration for smoothing tool input deltas. Tool inputs are streamed character by character by default. Use `include` or `exclude` to control smoothing for individual tools.
+ *
+ * @returns A transform stream that smooths streaming output.
+ */
+export function smoothStream<TOOLS extends ToolSet>({
+  delayInMs = 10,
+  chunking = 'word',
+  toolInputSmoothing,
+  _internal: { delay = originalDelay } = {},
+}: {
+  delayInMs?: number | null;
+  chunking?: TextChunking;
+  toolInputSmoothing?: {
+    /**
+     * Controls how tool input JSON is chunked. Defaults to character-by-character chunking.
+     */
+    chunking?: 'character' | RegExp | ChunkDetector;
+    /**
+     * Only smooth tool inputs for these tools.
+     */
+    include?: ReadonlyArray<keyof TOOLS & string>;
+    /**
+     * Do not smooth tool inputs for these tools.
+     */
+    exclude?: ReadonlyArray<keyof TOOLS & string>;
+  };
+  /**
+   * Internal. For test use only. May change without notice.
+   */
+  _internal?: {
+    delay?: (delayInMs: number | null) => Promise<void>;
+  };
+} = {}): (options: {
+  tools: TOOLS;
+}) => TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>> {
+  const detectChunk = createChunkDetector({
+    chunking,
+    argument: 'chunking',
+    validChunkingDescription:
+      '"word", "line", a RegExp, an Intl.Segmenter, or a ChunkDetector function',
+  });
 
-      return buffer.slice(0, match.index) + match?.[0];
-    };
+  const toolInputChunking = toolInputSmoothing?.chunking;
+  if (
+    toolInputSmoothing != null &&
+    toolInputChunking !== undefined &&
+    toolInputChunking !== 'character' &&
+    !(toolInputChunking instanceof RegExp) &&
+    typeof toolInputChunking !== 'function'
+  ) {
+    throw new InvalidArgumentError({
+      argument: 'toolInputSmoothing.chunking',
+      message: `Chunking must be "character", a RegExp, or a ChunkDetector function. Received: ${toolInputChunking}`,
+    });
   }
+
+  const detectToolInputChunk =
+    toolInputChunking == null || toolInputChunking === 'character'
+      ? (buffer: string) => {
+          const codePoint = buffer.codePointAt(0);
+          return codePoint == null ? null : String.fromCodePoint(codePoint);
+        }
+      : createChunkDetector({
+          chunking: toolInputChunking,
+          argument: 'toolInputSmoothing.chunking',
+          validChunkingDescription:
+            '"character", a RegExp, or a ChunkDetector function',
+        });
 
   return () => {
     let buffer = '';
     let id = '';
     let type: 'text-delta' | 'reasoning-delta' | undefined = undefined;
     let providerMetadata: SharedV4ProviderMetadata | undefined = undefined;
+    let activeToolInputId: string | undefined;
+    const toolInputStates = new Map<
+      string,
+      {
+        buffer: string;
+        providerMetadata: SharedV4ProviderMetadata | undefined;
+        smooth: boolean;
+      }
+    >();
 
     function flushBuffer(
       controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
@@ -126,37 +197,161 @@ export function smoothStream<TOOLS extends ToolSet>({
       }
     }
 
+    function flushToolInputBuffer(
+      id: string,
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      const state = toolInputStates.get(id);
+
+      if (state != null && state.buffer.length > 0) {
+        controller.enqueue({
+          type: 'tool-input-delta',
+          id,
+          delta: state.buffer,
+          ...(state.providerMetadata != null
+            ? { providerMetadata: state.providerMetadata }
+            : {}),
+        });
+        state.buffer = '';
+        state.providerMetadata = undefined;
+      }
+    }
+
+    function flushActiveToolInputBuffer(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      if (activeToolInputId != null) {
+        flushToolInputBuffer(activeToolInputId, controller);
+        activeToolInputId = undefined;
+      }
+    }
+
+    function flushAllBuffers(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      flushBuffer(controller);
+      flushActiveToolInputBuffer(controller);
+
+      // Only the active tool input can normally have a buffer. Iterate over all
+      // states as a safeguard for malformed or interrupted streams.
+      for (const id of toolInputStates.keys()) {
+        flushToolInputBuffer(id, controller);
+      }
+    }
+
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async transform(chunk, controller) {
-        // Handle non-smoothable chunks: flush buffer and pass through
-        if (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') {
+        if (chunk.type === 'text-delta' || chunk.type === 'reasoning-delta') {
+          flushActiveToolInputBuffer(controller);
+
+          // Flush buffer when type or id changes
+          if ((chunk.type !== type || chunk.id !== id) && buffer.length > 0) {
+            flushBuffer(controller);
+          }
+
+          buffer += chunk.text;
+          id = chunk.id;
+          type = chunk.type;
+
+          // Preserve providerMetadata (e.g., Anthropic thinking signatures)
+          if (chunk.providerMetadata != null) {
+            providerMetadata = chunk.providerMetadata;
+          }
+
+          let match;
+
+          while ((match = detectChunk(buffer)) != null) {
+            controller.enqueue({ type, text: match, id });
+            buffer = buffer.slice(match.length);
+
+            await delay(delayInMs);
+          }
+          return;
+        }
+
+        if (chunk.type === 'tool-input-start') {
           flushBuffer(controller);
+          flushActiveToolInputBuffer(controller);
+
+          const { include, exclude } = toolInputSmoothing ?? {};
+          toolInputStates.set(chunk.id, {
+            buffer: '',
+            providerMetadata: undefined,
+            smooth:
+              toolInputSmoothing != null &&
+              (include == null || include.includes(chunk.toolName)) &&
+              (exclude == null || !exclude.includes(chunk.toolName)),
+          });
+
           controller.enqueue(chunk);
           return;
         }
 
-        // Flush buffer when type or id changes
-        if ((chunk.type !== type || chunk.id !== id) && buffer.length > 0) {
+        if (chunk.type === 'tool-input-delta') {
           flushBuffer(controller);
+
+          const state = toolInputStates.get(chunk.id);
+          if (state == null || !state.smooth) {
+            flushActiveToolInputBuffer(controller);
+            controller.enqueue(chunk);
+            return;
+          }
+
+          if (activeToolInputId != null && activeToolInputId !== chunk.id) {
+            flushActiveToolInputBuffer(controller);
+          }
+          activeToolInputId = chunk.id;
+
+          state.buffer += chunk.delta;
+          if (chunk.providerMetadata != null) {
+            state.providerMetadata = chunk.providerMetadata;
+          }
+
+          let match;
+
+          while ((match = detectToolInputChunk(state.buffer)) != null) {
+            const isLastBufferedChunk = match.length === state.buffer.length;
+            controller.enqueue({
+              type: 'tool-input-delta',
+              id: chunk.id,
+              delta: match,
+              ...(isLastBufferedChunk && state.providerMetadata != null
+                ? { providerMetadata: state.providerMetadata }
+                : {}),
+            });
+            state.buffer = state.buffer.slice(match.length);
+
+            if (isLastBufferedChunk) {
+              state.providerMetadata = undefined;
+            }
+
+            await delay(delayInMs);
+          }
+          return;
         }
 
-        buffer += chunk.text;
-        id = chunk.id;
-        type = chunk.type;
+        if (chunk.type === 'tool-input-end') {
+          flushBuffer(controller);
 
-        // Preserve providerMetadata (e.g., Anthropic thinking signatures)
-        if (chunk.providerMetadata != null) {
-          providerMetadata = chunk.providerMetadata;
+          if (activeToolInputId != null && activeToolInputId !== chunk.id) {
+            flushActiveToolInputBuffer(controller);
+          }
+
+          flushToolInputBuffer(chunk.id, controller);
+          if (activeToolInputId === chunk.id) {
+            activeToolInputId = undefined;
+          }
+          toolInputStates.delete(chunk.id);
+          controller.enqueue(chunk);
+          return;
         }
 
-        let match;
-
-        while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
-          buffer = buffer.slice(match.length);
-
-          await delay(delayInMs);
-        }
+        // Handle non-smoothable chunks: flush buffers and pass through.
+        flushAllBuffers(controller);
+        controller.enqueue(chunk);
+      },
+      flush(controller) {
+        flushAllBuffers(controller);
       },
     });
   };


### PR DESCRIPTION
## Background

Developers can now smooth streamed tool-call inputs for more natural incremental UI updates while retaining the existing default pass-through behavior.

## Summary

Added opt-in `toolInputSmoothing` support to `smoothStream`, including character or custom chunking, include/exclude filters, parallel-call buffering, metadata preservation, documentation, an Anthropic example, and a patch changeset.

## Testing

Added focused coverage for Unicode character smoothing, custom and malformed partial JSON, metadata, per-tool filtering, interleaved calls, invalid options, and flushing on end, error, abort, and stream close.

## End-to-end Validation

- Built `ai` and ran the live Anthropic example with `claude-sonnet-4-6`; it produced the expected weather-tool JSON through validated character-level deltas.

## Related Issues

Fixes #7720

Co-authored-by: Shinchan3102 <106232138+Shinchan3102@users.noreply.github.com>