### PR TITLE
[v5.0] fix: UI message validation rejects persisted assistant responses with empty parts

### DIFF
--- a/.changeset/calm-chats-rest.md
+++ b/.changeset/calm-chats-rest.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Allow validating assistant UI messages with empty parts so persisted errored responses remain loadable.

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -76,6 +76,36 @@ describe('validateUIMessages', () => {
         ]]
       `);
     });
+
+    it('should validate chat ending with assistant message with empty parts array', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            id: '2',
+            role: 'assistant',
+            parts: [],
+          },
+        ],
+      });
+
+      expect(messages).toEqual([
+        {
+          id: '1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+        {
+          id: '2',
+          role: 'assistant',
+          parts: [],
+        },
+      ]);
+    });
   });
 
   describe('metadata', () => {
@@ -1232,6 +1262,37 @@ describe('safeValidateUIMessages', () => {
     expectToBe(result.success, false);
     expect(result.error.name).toBe('AI_TypeValidationError');
     expect(result.error.message).toContain('Type validation failed');
+  });
+
+  it('should return success result for chat ending with assistant message with empty parts array', async () => {
+    const result = await safeValidateUIMessages({
+      messages: [
+        {
+          id: '1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+        {
+          id: '2',
+          role: 'assistant',
+          parts: [],
+        },
+      ],
+    });
+
+    expectToBe(result.success, true);
+    expect(result.data).toEqual([
+      {
+        id: '1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [],
+      },
+    ]);
   });
 
   it('should return failure result when metadata validation fails', async () => {

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -22,12 +22,12 @@ const uiMessagesSchema = lazyValidator(() =>
   zodSchema(
     z
       .array(
-        z.object({
-          id: z.string(),
-          role: z.enum(['system', 'user', 'assistant']),
-          metadata: z.unknown().optional(),
-          parts: z
-            .array(
+        z
+          .object({
+            id: z.string(),
+            role: z.enum(['system', 'user', 'assistant']),
+            metadata: z.unknown().optional(),
+            parts: z.array(
               z.union([
                 z.object({
                   type: z.literal('text'),
@@ -217,9 +217,21 @@ const uiMessagesSchema = lazyValidator(() =>
                   }),
                 }),
               ]),
-            )
-            .nonempty('Message must contain at least one part'),
-        }),
+            ),
+          })
+          .superRefine((message, context) => {
+            if (message.role !== 'assistant' && message.parts.length === 0) {
+              context.addIssue({
+                origin: 'array',
+                code: 'too_small',
+                minimum: 1,
+                inclusive: true,
+                input: message.parts,
+                path: ['parts'],
+                message: 'Message must contain at least one part',
+              });
+            }
+          }),
       )
       .nonempty('Messages array must not be empty'),
   ),


### PR DESCRIPTION
## Background

Persisted chats could become unloadable when an errored assistant response was saved with an empty parts array.

## Summary

Allowed assistant UI messages to have empty parts while retaining non-empty parts validation for user and system messages.

## Testing

Added regression coverage for validateUIMessages and safeValidateUIMessages using chats ending with an empty assistant response.

## End-to-end Validation

- `pnpm --filter ai build` followed by an inline `pnpm tsx` persisted-chat validation returned `{"success":true,"messageCount":2}`.

## Related Issues

Fixes #11053

Backport of #17201

Co-authored-by: davidroeca <6155705+davidroeca@users.noreply.github.com>