### PR TITLE
reproduction: could not reproduce bug: short abort signals in streamText trigger onError

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-8088-short-abort-callback.ts
+++ b/examples/ai-functions/src/reproduction/issue-8088-short-abort-callback.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { streamText } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+
+async function main() {
+  const abortController = new AbortController();
+  const callbacks: Array<{
+    name: 'onAbort' | 'onError';
+    errorName?: string;
+    steps?: number;
+  }> = [];
+
+  const model = new MockLanguageModelV4({
+    doStream: async ({ abortSignal }) => {
+      await new Promise<never>((_, reject) => {
+        if (abortSignal == null) {
+          reject(new Error('Expected streamText to forward the abort signal'));
+          return;
+        }
+
+        if (abortSignal.aborted) {
+          reject(abortSignal.reason);
+          return;
+        }
+
+        abortSignal.addEventListener(
+          'abort',
+          () => reject(abortSignal.reason),
+          { once: true },
+        );
+      });
+
+      throw new Error('unreachable');
+    },
+  });
+
+  setTimeout(() => abortController.abort(), 100);
+
+  const { textStream } = streamText({
+    model,
+    prompt: 'Start a response that will be cancelled immediately.',
+    abortSignal: abortController.signal,
+    onError: ({ error }) => {
+      callbacks.push({
+        name: 'onError',
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+    },
+    onAbort: ({ steps }) => {
+      callbacks.push({ name: 'onAbort', steps: steps.length });
+    },
+  });
+
+  for await (const _ of textStream) {
+    // The model call is aborted before a provider stream is returned.
+  }
+
+  console.log(JSON.stringify(callbacks, null, 2));
+
+  assert.deepEqual(
+    callbacks,
+    [{ name: 'onAbort', steps: 0 }],
+    'A short AbortSignal cancellation must call onAbort, not onError.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

bug: short abort signals in `streamText()` trigger `onError()` instead of `onAbort()`

## Reproduction

- Added `examples/ai-functions/src/reproduction/issue-8088-short-abort-callback.ts` to test a 100 ms abort before the provider stream is returned; it observed one `onAbort` call and zero `onError` calls, so the reported outcome did not occur.
- A live OpenAI Responses API check using `gpt-5-nano`, the reported messages, and a 100 ms abort also invoked only `onAbort` on `ai@7.0.26` and `@ai-sdk/openai@4.0.13`.
- The original AI SDK 5 snippet produces `AI_InvalidPromptError` on the current SDK because system messages inside `messages` now require `allowSystemInMessages: true`; enabling it allowed the abort scenario to complete correctly.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/ai-sdk-core/error-handling
- https://platform.openai.com/docs/models/default-usage-policies-by-endpoint
- https://platform.openai.com/docs/api-reference/responses-streaming/response/function_call_arguments/done?api-mode=responses

## Related Issues

Could not reproduce #8088