### PR TITLE
reproduction: could not reproduce Thought Signatures for Images are missing in Streaming

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts
+++ b/examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts
@@ -1,0 +1,125 @@
+import { google, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { streamText } from 'ai';
+
+const modelId = 'gemini-3-pro-image-preview';
+const firstPrompt =
+  'Create a simple square image of a yellow moon in a black sky.';
+
+const providerOptions = {
+  google: {
+    responseModalities: ['TEXT', 'IMAGE'],
+  } satisfies GoogleLanguageModelOptions,
+};
+
+async function main() {
+  const first = streamText({
+    model: google(modelId),
+    prompt: firstPrompt,
+    providerOptions,
+  });
+
+  let streamedImageCount = 0;
+  let signedStreamedImageCount = 0;
+  const turn1EventTypes: string[] = [];
+
+  for await (const part of first.fullStream) {
+    turn1EventTypes.push(part.type);
+
+    if (part.type === 'error') {
+      throw part.error;
+    }
+
+    if (part.type === 'file' && part.file.mediaType.startsWith('image/')) {
+      streamedImageCount++;
+
+      if (typeof part.providerMetadata?.google?.thoughtSignature === 'string') {
+        signedStreamedImageCount++;
+      }
+    }
+  }
+
+  if (streamedImageCount === 0) {
+    throw new Error(
+      `Turn 1 did not stream an image. finishReason=${await first.finishReason}; text=${JSON.stringify(await first.text)}; eventTypes=${JSON.stringify(turn1EventTypes)}`,
+    );
+  }
+
+  if (signedStreamedImageCount === 0) {
+    throw new Error(
+      'Issue #10660 reproduced: the streamed image had no Google thoughtSignature.',
+    );
+  }
+
+  const firstResponseMessages = (await first.response).messages;
+  const signedHistoryImageCount = firstResponseMessages.reduce(
+    (count, message) => {
+      if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+        return count;
+      }
+
+      return (
+        count +
+        message.content.filter(
+          part =>
+            part.type === 'file' &&
+            typeof part.providerOptions?.google?.thoughtSignature === 'string',
+        ).length
+      );
+    },
+    0,
+  );
+
+  if (signedHistoryImageCount === 0) {
+    throw new Error(
+      'Issue #10660 reproduced: streamText did not preserve the image thoughtSignature in response history.',
+    );
+  }
+
+  const second = streamText({
+    model: google(modelId),
+    messages: [
+      { role: 'user', content: firstPrompt },
+      ...firstResponseMessages,
+      {
+        role: 'user',
+        content: 'Nice, but now make the moon look like Swiss cheese.',
+      },
+    ],
+    providerOptions,
+  });
+
+  let refinedImageCount = 0;
+
+  for await (const part of second.fullStream) {
+    if (part.type === 'error') {
+      throw part.error;
+    }
+
+    if (part.type === 'file' && part.file.mediaType.startsWith('image/')) {
+      refinedImageCount++;
+    }
+  }
+
+  if (refinedImageCount === 0) {
+    throw new Error(
+      'Issue #10660 reproduced: the follow-up streaming turn did not produce a refined image.',
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        modelId,
+        streamedImageCount,
+        signedStreamedImageCount,
+        signedHistoryImageCount,
+        refinedImageCount,
+        result: 'The streamed image signature round-tripped successfully.',
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main();


### PR DESCRIPTION
## Bug

Thought Signatures for Images are missing in Streaming

## Reproduction

- The current checkout uses `ai@7.0.26` and `@ai-sdk/google@4.0.14`; `packages/google/CHANGELOG.md` records image thought-signature support as fixed in version 3.0.38.
- The live `gemini-3-pro-image-preview` stream emitted an image with a Google `thoughtSignature`, and `streamText` preserved it in the response history.
- Returning that history in a second streaming request successfully produced a refined image, so the reported user-visible failure did not occur.
- Runnable reproduction: `examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts`.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/generate-content/gemini-3
- https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
- https://ai.google.dev/gemini-api/docs/generate-content/image-generation

## Related Issues

Could not reproduce #10660