### PR TITLE
fix(amazon-bedrock): expose request body in doGenerate and doStream return values

### DIFF
--- a/.changeset/fix-bedrock-request-body.md
+++ b/.changeset/fix-bedrock-request-body.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Expose the request body in `doGenerate` and `doStream` return values so callers can inspect the Bedrock Converse API payload that was sent.

--- a/packages/amazon-bedrock/src/__snapshots__/amazon-bedrock-chat-language-model.test.ts.snap
+++ b/packages/amazon-bedrock/src/__snapshots__/amazon-bedrock-chat-language-model.test.ts.snap
@@ -44,6 +44,29 @@ There are 3 r's.",
       },
     },
   },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
+    },
+  },
   "response": {
     "headers": {
       "content-length": "865",
@@ -105,6 +128,29 @@ There are **3** "r"s in "strawberry."",
       "usage": {
         "cacheWriteInputTokens": 0,
       },
+    },
+  },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
     },
   },
   "response": {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -286,6 +286,18 @@ describe('doStream', () => {
         }
       `);
     });
+
+    it('should expose the request body', async () => {
+      const { request } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(request?.body).toMatchObject({
+        messages: expect.any(Array),
+        system: expect.any(Array),
+      });
+    });
   });
 
   describe('reasoning', () => {
@@ -3286,6 +3298,17 @@ describe('doGenerate', () => {
           "timestamp": undefined,
         }
       `);
+    });
+
+    it('should expose the request body', async () => {
+      const { request } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(request?.body).toMatchObject({
+        messages: expect.any(Array),
+        system: expect.any(Array),
+      });
     });
 
     it('should expose the raw response headers', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -655,6 +655,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
         raw: response.stopReason ?? undefined,
       },
       usage: convertAmazonBedrockUsage(response.usage),
+      request: { body: args },
       response: {
         id: responseHeaders?.['x-amzn-requestid'] ?? undefined,
         timestamp:
@@ -1090,7 +1091,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           },
         }),
       ),
-      // TODO request?
+      request: { body: args },
       response: { headers: responseHeaders },
     };
   }


### PR DESCRIPTION
## Summary

The Amazon Bedrock provider was not exposing the `request` field in the return values of `doGenerate()` and `doStream()`, even though other providers (e.g. Anthropic, OpenAI) do. This made it impossible for callers to inspect the Bedrock Converse API payload that was actually sent.

This was marked with a `// TODO request?` comment in the `doStream` implementation.

## Changes

- Added `request: { body: args }` to the return object of `doGenerate()` (where `args` is the Bedrock Converse API request body)
- Added `request: { body: args }` to the return object of `doStream()` (replacing the `// TODO request?` comment)
- Added test cases asserting `request.body` is exposed with expected `messages` and `system` fields for both methods
- Updated snapshots to include the new `request` field
- Added a patch changeset for `@ai-sdk/amazon-bedrock`

Closes #13927

## Test plan

- [x] All 130 existing tests pass in `packages/amazon-bedrock`
- [x] New tests added for `request.body` in both `doGenerate` and `doStream`
- [x] Snapshots updated to reflect new return value shape