### PR TITLE
fix: Azure DeepSeek structured output returns JSON in reasoning with empty text

### DIFF
--- a/.changeset/azure-deepseek-json-schema.md
+++ b/.changeset/azure-deepseek-json-schema.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/deepseek': patch
+'@ai-sdk/azure': patch
+---
+
+fix: Azure DeepSeek structured output returns JSON in reasoning with empty text

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -477,6 +477,56 @@ describe('deepseek', () => {
     `);
   });
 
+  it('should send a json_schema response format for structured output', async () => {
+    prepareJsonFixtureResponse('azure-deepseek-reasoning.1', undefined, 'chat');
+
+    await provider.deepseek('deepseek-v4-flash').doGenerate({
+      prompt: TEST_PROMPT,
+      reasoning: 'high',
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { sentiment: { type: 'string' } },
+          required: ['sentiment'],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello",
+            "role": "user",
+          },
+        ],
+        "model": "deepseek-v4-flash",
+        "reasoning_effort": "high",
+        "response_format": {
+          "json_schema": {
+            "name": "response",
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "sentiment": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "sentiment",
+              ],
+              "type": "object",
+            },
+            "strict": true,
+          },
+          "type": "json_schema",
+        },
+      }
+    `);
+  });
+
   it('should stream reasoning content', async () => {
     prepareChunksFixtureResponse(
       'azure-deepseek-reasoning.1',

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -262,6 +262,8 @@ export function createAzure(
       headers: getHeaders,
       fetch,
       supportsThinking: false,
+      // json_object with thinking enabled makes Azure return the JSON in reasoning_content with empty content
+      supportsStructuredOutputs: true,
     });
 
   const createCompletionModel = (modelId: string) =>

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -9,10 +9,12 @@ export function convertToDeepSeekChatMessages({
   prompt,
   responseFormat,
   modelId,
+  supportsStructuredOutputs = false,
 }: {
   prompt: LanguageModelV4Prompt;
   responseFormat: LanguageModelV4CallOptions['responseFormat'];
   modelId: string;
+  supportsStructuredOutputs?: boolean;
 }): {
   messages: DeepSeekChatPrompt;
   warnings: Array<SharedV4Warning>;
@@ -28,7 +30,7 @@ export function convertToDeepSeekChatMessages({
         role: 'system',
         content: 'Return JSON.',
       });
-    } else {
+    } else if (!supportsStructuredOutputs) {
       messages.push({
         role: 'system',
         content:

--- a/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
@@ -27,6 +27,13 @@ export const deepseekLanguageModelChatOptions = z.object({
    * is mapped to `max` server-side for compatibility with other providers.
    */
   reasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+
+  /**
+   * Whether to use strict JSON schema validation for structured outputs.
+   * Only applies when the serving endpoint supports JSON schema response
+   * formats (e.g. Azure). Defaults to `true`.
+   */
+  strictJsonSchema: z.boolean().optional(),
 });
 
 export type DeepSeekLanguageModelChatOptions = z.infer<

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
@@ -1,9 +1,10 @@
-import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import type { JSONSchema7, LanguageModelV4Prompt } from '@ai-sdk/provider';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createDeepSeek } from '../deepseek-provider';
+import { DeepSeekChatLanguageModel } from './deepseek-chat-language-model';
 import type { DeepSeekLanguageModelChatOptions } from './deepseek-chat-language-model-options';
 
 const TEST_PROMPT: LanguageModelV4Prompt = [
@@ -563,6 +564,104 @@ describe('DeepSeekChatLanguageModel', () => {
           });
 
           expect(result).toMatchSnapshot();
+        });
+      });
+
+      describe('json response format with structured outputs', () => {
+        const structuredOutputsModel = new DeepSeekChatLanguageModel(
+          'deepseek-v4-flash',
+          {
+            provider: 'azure.deepseek',
+            url: () => 'https://api.deepseek.com/chat/completions',
+            headers: () => ({}),
+            supportsStructuredOutputs: true,
+          },
+        );
+
+        const TEST_SCHEMA: JSONSchema7 = {
+          type: 'object',
+          properties: { sentiment: { type: 'string' } },
+          required: ['sentiment'],
+          additionalProperties: false,
+        };
+
+        beforeEach(() => {
+          prepareJsonFixtureResponse('deepseek-json');
+        });
+
+        it('should send json_schema response format and skip schema injection', async () => {
+          const { warnings } = await structuredOutputsModel.doGenerate({
+            prompt: TEST_PROMPT,
+            responseFormat: {
+              type: 'json',
+              name: 'sentiment',
+              schema: TEST_SCHEMA,
+            },
+          });
+
+          expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+            {
+              "messages": [
+                {
+                  "content": "Hello",
+                  "role": "user",
+                },
+              ],
+              "model": "deepseek-v4-flash",
+              "response_format": {
+                "json_schema": {
+                  "name": "sentiment",
+                  "schema": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "sentiment": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "sentiment",
+                    ],
+                    "type": "object",
+                  },
+                  "strict": true,
+                },
+                "type": "json_schema",
+              },
+            }
+          `);
+          expect(warnings).toStrictEqual([]);
+        });
+
+        it('should honor strictJsonSchema provider option', async () => {
+          await structuredOutputsModel.doGenerate({
+            prompt: TEST_PROMPT,
+            responseFormat: { type: 'json', schema: TEST_SCHEMA },
+            providerOptions: {
+              azure: {
+                strictJsonSchema: false,
+              } satisfies DeepSeekLanguageModelChatOptions,
+            },
+          });
+
+          const body = await server.calls[0].requestBodyJson;
+          expect(body.response_format).toMatchObject({
+            type: 'json_schema',
+            json_schema: { strict: false, name: 'response' },
+          });
+        });
+
+        it('should fall back to json_object without a schema', async () => {
+          await structuredOutputsModel.doGenerate({
+            prompt: TEST_PROMPT,
+            responseFormat: { type: 'json' },
+          });
+
+          const body = await server.calls[0].requestBodyJson;
+          expect(body.response_format).toStrictEqual({ type: 'json_object' });
+          expect(body.messages[0]).toStrictEqual({
+            role: 'system',
+            content: 'Return JSON.',
+          });
         });
       });
 

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -50,6 +50,7 @@ export type DeepSeekChatConfig = {
   url: (options: { modelId: string; path: string }) => string;
   fetch?: FetchFunction;
   supportsThinking?: boolean;
+  supportsStructuredOutputs?: boolean;
 };
 
 export class DeepSeekChatLanguageModel implements LanguageModelV4 {
@@ -117,10 +118,14 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
         schema: deepseekLanguageModelChatOptions,
       })) ?? {};
 
+    const supportsStructuredOutputs =
+      this.config.supportsStructuredOutputs === true;
+
     const { messages, warnings } = convertToDeepSeekChatMessages({
       prompt,
       responseFormat,
       modelId: this.modelId,
+      supportsStructuredOutputs,
     });
     const allWarnings: SharedV4Warning[] = [...warnings];
 
@@ -175,7 +180,19 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
         frequency_penalty: frequencyPenalty,
         presence_penalty: presencePenalty,
         response_format:
-          responseFormat?.type === 'json' ? { type: 'json_object' } : undefined,
+          responseFormat?.type === 'json'
+            ? supportsStructuredOutputs && responseFormat.schema != null
+              ? {
+                  type: 'json_schema',
+                  json_schema: {
+                    schema: responseFormat.schema,
+                    strict: deepseekOptions.strictJsonSchema ?? true,
+                    name: responseFormat.name ?? 'response',
+                    description: responseFormat.description,
+                  },
+                }
+              : { type: 'json_object' }
+            : undefined,
         stop: stopSequences,
         messages,
         tools: deepseekTools,


### PR DESCRIPTION
## Background

A gateway customer reported that structured-output calls to `deepseek/deepseek-v4-flash` on Azure fail with `NoObjectGeneratedError` in ~34% of calls: the response is HTTP 200 with valid JSON, but the JSON is entirely in `reasoning` and `text` is empty. Direct Azure calls and Fireworks-served calls for the same model do not fail.

Root cause: `DeepSeekChatLanguageModel` downgrades `responseFormat: json` to `response_format: {type: 'json_object'}` with the schema injected into a system message. When `reasoning_effort` is also set, the Azure DeepSeek deployment misattributes the constrained JSON output to `reasoning_content` and returns empty `content`. Verified by direct-to-Azure A/B with otherwise identical request bodies: `json_object` + reasoning → 0/3 responses with text (one echoed the input messages into reasoning), `json_schema` + reasoning → 3/3 with proper reasoning and the JSON in `content`.

## Summary

- Add `supportsStructuredOutputs` to `DeepSeekChatConfig`. When enabled and a schema is present, send an OpenAI-shaped `json_schema` response format (`strict` defaults to true, new `strictJsonSchema` provider option) and skip the system-message schema injection and its compatibility warning.
- Enable the flag in `azure.deepseek()`. The native DeepSeek API path is unchanged and keeps `json_object`.

## Manual Verification

- Ran a structured-output request with `reasoning: 'high'` via `azure.deepseek('deepseek-v4-flash')` against a real Azure deployment with this fix: reasoning and structured output are both returned correctly.
- Direct-to-Azure A/B described above (0/3 → 3/3 with identical bodies except `response_format`).
- Linked the built `@ai-sdk/azure` + `@ai-sdk/deepseek` packages into a local AI Gateway checkout: a repro that fails 4/4 against the production gateway passes 4/4 against the local gateway running this fix.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Backport to the `@ai-sdk/azure@2.x`/`3.x` + `@ai-sdk/deepseek@1.x`/`2.x` lines used by older gateway protocol versions.