### PR TITLE
feat(tui): add ChatTransport support

### DIFF
--- a/.changeset/bright-tools-travel.md
+++ b/.changeset/bright-tools-travel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/tui': patch
+---
+
+Allow `runAgentTUI` to communicate with remote agents through a `ChatTransport`.

--- a/content/docs/03-agents/08-terminal-ui.mdx
+++ b/content/docs/03-agents/08-terminal-ui.mdx
@@ -5,10 +5,10 @@ description: Run AI SDK agents in an interactive terminal UI.
 
 # Terminal UI
 
-The `@ai-sdk/tui` package lets you run a `ToolLoopAgent` in an interactive
-terminal interface. It is useful for local development, demos, and internal
-tools where a terminal experience is enough and you do not want to build a
-custom UI.
+The `@ai-sdk/tui` package lets you run a local `ToolLoopAgent` or connect to a
+remote agent through a `ChatTransport` in an interactive terminal interface.
+It is useful for local development, demos, and internal tools where a terminal
+experience is enough and you do not want to build a custom UI.
 
 The terminal UI handles prompt input, streamed assistant responses, markdown
 rendering, tool cards, reasoning sections, scrolling, and tool approval prompts.
@@ -54,6 +54,27 @@ await runAgentTUI({
 ```
 
 `runAgentTUI` runs until the user exits with `Esc` or `Ctrl+C`.
+
+## Connecting to a Remote Agent
+
+Pass a `ChatTransport` instead of an `agent` to connect the terminal UI to a
+remote AI SDK UI message endpoint:
+
+```ts
+import { runAgentTUI } from '@ai-sdk/tui';
+import { DefaultChatTransport } from 'ai';
+
+await runAgentTUI({
+  title: 'Remote Agent',
+  transport: new DefaultChatTransport({
+    api: 'https://example.com/api/chat',
+  }),
+});
+```
+
+The transport controls the endpoint, authentication, request body, and other
+remote communication behavior. The terminal UI keeps its internal chat id and
+message history private to the transport contract.
 
 ## Sandbox
 
@@ -134,10 +155,10 @@ await runAgentTUI({ title: 'Weather Agent', agent });
 
 ## Compatibility
 
-`runAgentTUI` is designed for agents that can be run directly from terminal user
-input. The agent must not require per-call options and must not use structured
+When using the `agent` option, the agent must be runnable directly from terminal
+user input. It must not require per-call options and must not use structured
 output, because the terminal UI cannot infer those values from a free-form
-prompt.
+prompt. Use a `transport` for remote agents that need custom request handling.
 
 Use `agent.generate()` or `agent.stream()` directly for examples or apps that
 need fixed prompts, call options, structured output, custom result inspection, or

--- a/content/docs/07-reference/06-ai-sdk-tui/01-run-agent-tui.mdx
+++ b/content/docs/07-reference/06-ai-sdk-tui/01-run-agent-tui.mdx
@@ -5,9 +5,9 @@ description: API Reference for the runAgentTUI function.
 
 # `runAgentTUI()`
 
-Runs a `ToolLoopAgent` in an interactive terminal UI. The terminal UI reads user
-prompts, streams assistant responses, renders markdown, displays tool and
-reasoning sections, and handles manual tool approvals.
+Runs a local agent or chat transport in an interactive terminal UI. The
+terminal UI reads user prompts, streams assistant responses, renders markdown,
+displays tool and reasoning sections, and handles manual tool approvals.
 
 `runAgentTUI` runs until the user exits with `Esc` or `Ctrl+C`.
 
@@ -49,9 +49,16 @@ await runAgentTUI({
             {
               name: 'agent',
               type: 'AgentTUIAgent',
-              isRequired: true,
+              isOptional: true,
               description:
-                'The agent to run. The agent must not require per-call options and must not use structured output.',
+                'The agent to run. Provide exactly one of `agent` or `transport`. The agent must not require per-call options and must not use structured output.',
+            },
+            {
+              name: 'transport',
+              type: 'ChatTransport<UIMessage>',
+              isOptional: true,
+              description:
+                'The transport used to communicate with a remote agent. Provide exactly one of `agent` or `transport`.',
             },
             {
               name: 'title',
@@ -168,6 +175,19 @@ await runAgentTUI({
 });
 ```
 
+## Example with a Chat Transport
+
+```ts
+import { DefaultChatTransport } from 'ai';
+
+await runAgentTUI({
+  title: 'Remote Assistant',
+  transport: new DefaultChatTransport({
+    api: 'https://example.com/api/chat',
+  }),
+});
+```
+
 ## Example with Sandbox
 
 ```ts
@@ -192,8 +212,9 @@ working directory or exposed ports.
 
 ## Compatibility
 
-Use `runAgentTUI` for agents that can run directly from free-form user input.
-Use `agent.generate()` or `agent.stream()` directly when you need fixed prompts,
+Use the `agent` option for agents that can run directly from free-form user
+input. Use the `transport` option to communicate with a remote agent. Use
+`agent.generate()` or `agent.stream()` directly when you need fixed prompts,
 per-call options, structured output, custom result inspection, or custom stream
 processing.
 

--- a/examples/harness-e2e-tui/lib/run-tui.ts
+++ b/examples/harness-e2e-tui/lib/run-tui.ts
@@ -11,7 +11,10 @@ import { config } from 'dotenv';
 
 type TUIHarnessAgent = HarnessAgent<any, any, any>;
 
-export type RunTUIOptions = Omit<RunAgentTUIOptions, 'agent'> & {
+export type RunTUIOptions = Omit<
+  Extract<RunAgentTUIOptions, { agent: AgentTUIAgent }>,
+  'agent'
+> & {
   agent: TUIHarnessAgent;
   entrypointUrl: string;
 };

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -1,6 +1,6 @@
 # @ai-sdk/tui
 
-Run AI SDK agents in a terminal UI.
+Run local or remote AI SDK agents in a terminal UI.
 
 `@ai-sdk/tui` provides a full-screen interface with streaming output,
 tool cards, approvals, markdown rendering, scrollback, and a pinned prompt.
@@ -49,6 +49,18 @@ await runAgentTUI({
 });
 ```
 
+To connect to a remote agent, pass a `ChatTransport` instead:
+
+```ts
+import { runAgentTUI } from '@ai-sdk/tui';
+import { DefaultChatTransport } from 'ai';
+
+await runAgentTUI({
+  title: 'Remote Agent',
+  transport: new DefaultChatTransport({ api: 'https://example.com/api/chat' }),
+});
+```
+
 ## Controls
 
 - `Enter`: submit prompt
@@ -73,9 +85,11 @@ await runAgentTUI({
 
 Settings:
 
-- `agent`: AI SDK agent to run.
+- `agent`: AI SDK agent to run. Provide either `agent` or `transport`.
+- `transport`: AI SDK chat transport used to communicate with a remote agent.
+  Provide either `agent` or `transport`.
 - `title`: optional title shown in the terminal UI.
 - `tools`: tool call rendering mode. Use `"full"` to show tool input and output, `"collapsed"` to show only tool cards, `"auto-collapsed"` to show the latest tool expanded until another visible section appears, or `"hidden"` to omit tool calls. Defaults to `"auto-collapsed"`.
 - `reasoning`: reasoning rendering mode. Use `"full"` to show reasoning, `"collapsed"` to show only reasoning cards, `"auto-collapsed"` to show the latest reasoning expanded until another visible section appears, or `"hidden"` to omit reasoning. Defaults to `"auto-collapsed"`.
 - `responseStatistics`: response header statistic. Use `"outputTokensPerSecond"` to show output token throughput or `"outputTokenCount"` to show output token count. Defaults to `"outputTokensPerSecond"`.
-- `sandbox`: optional sandbox session forwarded to every agent call as `experimental_sandbox` for tool descriptions and tool execution.
+- `sandbox`: optional sandbox session forwarded to every agent call as `experimental_sandbox` for tool descriptions and tool execution. Only available with `agent`.

--- a/packages/tui/src/agent-tui-runner.ts
+++ b/packages/tui/src/agent-tui-runner.ts
@@ -11,8 +11,10 @@ import {
 } from './tui/terminal-renderer';
 import {
   convertToModelMessages,
+  generateId,
   getToolName,
   isToolUIPart,
+  type ChatTransport,
   type StepResultPerformance,
   type Experimental_SandboxSession,
   type LanguageModelUsage,
@@ -77,17 +79,16 @@ export type AgentTUIRenderer = {
   ): Promise<UIMessage | undefined>;
 };
 
-export type AgentTUIRunnerOptions<
-  TAgent extends AgentTUIAgent = AgentTUIAgent,
-> = Omit<RunAgentTUIOptions, 'agent'> & {
-  agent: TAgent;
+export type AgentTUIRunnerOptions = RunAgentTUIOptions & {
   renderer?: AgentTUIRenderer;
   screen?: TerminalOutput;
   userInput?: TerminalInput;
 };
 
-export class AgentTUIRunner<TAgent extends AgentTUIAgent = AgentTUIAgent> {
-  private readonly agent: TAgent;
+export class AgentTUIRunner {
+  private readonly agent?: AgentTUIAgent;
+  private readonly transport?: ChatTransport<UIMessage>;
+  private readonly chatId = generateId();
   private readonly renderer: AgentTUIRenderer;
   private readonly title?: string;
   private readonly tools: TerminalPartDisplayMode;
@@ -96,8 +97,9 @@ export class AgentTUIRunner<TAgent extends AgentTUIAgent = AgentTUIAgent> {
   private readonly contextSize?: number;
   private readonly sandbox?: Experimental_SandboxSession;
 
-  constructor(options: AgentTUIRunnerOptions<TAgent>) {
+  constructor(options: AgentTUIRunnerOptions) {
     this.agent = options.agent;
+    this.transport = options.transport;
     this.renderer = createRenderer(options) ?? createDefaultRenderer(options);
     this.title = options.title;
     this.tools = options.tools ?? 'auto-collapsed';
@@ -213,9 +215,26 @@ export class AgentTUIRunner<TAgent extends AgentTUIAgent = AgentTUIAgent> {
     generateMessageId: () => string,
   ): Promise<AgentTUIStreamResult> {
     const abortController = new AbortController();
-    const result = await this.agent.stream({
+    const abort = () => abortController.abort();
+
+    if (this.transport) {
+      return {
+        uiMessageStream: await this.transport.sendMessages({
+          trigger: 'submit-message',
+          chatId: this.chatId,
+          messageId: undefined,
+          messages,
+          abortSignal: abortController.signal,
+        }),
+        message: lastAssistantMessage(messages),
+        abort,
+      };
+    }
+
+    const agent = this.agent!;
+    const result = await agent.stream({
       prompt: await convertToModelMessages(messages, {
-        tools: this.agent.tools as ToolSet,
+        tools: agent.tools as ToolSet,
       }),
       abortSignal: abortController.signal,
       options: undefined,
@@ -229,7 +248,7 @@ export class AgentTUIRunner<TAgent extends AgentTUIAgent = AgentTUIAgent> {
         messages,
       ),
       message: lastAssistantMessage(messages),
-      abort: () => abortController.abort(),
+      abort,
     };
   }
 }

--- a/packages/tui/src/agent-tui.test.ts
+++ b/packages/tui/src/agent-tui.test.ts
@@ -11,6 +11,7 @@ import {
   readUIMessageStream,
   type Agent,
   type AgentStreamParameters,
+  type ChatTransport,
   type Experimental_SandboxSession,
   type ModelMessage,
   type TextStreamPart,
@@ -163,6 +164,39 @@ describe('AgentTUIRunner', () => {
         createUserModelMessage('second'),
       ],
     ]);
+    expect(renderer.submittedPrompts).toEqual(['first', 'second']);
+  });
+
+  it('sends UI message history through a chat transport', async () => {
+    const transportCalls: ChatTransportCall[] = [];
+    const renderer = useRenderer(
+      createRenderer({
+        prompts: ['first', 'second', undefined],
+      }),
+    );
+    const transport = createChatTransport(transportCalls);
+
+    await new AgentTUIRunner({ transport, title: 'Test Agent' }).run();
+
+    expect(transportCalls).toHaveLength(2);
+    expect(transportCalls[0]).toMatchObject({
+      trigger: 'submit-message',
+      messageId: undefined,
+      messages: [createUserUIMessage('message-1', 'first')],
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(transportCalls[1]).toMatchObject({
+      trigger: 'submit-message',
+      messageId: undefined,
+      messages: [
+        createUserUIMessage('message-1', 'first'),
+        createAssistantUIMessage('response-1', 'response to first'),
+        createUserUIMessage('message-2', 'second'),
+      ],
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(transportCalls[0]?.chatId).toEqual(expect.any(String));
+    expect(transportCalls[1]?.chatId).toBe(transportCalls[0]?.chatId);
     expect(renderer.submittedPrompts).toEqual(['first', 'second']);
   });
 
@@ -384,6 +418,28 @@ describe('AgentTUIRunner', () => {
 });
 
 type AgentTUIStreamCall = AgentStreamParameters<never, any, any>;
+type ChatTransportCall = Parameters<
+  ChatTransport<UIMessage>['sendMessages']
+>[0];
+
+function createChatTransport(
+  calls: ChatTransportCall[],
+): ChatTransport<UIMessage> {
+  return {
+    async sendMessages(options) {
+      calls.push(options);
+
+      const responseNumber = calls.length;
+      return createUIMessageChunkStream(
+        `response-${responseNumber}`,
+        `response to ${lastUserUIMessageText(options.messages)}`,
+      );
+    },
+    async reconnectToStream() {
+      return null;
+    },
+  };
+}
 
 function createAgent(
   streamCalls: AgentTUIStreamCall[],
@@ -642,6 +698,47 @@ function createUserModelMessage(text: string): ModelMessage {
     role: 'user',
     content: [{ type: 'text', text }],
   };
+}
+
+function createUserUIMessage(id: string, text: string): UIMessage {
+  return { id, role: 'user', parts: [{ type: 'text', text }] };
+}
+
+function createAssistantUIMessage(id: string, text: string): UIMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }] };
+}
+
+function lastUserUIMessageText(messages: UIMessage[]) {
+  let message: UIMessage | undefined;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role === 'user') {
+      message = messages[index];
+      break;
+    }
+  }
+  const part = message?.parts.find(part => part.type === 'text');
+
+  if (!part || part.type !== 'text') {
+    throw new Error('Expected at least one user text message.');
+  }
+
+  return part.text;
+}
+
+function createUIMessageChunkStream(
+  messageId: string,
+  text: string,
+): ReadableStream<UIMessageChunk> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'start', messageId });
+      controller.enqueue({ type: 'text-start', id: 'text-1' });
+      controller.enqueue({ type: 'text-delta', id: 'text-1', delta: text });
+      controller.enqueue({ type: 'text-end', id: 'text-1' });
+      controller.enqueue({ type: 'finish' });
+      controller.close();
+    },
+  });
 }
 
 function createAssistantModelMessage(text: string): ModelMessage {

--- a/packages/tui/src/run-agent-tui.test-d.ts
+++ b/packages/tui/src/run-agent-tui.test-d.ts
@@ -11,7 +11,9 @@ import {
   ToolLoopAgent,
   tool,
   type Agent,
+  type ChatTransport,
   type Experimental_SandboxSession,
+  type UIMessage,
 } from 'ai';
 import { assertType, describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
@@ -21,6 +23,7 @@ const model = new MockLanguageModelV4({
     stream: new ReadableStream(),
   }),
 });
+const transport = null as unknown as ChatTransport<UIMessage>;
 
 describe('runAgentTUI types', () => {
   it('exports documented public types from the package root', () => {
@@ -43,6 +46,19 @@ describe('runAgentTUI types', () => {
     expectTypeOf(agent).toMatchTypeOf<AgentTUIAgent>();
     expectTypeOf(runAgentTUI({ agent })).toEqualTypeOf<Promise<void>>();
     assertType<Promise<void>>(runAgentTUI({ agent }));
+  });
+
+  it('accepts a chat transport', () => {
+    expectTypeOf(runAgentTUI({ transport })).toEqualTypeOf<Promise<void>>();
+  });
+
+  it('requires exactly one agent source', () => {
+    const agent = new ToolLoopAgent({ model });
+
+    // @ts-expect-error agent and transport are mutually exclusive.
+    runAgentTUI({ agent, transport });
+    // @ts-expect-error agent or transport is required.
+    runAgentTUI({});
   });
 
   it('accepts a ToolLoopAgent with tools', () => {

--- a/packages/tui/src/run-agent-tui.ts
+++ b/packages/tui/src/run-agent-tui.ts
@@ -1,5 +1,10 @@
 import { AgentTUIRunner } from './agent-tui-runner';
-import type { Agent, Experimental_SandboxSession } from 'ai';
+import type {
+  Agent,
+  ChatTransport,
+  Experimental_SandboxSession,
+  UIMessage,
+} from 'ai';
 
 /**
  * Controls how terminal UI sections for stream parts are displayed.
@@ -36,11 +41,6 @@ export type AgentTUIAgent = Agent<any, any, any, any>;
  */
 export type RunAgentTUIOptions = {
   /**
-   * The agent to run.
-   */
-  agent: AgentTUIAgent;
-
-  /**
    * The title shown in the terminal UI.
    */
   title?: string;
@@ -73,12 +73,29 @@ export type RunAgentTUIOptions = {
    * percentage of this context window.
    */
   contextSize?: number;
+} & (
+  | {
+      /**
+       * The agent to run.
+       */
+      agent: AgentTUIAgent;
+      transport?: never;
 
-  /**
-   * Sandbox session that is passed through to agent tool execution.
-   */
-  sandbox?: Experimental_SandboxSession;
-};
+      /**
+       * Sandbox session that is passed through to agent tool execution.
+       */
+      sandbox?: Experimental_SandboxSession;
+    }
+  | {
+      agent?: never;
+
+      /**
+       * The transport used to communicate with a remote agent.
+       */
+      transport: ChatTransport<UIMessage>;
+      sandbox?: never;
+    }
+);
 
 /**
  * Runs an agent in the default terminal UI until the user exits.


### PR DESCRIPTION
## Background

`runAgentTUI` only accepted an in-process `Agent`, even though its terminal
renderer already consumes `UIMessageChunk`. Remote agents exposed through an
AI SDK UI message endpoint could therefore not reuse the TUI through their
existing `ChatTransport`.

## Summary

- accept either an `agent` or a `ChatTransport` in `runAgentTUI`
- send the runner's existing UI-message history through the transport with an
  internally generated chat id
- keep the existing Agent execution path unchanged
- document and test transport-backed multi-turn conversations

## Manual Verification

Built `ai` and `@ai-sdk/tui`, then ran the built TUI in a real terminal with a
minimal `ChatTransport`. Entering `hello` streamed and rendered
`transport received: hello`, returned to the input prompt, and exited cleanly
with Ctrl+C.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17245
