### PR TITLE
fix(provider/google): forward Vertex-only imageConfig options (personGeneration, prominentPeople, imageOutputOptions)

### DIFF
--- a/.changeset/olive-donkeys-attack.md
+++ b/.changeset/olive-donkeys-attack.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): forward Vertex-only imageConfig options (personGeneration, prominentPeople, imageOutputOptions)

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -203,6 +203,24 @@ The following optional provider options are available for Google models:
     - 2K
     - 4K
 
+  - **personGeneration** _string_
+
+    Optional. Controls the generation of people in images. Available on Vertex AI only. Can be one of the following:
+    - `ALLOW_NONE`
+    - `ALLOW_ADULT`
+    - `ALLOW_ALL`
+
+  - **prominentPeople** _string_
+
+    Optional. Controls whether generation of prominent people (celebrities) is allowed. When set together with `personGeneration`, `personGeneration` takes precedence. Available on Vertex AI only. Can be one of the following:
+    - `PROMINENT_PEOPLE_UNSPECIFIED`
+    - `ALLOW_PROMINENT_PEOPLE`
+    - `BLOCK_PROMINENT_PEOPLE`
+
+  - **imageOutputOptions** _\{ mimeType?: 'image/jpeg' | 'image/png', compressionQuality?: number \}_
+
+    Optional. The image output format for generated images. Available on Vertex AI only.
+
 - **audioTimestamp** _boolean_
 
   Optional. Enables timestamp understanding for audio-only files.

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -206,9 +206,10 @@ The following optional provider options are available for Google models:
   - **personGeneration** _string_
 
     Optional. Controls the generation of people in images. Available on Vertex AI only. Can be one of the following:
-    - `ALLOW_NONE`
-    - `ALLOW_ADULT`
+    - `PERSON_GENERATION_UNSPECIFIED`
     - `ALLOW_ALL`
+    - `ALLOW_ADULT`
+    - `ALLOW_NONE`
 
   - **prominentPeople** _string_
 

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -203,24 +203,7 @@ The following optional provider options are available for Google models:
     - 2K
     - 4K
 
-  - **personGeneration** _string_
-
-    Optional. Controls the generation of people in images. Available on Vertex AI only. Can be one of the following:
-    - `PERSON_GENERATION_UNSPECIFIED`
-    - `ALLOW_ALL`
-    - `ALLOW_ADULT`
-    - `ALLOW_NONE`
-
-  - **prominentPeople** _string_
-
-    Optional. Controls whether generation of prominent people (celebrities) is allowed. When set together with `personGeneration`, `personGeneration` takes precedence. Available on Vertex AI only. Can be one of the following:
-    - `PROMINENT_PEOPLE_UNSPECIFIED`
-    - `ALLOW_PROMINENT_PEOPLE`
-    - `BLOCK_PROMINENT_PEOPLE`
-
-  - **imageOutputOptions** _\{ mimeType?: 'image/jpeg' | 'image/png', compressionQuality?: number \}_
-
-    Optional. The image output format for generated images. Available on Vertex AI only.
+  Additional `imageConfig` fields (`personGeneration`, `prominentPeople`, `imageOutputOptions`) are supported on Vertex AI only, see the [Google Vertex provider](/providers/ai-sdk-providers/google-vertex) documentation.
 
 - **audioTimestamp** _boolean_
 

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -203,8 +203,6 @@ The following optional provider options are available for Google models:
     - 2K
     - 4K
 
-  Additional `imageConfig` fields (`personGeneration`, `prominentPeople`, `imageOutputOptions`) are supported on Vertex AI only, see the [Google Vertex provider](/providers/ai-sdk-providers/google-vertex) documentation.
-
 - **audioTimestamp** _boolean_
 
   Optional. Enables timestamp understanding for audio-only files.

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -326,7 +326,6 @@ The following optional provider options are available for Google Vertex models:
   Optional. Configuration for image generation. Only supported by Gemini image models.
 
   See [Google's GenerationConfig documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerationConfig) for usage details.
-
   - **aspectRatio** _string_
 
     Optional. The aspect ratio of generated images. Defaults to 1:1 squares, or to matching the output image size to that of an input image. Can be one of the following:

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -321,6 +321,52 @@ The following optional provider options are available for Google Vertex models:
 
   Consult [Google's Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls) for usage details.
 
+- **imageConfig** _object_
+
+  Optional. Configuration for image generation. Only supported by Gemini image models.
+
+  See [Google's GenerationConfig documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerationConfig) for usage details.
+
+  - **aspectRatio** _string_
+
+    Optional. The aspect ratio of generated images. Defaults to 1:1 squares, or to matching the output image size to that of an input image. Can be one of the following:
+    - 1:1
+    - 2:3
+    - 3:2
+    - 3:4
+    - 4:3
+    - 4:5
+    - 5:4
+    - 9:16
+    - 16:9
+    - 21:9
+
+  - **imageSize** _string_
+
+    Optional. Controls the output image resolution. Defaults to 1K. Can be one of the following:
+    - 1K
+    - 2K
+    - 4K
+
+  - **personGeneration** _string_
+
+    Optional. Controls the generation of people in images. Can be one of the following:
+    - `PERSON_GENERATION_UNSPECIFIED`
+    - `ALLOW_ALL`
+    - `ALLOW_ADULT`
+    - `ALLOW_NONE`
+
+  - **prominentPeople** _string_
+
+    Optional. Controls whether generation of prominent people (celebrities) is allowed. When set together with `personGeneration`, `personGeneration` takes precedence. Can be one of the following:
+    - `PROMINENT_PEOPLE_UNSPECIFIED`
+    - `ALLOW_PROMINENT_PEOPLE`
+    - `BLOCK_PROMINENT_PEOPLE`
+
+  - **imageOutputOptions** _\{ mimeType?: 'image/jpeg' | 'image/png', compressionQuality?: number \}_
+
+    Optional. The image output format for generated images.
+
 - **streamFunctionCallArguments** _boolean_
 
   Optional. When set to true, function call arguments will be streamed

--- a/packages/google/src/google-language-model-options.ts
+++ b/packages/google/src/google-language-model-options.ts
@@ -182,7 +182,12 @@ export const googleLanguageModelOptions = lazySchema(() =>
            * Vertex AI only.
            */
           personGeneration: z
-            .enum(['ALLOW_NONE', 'ALLOW_ADULT', 'ALLOW_ALL'])
+            .enum([
+              'PERSON_GENERATION_UNSPECIFIED',
+              'ALLOW_ALL',
+              'ALLOW_ADULT',
+              'ALLOW_NONE',
+            ])
             .optional(),
 
           /**

--- a/packages/google/src/google-language-model-options.ts
+++ b/packages/google/src/google-language-model-options.ts
@@ -176,6 +176,41 @@ export const googleLanguageModelOptions = lazySchema(() =>
             ])
             .optional(),
           imageSize: z.enum(['1K', '2K', '4K', '512']).optional(),
+
+          /**
+           * Optional. Controls the generation of people in images.
+           * Vertex AI only.
+           */
+          personGeneration: z
+            .enum(['ALLOW_NONE', 'ALLOW_ADULT', 'ALLOW_ALL'])
+            .optional(),
+
+          /**
+           * Optional. Controls whether generation of prominent people
+           * (celebrities) is allowed. When set together with
+           * `personGeneration`, `personGeneration` takes precedence.
+           * Vertex AI only.
+           *
+           * https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerationConfig
+           */
+          prominentPeople: z
+            .enum([
+              'PROMINENT_PEOPLE_UNSPECIFIED',
+              'ALLOW_PROMINENT_PEOPLE',
+              'BLOCK_PROMINENT_PEOPLE',
+            ])
+            .optional(),
+
+          /**
+           * Optional. The image output format for generated images.
+           * Vertex AI only.
+           */
+          imageOutputOptions: z
+            .object({
+              mimeType: z.enum(['image/jpeg', 'image/png']).optional(),
+              compressionQuality: z.number().optional(),
+            })
+            .optional(),
         })
         .optional(),
 

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -3098,6 +3098,78 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass imageConfig.personGeneration, imageConfig.prominentPeople and imageConfig.imageOutputOptions on Vertex', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    const vertexModel = new GoogleLanguageModel('gemini-pro', {
+      provider: 'google.vertex.chat',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    const { warnings } = await vertexModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          imageConfig: {
+            aspectRatio: '16:9',
+            personGeneration: 'ALLOW_ADULT',
+            prominentPeople: 'BLOCK_PROMINENT_PEOPLE',
+            imageOutputOptions: {
+              mimeType: 'image/jpeg',
+              compressionQuality: 75,
+            },
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        imageConfig: {
+          aspectRatio: '16:9',
+          personGeneration: 'ALLOW_ADULT',
+          prominentPeople: 'BLOCK_PROMINENT_PEOPLE',
+          imageOutputOptions: {
+            mimeType: 'image/jpeg',
+            compressionQuality: 75,
+          },
+        },
+      },
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it('should warn and drop Vertex-only imageConfig fields on the Gemini API', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          imageConfig: {
+            aspectRatio: '16:9',
+            prominentPeople: 'BLOCK_PROMINENT_PEOPLE',
+          },
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.generationConfig.imageConfig).toEqual({
+      aspectRatio: '16:9',
+    });
+    expect(warnings).toEqual([
+      {
+        type: 'other',
+        message:
+          "'imageConfig.prominentPeople' is a Vertex AI option and is " +
+          'ignored with the current Google provider (google.generative-ai).',
+      },
+    ]);
+  });
+
   it('should pass retrievalConfig in provider options', async () => {
     prepareJsonFixtureResponse('google-text', {
       url: TEST_URL_GEMINI_2_0_FLASH_EXP,

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -228,7 +228,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       : googleOptions?.serviceTier;
 
     // personGeneration, prominentPeople and imageOutputOptions are only
-    // supported by the Vertex AI API; the Gemini API rejects them.
+    // supported by the Vertex AI API, the Gemini API rejects them.
     let imageConfig = googleOptions?.imageConfig;
     if (imageConfig != null && !isVertexProvider) {
       const {

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -227,6 +227,35 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       ? undefined
       : googleOptions?.serviceTier;
 
+    // personGeneration, prominentPeople and imageOutputOptions are only
+    // supported by the Vertex AI API; the Gemini API rejects them.
+    let imageConfig = googleOptions?.imageConfig;
+    if (imageConfig != null && !isVertexProvider) {
+      const {
+        personGeneration,
+        prominentPeople,
+        imageOutputOptions,
+        ...geminiApiImageConfig
+      } = imageConfig;
+      const droppedImageConfigFields = Object.entries({
+        personGeneration,
+        prominentPeople,
+        imageOutputOptions,
+      })
+        .filter(([, value]) => value != null)
+        .map(([key]) => `'imageConfig.${key}'`);
+      if (droppedImageConfigFields.length > 0) {
+        warnings.push({
+          type: 'other',
+          message:
+            `${droppedImageConfigFields.join(', ')} ` +
+            `${droppedImageConfigFields.length === 1 ? 'is a Vertex AI option and is' : 'are Vertex AI options and are'} ` +
+            `ignored with the current Google provider (${this.config.provider}).`,
+        });
+        imageConfig = geminiApiImageConfig;
+      }
+    }
+
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
     const isGemini3Model = /^gemini-3[.-]/.test(this.modelId);
     const supportsFunctionResponseParts = isGemini3Model;
@@ -328,9 +357,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
           ...(googleOptions?.mediaResolution && {
             mediaResolution: googleOptions.mediaResolution,
           }),
-          ...(googleOptions?.imageConfig && {
-            imageConfig: googleOptions.imageConfig,
-          }),
+          ...(imageConfig && { imageConfig }),
         },
         contents,
         systemInstruction: isGemmaModel ? undefined : systemInstruction,


### PR DESCRIPTION
## Background

`providerOptions.google.imageConfig` is validated against a zod schema that only defines `aspectRatio` and `imageSize`. Zod object parsing strips unknown keys, so the Vertex-only `ImageConfig` fields — `personGeneration`, `prominentPeople`, and `imageOutputOptions` — are silently dropped from the request in `parseProviderOptions` before they reach the wire.

A user routing `gemini-3.1-flash-image` through Vertex reported that `imageConfig.prominentPeople` had no effect: an intentionally invalid value returned `200` with a generated image instead of Vertex's `400 INVALID_ARGUMENT`, because the field never left the SDK.

Verified against the published `@ai-sdk/google-vertex@5.0.19` with a request-capturing `fetch`:

```
input:    imageConfig: { aspectRatio: '1:1', prominentPeople: 'BLOCK_PROMINENT_PEOPLE' }
outgoing: generationConfig.imageConfig: {"aspectRatio":"1:1"}
```

## Summary

Adds the missing fields to the `imageConfig` provider-options schema, with values verified against the live Vertex `v1` API:

- `personGeneration`: `ALLOW_NONE | ALLOW_ADULT | ALLOW_ALL` (live Vertex rejects the `DONT_ALLOW` value that Imagen-style APIs use)
- `prominentPeople`: `PROMINENT_PEOPLE_UNSPECIFIED | ALLOW_PROMINENT_PEOPLE | BLOCK_PROMINENT_PEOPLE`
- `imageOutputOptions`: `{ mimeType?: 'image/jpeg' | 'image/png', compressionQuality?: number }`

The Gemini API rejects all three fields with `400 Unknown name` (verified live), so on non-Vertex Google providers they are dropped with a call warning instead of being sent — same pattern as `streamFunctionCallArguments` and `serviceTier`. This preserves the previous behavior for Gemini API callers while making the drop visible.

Also documents the new fields on the Google provider docs page.

## Verification

Built the workspace and ran a live end-to-end check against Vertex (`gemini-3.1-flash-image-preview`, location `global`) and the Gemini API:

```
1. outgoing imageConfig: {"aspectRatio":"1:1","prominentPeople":"BLOCK_PROMINENT_PEOPLE"}
2. valid prominentPeople: 200, image generated
3. gemini api: finished with 1 file(s), warnings: [{"type":"other","message":"'imageConfig.prominentPeople' is a Vertex AI option and is ignored with the current Google provider (google.generative-ai)."}]
4. bad value rejected client-side: AI_InvalidArgumentError: invalid google provider options
```

An invalid `prominentPeople` value now fails loudly (client-side schema error) instead of silently succeeding.

## Tests

- new: Vertex provider forwards `personGeneration`, `prominentPeople`, `imageOutputOptions` in `generationConfig.imageConfig` with no warnings
- new: Gemini API provider drops Vertex-only fields, still forwards `aspectRatio`, and emits a warning
- `pnpm test` in `packages/google` and `packages/google-vertex`: 691 + 250 passing (node + edge)
- `pnpm check` and `pnpm type-check:full` clean