### PR TITLE
feat(provider/cartesia): add Ink 2 streaming transcription

### DIFF
--- a/.changeset/soft-taxis-listen.md
+++ b/.changeset/soft-taxis-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cartesia': patch
+---
+
+Add Ink 2 streaming transcription through `TranscriptionModelV4.doStream` and the shared WebSocket transport.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -98,7 +98,11 @@ The `audio` stream must contain raw audio chunks. `Uint8Array` chunks are raw by
   the provider.
 </Note>
 
-OpenAI streaming transcription uses `openai.transcription('gpt-realtime-whisper')`. xAI uses the same `xai.transcription()` model for request/response and streaming transcription; `experimental_streamTranscribe` uses xAI's WebSocket STT transport under the hood.
+OpenAI streaming transcription uses `openai.transcription('gpt-realtime-whisper')`.
+Cartesia uses `cartesia.transcription('ink-2')` for streaming-only Ink 2
+transcription. xAI uses the same `xai.transcription()` model for request/response
+and streaming transcription; `experimental_streamTranscribe` selects the
+provider's WebSocket STT transport.
 
 ```ts
 import { xai } from '@ai-sdk/xai';
@@ -316,5 +320,6 @@ try {
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
 | [xAI](/providers/ai-sdk-providers/xai#transcription-models)                     | `default`                |
 | [Cartesia](/providers/ai-sdk-providers/cartesia#transcription-models)           | `ink-whisper`            |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#streaming-transcription-models) | `ink-2`                  |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/95-cartesia.mdx
+++ b/content/providers/01-ai-sdk-providers/95-cartesia.mdx
@@ -6,7 +6,8 @@ description: Learn how to use the Cartesia provider for the AI SDK.
 # Cartesia Provider
 
 The [Cartesia](https://cartesia.ai/) provider contains Sonic speech generation,
-Ink-Whisper batch transcription, and Ink 2 realtime transcription support.
+Ink-Whisper batch transcription, and Ink 2 realtime and streaming transcription
+support.
 
 ## Setup
 
@@ -68,6 +69,11 @@ You can use the following optional settings to customize the Cartesia provider i
   Defaults to the global `fetch` function.
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
+
+- **webSocket** _WebSocketConstructor_
+
+  Custom WebSocket implementation for Ink 2 streaming transcription.
+  Defaults to the global `WebSocket` constructor.
 
 ## Speech Models
 
@@ -191,6 +197,57 @@ the current input is complete.
 
 See [Realtime](/docs/ai-sdk-core/realtime) for the complete browser session
 setup.
+
+### Model Capabilities
+
+| Model   | Streaming Transcription | Turn Detection      |
+| ------- | ----------------------- | ------------------- |
+| `ink-2` | <Check size={18} />     | <Check size={18} /> |
+
+## Streaming Transcription Models
+
+<Note type="warning">Streaming transcription is an experimental feature.</Note>
+
+Ink 2 is also available through the transcription streaming API. Create the
+model with `.transcription()` and pass it to `experimental_streamTranscribe`:
+
+```ts
+import { cartesia } from '@ai-sdk/cartesia';
+import { experimental_streamTranscribe as streamTranscribe } from 'ai';
+
+const result = streamTranscribe({
+  model: cartesia.transcription('ink-2'),
+  audio, // ReadableStream<Uint8Array | string> containing raw audio chunks
+  inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+  providerOptions: {
+    cartesia: {
+      language: 'en',
+    },
+  },
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === 'transcript-partial') {
+    console.log('partial:', part.text);
+  }
+
+  if (part.type === 'transcript-final') {
+    console.log('final:', part.text);
+  }
+}
+```
+
+The provider creates a short-lived, STT-scoped Cartesia access token before
+opening the WebSocket, so the API key is not included in the WebSocket URL.
+Send audio chunks at approximately their playback rate; Cartesia's realtime
+endpoint is intended for live audio rather than bulk file upload.
+
+Ink 2 supports English audio and uses Cartesia's native turn detection by
+default. To finalize only when the input audio stream ends, pass
+`providerOptions.cartesia.streaming.turnDetection: false`.
+
+See [Transcription](/docs/ai-sdk-core/transcription) for more information about
+streaming transcription.
 
 ### Model Capabilities
 

--- a/examples/ai-functions/src/stream-transcribe/cartesia/basic.ts
+++ b/examples/ai-functions/src/stream-transcribe/cartesia/basic.ts
@@ -1,0 +1,58 @@
+import { cartesia } from '@ai-sdk/cartesia';
+import { openai } from '@ai-sdk/openai';
+import {
+  experimental_streamTranscribe as streamTranscribe,
+  generateSpeech,
+} from 'ai';
+import { setTimeout as delay } from 'node:timers/promises';
+import { run } from '../../lib/run';
+
+run(async () => {
+  // Generate raw PCM audio (24kHz, 16-bit, mono) to transcribe.
+  const speech = await generateSpeech({
+    model: openai.speech('tts-1'),
+    text: 'Hello from the AI SDK! Streaming transcription is experimental.',
+    outputFormat: 'pcm',
+  });
+
+  // Stream the raw audio in chunks, as a microphone would.
+  const bytes = speech.audio.uint8Array;
+  // Cartesia's realtime endpoint expects audio at approximately playback rate.
+  // At 24kHz, 16-bit mono PCM, 4,800 bytes represents 100ms of audio.
+  const chunkSize = 4800;
+  let offset = 0;
+  const audio = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(bytes.slice(offset, offset + chunkSize));
+      offset += chunkSize;
+      if (offset < bytes.length) {
+        await delay(100);
+      }
+    },
+  });
+
+  const result = streamTranscribe({
+    model: cartesia.transcription('ink-2'),
+    audio,
+    inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'transcript-partial') {
+      console.log('partial:', part.text);
+    }
+
+    if (part.type === 'transcript-final') {
+      console.log('final:', part.text);
+    }
+  }
+
+  console.log('Text:', await result.text);
+  console.log('Duration:', await result.durationInSeconds);
+  console.log('Warnings:', await result.warnings);
+});

--- a/packages/cartesia/README.md
+++ b/packages/cartesia/README.md
@@ -1,7 +1,7 @@
 # AI SDK - Cartesia Provider
 
 The **[Cartesia provider](https://ai-sdk.dev/providers/ai-sdk-providers/cartesia)** for the [AI SDK](https://ai-sdk.dev/docs)
-contains Sonic 3.5 speech generation, Ink-Whisper batch transcription, and Ink 2 realtime transcription support.
+contains Sonic 3.5 speech generation, Ink-Whisper batch transcription, and Ink 2 realtime and streaming transcription support.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Cartesia (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 

--- a/packages/cartesia/src/cartesia-config.ts
+++ b/packages/cartesia/src/cartesia-config.ts
@@ -1,9 +1,14 @@
-import type { FetchFunction } from '@ai-sdk/provider-utils';
+import type {
+  FetchFunction,
+  WebSocketConstructor,
+} from '@ai-sdk/provider-utils';
 
 export type CartesiaConfig = {
   provider: string;
   url: (options: { modelId: string; path: string }) => string;
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
+  version?: string;
+  webSocket?: WebSocketConstructor;
   generateId?: () => string;
 };

--- a/packages/cartesia/src/cartesia-provider.ts
+++ b/packages/cartesia/src/cartesia-provider.ts
@@ -10,6 +10,7 @@ import {
   loadApiKey,
   withUserAgentSuffix,
   type FetchFunction,
+  type WebSocketConstructor,
 } from '@ai-sdk/provider-utils';
 import { CartesiaTranscriptionModel } from './cartesia-transcription-model';
 import type { CartesiaTranscriptionModelId } from './cartesia-transcription-options';
@@ -75,6 +76,11 @@ export interface CartesiaProviderSettings {
    * or to provide a custom fetch implementation for e.g. testing.
    */
   fetch?: FetchFunction;
+
+  /**
+   * Custom WebSocket implementation for streaming transcription.
+   */
+  webSocket?: WebSocketConstructor;
 }
 
 /**
@@ -103,6 +109,8 @@ export function createCartesia(
       url: ({ path }) => `https://api.cartesia.ai${path}`,
       headers: getHeaders,
       fetch: options.fetch,
+      version: options.version ?? CARTESIA_API_VERSION,
+      webSocket: options.webSocket,
     });
 
   const createSpeechModel = (modelId: CartesiaSpeechModelId) =>

--- a/packages/cartesia/src/cartesia-transcription-model-options.ts
+++ b/packages/cartesia/src/cartesia-transcription-model-options.ts
@@ -6,6 +6,16 @@ export const cartesiaTranscriptionModelOptionsSchema = z.object({
   language: z.string().nullish(),
   /** The timestamp granularities to populate. Currently only `word` is supported. */
   timestampGranularities: z.array(z.enum(['word'])).nullish(),
+  /** Options for realtime Ink 2 transcription over WebSocket. */
+  streaming: z
+    .object({
+      /**
+       * Use Cartesia's native turn detection endpoint. Defaults to true.
+       * Disable this to finalize the transcript only when the audio stream ends.
+       */
+      turnDetection: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export type CartesiaTranscriptionModelOptions = z.infer<

--- a/packages/cartesia/src/cartesia-transcription-model.test.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.test.ts
@@ -1,4 +1,8 @@
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
 import { CartesiaTranscriptionModel } from './cartesia-transcription-model';
 import { createCartesia } from './cartesia-provider';
 import { readFile } from 'node:fs/promises';
@@ -16,7 +20,47 @@ const model = provider.transcription('ink-whisper');
 
 const server = createTestServer({
   'https://api.cartesia.ai/stt': {},
+  'https://api.cartesia.ai/access-token': {
+    response: {
+      type: 'json-value',
+      body: { token: 'test-access-token' },
+    },
+  },
 });
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: unknown) => void) | null = null;
+
+  constructor(public url: string | URL) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.({});
+  }
+
+  message(value: unknown) {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+
+  serverClose() {
+    this.readyState = 3;
+    this.onclose?.({});
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
 
 function prepareJsonFixtureResponse(
   filename: string,
@@ -147,5 +191,245 @@ describe('doGenerate', () => {
       expect(result.response.timestamp.getTime()).toEqual(testDate.getTime());
       expect(result.response.modelId).toBe('ink-whisper');
     });
+  });
+});
+
+describe('doStream', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+  });
+
+  it('streams Ink 2 turn-detected transcription over WebSocket', async () => {
+    const testDate = new Date(0);
+    const model = new CartesiaTranscriptionModel('ink-2', {
+      provider: 'cartesia.transcription',
+      url: ({ path }) => `https://api.cartesia.ai${path}`,
+      headers: () => ({
+        Authorization: 'Bearer test-api-key',
+        'Cartesia-Version': '2026-03-01',
+      }),
+      version: '2026-03-01',
+      webSocket: MockWebSocket,
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        cartesia: { language: 'en' },
+      },
+    });
+
+    expect(server.calls[0].requestUrl).toBe(
+      'https://api.cartesia.ai/access-token',
+    );
+    expect(await server.calls[0].requestBodyJson).toEqual({
+      grants: { stt: true },
+    });
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'cartesia-version': '2026-03-01',
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url.toString()).toBe(
+      'wss://api.cartesia.ai/stt/turns/websocket?model=ink-2&encoding=pcm_s16le&sample_rate=16000&cartesia_version=2026-03-01&access_token=test-access-token',
+    );
+
+    ws.open();
+    await flush();
+    expect(ws.send).toHaveBeenNthCalledWith(1, new Uint8Array([1, 2, 3]));
+    expect(JSON.parse(ws.send.mock.calls[1][0])).toEqual({ type: 'close' });
+
+    ws.message({
+      type: 'turn.update',
+      request_id: 'turn-1',
+      transcript: 'Hello',
+    });
+    ws.message({
+      type: 'turn.end',
+      request_id: 'turn-1',
+      transcript: 'Hello world',
+    });
+    ws.message({
+      type: 'turn.end',
+      request_id: 'turn-1',
+      transcript: 'How are you?',
+    });
+    await flush();
+    ws.serverClose();
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-partial',
+        id: 'turn-1',
+        text: 'Hello',
+      },
+      {
+        type: 'transcript-final',
+        id: 'turn-1',
+        text: 'Hello world',
+      },
+      {
+        type: 'transcript-final',
+        id: 'turn-1',
+        text: 'How are you?',
+      },
+      {
+        type: 'finish',
+        text: 'Hello world How are you?',
+        segments: [],
+        language: 'en',
+      },
+    ]);
+    expect(result.request).toEqual({
+      body: 'wss://api.cartesia.ai/stt/turns/websocket?model=ink-2&encoding=pcm_s16le&sample_rate=16000&cartesia_version=2026-03-01',
+    });
+    expect(result.response).toEqual({
+      timestamp: testDate,
+      modelId: 'ink-2',
+    });
+  });
+
+  it('supports manual finalization when turn detection is disabled', async () => {
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    });
+    const result = await provider.transcription('ink-2').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcmu', rate: 8000 },
+      providerOptions: {
+        cartesia: {
+          language: 'en',
+          streaming: { turnDetection: false },
+        },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url.toString()).toContain(
+      'wss://api.cartesia.ai/stt/websocket?model=ink-2&encoding=pcm_mulaw&sample_rate=8000',
+    );
+    expect(ws.url.toString()).toContain('&language=en');
+
+    ws.open();
+    await flush();
+    expect(ws.send).toHaveBeenNthCalledWith(2, 'finalize');
+
+    ws.message({
+      type: 'transcript',
+      request_id: 'request-1',
+      text: 'Hello ',
+      is_final: true,
+      duration: 0.5,
+    });
+    ws.message({
+      type: 'transcript',
+      request_id: 'request-1',
+      text: 'world',
+      is_final: true,
+      duration: 0.4,
+    });
+    ws.message({ type: 'flush_done', request_id: 'request-1' });
+    await flush();
+    expect(ws.send).toHaveBeenNthCalledWith(3, 'close');
+    ws.message({ type: 'done', request_id: 'request-1' });
+
+    expect((await partsPromise).at(-1)).toEqual({
+      type: 'finish',
+      text: 'Hello world',
+      segments: [],
+      language: 'en',
+      durationInSeconds: 0.9,
+    });
+  });
+
+  it('rejects unsupported model operations and Ink 2 languages', async () => {
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    });
+
+    await expect(
+      provider.transcription('ink-whisper').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      }),
+    ).rejects.toMatchObject({ name: 'AI_UnsupportedFunctionalityError' });
+
+    await expect(
+      provider.transcription('ink-2').doGenerate({
+        audio: new Uint8Array(),
+        mediaType: 'audio/wav',
+      }),
+    ).rejects.toMatchObject({ name: 'AI_UnsupportedFunctionalityError' });
+
+    await expect(
+      provider.transcription('ink-2').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+        providerOptions: { cartesia: { language: 'es' } },
+      }),
+    ).rejects.toThrow('currently supports English only');
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  it('closes the WebSocket and stops reading audio when cancelled', async () => {
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    });
+    let audioCancelled = false;
+    const audio = new ReadableStream<Uint8Array>({
+      cancel() {
+        audioCancelled = true;
+      },
+    });
+    const result = await provider.transcription('ink-2').doStream!({
+      audio,
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await flush();
+
+    await result.stream.cancel();
+    await flush();
+
+    expect(ws.close).toHaveBeenCalled();
+    expect(audioCancelled).toBe(true);
+  });
+
+  it('cancels input when the WebSocket constructor fails', async () => {
+    let audioCancelled = false;
+    const audio = new ReadableStream<Uint8Array>({
+      cancel() {
+        audioCancelled = true;
+      },
+    });
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: class {
+        constructor() {
+          throw new Error('connection failed');
+        }
+      } as never,
+    });
+
+    const result = await provider.transcription('ink-2').doStream!({
+      audio,
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    await expect(convertReadableStreamToArray(result.stream)).rejects.toThrow(
+      'connection failed',
+    );
+    await flush();
+    expect(audioCancelled).toBe(true);
   });
 });

--- a/packages/cartesia/src/cartesia-transcription-model.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.ts
@@ -1,19 +1,36 @@
-import type { TranscriptionModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  InvalidArgumentError,
+  UnsupportedFunctionalityError,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
+  type Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
+  type SharedV4Warning,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
 import {
   combineHeaders,
+  connectToWebSocket,
   convertBase64ToUint8Array,
   createJsonResponseHandler,
   mediaTypeToExtension,
   parseProviderOptions,
   postFormDataToApi,
+  postJsonToApi,
+  safeParseJSON,
   serializeModelOptions,
+  toWebSocketUrl,
+  waitForWebSocketBufferDrain,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
+  type WebSocketConnection,
+  type WebSocketLike,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { CartesiaConfig } from './cartesia-config';
 import { cartesiaFailedResponseHandler } from './cartesia-error';
-import { cartesiaTranscriptionModelOptionsSchema } from './cartesia-transcription-model-options';
+import {
+  cartesiaTranscriptionModelOptionsSchema,
+  type CartesiaTranscriptionModelOptions,
+} from './cartesia-transcription-model-options';
 import type { CartesiaTranscriptionModelId } from './cartesia-transcription-options';
 
 interface CartesiaTranscriptionModelConfig extends CartesiaConfig {
@@ -21,6 +38,17 @@ interface CartesiaTranscriptionModelConfig extends CartesiaConfig {
     currentDate?: () => Date;
   };
 }
+
+type CartesiaStreamingTranscriptionEvent = {
+  type?: string;
+  request_id?: string;
+  transcript?: string;
+  text?: string;
+  is_final?: boolean;
+  duration?: number;
+  message?: string;
+  error_code?: string;
+};
 
 export class CartesiaTranscriptionModel implements TranscriptionModelV4 {
   readonly specificationVersion = 'v4';
@@ -62,6 +90,15 @@ export class CartesiaTranscriptionModel implements TranscriptionModelV4 {
       schema: cartesiaTranscriptionModelOptionsSchema,
     });
 
+    if (cartesiaOptions?.streaming != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'providerOptions.cartesia.streaming',
+        details:
+          'Cartesia batch transcription does not support streaming options.',
+      });
+    }
+
     // Create form data with base fields
     const formData = new FormData();
     const blob =
@@ -98,6 +135,12 @@ export class CartesiaTranscriptionModel implements TranscriptionModelV4 {
   async doGenerate(
     options: Parameters<TranscriptionModelV4['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    if (isStreamingTranscriptionModelId(this.modelId)) {
+      throw new UnsupportedFunctionalityError({
+        functionality: `non-streaming transcription with ${this.modelId}`,
+      });
+    }
+
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { formData, warnings } = await this.getArgs(options);
 
@@ -139,6 +182,344 @@ export class CartesiaTranscriptionModel implements TranscriptionModelV4 {
       },
     };
   }
+
+  async doStream(
+    options: TranscriptionModelV4StreamOptions,
+  ): Promise<
+    Awaited<ReturnType<NonNullable<TranscriptionModelV4['doStream']>>>
+  > {
+    if (!isStreamingTranscriptionModelId(this.modelId)) {
+      throw new UnsupportedFunctionalityError({
+        functionality: `streaming transcription with ${this.modelId}`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+    const cartesiaOptions = await parseProviderOptions({
+      provider: 'cartesia',
+      providerOptions: options.providerOptions,
+      schema: cartesiaTranscriptionModelOptionsSchema,
+    });
+
+    if (
+      cartesiaOptions?.language != null &&
+      cartesiaOptions.language !== 'en'
+    ) {
+      throw new InvalidArgumentError({
+        argument: 'providerOptions',
+        message: 'Cartesia Ink 2 currently supports English only.',
+      });
+    }
+
+    if (cartesiaOptions?.timestampGranularities != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'providerOptions.cartesia.timestampGranularities',
+        details:
+          'Cartesia streaming transcription does not support timestamp granularities.',
+      });
+    }
+
+    const token = await this.createStreamingAccessToken(options);
+    const useTurnDetection =
+      cartesiaOptions?.streaming?.turnDetection !== false;
+    const url = buildCartesiaStreamingTranscriptionUrl({
+      baseURL: this.config.url({ path: '/', modelId: this.modelId }),
+      version: this.config.version ?? '2026-03-01',
+      modelId: this.modelId,
+      inputAudioFormat: options.inputAudioFormat,
+      providerOptions: cartesiaOptions,
+      token,
+      useTurnDetection,
+    });
+    const requestUrl = new URL(url);
+    requestUrl.searchParams.delete('access_token');
+
+    return {
+      request: { body: requestUrl.toString() },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+      },
+      stream: createCartesiaStreamingTranscriptionStream({
+        webSocket: this.config.webSocket,
+        url,
+        warnings,
+        language: cartesiaOptions?.language ?? 'en',
+        useTurnDetection,
+        audio: options.audio,
+        abortSignal: options.abortSignal,
+        includeRawChunks: options.includeRawChunks,
+      }),
+    };
+  }
+
+  private async createStreamingAccessToken(
+    options: TranscriptionModelV4StreamOptions,
+  ): Promise<string> {
+    const { value } = await postJsonToApi({
+      url: this.config.url({ path: '/access-token', modelId: this.modelId }),
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body: { grants: { stt: true } },
+      failedResponseHandler: cartesiaFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        cartesiaAccessTokenResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return value.token;
+  }
+}
+
+function createCartesiaStreamingTranscriptionStream({
+  webSocket,
+  url,
+  warnings,
+  language,
+  useTurnDetection,
+  audio,
+  abortSignal,
+  includeRawChunks,
+}: {
+  webSocket: CartesiaConfig['webSocket'];
+  url: URL;
+  warnings: SharedV4Warning[];
+  language: string;
+  useTurnDetection: boolean;
+  audio: ReadableStream<Uint8Array | string>;
+  abortSignal: AbortSignal | undefined;
+  includeRawChunks: boolean | undefined;
+}): ReadableStream<TranscriptionModelV4StreamPart> {
+  let finished = false;
+  let cleanup: (closeCode?: number) => void = () => {};
+
+  return new ReadableStream({
+    start: controller => {
+      const finalTexts: string[] = [];
+      let durationInSeconds = 0;
+      let audioReader:
+        | ReadableStreamDefaultReader<Uint8Array | string>
+        | undefined;
+      let connection: WebSocketConnection | undefined;
+
+      cleanup = (closeCode?: number) => {
+        if (audioReader != null) {
+          void audioReader.cancel().catch(() => {});
+        } else {
+          // Pre-open failure or abort: cancel the caller's audio stream so an
+          // upstream producer piping into it does not hang.
+          void audio.cancel().catch(() => {});
+        }
+        connection?.close(closeCode);
+      };
+
+      const finishWithError = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.error(error);
+      };
+
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        controller.enqueue({
+          type: 'finish',
+          text: finalTexts.join(useTurnDetection ? ' ' : ''),
+          segments: [],
+          language,
+          ...(durationInSeconds > 0 ? { durationInSeconds } : {}),
+        });
+        controller.close();
+        cleanup(1000);
+      };
+
+      const sendAudio = async (socket: WebSocketLike) => {
+        audioReader = audio.getReader();
+        try {
+          while (true) {
+            const { done, value } = await audioReader.read();
+            if (done || finished) break;
+            socket.send(
+              value instanceof Uint8Array
+                ? value
+                : convertBase64ToUint8Array(value),
+            );
+            await waitForWebSocketBufferDrain(socket);
+          }
+        } finally {
+          audioReader.releaseLock();
+          audioReader = undefined;
+        }
+
+        if (!finished) {
+          socket.send(
+            useTurnDetection ? JSON.stringify({ type: 'close' }) : 'finalize',
+          );
+        }
+      };
+
+      connection = connectToWebSocket({
+        url,
+        webSocket,
+        abortSignal,
+        onAbort: finishWithError,
+        onProcessingError: finishWithError,
+        onOpen: socket => {
+          controller.enqueue({ type: 'stream-start', warnings });
+          void sendAudio(socket).catch(finishWithError);
+        },
+        onMessageText: async text => {
+          const parsed = await safeParseJSON({ text });
+          if (!parsed.success) return;
+          const raw = parsed.value as CartesiaStreamingTranscriptionEvent;
+
+          if (includeRawChunks) {
+            controller.enqueue({ type: 'raw', rawValue: raw });
+          }
+
+          switch (raw.type) {
+            case 'turn.update':
+            case 'turn.eager_end': {
+              controller.enqueue({
+                type: 'transcript-partial',
+                id: raw.request_id,
+                text: raw.transcript ?? '',
+              });
+              break;
+            }
+
+            case 'turn.end': {
+              const text = raw.transcript ?? '';
+              finalTexts.push(text);
+              controller.enqueue({
+                type: 'transcript-final',
+                id: raw.request_id,
+                text,
+              });
+              break;
+            }
+
+            case 'transcript': {
+              const transcript = raw.text ?? '';
+              if (raw.is_final === true) {
+                finalTexts.push(transcript);
+                durationInSeconds += raw.duration ?? 0;
+                controller.enqueue({
+                  type: 'transcript-final',
+                  id: raw.request_id,
+                  text: transcript,
+                });
+              } else {
+                controller.enqueue({
+                  type: 'transcript-partial',
+                  id: raw.request_id,
+                  text: transcript,
+                  ...(raw.duration != null
+                    ? { durationInSeconds: raw.duration }
+                    : {}),
+                });
+              }
+              break;
+            }
+
+            case 'flush_done': {
+              connection?.socket?.send('close');
+              break;
+            }
+
+            case 'done': {
+              finish();
+              break;
+            }
+
+            case 'error': {
+              finishWithError(
+                new Error(
+                  raw.message ??
+                    raw.error_code ??
+                    'Cartesia streaming transcription error',
+                ),
+              );
+              break;
+            }
+          }
+        },
+        onSocketError: () => {
+          finishWithError(new Error('Cartesia streaming transcription error'));
+        },
+        onClose: () => {
+          if (!finished) finish();
+        },
+      });
+    },
+
+    cancel: () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    },
+  });
+}
+
+function buildCartesiaStreamingTranscriptionUrl({
+  baseURL,
+  version,
+  modelId,
+  inputAudioFormat,
+  providerOptions,
+  token,
+  useTurnDetection,
+}: {
+  baseURL: string;
+  version: string;
+  modelId: string;
+  inputAudioFormat: TranscriptionModelV4StreamOptions['inputAudioFormat'];
+  providerOptions: CartesiaTranscriptionModelOptions | undefined;
+  token: string;
+  useTurnDetection: boolean;
+}) {
+  const url = toWebSocketUrl(
+    new URL(
+      useTurnDetection ? '/stt/turns/websocket' : '/stt/websocket',
+      baseURL,
+    ),
+  );
+  url.searchParams.set('model', modelId);
+  url.searchParams.set(
+    'encoding',
+    cartesiaEncodingFromInputAudioFormat(inputAudioFormat.type),
+  );
+  url.searchParams.set('sample_rate', String(inputAudioFormat.rate ?? 24000));
+  url.searchParams.set('cartesia_version', version);
+  url.searchParams.set('access_token', token);
+  if (!useTurnDetection && providerOptions?.language != null) {
+    url.searchParams.set('language', providerOptions.language);
+  }
+  return url;
+}
+
+function cartesiaEncodingFromInputAudioFormat(type: string): string {
+  switch (type) {
+    case 'audio/pcm':
+      return 'pcm_s16le';
+    case 'audio/pcmu':
+      return 'pcm_mulaw';
+    case 'audio/pcma':
+      return 'pcm_alaw';
+    default:
+      throw new InvalidArgumentError({
+        argument: 'inputAudioFormat',
+        message: `Unsupported Cartesia streaming audio format: ${type}`,
+      });
+  }
+}
+
+function isStreamingTranscriptionModelId(modelId: string): boolean {
+  return modelId === 'ink-2' || modelId.startsWith('ink-2-');
 }
 
 const cartesiaTranscriptionResponseSchema = z.object({
@@ -154,4 +535,8 @@ const cartesiaTranscriptionResponseSchema = z.object({
       }),
     )
     .nullish(),
+});
+
+const cartesiaAccessTokenResponseSchema = z.object({
+  token: z.string().min(1),
 });

--- a/packages/cartesia/src/cartesia-transcription-options.ts
+++ b/packages/cartesia/src/cartesia-transcription-options.ts
@@ -1,1 +1,4 @@
-export type CartesiaTranscriptionModelId = 'ink-whisper' | (string & {});
+export type CartesiaTranscriptionModelId =
+  | 'ink-whisper'
+  | 'ink-2'
+  | (string & {});


### PR DESCRIPTION
## Summary

- add `TranscriptionModelV4.doStream` support for Cartesia Ink 2 using the shared WebSocket transport
- support Cartesia's native turn-detection endpoint and manual finalization while preserving the existing `experimental_realtime` API
- add Node/Edge coverage, provider documentation, an example, and a patch changeset

This is the streaming-transcription follow-up to #16815 and builds on the shared transport/API work from #17093, #17094, and #17095.

## Testing

- `pnpm --filter @ai-sdk/cartesia test`
- `pnpm --filter @ai-sdk/cartesia type-check`
- `pnpm --filter @example/ai-functions type-check`
- `pnpm turbo build --filter=@ai-sdk/cartesia`
- `pnpm validate:docs`
- `pnpm konsistent`
- `pnpm exec ultracite check <changed TypeScript files>`
