### PR TITLE
feat(elevenlabs): add realtime Scribe transcription

### DIFF
--- a/.changeset/elevenlabs-realtime-scribe.md
+++ b/.changeset/elevenlabs-realtime-scribe.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': patch
+---
+
+Add streaming transcription support for ElevenLabs Scribe v2 Realtime through `experimental_streamTranscribe`.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -91,7 +91,8 @@ The `audio` stream must contain raw audio chunks. `Uint8Array` chunks are raw by
 <Note>
   String model IDs resolve through the global provider (AI Gateway by
   default). AI Gateway supports streaming transcription for supported models
-  (e.g. `openai/gpt-realtime-whisper`, `xai/grok-stt`), so string IDs work:
+  (e.g. `openai/gpt-realtime-whisper`, `elevenlabs/eleven-scribe-2-realtime`,
+  `xai/grok-stt`), so string IDs work:
   `experimental_streamTranscribe({ model: 'openai/gpt-realtime-whisper', ...
   })`. You can also pass a provider model instance (e.g.
   `openai.transcription('gpt-realtime-whisper')`) to stream directly against
@@ -100,9 +101,11 @@ The `audio` stream must contain raw audio chunks. `Uint8Array` chunks are raw by
 
 OpenAI streaming transcription uses `openai.transcription('gpt-realtime-whisper')`.
 Cartesia uses `cartesia.transcription('ink-2')` for streaming-only Ink 2
-transcription. xAI uses the same `xai.transcription()` model for request/response
-and streaming transcription; `experimental_streamTranscribe` selects the
-provider's WebSocket STT transport.
+transcription. ElevenLabs uses
+`elevenLabs.transcription('scribe_v2_realtime')` for Scribe v2 Realtime. xAI
+uses the same `xai.transcription()` model for request/response and streaming
+transcription; `experimental_streamTranscribe` selects the provider's
+WebSocket STT transport.
 
 ```ts
 import { xai } from '@ai-sdk/xai';
@@ -297,6 +300,8 @@ try {
 | [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `gpt-4o-mini-transcribe` |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v1`              |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v1_experimental` |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v2`              |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#streaming-transcription-models) | `scribe_v2_realtime`     |
 | [Groq](/providers/ai-sdk-providers/groq#transcription-models)                   | `whisper-large-v3-turbo` |
 | [Groq](/providers/ai-sdk-providers/groq#transcription-models)                   | `whisper-large-v3`       |
 | [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `whisper-1`              |

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -293,38 +293,38 @@ try {
 
 ## Transcription Models
 
-| Provider                                                                        | Model                    |
-| ------------------------------------------------------------------------------- | ------------------------ |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `whisper-1`              |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `gpt-4o-transcribe`      |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)               | `gpt-4o-mini-transcribe` |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v1`              |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v1_experimental` |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)       | `scribe_v2`              |
+| Provider                                                                            | Model                    |
+| ----------------------------------------------------------------------------------- | ------------------------ |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `whisper-1`              |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-transcribe`      |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-mini-transcribe` |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v1`              |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v1_experimental` |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v2`              |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#streaming-transcription-models) | `scribe_v2_realtime`     |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                   | `whisper-large-v3-turbo` |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                   | `whisper-large-v3`       |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `whisper-1`              |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `gpt-4o-transcribe`      |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)          | `gpt-4o-mini-transcribe` |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                | `machine`                |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                | `low_cost`               |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                | `fusion`                 |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `base` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `enhanced` (+ variants)  |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `nova` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `nova-2` (+ variants)    |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)           | `nova-3` (+ variants)    |
-| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)               | `default`                |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)       | `universal-3-5-pro`      |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)       | `universal-3-pro`        |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `whisper`                |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                     | `wizper`                 |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_2`                |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `chirp_3`                |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models) | `telephony`              |
-| [xAI](/providers/ai-sdk-providers/xai#transcription-models)                     | `default`                |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#transcription-models)           | `ink-whisper`            |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#streaming-transcription-models) | `ink-2`                  |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                       | `whisper-large-v3-turbo` |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                       | `whisper-large-v3`       |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `whisper-1`              |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `gpt-4o-transcribe`      |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `gpt-4o-mini-transcribe` |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `machine`                |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `low_cost`               |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `fusion`                 |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `base` (+ variants)      |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `enhanced` (+ variants)  |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova` (+ variants)      |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova-2` (+ variants)    |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova-3` (+ variants)    |
+| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)                   | `default`                |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)           | `universal-3-5-pro`      |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)           | `universal-3-pro`        |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                         | `whisper`                |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                         | `wizper`                 |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `chirp_2`                |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `chirp_3`                |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `telephony`              |
+| [xAI](/providers/ai-sdk-providers/xai#transcription-models)                         | `default`                |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#transcription-models)               | `ink-whisper`            |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#streaming-transcription-models)     | `ink-2`                  |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -110,7 +110,6 @@ const result = await generateSpeech({
 
 - **voiceSettings** _object or null_  
   Optional. Voice settings that override stored settings for the given voice. These are applied only to the current request.
-
   - **stability** _double or null_  
     Optional. Determines how stable the voice is and the randomness between each generation. Lower values introduce broader emotional range; higher values result in a more monotonous voice.
   - **useSpeakerBoost** _boolean or null_  
@@ -123,7 +122,6 @@ const result = await generateSpeech({
 - **pronunciationDictionaryLocators** _array of objects or null_  
   Optional. A list of pronunciation dictionary locators to apply to the text, in order. Up to 3 locators per request.  
   Each locator object:
-
   - **pronunciationDictionaryId** _string_ (required)  
     The ID of the pronunciation dictionary.
   - **versionId** _string or null_ (optional)  
@@ -147,7 +145,6 @@ const result = await generateSpeech({
 - **applyTextNormalization** _enum_  
   Optional. Controls text normalization.  
   Allowed values: `'auto'` (default), `'on'`, `'off'`.
-
   - `'auto'`: System decides whether to apply normalization (e.g., spelling out numbers).
   - `'on'`: Always apply normalization.
   - `'off'`: Never apply normalization.  

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -36,7 +36,7 @@ You can use the following optional settings to customize the ElevenLabs provider
 
 - **apiKey** _string_
 
-  API key that is being sent using the `Authorization` header.
+  API key that is being sent using the `xi-api-key` header.
   It defaults to the `ELEVENLABS_API_KEY` environment variable.
 
 - **headers** _Record&lt;string,string&gt;_
@@ -49,6 +49,12 @@ You can use the following optional settings to customize the ElevenLabs provider
   Defaults to the global `fetch` function.
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
+
+- **webSocket** _WebSocketConstructor_
+
+  Custom WebSocket implementation for realtime transcription. A
+  header-capable implementation is required in runtimes whose native WebSocket
+  constructor cannot send the `xi-api-key` authentication header.
 
 ## Speech Models
 
@@ -168,10 +174,10 @@ const result = await generateSpeech({
 You can create models that call the [ElevenLabs transcription API](https://elevenlabs.io/speech-to-text)
 using the `.transcription()` factory method.
 
-The first argument is the model id e.g. `scribe_v1`.
+The first argument is the model id e.g. `scribe_v2`.
 
 ```ts
-const model = elevenLabs.transcription('scribe_v1');
+const model = elevenLabs.transcription('scribe_v2');
 ```
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format can sometimes improve transcription performance if known beforehand.
@@ -184,7 +190,7 @@ import {
 } from '@ai-sdk/elevenlabs';
 
 const result = await transcribe({
-  model: elevenLabs.transcription('scribe_v1'),
+  model: elevenLabs.transcription('scribe_v2'),
   audio: new Uint8Array([1, 2, 3, 4]),
   providerOptions: {
     elevenlabs: {
@@ -233,9 +239,57 @@ The following provider options are available:
   For `'pcm_s16le_16'`, the input audio must be 16-bit PCM at a 16kHz sample rate, single channel (mono), and little-endian byte order.
   Latency will be lower than with passing an encoded waveform.
 
+### Realtime Transcription
+
+Scribe v2 Realtime supports live transcription through the experimental
+`streamTranscribe` API. It accepts raw PCM audio at 8, 16, 22.05, 24, 44.1, or
+48 kHz, or 8 kHz mu-law audio.
+
+```ts
+import {
+  createElevenLabs,
+  type ElevenLabsProviderSettings,
+} from '@ai-sdk/elevenlabs';
+import { experimental_streamTranscribe as streamTranscribe } from 'ai';
+import { WebSocket } from 'ws';
+
+const elevenLabs = createElevenLabs({
+  webSocket: WebSocket as unknown as ElevenLabsProviderSettings['webSocket'],
+});
+
+const result = streamTranscribe({
+  model: elevenLabs.transcription('scribe_v2_realtime'),
+  audio,
+  inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+  providerOptions: {
+    elevenlabs: {
+      languageCode: 'en',
+      streaming: {
+        includeLanguageDetection: true,
+        includeTimestamps: true,
+      },
+    },
+  },
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === 'transcript-partial') {
+    console.log(part.text);
+  }
+}
+```
+
+The `streaming` provider options mirror ElevenLabs' realtime transcription
+settings: `commitStrategy`, `enableLogging`, `filterBackgroundAudio`,
+`includeLanguageDetection`, `includeTimestamps`, `keyterms`,
+`minSilenceDurationMs`, `minSpeechDurationMs`, `noVerbatim`, `previousText`,
+`vadSilenceThresholdSecs`, and `vadThreshold`.
+
 ### Model Capabilities
 
 | Model                    | Transcription | Duration  | Segments  | Language  |
 | ------------------------ | ------------- | --------- | --------- | --------- |
 | `scribe_v1`              | <Check />     | <Check /> | <Check /> | <Check /> |
 | `scribe_v1_experimental` | <Check />     | <Check /> | <Check /> | <Check /> |
+| `scribe_v2`              | <Check />     | <Check /> | <Check /> | <Check /> |
+| `scribe_v2_realtime`     | <Check />     | <Check /> | <Check /> | <Check /> |

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -110,6 +110,7 @@ const result = await generateSpeech({
 
 - **voiceSettings** _object or null_  
   Optional. Voice settings that override stored settings for the given voice. These are applied only to the current request.
+
   - **stability** _double or null_  
     Optional. Determines how stable the voice is and the randomness between each generation. Lower values introduce broader emotional range; higher values result in a more monotonous voice.
   - **useSpeakerBoost** _boolean or null_  
@@ -122,6 +123,7 @@ const result = await generateSpeech({
 - **pronunciationDictionaryLocators** _array of objects or null_  
   Optional. A list of pronunciation dictionary locators to apply to the text, in order. Up to 3 locators per request.  
   Each locator object:
+
   - **pronunciationDictionaryId** _string_ (required)  
     The ID of the pronunciation dictionary.
   - **versionId** _string or null_ (optional)  
@@ -145,6 +147,7 @@ const result = await generateSpeech({
 - **applyTextNormalization** _enum_  
   Optional. Controls text normalization.  
   Allowed values: `'auto'` (default), `'on'`, `'off'`.
+
   - `'auto'`: System decides whether to apply normalization (e.g., spelling out numbers).
   - `'on'`: Always apply normalization.
   - `'off'`: Never apply normalization.  
@@ -239,11 +242,21 @@ The following provider options are available:
   For `'pcm_s16le_16'`, the input audio must be 16-bit PCM at a 16kHz sample rate, single channel (mono), and little-endian byte order.
   Latency will be lower than with passing an encoded waveform.
 
-### Realtime Transcription
+### Model Capabilities
 
-Scribe v2 Realtime supports live transcription through the experimental
-`streamTranscribe` API. It accepts raw PCM audio at 8, 16, 22.05, 24, 44.1, or
-48 kHz, or 8 kHz mu-law audio.
+| Model                    | Transcription | Duration  | Segments  | Language  |
+| ------------------------ | ------------- | --------- | --------- | --------- |
+| `scribe_v1`              | <Check />     | <Check /> | <Check /> | <Check /> |
+| `scribe_v1_experimental` | <Check />     | <Check /> | <Check /> | <Check /> |
+| `scribe_v2`              | <Check />     | <Check /> | <Check /> | <Check /> |
+
+## Streaming Transcription Models
+
+<Note type="warning">Streaming transcription is an experimental feature.</Note>
+
+Scribe v2 Realtime supports live transcription through
+`experimental_streamTranscribe`. It accepts raw PCM audio at 8, 16, 22.05, 24,
+44.1, or 48 kHz, or 8 kHz mu-law audio.
 
 ```ts
 import {
@@ -274,10 +287,18 @@ const result = streamTranscribe({
 
 for await (const part of result.fullStream) {
   if (part.type === 'transcript-partial') {
-    console.log(part.text);
+    console.log('partial:', part.text);
+  }
+
+  if (part.type === 'transcript-final') {
+    console.log('final:', part.text);
   }
 }
 ```
+
+The ElevenLabs realtime endpoint authenticates with a WebSocket header. Use a
+header-capable WebSocket implementation, such as `ws`, in runtimes whose native
+WebSocket constructor cannot send headers.
 
 The `streaming` provider options mirror ElevenLabs' realtime transcription
 settings: `commitStrategy`, `enableLogging`, `filterBackgroundAudio`,
@@ -285,11 +306,11 @@ settings: `commitStrategy`, `enableLogging`, `filterBackgroundAudio`,
 `minSilenceDurationMs`, `minSpeechDurationMs`, `noVerbatim`, `previousText`,
 `vadSilenceThresholdSecs`, and `vadThreshold`.
 
+See [Transcription](/docs/ai-sdk-core/transcription) for more information about
+streaming transcription.
+
 ### Model Capabilities
 
-| Model                    | Transcription | Duration  | Segments  | Language  |
-| ------------------------ | ------------- | --------- | --------- | --------- |
-| `scribe_v1`              | <Check />     | <Check /> | <Check /> | <Check /> |
-| `scribe_v1_experimental` | <Check />     | <Check /> | <Check /> | <Check /> |
-| `scribe_v2`              | <Check />     | <Check /> | <Check /> | <Check /> |
-| `scribe_v2_realtime`     | <Check />     | <Check /> | <Check /> | <Check /> |
+| Model                | Streaming Transcription | Timestamps          | Language Detection  |
+| -------------------- | ----------------------- | ------------------- | ------------------- |
+| `scribe_v2_realtime` | <Check size={18} />     | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -303,6 +303,11 @@ settings: `commitStrategy`, `enableLogging`, `filterBackgroundAudio`,
 `minSilenceDurationMs`, `minSpeechDurationMs`, `noVerbatim`, `previousText`,
 `vadSilenceThresholdSecs`, and `vadThreshold`.
 
+ElevenLabs delivers detected language on its timestamp-bearing committed event.
+When `includeLanguageDetection` is enabled, the provider requests that event
+internally, but only returns timestamp segments when `includeTimestamps` is also
+enabled. `filterBackgroundAudio` cannot be combined with either option.
+
 See [Transcription](/docs/ai-sdk-core/transcription) for more information about
 streaming transcription.
 

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -301,7 +301,7 @@ The `streaming` provider options mirror ElevenLabs' realtime transcription
 settings: `commitStrategy`, `enableLogging`, `filterBackgroundAudio`,
 `includeLanguageDetection`, `includeTimestamps`, `keyterms`,
 `minSilenceDurationMs`, `minSpeechDurationMs`, `noVerbatim`, `previousText`,
-`vadSilenceThresholdSecs`, and `vadThreshold`.
+`secondaryLanguages`, `vadSilenceThresholdSecs`, and `vadThreshold`.
 
 ElevenLabs delivers detected language on its timestamp-bearing committed event.
 When `includeLanguageDetection` is enabled, the provider requests that event

--- a/examples/ai-functions/src/stream-transcribe/elevenlabs/basic.ts
+++ b/examples/ai-functions/src/stream-transcribe/elevenlabs/basic.ts
@@ -7,6 +7,7 @@ import {
   experimental_streamTranscribe as streamTranscribe,
   generateSpeech,
 } from 'ai';
+import { setTimeout as delay } from 'node:timers/promises';
 import { WebSocket } from 'ws';
 import { run } from '../../lib/run';
 
@@ -25,15 +26,23 @@ run(async () => {
     outputFormat: 'pcm',
   });
 
-  // Stream the raw audio in chunks, as a microphone would:
+  // Stream the raw audio in chunks, as a microphone would.
   const bytes = speech.audio.uint8Array;
-  const chunkSize = 16 * 1024;
+  // At 24kHz, 16-bit mono PCM, 4,800 bytes represents 100ms of audio.
+  const chunkSize = 4800;
+  let offset = 0;
   const audio = new ReadableStream<Uint8Array>({
-    start(controller) {
-      for (let i = 0; i < bytes.length; i += chunkSize) {
-        controller.enqueue(bytes.slice(i, i + chunkSize));
+    async pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
       }
-      controller.close();
+
+      controller.enqueue(bytes.slice(offset, offset + chunkSize));
+      offset += chunkSize;
+      if (offset < bytes.length) {
+        await delay(100);
+      }
     },
   });
 

--- a/examples/ai-functions/src/stream-transcribe/elevenlabs/basic.ts
+++ b/examples/ai-functions/src/stream-transcribe/elevenlabs/basic.ts
@@ -1,0 +1,68 @@
+import {
+  createElevenLabs,
+  type ElevenLabsProviderSettings,
+} from '@ai-sdk/elevenlabs';
+import { openai } from '@ai-sdk/openai';
+import {
+  experimental_streamTranscribe as streamTranscribe,
+  generateSpeech,
+} from 'ai';
+import { WebSocket } from 'ws';
+import { run } from '../../lib/run';
+
+// ElevenLabs realtime STT authenticates via WebSocket headers. The native
+// WebSocket in Node.js, browsers, Deno, and Bun cannot send headers, so a
+// header-capable implementation (e.g. the `ws` package) is required.
+const elevenLabs = createElevenLabs({
+  webSocket: WebSocket as unknown as ElevenLabsProviderSettings['webSocket'],
+});
+
+run(async () => {
+  // Generate raw PCM audio (24kHz, 16-bit, mono) to transcribe:
+  const speech = await generateSpeech({
+    model: openai.speech('tts-1'),
+    text: 'Hello from the AI SDK! Streaming transcription is experimental.',
+    outputFormat: 'pcm',
+  });
+
+  // Stream the raw audio in chunks, as a microphone would:
+  const bytes = speech.audio.uint8Array;
+  const chunkSize = 16 * 1024;
+  const audio = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.slice(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });
+
+  const result = streamTranscribe({
+    model: elevenLabs.transcription('scribe_v2_realtime'),
+    audio,
+    inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    providerOptions: {
+      elevenlabs: {
+        streaming: {
+          includeLanguageDetection: true,
+          includeTimestamps: true,
+        },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'transcript-partial') {
+      console.log('partial:', part.text);
+    }
+
+    if (part.type === 'transcript-final') {
+      console.log('final:', part.text);
+    }
+  }
+
+  console.log('Text:', await result.text);
+  console.log('Language:', await result.language);
+  console.log('Duration:', await result.durationInSeconds);
+  console.log('Warnings:', await result.warnings);
+});

--- a/packages/elevenlabs/README.md
+++ b/packages/elevenlabs/README.md
@@ -1,7 +1,7 @@
 # AI SDK - ElevenLabs Provider
 
 The **[ElevenLabs provider](https://ai-sdk.dev/providers/ai-sdk-providers/elevenlabs)** for the [AI SDK](https://ai-sdk.dev/docs)
-contains language model support for the ElevenLabs chat and completion APIs and embedding model support for the ElevenLabs embeddings API.
+contains speech generation plus batch and realtime transcription support for the ElevenLabs APIs.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access ElevenLabs (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 

--- a/packages/elevenlabs/src/elevenlabs-config.ts
+++ b/packages/elevenlabs/src/elevenlabs-config.ts
@@ -1,4 +1,7 @@
-import type { FetchFunction } from '@ai-sdk/provider-utils';
+import type {
+  FetchFunction,
+  WebSocketConstructor,
+} from '@ai-sdk/provider-utils';
 
 export type ElevenLabsConfig = {
   provider: string;
@@ -6,4 +9,5 @@ export type ElevenLabsConfig = {
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
   generateId?: () => string;
+  webSocket?: WebSocketConstructor;
 };

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -8,6 +8,7 @@ import {
   loadApiKey,
   withUserAgentSuffix,
   type FetchFunction,
+  type WebSocketConstructor,
 } from '@ai-sdk/provider-utils';
 import { ElevenLabsTranscriptionModel } from './elevenlabs-transcription-model';
 import type { ElevenLabsTranscriptionModelId } from './elevenlabs-transcription-options';
@@ -55,6 +56,12 @@ export interface ElevenLabsProviderSettings {
    * or to provide a custom fetch implementation for e.g. testing.
    */
   fetch?: FetchFunction;
+
+  /**
+   * Custom WebSocket implementation. Required in runtimes whose native
+   * WebSocket constructor does not support headers for realtime transcription.
+   */
+  webSocket?: WebSocketConstructor;
 }
 
 /**
@@ -82,6 +89,7 @@ export function createElevenLabs(
       url: ({ path }) => `https://api.elevenlabs.io${path}`,
       headers: getHeaders,
       fetch: options.fetch,
+      webSocket: options.webSocket,
     });
 
   const createSpeechModel = (modelId: ElevenLabsSpeechModelId) =>

--- a/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
@@ -13,20 +13,20 @@ export const elevenLabsTranscriptionModelOptionsSchema = z.object({
   fileFormat: z.enum(['pcm_s16le_16', 'other']).nullish().default('other'),
   streaming: z
     .object({
-      commitStrategy: z.enum(['manual', 'vad']).nullish(),
-      enableLogging: z.boolean().nullish(),
-      filterBackgroundAudio: z.boolean().nullish(),
-      includeLanguageDetection: z.boolean().nullish(),
-      includeTimestamps: z.boolean().nullish(),
-      keyterms: z.array(z.string().max(20)).max(50).nullish(),
-      minSilenceDurationMs: z.number().int().min(50).max(2000).nullish(),
-      minSpeechDurationMs: z.number().int().min(50).max(2000).nullish(),
-      noVerbatim: z.boolean().nullish(),
-      previousText: z.string().nullish(),
-      vadSilenceThresholdSecs: z.number().min(0.3).max(3).nullish(),
-      vadThreshold: z.number().min(0.1).max(0.9).nullish(),
+      commitStrategy: z.enum(['manual', 'vad']).optional(),
+      enableLogging: z.boolean().optional(),
+      filterBackgroundAudio: z.boolean().optional(),
+      includeLanguageDetection: z.boolean().optional(),
+      includeTimestamps: z.boolean().optional(),
+      keyterms: z.array(z.string().max(20)).max(50).optional(),
+      minSilenceDurationMs: z.number().int().min(50).max(2000).optional(),
+      minSpeechDurationMs: z.number().int().min(50).max(2000).optional(),
+      noVerbatim: z.boolean().optional(),
+      previousText: z.string().optional(),
+      vadSilenceThresholdSecs: z.number().min(0.3).max(3).optional(),
+      vadThreshold: z.number().min(0.1).max(0.9).optional(),
     })
-    .nullish(),
+    .optional(),
 });
 
 export type ElevenLabsTranscriptionModelOptions = z.infer<

--- a/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
@@ -11,6 +11,22 @@ export const elevenLabsTranscriptionModelOptionsSchema = z.object({
     .default('word'),
   diarize: z.boolean().nullish().default(false),
   fileFormat: z.enum(['pcm_s16le_16', 'other']).nullish().default('other'),
+  streaming: z
+    .object({
+      commitStrategy: z.enum(['manual', 'vad']).nullish(),
+      enableLogging: z.boolean().nullish(),
+      filterBackgroundAudio: z.boolean().nullish(),
+      includeLanguageDetection: z.boolean().nullish(),
+      includeTimestamps: z.boolean().nullish(),
+      keyterms: z.array(z.string().max(20)).max(50).nullish(),
+      minSilenceDurationMs: z.number().int().min(50).max(2000).nullish(),
+      minSpeechDurationMs: z.number().int().min(50).max(2000).nullish(),
+      noVerbatim: z.boolean().nullish(),
+      previousText: z.string().nullish(),
+      vadSilenceThresholdSecs: z.number().min(0.3).max(3).nullish(),
+      vadThreshold: z.number().min(0.1).max(0.9).nullish(),
+    })
+    .nullish(),
 });
 
 export type ElevenLabsTranscriptionModelOptions = z.infer<

--- a/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model-options.ts
@@ -13,20 +13,21 @@ export const elevenLabsTranscriptionModelOptionsSchema = z.object({
   fileFormat: z.enum(['pcm_s16le_16', 'other']).nullish().default('other'),
   streaming: z
     .object({
-      commitStrategy: z.enum(['manual', 'vad']).optional(),
-      enableLogging: z.boolean().optional(),
-      filterBackgroundAudio: z.boolean().optional(),
-      includeLanguageDetection: z.boolean().optional(),
-      includeTimestamps: z.boolean().optional(),
-      keyterms: z.array(z.string().max(20)).max(50).optional(),
-      minSilenceDurationMs: z.number().int().min(50).max(2000).optional(),
-      minSpeechDurationMs: z.number().int().min(50).max(2000).optional(),
-      noVerbatim: z.boolean().optional(),
-      previousText: z.string().optional(),
-      vadSilenceThresholdSecs: z.number().min(0.3).max(3).optional(),
-      vadThreshold: z.number().min(0.1).max(0.9).optional(),
+      commitStrategy: z.enum(['manual', 'vad']).nullish(),
+      enableLogging: z.boolean().nullish(),
+      filterBackgroundAudio: z.boolean().nullish(),
+      includeLanguageDetection: z.boolean().nullish(),
+      includeTimestamps: z.boolean().nullish(),
+      keyterms: z.array(z.string().max(20)).max(50).nullish(),
+      minSilenceDurationMs: z.number().int().min(50).max(2000).nullish(),
+      minSpeechDurationMs: z.number().int().min(50).max(2000).nullish(),
+      noVerbatim: z.boolean().nullish(),
+      previousText: z.string().nullish(),
+      secondaryLanguages: z.array(z.string()).nullish(),
+      vadSilenceThresholdSecs: z.number().min(0.3).max(3).nullish(),
+      vadThreshold: z.number().min(0.1).max(0.9).nullish(),
     })
-    .optional(),
+    .nullish(),
 });
 
 export type ElevenLabsTranscriptionModelOptions = z.infer<

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -53,6 +53,11 @@ class MockWebSocket {
   message(value: unknown) {
     this.onmessage?.({ data: JSON.stringify(value) });
   }
+
+  remoteClose() {
+    this.readyState = 3;
+    this.onclose?.({});
+  }
 }
 
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
@@ -385,6 +390,106 @@ describe('doStream', () => {
       modelId: 'scribe_v2_realtime',
     });
     expect(ws.close).toHaveBeenCalledWith(1000);
+  });
+
+  it('finishes with committed text when the socket closes before timestamps arrive', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        elevenlabs: { streaming: { includeTimestamps: true } },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'committed_transcript', text: 'Hello' });
+    ws.remoteClose();
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'Hello',
+      },
+      {
+        type: 'finish',
+        text: 'Hello',
+        segments: [],
+        language: undefined,
+        durationInSeconds: undefined,
+      },
+    ]);
+  });
+
+  it('finishes a timestamp-only response to the final commit', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        elevenlabs: { streaming: { includeTimestamps: true } },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({
+      message_type: 'committed_transcript_with_timestamps',
+      text: 'Hello',
+      language_code: 'en',
+      words: [{ text: 'Hello', start: 0, end: 0.4, type: 'word' }],
+    });
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'Hello',
+        startSecond: 0,
+        endSecond: 0.4,
+      },
+      {
+        type: 'finish',
+        text: 'Hello',
+        segments: [{ text: 'Hello', startSecond: 0, endSecond: 0.4 }],
+        language: 'en',
+        durationInSeconds: 0.4,
+      },
+    ]);
+  });
+
+  it('errors when the upstream closes before the final commit', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: new ReadableStream<Uint8Array>(),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    ws.remoteClose();
+
+    await expect(partsPromise).rejects.toThrow(
+      'ElevenLabs realtime transcription stream closed before completion',
+    );
   });
 
   it('supports 8 kHz mu-law input', async () => {

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -1,4 +1,9 @@
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
 import { ElevenLabsTranscriptionModel } from './elevenlabs-transcription-model';
 import { createElevenLabs } from './elevenlabs-provider';
 import { readFile } from 'node:fs/promises';
@@ -18,6 +23,40 @@ const server = createTestServer({
   'https://api.elevenlabs.io/v1/speech-to-text': {},
 });
 
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  bufferedAmount = 0;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: unknown) => void) | null = null;
+
+  constructor(
+    public url: string | URL,
+    public protocols?: string | string[],
+    public options?: { headers?: Record<string, string | undefined> },
+  ) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.({});
+  }
+
+  message(value: unknown) {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
 function prepareJsonFixtureResponse(
   filename: string,
   headers?: Record<string, string>,
@@ -32,6 +71,15 @@ function prepareJsonFixtureResponse(
 }
 
 describe('doGenerate', () => {
+  it('should reject scribe_v2_realtime for non-streaming transcription', async () => {
+    await expect(
+      provider.transcription('scribe_v2_realtime').doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
+  });
+
   describe('transcription', () => {
     beforeEach(() => prepareJsonFixtureResponse('elevenlabs-transcription'));
 
@@ -190,5 +238,317 @@ describe('doGenerate', () => {
 
       expect(result).toMatchSnapshot();
     });
+  });
+});
+
+describe('doStream', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+  });
+
+  it('streams Scribe v2 Realtime and maps partial, committed, and timestamped output', async () => {
+    const testDate = new Date(0);
+    const model = new ElevenLabsTranscriptionModel('scribe_v2_realtime', {
+      provider: 'test-provider',
+      url: ({ path }) => `https://api.elevenlabs.io${path}`,
+      headers: () => ({
+        'xi-api-key': 'test-api-key',
+        'Custom-Provider-Header': 'provider-value',
+      }),
+      webSocket: MockWebSocket,
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3]), 'BAUG']),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      headers: { 'Custom-Request-Header': 'request-value' },
+      providerOptions: {
+        elevenlabs: {
+          languageCode: 'en',
+          streaming: {
+            commitStrategy: 'manual',
+            enableLogging: false,
+            includeLanguageDetection: true,
+            includeTimestamps: true,
+            keyterms: ['Vercel', 'AI SDK'],
+            minSilenceDurationMs: 200,
+            minSpeechDurationMs: 150,
+            noVerbatim: true,
+            previousText: 'Earlier context',
+            vadSilenceThresholdSecs: 1.2,
+            vadThreshold: 0.5,
+          },
+        },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    const url = new URL(ws.url);
+    expect(url.origin + url.pathname).toBe(
+      'wss://api.elevenlabs.io/v1/speech-to-text/realtime',
+    );
+    expect(Object.fromEntries(url.searchParams)).toMatchObject({
+      audio_format: 'pcm_16000',
+      commit_strategy: 'manual',
+      enable_logging: 'false',
+      include_language_detection: 'true',
+      include_timestamps: 'true',
+      language_code: 'en',
+      min_silence_duration_ms: '200',
+      min_speech_duration_ms: '150',
+      model_id: 'scribe_v2_realtime',
+      no_verbatim: 'true',
+      vad_silence_threshold_secs: '1.2',
+      vad_threshold: '0.5',
+    });
+    expect(url.searchParams.getAll('keyterms')).toEqual(['Vercel', 'AI SDK']);
+    expect(ws.options?.headers).toMatchObject({
+      'xi-api-key': 'test-api-key',
+      'Custom-Provider-Header': 'provider-value',
+      'Custom-Request-Header': 'request-value',
+    });
+
+    ws.open();
+    ws.message({
+      message_type: 'session_started',
+      session_id: 'session-1',
+      config: {},
+    });
+    await flush();
+
+    expect(ws.send.mock.calls.map(([value]) => JSON.parse(value))).toEqual([
+      {
+        message_type: 'input_audio_chunk',
+        audio_base_64: 'AQID',
+        commit: false,
+        sample_rate: 16000,
+        previous_text: 'Earlier context',
+      },
+      {
+        message_type: 'input_audio_chunk',
+        audio_base_64: 'BAUG',
+        commit: false,
+        sample_rate: 16000,
+      },
+      {
+        message_type: 'input_audio_chunk',
+        audio_base_64: '',
+        commit: true,
+        sample_rate: 16000,
+      },
+    ]);
+
+    ws.message({ message_type: 'partial_transcript', text: 'Hello wor' });
+    ws.message({
+      message_type: 'committed_transcript',
+      text: 'Hello world.',
+    });
+    ws.message({
+      message_type: 'committed_transcript_with_timestamps',
+      text: 'Hello world.',
+      language_code: 'en',
+      words: [
+        { text: 'Hello', start: 0, end: 0.4, type: 'word' },
+        { text: ' ', start: 0.4, end: 0.45, type: 'spacing' },
+        { text: 'world.', start: 0.45, end: 0.9, type: 'word' },
+      ],
+    });
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-partial',
+        id: 'session-1',
+        text: 'Hello wor',
+      },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'Hello world.',
+      },
+      {
+        type: 'finish',
+        text: 'Hello world.',
+        segments: [
+          { text: 'Hello', startSecond: 0, endSecond: 0.4 },
+          { text: ' ', startSecond: 0.4, endSecond: 0.45 },
+          { text: 'world.', startSecond: 0.45, endSecond: 0.9 },
+        ],
+        language: 'en',
+        durationInSeconds: 0.9,
+      },
+    ]);
+    expect(result.response).toEqual({
+      timestamp: testDate,
+      modelId: 'scribe_v2_realtime',
+    });
+    expect(ws.close).toHaveBeenCalledWith(1000);
+  });
+
+  it('supports 8 kHz mu-law input', async () => {
+    const model = createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime');
+    const result = await model.doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcmu', rate: 8000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    expect(new URL(ws.url).searchParams.get('audio_format')).toBe('ulaw_8000');
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'committed_transcript', text: 'Hello' });
+    await expect(partsPromise).resolves.toBeDefined();
+  });
+
+  it('defaults PCM input without a rate to 16 kHz', async () => {
+    const model = createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime');
+    const result = await model.doStream!({
+      audio: convertArrayToReadableStream([]),
+      inputAudioFormat: { type: 'audio/pcm' },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    expect(new URL(ws.url).searchParams.get('audio_format')).toBe('pcm_16000');
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'committed_transcript', text: 'Hello' });
+    await expect(partsPromise).resolves.toBeDefined();
+  });
+
+  it('rejects non-realtime models and unsupported input formats', async () => {
+    await expect(
+      createElevenLabs({
+        apiKey: 'test-api-key',
+        webSocket: MockWebSocket,
+      }).transcription('scribe_v2').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
+
+    await expect(
+      createElevenLabs({
+        apiKey: 'test-api-key',
+        webSocket: MockWebSocket,
+      }).transcription('scribe_v2_realtime').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 32000 },
+      }),
+    ).rejects.toThrow('ElevenLabs realtime transcription supports');
+  });
+
+  it('rejects background filtering together with timestamps', async () => {
+    await expect(
+      createElevenLabs({
+        apiKey: 'test-api-key',
+        webSocket: MockWebSocket,
+      }).transcription('scribe_v2_realtime').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+        providerOptions: {
+          elevenlabs: {
+            streaming: {
+              filterBackgroundAudio: true,
+              includeTimestamps: true,
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow('cannot be combined');
+  });
+
+  it('warns about batch-only provider options', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        elevenlabs: { diarize: true, numSpeakers: 2 },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'committed_transcript', text: 'Hello' });
+    const parts = await partsPromise;
+    expect(parts[0]).toEqual({
+      type: 'stream-start',
+      warnings: [
+        {
+          type: 'unsupported',
+          feature: 'providerOptions.elevenlabs.diarize',
+          details:
+            'ElevenLabs realtime transcription does not support diarize.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'providerOptions.elevenlabs.numSpeakers',
+          details:
+            'ElevenLabs realtime transcription does not support numSpeakers.',
+        },
+      ],
+    });
+  });
+
+  it('errors the stream with the provider error message', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    const assertion = expect(partsPromise).rejects.toThrow('quota exhausted');
+    ws.message({ message_type: 'quota_exceeded', error: 'quota exhausted' });
+    await assertion;
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('cancels the audio stream when the WebSocket constructor throws', async () => {
+    let audioCancelled = false;
+    const audio = new ReadableStream<Uint8Array>({
+      cancel() {
+        audioCancelled = true;
+      },
+    });
+    const model = createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: class {
+        constructor() {
+          throw new Error('constructor failed');
+        }
+      } as never,
+    }).transcription('scribe_v2_realtime');
+
+    const result = await model.doStream!({
+      audio,
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+    await expect(convertReadableStreamToArray(result.stream)).rejects.toThrow(
+      'constructor failed',
+    );
+    expect(audioCancelled).toBe(true);
   });
 });

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -85,6 +85,29 @@ describe('doGenerate', () => {
     ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
   });
 
+  it('warns when streaming options are passed to batch transcription', async () => {
+    prepareJsonFixtureResponse('elevenlabs-transcription');
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        elevenlabs: {
+          streaming: { includeTimestamps: true },
+        },
+      },
+    });
+
+    expect(result.warnings).toEqual([
+      {
+        type: 'unsupported',
+        feature: 'providerOptions.elevenlabs.streaming',
+        details:
+          'ElevenLabs batch transcription does not support streaming options.',
+      },
+    ]);
+  });
+
   describe('transcription', () => {
     beforeEach(() => prepareJsonFixtureResponse('elevenlabs-transcription'));
 

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -58,6 +58,10 @@ class MockWebSocket {
     this.readyState = 3;
     this.onclose?.({});
   }
+
+  error() {
+    this.onerror?.({});
+  }
 }
 
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
@@ -304,6 +308,7 @@ describe('doStream', () => {
             minSpeechDurationMs: 150,
             noVerbatim: true,
             previousText: 'Earlier context',
+            secondaryLanguages: ['es', 'fr'],
             vadSilenceThresholdSecs: 1.2,
             vadThreshold: 0.5,
           },
@@ -332,6 +337,10 @@ describe('doStream', () => {
       vad_threshold: '0.5',
     });
     expect(url.searchParams.getAll('keyterms')).toEqual(['Vercel', 'AI SDK']);
+    expect(url.searchParams.getAll('secondary_languages')).toEqual([
+      'es',
+      'fr',
+    ]);
     expect(ws.options?.headers).toMatchObject({
       'xi-api-key': 'test-api-key',
       'Custom-Provider-Header': 'provider-value',
@@ -388,7 +397,7 @@ describe('doStream', () => {
       { type: 'stream-start', warnings: [] },
       {
         type: 'transcript-partial',
-        id: 'session-1',
+        id: 'session-1:0',
         text: 'Hello wor',
       },
       {
@@ -546,6 +555,151 @@ describe('doStream', () => {
     ]);
   });
 
+  it('drains commits received after the input ends and correlates partial IDs', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+
+    ws.message({ message_type: 'partial_transcript', text: 'First' });
+    ws.message({ message_type: 'committed_transcript', text: ' First  ' });
+    await flush();
+    expect(ws.close).not.toHaveBeenCalled();
+
+    // A server-initiated VAD/36-second commit can arrive just before the
+    // explicit final commit. The first one must not finish the stream early.
+    ws.message({ message_type: 'partial_transcript', text: 'Second' });
+    ws.message({ message_type: 'committed_transcript', text: ' Second ' });
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-partial',
+        id: 'session-1:0',
+        text: 'First',
+      },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'First',
+      },
+      {
+        type: 'transcript-partial',
+        id: 'session-1:1',
+        text: 'Second',
+      },
+      {
+        type: 'transcript-final',
+        id: 'session-1:1',
+        text: 'Second',
+      },
+      {
+        type: 'finish',
+        text: 'First Second',
+        segments: [],
+        language: undefined,
+        durationInSeconds: undefined,
+      },
+    ]);
+  });
+
+  it('handles legacy final transcript event variants', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        elevenlabs: { streaming: { includeTimestamps: true } },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'final_transcript', text: 'Legacy final' });
+    ws.message({
+      message_type: 'final_transcript_with_timestamps',
+      text: 'Legacy final',
+      language_code: 'en',
+      words: [{ text: 'Legacy final', start: 0, end: 0.5, type: 'word' }],
+    });
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'Legacy final',
+      },
+      {
+        type: 'finish',
+        text: 'Legacy final',
+        segments: [{ text: 'Legacy final', startSecond: 0, endSecond: 0.5 }],
+        language: 'en',
+        durationInSeconds: 0.5,
+      },
+    ]);
+  });
+
+  it('finishes normally when the final empty commit is rejected', async () => {
+    let audioController: ReadableStreamDefaultController<Uint8Array>;
+    const audio = new ReadableStream<Uint8Array>({
+      start(controller) {
+        audioController = controller;
+        controller.enqueue(new Uint8Array([1]));
+      },
+    });
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio,
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'committed_transcript', text: 'Already done' });
+    audioController!.close();
+    await flush();
+    ws.message({
+      message_type: 'insufficient_audio_activity',
+      error: 'not enough audio',
+    });
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'Already done',
+      },
+      {
+        type: 'finish',
+        text: 'Already done',
+        segments: [],
+        language: undefined,
+        durationInSeconds: undefined,
+      },
+    ]);
+  });
+
   it('errors when the upstream closes before the final commit', async () => {
     const result = await createElevenLabs({
       apiKey: 'test-api-key',
@@ -668,6 +822,42 @@ describe('doStream', () => {
     ).rejects.toThrow('cannot be combined');
   });
 
+  it('accepts explicit null values in realtime provider options', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        elevenlabs: {
+          streaming: {
+            commitStrategy: null,
+            enableLogging: null,
+            filterBackgroundAudio: null,
+            includeLanguageDetection: null,
+            includeTimestamps: null,
+            keyterms: null,
+            minSilenceDurationMs: null,
+            minSpeechDurationMs: null,
+            noVerbatim: null,
+            previousText: null,
+            secondaryLanguages: null,
+            vadSilenceThresholdSecs: null,
+            vadThreshold: null,
+          },
+        },
+      },
+    });
+
+    const url = new URL(MockWebSocket.instances[0].url);
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      model_id: 'scribe_v2_realtime',
+      audio_format: 'pcm_16000',
+    });
+    await result.stream.cancel();
+  });
+
   it('warns about batch-only provider options', async () => {
     const result = await createElevenLabs({
       apiKey: 'test-api-key',
@@ -723,6 +913,26 @@ describe('doStream', () => {
     ws.message({ message_type: 'quota_exceeded', error: 'quota exhausted' });
     await assertion;
     expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('explains the native WebSocket header requirement on socket errors', async () => {
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    try {
+      const result = await createElevenLabs({
+        apiKey: 'test-api-key',
+      }).transcription('scribe_v2_realtime').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      });
+
+      const partsPromise = convertReadableStreamToArray(result.stream);
+      MockWebSocket.instances[0].error();
+      await expect(partsPromise).rejects.toThrow(
+        'Pass a header-capable WebSocket implementation',
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('cancels the audio stream when the WebSocket constructor throws', async () => {

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -415,6 +415,57 @@ describe('doStream', () => {
     expect(ws.close).toHaveBeenCalledWith(1000);
   });
 
+  it('detects language without returning timestamps unless requested', async () => {
+    const result = await createElevenLabs({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    }).transcription('scribe_v2_realtime').doStream!({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        elevenlabs: {
+          streaming: {
+            includeLanguageDetection: true,
+            includeTimestamps: false,
+          },
+        },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    const url = new URL(ws.url);
+    expect(url.searchParams.get('include_language_detection')).toBe('true');
+    expect(url.searchParams.get('include_timestamps')).toBe('true');
+
+    ws.open();
+    ws.message({ message_type: 'session_started', session_id: 'session-1' });
+    await flush();
+    ws.message({ message_type: 'committed_transcript', text: 'Hola' });
+    ws.message({
+      message_type: 'committed_transcript_with_timestamps',
+      text: 'Hola',
+      language_code: 'es',
+      words: [{ text: 'Hola', start: 0, end: 0.4, type: 'word' }],
+    });
+
+    await expect(partsPromise).resolves.toEqual([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'transcript-final',
+        id: 'session-1:0',
+        text: 'Hola',
+      },
+      {
+        type: 'finish',
+        text: 'Hola',
+        segments: [],
+        language: 'es',
+        durationInSeconds: undefined,
+      },
+    ]);
+  });
+
   it('finishes with committed text when the socket closes before timestamps arrive', async () => {
     const result = await createElevenLabs({
       apiKey: 'test-api-key',
@@ -590,6 +641,26 @@ describe('doStream', () => {
             streaming: {
               filterBackgroundAudio: true,
               includeTimestamps: true,
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow('cannot be combined');
+  });
+
+  it('rejects background filtering together with language detection', async () => {
+    await expect(
+      createElevenLabs({
+        apiKey: 'test-api-key',
+        webSocket: MockWebSocket,
+      }).transcription('scribe_v2_realtime').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+        providerOptions: {
+          elevenlabs: {
+            streaming: {
+              filterBackgroundAudio: true,
+              includeLanguageDetection: true,
             },
           },
         },

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -1,21 +1,71 @@
-import type { TranscriptionModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  InvalidArgumentError,
+  UnsupportedFunctionalityError,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
+  type SharedV4Warning,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
 import {
   combineHeaders,
   convertBase64ToUint8Array,
+  convertToBase64,
+  connectToWebSocket,
   createJsonResponseHandler,
   mediaTypeToExtension,
   parseProviderOptions,
   postFormDataToApi,
+  safeParseJSON,
   serializeModelOptions,
+  toWebSocketUrl,
+  waitForWebSocketBufferDrain,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
+  type WebSocketConnection,
+  type WebSocketLike,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { ElevenLabsConfig } from './elevenlabs-config';
 import { elevenlabsFailedResponseHandler } from './elevenlabs-error';
-import { elevenLabsTranscriptionModelOptionsSchema } from './elevenlabs-transcription-model-options';
+import {
+  elevenLabsTranscriptionModelOptionsSchema,
+  type ElevenLabsTranscriptionModelOptions,
+} from './elevenlabs-transcription-model-options';
 import type { ElevenLabsTranscriptionModelId } from './elevenlabs-transcription-options';
 import type { ElevenLabsTranscriptionAPITypes } from './elevenlabs-api-types';
+
+type ElevenLabsRealtimeTranscriptionEvent = {
+  message_type?: string;
+  session_id?: string;
+  text?: string;
+  language_code?: string | null;
+  words?: Array<{
+    text?: string;
+    start?: number;
+    end?: number;
+    type?: string;
+  }> | null;
+  error?: string;
+};
+
+const elevenLabsRealtimeErrorTypes = new Set([
+  'auth_error',
+  'chunk_size_exceeded',
+  'commit_throttled',
+  'error',
+  'input_error',
+  'insufficient_audio_activity',
+  'queue_overflow',
+  'quota_exceeded',
+  'rate_limited',
+  'resource_exhausted',
+  'session_time_limit_exceeded',
+  'transcriber_error',
+  'unaccepted_terms',
+]);
+
+function isRealtimeTranscriptionModelId(modelId: string): boolean {
+  return modelId === 'scribe_v2_realtime';
+}
 
 interface ElevenLabsTranscriptionModelConfig extends ElevenLabsConfig {
   _internal?: {
@@ -114,6 +164,12 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
   async doGenerate(
     options: Parameters<TranscriptionModelV4['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    if (isRealtimeTranscriptionModelId(this.modelId)) {
+      throw new UnsupportedFunctionalityError({
+        functionality: `non-streaming transcription with ${this.modelId}`,
+      });
+    }
+
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { formData, warnings } = await this.getArgs(options);
 
@@ -155,6 +211,424 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
       },
     };
   }
+
+  async doStream(
+    options: TranscriptionModelV4StreamOptions,
+  ): Promise<
+    Awaited<ReturnType<NonNullable<TranscriptionModelV4['doStream']>>>
+  > {
+    if (!isRealtimeTranscriptionModelId(this.modelId)) {
+      throw new UnsupportedFunctionalityError({
+        functionality: `streaming transcription with ${this.modelId}`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const elevenLabsOptions = await parseProviderOptions({
+      provider: 'elevenlabs',
+      providerOptions: options.providerOptions,
+      schema: elevenLabsTranscriptionModelOptionsSchema,
+    });
+    const streamingOptions = elevenLabsOptions?.streaming;
+    const warnings: SharedV4Warning[] = [];
+
+    const rawElevenLabsOptions = options.providerOptions?.elevenlabs ?? {};
+    for (const option of [
+      'diarize',
+      'fileFormat',
+      'numSpeakers',
+      'tagAudioEvents',
+      'timestampsGranularity',
+    ]) {
+      if (
+        rawElevenLabsOptions[option as keyof typeof rawElevenLabsOptions] !=
+        null
+      ) {
+        warnings.push({
+          type: 'unsupported',
+          feature: `providerOptions.elevenlabs.${option}`,
+          details: `ElevenLabs realtime transcription does not support ${option}.`,
+        });
+      }
+    }
+
+    if (
+      streamingOptions?.filterBackgroundAudio === true &&
+      streamingOptions.includeTimestamps === true
+    ) {
+      throw new InvalidArgumentError({
+        argument: 'providerOptions',
+        message:
+          'providerOptions.elevenlabs.streaming.filterBackgroundAudio cannot be combined with includeTimestamps',
+      });
+    }
+
+    const inputFormat = getElevenLabsRealtimeAudioFormat(
+      options.inputAudioFormat,
+    );
+    const url = buildElevenLabsRealtimeTranscriptionUrl({
+      baseUrl: toWebSocketUrl(
+        this.config.url({
+          path: '/v1/speech-to-text/realtime',
+          modelId: this.modelId,
+        }),
+      ),
+      inputFormat: inputFormat.audioFormat,
+      languageCode: elevenLabsOptions?.languageCode ?? undefined,
+      modelId: this.modelId,
+      streamingOptions,
+    });
+
+    return {
+      request: { body: url.toString() },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+      },
+      stream: createElevenLabsRealtimeTranscriptionStream({
+        abortSignal: options.abortSignal,
+        audio: options.audio,
+        headers: combineHeaders(this.config.headers?.(), options.headers),
+        includeRawChunks: options.includeRawChunks,
+        includeTimestamps: streamingOptions?.includeTimestamps === true,
+        language: elevenLabsOptions?.languageCode ?? undefined,
+        previousText: streamingOptions?.previousText ?? undefined,
+        sampleRate: inputFormat.sampleRate,
+        url,
+        warnings,
+        webSocket: this.config.webSocket,
+      }),
+    };
+  }
+}
+
+function getElevenLabsRealtimeAudioFormat(
+  inputAudioFormat: TranscriptionModelV4StreamOptions['inputAudioFormat'],
+): { audioFormat: string; sampleRate: number } {
+  const type = inputAudioFormat.type.toLowerCase();
+  const rate = inputAudioFormat.rate;
+
+  if (type === 'audio/pcmu') {
+    if (rate != null && rate !== 8000) {
+      throw new InvalidArgumentError({
+        argument: 'inputAudioFormat',
+        message: 'ElevenLabs only supports audio/pcmu at 8000 Hz',
+      });
+    }
+    return { audioFormat: 'ulaw_8000', sampleRate: 8000 };
+  }
+
+  const supportedPcmRates = [8000, 16000, 22050, 24000, 44100, 48000];
+  const pcmRate = rate ?? 16000;
+  if (type !== 'audio/pcm' || !supportedPcmRates.includes(pcmRate)) {
+    throw new InvalidArgumentError({
+      argument: 'inputAudioFormat',
+      message:
+        'ElevenLabs realtime transcription supports audio/pcm at 8000, 16000, 22050, 24000, 44100, or 48000 Hz, and audio/pcmu at 8000 Hz',
+    });
+  }
+
+  return { audioFormat: `pcm_${pcmRate}`, sampleRate: pcmRate };
+}
+
+function buildElevenLabsRealtimeTranscriptionUrl({
+  baseUrl,
+  inputFormat,
+  languageCode,
+  modelId,
+  streamingOptions,
+}: {
+  baseUrl: URL;
+  inputFormat: string;
+  languageCode: string | undefined;
+  modelId: string;
+  streamingOptions:
+    | NonNullable<ElevenLabsTranscriptionModelOptions['streaming']>
+    | null
+    | undefined;
+}): URL {
+  const url = new URL(baseUrl);
+  url.searchParams.set('model_id', modelId);
+  url.searchParams.set('audio_format', inputFormat);
+
+  const parameters = {
+    commit_strategy: streamingOptions?.commitStrategy,
+    enable_logging: streamingOptions?.enableLogging,
+    filter_background_audio: streamingOptions?.filterBackgroundAudio,
+    include_language_detection: streamingOptions?.includeLanguageDetection,
+    include_timestamps: streamingOptions?.includeTimestamps,
+    language_code: languageCode,
+    min_silence_duration_ms: streamingOptions?.minSilenceDurationMs,
+    min_speech_duration_ms: streamingOptions?.minSpeechDurationMs,
+    no_verbatim: streamingOptions?.noVerbatim,
+    vad_silence_threshold_secs: streamingOptions?.vadSilenceThresholdSecs,
+    vad_threshold: streamingOptions?.vadThreshold,
+  };
+  for (const [key, value] of Object.entries(parameters)) {
+    if (value != null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  for (const keyterm of streamingOptions?.keyterms ?? []) {
+    url.searchParams.append('keyterms', keyterm);
+  }
+
+  return url;
+}
+
+function createElevenLabsRealtimeTranscriptionStream({
+  abortSignal,
+  audio,
+  headers,
+  includeRawChunks,
+  includeTimestamps,
+  language,
+  previousText,
+  sampleRate,
+  url,
+  warnings,
+  webSocket,
+}: {
+  abortSignal: AbortSignal | undefined;
+  audio: ReadableStream<Uint8Array | string>;
+  headers: Record<string, string | undefined>;
+  includeRawChunks: boolean | undefined;
+  includeTimestamps: boolean;
+  language: string | undefined;
+  previousText: string | undefined;
+  sampleRate: number;
+  url: URL;
+  warnings: SharedV4Warning[];
+  webSocket: ElevenLabsConfig['webSocket'];
+}) {
+  let finished = false;
+  let cleanup: (closeCode?: number) => void = () => {};
+
+  return new ReadableStream({
+    start: controller => {
+      let audioReader:
+        | ReadableStreamDefaultReader<Uint8Array | string>
+        | undefined;
+      let connection: WebSocketConnection | undefined;
+      let detectedLanguage = language;
+      let endOfInput = false;
+      let segmentIndex = 0;
+      let sessionId: string | undefined;
+      let committedEventCount = 0;
+      let committedEventsAtEndOfInput = 0;
+      let finalCommitEventCount: number | undefined;
+      let timestampedCommitCount = 0;
+      const finalSegments: Array<{
+        text: string;
+        startSecond: number;
+        endSecond: number;
+      }> = [];
+      const finalTexts: string[] = [];
+
+      cleanup = (closeCode?: number) => {
+        if (audioReader != null) {
+          void audioReader.cancel().catch(() => {});
+        } else {
+          void audio.cancel().catch(() => {});
+        }
+        connection?.close(closeCode);
+      };
+
+      const finishWithError = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.error(error);
+      };
+
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        controller.enqueue({
+          type: 'finish',
+          text: finalTexts.join(' ').trim(),
+          segments: finalSegments,
+          language: detectedLanguage,
+          durationInSeconds: finalSegments.at(-1)?.endSecond,
+        });
+        controller.close();
+        cleanup(1000);
+      };
+
+      const sendAudio = async (socket: WebSocketLike) => {
+        audioReader = audio.getReader();
+        let firstChunk = true;
+        try {
+          while (true) {
+            const { done, value } = await audioReader.read();
+            if (done || finished) break;
+            socket.send(
+              JSON.stringify({
+                message_type: 'input_audio_chunk',
+                audio_base_64: convertToBase64(value),
+                commit: false,
+                sample_rate: sampleRate,
+                ...(firstChunk && previousText != null
+                  ? { previous_text: previousText }
+                  : {}),
+              }),
+            );
+            firstChunk = false;
+            await waitForWebSocketBufferDrain(socket);
+          }
+        } finally {
+          audioReader.releaseLock();
+          audioReader = undefined;
+        }
+        if (!finished) {
+          committedEventsAtEndOfInput = committedEventCount;
+          endOfInput = true;
+          socket.send(
+            JSON.stringify({
+              message_type: 'input_audio_chunk',
+              audio_base_64: '',
+              commit: true,
+              sample_rate: sampleRate,
+            }),
+          );
+        }
+      };
+
+      connection = connectToWebSocket({
+        abortSignal,
+        headers,
+        onAbort: finishWithError,
+        onClose: () => {
+          if (finished) return;
+          finished = true;
+          cleanup();
+          controller.close();
+        },
+        onMessageText: async text => {
+          const parsed = await safeParseJSON({ text });
+          if (!parsed.success) return;
+          const raw = parsed.value as ElevenLabsRealtimeTranscriptionEvent;
+
+          if (includeRawChunks) {
+            controller.enqueue({ type: 'raw', rawValue: raw });
+          }
+
+          if (
+            raw.message_type != null &&
+            elevenLabsRealtimeErrorTypes.has(raw.message_type)
+          ) {
+            finishWithError(
+              new Error(raw.error ?? 'ElevenLabs realtime transcription error'),
+            );
+            return;
+          }
+
+          switch (raw.message_type) {
+            case 'session_started': {
+              sessionId = raw.session_id;
+              controller.enqueue({ type: 'stream-start', warnings });
+              const socket = connection?.socket;
+              if (socket == null) {
+                finishWithError(new Error('WebSocket is not connected.'));
+                break;
+              }
+              void sendAudio(socket).catch(finishWithError);
+              break;
+            }
+            case 'partial_transcript': {
+              controller.enqueue({
+                type: 'transcript-partial',
+                id: sessionId,
+                text: raw.text ?? '',
+              });
+              break;
+            }
+            case 'committed_transcript': {
+              committedEventCount++;
+              const text = raw.text ?? '';
+              const id = `${sessionId ?? 'session'}:${segmentIndex++}`;
+
+              if (text.length > 0) {
+                finalTexts.push(text);
+                controller.enqueue({
+                  type: 'transcript-final',
+                  id,
+                  text,
+                });
+              }
+
+              // When timestamps are requested, ElevenLabs follows this event
+              // with committed_transcript_with_timestamps for the same commit.
+              if (
+                endOfInput &&
+                committedEventCount > committedEventsAtEndOfInput
+              ) {
+                finalCommitEventCount = committedEventCount;
+                if (!includeTimestamps) finish();
+              }
+              break;
+            }
+            case 'committed_transcript_with_timestamps': {
+              const text = raw.text ?? '';
+              const words = raw.words ?? [];
+              const timestampedWords = words.filter(
+                (word): word is typeof word & { start: number; end: number } =>
+                  typeof word.start === 'number' &&
+                  typeof word.end === 'number',
+              );
+              detectedLanguage = raw.language_code ?? detectedLanguage;
+
+              // Normally this is paired with the preceding committed_transcript.
+              // Still handle a timestamp-only server response defensively.
+              if (
+                finalTexts[timestampedCommitCount] == null &&
+                text.length > 0
+              ) {
+                const id = `${sessionId ?? 'session'}:${segmentIndex++}`;
+                finalTexts.push(text);
+                controller.enqueue({
+                  type: 'transcript-final',
+                  id,
+                  text,
+                  startSecond: timestampedWords[0]?.start,
+                  endSecond: timestampedWords.at(-1)?.end,
+                });
+              }
+              timestampedCommitCount++;
+              finalSegments.push(
+                ...timestampedWords.map(word => ({
+                  text: word.text ?? '',
+                  startSecond: word.start,
+                  endSecond: word.end,
+                })),
+              );
+
+              if (
+                endOfInput &&
+                finalCommitEventCount != null &&
+                timestampedCommitCount >= finalCommitEventCount
+              ) {
+                finish();
+              }
+              break;
+            }
+          }
+        },
+        onProcessingError: finishWithError,
+        onSocketError: () => {
+          finishWithError(new Error('ElevenLabs realtime transcription error'));
+        },
+        url,
+        webSocket,
+      });
+    },
+
+    cancel: () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    },
+  });
 }
 
 const elevenlabsTranscriptionResponseSchema = z.object({

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -500,9 +500,15 @@ function createElevenLabsRealtimeTranscriptionStream({
         onAbort: finishWithError,
         onClose: () => {
           if (finished) return;
-          finished = true;
-          cleanup();
-          controller.close();
+          if (endOfInput && finalCommitEventCount != null) {
+            finish();
+            return;
+          }
+          finishWithError(
+            new Error(
+              'ElevenLabs realtime transcription stream closed before completion.',
+            ),
+          );
         },
         onMessageText: async text => {
           const parsed = await safeParseJSON({ text });
@@ -605,8 +611,9 @@ function createElevenLabsRealtimeTranscriptionStream({
 
               if (
                 endOfInput &&
-                finalCommitEventCount != null &&
-                timestampedCommitCount >= finalCommitEventCount
+                timestampedCommitCount > committedEventsAtEndOfInput &&
+                (finalCommitEventCount == null ||
+                  timestampedCommitCount >= finalCommitEventCount)
               ) {
                 finish();
               }

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -113,6 +113,15 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
       schema: elevenLabsTranscriptionModelOptionsSchema,
     });
 
+    if (elevenlabsOptions?.streaming != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'providerOptions.elevenlabs.streaming',
+        details:
+          'ElevenLabs batch transcription does not support streaming options.',
+      });
+    }
+
     // Create form data with base fields
     const formData = new FormData();
     const blob =
@@ -344,7 +353,6 @@ function buildElevenLabsRealtimeTranscriptionUrl({
   modelId: string;
   streamingOptions:
     | NonNullable<ElevenLabsTranscriptionModelOptions['streaming']>
-    | null
     | undefined;
 }): URL {
   const url = new URL(baseUrl);

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -263,12 +263,13 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
 
     if (
       streamingOptions?.filterBackgroundAudio === true &&
-      streamingOptions.includeTimestamps === true
+      (streamingOptions.includeTimestamps === true ||
+        streamingOptions.includeLanguageDetection === true)
     ) {
       throw new InvalidArgumentError({
         argument: 'providerOptions',
         message:
-          'providerOptions.elevenlabs.streaming.filterBackgroundAudio cannot be combined with includeTimestamps',
+          'providerOptions.elevenlabs.streaming.filterBackgroundAudio cannot be combined with includeTimestamps or includeLanguageDetection',
       });
     }
 
@@ -298,6 +299,8 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
         abortSignal: options.abortSignal,
         audio: options.audio,
         headers: combineHeaders(this.config.headers?.(), options.headers),
+        includeLanguageDetection:
+          streamingOptions?.includeLanguageDetection === true,
         includeRawChunks: options.includeRawChunks,
         includeTimestamps: streamingOptions?.includeTimestamps === true,
         language: elevenLabsOptions?.languageCode ?? undefined,
@@ -358,13 +361,18 @@ function buildElevenLabsRealtimeTranscriptionUrl({
   const url = new URL(baseUrl);
   url.searchParams.set('model_id', modelId);
   url.searchParams.set('audio_format', inputFormat);
+  const includeDetailedCommit =
+    streamingOptions?.includeTimestamps === true ||
+    streamingOptions?.includeLanguageDetection === true;
 
   const parameters = {
     commit_strategy: streamingOptions?.commitStrategy,
     enable_logging: streamingOptions?.enableLogging,
     filter_background_audio: streamingOptions?.filterBackgroundAudio,
     include_language_detection: streamingOptions?.includeLanguageDetection,
-    include_timestamps: streamingOptions?.includeTimestamps,
+    include_timestamps: includeDetailedCommit
+      ? true
+      : streamingOptions?.includeTimestamps,
     language_code: languageCode,
     min_silence_duration_ms: streamingOptions?.minSilenceDurationMs,
     min_speech_duration_ms: streamingOptions?.minSpeechDurationMs,
@@ -388,6 +396,7 @@ function createElevenLabsRealtimeTranscriptionStream({
   abortSignal,
   audio,
   headers,
+  includeLanguageDetection,
   includeRawChunks,
   includeTimestamps,
   language,
@@ -400,6 +409,7 @@ function createElevenLabsRealtimeTranscriptionStream({
   abortSignal: AbortSignal | undefined;
   audio: ReadableStream<Uint8Array | string>;
   headers: Record<string, string | undefined>;
+  includeLanguageDetection: boolean;
   includeRawChunks: boolean | undefined;
   includeTimestamps: boolean;
   language: string | undefined;
@@ -426,6 +436,8 @@ function createElevenLabsRealtimeTranscriptionStream({
       let committedEventsAtEndOfInput = 0;
       let finalCommitEventCount: number | undefined;
       let timestampedCommitCount = 0;
+      const expectDetailedCommit =
+        includeTimestamps || includeLanguageDetection;
       const finalSegments: Array<{
         text: string;
         startSecond: number;
@@ -578,7 +590,7 @@ function createElevenLabsRealtimeTranscriptionStream({
                 committedEventCount > committedEventsAtEndOfInput
               ) {
                 finalCommitEventCount = committedEventCount;
-                if (!includeTimestamps) finish();
+                if (!expectDetailedCommit) finish();
               }
               break;
             }
@@ -604,18 +616,24 @@ function createElevenLabsRealtimeTranscriptionStream({
                   type: 'transcript-final',
                   id,
                   text,
-                  startSecond: timestampedWords[0]?.start,
-                  endSecond: timestampedWords.at(-1)?.end,
+                  ...(includeTimestamps
+                    ? {
+                        startSecond: timestampedWords[0]?.start,
+                        endSecond: timestampedWords.at(-1)?.end,
+                      }
+                    : {}),
                 });
               }
               timestampedCommitCount++;
-              finalSegments.push(
-                ...timestampedWords.map(word => ({
-                  text: word.text ?? '',
-                  startSecond: word.start,
-                  endSecond: word.end,
-                })),
-              );
+              if (includeTimestamps) {
+                finalSegments.push(
+                  ...timestampedWords.map(word => ({
+                    text: word.text ?? '',
+                    startSecond: word.start,
+                    endSecond: word.end,
+                  })),
+                );
+              }
 
               if (
                 endOfInput &&

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -63,6 +63,14 @@ const elevenLabsRealtimeErrorTypes = new Set([
   'unaccepted_terms',
 ]);
 
+const elevenLabsLateFinalizationErrorTypes = new Set([
+  'commit_throttled',
+  'input_error',
+  'insufficient_audio_activity',
+]);
+
+const finalCommitGracePeriodMs = 250;
+
 function isRealtimeTranscriptionModelId(modelId: string): boolean {
   return modelId === 'scribe_v2_realtime';
 }
@@ -238,7 +246,7 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
       providerOptions: options.providerOptions,
       schema: elevenLabsTranscriptionModelOptionsSchema,
     });
-    const streamingOptions = elevenLabsOptions?.streaming;
+    const streamingOptions = elevenLabsOptions?.streaming ?? undefined;
     const warnings: SharedV4Warning[] = [];
 
     const rawElevenLabsOptions = options.providerOptions?.elevenlabs ?? {};
@@ -261,6 +269,10 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV4 {
       }
     }
 
+    // ElevenLabs documents filter_background_audio as incompatible with
+    // include_timestamps. Language detection is delivered on the same
+    // timestamp-bearing event, so it also requires include_timestamps here.
+    // https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime
     if (
       streamingOptions?.filterBackgroundAudio === true &&
       (streamingOptions.includeTimestamps === true ||
@@ -388,6 +400,9 @@ function buildElevenLabsRealtimeTranscriptionUrl({
   for (const keyterm of streamingOptions?.keyterms ?? []) {
     url.searchParams.append('keyterms', keyterm);
   }
+  for (const secondaryLanguage of streamingOptions?.secondaryLanguages ?? []) {
+    url.searchParams.append('secondary_languages', secondaryLanguage);
+  }
 
   return url;
 }
@@ -430,6 +445,8 @@ function createElevenLabsRealtimeTranscriptionStream({
       let connection: WebSocketConnection | undefined;
       let detectedLanguage = language;
       let endOfInput = false;
+      let finalCommitGracePeriod: ReturnType<typeof setTimeout> | undefined;
+      let receivedPostInputCommit = false;
       let segmentIndex = 0;
       let sessionId: string | undefined;
       let committedEventCount = 0;
@@ -446,6 +463,7 @@ function createElevenLabsRealtimeTranscriptionStream({
       const finalTexts: string[] = [];
 
       cleanup = (closeCode?: number) => {
+        clearTimeout(finalCommitGracePeriod);
         if (audioReader != null) {
           void audioReader.cancel().catch(() => {});
         } else {
@@ -473,6 +491,11 @@ function createElevenLabsRealtimeTranscriptionStream({
         });
         controller.close();
         cleanup(1000);
+      };
+
+      const scheduleFinish = () => {
+        clearTimeout(finalCommitGracePeriod);
+        finalCommitGracePeriod = setTimeout(finish, finalCommitGracePeriodMs);
       };
 
       const sendAudio = async (socket: WebSocketLike) => {
@@ -520,7 +543,7 @@ function createElevenLabsRealtimeTranscriptionStream({
         onAbort: finishWithError,
         onClose: () => {
           if (finished) return;
-          if (endOfInput && finalCommitEventCount != null) {
+          if (endOfInput && receivedPostInputCommit) {
             finish();
             return;
           }
@@ -543,6 +566,15 @@ function createElevenLabsRealtimeTranscriptionStream({
             raw.message_type != null &&
             elevenLabsRealtimeErrorTypes.has(raw.message_type)
           ) {
+            if (
+              endOfInput &&
+              (committedEventCount > 0 || timestampedCommitCount > 0) &&
+              elevenLabsLateFinalizationErrorTypes.has(raw.message_type)
+            ) {
+              receivedPostInputCommit = true;
+              finish();
+              return;
+            }
             finishWithError(
               new Error(raw.error ?? 'ElevenLabs realtime transcription error'),
             );
@@ -564,18 +596,20 @@ function createElevenLabsRealtimeTranscriptionStream({
             case 'partial_transcript': {
               controller.enqueue({
                 type: 'transcript-partial',
-                id: sessionId,
+                id: `${sessionId ?? 'session'}:${segmentIndex}`,
                 text: raw.text ?? '',
               });
               break;
             }
+            case 'final_transcript':
             case 'committed_transcript': {
               committedEventCount++;
-              const text = raw.text ?? '';
-              const id = `${sessionId ?? 'session'}:${segmentIndex++}`;
+              const text = (raw.text ?? '').trim();
+              const id = `${sessionId ?? 'session'}:${segmentIndex}`;
 
               if (text.length > 0) {
                 finalTexts.push(text);
+                segmentIndex++;
                 controller.enqueue({
                   type: 'transcript-final',
                   id,
@@ -589,13 +623,20 @@ function createElevenLabsRealtimeTranscriptionStream({
                 endOfInput &&
                 committedEventCount > committedEventsAtEndOfInput
               ) {
+                receivedPostInputCommit = true;
                 finalCommitEventCount = committedEventCount;
-                if (!expectDetailedCommit) finish();
+                if (
+                  !expectDetailedCommit ||
+                  raw.message_type === 'final_transcript'
+                ) {
+                  scheduleFinish();
+                }
               }
               break;
             }
+            case 'final_transcript_with_timestamps':
             case 'committed_transcript_with_timestamps': {
-              const text = raw.text ?? '';
+              const text = (raw.text ?? '').trim();
               const words = raw.words ?? [];
               const timestampedWords = words.filter(
                 (word): word is typeof word & { start: number; end: number } =>
@@ -641,7 +682,8 @@ function createElevenLabsRealtimeTranscriptionStream({
                 (finalCommitEventCount == null ||
                   timestampedCommitCount >= finalCommitEventCount)
               ) {
-                finish();
+                receivedPostInputCommit = true;
+                scheduleFinish();
               }
               break;
             }
@@ -649,7 +691,18 @@ function createElevenLabsRealtimeTranscriptionStream({
         },
         onProcessingError: finishWithError,
         onSocketError: () => {
-          finishWithError(new Error('ElevenLabs realtime transcription error'));
+          finishWithError(
+            new Error(
+              'ElevenLabs realtime transcription error.' +
+                (webSocket == null
+                  ? ' Note: the native WebSocket implementation in browsers,' +
+                    ' Node.js, Deno, and Bun cannot send the xi-api-key header' +
+                    ' required by ElevenLabs. Pass a header-capable WebSocket' +
+                    " implementation (e.g. the 'ws' package) via" +
+                    ' createElevenLabs({ webSocket }).'
+                  : ''),
+            ),
+          );
         },
         url,
         webSocket,

--- a/packages/elevenlabs/src/elevenlabs-transcription-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-options.ts
@@ -2,4 +2,5 @@ export type ElevenLabsTranscriptionModelId =
   | 'scribe_v1'
   | 'scribe_v1_experimental'
   | 'scribe_v2'
+  | 'scribe_v2_realtime'
   | (string & {});


### PR DESCRIPTION
## Summary

- add realtime streaming transcription support for ElevenLabs Scribe v2 Realtime
- implement the AI SDK v4 `doStream` transcription interface over the ElevenLabs WebSocket API
- support PCM and μ-law audio, commit strategies, language detection, word timestamps, and realtime transcript events
- preserve language detection when timestamps are not exposed to the caller
- finalize cleanly when ElevenLabs closes after the committed transcript, including timestamp-optional responses
- document Scribe alongside the other streaming transcription models and add a playback-paced example

## Why

AI Gateway streaming transcription needs a provider-level implementation. The published ElevenLabs provider currently supports only request/response transcription, so Gateway cannot construct or run a Scribe realtime stream without this change.

This is intentionally scoped to Scribe realtime transcription. It does not add ElevenAgents or the general realtime agent/session API.

Companion Gateway PR: https://github.com/vercel/ai-gateway/pull/2642

## Validation

- `pnpm --filter @ai-sdk/elevenlabs test` — 30 Node tests and 30 Edge tests passed
- `pnpm --filter @ai-sdk/elevenlabs type-check`
- `pnpm --filter @ai-sdk/elevenlabs build`
- `pnpm --filter @example/ai-functions type-check`
- `pnpm exec ultracite check` on the changed TypeScript files
- full GitHub CI on Node 22, 24, and 26

## Manual verification

Verified end to end through the companion AI Gateway preview with live microphone audio. Partial and committed transcripts, timestamps, language detection, manual finalization, and clean provider close behavior all completed successfully.