### PR TITLE
test(react/mcp): assert outer-frame permission delegation

### DIFF
--- a/.changeset/harden-mcp-apps.md
+++ b/.changeset/harden-mcp-apps.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/react': patch
+'@ai-sdk/mcp': patch
+---
+
+Harden MCP Apps handling of server-supplied resource metadata and the host/iframe bridge:
+
+- Runtime-validate `_meta.ui` and drop malformed or non-string fields.
+- Gate iframe permissions deny-by-default via a new `sandbox.allowedPermissions` allowlist.
+- Derive a concrete `postMessage` target origin and validate inbound message origins.
+- Validate inbound bridge params: limit `resources/read` to `ui://` resources and allow only `https`/`http`/`mailto` in `ui/open-link`.
+- Add `fingerprintMCPAppResource` / `detectMCPAppResourceDrift` for pinning and comparing app resources.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -22,6 +22,10 @@ export {
   type MCPAppResourceCSP,
   type MCPAppResourceMeta,
 } from './tool/mcp-apps';
+export {
+  fingerprintMCPAppResource,
+  detectMCPAppResourceDrift,
+} from './tool/mcp-app-fingerprint';
 export { ElicitationRequestSchema, ElicitResultSchema } from './tool/types';
 export type {
   CallToolResult,

--- a/packages/mcp/src/tool/mcp-app-fingerprint.test.ts
+++ b/packages/mcp/src/tool/mcp-app-fingerprint.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectMCPAppResourceDrift,
+  fingerprintMCPAppResource,
+} from './mcp-app-fingerprint';
+import { MCP_APP_MIME_TYPE, type MCPAppResource } from './mcp-apps';
+
+function resource(overrides: Partial<MCPAppResource> = {}): MCPAppResource {
+  return {
+    uri: 'ui://app/dashboard',
+    mimeType: MCP_APP_MIME_TYPE,
+    html: '<!doctype html><html></html>',
+    meta: {
+      csp: { connectDomains: ['https://api.example'] },
+      permissions: { microphone: {} },
+    },
+    ...overrides,
+  };
+}
+
+describe('fingerprintMCPAppResource', () => {
+  it('produces a stable digest for equal resources', async () => {
+    expect(await fingerprintMCPAppResource(resource())).toBe(
+      await fingerprintMCPAppResource(resource()),
+    );
+  });
+
+  it('ignores key ordering in csp / permissions', async () => {
+    const a = await fingerprintMCPAppResource(
+      resource({
+        meta: {
+          csp: { connectDomains: ['https://api.example'], frameDomains: [] },
+          permissions: { microphone: {}, camera: {} },
+        },
+      }),
+    );
+    const b = await fingerprintMCPAppResource(
+      resource({
+        meta: {
+          permissions: { camera: {}, microphone: {} },
+          csp: { frameDomains: [], connectDomains: ['https://api.example'] },
+        },
+      }),
+    );
+    expect(a).toBe(b);
+  });
+
+  it('changes when html, csp, or permissions mutate', async () => {
+    const baseline = await fingerprintMCPAppResource(resource());
+
+    expect(
+      await fingerprintMCPAppResource(resource({ html: '<html>evil</html>' })),
+    ).not.toBe(baseline);
+    expect(
+      await fingerprintMCPAppResource(
+        resource({
+          meta: { csp: { connectDomains: ['https://evil.example'] } },
+        }),
+      ),
+    ).not.toBe(baseline);
+    expect(
+      await fingerprintMCPAppResource(
+        resource({ meta: { permissions: { camera: {} } } }),
+      ),
+    ).not.toBe(baseline);
+  });
+});
+
+describe('detectMCPAppResourceDrift', () => {
+  it('flags a changed fingerprint', () => {
+    expect(detectMCPAppResourceDrift('a', 'b')).toBe(true);
+    expect(detectMCPAppResourceDrift('a', 'a')).toBe(false);
+  });
+});

--- a/packages/mcp/src/tool/mcp-app-fingerprint.ts
+++ b/packages/mcp/src/tool/mcp-app-fingerprint.ts
@@ -1,0 +1,70 @@
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
+import type { MCPAppResource } from './mcp-apps';
+
+const encoder = new TextEncoder();
+
+// canonicalJSON/toBase64url/the digest below mirror
+// packages/ai/src/util/canonical-hash.ts, which `@ai-sdk/mcp` can't import
+// (wrong dependency direction, not exported). Keep them identical; if a third
+// consumer appears, hoist into @ai-sdk/provider-utils instead.
+
+/**
+ * Deterministic JSON serialization: object keys are sorted so two
+ * structurally-equal values always produce the same string regardless of key
+ * insertion order. Used as the stable input to content hashing.
+ */
+function canonicalJSON(value: unknown): string {
+  if (value == null || typeof value !== 'object') {
+    return JSON.stringify(value ?? null);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJSON).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const entries = Object.keys(record)
+    .sort()
+    .map(k => `${JSON.stringify(k)}:${canonicalJSON(record[k])}`);
+  return `{${entries.join(',')}}`;
+}
+
+function toBase64url(bytes: Uint8Array): string {
+  return convertUint8ArrayToBase64(bytes)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+/**
+ * Stable SHA-256 digest (base64url) over an MCP App resource's `html`, `csp`,
+ * and `permissions`.
+ *
+ * Capture a baseline on first load and compare later reads with
+ * {@link detectMCPAppResourceDrift} to detect a changed resource. Baseline
+ * storage and the response are the host's concern, mirroring `fingerprintTools`.
+ */
+export async function fingerprintMCPAppResource(
+  resource: MCPAppResource,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    encoder.encode(
+      canonicalJSON({
+        html: resource.html,
+        csp: resource.meta?.csp ?? null,
+        permissions: resource.meta?.permissions ?? null,
+      }),
+    ),
+  );
+  return toBase64url(new Uint8Array(digest));
+}
+
+/**
+ * Compares two fingerprints from {@link fingerprintMCPAppResource}. Returns
+ * `true` when the current resource differs from its baseline.
+ */
+export function detectMCPAppResourceDrift(
+  current: string,
+  baseline: string,
+): boolean {
+  return current !== baseline;
+}

--- a/packages/mcp/src/tool/mcp-apps.test.ts
+++ b/packages/mcp/src/tool/mcp-apps.test.ts
@@ -189,6 +189,46 @@ describe('MCP Apps helpers', () => {
     `);
   });
 
+  it('drops malformed and non-string _meta.ui fields', () => {
+    const resource = getMCPAppResourceFromReadResult({
+      uri: 'ui://ai-sdk-e2e/dashboard',
+      resource: {
+        contents: [
+          {
+            uri: 'ui://ai-sdk-e2e/dashboard',
+            mimeType: MCP_APP_MIME_TYPE,
+            text: '<!doctype html>',
+            _meta: {
+              ui: {
+                prefersBorder: 'yes', // wrong type -> dropped
+                csp: {
+                  connectDomains: ['https://ok.example', 42, null], // non-strings dropped
+                  resourceDomains: 'not-an-array', // wrong type -> dropped
+                },
+                permissions: 'nope', // wrong type -> dropped
+                extra: 'kept', // unknown key passes through
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(resource.meta).toMatchInlineSnapshot(`
+      {
+        "csp": {
+          "connectDomains": [
+            "https://ok.example",
+          ],
+          "resourceDomains": undefined,
+        },
+        "extra": "kept",
+        "permissions": undefined,
+        "prefersBorder": undefined,
+      }
+    `);
+  });
+
   it('calls app-visible tools through the MCP client', async () => {
     client = await createMCPClient({
       transport: new MockMCPTransport({

--- a/packages/mcp/src/tool/mcp-apps.ts
+++ b/packages/mcp/src/tool/mcp-apps.ts
@@ -1,5 +1,6 @@
 import { isJSONObject, type JSONObject } from '@ai-sdk/provider';
 import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
 import type { MCPClient } from './mcp-client';
 import type {
   ClientCapabilities,
@@ -87,12 +88,42 @@ function getToolUiMeta(meta?: ToolMeta): JSONObject | undefined {
   return isJSONObject(uiMeta) ? uiMeta : undefined;
 }
 
+/**
+ * Filters a string array to its string elements, dropping the field entirely
+ * (rather than failing the parse) if the value is not an array.
+ */
+const optionalStringArray = z
+  .array(z.unknown())
+  .transform(items => items.filter((v): v is string => typeof v === 'string'))
+  .optional()
+  .catch(undefined);
+
+const MCPAppResourceCSPSchema = z.looseObject({
+  connectDomains: optionalStringArray,
+  resourceDomains: optionalStringArray,
+  frameDomains: optionalStringArray,
+});
+
+/**
+ * Runtime schema for `_meta.ui` on an MCP App resource. Each known field is
+ * validated; a malformed field is dropped (`.catch(undefined)`) rather than
+ * failing the whole parse, and unknown keys pass through for forward-compat.
+ */
+const MCPAppResourceMetaSchema = z.looseObject({
+  prefersBorder: z.boolean().optional().catch(undefined),
+  csp: MCPAppResourceCSPSchema.optional().catch(undefined),
+  permissions: z.record(z.string(), z.unknown()).optional().catch(undefined),
+});
+
 function getResourceUiMeta(meta: unknown): MCPAppResourceMeta | undefined {
   const resourceMeta = isJSONObject(meta) ? meta : undefined;
   const rawUiMeta = resourceMeta?.ui;
-  const uiMeta = isJSONObject(rawUiMeta) ? rawUiMeta : undefined;
+  if (!isJSONObject(rawUiMeta)) {
+    return undefined;
+  }
 
-  return uiMeta as MCPAppResourceMeta | undefined;
+  const parsed = MCPAppResourceMetaSchema.safeParse(rawUiMeta);
+  return parsed.success ? (parsed.data as MCPAppResourceMeta) : undefined;
 }
 
 function parseVisibility(value: unknown): MCPAppToolVisibility[] | undefined {

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -1,0 +1,91 @@
+import { MCP_APP_MIME_TYPE, type MCPAppResource } from '@ai-sdk/mcp';
+import { cleanup, render } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { MCPAppFrame } from './app-frame';
+import type { MCPAppPermission } from './sandbox';
+
+// The `allow` attribute is set in JSX and does not depend on the bridge
+// handshake. Null the iframe's contentWindow so the bridge effect no-ops:
+// jsdom cannot service the child-window postMessage the bridge teardown makes.
+let originalContentWindow: PropertyDescriptor | undefined;
+beforeAll(() => {
+  originalContentWindow = Object.getOwnPropertyDescriptor(
+    HTMLIFrameElement.prototype,
+    'contentWindow',
+  );
+  Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+    configurable: true,
+    get: () => null,
+  });
+});
+afterAll(() => {
+  if (originalContentWindow != null) {
+    Object.defineProperty(
+      HTMLIFrameElement.prototype,
+      'contentWindow',
+      originalContentWindow,
+    );
+  }
+});
+afterEach(cleanup);
+
+const app = {
+  resourceUri: 'ui://test/app',
+  mimeType: MCP_APP_MIME_TYPE,
+} as const;
+
+function renderFrame({
+  permissions,
+  allowedPermissions,
+}: {
+  permissions?: Record<string, unknown>;
+  allowedPermissions?: MCPAppPermission[];
+}) {
+  const resource: MCPAppResource = {
+    uri: app.resourceUri,
+    mimeType: MCP_APP_MIME_TYPE,
+    html: '<!doctype html>',
+    meta: permissions != null ? { permissions } : undefined,
+  };
+
+  const { container } = render(
+    <MCPAppFrame
+      app={app}
+      resource={resource}
+      sandbox={{ url: 'https://proxy.example/sandbox', allowedPermissions }}
+    />,
+  );
+
+  return container.querySelector('iframe')!;
+}
+
+// The outer proxy iframe must carry the `allow` attribute itself: iframe
+// Permissions Policy is delegated top-down, so a feature the outer frame does
+// not delegate can never reach the inner app frame the proxy creates.
+describe('MCPAppFrame permission delegation', () => {
+  it('delegates the intersection of server-requested and host-allowed features', () => {
+    const iframe = renderFrame({
+      permissions: { geolocation: {}, camera: {} },
+      allowedPermissions: ['geolocation'],
+    });
+
+    expect(iframe.getAttribute('allow')).toBe('geolocation');
+  });
+
+  it('emits no allow attribute without a host allowlist (deny-by-default)', () => {
+    const iframe = renderFrame({
+      permissions: { geolocation: {}, camera: {} },
+    });
+
+    expect(iframe.hasAttribute('allow')).toBe(false);
+  });
+
+  it('emits no allow attribute when nothing is both requested and allowed', () => {
+    const iframe = renderFrame({
+      permissions: { geolocation: {} },
+      allowedPermissions: ['camera'],
+    });
+
+    expect(iframe.hasAttribute('allow')).toBe(false);
+  });
+});

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -9,6 +9,22 @@ import {
 import type { MCPAppFrameProps } from './types';
 import { normalizeMCPAppToolResult } from './utils';
 
+/**
+ * Derives the concrete origin of the sandbox proxy from its URL, so outbound
+ * postMessage targets a specific origin instead of `'*'` and inbound messages
+ * can be origin-checked. The proxy must be served from a stable, concrete
+ * origin (the default outer sandbox keeps `allow-same-origin`). Falls back to
+ * the host origin on a malformed URL, never `'*'`.
+ */
+function deriveTargetOrigin(url: string): string {
+  const location = typeof window !== 'undefined' ? window.location : undefined;
+  try {
+    return new URL(url, location?.href).origin;
+  } catch {
+    return location?.origin ?? 'null';
+  }
+}
+
 function sendToolState({
   bridge,
   input,
@@ -50,10 +66,13 @@ export function MCPAppFrame({
   inputRef.current = input;
   outputRef.current = output;
   hostContextRef.current = hostContext;
-  const targetOrigin = sandbox.targetOrigin ?? '*';
   const sandboxUrl = String(sandbox.url);
+  const targetOrigin = sandbox.targetOrigin ?? deriveTargetOrigin(sandboxUrl);
   const resourceCSP = getMCPAppCSP(resource.meta?.csp);
-  const resourceAllow = getMCPAppAllowAttribute(resource.meta?.permissions);
+  const resourceAllow = getMCPAppAllowAttribute(
+    resource.meta?.permissions,
+    sandbox.allowedPermissions,
+  );
   const innerSandbox = sandbox.innerSandbox ?? MCP_APP_DEFAULT_INNER_SANDBOX;
   const bridgeHandlers = useMemo(
     () => ({
@@ -92,8 +111,12 @@ export function MCPAppFrame({
     bridgeRef.current = bridge;
 
     const onMessage = (event: MessageEvent) => {
+      // Only handle messages from the proxy window and expected origin.
+      if (!bridge.acceptsEvent(event)) {
+        return;
+      }
+
       if (
-        event.source === targetWindow &&
         event.data?.jsonrpc === '2.0' &&
         event.data.method === 'ui/notifications/sandbox-proxy-ready'
       ) {
@@ -158,6 +181,9 @@ export function MCPAppFrame({
       src={sandboxUrl}
       className={sandbox.className}
       style={sandbox.style}
+      // Permissions Policy is hierarchical: the outer frame must delegate a
+      // feature for the proxy to re-delegate it to the inner app frame.
+      allow={resourceAllow}
       sandbox={sandbox.outerSandbox ?? MCP_APP_DEFAULT_OUTER_SANDBOX}
     />
   );

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -11,6 +11,14 @@ function messageEvent(targetWindow: Window, data: unknown): MessageEvent {
   return { source: targetWindow, data } as MessageEvent;
 }
 
+function originEvent(
+  targetWindow: Window,
+  origin: string,
+  data: unknown,
+): MessageEvent {
+  return { source: targetWindow, origin, data } as unknown as MessageEvent;
+}
+
 describe('MCPAppBridge', () => {
   it('responds to app initialization requests', async () => {
     const targetWindow = createTargetWindow();
@@ -192,5 +200,109 @@ describe('MCPAppBridge', () => {
     expect(callTool).not.toHaveBeenCalled();
     const [response] = targetWindow.postMessage.mock.calls[0];
     expect(response.error?.message).toContain('not app-visible');
+  });
+
+  it('drops messages from an unexpected origin when a concrete origin is set', () => {
+    const targetWindow = createTargetWindow();
+    const onError = vi.fn();
+    const bridge = new MCPAppBridge({
+      targetWindow,
+      targetOrigin: 'https://proxy.example',
+      handlers: { onError },
+    });
+
+    bridge.handleMessage(
+      originEvent(targetWindow, 'https://evil.example', {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'ui/initialize',
+        params: {},
+      }),
+    );
+
+    expect(targetWindow.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('handles messages from the matching origin', async () => {
+    const targetWindow = createTargetWindow();
+    const bridge = new MCPAppBridge({
+      targetWindow,
+      targetOrigin: 'https://proxy.example',
+    });
+
+    bridge.handleMessage(
+      originEvent(targetWindow, 'https://proxy.example', {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'ui/initialize',
+        params: {},
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(targetWindow.postMessage).toHaveBeenCalled();
+    });
+    const [, origin] = targetWindow.postMessage.mock.calls[0];
+    expect(origin).toBe('https://proxy.example');
+  });
+
+  async function requestResult(method: string, params: unknown) {
+    const targetWindow = createTargetWindow();
+    const bridge = new MCPAppBridge({
+      targetWindow,
+      handlers: {
+        readResource: async p => ({ ok: p }),
+        openLink: async p => ({ ok: p }),
+        requestDisplayMode: p => ({ mode: p.mode }),
+      },
+    });
+    bridge.handleMessage(
+      messageEvent(targetWindow, { jsonrpc: '2.0', id: 9, method, params }),
+    );
+    await vi.waitFor(() => {
+      expect(targetWindow.postMessage).toHaveBeenCalled();
+    });
+    return targetWindow.postMessage.mock.calls[0][0];
+  }
+
+  it('rejects resources/read outside the ui:// scope', async () => {
+    const response = await requestResult('resources/read', {
+      uri: 'file:///etc/passwd',
+    });
+    expect(response.result).toBeUndefined();
+    expect(response.error.message).toContain('ui://');
+  });
+
+  it('allows resources/read for ui:// resources', async () => {
+    const response = await requestResult('resources/read', {
+      uri: 'ui://app/data',
+    });
+    expect(response.result).toEqual({ ok: { uri: 'ui://app/data' } });
+  });
+
+  it('rejects ui/open-link with a javascript: scheme', async () => {
+    const response = await requestResult('ui/open-link', {
+      // eslint-disable-next-line no-script-url
+      url: 'javascript:alert(1)',
+    });
+    expect(response.result).toBeUndefined();
+    expect(response.error.message).toContain('scheme');
+  });
+
+  it('allows ui/open-link with an https URL', async () => {
+    const response = await requestResult('ui/open-link', {
+      url: 'https://example.com',
+    });
+    expect(response.result).toEqual({ ok: { url: 'https://example.com' } });
+  });
+
+  it('rejects malformed request params', async () => {
+    const readResponse = await requestResult('resources/read', { uri: 42 });
+    expect(readResponse.error.message).toContain('resources/read');
+
+    const modeResponse = await requestResult('ui/request-display-mode', {
+      mode: 'zoomed',
+    });
+    expect(modeResponse.error.message).toContain('ui/request-display-mode');
   });
 });

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -64,6 +64,61 @@ function assertToolCallParams(params: unknown): MCPAppToolCallParams {
 }
 
 /**
+ * Validates `resources/read` params and limits reads to `ui://` app resources.
+ */
+function assertResourceReadParams(params: unknown): { uri: string } {
+  if (!isJSONObject(params) || typeof params.uri !== 'string') {
+    throw new Error('Invalid resources/read params');
+  }
+  if (!params.uri.startsWith('ui://')) {
+    throw new Error(
+      `resources/read is limited to ui:// resources: ${params.uri}`,
+    );
+  }
+  return { uri: params.uri };
+}
+
+/**
+ * Validates `ui/open-link` params and allows only `https:`/`http:`/`mailto:`
+ * URLs.
+ */
+function assertOpenLinkParams(params: unknown): { url: string } {
+  if (!isJSONObject(params) || typeof params.url !== 'string') {
+    throw new Error('Invalid ui/open-link params');
+  }
+
+  let scheme: string;
+  try {
+    scheme = new URL(params.url).protocol;
+  } catch {
+    throw new Error(`Invalid ui/open-link url: ${params.url}`);
+  }
+
+  if (scheme !== 'https:' && scheme !== 'http:' && scheme !== 'mailto:') {
+    throw new Error(`Disallowed ui/open-link scheme: ${scheme}`);
+  }
+
+  return { url: params.url };
+}
+
+/**
+ * Validates params for `ui/request-display-mode`.
+ */
+function assertDisplayModeParams(params: unknown): {
+  mode: 'inline' | 'fullscreen' | 'pip';
+} {
+  if (
+    !isJSONObject(params) ||
+    (params.mode !== 'inline' &&
+      params.mode !== 'fullscreen' &&
+      params.mode !== 'pip')
+  ) {
+    throw new Error('Invalid ui/request-display-mode params');
+  }
+  return { mode: params.mode };
+}
+
+/**
  * Host-side JSON-RPC bridge for one MCP App iframe.
  *
  * It handles the MCP Apps initialization handshake, sends tool input/result
@@ -146,10 +201,22 @@ export class MCPAppBridge {
   }
 
   /**
+   * Whether a `message` event came from the expected proxy window and origin.
+   * The origin check is skipped only when `targetOrigin` is the `'*'` default.
+   * Callers that intercept events before {@link handleMessage} share this check.
+   */
+  acceptsEvent(event: MessageEvent): boolean {
+    return (
+      event.source === this.targetWindow &&
+      (this.targetOrigin === '*' || event.origin === this.targetOrigin)
+    );
+  }
+
+  /**
    * Processes one `message` event from the sandbox proxy iframe.
    */
   handleMessage(event: MessageEvent): void {
-    if (event.source !== this.targetWindow || !isJsonRpcMessage(event.data)) {
+    if (!this.acceptsEvent(event) || !isJsonRpcMessage(event.data)) {
       return;
     }
 
@@ -307,7 +374,9 @@ export class MCPAppBridge {
         if (this.handlers.readResource == null) {
           throw new Error('No resources/read handler configured');
         }
-        return this.handlers.readResource(request.params as { uri: string });
+        return this.handlers.readResource(
+          assertResourceReadParams(request.params),
+        );
 
       case 'resources/list':
         if (this.handlers.listResources == null) {
@@ -319,7 +388,7 @@ export class MCPAppBridge {
         if (this.handlers.openLink == null) {
           throw new Error('No ui/open-link handler configured');
         }
-        return this.handlers.openLink(request.params as { url: string });
+        return this.handlers.openLink(assertOpenLinkParams(request.params));
 
       case 'ui/message':
         return this.handlers.sendMessage?.(request.params) ?? {};
@@ -330,7 +399,7 @@ export class MCPAppBridge {
       case 'ui/request-display-mode':
         return (
           this.handlers.requestDisplayMode?.(
-            request.params as { mode: 'inline' | 'fullscreen' | 'pip' },
+            assertDisplayModeParams(request.params),
           ) ?? { mode: this.hostContext.displayMode ?? 'inline' }
         );
 

--- a/packages/react/src/mcp-apps/index.ts
+++ b/packages/react/src/mcp-apps/index.ts
@@ -1,4 +1,5 @@
 export { MCPAppRenderer as experimental_MCPAppRenderer } from './app-renderer';
+export type { MCPAppPermission } from './sandbox';
 export type {
   MCPAppBridgeHandlers,
   MCPAppMetadata,

--- a/packages/react/src/mcp-apps/sandbox.test.ts
+++ b/packages/react/src/mcp-apps/sandbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getMCPAppCSP } from './sandbox';
+import { getMCPAppAllowAttribute, getMCPAppCSP } from './sandbox';
 
 describe('getMCPAppCSP', () => {
   it('returns undefined when no csp is provided', () => {
@@ -99,5 +99,43 @@ describe('getMCPAppCSP', () => {
     expect(csp).toContain("connect-src 'self';");
     expect(csp).not.toContain('insecure.example.com');
     expect(csp).not.toContain('javascript:');
+  });
+});
+
+describe('getMCPAppAllowAttribute', () => {
+  it('denies all server-requested permissions without a host allowlist', () => {
+    expect(
+      getMCPAppAllowAttribute({
+        camera: {},
+        microphone: {},
+        geolocation: {},
+        clipboardWrite: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  it('grants only the intersection of server-requested and host-allowed', () => {
+    expect(
+      getMCPAppAllowAttribute({ microphone: {}, camera: {} }, [
+        'microphone',
+        'geolocation',
+      ]),
+    ).toBe('microphone');
+  });
+
+  it('maps clipboardWrite to the clipboard-write feature', () => {
+    expect(
+      getMCPAppAllowAttribute({ clipboardWrite: {} }, ['clipboardWrite']),
+    ).toBe('clipboard-write');
+  });
+
+  it('returns undefined when nothing is both requested and allowed', () => {
+    expect(
+      getMCPAppAllowAttribute({ camera: {} }, ['microphone']),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the server requests no permissions', () => {
+    expect(getMCPAppAllowAttribute(undefined, ['camera'])).toBeUndefined();
   });
 });

--- a/packages/react/src/mcp-apps/sandbox.ts
+++ b/packages/react/src/mcp-apps/sandbox.ts
@@ -95,29 +95,48 @@ export function getMCPAppCSP(csp?: MCPAppResourceCSP): string | undefined {
 }
 
 /**
+ * A permission an MCP App may request and a host may allow.
+ */
+export type MCPAppPermission =
+  | 'camera'
+  | 'microphone'
+  | 'geolocation'
+  | 'clipboardWrite';
+
+const MCP_APP_PERMISSION_FEATURES: Record<MCPAppPermission, string> = {
+  camera: 'camera',
+  microphone: 'microphone',
+  geolocation: 'geolocation',
+  clipboardWrite: 'clipboard-write',
+};
+
+/**
  * Converts MCP App permission metadata into an iframe `allow` attribute.
+ *
+ * Deny-by-default: a capability is granted only when it is both requested in
+ * `permissions` and present in the host `allowedPermissions` allowlist.
+ * Omitting the allowlist grants nothing, mirroring `allowedTools` in the bridge.
  *
  * @example
  * ```ts
- * const allow = getMCPAppAllowAttribute({
- *   microphone: {},
- *   clipboardWrite: {},
- * });
- * // "microphone; clipboard-write"
+ * const allow = getMCPAppAllowAttribute(
+ *   { microphone: {}, camera: {} },
+ *   ['microphone'],
+ * );
+ * // "microphone" — camera requested by server but not host-allowed
  * ```
  */
 export function getMCPAppAllowAttribute(
   permissions?: Record<string, unknown>,
+  allowedPermissions?: MCPAppPermission[],
 ): string | undefined {
-  if (permissions == null) {
+  if (permissions == null || allowedPermissions == null) {
     return undefined;
   }
 
-  const allow = [];
-  if (permissions.camera) allow.push('camera');
-  if (permissions.microphone) allow.push('microphone');
-  if (permissions.geolocation) allow.push('geolocation');
-  if (permissions.clipboardWrite) allow.push('clipboard-write');
+  const allow = allowedPermissions
+    .filter(permission => Boolean(permissions[permission]))
+    .map(permission => MCP_APP_PERMISSION_FEATURES[permission]);
 
   return allow.length > 0 ? allow.join('; ') : undefined;
 }

--- a/packages/react/src/mcp-apps/types.ts
+++ b/packages/react/src/mcp-apps/types.ts
@@ -1,6 +1,7 @@
 import type { MCPAppResource } from '@ai-sdk/mcp';
 import type { DynamicToolUIPart, ToolUIPart, UITools } from 'ai';
 import type { CSSProperties, ReactNode } from 'react';
+import type { MCPAppPermission } from './sandbox';
 
 export type { MCPAppResource };
 
@@ -55,6 +56,12 @@ export type MCPAppSandboxConfig = {
   targetOrigin?: string;
   outerSandbox?: string;
   innerSandbox?: string;
+  /**
+   * Iframe capabilities the host allows an app to use. Deny-by-default: a
+   * server-requested permission (camera/microphone/geolocation/clipboardWrite)
+   * is only granted when it also appears here. Omitting this grants nothing.
+   */
+  allowedPermissions?: MCPAppPermission[];
 };
 
 export type MCPAppFrameProps = {


### PR DESCRIPTION
Follow-up to #17249.

Adds a jsdom component test for the outer-frame permission delegation fix from #17249. Iframe Permissions Policy is delegated top-down, so the outer proxy iframe must carry the `allow` attribute for a feature to reach the inner app frame.

## Coverage

Happy path:

- Host allows `geolocation`, server requests `geolocation` and `camera`, so the outer iframe renders `allow="geolocation"` (the intersection).

Unhappy path:

- No host allowlist: no `allow` attribute is emitted (deny-by-default).
- Host allowlist disjoint from the server request: no `allow` attribute is emitted.

## Notes

- jsdom cannot service the child-window `postMessage` the bridge makes on teardown, so the test nulls the iframe `contentWindow` to no-op the bridge effect and isolates the rendered attribute (what this change verifies).
- This is a lighter, in-process check that the SDK emits the correct attribute. A full browser test that a granted capability is actually usable also needs the sandbox proxy to give the inner frame a usable origin (`allow-same-origin`) and can follow separately.
- Test-only, no published behavior changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
