### PR TITLE
fix(amazon-bedrock): omit unsupported maxItems schema keyword

### DIFF
--- a/.changeset/calm-frogs-juggle.md
+++ b/.changeset/calm-frogs-juggle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Fix native structured output requests when schemas contain the unsupported `maxItems` keyword.

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -4954,6 +4954,63 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should omit maxItems from native structured-output schemas', async () => {
+    server.urls[newerAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            content: [{ text: '{"tags":["test"]}' }],
+            role: 'assistant',
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'end_turn',
+      },
+    };
+
+    await newerAnthropicModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate tags' }],
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 3,
+            },
+            maxItems: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
+    ).toEqual({
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          maxItems: { type: 'string' },
+        },
+      },
+    });
+  });
+
   it('should use JSON instructions instead of a response tool when structured output is combined with tools on models without strict tool support', async () => {
     server.urls[opusAnthropicGenerateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -1,5 +1,6 @@
 import type {
   JSONObject,
+  JSONValue,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
@@ -355,7 +356,9 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           ...amazonBedrockOptions.additionalModelRequestFields?.output_config,
           format: {
             type: 'json_schema',
-            schema: responseFormat!.schema,
+            schema: removeUnsupportedNativeStructuredOutputKeywords(
+              responseFormat!.schema,
+            ),
           },
         },
       };
@@ -1100,6 +1103,85 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
     const encodedModelId = encodeURIComponent(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}`;
   }
+}
+
+/**
+ * Bedrock's native structured-output API rejects the JSON Schema `maxItems`
+ * keyword. Remove it only from schema nodes so that a user property named
+ * `maxItems` remains part of the output contract.
+ */
+function removeUnsupportedNativeStructuredOutputKeywords(
+  schema: JSONObject,
+): JSONObject {
+  return visitSchema(schema);
+}
+
+function visitSchema(schema: JSONObject): JSONObject {
+  const { maxItems: _, ...result } = schema;
+
+  for (const key of [
+    'additionalItems',
+    'additionalProperties',
+    'contains',
+    'if',
+    'not',
+    'propertyNames',
+    'then',
+    'else',
+  ] as const) {
+    if (isJSONObject(result[key])) {
+      result[key] = visitSchema(result[key]);
+    }
+  }
+
+  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+    if (Array.isArray(result[key])) {
+      result[key] = result[key].map(item =>
+        isJSONObject(item) ? visitSchema(item) : item,
+      );
+    }
+  }
+
+  if (Array.isArray(result.items)) {
+    result.items = Array.isArray(result.items)
+      ? result.items.map(item =>
+          isJSONObject(item) ? visitSchema(item) : item,
+        )
+      : result.items;
+  } else if (isJSONObject(result.items)) {
+    result.items = visitSchema(result.items);
+  }
+
+  for (const key of [
+    'definitions',
+    '$defs',
+    'patternProperties',
+    'properties',
+  ] as const) {
+    if (isJSONObject(result[key])) {
+      result[key] = Object.fromEntries(
+        Object.entries(result[key]).map(([name, definition]) => [
+          name,
+          isJSONObject(definition) ? visitSchema(definition) : definition,
+        ]),
+      );
+    }
+  }
+
+  if (isJSONObject(result.dependencies)) {
+    result.dependencies = Object.fromEntries(
+      Object.entries(result.dependencies).map(([name, dependency]) => [
+        name,
+        isJSONObject(dependency) ? visitSchema(dependency) : dependency,
+      ]),
+    );
+  }
+
+  return result;
+}
+
+function isJSONObject(value: JSONValue | undefined): value is JSONObject {
+  return value != null && !Array.isArray(value) && typeof value === 'object';
 }
 
 class JsonObjectTextExtractor {


### PR DESCRIPTION
## Summary

- Remove the `maxItems` keyword from schemas sent through Bedrock's native structured-output API.
- Preserve a user output property literally named `maxItems` and keep the original caller schema unchanged.

## Root cause

Bedrock rejects `maxItems` in `output_config.format.schema`. The native structured-output path forwarded the SDK schema unchanged, unlike the tool fallback.

## Validation

- `pnpm test:node` equivalent focused run: `131/131` tests passed for `amazon-bedrock-chat-language-model.test.ts`
- `tsc --noEmit --pretty false`
- `oxfmt` on changed TypeScript files
- `git diff --check`

Fixes #17197.