### PR TITLE
fix(harness-codex): honor executable and final response

### DIFF
--- a/.changeset/codex-bridge-runtime.md
+++ b/.changeset/codex-bridge-runtime.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-codex': patch
+---
+
+Honor explicit and ambient Codex executables and expose only the final agent message as harness text.

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
@@ -3,7 +3,7 @@ import type { CodexStepTracker } from './codex-step-tracker';
 import { createEmitStreamEvent } from './create-emit-stream-event';
 
 describe('createEmitStreamEvent', () => {
-  it('emits thread, accumulated text, and usage events', () => {
+  it('emits thread, final text, and usage events', () => {
     const emitted: Record<string, unknown>[] = [];
     const observed: unknown[] = [];
     const usages: unknown[] = [];
@@ -51,21 +51,27 @@ describe('createEmitStreamEvent', () => {
             "type": "bridge-thread",
           },
           {
-            "id": "message-1",
+            "rawValue": {
+              "item": {
+                "id": "message-1",
+                "text": "hello world",
+                "type": "agent_message",
+              },
+              "type": "item.completed",
+            },
+            "type": "raw",
+          },
+          {
+            "id": "codex-final-message",
             "type": "text-start",
           },
           {
-            "delta": "hello",
-            "id": "message-1",
+            "delta": "hello world",
+            "id": "codex-final-message",
             "type": "text-delta",
           },
           {
-            "delta": " world",
-            "id": "message-1",
-            "type": "text-delta",
-          },
-          {
-            "id": "message-1",
+            "id": "codex-final-message",
             "type": "text-end",
           },
         ],
@@ -113,6 +119,73 @@ describe('createEmitStreamEvent', () => {
         ],
       }
     `);
+  });
+
+  it('emits only the last completed agent message as text', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishStep: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: () => {},
+    });
+    const progress = {
+      type: 'item.completed' as const,
+      item: { type: 'agent_message', id: 'progress', text: 'Working on it.' },
+    };
+    const final = {
+      type: 'item.completed' as const,
+      item: { type: 'agent_message', id: 'final', text: 'Done.' },
+    };
+
+    emitStreamEvent(progress);
+    emitStreamEvent(final);
+    emitStreamEvent({ type: 'turn.completed' });
+
+    expect(emitted).toEqual([
+      { type: 'raw', rawValue: progress },
+      { type: 'raw', rawValue: final },
+      { type: 'text-start', id: 'codex-final-message' },
+      { type: 'text-delta', id: 'codex-final-message', delta: 'Done.' },
+      { type: 'text-end', id: 'codex-final-message' },
+    ]);
+  });
+
+  it('does not promote an agent message when the turn fails', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const errors: unknown[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishStep: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: error => errors.push(error),
+    });
+
+    emitStreamEvent({
+      type: 'item.completed',
+      item: { type: 'agent_message', id: 'progress', text: 'Working on it.' },
+    });
+    emitStreamEvent({
+      type: 'turn.failed',
+      error: { message: 'failed' },
+    });
+
+    expect(emitted.some(event => String(event.type).startsWith('text-'))).toBe(
+      false,
+    );
+    expect(errors).toHaveLength(1);
   });
 
   it('preserves command and MCP result translation', () => {

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.ts
@@ -71,7 +71,7 @@ export function createEmitStreamEvent({
   emitWarning: BridgeTurn['emitWarning'];
   emitError: BridgeTurn['emitError'];
 }): (event: CodexEvent) => void {
-  const textByItem = new Map<string, string>();
+  let finalText: string | undefined;
   const reasoningByItem = new Map<string, string>();
 
   return event => {
@@ -85,6 +85,7 @@ export function createEmitStreamEvent({
     }
     if (event.type === 'turn.completed') {
       if (event.usage) setTurnUsage(mapUsage(event.usage));
+      if (finalText !== undefined) emitFinalText({ send, text: finalText });
       stepTracker.finishStep();
       return;
     }
@@ -110,25 +111,10 @@ export function createEmitStreamEvent({
     };
 
     if (item.type === 'agent_message' && typeof item.text === 'string') {
-      /*
-       * The presence of `id` in `textByItem` — not the `item.started` event —
-       * marks the text part as opened. Codex does not guarantee an
-       * `item.started` event carrying text precedes the first `item.updated`
-       * with text, so keying the `text-start` off the event type can emit a
-       * `text-delta` for a part that was never opened. Opening lazily on the
-       * first event with text keeps `text-start` before any `text-delta`.
-       */
-      if (!textByItem.has(id)) {
-        send({ type: 'text-start', id });
-        textByItem.set(id, '');
+      if (event.type === 'item.completed') {
+        finalText = item.text;
+        send({ type: 'raw', rawValue: event });
       }
-      const last = textByItem.get(id) ?? '';
-      const next = item.text;
-      if (next.length > last.length) {
-        send({ type: 'text-delta', id, delta: next.slice(last.length) });
-        textByItem.set(id, next);
-      }
-      if (event.type === 'item.completed') send({ type: 'text-end', id });
       observeStep();
       return;
     }
@@ -246,6 +232,13 @@ export function createEmitStreamEvent({
       emitWarning({ message });
     }
   };
+}
+
+function emitFinalText({ send, text }: { send: Emit; text: string }): void {
+  const id = 'codex-final-message';
+  send({ type: 'text-start', id });
+  send({ type: 'text-delta', id, delta: text });
+  send({ type: 'text-end', id });
 }
 
 function extractMcpToolCallResult(item: CodexItem): unknown {

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -1,20 +1,28 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-type CodexOptions = { config?: { mcp_servers?: unknown } };
-const CODEX_ENV_KEYS = [
+type CodexOptions = {
+  codexPathOverride?: string;
+  config?: { mcp_servers?: unknown };
+};
+
+const ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
   'AI_GATEWAY_BASE_URL',
   'OPENAI_BASE_URL',
   'CODEX_API_KEY',
+  'CODEX_PATH',
+  'CODEX_CLI',
+  'CODEX_BINARY',
+  'PATH',
 ] as const;
 
 const state = vi.hoisted(() => ({
   codexOptions: [] as CodexOptions[],
   originalArgv: [] as string[],
-  originalEnv: {} as Record<
-    (typeof CODEX_ENV_KEYS)[number],
-    string | undefined
-  >,
+  originalEnv: {} as Record<string, string | undefined>,
 }));
 
 vi.mock('@openai/codex-sdk', () => ({
@@ -58,6 +66,8 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
       },
       {
         emit: () => {},
+        emitWarning: () => {},
+        emitError: () => {},
         requestToolResult: async () => ({ output: {} }),
         abortSignal: new AbortController().signal,
         pendingUserMessages: [],
@@ -67,15 +77,15 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
 }));
 
 describe('Codex bridge config', () => {
+  const tempDirs: string[] = [];
+
   beforeEach(() => {
     state.codexOptions = [];
     state.originalArgv = [...process.argv];
     state.originalEnv = Object.fromEntries(
-      CODEX_ENV_KEYS.map(key => [key, process.env[key]]),
-    ) as Record<(typeof CODEX_ENV_KEYS)[number], string | undefined>;
-    for (const key of CODEX_ENV_KEYS) {
-      delete process.env[key];
-    }
+      ENV_KEYS.map(key => [key, process.env[key]]),
+    );
+    for (const key of ENV_KEYS) delete process.env[key];
     process.argv.splice(
       0,
       process.argv.length,
@@ -90,23 +100,72 @@ describe('Codex bridge config', () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     process.argv.splice(0, process.argv.length, ...state.originalArgv);
-    for (const key of CODEX_ENV_KEYS) {
+    for (const key of ENV_KEYS) {
       const value = state.originalEnv[key];
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
     }
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map(path => rm(path, { recursive: true, force: true })),
+    );
     vi.resetModules();
   });
 
-  test('does not register host tools as Codex MCP servers', async () => {
+  it('does not register host tools as Codex MCP servers', async () => {
     await import('./index');
 
     expect(state.codexOptions).toHaveLength(1);
     expect(state.codexOptions[0]?.config?.mcp_servers).toBeUndefined();
+  });
+
+  it.each(['CODEX_PATH', 'CODEX_CLI', 'CODEX_BINARY'] as const)(
+    'passes %s as codexPathOverride',
+    async key => {
+      process.env[key] = ' /opt/codex/custom ';
+
+      await import('./index');
+
+      expect(state.codexOptions[0]?.codexPathOverride).toBe(
+        '/opt/codex/custom',
+      );
+    },
+  );
+
+  it('uses the first non-empty explicit executable', async () => {
+    process.env.CODEX_PATH = ' ';
+    process.env.CODEX_CLI = ' /opt/codex/cli ';
+    process.env.CODEX_BINARY = '/opt/codex/binary';
+
+    await import('./index');
+
+    expect(state.codexOptions[0]?.codexPathOverride).toBe('/opt/codex/cli');
+  });
+
+  it('uses an executable codex on PATH', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'harness-codex-'));
+    tempDirs.push(dir);
+    const executable = join(
+      dir,
+      process.platform === 'win32' ? 'codex.exe' : 'codex',
+    );
+    await writeFile(executable, '');
+    await chmod(executable, 0o755);
+    process.env.PATH = [dir, '/not-a-real-bin'].join(delimiter);
+
+    await import('./index');
+
+    expect(state.codexOptions[0]?.codexPathOverride).toBe(executable);
+  });
+
+  it('leaves the SDK bundled executable as the fallback', async () => {
+    process.env.PATH = '/not-a-real-bin';
+
+    await import('./index');
+
+    expect(state.codexOptions[0]).not.toHaveProperty('codexPathOverride');
   });
 });

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -15,7 +15,9 @@ import {
   type BridgeTurn,
 } from '@ai-sdk/harness/bridge';
 import type { StartMessage } from '../codex-bridge-protocol';
+import { accessSync, constants, statSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
+import { delimiter, join } from 'node:path';
 // Temporary workaround for upstream codex MCP-tool bug — see ./cli-relay.ts
 import {
   CLI_SHIM_FILENAME,
@@ -48,6 +50,27 @@ import { argv, env as procEnv, stdout } from 'node:process';
  *   3. the dependency entry in `src/bridge/package.json`.
  */
 import * as codexSdkModule from '@openai/codex-sdk';
+
+function resolveCodexPathOverride(): string | undefined {
+  for (const value of [
+    procEnv.CODEX_PATH,
+    procEnv.CODEX_CLI,
+    procEnv.CODEX_BINARY,
+  ]) {
+    const path = value?.trim();
+    if (path) return path;
+  }
+
+  const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+  for (const dir of (procEnv.PATH ?? '').split(delimiter)) {
+    if (!dir) continue;
+    const path = join(dir, binaryName);
+    try {
+      accessSync(path, constants.X_OK);
+      if (statSync(path).isFile()) return path;
+    } catch {}
+  }
+}
 
 const args = parseArgs(argv.slice(2));
 const workdir = requireArg({ value: args.workdir, name: '--workdir' });
@@ -153,8 +176,10 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   }
   const usesConfiguredModelProvider =
     typeof codexConfig.model_provider === 'string';
+  const codexPathOverride = resolveCodexPathOverride();
 
   const codex = new codexSdk.Codex({
+    ...(codexPathOverride ? { codexPathOverride } : {}),
     ...(procEnv.CODEX_API_KEY ? { apiKey: procEnv.CODEX_API_KEY } : {}),
     ...(!usesConfiguredModelProvider && apiBaseUrl
       ? { baseUrl: apiBaseUrl }


### PR DESCRIPTION
## Background

The Codex bridge currently lets the SDK select its package-bundled CLI even when the environment provides an explicit or ambient Codex executable. It also translates every completed agent message into harness text, which concatenates progress messages with the final answer.

This PR is intentionally stacked on #17808, which extracts bridge event emission into testable factories. The diff here is one signed commit on top and applies the final-answer behavior inside the extracted emitter. Please review #17808 first; after it merges, this PR can retarget to `main`.

## Summary

- Resolve `CODEX_PATH`, `CODEX_CLI`, `CODEX_BINARY`, then an executable `codex` on `PATH`, while preserving the SDK bundled fallback.
- Preserve completed agent messages as raw provider events and emit only the latest completed message as final harness text.
- Emit final text only after a successful turn and before the final step closes, so failed turns cannot promote a progress message.

## End-to-End Verification

No live Codex run is included because producing both an intermediate completed agent message and a final completed agent message is nondeterministic. The observable executable-selection and final-message contracts are verified at the bridge boundary.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
