### PR TITLE
fix(amazon-bedrock): forward disableParallelToolUse

### DIFF
--- a/.changeset/bright-beds-argue.md
+++ b/.changeset/bright-beds-argue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix: forward Anthropic's disableParallelToolUse setting to Bedrock

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -308,7 +308,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(transformedBody).toHaveProperty('anthropic_version');
   });
 
-  it('should strip disable_parallel_tool_use from tool_choice', () => {
+  it('should preserve disable_parallel_tool_use in tool_choice', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
@@ -334,10 +334,10 @@ describe('amazon-bedrock-anthropic-provider', () => {
       new Set(),
     );
 
-    expect(transformedBody?.tool_choice).toEqual({ type: 'auto' });
-    expect(transformedBody?.tool_choice).not.toHaveProperty(
-      'disable_parallel_tool_use',
-    );
+    expect(transformedBody?.tool_choice).toEqual({
+      type: 'auto',
+      disable_parallel_tool_use: true,
+    });
   });
 
   it('should preserve tool_choice name when present', () => {
@@ -370,6 +370,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(transformedBody?.tool_choice).toEqual({
       type: 'tool',
       name: 'my_tool',
+      disable_parallel_tool_use: true,
     });
   });
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -276,6 +276,12 @@ export function createAmazonBedrockAnthropic(
             ? {
                 type: tool_choice.type,
                 ...(tool_choice.name != null ? { name: tool_choice.name } : {}),
+                ...(tool_choice.disable_parallel_tool_use != null
+                  ? {
+                      disable_parallel_tool_use:
+                        tool_choice.disable_parallel_tool_use,
+                    }
+                  : {}),
               }
             : undefined;
 


### PR DESCRIPTION
## Summary

- Forward Anthropic's `disable_parallel_tool_use` from the provider tool choice to Bedrock.
- Cover automatic and named tool choices with the existing adapter request-transform tests.

The adapter previously reconstructed `tool_choice` using only its type and optional name, silently dropping the parallel-tool-use control before the request reached Bedrock.

Fixes #17267.

## Validation

- `vitest run packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts` (37 passed)
- Prettier and `git diff --check`
