### PR TITLE
docs: add The Context Company as an observability provider

### DIFF
--- a/content/providers/03-observability/index.mdx
+++ b/content/providers/03-observability/index.mdx
@@ -25,6 +25,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [Scorecard](/providers/observability/scorecard)
 - [Sentry](/providers/observability/sentry)
 - [SigNoz](/providers/observability/signoz)
+- [The Context Company](/providers/observability/the-context-company)
 - [Traceloop](/providers/observability/traceloop)
 - [Weave](/providers/observability/weave)
 

--- a/content/providers/03-observability/the-context-company.mdx
+++ b/content/providers/03-observability/the-context-company.mdx
@@ -10,10 +10,8 @@ description: AI agent observability for AI SDK applications with The Context Com
 The integration provides:
 
 - Complete traces for model calls, agent steps, tool executions, errors, usage, latency, and cost
-- [Pattern detection](https://docs.thecontextcompany.com/features/patterns) for recurring user confusion, frustration, task failures, and custom signals
-- [Insight search](https://docs.thecontextcompany.com/features/insight-search) to investigate production behavior using natural-language questions backed by specific runs
-- [Recaps](https://docs.thecontextcompany.com/features/weekly-insights) that surface trends, anomalies, shifting user behavior, and the runs behind each finding
-- Sessions, user and organization analytics, feedback, and custom metadata
+- First-class sessions, user and organization analytics, feedback, and custom metadata
+- [Pattern detection](https://docs.thecontextcompany.com/features/patterns), [insight search](https://docs.thecontextcompany.com/features/insight-search), and [recaps](https://docs.thecontextcompany.com/features/weekly-insights) that analyze behavior across runs and link findings to supporting traces
 
 The `@contextcompany/ai-sdk` package supports AI SDK 7's telemetry interface. It registers the AI SDK OpenTelemetry integration and exports traces to The Context Company.
 
@@ -108,6 +106,34 @@ export async function POST(req: Request) {
 `tcc.runId` must be a UUID. Preserve it in your application when you need to submit user feedback, open a specific run, or correlate the run with application data.
 
 The integration supports text generation, streaming, structured output, multi-step agents, tools, embeddings, and reranking.
+
+## Multi-step agents and tools
+
+No additional tracing code is required for tools or multi-step agents. AI SDK 7 emits the complete operation through the integration registered by `registerTCC`.
+
+The resulting trace contains:
+
+- One agent run for the complete operation
+- One model step for every `chat` operation
+- One tool-call record for every `execute_tool` operation
+
+The integration also captures token usage, cached tokens, model IDs, finish reasons, errors, and aborts.
+
+## Feedback
+
+Calls without `tcc.runId` still receive a generated run ID. Provide an explicit UUID when you need feedback, deep links, or correlation with application data.
+
+Preserve the run ID in your application, then submit feedback from a server route:
+
+```typescript filename="feedback-route.ts"
+import { submitFeedback } from '@contextcompany/ai-sdk/nextjs';
+
+await submitFeedback({
+  runId,
+  score: 'thumbs_up',
+  text: 'This was helpful!',
+});
+```
 
 ## Resources
 

--- a/content/providers/03-observability/the-context-company.mdx
+++ b/content/providers/03-observability/the-context-company.mdx
@@ -5,35 +5,35 @@ description: AI agent observability for AI SDK applications with The Context Com
 
 # The Context Company Observability
 
-[The Context Company](https://www.thecontextcompany.com/) ([AI SDK documentation](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk)) helps teams monitor and improve production AI agents. It combines complete AI SDK traces with analysis across runs to show what is breaking, why users struggle, and what to fix next.
+[The Context Company](https://www.thecontextcompany.com/) ([AI SDK documentation](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk)) provides observability for AI applications built with the AI SDK. Its integration captures complete traces and connects them with analysis across runs.
 
 The integration provides:
 
 - Complete traces for model calls, agent steps, tool executions, errors, usage, latency, and cost
-- First-class sessions, user and organization analytics, feedback, and custom metadata
+- Sessions, user and organization analytics, feedback, and custom metadata
 - [Pattern detection](https://docs.thecontextcompany.com/features/patterns), [insight search](https://docs.thecontextcompany.com/features/insight-search), and [recaps](https://docs.thecontextcompany.com/features/weekly-insights) that analyze behavior across runs and link findings to supporting traces
 
 The `@contextcompany/ai-sdk` package supports AI SDK 7's telemetry interface. It registers the AI SDK OpenTelemetry integration and exports traces to The Context Company.
 
-<Note>
-  `@contextcompany/ai-sdk` requires AI SDK 7 and Node.js 22 or later. For AI SDK
-  5 or 6, use The Context Company's [legacy integration
-  guide](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk/v5-v6).
-</Note>
+`@contextcompany/ai-sdk` requires AI SDK 7 and Node.js 22 or later. For AI SDK 5 or 6, use The Context Company's [legacy integration guide](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk/v5-v6).
 
 ## Setup
 
-Install the AI SDK integration:
+### 1. Install the packages
+
+Install `@contextcompany/ai-sdk`, `ai`, and `@opentelemetry/api`:
 
 <InstallPackages packages="@contextcompany/ai-sdk ai @opentelemetry/api" />
 
-Set your API key:
+### 2. Set your API key
 
 ```bash filename=".env.local"
 TCC_API_KEY="..."
 ```
 
-### Next.js
+### 3. Register the integration
+
+#### Next.js
 
 Create an `instrumentation.ts` file in your project root. If your application uses a `src` directory, place the file inside `src` instead.
 
@@ -48,7 +48,7 @@ export async function register() {
 
 `registerTCC` composes with `@vercel/otel` and is idempotent, so development reloads do not register duplicate integrations.
 
-### Node.js
+#### Node.js
 
 For other Node.js frameworks, register the integration before making AI SDK calls. Keep the returned handle so queued traces can be flushed during shutdown.
 

--- a/content/providers/03-observability/the-context-company.mdx
+++ b/content/providers/03-observability/the-context-company.mdx
@@ -5,7 +5,15 @@ description: AI agent observability for AI SDK applications with The Context Com
 
 # The Context Company Observability
 
-[The Context Company](https://www.thecontextcompany.com/) is an AI observability platform that helps teams understand how users interact with production AI agents. Its AI SDK integration captures runs, model calls, tool executions, token usage, costs, sessions, users, organizations, and custom metadata. The platform uses this data to surface patterns such as user confusion, frustration, and silent failures.
+[The Context Company](https://www.thecontextcompany.com/) ([AI SDK documentation](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk)) helps teams monitor and improve production AI agents. It combines complete AI SDK traces with analysis across runs to show what is breaking, why users struggle, and what to fix next.
+
+The integration provides:
+
+- Complete traces for model calls, agent steps, tool executions, errors, usage, latency, and cost
+- [Pattern detection](https://docs.thecontextcompany.com/features/patterns) for recurring user confusion, frustration, task failures, and custom signals
+- [Insight search](https://docs.thecontextcompany.com/features/insight-search) to investigate production behavior using natural-language questions backed by specific runs
+- [Recaps](https://docs.thecontextcompany.com/features/weekly-insights) that surface trends, anomalies, shifting user behavior, and the runs behind each finding
+- Sessions, user and organization analytics, feedback, and custom metadata
 
 The `@contextcompany/ai-sdk` package supports AI SDK 7's telemetry interface. It registers the AI SDK OpenTelemetry integration and exports traces to The Context Company.
 

--- a/content/providers/03-observability/the-context-company.mdx
+++ b/content/providers/03-observability/the-context-company.mdx
@@ -1,0 +1,108 @@
+---
+title: The Context Company
+description: AI agent observability for AI SDK applications with The Context Company
+---
+
+# The Context Company Observability
+
+[The Context Company](https://www.thecontextcompany.com/) is an AI observability platform that helps teams understand how users interact with production AI agents. Its AI SDK integration captures runs, model calls, tool executions, token usage, costs, sessions, users, organizations, and custom metadata. The platform uses this data to surface patterns such as user confusion, frustration, and silent failures.
+
+The `@contextcompany/ai-sdk` package supports AI SDK 7's telemetry interface. It registers the AI SDK OpenTelemetry integration and exports traces to The Context Company.
+
+<Note>
+  `@contextcompany/ai-sdk` requires AI SDK 7 and Node.js 22 or later. For AI SDK
+  5 or 6, use The Context Company's [legacy integration
+  guide](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk/v5-v6).
+</Note>
+
+## Setup
+
+Install the AI SDK integration:
+
+<InstallPackages packages="@contextcompany/ai-sdk ai @opentelemetry/api" />
+
+Set your API key:
+
+```bash filename=".env.local"
+TCC_API_KEY="..."
+```
+
+### Next.js
+
+Create an `instrumentation.ts` file in your project root. If your application uses a `src` directory, place the file inside `src` instead.
+
+```typescript filename="instrumentation.ts"
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { registerTCC } = await import('@contextcompany/ai-sdk/nextjs');
+    registerTCC();
+  }
+}
+```
+
+`registerTCC` composes with `@vercel/otel` and is idempotent, so development reloads do not register duplicate integrations.
+
+### Node.js
+
+For other Node.js frameworks, register the integration before making AI SDK calls. Keep the returned handle so queued traces can be flushed during shutdown.
+
+```typescript filename="telemetry.ts"
+import { registerTCC } from '@contextcompany/ai-sdk';
+
+export const tcc = registerTCC();
+```
+
+Call `shutdown()` when the process exits:
+
+```typescript filename="app.ts"
+import { tcc } from './telemetry';
+
+process.once('SIGTERM', async () => {
+  await tcc.shutdown();
+  process.exit(0);
+});
+```
+
+## Usage
+
+Once registered, AI SDK 7 calls emit telemetry automatically. Use `tccTelemetry` to attach an explicit run ID and request-specific context. TCC-specific metadata uses the `tcc.*` namespace, while custom application metadata remains unprefixed.
+
+```typescript filename="app/api/chat/route.ts"
+import { tccTelemetry } from '@contextcompany/ai-sdk/nextjs';
+import { streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const { messages, sessionId, userId, orgId } = await req.json();
+  const runId = crypto.randomUUID();
+
+  const result = streamText({
+    model,
+    messages,
+    ...tccTelemetry({
+      metadata: {
+        'tcc.runId': runId,
+        'tcc.sessionId': sessionId,
+        'tcc.conversational': true,
+        'tcc.agent': 'support-assistant',
+        'tcc.userId': userId,
+        'tcc.orgId': orgId,
+        environment: 'production',
+      },
+    }),
+  });
+
+  return result.toUIMessageStreamResponse({
+    messageMetadata: () => ({ runId }),
+  });
+}
+```
+
+`tcc.runId` must be a UUID. Preserve it in your application when you need to submit user feedback, open a specific run, or correlate the run with application data.
+
+The integration supports text generation, streaming, structured output, multi-step agents, tools, embeddings, and reranking.
+
+## Resources
+
+- [The Context Company AI SDK guide](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk)
+- [AI SDK 7 example application](https://github.com/The-Context-Company/observatory/tree/main/examples/nextjs-aisdk)
+- [`@contextcompany/ai-sdk` on npm](https://www.npmjs.com/package/@contextcompany/ai-sdk)


### PR DESCRIPTION
## Background

The Context Company supports AI SDK 7's telemetry interface through [`@contextcompany/ai-sdk`](https://www.npmjs.com/package/@contextcompany/ai-sdk), but it is not currently listed in the observability provider directory.

The integration captures AI SDK traces for model calls, agent steps, tool executions, usage, errors, and request context, and connects them with sessions, application metadata, and feedback.

## Summary

- adds The Context Company to the observability integrations index
- adds an AI SDK 7 setup guide for Next.js and Node.js
- documents run IDs, sessions, users, organizations, agents, and custom metadata
- links to the [full integration documentation](https://docs.thecontextcompany.com/frameworks/vercel-ai-sdk) and [example application](https://github.com/The-Context-Company/observatory/tree/main/examples/nextjs-aisdk)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
