### PR TITLE
[v6.0] reproduction: could not reproduce websearchpreview: string too long error when generating toolcall

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-8132-web-search-preview-tool-call-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-8132-web-search-preview-tool-call-id.ts
@@ -1,0 +1,121 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, type ModelMessage } from 'ai';
+
+async function main() {
+  let responsesApiBody: unknown;
+  let chatCompletionsApiBody: unknown;
+  const openai = createOpenAI({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      const responseBody = await response
+        .clone()
+        .json()
+        .catch(() => undefined);
+
+      if (String(input).endsWith('/responses')) {
+        responsesApiBody = responseBody;
+      } else if (String(input).endsWith('/chat/completions')) {
+        chatCompletionsApiBody = responseBody;
+      }
+
+      return response;
+    },
+  });
+
+  const prompt =
+    'Use web search to find the current title of the OpenAI API documentation homepage.';
+
+  const firstTurn = await generateText({
+    model: openai.responses('gpt-4o-mini'),
+    prompt,
+    tools: {
+      web_search_preview: openai.tools.webSearchPreview({}),
+    },
+  });
+
+  const webSearchCall = firstTurn.toolCalls.find(
+    toolCall => toolCall.toolName === 'web_search_preview',
+  );
+
+  if (webSearchCall == null) {
+    throw new Error(
+      'The live Responses API call did not produce a web_search_preview tool call.',
+    );
+  }
+
+  const responseMessage = firstTurn.response.messages[0];
+  if (responseMessage?.role !== 'assistant') {
+    throw new Error(
+      'Expected the first Responses API message to be assistant.',
+    );
+  }
+  if (!Array.isArray(responseMessage.content)) {
+    throw new Error(
+      'Expected the Responses API assistant content to be parts.',
+    );
+  }
+
+  const assistantContent = responseMessage.content.filter(
+    part => part.type !== 'tool-result',
+  );
+  const toolContent = responseMessage.content.filter(
+    part => part.type === 'tool-result',
+  );
+  const reportedToolCallId =
+    'ws_689e2d4880a0819d98acca37694989b00b15d90494fc6b87';
+
+  const messages: ModelMessage[] = [
+    { role: 'user', content: prompt },
+    {
+      role: 'assistant',
+      content: assistantContent.map(part =>
+        part.type === 'tool-call'
+          ? { ...part, toolCallId: reportedToolCallId }
+          : part,
+      ),
+    },
+    {
+      role: 'tool',
+      content: toolContent.map(part => ({
+        ...part,
+        toolCallId: reportedToolCallId,
+      })),
+    },
+    {
+      role: 'user',
+      content: 'Reply with only that title.',
+    },
+  ];
+
+  const secondTurn = await generateText({
+    model: openai.chat('gpt-4o-mini'),
+    messages,
+  });
+
+  if (secondTurn.text.length === 0) {
+    throw new Error(
+      'The Chat Completions request accepted the ID but returned no text.',
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        generatedToolCallId: webSearchCall.toolCallId,
+        generatedToolCallIdLength: webSearchCall.toolCallId.length,
+        reportedToolCallId,
+        reportedToolCallIdLength: reportedToolCallId.length,
+        responsesApiBody,
+        chatCompletionsApiBody,
+        responseText: secondTurn.text,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/openai/src/chat/__fixtures__/issue-8132-long-tool-call-id.json
+++ b/packages/openai/src/chat/__fixtures__/issue-8132-long-tool-call-id.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-E1oMwyGAs7Hh9FR5oUTj0lK67dvjY",
+  "object": "chat.completion",
+  "created": 1784100654,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "OpenAI API Documentation",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 434,
+    "completion_tokens": 4,
+    "total_tokens": 438,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_b29d6a4e3f"
+}

--- a/packages/openai/src/issue-8132-web-search-preview-tool-call-id.test.ts
+++ b/packages/openai/src/issue-8132-web-search-preview-tool-call-id.test.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { createOpenAI } from './openai-provider';
+
+describe('issue #8132', () => {
+  const server = createTestServer({
+    'https://api.openai.com/v1/responses': {},
+    'https://api.openai.com/v1/chat/completions': {},
+  });
+
+  it('round-trips a web search preview ID longer than 40 characters', async () => {
+    server.urls['https://api.openai.com/v1/responses'].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/responses/__fixtures__/issue-8132-web-search-preview.json',
+          'utf8',
+        ),
+      ),
+    };
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/chat/__fixtures__/issue-8132-long-tool-call-id.json',
+          'utf8',
+        ),
+      ),
+    };
+
+    const openai = createOpenAI({ apiKey: 'test-api-key' });
+    const responsesResult = await openai.responses('gpt-4o-mini').doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Search the web.' }],
+        },
+      ],
+      tools: [
+        {
+          type: 'provider',
+          id: 'openai.web_search_preview',
+          name: 'web_search_preview',
+          args: {},
+        },
+      ],
+    });
+
+    const reportedToolCallId =
+      'ws_689e2d4880a0819d98acca37694989b00b15d90494fc6b87';
+    const assistantContent = responsesResult.content
+      .filter(part => part.type === 'text' || part.type === 'tool-call')
+      .map(part =>
+        part.type === 'tool-call'
+          ? { ...part, toolCallId: reportedToolCallId }
+          : part,
+      );
+    const toolContent = responsesResult.content
+      .filter(part => part.type === 'tool-result')
+      .map(part => ({
+        type: 'tool-result' as const,
+        toolCallId: reportedToolCallId,
+        toolName: part.toolName,
+        output: { type: 'json' as const, value: part.result },
+      }));
+    const prompt: LanguageModelV3Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Search the web.' }],
+      },
+      { role: 'assistant', content: assistantContent },
+      { role: 'tool', content: toolContent },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Reply with the title.' }],
+      },
+    ];
+
+    const chatResult = await openai.chat('gpt-4o-mini').doGenerate({ prompt });
+
+    expect(reportedToolCallId).toHaveLength(51);
+    expect(
+      (await server.calls[1].requestBodyJson).messages[1].tool_calls[0].id,
+    ).toBe(reportedToolCallId);
+    expect(chatResult.content).toEqual([
+      { type: 'text', text: 'OpenAI API Documentation' },
+    ]);
+  });
+});

--- a/packages/openai/src/responses/__fixtures__/issue-8132-web-search-preview.json
+++ b/packages/openai/src/responses/__fixtures__/issue-8132-web-search-preview.json
@@ -1,0 +1,165 @@
+{
+  "id": "resp_09354705ace9fe75006a5737295be8819d8296b38849681a04",
+  "object": "response",
+  "created_at": 1784100649,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1784100651,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-4o-mini-2024-07-18",
+  "moderation": null,
+  "output": [
+    {
+      "id": "ws_09354705ace9fe75006a573729fc8c819db0c9744efca3ee7e",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": ["OpenAI API documentation homepage title"],
+        "query": "OpenAI API documentation homepage title",
+        "sources": [
+          {
+            "type": "url",
+            "url": "https://platform.openai.com/docs/quickstart/make-your-first-api-request?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://developers.openai.com/api/docs/models?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://platform.openai.com/docs/api-reference/backward-compatibility?lang=ruby&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://developers.openai.com/api/docs/models/all?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://platform.openai.com/docs/api-reference/models/object?lang=curl&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://openai.com/api/?trk=public_post_comment-text&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://public-api.org/api/1665/openai?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://apis.io/apis/openai/openai-responses-api/?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://apis.io/apis/openai/openai-models-api/?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://apis.io/apis/openai-apis/openai-assistants-api/?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://apis.io/apis/openai-apis/openai-completions-api/?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://min.news/en/tech/64d95c2510ee06d4c1f89ead6da8cb50.html?utm_source=openai"
+          }
+        ]
+      }
+    },
+    {
+      "id": "msg_09354705ace9fe75006a57372ad080819d99ee052fe788798c",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "The current title of the OpenAI API documentation homepage is \"OpenAI API Documentation.\" You can access it at https://platform.openai.com/docs. "
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": null,
+    "effort": null,
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tool_usage": {
+    "image_gen": {
+      "input_tokens": 0,
+      "input_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "output_tokens": 0,
+      "output_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "total_tokens": 0
+    },
+    "web_search": {
+      "num_requests": 1
+    }
+  },
+  "tools": [
+    {
+      "type": "web_search_preview",
+      "search_content_types": ["text"],
+      "search_context_size": "medium",
+      "user_location": {
+        "type": "approximate",
+        "city": null,
+        "country": "US",
+        "region": null,
+        "timezone": null
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 317,
+    "input_tokens_details": {
+      "cache_write_tokens": 0,
+      "cached_tokens": 0
+    },
+    "output_tokens": 49,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 366
+  },
+  "user": null,
+  "metadata": {}
+}


### PR DESCRIPTION
## Bug

web_search_preview: string too long error when generating tool_call ids

## Reproduction

- Expected a 51-character `web_search_preview` tool-call ID to cause the reported maximum-length error, but the live Chat Completions request accepted it and returned `OpenAI API Documentation`.
- The live Responses API generated a 53-character `ws_...` ID, confirming that IDs longer than 40 characters are still emitted.
- Runnable reproduction: `examples/ai-functions/src/reproduction/issue-8132-web-search-preview-tool-call-id.ts`.
- Recorded live fixtures: `packages/openai/src/responses/__fixtures__/issue-8132-web-search-preview.json` and `packages/openai/src/chat/__fixtures__/issue-8132-long-tool-call-id.json`.
- Provider test: `packages/openai/src/issue-8132-web-search-preview-tool-call-id.test.ts`.
- The issue did not specify the exact model or provider transition; the documented `gpt-4o-mini` Responses-to-Chat flow was tested.

## Relevant Documentation

- https://platform.openai.com/docs/guides/tools-web-search
- https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal/delta?lang=curl
- https://ai.google.dev/gemini-api/docs/openai

## Related Issues

Could not reproduce #8132