### PR TITLE
Revert "fix: AI Gateway usage token counts are undefined in AI SDK results"

### DIFF
--- a/.changeset/bright-badgers-count.md
+++ b/.changeset/bright-badgers-count.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/gateway': patch
----
-
-Normalize flat language model usage returned by AI Gateway so token counts are available to AI SDK callers.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -63,13 +63,6 @@ describe('GatewayLanguageModel', () => {
       id = 'test-id',
       created = 1711115037,
       model = 'test-model',
-    }: {
-      content?: { type: string; text: string };
-      usage?: unknown;
-      finish_reason?: string;
-      id?: string;
-      created?: number;
-      model?: string;
     } = {}) {
       server.urls['https://api.test.com/language-model'].response = {
         type: 'json-value',
@@ -114,15 +107,12 @@ describe('GatewayLanguageModel', () => {
       expect(content).toEqual({ type: 'text', text: 'Hello, World!' });
     });
 
-    it('should normalize flat usage information', async () => {
+    it('should extract usage information', async () => {
       prepareJsonResponse({
         content: { type: 'text', text: 'Test' },
         usage: {
-          inputTokens: 10,
-          outputTokens: 20,
-          totalTokens: 30,
-          reasoningTokens: 2,
-          cachedInputTokens: 3,
+          prompt_tokens: 10,
+          completion_tokens: 20,
         },
       });
 
@@ -131,17 +121,8 @@ describe('GatewayLanguageModel', () => {
       });
 
       expect(usage).toEqual({
-        inputTokens: {
-          total: 10,
-          noCache: undefined,
-          cacheRead: 3,
-          cacheWrite: undefined,
-        },
-        outputTokens: {
-          total: 20,
-          text: undefined,
-          reasoning: 2,
-        },
+        prompt_tokens: 10,
+        completion_tokens: 20,
       });
     });
 
@@ -627,11 +608,8 @@ describe('GatewayLanguageModel', () => {
             type: 'finish',
             finishReason: finish_reason,
             usage: {
-              inputTokens: 10,
-              outputTokens: 20,
-              totalTokens: 30,
-              reasoningTokens: 2,
-              cachedInputTokens: 3,
+              prompt_tokens: 10,
+              completion_tokens: 20,
             },
           })}\n\n`,
         ],
@@ -666,17 +644,8 @@ describe('GatewayLanguageModel', () => {
             "finishReason": "stop",
             "type": "finish",
             "usage": {
-              "inputTokens": {
-                "cacheRead": 3,
-                "cacheWrite": undefined,
-                "noCache": undefined,
-                "total": 10,
-              },
-              "outputTokens": {
-                "reasoning": 2,
-                "text": undefined,
-                "total": 20,
-              },
+              "completion_tokens": 20,
+              "prompt_tokens": 10,
             },
           },
         ]

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -4,7 +4,6 @@ import type {
   LanguageModelV4StreamPart,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamResult,
-  LanguageModelV4Usage,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -101,7 +100,6 @@ export class GatewayLanguageModel implements LanguageModelV4 {
 
       return {
         ...responseBody,
-        usage: normalizeGatewayUsage(responseBody.usage),
         request: { body: args },
         response: { headers: responseHeaders, body: rawResponse },
         warnings,
@@ -170,10 +168,6 @@ export class GatewayLanguageModel implements LanguageModelV4 {
                   typeof streamPart.timestamp === 'string'
                 ) {
                   streamPart.timestamp = new Date(streamPart.timestamp);
-                }
-
-                if (streamPart.type === 'finish') {
-                  streamPart.usage = normalizeGatewayUsage(streamPart.usage);
                 }
 
                 controller.enqueue(streamPart);
@@ -245,40 +239,4 @@ function maybeBase64EncodeFileData<T extends { type: string }>(data: T): T {
     }
   }
   return data;
-}
-
-function normalizeGatewayUsage(
-  usage: LanguageModelV4Usage,
-): LanguageModelV4Usage {
-  if (usage == null || typeof usage !== 'object') {
-    return usage;
-  }
-
-  const legacyUsage = usage as unknown as {
-    inputTokens?: number;
-    outputTokens?: number;
-    reasoningTokens?: number;
-    cachedInputTokens?: number;
-  };
-
-  if (
-    typeof legacyUsage.inputTokens !== 'number' &&
-    typeof legacyUsage.outputTokens !== 'number'
-  ) {
-    return usage;
-  }
-
-  return {
-    inputTokens: {
-      total: legacyUsage.inputTokens,
-      noCache: undefined,
-      cacheRead: legacyUsage.cachedInputTokens,
-      cacheWrite: undefined,
-    },
-    outputTokens: {
-      total: legacyUsage.outputTokens,
-      text: undefined,
-      reasoning: legacyUsage.reasoningTokens,
-    },
-  };
 }


### PR DESCRIPTION
## Background

#17227 introduced backwards compatibility for ai gateway usage. However, this only happens if incompatible AI SDK and gateway versions are used and should not be an issue in practice. Thus the fix unnecessarily complicates the codebase.

## Summary

Revert #17227