### PR TITLE
[v5.0] fix: OpenAI-compatible chat SSE errors lose structured error fields

### DIFF
--- a/.changeset/bright-streams-smile.md
+++ b/.changeset/bright-streams-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Preserve structured error data from chat completion SSE streams.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2032,11 +2032,11 @@ describe('doStream', () => {
     `);
   });
 
-  it('should handle error stream parts', async () => {
+  it('should preserve structured error stream parts', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',
       chunks: [
-        `data: {"error": {"message": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.", "code": "Client specified an invalid argument"}}\n\n`,
+        `data: {"error": {"message": "Context length exceeded", "code": "CONTEXT_LENGTH_EXCEEDED"}}\n\n`,
         'data: [DONE]\n\n',
       ],
     };
@@ -2053,7 +2053,10 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
-          "error": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.",
+          "error": {
+            "code": "CONTEXT_LENGTH_EXCEEDED",
+            "message": "Context length exceeded",
+          },
           "type": "error",
         },
         {

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -434,9 +434,18 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
             metadataExtractor?.processChunk(chunk.rawValue);
 
             // handle error chunks:
+<<<<<<< HEAD
             if ('error' in value) {
               finishReason = 'error';
               controller.enqueue({ type: 'error', error: value.error.message });
+=======
+            if ('error' in chunk.value) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({
+                type: 'error',
+                error: chunk.value.error,
+              });
+>>>>>>> 0b612675e (fix: OpenAI-compatible chat SSE errors lose structured error fields (#17230))
               return;
             }
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -434,18 +434,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
             metadataExtractor?.processChunk(chunk.rawValue);
 
             // handle error chunks:
-<<<<<<< HEAD
             if ('error' in value) {
               finishReason = 'error';
-              controller.enqueue({ type: 'error', error: value.error.message });
-=======
-            if ('error' in chunk.value) {
-              finishReason = { unified: 'error', raw: undefined };
-              controller.enqueue({
-                type: 'error',
-                error: chunk.value.error,
-              });
->>>>>>> 0b612675e (fix: OpenAI-compatible chat SSE errors lose structured error fields (#17230))
+              controller.enqueue({ type: 'error', error: value.error });
               return;
             }
 


### PR DESCRIPTION
## Background

OpenAI-compatible SSE errors were exposed as message strings, discarding machine-readable codes needed for programmatic error handling.

## Summary

The chat stream transformer now forwards the complete parsed SSE error object instead of only its message.

## Testing

Updated the existing chat stream regression test and inline snapshot to verify that the error message and code are preserved.

## End-to-end Validation

- `pnpm tsx --eval <synthetic SSE fullStream validation>` — observed `{"message":"Context length exceeded","code":"CONTEXT_LENGTH_EXCEEDED"}`.
- `pnpm tsx --eval <live OpenAI-compatible streamText validation>` — OpenAI returned `OK.` with finish reason `stop`.

## Related Issues

Fixes #13506

Backport of #17230

Co-authored-by: StellaCheong59 <178243329+StellaCheong59@users.noreply.github.com>