### PR TITLE
[v5.0] reproduction: could not reproduce websearchpreview: string too long error when generating toolcall

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/openai": "workspace:*",
+    "ai": "workspace:*",
+    "dotenv": "16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-8132-web-search-preview-tool-call-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-8132-web-search-preview-tool-call-id.ts
@@ -1,0 +1,178 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, type ModelMessage } from 'ai';
+import 'dotenv/config';
+
+const reportedToolCallId =
+  'ws_689e2d4880a0819d98acca37694989b00b15d90494fc6b87';
+
+function findWebSearchToolCallId(messages: ModelMessage[]): string {
+  for (const message of messages) {
+    if (message.role !== 'assistant' || typeof message.content === 'string') {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === 'tool-call' && part.toolName === 'web_search_preview') {
+        return part.toolCallId;
+      }
+    }
+  }
+
+  throw new Error('The Responses API did not return a web search tool call.');
+}
+
+async function main() {
+  const searchResult = await generateText({
+    model: openai.responses('gpt-4o-mini'),
+    prompt:
+      'Use web search to find the title of the official OpenAI API documentation page.',
+    tools: {
+      web_search_preview: openai.tools.webSearchPreview({
+        searchContextSize: 'low',
+      }),
+    },
+    toolChoice: {
+      type: 'tool',
+      toolName: 'web_search_preview',
+    },
+    maxRetries: 0,
+  });
+
+  const webSearchToolCallId = findWebSearchToolCallId(
+    searchResult.response.messages,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        responsesApi: {
+          toolCallId: webSearchToolCallId,
+          toolCallIdLength: webSearchToolCallId.length,
+          body: searchResult.response.body,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (webSearchToolCallId.length <= 40) {
+    throw new Error(
+      `Expected OpenAI to generate a web search tool-call ID longer than 40 characters, but got ${webSearchToolCallId.length}.`,
+    );
+  }
+
+  const webSearchToolResult = searchResult.toolResults.find(
+    result => result.toolCallId === webSearchToolCallId,
+  );
+
+  if (webSearchToolResult == null) {
+    throw new Error('The Responses API did not return a web search result.');
+  }
+
+  const followUpResult = await generateText({
+    model: openai.chat('gpt-4o-mini'),
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Use web search to find the title of the official OpenAI API documentation page.',
+      },
+      ...searchResult.response.messages,
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: webSearchToolCallId,
+            toolName: 'web_search_preview',
+            output: {
+              type: 'json',
+              value: webSearchToolResult.output,
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Reply with only the documentation page title.',
+      },
+    ],
+    maxRetries: 0,
+  });
+
+  const reportedIdFollowUpResult = await generateText({
+    model: openai.chat('gpt-4o-mini'),
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Use web search to find the title of the official OpenAI API documentation page.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: reportedToolCallId,
+            toolName: 'web_search_preview',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: reportedToolCallId,
+            toolName: 'web_search_preview',
+            output: {
+              type: 'json',
+              value: {
+                action: {
+                  type: 'search',
+                  query: 'official OpenAI API documentation page title',
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Reply with only the documentation page title.',
+      },
+    ],
+    maxRetries: 0,
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        generatedIdChatCompletionsApi: {
+          text: followUpResult.text,
+          body: followUpResult.response.body,
+        },
+        reportedIdChatCompletionsApi: {
+          toolCallId: reportedToolCallId,
+          toolCallIdLength: reportedToolCallId.length,
+          text: reportedIdFollowUpResult.text,
+          body: reportedIdFollowUpResult.response.body,
+        },
+        reportedToolCallIdLength: reportedToolCallId.length,
+        expectedIssueBehavior:
+          'Chat Completions rejects messages[*].tool_calls[*].id longer than 40 characters.',
+        observedBehavior:
+          'Chat Completions accepted the long web-search tool-call ID and returned a text response.',
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/chat/__fixtures__/issue-8132-long-tool-call-id.json
+++ b/packages/openai/src/chat/__fixtures__/issue-8132-long-tool-call-id.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-E1pM8f3R7mTNOR0nc3JsNVewLODyz",
+  "object": "chat.completion",
+  "created": 1784104448,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "OpenAI API Documentation",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 72,
+    "completion_tokens": 4,
+    "total_tokens": 76,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_844ddd95ff"
+}

--- a/packages/openai/src/issue-8132-web-search-preview-tool-call-id.test.ts
+++ b/packages/openai/src/issue-8132-web-search-preview-tool-call-id.test.ts
@@ -1,0 +1,144 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { createOpenAI } from './openai-provider';
+
+const reportedToolCallId =
+  'ws_689e2d4880a0819d98acca37694989b00b15d90494fc6b87';
+
+const server = createTestServer({
+  'https://api.openai.com/v1/responses': {
+    response: {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/responses/__fixtures__/issue-8132-web-search-preview.json',
+          'utf8',
+        ),
+      ),
+    },
+  },
+  'https://api.openai.com/v1/chat/completions': {
+    response: {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/chat/__fixtures__/issue-8132-long-tool-call-id.json',
+          'utf8',
+        ),
+      ),
+    },
+  },
+});
+
+describe('issue #8132', () => {
+  it('accepts a web-search tool-call ID longer than 40 characters', async () => {
+    const openai = createOpenAI({ apiKey: 'test-api-key' });
+    const responsesResult = await openai.responses('gpt-4o-mini').doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Find the title of the official OpenAI API documentation.',
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: 'provider-defined',
+          id: 'openai.web_search_preview',
+          name: 'web_search_preview',
+          args: { searchContextSize: 'low' },
+        },
+      ],
+      toolChoice: {
+        type: 'tool',
+        toolName: 'web_search_preview',
+      },
+    });
+
+    const generatedToolCall = responsesResult.content.find(
+      part =>
+        part.type === 'tool-call' && part.toolName === 'web_search_preview',
+    );
+
+    expect(generatedToolCall).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'ws_0af1b57ae87e2013006a5745fe6064819ead94dd7bec539ecc',
+      providerExecuted: true,
+    });
+
+    if (generatedToolCall?.type !== 'tool-call') {
+      throw new Error('The fixture did not contain a web search tool call.');
+    }
+
+    expect(generatedToolCall.toolCallId).toHaveLength(53);
+    expect(reportedToolCallId).toHaveLength(51);
+
+    const chatResult = await openai.chat('gpt-4o-mini').doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Find the title of the official OpenAI API documentation.',
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: reportedToolCallId,
+              toolName: 'web_search_preview',
+              input: {},
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: reportedToolCallId,
+              toolName: 'web_search_preview',
+              output: {
+                type: 'json',
+                value: {
+                  action: {
+                    type: 'search',
+                    query: 'official OpenAI API documentation page title',
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Reply with only the documentation page title.',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(chatResult.content).toContainEqual({
+      type: 'text',
+      text: 'OpenAI API Documentation',
+      providerMetadata: undefined,
+    });
+
+    const chatRequest = await server.calls[1].requestBodyJson;
+    expect(chatRequest.messages[1].tool_calls[0].id).toBe(reportedToolCallId);
+    expect(chatRequest.messages[2].tool_call_id).toBe(reportedToolCallId);
+  });
+});

--- a/packages/openai/src/responses/__fixtures__/issue-8132-web-search-preview.json
+++ b/packages/openai/src/responses/__fixtures__/issue-8132-web-search-preview.json
@@ -1,0 +1,169 @@
+{
+  "id": "resp_0af1b57ae87e2013006a5745fe26d8819ea9f206ec2c2eadac",
+  "object": "response",
+  "created_at": 1784104446,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1784104447,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-4o-mini-2024-07-18",
+  "moderation": null,
+  "output": [
+    {
+      "id": "ws_0af1b57ae87e2013006a5745fe6064819ead94dd7bec539ecc",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "Use web search to find the title of the official OpenAI API documentation page."
+        ],
+        "query": "Use web search to find the title of the official OpenAI API documentation page.",
+        "sources": [
+          {
+            "type": "url",
+            "url": "https://platform.openai.com/docs/quickstart/make-your-first-api-request?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://developers.openai.com/api/docs/models?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://platform.openai.com/docs/api-reference/backward-compatibility?lang=ruby&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://platform.openai.com/docs/api-reference/models/object?lang=curl&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://openai.com/api/?trk=public_post_comment-text&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://developers.openai.com/api/docs/models/all?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://openai.com/api/?src_trk=em662f12e8ce7730.67771400510222362&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://openai.com/api/?src_trk=em6624b0c62e3a05.290691122031174284&utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://developers.openai.com/api/docs/models/compare?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://apis.io/apis/openai/openai-responses-api/?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://apis.io/apis/openai/openai-models-api/?utm_source=openai"
+          },
+          {
+            "type": "url",
+            "url": "https://min.news/en/tech/64d95c2510ee06d4c1f89ead6da8cb50.html?utm_source=openai"
+          }
+        ]
+      }
+    },
+    {
+      "id": "msg_0af1b57ae87e2013006a5745fede8c819e8637256332976fe6",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "The official OpenAI API documentation page is titled \"OpenAI API Documentation.\" You can access it at https://platform.openai.com/docs. This comprehensive resource provides detailed information on the API's features, usage, and best practices. "
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": null,
+    "effort": null,
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "auto",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": {
+    "type": "web_search_preview"
+  },
+  "tool_usage": {
+    "image_gen": {
+      "input_tokens": 0,
+      "input_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "output_tokens": 0,
+      "output_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "total_tokens": 0
+    },
+    "web_search": {
+      "num_requests": 1
+    }
+  },
+  "tools": [
+    {
+      "type": "web_search_preview",
+      "search_content_types": ["text"],
+      "search_context_size": "low",
+      "user_location": {
+        "type": "approximate",
+        "city": null,
+        "country": "US",
+        "region": null,
+        "timezone": null
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 325,
+    "input_tokens_details": {
+      "cache_write_tokens": 0,
+      "cached_tokens": 0
+    },
+    "output_tokens": 47,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 372
+  },
+  "user": null,
+  "metadata": {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../../packages/openai
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19630,7 +19652,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19644,13 +19666,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19658,22 +19680,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19683,7 +19705,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19713,7 +19735,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24963,7 +24985,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29439,7 +29461,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30208,7 +30230,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30305,7 +30327,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33789,7 +33811,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33817,7 +33839,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34896,7 +34918,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36436,7 +36458,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37393,7 +37415,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37830,7 +37852,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -40029,7 +40051,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

web_search_preview: string too long error when generating tool_call ids

## Reproduction

- Runnable reproduction `examples/ai-functions/src/reproduction/issue-8132-web-search-preview-tool-call-id.ts` expected the reported maximum-length error, but the live Responses-to-Chat flow completed and returned a documentation title.
- The live Responses API generated a 53-character `ws_...` ID, and Chat Completions accepted it instead of rejecting IDs longer than 40 characters.
- A narrowing request using the exact reported 51-character ID was also accepted and returned `OpenAI API Documentation`.
- Recorded live fixtures are in `packages/openai/src/responses/__fixtures__/issue-8132-web-search-preview.json` and `packages/openai/src/chat/__fixtures__/issue-8132-long-tool-call-id.json`; the provider regression test is `packages/openai/src/issue-8132-web-search-preview-tool-call-id.test.ts`.
- The issue does not identify its exact model or provider transition; the documented `gpt-4o-mini` Responses-to-Chat flow was tested on the release-v5.0 target branch.

## Relevant Documentation

- https://platform.openai.com/docs/guides/tools-web-search
- https://platform.openai.com/docs/api-reference/chat/create
- https://ai.google.dev/gemini-api/docs/openai
- https://ai.google.dev/gemini-api/docs/function-calling

## Related Issues

Could not reproduce #8132