### PR TITLE
feat: add non-streaming Mistral Voxtral speech generation

### DIFF
--- a/.changeset/tidy-hounds-speak.md
+++ b/.changeset/tidy-hounds-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Add non-streaming Voxtral text-to-speech support with saved voice IDs and one-off reference audio.

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -5,7 +5,8 @@ description: Learn how to use Mistral.
 
 # Mistral AI Provider
 
-The [Mistral AI](https://mistral.ai/) provider contains language model support for the Mistral chat API.
+The [Mistral AI](https://mistral.ai/) provider contains language, embedding,
+and speech model support for Mistral APIs.
 
 ## Setup
 
@@ -311,6 +312,63 @@ const result = await generateText({
   full list of available models. The table above lists popular models. You can
   also pass any available provider model ID as a string if needed.
 </Note>
+
+## Speech Models
+
+You can create models that call the [Mistral speech API](https://docs.mistral.ai/api/endpoint/audio/speech)
+using the `.speech()` factory method:
+
+```ts
+const model = mistral.speech('voxtral-mini-tts-2603');
+```
+
+Use the model with the [`generateSpeech`](/docs/reference/ai-sdk-core/generate-speech)
+function:
+
+```ts
+import { mistral } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+
+const { audio } = await generateSpeech({
+  model: mistral.speech('voxtral-mini-tts-2603'),
+  text: 'Hello from the AI SDK!',
+  voice: 'en_paul_neutral',
+  outputFormat: 'mp3',
+});
+```
+
+Mistral supports `pcm`, `wav`, `mp3`, `flac`, and `opus` output formats.
+Speech generation is non-streaming. The `instructions`, `speed`, and `language`
+settings are not supported.
+
+### Reference Audio
+
+For one-off voice cloning, pass a base64-encoded reference audio clip with the
+`refAudio` provider option:
+
+```ts
+import { mistral, type MistralSpeechModelOptions } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+
+const { audio } = await generateSpeech({
+  model: mistral.speech('voxtral-mini-tts-2603'),
+  text: 'This speech uses a one-off reference voice.',
+  providerOptions: {
+    mistral: {
+      refAudio: referenceAudioBase64,
+    } satisfies MistralSpeechModelOptions,
+  },
+});
+```
+
+Every request requires either the `voice` setting or the `refAudio` provider
+option. They cannot be used together. Reference audio is redacted from request
+metadata and API errors.
+
+<Warning>
+  Only clone voices when you have explicit consent and comply with Mistral's
+  voice cloning usage policy and applicable disclosure requirements.
+</Warning>
 
 ## Embedding Models
 

--- a/examples/ai-functions/src/generate-speech/mistral/basic.ts
+++ b/examples/ai-functions/src/generate-speech/mistral/basic.ts
@@ -1,0 +1,18 @@
+import { mistral } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: mistral.speech('voxtral-mini-tts-2603'),
+    text: 'Hello from the AI SDK!',
+    voice: 'en_paul_neutral',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/reproduction/issue-14245-mistral-speech.ts
+++ b/examples/ai-functions/src/reproduction/issue-14245-mistral-speech.ts
@@ -1,0 +1,34 @@
+import { mistral } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+
+async function main() {
+  const result = await generateSpeech({
+    model: mistral.speech('voxtral-mini-tts-2603'),
+    text: 'Hello from the AI SDK. This is a live Mistral speech test.',
+    voice: 'en_paul_neutral',
+    outputFormat: 'mp3',
+    maxRetries: 0,
+  });
+
+  const output = {
+    byteLength: result.audio.uint8Array.byteLength,
+    mediaType: result.audio.mediaType,
+    modelId: result.responses[0]?.modelId,
+    warnings: result.warnings,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (output.byteLength === 0) {
+    throw new Error('Mistral returned empty speech audio.');
+  }
+
+  if (output.modelId !== 'voxtral-mini-tts-2603') {
+    throw new Error(`Unexpected response model id: ${output.modelId}`);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -9,4 +9,8 @@ export type {
   MistralLanguageModelChatOptions as MistralLanguageModelOptions,
 } from './mistral-chat-language-model-options';
 export type { MistralEmbeddingModelOptions } from './mistral-embedding-model-options';
+export type {
+  MistralSpeechModelId,
+  MistralSpeechModelOptions,
+} from './mistral-speech-model-options';
 export { VERSION } from './version';

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -3,6 +3,7 @@ import {
   type EmbeddingModelV4,
   type LanguageModelV4,
   type ProviderV4,
+  type SpeechModelV4,
 } from '@ai-sdk/provider';
 import {
   loadApiKey,
@@ -14,6 +15,8 @@ import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-language-model-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
 import type { MistralEmbeddingModelId } from './mistral-embedding-model-options';
+import { MistralSpeechModel } from './mistral-speech-model';
+import type { MistralSpeechModelId } from './mistral-speech-model-options';
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV4 {
@@ -38,6 +41,16 @@ export interface MistralProvider extends ProviderV4 {
    * Creates a model for text embeddings.
    */
   embeddingModel: (modelId: MistralEmbeddingModelId) => EmbeddingModelV4;
+
+  /**
+   * Creates a model for speech generation.
+   */
+  speech(modelId: MistralSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates a model for speech generation.
+   */
+  speechModel(modelId: MistralSpeechModelId): SpeechModelV4;
 
   /**
    * @deprecated Use `embedding` instead.
@@ -116,6 +129,14 @@ export function createMistral(
       fetch: options.fetch,
     });
 
+  const createSpeechModel = (modelId: MistralSpeechModelId) =>
+    new MistralSpeechModel(modelId, {
+      provider: 'mistral.speech',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const provider = function (modelId: MistralChatModelId) {
     if (new.target) {
       throw new Error(
@@ -133,6 +154,8 @@ export function createMistral(
   provider.embeddingModel = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
+  provider.speech = createSpeechModel;
+  provider.speechModel = createSpeechModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });

--- a/packages/mistral/src/mistral-speech-model-options.ts
+++ b/packages/mistral/src/mistral-speech-model-options.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod/v4';
+
+export type MistralSpeechModelId = 'voxtral-mini-tts-2603' | (string & {});
+
+export const mistralSpeechModelOptions = z.object({
+  /**
+   * Base64-encoded reference audio to use for one-off voice cloning.
+   *
+   * This cannot be used together with the standard `voice` option.
+   */
+  refAudio: z.string().optional(),
+});
+
+export type MistralSpeechModelOptions = z.infer<
+  typeof mistralSpeechModelOptions
+>;

--- a/packages/mistral/src/mistral-speech-model.test.ts
+++ b/packages/mistral/src/mistral-speech-model.test.ts
@@ -1,0 +1,350 @@
+import { APICallError, InvalidArgumentError } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createMistral } from './mistral-provider';
+import { MistralSpeechModel } from './mistral-speech-model';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const SPEECH_URL = 'https://api.mistral.ai/v1/audio/speech';
+const provider = createMistral({ apiKey: 'test-api-key' });
+const model = provider.speech('voxtral-mini-tts-2603');
+
+const server = createTestServer({
+  [SPEECH_URL]: {},
+});
+
+describe('MistralSpeechModel', () => {
+  function prepareJsonResponse({
+    audioData = 'AQIDBA==',
+    headers,
+  }: {
+    audioData?: string;
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls[SPEECH_URL].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        audio_data: audioData,
+      },
+    };
+  }
+
+  it('should expose correct provider and model information', () => {
+    expect(model.provider).toBe('mistral.speech');
+    expect(model.modelId).toBe('voxtral-mini-tts-2603');
+    expect(model.specificationVersion).toBe('v4');
+  });
+
+  it('should create speech models with both provider factories', () => {
+    expect(provider.speech('voxtral-mini-tts-2603')).toBeInstanceOf(
+      MistralSpeechModel,
+    );
+    expect(provider.speechModel('voxtral-mini-tts-2603')).toBeInstanceOf(
+      MistralSpeechModel,
+    );
+  });
+
+  it('should send text with non-streaming defaults', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'voxtral-mini-tts-2603',
+      input: 'Hello from the AI SDK!',
+      voice_id: 'en_paul_neutral',
+      response_format: 'mp3',
+      stream: false,
+    });
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestUrl).toBe(SPEECH_URL);
+  });
+
+  it('should map voice to voice_id', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'preset-or-custom-voice-id',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      voice_id: 'preset-or-custom-voice-id',
+    });
+  });
+
+  it.each(['pcm', 'wav', 'mp3', 'flac', 'opus'])(
+    'should accept the %s output format',
+    async outputFormat => {
+      prepareJsonResponse();
+
+      await model.doGenerate({
+        text: 'Hello from the AI SDK!',
+        voice: 'en_paul_neutral',
+        outputFormat,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        response_format: outputFormat,
+      });
+    },
+  );
+
+  it('should warn and use mp3 for unsupported output formats', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+      outputFormat: 'aac',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      response_format: 'mp3',
+    });
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'outputFormat',
+      details: 'Unsupported output format: aac. Using mp3 instead.',
+    });
+  });
+
+  it('should map refAudio and redact it from request metadata', async () => {
+    prepareJsonResponse();
+    const refAudio = 'c2Vuc2l0aXZlLXZvaWNlLXNhbXBsZQ==';
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      providerOptions: {
+        mistral: {
+          refAudio,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      ref_audio: refAudio,
+    });
+    expect(result.request?.body).toMatchObject({
+      ref_audio: '[base64 audio redacted]',
+    });
+    expect(JSON.stringify(result.request)).not.toContain(refAudio);
+  });
+
+  it('should reject voice and refAudio when used together', async () => {
+    await expect(
+      model.doGenerate({
+        text: 'Hello from the AI SDK!',
+        voice: 'voice-id',
+        providerOptions: {
+          mistral: {
+            refAudio: 'c2FtcGxl',
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(InvalidArgumentError);
+  });
+
+  it('should require either voice or refAudio', async () => {
+    await expect(
+      model.doGenerate({
+        text: 'Hello from the AI SDK!',
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_InvalidArgumentError',
+      argument: 'voice',
+    });
+  });
+
+  it('should warn for unsupported standard speech options', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+      instructions: 'Speak cheerfully.',
+      speed: 1.25,
+      language: 'en',
+    });
+
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'instructions',
+      }),
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'speed',
+      }),
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'language',
+      }),
+    ]);
+  });
+
+  it('should return base64 audio data', async () => {
+    prepareJsonResponse({ audioData: 'AQIDBA==' });
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+    });
+
+    expect(result.audio).toBe('AQIDBA==');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should include response timestamp, model id, headers, and body', async () => {
+    prepareJsonResponse({
+      headers: { 'x-request-id': 'test-request-id' },
+    });
+    const testDate = new Date(0);
+    const customModel = new MistralSpeechModel('voxtral-mini-tts-2603', {
+      provider: 'mistral.speech',
+      baseURL: 'https://api.mistral.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId: 'voxtral-mini-tts-2603',
+      headers: expect.objectContaining({
+        'x-request-id': 'test-request-id',
+      }),
+      body: { audio_data: 'AQIDBA==' },
+    });
+  });
+
+  it('should pass provider and request headers', async () => {
+    prepareJsonResponse();
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      headers: {
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await customProvider.speech('voxtral-mini-tts-2603').doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain(
+      'ai-sdk/mistral/0.0.0-test',
+    );
+  });
+
+  it('should use a custom base URL and fetch implementation', async () => {
+    const customFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response(JSON.stringify({ audio_data: 'AQIDBA==' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    );
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      baseURL: 'https://custom.mistral.test/v1/',
+      fetch: customFetch,
+    });
+
+    await customProvider.speech('voxtral-mini-tts-2603').doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+    });
+
+    expect(customFetch).toHaveBeenCalledOnce();
+    expect(customFetch.mock.calls[0][0]).toBe(
+      'https://custom.mistral.test/v1/audio/speech',
+    );
+  });
+
+  it('should forward the abort signal', async () => {
+    const abortController = new AbortController();
+    const customFetch = vi.fn(async (_input, init) => {
+      expect(init?.signal).toBe(abortController.signal);
+      return new Response(JSON.stringify({ audio_data: 'AQIDBA==' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      fetch: customFetch,
+    });
+
+    await customProvider.speech('voxtral-mini-tts-2603').doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'en_paul_neutral',
+      abortSignal: abortController.signal,
+    });
+
+    expect(customFetch).toHaveBeenCalledOnce();
+  });
+
+  it('should handle moderation errors without exposing refAudio', async () => {
+    server.urls[SPEECH_URL].response = {
+      type: 'error',
+      status: 400,
+      body: JSON.stringify({
+        object: 'error',
+        message: 'The request was rejected by voice safety moderation.',
+        type: 'moderation_error',
+        param: 'ref_audio',
+        code: 'voice_safety_rejection',
+      }),
+    };
+    const refAudio = 'c2Vuc2l0aXZlLXZvaWNlLXNhbXBsZQ==';
+
+    let error: unknown;
+    try {
+      await model.doGenerate({
+        text: 'Hello from the AI SDK!',
+        providerOptions: {
+          mistral: {
+            refAudio,
+          },
+        },
+      });
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(APICallError);
+    if (!APICallError.isInstance(error)) {
+      throw new Error('Expected an APICallError.');
+    }
+    expect(error).toMatchObject({
+      message: 'The request was rejected by voice safety moderation.',
+      statusCode: 400,
+      requestBodyValues: {
+        ref_audio: '[base64 audio redacted]',
+      },
+    });
+    expect(JSON.stringify(error.requestBodyValues)).not.toContain(refAudio);
+  });
+});

--- a/packages/mistral/src/mistral-speech-model.ts
+++ b/packages/mistral/src/mistral-speech-model.ts
@@ -1,0 +1,209 @@
+import {
+  InvalidArgumentError,
+  type SharedV4Warning,
+  type SpeechModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { mistralFailedResponseHandler } from './mistral-error';
+import {
+  mistralSpeechModelOptions,
+  type MistralSpeechModelId,
+} from './mistral-speech-model-options';
+
+type MistralSpeechConfig = {
+  provider: string;
+  baseURL: string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+};
+
+type MistralSpeechOutputFormat = 'pcm' | 'wav' | 'mp3' | 'flac' | 'opus';
+
+type MistralSpeechRequest = {
+  model: string;
+  input: string;
+  voice_id?: string;
+  ref_audio?: string;
+  response_format: MistralSpeechOutputFormat;
+  stream: false;
+};
+
+const mistralSpeechResponseSchema = z.object({
+  audio_data: z.string(),
+});
+
+export class MistralSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: MistralSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: MistralSpeechModelId;
+    config: MistralSpeechConfig;
+  }) {
+    return new MistralSpeechModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: MistralSpeechModelId,
+    private readonly config: MistralSpeechConfig,
+  ) {}
+
+  private async getArgs({
+    text,
+    voice,
+    outputFormat = 'mp3',
+    instructions,
+    speed,
+    language,
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+    const mistralOptions = await parseProviderOptions({
+      provider: 'mistral',
+      providerOptions,
+      schema: mistralSpeechModelOptions,
+    });
+
+    if (voice != null && mistralOptions?.refAudio != null) {
+      throw new InvalidArgumentError({
+        argument: 'voice',
+        message:
+          'Mistral speech generation accepts either `voice` or `providerOptions.mistral.refAudio`, but not both.',
+      });
+    }
+
+    if (voice == null && mistralOptions?.refAudio == null) {
+      throw new InvalidArgumentError({
+        argument: 'voice',
+        message:
+          'Mistral speech generation requires either `voice` or `providerOptions.mistral.refAudio`.',
+      });
+    }
+
+    let resolvedOutputFormat: MistralSpeechOutputFormat = 'mp3';
+    if (
+      outputFormat === 'pcm' ||
+      outputFormat === 'wav' ||
+      outputFormat === 'mp3' ||
+      outputFormat === 'flac' ||
+      outputFormat === 'opus'
+    ) {
+      resolvedOutputFormat = outputFormat;
+    } else {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'outputFormat',
+        details: `Unsupported output format: ${outputFormat}. Using mp3 instead.`,
+      });
+    }
+
+    if (instructions != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'Mistral speech models do not support the `instructions` option. It was ignored.',
+      });
+    }
+
+    if (speed != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'speed',
+        details:
+          'Mistral speech models do not support the `speed` option. It was ignored.',
+      });
+    }
+
+    if (language != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'language',
+        details:
+          'Mistral speech models do not support the `language` option. Language is inferred from the input text and voice.',
+      });
+    }
+
+    const requestBody: MistralSpeechRequest = {
+      model: this.modelId,
+      input: text,
+      voice_id: voice,
+      ref_audio: mistralOptions?.refAudio,
+      response_format: resolvedOutputFormat,
+      stream: false,
+    };
+
+    return { requestBody, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestBody, warnings } = await this.getArgs(options);
+    const redactedRequestBody = {
+      ...requestBody,
+      ref_audio:
+        requestBody.ref_audio == null ? undefined : '[base64 audio redacted]',
+    };
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postToApi({
+      url: `${this.config.baseURL}/audio/speech`,
+      headers: {
+        ...combineHeaders(this.config.headers?.(), options.headers),
+        'Content-Type': 'application/json',
+      },
+      body: {
+        content: JSON.stringify(requestBody),
+        values: redactedRequestBody,
+      },
+      failedResponseHandler: mistralFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        mistralSpeechResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      audio: response.audio_data,
+      warnings,
+      request: {
+        body: redactedRequestBody,
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Background

Users need first-class Mistral Voxtral text-to-speech support through the AI SDK's existing generateSpeech API, including saved voices and one-off reference audio.

## Summary

Added MistralSpeechModel, speech and speechModel factories, public model and provider-option types, supported output formats, reference-audio redaction, validation, documentation, examples, and a patch changeset.

## Testing

Added 20 focused tests covering factories, request mapping, formats, voice and reference-audio validation, warnings, responses, headers, custom fetch, abort signals, moderation errors, and sensitive-data redaction.

## End-to-end Validation

- Ran the reproduction against Mistral's live API; Voxtral returned 29,371 bytes of audio/mpeg with the expected model ID and no warnings.

## Related Issues

Fixes #14245

Co-authored-by: sovetski <13520683+sovetski@users.noreply.github.com>