### PR TITLE
[v5.0] reproduction: could not reproduce Bug zai/glm-4.7 provider cerebras

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/gateway": "4.0.20",
+    "ai": "7.0.28",
+    "zod": "4.1.13"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.21.0",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11783-gateway-cerebras.ts
+++ b/examples/ai-functions/src/reproduction/issue-11783-gateway-cerebras.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { ToolLoopAgent, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  const agent = new ToolLoopAgent({
+    model: 'zai/glm-4.7',
+    providerOptions: {
+      gateway: {
+        only: ['cerebras'],
+      },
+      cerebras: {},
+    },
+    stopWhen: [stepCountIs(1)],
+    toolChoice: 'required',
+    tools: {
+      getWeather: tool({
+        description: 'Get the weather for a city.',
+        inputSchema: z.object({
+          city: z.string(),
+        }),
+        execute: async ({ city }) => ({
+          city,
+          conditions: 'sunny',
+          temperatureFahrenheit: 72,
+        }),
+      }),
+    },
+  });
+
+  const result = await agent.stream({
+    prompt:
+      'Call the getWeather tool exactly once for San Francisco. Do not answer without calling the tool.',
+  });
+
+  const observedPartTypes: string[] = [];
+  const errors: unknown[] = [];
+  let toolCallCount = 0;
+  let toolResultCount = 0;
+
+  for await (const part of result.fullStream) {
+    observedPartTypes.push(part.type);
+
+    if (part.type === 'tool-call') {
+      toolCallCount += 1;
+      console.log(
+        JSON.stringify({
+          type: part.type,
+          toolName: part.toolName,
+          input: part.input,
+        }),
+      );
+    } else if (part.type === 'tool-result') {
+      toolResultCount += 1;
+      console.log(
+        JSON.stringify({
+          type: part.type,
+          toolName: part.toolName,
+          output: part.output,
+        }),
+      );
+    } else if (part.type === 'error') {
+      errors.push(part.error);
+      console.error(
+        JSON.stringify({
+          type: part.type,
+          error:
+            part.error instanceof Error
+              ? {
+                  name: part.error.name,
+                  message: part.error.message,
+                  stack: part.error.stack,
+                }
+              : part.error,
+        }),
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      observedPartTypes,
+      toolCallCount,
+      toolResultCount,
+      errorCount: errors.length,
+      finishReason: await result.finishReason,
+      providerMetadata: await result.providerMetadata,
+    }),
+  );
+
+  assert.equal(
+    errors.length,
+    0,
+    `Expected no stream errors, received ${errors.length}.`,
+  );
+  assert.equal(toolCallCount, 1, 'Expected exactly one tool call.');
+  assert.equal(toolResultCount, 1, 'Expected exactly one tool result.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

[Bug] zai/glm-4.7 provider cerebras

## Reproduction

- Created runnable reproduction at `examples/ai-functions/src/reproduction/issue-11783-gateway-cerebras.ts` with supporting `examples/ai-functions/package.json`.
- The issue predicts an `AI_TypeValidationError` wrapping a provider 500; the live stream instead completed one tool call and one tool result with zero error events.
- Gateway metadata confirmed `zai/glm-4.7` was served by Cerebras in one successful HTTP 200 attempt.
- The scenario passed with the reported `ai@6.0.6` and `@ai-sdk/gateway@3.0.5`, and with current `ai@7.0.28` and `@ai-sdk/gateway@4.0.20`.
- The issue omits its prompt, tool definitions, and complete messages, so the reporter's application-specific request could not be tested exactly.

## Relevant Documentation

- https://vercel.com/ai-gateway/models/glm-4.7/providers
- https://vercel.com/docs/ai-gateway/models-and-providers/provider-options
- https://ai-sdk.dev/docs/agents/loop-control
- https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent

## Related Issues

Could not reproduce #11783