### PR TITLE
[v6.0] reproduction: could not reproduce Bug zai/glm-4.7 provider cerebras

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11783-gateway-cerebras.ts
+++ b/examples/ai-functions/src/reproduction/issue-11783-gateway-cerebras.ts
@@ -1,0 +1,89 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { stepCountIs, tool, ToolLoopAgent } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  const events: Array<{ type: string; error?: unknown }> = [];
+
+  const agent = new ToolLoopAgent({
+    model: 'zai/glm-4.7',
+    providerOptions: {
+      gateway: {
+        only: ['cerebras'],
+      } satisfies GatewayProviderOptions,
+      cerebras: {},
+    },
+    tools: {
+      getWeather: tool({
+        description: 'Get the current weather for a city.',
+        inputSchema: z.object({
+          city: z.string(),
+        }),
+        execute: async ({ city }) => ({
+          city,
+          condition: 'sunny',
+          temperatureFahrenheit: 72,
+        }),
+      }),
+    },
+    toolChoice: 'required',
+    stopWhen: [stepCountIs(1)],
+  });
+
+  const result = await agent.stream({
+    prompt:
+      'Call the getWeather tool exactly once for San Francisco. Do not answer without calling the tool.',
+  });
+
+  for await (const event of result.fullStream) {
+    events.push({
+      type: event.type,
+      ...('error' in event ? { error: event.error } : {}),
+    });
+  }
+
+  const errorEvents = events.filter(event => event.type === 'error');
+  const toolCallEvents = events.filter(event => event.type === 'tool-call');
+  const toolResultEvents = events.filter(event => event.type === 'tool-result');
+  const steps = await result.steps;
+  const providerMetadata = await result.providerMetadata;
+
+  console.log(
+    JSON.stringify(
+      {
+        eventTypes: events.map(event => event.type),
+        errors: errorEvents,
+        toolCallCount: toolCallEvents.length,
+        toolResultCount: toolResultEvents.length,
+        stepCount: steps.length,
+        finishReason: await result.finishReason,
+        providerMetadata,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (errorEvents.length > 0) {
+    throw new Error(
+      `Issue #11783 reproduced: agent stream emitted ${errorEvents.length} error event(s).`,
+    );
+  }
+
+  if (toolCallEvents.length !== 1 || toolResultEvents.length !== 1) {
+    throw new Error(
+      `Expected one tool call and one tool result, received ${toolCallEvents.length} and ${toolResultEvents.length}.`,
+    );
+  }
+
+  if (steps.length !== 1) {
+    throw new Error(
+      `Expected stopWhen to stop after one step, got ${steps.length}.`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

[Bug] zai/glm-4.7 provider cerebras

## Reproduction

- Added runnable live reproduction at `examples/ai-functions/src/reproduction/issue-11783-gateway-cerebras.ts` using Cerebras-only routing, a forced tool call, and `stopWhen: [stepCountIs(1)]`.
- The target branch completed one tool call and one tool result in one step with zero error events; Gateway metadata confirmed Cerebras returned HTTP 200.
- An isolated run with the reported `ai@6.0.6` and `@ai-sdk/gateway@3.0.5` versions also completed successfully, so the expected `AI_TypeValidationError` wrapping a provider 500 was not observed.
- The reporter's exact application request could not be tested because the issue omits its prompt, tool definitions, and complete messages.

## Relevant Documentation

- https://vercel.com/ai-gateway/models/glm-4.7/providers
- https://vercel.com/docs/ai-gateway/models-and-providers/provider-options
- https://ai-sdk.dev/docs/agents/loop-control
- https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent

## Related Issues

Could not reproduce #11783