### PR TITLE
feat: add Mistral Conversations API support with web search tools

### DIFF
--- a/.changeset/tidy-mistral-search.md
+++ b/.changeset/tidy-mistral-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Add Mistral Conversations API models with typed web search and premium web search provider tools.

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -223,6 +223,67 @@ Mistral language models can also be used in the `streamText` function
 and support structured data generation with [`Output`](/docs/reference/ai-sdk-core/output)
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Conversations API and Web Search
+
+Mistral's built-in `web_search` and `web_search_premium` tools are available
+through the Mistral Conversations API. Create a Conversations model with
+`mistral.conversations()` and add the corresponding provider-executed tool from
+`mistral.tools`:
+
+```ts
+import {
+  mistral,
+  type MistralLanguageModelConversationsOptions,
+} from '@ai-sdk/mistral';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: mistral.conversations('mistral-medium-latest'),
+  tools: {
+    webSearch: mistral.tools.webSearch(),
+  },
+  providerOptions: {
+    mistral: {
+      store: false,
+    } satisfies MistralLanguageModelConversationsOptions,
+  },
+  prompt:
+    'Use web search to find the current stable Node.js release. Explain whether it is LTS and cite sources.',
+});
+
+console.log(result.text);
+console.log(result.sources);
+```
+
+The provider maps Mistral's server-side tool executions to AI SDK tool calls and
+tool results. Web references are returned as URL source parts and are available
+through `result.sources` with `generateText`, or as `source` parts when using
+`streamText`.
+
+Use `mistral.tools.webSearchPremium()` to enable Mistral's premium search:
+
+```ts
+const result = await generateText({
+  model: mistral.conversations('mistral-medium-latest'),
+  tools: {
+    webSearch: mistral.tools.webSearchPremium(),
+  },
+  prompt: 'Search for recent reporting about renewable energy policy.',
+});
+```
+
+The following optional provider option is available for Conversations models:
+
+- **store** _boolean_
+
+  Whether Mistral should persist the conversation. Set this to `false` for a
+  non-persistent conversation.
+
+The web search tools are not supported by Mistral's Chat Completions API, so use
+`mistral.conversations()` rather than `mistral()` or `mistral.chat()`. Search
+queries and retrieved content are processed by Mistral. Premium web search may
+have separate plan, availability, and billing requirements.
+
 #### Structured Outputs
 
 Mistral chat models support structured outputs using JSON Schema. You can use `generateText` or `streamText` with [`Output`](/docs/reference/ai-sdk-core/output)

--- a/examples/ai-functions/src/generate-text/mistral/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/mistral/tool-call.ts
@@ -1,64 +1,24 @@
 import { mistral } from '@ai-sdk/mistral';
-import { generateText, tool } from 'ai';
-import { z } from 'zod';
-import { weatherTool } from '../../tools/weather-tool';
+import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: mistral('mistral-large-latest'),
-    maxOutputTokens: 512,
+    model: mistral.conversations('mistral-medium-latest'),
     tools: {
-      weather: weatherTool,
-      cityAttractions: tool({
-        inputSchema: z.object({ city: z.string() }),
-      }),
+      webSearch: mistral.tools.webSearch(),
+    },
+    providerOptions: {
+      mistral: {
+        store: false,
+      },
     },
     prompt:
-      'What is the weather in San Francisco and what attractions should I visit?',
+      'Use web search to find the current stable Node.js release. Explain whether it is LTS and cite sources.',
   });
 
-  // typed tool calls:
-  for (const toolCall of result.toolCalls) {
-    if (toolCall.dynamic) {
-      continue;
-    }
-
-    switch (toolCall.toolName) {
-      case 'cityAttractions': {
-        toolCall.input.city; // string
-        break;
-      }
-
-      case 'weather': {
-        toolCall.input.location; // string
-        break;
-      }
-    }
-  }
-
-  // typed tool results for tools with execute method:
-  for (const toolResult of result.toolResults) {
-    if (toolResult.dynamic) {
-      continue;
-    }
-
-    switch (toolResult.toolName) {
-      // NOT AVAILABLE (NO EXECUTE METHOD)
-      // case 'cityAttractions': {
-      //   toolResult.input.city; // string
-      //   toolResult.result;
-      //   break;
-      // }
-
-      case 'weather': {
-        toolResult.input.location; // string
-        toolResult.output.location; // string
-        toolResult.output.temperature; // number
-        break;
-      }
-    }
-  }
-
-  console.log(JSON.stringify(result, null, 2));
+  console.log(result.text);
+  console.log('Sources:', result.sources);
+  console.log('Tool calls:', result.toolCalls);
+  console.log('Tool results:', result.toolResults);
 });

--- a/packages/mistral/src/conversations/convert-to-mistral-conversation-input.ts
+++ b/packages/mistral/src/conversations/convert-to-mistral-conversation-input.ts
@@ -1,0 +1,261 @@
+import {
+  UnsupportedFunctionalityError,
+  type LanguageModelV4Prompt,
+  type LanguageModelV4ToolResultOutput,
+} from '@ai-sdk/provider';
+import {
+  convertToBase64,
+  getTopLevelMediaType,
+  resolveFullMediaType,
+  type ToolNameMapping,
+} from '@ai-sdk/provider-utils';
+
+type MistralConversationContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: string }
+  | { type: 'document_url'; document_url: string };
+
+export type MistralConversationInput =
+  | {
+      type: 'message.input';
+      role: 'user';
+      content: MistralConversationContentPart[];
+    }
+  | {
+      type: 'message.output';
+      role: 'assistant';
+      content: Array<{ type: 'text'; text: string }>;
+    }
+  | {
+      type: 'function.call';
+      tool_call_id: string;
+      name: string;
+      arguments: string;
+    }
+  | {
+      type: 'function.result';
+      tool_call_id: string;
+      result: string;
+    }
+  | {
+      type: 'tool.execution';
+      id: string;
+      name: string;
+      arguments: string;
+      info?: Record<string, unknown>;
+    };
+
+export function convertToMistralConversationInput({
+  prompt,
+  toolNameMapping,
+}: {
+  prompt: LanguageModelV4Prompt;
+  toolNameMapping: ToolNameMapping;
+}): {
+  inputs: MistralConversationInput[];
+  instructions: string | undefined;
+} {
+  const inputs: MistralConversationInput[] = [];
+  const instructions: string[] = [];
+
+  for (const message of prompt) {
+    switch (message.role) {
+      case 'system':
+        instructions.push(message.content);
+        break;
+
+      case 'user':
+        inputs.push({
+          type: 'message.input',
+          role: 'user',
+          content: message.content.map(part => {
+            if (part.type === 'text') {
+              return { type: 'text', text: part.text };
+            }
+
+            if (part.data.type === 'reference') {
+              throw new UnsupportedFunctionalityError({
+                functionality: 'file parts with provider references',
+              });
+            }
+
+            if (part.data.type === 'text') {
+              throw new UnsupportedFunctionalityError({
+                functionality: 'text file parts',
+              });
+            }
+
+            const data =
+              part.data.type === 'url'
+                ? part.data.url.toString()
+                : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`;
+
+            if (getTopLevelMediaType(part.mediaType) === 'image') {
+              return { type: 'image_url', image_url: data };
+            }
+
+            const fullMediaType =
+              part.data.type === 'data'
+                ? resolveFullMediaType({ part })
+                : part.mediaType;
+
+            if (fullMediaType !== 'application/pdf') {
+              throw new UnsupportedFunctionalityError({
+                functionality: 'Only images and PDF file parts are supported',
+              });
+            }
+
+            return { type: 'document_url', document_url: data };
+          }),
+        });
+        break;
+
+      case 'assistant': {
+        const providerExecutedToolCallIds = new Set(
+          message.content.flatMap(part =>
+            part.type === 'tool-call' && part.providerExecuted
+              ? [part.toolCallId]
+              : [],
+          ),
+        );
+        const providerToolResults = new Map<
+          string,
+          LanguageModelV4ToolResultOutput
+        >();
+
+        for (const part of message.content) {
+          if (
+            part.type === 'tool-result' &&
+            providerExecutedToolCallIds.has(part.toolCallId)
+          ) {
+            providerToolResults.set(part.toolCallId, part.output);
+          }
+        }
+
+        let text = '';
+
+        const flushText = () => {
+          if (text.length === 0) {
+            return;
+          }
+
+          inputs.push({
+            type: 'message.output',
+            role: 'assistant',
+            content: [{ type: 'text', text }],
+          });
+          text = '';
+        };
+
+        for (const part of message.content) {
+          switch (part.type) {
+            case 'text':
+            case 'reasoning':
+              text += part.text;
+              break;
+
+            case 'tool-call': {
+              flushText();
+
+              if (part.providerExecuted) {
+                const output = providerToolResults.get(part.toolCallId);
+                inputs.push({
+                  type: 'tool.execution',
+                  id: part.toolCallId,
+                  name: toolNameMapping.toProviderToolName(part.toolName),
+                  arguments: JSON.stringify(part.input),
+                  info: getToolExecutionInfo(output),
+                });
+              } else {
+                inputs.push({
+                  type: 'function.call',
+                  tool_call_id: part.toolCallId,
+                  name: part.toolName,
+                  arguments: JSON.stringify(part.input),
+                });
+              }
+              break;
+            }
+
+            case 'tool-result':
+              if (!providerExecutedToolCallIds.has(part.toolCallId)) {
+                inputs.push({
+                  type: 'function.result',
+                  tool_call_id: part.toolCallId,
+                  result: stringifyToolResult(part.output),
+                });
+              }
+              break;
+
+            case 'file':
+            case 'reasoning-file':
+            case 'custom':
+              throw new UnsupportedFunctionalityError({
+                functionality: `${part.type} parts in assistant messages`,
+              });
+          }
+        }
+
+        flushText();
+        break;
+      }
+
+      case 'tool':
+        for (const part of message.content) {
+          if (part.type === 'tool-approval-response') {
+            continue;
+          }
+
+          inputs.push({
+            type: 'function.result',
+            tool_call_id: part.toolCallId,
+            result: stringifyToolResult(part.output),
+          });
+        }
+        break;
+    }
+  }
+
+  return {
+    inputs,
+    instructions:
+      instructions.length > 0 ? instructions.join('\n\n') : undefined,
+  };
+}
+
+function stringifyToolResult(output: LanguageModelV4ToolResultOutput): string {
+  switch (output.type) {
+    case 'text':
+    case 'error-text':
+      return output.value;
+    case 'execution-denied':
+      return output.reason ?? 'Tool call execution denied.';
+    case 'content':
+    case 'json':
+    case 'error-json':
+      return JSON.stringify(output.value);
+  }
+}
+
+function getToolExecutionInfo(
+  output: LanguageModelV4ToolResultOutput | undefined,
+): Record<string, unknown> | undefined {
+  if (output?.type !== 'json') {
+    return undefined;
+  }
+
+  const value = output.value;
+  if (
+    value != null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    'info' in value &&
+    value.info != null &&
+    typeof value.info === 'object' &&
+    !Array.isArray(value.info)
+  ) {
+    return value.info as Record<string, unknown>;
+  }
+
+  return undefined;
+}

--- a/packages/mistral/src/conversations/mistral-conversations-language-model-options.ts
+++ b/packages/mistral/src/conversations/mistral-conversations-language-model-options.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod/v4';
+
+export const mistralLanguageModelConversationsOptions = z.object({
+  /**
+   * Whether Mistral should persist the conversation.
+   *
+   * Set to `false` to create a non-persistent conversation.
+   */
+  store: z.boolean().optional(),
+});
+
+export type MistralLanguageModelConversationsOptions = z.infer<
+  typeof mistralLanguageModelConversationsOptions
+>;

--- a/packages/mistral/src/conversations/mistral-conversations-language-model.test.ts
+++ b/packages/mistral/src/conversations/mistral-conversations-language-model.test.ts
@@ -1,0 +1,633 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createMistral } from '../mistral-provider';
+
+vi.mock('../version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const CONVERSATIONS_URL = 'https://api.mistral.ai/v1/conversations';
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'system', content: 'Use web search for current information.' },
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'What is the latest Node.js release?' }],
+  },
+];
+
+const provider = createMistral({
+  apiKey: 'test-api-key',
+  generateId: () => 'source-id',
+});
+const model = provider.conversations('mistral-small-latest');
+
+const server = createTestServer({
+  [CONVERSATIONS_URL]: {},
+});
+
+describe('doGenerate', () => {
+  it('should send web search tools to the Conversations API', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+      ],
+      temperature: 0.3,
+      providerOptions: {
+        mistral: {
+          store: false,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'mistral-small-latest',
+      inputs: [
+        {
+          type: 'message.input',
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is the latest Node.js release?' },
+          ],
+        },
+      ],
+      instructions: 'Use web search for current information.',
+      tools: [{ type: 'web_search' }],
+      completion_args: {
+        temperature: 0.3,
+      },
+      store: false,
+    });
+  });
+
+  it('should extract provider-executed tools, text, sources, usage, and metadata', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+      ],
+    });
+
+    expect(result.content).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{"query":"latest Node.js release"}",
+          "providerExecuted": true,
+          "toolCallId": "tool-exec-1",
+          "toolName": "search",
+          "type": "tool-call",
+        },
+        {
+          "result": {
+            "info": {
+              "result": "search results",
+            },
+          },
+          "toolCallId": "tool-exec-1",
+          "toolName": "search",
+          "type": "tool-result",
+        },
+        {
+          "providerMetadata": {
+            "mistral": {
+              "entryId": "message-1",
+            },
+          },
+          "text": "Node.js 26.5.0 is current",
+          "type": "text",
+        },
+        {
+          "id": "source-id",
+          "providerMetadata": {
+            "mistral": {
+              "description": "Release announcement",
+              "favicon": "https://nodejs.org/favicon.ico",
+              "tool": "web_search",
+            },
+          },
+          "sourceType": "url",
+          "title": "Node.js 26.5.0",
+          "type": "source",
+          "url": "https://nodejs.org/en/blog/release/v26.5.0",
+        },
+        {
+          "providerMetadata": {
+            "mistral": {
+              "entryId": "message-1",
+            },
+          },
+          "text": ".",
+          "type": "text",
+        },
+      ]
+    `);
+    expect(result.finishReason).toStrictEqual({
+      unified: 'stop',
+      raw: 'stop',
+    });
+    expect(result.usage).toMatchInlineSnapshot(`
+      {
+        "inputTokens": {
+          "cacheRead": undefined,
+          "cacheWrite": undefined,
+          "noCache": 12,
+          "total": 12,
+        },
+        "outputTokens": {
+          "reasoning": undefined,
+          "text": 8,
+          "total": 8,
+        },
+        "raw": {
+          "completion_tokens": 8,
+          "connector_tokens": 100,
+          "connectors": {
+            "web_search": 1,
+          },
+          "prompt_tokens": 12,
+          "total_tokens": 120,
+        },
+      }
+    `);
+    expect(result.providerMetadata).toStrictEqual({
+      mistral: {
+        conversationId: 'conversation-1',
+      },
+    });
+    expect(result.response).toMatchObject({
+      id: 'conversation-1',
+      modelId: 'mistral-small-latest',
+      timestamp: new Date('2026-07-15T10:00:00.000Z'),
+    });
+  });
+
+  it('should serialize premium web search', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search_premium',
+          name: 'premiumSearch',
+          args: {},
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      tools: [{ type: 'web_search_premium' }],
+    });
+  });
+
+  it('should warn and omit required tool choice for built-in tools', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+      ],
+      toolChoice: { type: 'required' },
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'required tool choice with Mistral built-in tools',
+      details:
+        "Mistral's Conversations API does not allow tool_choice 'required' when built-in tools are present.",
+    });
+    expect(
+      (await server.calls[0].requestBodyJson).completion_args,
+    ).toBeUndefined();
+  });
+
+  it('should support mixed function and built-in tools', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+        {
+          type: 'function',
+          name: 'weather',
+          description: 'Get the weather',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+          },
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      tools: [
+        { type: 'web_search' },
+        {
+          type: 'function',
+          function: {
+            name: 'weather',
+            description: 'Get the weather',
+            parameters: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it('should extract client-executed function calls', async () => {
+    server.urls[CONVERSATIONS_URL].response = {
+      type: 'json-value',
+      body: {
+        object: 'conversation.response',
+        conversation_id: 'conversation-1',
+        outputs: [
+          {
+            type: 'function.call',
+            id: 'function-call-entry-1',
+            tool_call_id: 'tool-call-1',
+            name: 'weather',
+            arguments: '{"city":"Paris"}',
+            created_at: '2026-07-15T10:00:00.000Z',
+            model: 'mistral-small-latest',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+        },
+      },
+    };
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'weather',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+          },
+        },
+      ],
+    });
+
+    expect(result.content).toStrictEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'tool-call-1',
+        toolName: 'weather',
+        input: '{"city":"Paris"}',
+      },
+    ]);
+    expect(result.finishReason).toStrictEqual({
+      unified: 'tool-calls',
+      raw: 'tool_calls',
+    });
+  });
+
+  it('should replay provider-executed tool calls as conversation entries', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tool-exec-previous',
+              toolName: 'search',
+              input: { query: 'previous query' },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'tool-exec-previous',
+              toolName: 'search',
+              output: {
+                type: 'json',
+                value: { info: { result: 'previous search results' } },
+              },
+            },
+            { type: 'text', text: 'Previous answer.' },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Tell me more.' }],
+        },
+      ],
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      inputs: [
+        {
+          type: 'tool.execution',
+          id: 'tool-exec-previous',
+          name: 'web_search',
+          arguments: '{"query":"previous query"}',
+          info: { result: 'previous search results' },
+        },
+        {
+          type: 'message.output',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Previous answer.' }],
+        },
+        {
+          type: 'message.input',
+          role: 'user',
+          content: [{ type: 'text', text: 'Tell me more.' }],
+        },
+      ],
+    });
+  });
+});
+
+describe('doStream', () => {
+  it('should stream provider-executed tool calls, results, sources, and metadata', async () => {
+    server.urls[CONVERSATIONS_URL].response = {
+      type: 'stream-chunks',
+      chunks: [
+        eventChunk('conversation.response.started', {
+          type: 'conversation.response.started',
+          created_at: '2026-07-15T10:00:00.000Z',
+          conversation_id: 'conversation-1',
+        }),
+        eventChunk('tool.execution.started', {
+          type: 'tool.execution.started',
+          id: 'tool-exec-1',
+          name: 'web_search',
+          arguments: '',
+        }),
+        eventChunk('tool.execution.delta', {
+          type: 'tool.execution.delta',
+          id: 'tool-exec-1',
+          name: 'web_search',
+          arguments: '{"query":"Node.js',
+        }),
+        eventChunk('tool.execution.delta', {
+          type: 'tool.execution.delta',
+          id: 'tool-exec-1',
+          name: 'web_search',
+          arguments: ' release"}',
+        }),
+        eventChunk('tool.execution.done', {
+          type: 'tool.execution.done',
+          id: 'tool-exec-1',
+          name: 'web_search',
+          info: { result: 'search results' },
+        }),
+        eventChunk('message.output.delta', {
+          type: 'message.output.delta',
+          id: 'message-1',
+          content: 'Node.js 26.5.0',
+        }),
+        eventChunk('message.output.delta', {
+          type: 'message.output.delta',
+          id: 'message-1',
+          content: {
+            type: 'tool_reference',
+            tool: 'web_search',
+            title: 'Node.js 26.5.0',
+            url: 'https://nodejs.org/en/blog/release/v26.5.0',
+            favicon: null,
+            description: null,
+          },
+        }),
+        eventChunk('conversation.response.done', {
+          type: 'conversation.response.done',
+          usage: {
+            prompt_tokens: 12,
+            completion_tokens: 8,
+            total_tokens: 120,
+            connector_tokens: 100,
+            connectors: { web_search: 1 },
+          },
+        }),
+      ],
+    };
+
+    const result = await model.doStream({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+      ],
+    });
+
+    expect(await convertReadableStreamToArray(result.stream))
+      .toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "conversation-1",
+          "modelId": "mistral-small-latest",
+          "timestamp": 2026-07-15T10:00:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "tool-exec-1",
+          "providerExecuted": true,
+          "toolName": "search",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"query":"Node.js",
+          "id": "tool-exec-1",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": " release"}",
+          "id": "tool-exec-1",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "tool-exec-1",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"query":"Node.js release"}",
+          "providerExecuted": true,
+          "toolCallId": "tool-exec-1",
+          "toolName": "search",
+          "type": "tool-call",
+        },
+        {
+          "result": {
+            "info": {
+              "result": "search results",
+            },
+          },
+          "toolCallId": "tool-exec-1",
+          "toolName": "search",
+          "type": "tool-result",
+        },
+        {
+          "id": "message-1",
+          "type": "text-start",
+        },
+        {
+          "delta": "Node.js 26.5.0",
+          "id": "message-1",
+          "type": "text-delta",
+        },
+        {
+          "id": "source-id",
+          "providerMetadata": {
+            "mistral": {
+              "description": null,
+              "favicon": null,
+              "tool": "web_search",
+            },
+          },
+          "sourceType": "url",
+          "title": "Node.js 26.5.0",
+          "type": "source",
+          "url": "https://nodejs.org/en/blog/release/v26.5.0",
+        },
+        {
+          "id": "message-1",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "mistral": {
+              "conversationId": "conversation-1",
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": undefined,
+              "cacheWrite": undefined,
+              "noCache": 12,
+              "total": 12,
+            },
+            "outputTokens": {
+              "reasoning": undefined,
+              "text": 8,
+              "total": 8,
+            },
+            "raw": {
+              "completion_tokens": 8,
+              "connector_tokens": 100,
+              "connectors": {
+                "web_search": 1,
+              },
+              "prompt_tokens": 12,
+              "total_tokens": 120,
+            },
+          },
+        },
+      ]
+      `);
+  });
+});
+
+function prepareJsonResponse() {
+  server.urls[CONVERSATIONS_URL].response = {
+    type: 'json-value',
+    body: {
+      object: 'conversation.response',
+      conversation_id: 'conversation-1',
+      outputs: [
+        {
+          object: 'entry',
+          type: 'tool.execution',
+          id: 'tool-exec-1',
+          name: 'web_search',
+          arguments: '{"query":"latest Node.js release"}',
+          info: { result: 'search results' },
+          created_at: '2026-07-15T10:00:00.000Z',
+          model: 'mistral-small-latest',
+        },
+        {
+          object: 'entry',
+          type: 'message.output',
+          id: 'message-1',
+          content: [
+            { type: 'text', text: 'Node.js 26.5.0 is current' },
+            {
+              type: 'tool_reference',
+              tool: 'web_search',
+              title: 'Node.js 26.5.0',
+              url: 'https://nodejs.org/en/blog/release/v26.5.0',
+              favicon: 'https://nodejs.org/favicon.ico',
+              description: 'Release announcement',
+            },
+            { type: 'text', text: '.' },
+          ],
+          created_at: '2026-07-15T10:00:01.000Z',
+          model: 'mistral-small-latest',
+        },
+      ],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 8,
+        total_tokens: 120,
+        connector_tokens: 100,
+        connectors: { web_search: 1 },
+      },
+    },
+  };
+}
+
+function eventChunk(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}

--- a/packages/mistral/src/conversations/mistral-conversations-language-model.ts
+++ b/packages/mistral/src/conversations/mistral-conversations-language-model.ts
@@ -1,0 +1,865 @@
+import type {
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createEventSourceResponseHandler,
+  createJsonResponseHandler,
+  createToolNameMapping,
+  generateId,
+  injectJsonInstructionIntoMessages,
+  isCustomReasoning,
+  mapReasoningToProviderEffort,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type ParseResult,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  convertMistralUsage,
+  type MistralUsage,
+} from '../convert-mistral-usage';
+import type { MistralChatModelId } from '../mistral-chat-language-model-options';
+import { mistralFailedResponseHandler } from '../mistral-error';
+import { convertToMistralConversationInput } from './convert-to-mistral-conversation-input';
+import { mistralLanguageModelConversationsOptions } from './mistral-conversations-language-model-options';
+import { prepareConversationTools } from './mistral-conversations-prepare-tools';
+
+type MistralConversationsConfig = {
+  provider: string;
+  baseURL: string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  generateId?: () => string;
+};
+
+const providerToolNames = {
+  'mistral.web_search': 'web_search',
+  'mistral.web_search_premium': 'web_search_premium',
+} as const;
+
+export class MistralConversationsLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: MistralChatModelId;
+
+  private readonly config: MistralConversationsConfig;
+  private readonly generateId: () => string;
+
+  static [WORKFLOW_SERIALIZE](model: MistralConversationsLanguageModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: MistralChatModelId;
+    config: MistralConversationsConfig;
+  }) {
+    return new MistralConversationsLanguageModel(
+      options.modelId,
+      options.config,
+    );
+  }
+
+  constructor(modelId: MistralChatModelId, config: MistralConversationsConfig) {
+    this.modelId = modelId;
+    this.config = config;
+    this.generateId = config.generateId ?? generateId;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    'application/pdf': [/^https:\/\/.*$/],
+  };
+
+  private async getArgs({
+    prompt,
+    maxOutputTokens,
+    temperature,
+    topP,
+    topK,
+    frequencyPenalty,
+    presencePenalty,
+    reasoning,
+    stopSequences,
+    responseFormat,
+    seed,
+    providerOptions,
+    tools,
+    toolChoice,
+  }: LanguageModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
+
+    const options =
+      (await parseProviderOptions({
+        provider: 'mistral',
+        providerOptions,
+        schema: mistralLanguageModelConversationsOptions,
+      })) ?? {};
+
+    if (topK != null) {
+      warnings.push({ type: 'unsupported', feature: 'topK' });
+    }
+
+    let reasoningEffort: 'high' | 'none' | undefined;
+    if (isCustomReasoning(reasoning)) {
+      reasoningEffort =
+        reasoning === 'none'
+          ? 'none'
+          : mapReasoningToProviderEffort({
+              reasoning,
+              effortMap: {
+                minimal: 'high',
+                low: 'high',
+                medium: 'high',
+                high: 'high',
+                xhigh: 'high',
+              },
+              warnings,
+            });
+    }
+
+    if (responseFormat?.type === 'json' && responseFormat.schema == null) {
+      prompt = injectJsonInstructionIntoMessages({
+        messages: prompt,
+        schema: responseFormat.schema,
+      });
+    }
+
+    const toolNameMapping = createToolNameMapping({
+      tools,
+      providerToolNames,
+    });
+
+    const {
+      tools: mistralTools,
+      toolChoice: mistralToolChoice,
+      toolWarnings,
+    } = prepareConversationTools({
+      tools,
+      toolChoice:
+        toolChoice?.type === 'tool'
+          ? {
+              ...toolChoice,
+              toolName: toolNameMapping.toProviderToolName(toolChoice.toolName),
+            }
+          : toolChoice,
+    });
+
+    const { inputs, instructions } = convertToMistralConversationInput({
+      prompt,
+      toolNameMapping,
+    });
+
+    const completionArgs = {
+      max_tokens: maxOutputTokens,
+      temperature,
+      top_p: topP,
+      ...(frequencyPenalty != null
+        ? { frequency_penalty: frequencyPenalty }
+        : {}),
+      ...(presencePenalty != null ? { presence_penalty: presencePenalty } : {}),
+      stop: stopSequences,
+      random_seed: seed,
+      reasoning_effort: reasoningEffort,
+      response_format:
+        responseFormat?.type === 'json'
+          ? responseFormat.schema != null
+            ? {
+                type: 'json_schema',
+                json_schema: {
+                  schema: responseFormat.schema,
+                  name: responseFormat.name ?? 'response',
+                  description: responseFormat.description,
+                },
+              }
+            : { type: 'json_object' }
+          : undefined,
+      tool_choice: mistralToolChoice,
+    };
+
+    return {
+      args: {
+        model: this.modelId,
+        inputs,
+        instructions,
+        tools: mistralTools,
+        completion_args: hasDefinedValue(completionArgs)
+          ? completionArgs
+          : undefined,
+        store: options.store,
+      },
+      warnings: [...warnings, ...toolWarnings],
+      toolNameMapping,
+    };
+  }
+
+  async doGenerate(
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
+    const {
+      args: body,
+      warnings,
+      toolNameMapping,
+    } = await this.getArgs(options);
+
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/conversations`,
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body,
+      failedResponseHandler: mistralFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        mistralConversationResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const content: LanguageModelV4Content[] = [];
+    let hasFunctionCall = false;
+
+    for (const output of response.outputs) {
+      switch (output.type) {
+        case 'tool.execution': {
+          const toolName = toolNameMapping.toCustomToolName(output.name);
+
+          content.push({
+            type: 'tool-call',
+            toolCallId: output.id,
+            toolName,
+            input: output.arguments,
+            providerExecuted: true,
+          });
+          content.push({
+            type: 'tool-result',
+            toolCallId: output.id,
+            toolName,
+            result: { info: output.info },
+          });
+          break;
+        }
+
+        case 'function.call':
+          hasFunctionCall = true;
+          content.push({
+            type: 'tool-call',
+            toolCallId: output.tool_call_id,
+            toolName: output.name,
+            input:
+              typeof output.arguments === 'string'
+                ? output.arguments
+                : JSON.stringify(output.arguments),
+          });
+          break;
+
+        case 'message.output':
+          addMessageOutputContent({
+            content,
+            messageContent: output.content,
+            generateId: this.generateId,
+            entryId: output.id,
+          });
+          break;
+      }
+    }
+
+    const firstOutput = response.outputs[0];
+
+    return {
+      content,
+      finishReason: hasFunctionCall
+        ? { unified: 'tool-calls', raw: 'tool_calls' }
+        : { unified: 'stop', raw: 'stop' },
+      usage: convertMistralUsage(response.usage),
+      providerMetadata: {
+        mistral: {
+          conversationId: response.conversation_id,
+        },
+      },
+      request: { body },
+      response: {
+        id: response.conversation_id,
+        timestamp:
+          firstOutput?.created_at != null
+            ? new Date(firstOutput.created_at)
+            : undefined,
+        modelId: firstOutput?.model ?? this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      warnings,
+    };
+  }
+
+  async doStream(
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
+    const { args, warnings, toolNameMapping } = await this.getArgs(options);
+    const body = { ...args, stream: true };
+
+    const { responseHeaders, value: response } = await postJsonToApi({
+      url: `${this.config.baseURL}/conversations`,
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body,
+      failedResponseHandler: mistralFailedResponseHandler,
+      successfulResponseHandler: createEventSourceResponseHandler(
+        mistralConversationEventSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const generateId = this.generateId;
+    const modelId = this.modelId;
+    let conversationId: string | undefined;
+    let finishEmitted = false;
+    let activeTextId: string | undefined;
+    let activeReasoningId: string | undefined;
+    let finishReason: LanguageModelV4FinishReason = {
+      unified: 'stop',
+      raw: 'stop',
+    };
+    let usage: MistralUsage | undefined;
+    const toolCalls = new Map<
+      string,
+      { toolName: string; input: string; providerExecuted: boolean }
+    >();
+
+    return {
+      stream: response.pipeThrough(
+        new TransformStream<
+          ParseResult<z.infer<typeof mistralConversationEventSchema>>,
+          LanguageModelV4StreamPart
+        >({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
+          transform(chunk, controller) {
+            if (options.includeRawChunks) {
+              controller.enqueue({ type: 'raw', rawValue: chunk.rawValue });
+            }
+
+            if (!chunk.success) {
+              controller.enqueue({ type: 'error', error: chunk.error });
+              return;
+            }
+
+            const event = chunk.value;
+
+            switch (event.type) {
+              case 'conversation.response.started':
+                conversationId = event.conversation_id;
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: event.conversation_id,
+                  timestamp:
+                    event.created_at != null
+                      ? new Date(event.created_at)
+                      : undefined,
+                  modelId,
+                });
+                break;
+
+              case 'tool.execution.started': {
+                const toolName = toolNameMapping.toCustomToolName(event.name);
+                toolCalls.set(event.id, {
+                  toolName,
+                  input: event.arguments,
+                  providerExecuted: true,
+                });
+                controller.enqueue({
+                  type: 'tool-input-start',
+                  id: event.id,
+                  toolName,
+                  providerExecuted: true,
+                });
+                if (event.arguments.length > 0) {
+                  controller.enqueue({
+                    type: 'tool-input-delta',
+                    id: event.id,
+                    delta: event.arguments,
+                  });
+                }
+                break;
+              }
+
+              case 'tool.execution.delta': {
+                const toolCall = toolCalls.get(event.id);
+                if (toolCall != null) {
+                  toolCall.input += event.arguments;
+                }
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: event.id,
+                  delta: event.arguments,
+                });
+                break;
+              }
+
+              case 'tool.execution.done': {
+                const toolCall = toolCalls.get(event.id);
+                const toolName =
+                  toolCall?.toolName ??
+                  toolNameMapping.toCustomToolName(event.name);
+                const input = toolCall?.input ?? '{}';
+
+                controller.enqueue({ type: 'tool-input-end', id: event.id });
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: event.id,
+                  toolName,
+                  input,
+                  providerExecuted: true,
+                });
+                controller.enqueue({
+                  type: 'tool-result',
+                  toolCallId: event.id,
+                  toolName,
+                  result: { info: event.info },
+                });
+                toolCalls.delete(event.id);
+                break;
+              }
+
+              case 'function.call.delta': {
+                finishReason = { unified: 'tool-calls', raw: 'tool_calls' };
+                let toolCall = toolCalls.get(event.tool_call_id);
+
+                if (toolCall == null) {
+                  toolCall = {
+                    toolName: event.name,
+                    input: '',
+                    providerExecuted: false,
+                  };
+                  toolCalls.set(event.tool_call_id, toolCall);
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    id: event.tool_call_id,
+                    toolName: event.name,
+                  });
+                }
+
+                const delta =
+                  typeof event.arguments === 'string'
+                    ? event.arguments
+                    : JSON.stringify(event.arguments);
+                toolCall.input += delta;
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: event.tool_call_id,
+                  delta,
+                });
+                break;
+              }
+
+              case 'message.output.delta': {
+                const eventContent = event.content;
+
+                if (typeof eventContent === 'string') {
+                  activeTextId = emitTextDelta({
+                    controller,
+                    activeTextId,
+                    textId: event.id,
+                    delta: eventContent,
+                  });
+                } else {
+                  switch (eventContent.type) {
+                    case 'text':
+                      activeTextId = emitTextDelta({
+                        controller,
+                        activeTextId,
+                        textId: event.id,
+                        delta: eventContent.text,
+                      });
+                      break;
+                    case 'tool_reference':
+                      if (eventContent.url != null) {
+                        controller.enqueue({
+                          type: 'source',
+                          sourceType: 'url',
+                          id: generateId(),
+                          url: eventContent.url,
+                          title: eventContent.title,
+                          providerMetadata: {
+                            mistral: {
+                              tool: eventContent.tool,
+                              favicon: eventContent.favicon,
+                              description: eventContent.description,
+                            },
+                          },
+                        });
+                      }
+                      break;
+                    case 'thinking': {
+                      const reasoningText = getThinkingText(eventContent);
+                      if (reasoningText.length > 0) {
+                        if (activeReasoningId == null) {
+                          activeReasoningId = generateId();
+                          controller.enqueue({
+                            type: 'reasoning-start',
+                            id: activeReasoningId,
+                          });
+                        }
+                        controller.enqueue({
+                          type: 'reasoning-delta',
+                          id: activeReasoningId,
+                          delta: reasoningText,
+                        });
+                      }
+                      break;
+                    }
+                    case 'image_url':
+                    case 'document_url':
+                    case 'tool_file':
+                      break;
+                  }
+                }
+                break;
+              }
+
+              case 'conversation.response.error':
+                controller.enqueue({
+                  type: 'error',
+                  error: new Error(event.message),
+                });
+                break;
+
+              case 'conversation.response.done':
+                usage = event.usage;
+                closeActiveParts(controller);
+                emitPendingFunctionCalls(controller);
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason,
+                  usage: convertMistralUsage(usage),
+                  providerMetadata:
+                    conversationId != null
+                      ? { mistral: { conversationId } }
+                      : undefined,
+                });
+                finishEmitted = true;
+                break;
+            }
+          },
+
+          flush(controller) {
+            if (finishEmitted) {
+              return;
+            }
+
+            closeActiveParts(controller);
+            emitPendingFunctionCalls(controller);
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: convertMistralUsage(usage),
+              providerMetadata:
+                conversationId != null
+                  ? { mistral: { conversationId } }
+                  : undefined,
+            });
+          },
+        }),
+      ),
+      request: { body },
+      response: { headers: responseHeaders },
+    };
+
+    function closeActiveParts(
+      controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
+    ) {
+      if (activeTextId != null) {
+        controller.enqueue({ type: 'text-end', id: activeTextId });
+        activeTextId = undefined;
+      }
+      if (activeReasoningId != null) {
+        controller.enqueue({
+          type: 'reasoning-end',
+          id: activeReasoningId,
+        });
+        activeReasoningId = undefined;
+      }
+    }
+
+    function emitPendingFunctionCalls(
+      controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
+    ) {
+      for (const [toolCallId, toolCall] of toolCalls) {
+        if (toolCall.providerExecuted) {
+          continue;
+        }
+        controller.enqueue({ type: 'tool-input-end', id: toolCallId });
+        controller.enqueue({
+          type: 'tool-call',
+          toolCallId,
+          toolName: toolCall.toolName,
+          input: toolCall.input,
+        });
+      }
+      toolCalls.clear();
+    }
+  }
+}
+
+function hasDefinedValue(record: Record<string, unknown>): boolean {
+  return Object.values(record).some(value => value !== undefined);
+}
+
+function emitTextDelta({
+  controller,
+  activeTextId,
+  textId,
+  delta,
+}: {
+  controller: TransformStreamDefaultController<LanguageModelV4StreamPart>;
+  activeTextId: string | undefined;
+  textId: string;
+  delta: string;
+}): string {
+  if (activeTextId == null) {
+    controller.enqueue({ type: 'text-start', id: textId });
+    activeTextId = textId;
+  }
+  controller.enqueue({ type: 'text-delta', id: activeTextId, delta });
+  return activeTextId;
+}
+
+function addMessageOutputContent({
+  content,
+  messageContent,
+  generateId,
+  entryId,
+}: {
+  content: LanguageModelV4Content[];
+  messageContent: z.infer<typeof mistralMessageOutputContentSchema>;
+  generateId: () => string;
+  entryId: string;
+}) {
+  if (typeof messageContent === 'string') {
+    if (messageContent.length > 0) {
+      content.push({
+        type: 'text',
+        text: messageContent,
+        providerMetadata: { mistral: { entryId } },
+      });
+    }
+    return;
+  }
+
+  for (const part of messageContent) {
+    switch (part.type) {
+      case 'text':
+        if (part.text.length > 0) {
+          content.push({
+            type: 'text',
+            text: part.text,
+            providerMetadata: { mistral: { entryId } },
+          });
+        }
+        break;
+      case 'tool_reference':
+        if (part.url != null) {
+          content.push({
+            type: 'source',
+            sourceType: 'url',
+            id: generateId(),
+            url: part.url,
+            title: part.title,
+            providerMetadata: {
+              mistral: {
+                tool: part.tool,
+                favicon: part.favicon,
+                description: part.description,
+              },
+            },
+          });
+        }
+        break;
+      case 'thinking': {
+        const reasoningText = getThinkingText(part);
+        if (reasoningText.length > 0) {
+          content.push({ type: 'reasoning', text: reasoningText });
+        }
+        break;
+      }
+      case 'image_url':
+      case 'document_url':
+      case 'tool_file':
+        break;
+    }
+  }
+}
+
+function getThinkingText(
+  part: Extract<
+    z.infer<typeof mistralOutputContentPartSchema>,
+    { type: 'thinking' }
+  >,
+) {
+  return part.thinking
+    .filter(
+      (item): item is Extract<typeof item, { type: 'text' }> =>
+        item.type === 'text',
+    )
+    .map(item => item.text)
+    .join('');
+}
+
+const mistralJsonRecordSchema = z.record(z.string(), z.json());
+
+const mistralToolReferenceSchema = z.object({
+  type: z.literal('tool_reference'),
+  tool: z.string(),
+  title: z.string(),
+  url: z.string().nullish(),
+  favicon: z.string().nullish(),
+  description: z.string().nullish(),
+});
+
+const mistralThinkingSchema = z.object({
+  type: z.literal('thinking'),
+  thinking: z.array(
+    z.discriminatedUnion('type', [
+      z.object({ type: z.literal('text'), text: z.string() }),
+      mistralToolReferenceSchema,
+      z.object({
+        type: z.literal('reference'),
+        reference_ids: z.array(z.union([z.string(), z.number()])),
+      }),
+    ]),
+  ),
+});
+
+const mistralOutputContentPartSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('text'), text: z.string() }),
+  mistralToolReferenceSchema,
+  mistralThinkingSchema,
+  z.object({
+    type: z.literal('image_url'),
+    image_url: z.union([z.string(), mistralJsonRecordSchema]),
+  }),
+  z.object({
+    type: z.literal('document_url'),
+    document_url: z.string(),
+  }),
+  z.object({
+    type: z.literal('tool_file'),
+    file_id: z.string().nullish(),
+    file_name: z.string().nullish(),
+  }),
+]);
+
+const mistralMessageOutputContentSchema = z.union([
+  z.string(),
+  z.array(mistralOutputContentPartSchema),
+]);
+
+const mistralConversationUsageSchema = z.object({
+  prompt_tokens: z.number(),
+  completion_tokens: z.number(),
+  total_tokens: z.number(),
+  connector_tokens: z.number().nullish(),
+  connectors: z.record(z.string(), z.number()).nullish(),
+});
+
+const mistralConversationOutputSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('tool.execution'),
+    id: z.string(),
+    name: z.string(),
+    arguments: z.string(),
+    info: mistralJsonRecordSchema.optional(),
+    created_at: z.string().nullish(),
+    model: z.string().nullish(),
+  }),
+  z.object({
+    type: z.literal('function.call'),
+    id: z.string().nullish(),
+    tool_call_id: z.string(),
+    name: z.string(),
+    arguments: z.union([z.string(), mistralJsonRecordSchema]),
+    created_at: z.string().nullish(),
+    model: z.string().nullish(),
+  }),
+  z.object({
+    type: z.literal('message.output'),
+    id: z.string(),
+    content: mistralMessageOutputContentSchema,
+    created_at: z.string().nullish(),
+    model: z.string().nullish(),
+  }),
+]);
+
+const mistralConversationResponseSchema = z.object({
+  object: z.literal('conversation.response'),
+  conversation_id: z.string(),
+  outputs: z.array(mistralConversationOutputSchema),
+  usage: mistralConversationUsageSchema,
+});
+
+const mistralConversationEventSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('conversation.response.started'),
+    created_at: z.string().nullish(),
+    conversation_id: z.string(),
+  }),
+  z.object({
+    type: z.literal('tool.execution.started'),
+    id: z.string(),
+    name: z.string(),
+    arguments: z.string(),
+  }),
+  z.object({
+    type: z.literal('tool.execution.delta'),
+    id: z.string(),
+    name: z.string(),
+    arguments: z.string(),
+  }),
+  z.object({
+    type: z.literal('tool.execution.done'),
+    id: z.string(),
+    name: z.string(),
+    info: mistralJsonRecordSchema.optional(),
+  }),
+  z.object({
+    type: z.literal('function.call.delta'),
+    id: z.string(),
+    tool_call_id: z.string(),
+    name: z.string(),
+    arguments: z.union([z.string(), mistralJsonRecordSchema]),
+  }),
+  z.object({
+    type: z.literal('message.output.delta'),
+    id: z.string(),
+    content: z.union([z.string(), mistralOutputContentPartSchema]),
+  }),
+  z.object({
+    type: z.literal('conversation.response.error'),
+    message: z.string(),
+    code: z.number(),
+  }),
+  z.object({
+    type: z.literal('conversation.response.done'),
+    usage: mistralConversationUsageSchema,
+  }),
+]);

--- a/packages/mistral/src/conversations/mistral-conversations-prepare-tools.ts
+++ b/packages/mistral/src/conversations/mistral-conversations-prepare-tools.ts
@@ -1,0 +1,131 @@
+import type {
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+
+export type MistralConversationTool =
+  | {
+      type: 'function';
+      function: {
+        name: string;
+        description: string | undefined;
+        parameters: unknown;
+        strict?: boolean;
+      };
+    }
+  | { type: 'web_search' }
+  | { type: 'web_search_premium' };
+
+export function prepareConversationTools({
+  tools,
+  toolChoice,
+}: {
+  tools: LanguageModelV4CallOptions['tools'];
+  toolChoice?: LanguageModelV4CallOptions['toolChoice'];
+}): {
+  tools: MistralConversationTool[] | undefined;
+  toolChoice: 'auto' | 'none' | 'required' | undefined;
+  toolWarnings: SharedV4Warning[];
+} {
+  tools = tools?.length ? tools : undefined;
+
+  const toolWarnings: SharedV4Warning[] = [];
+
+  if (tools == null) {
+    return { tools: undefined, toolChoice: undefined, toolWarnings };
+  }
+
+  const mistralTools: MistralConversationTool[] = [];
+
+  for (const tool of tools) {
+    if (tool.type === 'function') {
+      mistralTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.inputSchema,
+          ...(tool.strict != null ? { strict: tool.strict } : {}),
+        },
+      });
+      continue;
+    }
+
+    switch (tool.id) {
+      case 'mistral.web_search':
+        mistralTools.push({ type: 'web_search' });
+        break;
+      case 'mistral.web_search_premium':
+        mistralTools.push({ type: 'web_search_premium' });
+        break;
+      default:
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `provider-defined tool ${tool.id}`,
+        });
+    }
+  }
+
+  if (toolChoice == null) {
+    return { tools: mistralTools, toolChoice: undefined, toolWarnings };
+  }
+
+  const hasBuiltInTool = mistralTools.some(tool => tool.type !== 'function');
+
+  switch (toolChoice.type) {
+    case 'auto':
+    case 'none':
+      return {
+        tools: mistralTools,
+        toolChoice: toolChoice.type,
+        toolWarnings,
+      };
+
+    case 'required':
+      if (hasBuiltInTool) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: 'required tool choice with Mistral built-in tools',
+          details:
+            "Mistral's Conversations API does not allow tool_choice 'required' when built-in tools are present.",
+        });
+        return { tools: mistralTools, toolChoice: undefined, toolWarnings };
+      }
+
+      return { tools: mistralTools, toolChoice: 'required', toolWarnings };
+
+    case 'tool': {
+      const selectedTools = mistralTools.filter(
+        tool =>
+          (tool.type === 'function'
+            ? tool.function.name
+            : tool.type === 'web_search'
+              ? 'web_search'
+              : 'web_search_premium') === toolChoice.toolName,
+      );
+      const selectedBuiltInTool = selectedTools.some(
+        tool => tool.type !== 'function',
+      );
+
+      if (selectedBuiltInTool) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `forcing Mistral built-in tool ${toolChoice.toolName}`,
+          details:
+            "Mistral's Conversations API does not support forcing a built-in tool.",
+        });
+        return {
+          tools: selectedTools,
+          toolChoice: undefined,
+          toolWarnings,
+        };
+      }
+
+      return {
+        tools: selectedTools,
+        toolChoice: 'required',
+        toolWarnings,
+      };
+    }
+  }
+}

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -8,6 +8,7 @@ export type {
   /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
   MistralLanguageModelChatOptions as MistralLanguageModelOptions,
 } from './mistral-chat-language-model-options';
+export type { MistralLanguageModelConversationsOptions } from './conversations/mistral-conversations-language-model-options';
 export type { MistralEmbeddingModelOptions } from './mistral-embedding-model-options';
 export type {
   MistralSpeechModelId,

--- a/packages/mistral/src/mistral-prepare-tools.test.ts
+++ b/packages/mistral/src/mistral-prepare-tools.test.ts
@@ -2,6 +2,30 @@ import { describe, it, expect } from 'vitest';
 import { prepareTools } from './mistral-prepare-tools';
 
 describe('prepareTools', () => {
+  it('should warn about Mistral provider tools on the Chat Completions API', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'provider',
+          id: 'mistral.web_search',
+          name: 'search',
+          args: {},
+        },
+      ],
+    });
+
+    expect(result).toStrictEqual({
+      tools: [],
+      toolChoice: undefined,
+      toolWarnings: [
+        {
+          type: 'unsupported',
+          feature: 'provider-defined tool mistral.web_search',
+        },
+      ],
+    });
+  });
+
   it('should pass through strict mode when strict is true', () => {
     const result = prepareTools({
       tools: [

--- a/packages/mistral/src/mistral-provider.test.ts
+++ b/packages/mistral/src/mistral-provider.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { createMistral } from './mistral-provider';
+
+describe('MistralProvider', () => {
+  const provider = createMistral({ apiKey: 'test-api-key' });
+
+  it('should create Conversations API models', () => {
+    const model = provider.conversations('mistral-small-latest');
+
+    expect(model.provider).toBe('mistral.conversations');
+    expect(model.modelId).toBe('mistral-small-latest');
+  });
+
+  it('should expose web search provider tools', () => {
+    expect(provider.tools.webSearch()).toMatchObject({
+      type: 'provider',
+      id: 'mistral.web_search',
+      args: {},
+    });
+    expect(provider.tools.webSearchPremium()).toMatchObject({
+      type: 'provider',
+      id: 'mistral.web_search_premium',
+      args: {},
+    });
+  });
+});

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -11,12 +11,14 @@ import {
   withUserAgentSuffix,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
+import { MistralConversationsLanguageModel } from './conversations/mistral-conversations-language-model';
 import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-language-model-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
 import type { MistralEmbeddingModelId } from './mistral-embedding-model-options';
 import { MistralSpeechModel } from './mistral-speech-model';
 import type { MistralSpeechModelId } from './mistral-speech-model-options';
+import { mistralTools } from './mistral-tools';
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV4 {
@@ -31,6 +33,11 @@ export interface MistralProvider extends ProviderV4 {
    * Creates a model for text generation.
    */
   chat(modelId: MistralChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a model that uses Mistral's Conversations API.
+   */
+  conversations(modelId: MistralChatModelId): LanguageModelV4;
 
   /**
    * Creates a model for text embeddings.
@@ -61,6 +68,11 @@ export interface MistralProvider extends ProviderV4 {
    * @deprecated Use `embeddingModel` instead.
    */
   textEmbeddingModel(modelId: MistralEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * Mistral-specific provider-executed tools.
+   */
+  tools: typeof mistralTools;
 }
 
 export interface MistralProviderSettings {
@@ -121,6 +133,15 @@ export function createMistral(
       generateId: options.generateId,
     });
 
+  const createConversationsModel = (modelId: MistralChatModelId) =>
+    new MistralConversationsLanguageModel(modelId, {
+      provider: 'mistral.conversations',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+      generateId: options.generateId,
+    });
+
   const createEmbeddingModel = (modelId: MistralEmbeddingModelId) =>
     new MistralEmbeddingModel(modelId, {
       provider: 'mistral.embedding',
@@ -150,18 +171,20 @@ export function createMistral(
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
+  provider.conversations = createConversationsModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;
+  provider.tools = mistralTools;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };
 
-  return provider;
+  return provider as MistralProvider;
 }
 
 /**

--- a/packages/mistral/src/mistral-tools.ts
+++ b/packages/mistral/src/mistral-tools.ts
@@ -1,0 +1,20 @@
+import { webSearch } from './tool/web-search';
+import { webSearchPremium } from './tool/web-search-premium';
+
+export const mistralTools = {
+  /**
+   * Web search allows Mistral models to access current information from the
+   * internet and return source citations.
+   *
+   * This tool requires a model created with `mistral.conversations()`.
+   */
+  webSearch,
+
+  /**
+   * Premium web search allows Mistral models to access a search engine and
+   * news articles with integrated news provider verification.
+   *
+   * This tool requires a model created with `mistral.conversations()`.
+   */
+  webSearchPremium,
+};

--- a/packages/mistral/src/tool/web-search-premium.ts
+++ b/packages/mistral/src/tool/web-search-premium.ts
@@ -1,0 +1,40 @@
+import {
+  createProviderExecutedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const webSearchPremiumInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      query: z.string().optional(),
+    }),
+  ),
+);
+
+const webSearchPremiumOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      info: z.record(z.string(), z.unknown()).optional(),
+    }),
+  ),
+);
+
+const webSearchPremiumToolFactory = createProviderExecutedToolFactory<
+  {
+    query?: string;
+  },
+  {
+    info?: Record<string, unknown>;
+  },
+  {}
+>({
+  id: 'mistral.web_search_premium',
+  inputSchema: webSearchPremiumInputSchema,
+  outputSchema: webSearchPremiumOutputSchema,
+});
+
+export const webSearchPremium = (
+  args: Parameters<typeof webSearchPremiumToolFactory>[0] = {},
+) => webSearchPremiumToolFactory(args);

--- a/packages/mistral/src/tool/web-search.test-d.ts
+++ b/packages/mistral/src/tool/web-search.test-d.ts
@@ -1,0 +1,11 @@
+import type { Tool } from '@ai-sdk/provider-utils';
+import { expectTypeOf, it } from 'vitest';
+import { mistral } from '../mistral-provider';
+
+it('should expose typed web search input and output', () => {
+  const tool = mistral.tools.webSearch();
+
+  expectTypeOf(tool).toExtend<
+    Tool<{ query?: string }, { info?: Record<string, unknown> }, {}>
+  >();
+});

--- a/packages/mistral/src/tool/web-search.ts
+++ b/packages/mistral/src/tool/web-search.ts
@@ -1,0 +1,40 @@
+import {
+  createProviderExecutedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const webSearchInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      query: z.string().optional(),
+    }),
+  ),
+);
+
+const webSearchOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      info: z.record(z.string(), z.unknown()).optional(),
+    }),
+  ),
+);
+
+const webSearchToolFactory = createProviderExecutedToolFactory<
+  {
+    query?: string;
+  },
+  {
+    info?: Record<string, unknown>;
+  },
+  {}
+>({
+  id: 'mistral.web_search',
+  inputSchema: webSearchInputSchema,
+  outputSchema: webSearchOutputSchema,
+});
+
+export const webSearch = (
+  args: Parameters<typeof webSearchToolFactory>[0] = {},
+) => webSearchToolFactory(args);


### PR DESCRIPTION
## Background

Users need typed access to Mistral's provider-executed web search tools so models can retrieve current information and return cited sources through AI SDK APIs.

## Summary

Added mistral.conversations(), mistral.tools.webSearch(), and mistral.tools.webSearchPremium(), including Conversations request conversion, server tool events, citations, usage, conversation metadata, mixed function tools, and the store option.

## Testing

Added Node and Edge tests for tool factories, request serialization, chat incompatibility warnings, function tools, provider-tool replay, non-streaming responses, streaming events, citations, usage, and metadata.

## End-to-end Validation

- Ran the updated Mistral tool-call example successfully against the live Conversations API.
- Verified standard and premium web search returned typed tool calls, tool results, and URL sources.
- Verified live streamText output included tool lifecycle, text, source, and finish events.

### Documentation

Updated the Mistral provider documentation with Conversations model usage, both web search variants, citation behavior, store=false privacy guidance, Chat Completions limitations, and premium availability considerations.

## Related Issues

Fixes #14312

Co-authored-by: rmarquet21 <43928856+rmarquet21@users.noreply.github.com>