### PR TITLE
[v5.0] reproduction: could not reproduce Manually persisted chat context includes providerOptions field and

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/examples/ai-functions/src/reproduction/issue-13997.ts
+++ b/examples/ai-functions/src/reproduction/issue-13997.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import {
+  generateText,
+  InvalidPromptError,
+  type ModelMessage,
+} from '../../../../packages/ai/dist/index.mjs';
+import { MockLanguageModelV2 } from '../../../../packages/ai/dist/test/index.mjs';
+
+const responseValues = {
+  finishReason: 'stop' as const,
+  usage: {
+    inputTokens: 3,
+    outputTokens: 10,
+    totalTokens: 13,
+    reasoningTokens: 5,
+    cachedInputTokens: undefined,
+  },
+  warnings: [],
+};
+
+function roundTripThroughMongoDefault<T>(value: T): T {
+  return JSON.parse(
+    JSON.stringify(value, (_key, nestedValue) =>
+      nestedValue === undefined ? null : nestedValue,
+    ),
+  );
+}
+
+function roundTripThroughMongoIgnoreUndefined<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function assertGenerateTextAccepts(messages: ModelMessage[]) {
+  return generateText({
+    model: new MockLanguageModelV2({
+      doGenerate: {
+        ...responseValues,
+        content: [{ type: 'text', text: 'The persisted context is valid.' }],
+      },
+    }),
+    messages,
+  });
+}
+
+async function main() {
+  const initialMessages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Which is bigger, 9.9 or 9.11?' }],
+    },
+  ];
+
+  const initialResult = await generateText({
+    model: new MockLanguageModelV2({
+      provider: 'openrouter',
+      doGenerate: {
+        ...responseValues,
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Compare the decimal values.',
+            providerMetadata: {
+              openrouter: {
+                reasoning_details: [
+                  {
+                    type: 'reasoning.encrypted',
+                    data: 'encrypted-reasoning-data',
+                    format: 'google-gemini-v1',
+                    index: 0,
+                  },
+                ],
+              },
+            },
+          },
+          { type: 'text', text: '9.9 is bigger than 9.11.' },
+        ],
+      },
+    }),
+    messages: initialMessages,
+  });
+
+  const context = [...initialMessages, ...initialResult.response.messages];
+  const assistantContent = context[1].content;
+  assert.ok(Array.isArray(assistantContent));
+
+  const textPart = assistantContent.find(part => part.type === 'text');
+  assert.equal(textPart?.providerOptions, undefined);
+
+  // The SDK-produced ModelMessage[] can be used directly on the next turn.
+  await assertGenerateTextAccepts(context);
+
+  // MongoDB's documented default serialization maps undefined fields to null.
+  const defaultPersistedContext =
+    roundTripThroughMongoDefault<ModelMessage[]>(context);
+  const defaultAssistantContent = defaultPersistedContext[1].content;
+  assert.ok(Array.isArray(defaultAssistantContent));
+  const defaultTextPart = defaultAssistantContent.find(
+    part => part.type === 'text',
+  );
+  assert.equal(defaultTextPart?.providerOptions, null);
+
+  let defaultSerializationError: unknown;
+  try {
+    await assertGenerateTextAccepts(defaultPersistedContext);
+  } catch (error) {
+    defaultSerializationError = error;
+  }
+  assert.ok(defaultSerializationError instanceof InvalidPromptError);
+
+  // MongoDB's ignoreUndefined option omits the undefined text-part field.
+  const correctedContext =
+    roundTripThroughMongoIgnoreUndefined<ModelMessage[]>(context);
+  const correctedAssistantContent = correctedContext[1].content;
+  assert.ok(Array.isArray(correctedAssistantContent));
+  const correctedTextPart = correctedAssistantContent.find(
+    part => part.type === 'text',
+  );
+  assert.equal('providerOptions' in correctedTextPart!, false);
+
+  const correctedReasoningPart = correctedAssistantContent.find(
+    part => part.type === 'reasoning',
+  );
+  assert.deepEqual(correctedReasoningPart?.providerOptions, {
+    openrouter: {
+      reasoning_details: [
+        {
+          type: 'reasoning.encrypted',
+          data: 'encrypted-reasoning-data',
+          format: 'google-gemini-v1',
+          index: 0,
+        },
+      ],
+    },
+  });
+  await assertGenerateTextAccepts(correctedContext);
+
+  console.log(
+    JSON.stringify(
+      {
+        directRoundTrip: 'accepted',
+        mongoDefault: {
+          textProviderOptions: defaultTextPart?.providerOptions,
+          validationError:
+            defaultSerializationError instanceof Error
+              ? defaultSerializationError.name
+              : String(defaultSerializationError),
+        },
+        mongoIgnoreUndefined: {
+          textProviderOptionsOmitted: !(
+            'providerOptions' in correctedTextPart!
+          ),
+          reasoningMetadataPreserved: true,
+          roundTrip: 'accepted',
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions: {}
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':


### PR DESCRIPTION
## Bug

Manually persisted chat context includes `providerOptions` field and breaks ModelMessage validation unless I manually remove it

## Reproduction

- `examples/ai-functions/src/reproduction/issue-13997.ts` shows SDK response messages include OpenRouter reasoning metadata while a plain text part has `providerOptions: undefined`.
- Passing the SDK-produced messages directly back to `generateText` succeeded instead of producing the reported `InvalidPromptError`.
- MongoDB's documented default `undefined`-to-`null` serialization produced the reported validation error on reload.
- The `ignoreUndefined: true` equivalent omitted the undefined field, preserved `reasoning_details`, and allowed the persisted context to be reused without product-code changes.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/model-message
- https://www.mongodb.com/docs/drivers/node/v6.x/data-formats/bson/undefined-values/
- https://openrouter.ai/docs/guides/best-practices/reasoning-tokens

## Related Issues

Could not reproduce #13997