### PR TITLE
[v5.0] reproduction: could not reproduce UI API: tool-approval-response not handled by Anthropic provider

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ai-sdk/anthropic": "3.0.36",
+    "ai": "6.0.69",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3",
+    "vitest": "4.1.0"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.test.ts
+++ b/examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { runReproduction } from './issue-13057-anthropic-tool-approval.js';
+
+describe('issue 13057 Anthropic tool approval', () => {
+  it('executes an approved UI tool and sends an immediate tool_result', async () => {
+    const fixtureUrls = [
+      new URL(
+        '../../../../packages/anthropic/src/__fixtures__/issue-13057-approved-tool.1.chunks.txt',
+        import.meta.url,
+      ),
+      new URL(
+        '../../../../packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt',
+        import.meta.url,
+      ),
+    ];
+    const fixtures = await Promise.all(
+      fixtureUrls.map(url => readFile(url, 'utf8')),
+    );
+    let responseIndex = 0;
+
+    const result = await runReproduction({
+      providerFetch: async () =>
+        new Response(fixtures[responseIndex++], {
+          headers: { 'content-type': 'text/event-stream' },
+          status: 200,
+        }),
+    });
+
+    expect(responseIndex).toBe(2);
+    expect(result.executionCount).toBe(1);
+    expect(result.capturedErrors).toEqual([]);
+    expect(
+      result.continuationChunks.some(
+        chunk => chunk.type === 'tool-output-available',
+      ),
+    ).toBe(true);
+  });
+});

--- a/examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.ts
+++ b/examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.ts
@@ -1,0 +1,211 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
+import {
+  createAgentUIStream,
+  readUIMessageStream,
+  tool,
+  ToolLoopAgent,
+  type UIMessage,
+} from 'ai';
+import { z } from 'zod';
+
+type AnthropicRequest = {
+  messages?: Array<{
+    role?: string;
+    content?: Array<{
+      type?: string;
+      id?: string;
+      tool_use_id?: string;
+    }>;
+  }>;
+};
+
+type ApprovalPart = {
+  type: 'tool-createIssue';
+  toolCallId: string;
+  state: 'approval-requested' | 'approval-responded';
+  input: { title: string };
+  approval: {
+    id: string;
+    approved?: boolean;
+  };
+};
+
+type ReproductionResult = {
+  executionCount: number;
+  capturedErrors: string[];
+  continuationChunks: Array<{ type: string; [key: string]: unknown }>;
+  capturedRequests: AnthropicRequest[];
+  capturedResponses: string[];
+};
+
+export async function runReproduction({
+  providerFetch = fetch,
+}: {
+  providerFetch?: typeof fetch;
+} = {}): Promise<ReproductionResult> {
+  const capturedRequests: AnthropicRequest[] = [];
+  const capturedResponses: string[] = [];
+  const capturedErrors: unknown[] = [];
+  let executionCount = 0;
+
+  const anthropic = createAnthropic({
+    fetch: async (url, options) => {
+      capturedRequests.push(
+        JSON.parse(options?.body as string) as AnthropicRequest,
+      );
+
+      const response = await providerFetch(url, options);
+      capturedResponses.push(await response.clone().text());
+      return response;
+    },
+  });
+
+  const createIssue = tool({
+    description: 'Create an issue',
+    inputSchema: z.object({ title: z.string() }),
+    needsApproval: true,
+    execute: async ({ title }) => {
+      executionCount++;
+      return { id: '123', title };
+    },
+  });
+
+  const agent = new ToolLoopAgent({
+    model: anthropic('claude-sonnet-4-5'),
+    instructions:
+      'When explicitly asked to create an issue, call createIssue exactly once.',
+    tools: { createIssue },
+  });
+
+  const userMessage = {
+    id: 'user-1',
+    role: 'user' as const,
+    parts: [
+      {
+        type: 'text' as const,
+        text: 'Use createIssue now to create an issue titled "Reproduce issue 13057".',
+      },
+    ],
+  };
+
+  const initialStream = await createAgentUIStream({
+    agent,
+    uiMessages: [userMessage],
+    onError: error => {
+      capturedErrors.push(error);
+      return error instanceof Error ? error.message : String(error);
+    },
+  });
+
+  let assistantMessage: UIMessage | undefined;
+  for await (const message of readUIMessageStream({
+    stream: initialStream,
+    terminateOnError: true,
+  })) {
+    assistantMessage = message;
+  }
+
+  assert.ok(assistantMessage, 'the first stream should produce an assistant');
+  assert.equal(assistantMessage.role, 'assistant');
+
+  const approvalPart = assistantMessage.parts.find(
+    part =>
+      typeof part === 'object' &&
+      part != null &&
+      'type' in part &&
+      part.type === 'tool-createIssue',
+  ) as ApprovalPart | undefined;
+
+  assert.ok(approvalPart, 'the first stream should request tool approval');
+  assert.equal(approvalPart.state, 'approval-requested');
+  assert.equal(executionCount, 0, 'the tool must not execute before approval');
+
+  approvalPart.state = 'approval-responded';
+  approvalPart.approval.approved = true;
+  const toolCallId = approvalPart.toolCallId;
+
+  const continuationStream = await createAgentUIStream({
+    agent,
+    uiMessages: [userMessage, assistantMessage],
+    onError: error => {
+      capturedErrors.push(error);
+      return error instanceof Error ? error.message : String(error);
+    },
+  });
+
+  const continuationChunks = [];
+  for await (const chunk of continuationStream) {
+    continuationChunks.push(chunk);
+  }
+
+  assert.equal(
+    executionCount,
+    1,
+    'the approved tool should execute exactly once',
+  );
+  assert.equal(
+    capturedErrors.length,
+    0,
+    `the UI streams should not fail: ${capturedErrors.map(String).join(', ')}`,
+  );
+  assert.ok(
+    continuationChunks.some(
+      chunk =>
+        chunk.type === 'tool-output-available' &&
+        chunk.toolCallId === toolCallId,
+    ),
+    'the UI stream should emit the approved tool output',
+  );
+
+  const continuationRequest = capturedRequests.at(-1);
+  assert.ok(
+    continuationRequest,
+    'Anthropic should receive a continuation request',
+  );
+
+  const toolUseMessageIndex =
+    continuationRequest.messages?.findIndex(message =>
+      message.content?.some(
+        part => part.type === 'tool_use' && part.id === toolCallId,
+      ),
+    ) ?? -1;
+
+  assert.notEqual(
+    toolUseMessageIndex,
+    -1,
+    'the Anthropic request should contain the original tool_use',
+  );
+
+  const toolResultMessage =
+    continuationRequest.messages?.[toolUseMessageIndex + 1];
+  assert.ok(
+    toolResultMessage?.content?.some(
+      part => part.type === 'tool_result' && part.tool_use_id === toolCallId,
+    ),
+    'Anthropic should receive a matching tool_result immediately after tool_use',
+  );
+
+  return {
+    executionCount,
+    capturedErrors: capturedErrors.map(String),
+    continuationChunks,
+    capturedRequests,
+    capturedResponses,
+  };
+}
+
+async function main() {
+  console.log(JSON.stringify(await runReproduction(), null, 2));
+}
+
+if (
+  process.argv[1] != null &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/anthropic/src/__fixtures__/issue-13057-approved-tool.1.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/issue-13057-approved-tool.1.chunks.txt
@@ -1,0 +1,27 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd3pnzH359YUmWrJzaSwh","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":618,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}    }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01TyLXoWW1gujar8anh7KHHN","name":"createIssue","input":{},"caller":{"type":"direct"}}           }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\": \"Reproduce issue 13057"}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}    }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0       }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":618,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":59}         }
+
+event: message_stop
+data: {"type":"message_stop"        }
+

--- a/packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt
@@ -1,0 +1,24 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd3po8uCihxcC6neNyhqA","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":704,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}               }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"'ve successfully created an issue with the title \"Reproduce issue 13057\". The issue has been assigned ID 123."}     }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0               }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":704,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":29}     }
+
+event: message_stop
+data: {"type":"message_stop"           }
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,31 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.36
+        version: 3.0.36(zod@3.25.76)
+      ai:
+        specifier: 6.0.69
+        version: 6.0.69(zod@3.25.76)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -2932,6 +2957,28 @@ packages:
 
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
+
+  '@ai-sdk/anthropic@3.0.36':
+    resolution: {integrity: sha512-GHQccfwC0j1JltN9M47RSlBpOyHoUam0mvbYMf8zpE0UD1tzIX5sDw2m/8nRlrTz6wGuKfaDxmoC3XH7uhTrXg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.32':
+    resolution: {integrity: sha512-7clZRr07P9rpur39t1RrbIe7x8jmwnwUWI8tZs+BvAfX3NFgdSVGGIaT7bTz2pb08jmLXzTSDbrOTqAQ7uBkBQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.13':
+    resolution: {integrity: sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.7':
+    resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
+    engines: {node: '>=18'}
 
   '@algolia/abtesting@1.1.0':
     resolution: {integrity: sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==}
@@ -10913,6 +10960,12 @@ packages:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
 
+  ai@6.0.69:
+    resolution: {integrity: sha512-zIURMSnNroaVvu47Bm3XhC2y3LRsm8jmkwBgupxF+N7q/s6MpIiv04w1ltlnWqC8+T2PT2rN+f0sUhF+vArkwg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -12790,6 +12843,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -19528,6 +19585,30 @@ snapshots:
 
   '@adobe/css-tools@4.4.0': {}
 
+  '@ai-sdk/anthropic@3.0.36(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.32(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.13(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.7':
+    dependencies:
+      json-schema: 0.4.0
+
   '@algolia/abtesting@1.1.0':
     dependencies:
       '@algolia/client-common': 5.35.0
@@ -24627,7 +24708,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.12.3
@@ -27396,7 +27477,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -28716,6 +28797,15 @@ snapshots:
       msw: 2.12.10(@types/node@20.17.24)(typescript@5.9.3)
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
+  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@22.19.19)(typescript@5.8.3)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+
   '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.0
@@ -29168,6 +29258,14 @@ snapshots:
     dependencies:
       clean-stack: 4.2.0
       indent-string: 5.0.0
+
+  ai@6.0.69(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.32(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
@@ -31320,9 +31418,11 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.1.0: {}
+
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -36840,7 +36940,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:
@@ -38497,6 +38597,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -38699,7 +38808,7 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   ts-node@10.9.2(@types/node@20.17.24)(typescript@5.4.5):
     dependencies:
@@ -39597,6 +39706,25 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
+  vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      less: 4.4.0
+      lightningcss: 1.31.1
+      sass: 1.90.0
+      terser: 5.43.1
+      tsx: 4.19.2
+      yaml: 2.7.0
+
   vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.3
@@ -39826,6 +39954,36 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.19
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.0
@@ -40035,6 +40193,38 @@ snapshots:
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Bug

UI API: tool-approval-response not handled by Anthropic provider in createAgentUIStream / ToolLoopAgent

## Reproduction

- Runnable reproduction added at `examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.ts` using the reported `ai@6.0.69` and `@ai-sdk/anthropic@3.0.36` versions.
- Live Anthropic runs executed the approved tool exactly once, streamed `tool-output-available`, sent an immediate matching `tool_result`, and completed without the reported second-stream error.
- The same successful behavior was observed with current `ai@7.0.28` and `@ai-sdk/anthropic@4.0.15` packages.
- The Anthropic provider still skips raw `tool-approval-response` parts, but AI SDK Core intercepted the approval and executed the tool before provider conversion.
- Recorded live responses are stored at `packages/anthropic/src/__fixtures__/issue-13057-approved-tool.1.chunks.txt` and `packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt`; the fixture-backed test is `examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.test.ts`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/create-agent-ui-stream

## Related Issues

Could not reproduce #13057