### PR TITLE
[v6.0] reproduction: could not reproduce UI API: tool-approval-response not handled by Anthropic provider

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.ts
+++ b/examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.ts
@@ -1,0 +1,270 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import {
+  createAgentUIStream,
+  isToolUIPart,
+  readUIMessageStream,
+  ToolLoopAgent,
+  tool,
+  type UIMessage,
+} from 'ai';
+import { writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+type AnthropicContentBlock = {
+  type?: string;
+  id?: string;
+  tool_use_id?: string;
+};
+
+type AnthropicMessage = {
+  role?: string;
+  content?: AnthropicContentBlock[];
+};
+
+type AnthropicRequest = {
+  messages?: AnthropicMessage[];
+};
+
+async function readAll<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader();
+  const values: T[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return values;
+    }
+    values.push(value);
+  }
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function hasImmediateMatchingToolResult(request: AnthropicRequest): boolean {
+  const messages = request.messages ?? [];
+
+  for (let index = 0; index < messages.length - 1; index++) {
+    const message = messages[index];
+    const nextMessage = messages[index + 1];
+
+    if (message.role !== 'assistant' || nextMessage.role !== 'user') {
+      continue;
+    }
+
+    const toolUseIds = new Set(
+      (message.content ?? [])
+        .filter(part => part.type === 'tool_use' && part.id != null)
+        .map(part => part.id),
+    );
+
+    if (
+      (nextMessage.content ?? []).some(
+        part =>
+          part.type === 'tool_result' &&
+          part.tool_use_id != null &&
+          toolUseIds.has(part.tool_use_id),
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function toChunksFixture(rawSse: string): string {
+  return `${rawSse
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('data: '))
+    .map(line => line.slice('data: '.length))
+    .filter(line => line !== '[DONE]')
+    .join('\n')}\n`;
+}
+
+async function main() {
+  const requests: AnthropicRequest[] = [];
+  const responseBodies: Array<Promise<string>> = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      assert(
+        typeof init?.body === 'string',
+        'Expected Anthropic request body to be JSON text.',
+      );
+      requests.push(JSON.parse(init.body) as AnthropicRequest);
+
+      const response = await globalThis.fetch(input, init);
+      responseBodies.push(response.clone().text());
+      return response;
+    },
+  });
+
+  let executeCount = 0;
+
+  const createIssue = tool({
+    description: 'Create an issue with the requested title.',
+    inputSchema: z.object({ title: z.string() }),
+    needsApproval: true,
+    execute: async ({ title }) => {
+      executeCount++;
+      return { id: '123', title };
+    },
+  });
+
+  const agent = new ToolLoopAgent({
+    model: anthropic('claude-sonnet-4-5'),
+    instructions:
+      'Call createIssue when the user asks to create an issue. After receiving its result, briefly confirm the created issue.',
+    tools: { createIssue },
+    prepareCall: options => {
+      const hasExistingToolCall =
+        Array.isArray(options.prompt) &&
+        options.prompt.some(
+          message =>
+            message.role === 'assistant' &&
+            Array.isArray(message.content) &&
+            message.content.some(part => part.type === 'tool-call'),
+        );
+
+      return {
+        ...options,
+        toolChoice: hasExistingToolCall
+          ? 'none'
+          : { type: 'tool', toolName: 'createIssue' },
+      };
+    },
+  });
+
+  const userMessage: UIMessage = {
+    id: 'user-1',
+    role: 'user',
+    parts: [{ type: 'text', text: 'Create an issue titled Reproduction.' }],
+  };
+
+  const firstStream = await createAgentUIStream({
+    agent,
+    uiMessages: [userMessage],
+  });
+
+  let approvalMessage: UIMessage | undefined;
+  for await (const message of readUIMessageStream({ stream: firstStream })) {
+    approvalMessage = message;
+  }
+
+  assert(approvalMessage != null, 'First stream did not produce a UI message.');
+
+  const approvalPart = approvalMessage.parts.find(
+    part => isToolUIPart(part) && part.state === 'approval-requested',
+  );
+  assert(
+    approvalPart != null && isToolUIPart(approvalPart),
+    'First stream did not request tool approval.',
+  );
+
+  const approvedMessage = structuredClone(approvalMessage);
+  approvedMessage.parts = approvedMessage.parts.map(part =>
+    isToolUIPart(part) &&
+    part.state === 'approval-requested' &&
+    part.approval.id === approvalPart.approval.id
+      ? {
+          ...part,
+          state: 'approval-responded',
+          approval: {
+            ...part.approval,
+            approved: true,
+          },
+        }
+      : part,
+  );
+
+  const secondStream = await createAgentUIStream({
+    agent,
+    uiMessages: [userMessage, approvedMessage],
+  });
+  const [chunksBranch, messageBranch] = secondStream.tee();
+
+  const chunksPromise = readAll(chunksBranch);
+  let finalMessage: UIMessage | undefined;
+  for await (const message of readUIMessageStream({
+    message: approvedMessage,
+    stream: messageBranch,
+    terminateOnError: true,
+  })) {
+    finalMessage = message;
+  }
+  const chunks = await chunksPromise;
+
+  const errors = chunks.filter(chunk => chunk.type === 'error');
+  assert(
+    errors.length === 0,
+    `Second stream returned an error: ${errors.map(error => error.errorText).join('; ')}`,
+  );
+  assert(
+    executeCount === 1,
+    `Expected the approved tool to execute once, but it executed ${executeCount} times.`,
+  );
+  assert(
+    chunks.some(
+      chunk =>
+        chunk.type === 'tool-output-available' &&
+        chunk.toolCallId === approvalPart.toolCallId,
+    ),
+    'Second stream did not emit tool-output-available for the approved call.',
+  );
+  assert(
+    finalMessage?.parts.some(
+      part =>
+        isToolUIPart(part) &&
+        part.toolCallId === approvalPart.toolCallId &&
+        part.state === 'output-available',
+    ),
+    'The live UI message did not transition the approved tool to output-available.',
+  );
+
+  const continuationRequestIndex = requests.findIndex(
+    hasImmediateMatchingToolResult,
+  );
+  assert(
+    continuationRequestIndex >= 0,
+    'Anthropic did not receive an immediate matching tool_result block.',
+  );
+
+  if (process.env.RECORD_FIXTURE === '1') {
+    const responses = await Promise.all(responseBodies);
+    const fixturePath = fileURLToPath(
+      new URL(
+        '../../../../packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt',
+        import.meta.url,
+      ),
+    );
+    await writeFile(
+      fixturePath,
+      toChunksFixture(responses[continuationRequestIndex]),
+    );
+    console.log(`Recorded fixture: ${fixturePath}`);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        executeCount,
+        streamedToolOutput: true,
+        finalToolState: 'output-available',
+        anthropicRequestHasImmediateToolResult: true,
+        providerRequestCount: requests.length,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt
@@ -1,0 +1,8 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd3pgisfZRny2wU2hDVao","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":117,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}} }
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Issue"}      }
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" created successfully! The issue \"Reproduction\" has been created with ID 123."}          }
+{"type":"content_block_stop","index":0            }
+{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":117,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":21} }
+{"type":"message_stop"              }

--- a/packages/anthropic/src/issue-13057.test.ts
+++ b/packages/anthropic/src/issue-13057.test.ts
@@ -1,0 +1,113 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+it('sends an immediate matching tool_result after an approved tool call', async () => {
+  server.urls['https://api.anthropic.com/v1/messages'].response = {
+    type: 'stream-chunks',
+    chunks: fs
+      .readFileSync(
+        'src/__fixtures__/issue-13057-approved-tool.2.chunks.txt',
+        'utf8',
+      )
+      .split('\n')
+      .filter(Boolean)
+      .map(line => `data: ${line}\n\n`),
+  };
+
+  const model = createAnthropic({ apiKey: 'test-api-key' })(
+    'claude-sonnet-4-5',
+  );
+
+  const prompt: LanguageModelV3Prompt = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Create an issue titled Reproduction.' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'toolu_issue_13057',
+          toolName: 'createIssue',
+          input: { title: 'Reproduction' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'toolu_issue_13057',
+          toolName: 'createIssue',
+          output: {
+            type: 'json',
+            value: { id: '123', title: 'Reproduction' },
+          },
+        },
+      ],
+    },
+  ];
+
+  const { stream } = await model.doStream({
+    prompt,
+    tools: [
+      {
+        type: 'function',
+        name: 'createIssue',
+        description: 'Create an issue with the requested title.',
+        inputSchema: {
+          type: 'object',
+          properties: { title: { type: 'string' } },
+          required: ['title'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    toolChoice: { type: 'none' },
+  });
+
+  await convertReadableStreamToArray(stream);
+
+  const request = await server.calls[0].requestBodyJson;
+  expect(request.messages).toEqual([
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Create an issue titled Reproduction.' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_issue_13057',
+          name: 'createIssue',
+          input: { title: 'Reproduction' },
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_issue_13057',
+          content: JSON.stringify({ id: '123', title: 'Reproduction' }),
+        },
+      ],
+    },
+  ]);
+});


### PR DESCRIPTION
## Bug

UI API: tool-approval-response not handled by Anthropic provider in createAgentUIStream / ToolLoopAgent

## Reproduction

- Live reproduction `examples/ai-functions/src/reproduction/issue-13057-anthropic-tool-approval.ts` succeeded with workspace versions `ai@6.0.226` and `@ai-sdk/anthropic@3.0.97`: the approved tool executed once, streamed `tool-output-available`, and reached `output-available`.
- The reported Anthropic missing-`tool_result` error was not observed; the continuation request contained an immediate matching `tool_result` block.
- An isolated comparison using the reported `ai@6.0.69` and `@ai-sdk/anthropic@3.0.36` versions produced the same successful result without configuration changes.
- The successful live continuation is recorded in `packages/anthropic/src/__fixtures__/issue-13057-approved-tool.2.chunks.txt` and covered by `packages/anthropic/src/issue-13057.test.ts`.
- The Anthropic provider still skips raw local `tool-approval-response` parts, but AI SDK Core intercepts the approval, executes the tool, and supplies the resulting `tool_result` before provider conversion.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/create-agent-ui-stream

## Related Issues

Could not reproduce #13057