### PR TITLE
[v6.0] feat: add OpenAI Responses API computer tool support

### DIFF
--- a/.changeset/fresh-computers-act.md
+++ b/.changeset/fresh-computers-act.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add the client-executed OpenAI Responses API computer tool with batched actions and screenshot outputs.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -794,6 +794,95 @@ The MCP tool can be configured with:
   to AI SDK tools first.
 </Note>
 
+#### Computer Tool
+
+The OpenAI Responses API supports the GA computer tool through
+`openai.tools.computer`. The model returns an ordered batch of browser or
+desktop actions for your application to execute, and your application returns
+an updated screenshot.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { generateText, isStepCount } from 'ai';
+import { captureScreenshot, executeComputerAction } from '@/utils/computer-use';
+
+const result = await generateText({
+  model: openai.responses('gpt-5.4'),
+  tools: {
+    computer: openai.tools.computer({
+      needsApproval: ({ pendingSafetyChecks }) =>
+        pendingSafetyChecks.length > 0,
+
+      execute: async ({ actions, pendingSafetyChecks }) => {
+        for (const action of actions) {
+          await executeComputerAction(action);
+        }
+
+        return {
+          output: {
+            type: 'computer_screenshot',
+            imageUrl: `data:image/png;base64,${await captureScreenshot()}`,
+            detail: 'original',
+          },
+          acknowledgedSafetyChecks: pendingSafetyChecks,
+        };
+      },
+    }),
+  },
+  prompt: 'Open the settings page and enable dark mode.',
+  stopWhen: isStepCount(10),
+});
+```
+
+The execute callback receives:
+
+- **actions** - An ordered array of `click`, `double_click`, `drag`,
+  `keypress`, `move`, `screenshot`, `scroll`, `type`, and `wait` actions.
+  Execute every action in order before capturing the next screenshot.
+- **pendingSafetyChecks** - Safety checks returned by OpenAI. Review these
+  before continuing and include accepted checks in
+  `acknowledgedSafetyChecks`.
+- **status** - The computer call status.
+
+The action union is also exported as `OpenAIComputerAction`. Action-specific
+fields are:
+
+| Action         | Fields                                               |
+| -------------- | ---------------------------------------------------- |
+| `click`        | `button`, `x`, `y`, optional `keys`                  |
+| `double_click` | `x`, `y`, optional `keys`                            |
+| `drag`         | `path` containing `{ x, y }` points, optional `keys` |
+| `keypress`     | `keys`                                               |
+| `move`         | `x`, `y`, optional `keys`                            |
+| `screenshot`   | No additional fields                                 |
+| `scroll`       | `x`, `y`, `scrollX`, `scrollY`, optional `keys`      |
+| `type`         | `text`                                               |
+| `wait`         | No additional fields                                 |
+
+Safety checks use the exported `OpenAIComputerSafetyCheck` type.
+
+Return a `computer_screenshot` with either:
+
+- **imageUrl** - A fully qualified URL or image data URL.
+- **fileId** - The ID of an uploaded screenshot file.
+
+`detail` can be `auto`, `low`, `high`, or `original`. `original` preserves the
+captured resolution and is recommended when accurate coordinates are
+important.
+
+Computer calls and `computer_call_output` screenshot results are carried
+through multi-step generations when using `store`, `previousResponseId`, or
+OpenAI conversations. You can also set `store: false`; the provider will
+serialize the complete call and screenshot result into each follow-up request.
+
+<Note type="warning">
+  Run computer use in an isolated browser or VM. Restrict reachable domains,
+  accounts, credentials, environment variables, and file-system access. Treat
+  on-screen content as untrusted prompt-injection input, require confirmation
+  immediately before consequential actions, and avoid exposing sensitive
+  information in screenshots.
+</Note>
+
 #### Local Shell Tool
 
 The OpenAI responses API support the local shell tool for Codex models through the `openai.tools.localShell` tool.

--- a/examples/ai-functions/src/generate-text/openai/responses.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses.ts
@@ -1,33 +1,43 @@
-import {
-  openai,
-  type OpenAILanguageModelResponsesOptions,
-} from '@ai-sdk/openai';
-import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { generateText, isStepCount } from 'ai';
+import fs from 'node:fs';
 import { run } from '../../lib/run';
 
 run(async () => {
+  const screenshot = fs
+    .readFileSync('./data/screenshot-editor.png')
+    .toString('base64');
+
   const result = await generateText({
-    model: openai.responses('gpt-4o-mini'),
-    prompt: 'Invent a new holiday and describe its traditions.',
-    maxOutputTokens: 1000,
-    providerOptions: {
-      openai: {
-        parallelToolCalls: false,
-        store: false,
-        metadata: {
-          key1: 'value1',
-          key2: 'value2',
+    model: openai.responses('gpt-5.4'),
+    tools: {
+      computer: openai.tools.computer({
+        needsApproval: ({ pendingSafetyChecks }) =>
+          pendingSafetyChecks.length > 0,
+        execute: async ({ actions, pendingSafetyChecks }) => {
+          // Replace this logging with an isolated browser or VM harness that
+          // executes every action in order.
+          for (const action of actions) {
+            console.log('Computer action:', action);
+          }
+
+          return {
+            output: {
+              type: 'computer_screenshot',
+              imageUrl: `data:image/png;base64,${screenshot}`,
+              detail: 'original',
+            },
+            acknowledgedSafetyChecks: pendingSafetyChecks,
+          };
         },
-        user: 'user_123',
-      } satisfies OpenAILanguageModelResponsesOptions,
+      }),
     },
+    prompt:
+      'Inspect the current screen and describe the editor. Do not change anything.',
+    stopWhen: isStepCount(3),
   });
 
   console.log(result.text);
-  console.log();
   console.log('Finish reason:', result.finishReason);
-  console.log('Usage:', result.usage);
-
-  console.log('Request:', JSON.stringify(result.request, null, 2));
-  console.log('Response:', JSON.stringify(result.response, null, 2));
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
 });

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -20,6 +20,14 @@ export type { OpenAIEmbeddingModelOptions } from './embedding/openai-embedding-o
 export type { OpenAISpeechModelOptions } from './speech/openai-speech-options';
 export type { OpenAITranscriptionModelOptions } from './transcription/openai-transcription-options';
 export type {
+<<<<<<< HEAD
+=======
+  OpenAIComputerAction,
+  OpenAIComputerSafetyCheck,
+} from './tool/computer';
+export type {
+  OpenaiResponsesCompactionProviderMetadata,
+>>>>>>> 0063c2d35 (feat: add OpenAI Responses API computer tool support (#17290))
   OpenaiResponsesProviderMetadata,
   OpenaiResponsesReasoningProviderMetadata,
   OpenaiResponsesTextProviderMetadata,

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -20,14 +20,10 @@ export type { OpenAIEmbeddingModelOptions } from './embedding/openai-embedding-o
 export type { OpenAISpeechModelOptions } from './speech/openai-speech-options';
 export type { OpenAITranscriptionModelOptions } from './transcription/openai-transcription-options';
 export type {
-<<<<<<< HEAD
-=======
   OpenAIComputerAction,
   OpenAIComputerSafetyCheck,
 } from './tool/computer';
 export type {
-  OpenaiResponsesCompactionProviderMetadata,
->>>>>>> 0063c2d35 (feat: add OpenAI Responses API computer tool support (#17290))
   OpenaiResponsesProviderMetadata,
   OpenaiResponsesReasoningProviderMetadata,
   OpenaiResponsesTextProviderMetadata,

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -1,5 +1,6 @@
 import { applyPatch } from './tool/apply-patch';
 import { codeInterpreter } from './tool/code-interpreter';
+import { computer } from './tool/computer';
 import { customTool } from './tool/custom';
 import { fileSearch } from './tool/file-search';
 import { imageGeneration } from './tool/image-generation';
@@ -39,6 +40,16 @@ export const openaiTools = {
    * @param container - The container to use for the code interpreter.
    */
   codeInterpreter,
+
+  /**
+   * The computer tool allows models to operate a browser or desktop through
+   * batched UI actions. Your application executes the actions and returns an
+   * updated screenshot.
+   *
+   * WARNING: Run computer use in an isolated environment, treat on-screen
+   * content as untrusted, and require confirmation for consequential actions.
+   */
+  computer,
 
   /**
    * File search is a tool available in the Responses API. It enables models to

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -18,6 +18,7 @@ import {
   applyPatchInputSchema,
   applyPatchOutputSchema,
 } from '../tool/apply-patch';
+import { computerInputSchema, computerOutputSchema } from '../tool/computer';
 import {
   localShellInputSchema,
   localShellOutputSchema,
@@ -71,6 +72,7 @@ export async function convertToOpenAIResponsesInput({
   hasLocalShellTool = false,
   hasShellTool = false,
   hasApplyPatchTool = false,
+  hasComputerTool = false,
   customProviderToolNames,
 }: {
   prompt: LanguageModelV3Prompt;
@@ -85,6 +87,7 @@ export async function convertToOpenAIResponsesInput({
   hasLocalShellTool?: boolean;
   hasShellTool?: boolean;
   hasApplyPatchTool?: boolean;
+  hasComputerTool?: boolean;
   customProviderToolNames?: Set<string>;
 }): Promise<{
   input: OpenAIResponsesInput;
@@ -355,7 +358,7 @@ export async function convertToOpenAIResponsesInput({
               }
 
               // Provider-defined tool calls (local_shell, shell, apply_patch,
-              // and custom tools) are stored by the API and can be sent as an
+              // computer, and custom tools) are stored by the API and can be sent as an
               // `item_reference` to reduce payload size. Plain client-executed
               // function calls must NOT be: the matching `function_call_output`
               // can only reference the call by `call_id` (`call_...`), which
@@ -368,6 +371,7 @@ export async function convertToOpenAIResponsesInput({
                 (hasLocalShellTool && resolvedToolName === 'local_shell') ||
                 (hasShellTool && resolvedToolName === 'shell') ||
                 (hasApplyPatchTool && resolvedToolName === 'apply_patch') ||
+                (hasComputerTool && resolvedToolName === 'computer') ||
                 (customProviderToolNames?.has(resolvedToolName) ?? false);
 
               if (store && id != null && isProviderDefinedToolCall) {
@@ -428,6 +432,55 @@ export async function convertToOpenAIResponsesInput({
                   id: id!,
                   status: 'completed',
                   operation: parsedInput.operation,
+                });
+
+                break;
+              }
+
+              if (hasComputerTool && resolvedToolName === 'computer') {
+                const parsedInput = await validateTypes({
+                  value: part.input,
+                  schema: computerInputSchema,
+                });
+                input.push({
+                  type: 'computer_call',
+                  call_id: part.toolCallId,
+                  id: id!,
+                  status: parsedInput.status,
+                  actions: parsedInput.actions.map(action => {
+                    switch (action.type) {
+                      case 'click':
+                      case 'double_click':
+                      case 'move':
+                        return {
+                          ...action,
+                          keys: action.keys,
+                        };
+                      case 'drag':
+                        return {
+                          ...action,
+                          keys: action.keys,
+                        };
+                      case 'scroll':
+                        return {
+                          type: 'scroll' as const,
+                          x: action.x,
+                          y: action.y,
+                          scroll_x: action.scrollX,
+                          scroll_y: action.scrollY,
+                          keys: action.keys,
+                        };
+                      default:
+                        return action;
+                    }
+                  }),
+                  pending_safety_checks: parsedInput.pendingSafetyChecks.map(
+                    safetyCheck => ({
+                      id: safetyCheck.id,
+                      code: safetyCheck.code,
+                      message: safetyCheck.message,
+                    }),
+                  ),
                 });
 
                 break;
@@ -789,6 +842,35 @@ export async function convertToOpenAIResponsesInput({
               call_id: part.toolCallId,
               status: parsedOutput.status,
               output: parsedOutput.output,
+            });
+            continue;
+          }
+
+          if (
+            hasComputerTool &&
+            resolvedToolName === 'computer' &&
+            output.type === 'json'
+          ) {
+            const parsedOutput = await validateTypes({
+              value: output.value,
+              schema: computerOutputSchema,
+            });
+
+            input.push({
+              type: 'computer_call_output',
+              call_id: part.toolCallId,
+              output: {
+                type: 'computer_screenshot',
+                image_url: parsedOutput.output.imageUrl,
+                file_id: parsedOutput.output.fileId,
+                detail: parsedOutput.output.detail,
+              },
+              acknowledged_safety_checks:
+                parsedOutput.acknowledgedSafetyChecks?.map(safetyCheck => ({
+                  id: safetyCheck.id,
+                  code: safetyCheck.code,
+                  message: safetyCheck.message,
+                })),
             });
             continue;
           }

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -17,6 +17,73 @@ const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
   ]),
 );
 
+const openaiResponsesComputerSafetyCheckSchema = z.object({
+  id: z.string(),
+  code: z.string().nullish(),
+  message: z.string().nullish(),
+});
+
+const openaiResponsesComputerActionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('click'),
+    button: z.enum(['left', 'right', 'wheel', 'back', 'forward']),
+    x: z.number(),
+    y: z.number(),
+    keys: z.array(z.string()).nullish(),
+  }),
+  z.object({
+    type: z.literal('double_click'),
+    x: z.number(),
+    y: z.number(),
+    keys: z.array(z.string()).nullish(),
+  }),
+  z.object({
+    type: z.literal('drag'),
+    path: z.array(z.object({ x: z.number(), y: z.number() })),
+    keys: z.array(z.string()).nullish(),
+  }),
+  z.object({
+    type: z.literal('keypress'),
+    keys: z.array(z.string()),
+  }),
+  z.object({
+    type: z.literal('move'),
+    x: z.number(),
+    y: z.number(),
+    keys: z.array(z.string()).nullish(),
+  }),
+  z.object({
+    type: z.literal('screenshot'),
+  }),
+  z.object({
+    type: z.literal('scroll'),
+    x: z.number(),
+    y: z.number(),
+    scroll_x: z.number(),
+    scroll_y: z.number(),
+    keys: z.array(z.string()).nullish(),
+  }),
+  z.object({
+    type: z.literal('type'),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal('wait'),
+  }),
+]);
+
+const openaiResponsesComputerCallSchema = z.object({
+  type: z.literal('computer_call'),
+  id: z.string(),
+  call_id: z.string().nullish(),
+  status: z.enum(['in_progress', 'completed', 'incomplete']),
+  action: openaiResponsesComputerActionSchema.nullish(),
+  actions: z.array(openaiResponsesComputerActionSchema).nullish(),
+  pending_safety_checks: z
+    .array(openaiResponsesComputerSafetyCheckSchema)
+    .nullish(),
+});
+
 export type OpenAIResponsesInput = Array<OpenAIResponsesInputItem>;
 
 export type OpenAIResponsesInputItem =
@@ -29,6 +96,7 @@ export type OpenAIResponsesInputItem =
   | OpenAIResponsesCustomToolCallOutput
   | OpenAIResponsesMcpApprovalResponse
   | OpenAIResponsesComputerCall
+  | OpenAIResponsesComputerCallOutput
   | OpenAIResponsesLocalShellCall
   | OpenAIResponsesLocalShellCallOutput
   | OpenAIResponsesShellCall
@@ -184,10 +252,28 @@ export type OpenAIResponsesMcpApprovalResponse = {
   approve: boolean;
 };
 
-export type OpenAIResponsesComputerCall = {
-  type: 'computer_call';
-  id: string;
-  status?: string;
+export type OpenAIResponsesComputerAction = InferSchema<
+  typeof openaiResponsesComputerActionSchema
+>;
+
+export type OpenAIResponsesComputerCall = InferSchema<
+  typeof openaiResponsesComputerCallSchema
+>;
+
+export type OpenAIResponsesComputerCallOutput = {
+  type: 'computer_call_output';
+  call_id: string;
+  output: {
+    type: 'computer_screenshot';
+    image_url?: string;
+    file_id?: string;
+    detail?: 'auto' | 'low' | 'high' | 'original';
+  };
+  acknowledged_safety_checks?: Array<{
+    id: string;
+    code?: string;
+    message?: string;
+  }>;
 };
 
 export type OpenAIResponsesLocalShellCall = {
@@ -347,6 +433,9 @@ export type OpenAIResponsesTool =
     }
   | {
       type: 'apply_patch';
+    }
+  | {
+      type: 'computer';
     }
   | {
       type: 'web_search';
@@ -671,11 +760,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             id: z.string(),
             status: z.string(),
           }),
-          z.object({
-            type: z.literal('computer_call'),
-            id: z.string(),
-            status: z.string(),
-          }),
+          openaiResponsesComputerCallSchema,
           z.object({
             type: z.literal('file_search_call'),
             id: z.string(),
@@ -901,11 +986,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
               env: z.record(z.string(), z.string()).optional(),
             }),
           }),
-          z.object({
-            type: z.literal('computer_call'),
-            id: z.string(),
-            status: z.literal('completed'),
-          }),
+          openaiResponsesComputerCallSchema,
           z.object({
             type: z.literal('mcp_call'),
             id: z.string(),
@@ -1323,11 +1404,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
               input: z.string(),
               id: z.string(),
             }),
-            z.object({
-              type: z.literal('computer_call'),
-              id: z.string(),
-              status: z.string().optional(),
-            }),
+            openaiResponsesComputerCallSchema,
             z.object({
               type: z.literal('reasoning'),
               id: z.string(),

--- a/packages/openai/src/responses/openai-responses-computer.test.ts
+++ b/packages/openai/src/responses/openai-responses-computer.test.ts
@@ -1,0 +1,427 @@
+import {
+  convertReadableStreamToArray,
+  mockId,
+} from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-input';
+import { OpenAIResponsesLanguageModel } from './openai-responses-language-model';
+
+const toolNameMapping = {
+  toProviderToolName: (name: string) => name,
+  toCustomToolName: (name: string) => name,
+};
+
+function createModel() {
+  return new OpenAIResponsesLanguageModel('gpt-5.4', {
+    provider: 'openai',
+    url: ({ path }) => `https://api.openai.com/v1${path}`,
+    headers: () => ({ Authorization: 'Bearer APIKEY' }),
+    generateId: mockId(),
+  });
+}
+
+const computerCall = {
+  type: 'computer_call',
+  id: 'computer_item_123',
+  call_id: 'computer_call_123',
+  status: 'completed',
+  pending_safety_checks: [
+    {
+      id: 'safety_123',
+      code: 'confirm_action',
+      message: 'Confirm this action.',
+    },
+  ],
+  actions: [
+    {
+      type: 'click',
+      button: 'left',
+      x: 100,
+      y: 200,
+      keys: ['CTRL'],
+    },
+    {
+      type: 'double_click',
+      x: 110,
+      y: 210,
+      keys: null,
+    },
+    {
+      type: 'drag',
+      path: [
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ],
+    },
+    { type: 'keypress', keys: ['CTRL', 'L'] },
+    { type: 'move', x: 120, y: 220 },
+    { type: 'screenshot' },
+    {
+      type: 'scroll',
+      x: 130,
+      y: 230,
+      scroll_x: 0,
+      scroll_y: 500,
+    },
+    { type: 'type', text: 'hello' },
+    { type: 'wait' },
+  ],
+} as const;
+
+const expectedInput = {
+  actions: [
+    {
+      type: 'click',
+      button: 'left',
+      x: 100,
+      y: 200,
+      keys: ['CTRL'],
+    },
+    { type: 'double_click', x: 110, y: 210 },
+    {
+      type: 'drag',
+      path: [
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ],
+    },
+    { type: 'keypress', keys: ['CTRL', 'L'] },
+    { type: 'move', x: 120, y: 220 },
+    { type: 'screenshot' },
+    {
+      type: 'scroll',
+      x: 130,
+      y: 230,
+      scrollX: 0,
+      scrollY: 500,
+    },
+    { type: 'type', text: 'hello' },
+    { type: 'wait' },
+  ],
+  pendingSafetyChecks: [
+    {
+      id: 'safety_123',
+      code: 'confirm_action',
+      message: 'Confirm this action.',
+    },
+  ],
+  status: 'completed',
+};
+
+describe('OpenAI Responses computer tool', () => {
+  const server = createTestServer({
+    'https://api.openai.com/v1/responses': {},
+  });
+
+  it('decodes batched actions in non-streaming responses', async () => {
+    server.urls['https://api.openai.com/v1/responses'].response = {
+      type: 'json-value',
+      body: {
+        id: 'resp_computer_test',
+        object: 'response',
+        created_at: 1741630255,
+        status: 'completed',
+        error: null,
+        incomplete_details: null,
+        instructions: null,
+        max_output_tokens: null,
+        model: 'gpt-5.4',
+        output: [computerCall],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      },
+    };
+
+    const result = await createModel().doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Use it.' }] }],
+      tools: [
+        {
+          type: 'provider',
+          id: 'openai.computer',
+          name: 'computer',
+          args: {},
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      tools: [{ type: 'computer' }],
+    });
+    expect(result.content).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'computer_call_123',
+        toolName: 'computer',
+        input: JSON.stringify(expectedInput),
+        providerMetadata: {
+          openai: { itemId: 'computer_item_123' },
+        },
+      },
+    ]);
+    expect(result.finishReason.unified).toBe('tool-calls');
+  });
+
+  it('decodes batched actions in streaming responses', async () => {
+    server.urls['https://api.openai.com/v1/responses'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data:${JSON.stringify({
+          type: 'response.created',
+          response: {
+            id: 'resp_computer_test',
+            created_at: 1741630255,
+            model: 'gpt-5.4',
+            service_tier: null,
+          },
+        })}\n\n`,
+        `data:${JSON.stringify({
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            type: 'computer_call',
+            id: computerCall.id,
+            call_id: computerCall.call_id,
+            status: 'in_progress',
+          },
+        })}\n\n`,
+        `data:${JSON.stringify({
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: computerCall,
+        })}\n\n`,
+        `data:${JSON.stringify({
+          type: 'response.completed',
+          response: {
+            incomplete_details: null,
+            reasoning: null,
+            service_tier: null,
+            usage: {
+              input_tokens: 100,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens: 50,
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await createModel().doStream({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Use it.' }] }],
+      tools: [
+        {
+          type: 'provider',
+          id: 'openai.computer',
+          name: 'computer',
+          args: {},
+        },
+      ],
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    expect(events).toContainEqual({
+      type: 'tool-input-start',
+      id: 'computer_call_123',
+      toolName: 'computer',
+    });
+    expect(events).toContainEqual({
+      type: 'tool-input-delta',
+      id: 'computer_call_123',
+      delta: JSON.stringify(expectedInput),
+    });
+    expect(events).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'computer_call_123',
+      toolName: 'computer',
+      input: JSON.stringify(expectedInput),
+      providerMetadata: {
+        openai: { itemId: 'computer_item_123' },
+      },
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'tool-calls' },
+    });
+  });
+
+  it.each([
+    {
+      store: true,
+      hasPreviousResponseId: false,
+      expectedCall: {
+        type: 'item_reference',
+        id: 'computer_item_123',
+      },
+    },
+    {
+      store: false,
+      hasPreviousResponseId: false,
+      expectedCall: {
+        type: 'computer_call',
+        id: 'computer_item_123',
+        call_id: 'computer_call_123',
+        status: 'completed',
+        actions: [
+          {
+            type: 'scroll',
+            x: 10,
+            y: 20,
+            scroll_x: 0,
+            scroll_y: 100,
+            keys: undefined,
+          },
+        ],
+        pending_safety_checks: [
+          {
+            id: 'safety_123',
+            code: 'confirm_action',
+            message: undefined,
+          },
+        ],
+      },
+    },
+    {
+      store: true,
+      hasPreviousResponseId: true,
+      expectedCall: undefined,
+    },
+  ])(
+    'serializes screenshot output (store: $store, previous response: $hasPreviousResponseId)',
+    async ({ store, hasPreviousResponseId, expectedCall }) => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'computer_call_123',
+                toolName: 'computer',
+                input: {
+                  actions: [
+                    {
+                      type: 'scroll',
+                      x: 10,
+                      y: 20,
+                      scrollX: 0,
+                      scrollY: 100,
+                    },
+                  ],
+                  pendingSafetyChecks: [
+                    {
+                      id: 'safety_123',
+                      code: 'confirm_action',
+                    },
+                  ],
+                  status: 'completed',
+                },
+                providerOptions: {
+                  openai: { itemId: 'computer_item_123' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'computer_call_123',
+                toolName: 'computer',
+                output: {
+                  type: 'json',
+                  value: {
+                    output: {
+                      type: 'computer_screenshot',
+                      imageUrl: 'data:image/png;base64,c2NyZWVuc2hvdA==',
+                      detail: 'original',
+                    },
+                    acknowledgedSafetyChecks: [
+                      {
+                        id: 'safety_123',
+                        code: 'confirm_action',
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        toolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store,
+        hasPreviousResponseId,
+        hasComputerTool: true,
+      });
+
+      expect(result.input).toEqual([
+        ...(expectedCall == null ? [] : [expectedCall]),
+        {
+          type: 'computer_call_output',
+          call_id: 'computer_call_123',
+          output: {
+            type: 'computer_screenshot',
+            image_url: 'data:image/png;base64,c2NyZWVuc2hvdA==',
+            file_id: undefined,
+            detail: 'original',
+          },
+          acknowledged_safety_checks: [
+            {
+              id: 'safety_123',
+              code: 'confirm_action',
+              message: undefined,
+            },
+          ],
+        },
+      ]);
+    },
+  );
+
+  it('serializes file ID screenshot output', async () => {
+    const result = await convertToOpenAIResponsesInput({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'computer_call_123',
+              toolName: 'computer',
+              output: {
+                type: 'json',
+                value: {
+                  output: {
+                    type: 'computer_screenshot',
+                    fileId: 'file_screenshot_123',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      toolNameMapping,
+      systemMessageMode: 'system',
+      providerOptionsName: 'openai',
+      store: true,
+      hasComputerTool: true,
+    });
+
+    expect(result.input).toEqual([
+      {
+        type: 'computer_call_output',
+        call_id: 'computer_call_123',
+        output: {
+          type: 'computer_screenshot',
+          image_url: undefined,
+          file_id: 'file_screenshot_123',
+          detail: undefined,
+        },
+        acknowledged_safety_checks: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -101,10 +101,6 @@ function extractApprovalRequestIdToToolCallIdMapping(
   return mapping;
 }
 
-<<<<<<< HEAD
-export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3';
-=======
 function mapComputerAction(
   action: OpenAIResponsesComputerAction,
 ): InferSchema<typeof computerInputSchema>['actions'][number] {
@@ -186,9 +182,8 @@ function mapComputerCallInput({
   };
 }
 
-export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
-  readonly specificationVersion = 'v4';
->>>>>>> 0063c2d35 (feat: add OpenAI Responses API computer tool support (#17290))
+export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = 'v3';
 
   readonly modelId: OpenAIResponsesModelId;
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -34,6 +34,7 @@ import type {
   codeInterpreterInputSchema,
   codeInterpreterOutputSchema,
 } from '../tool/code-interpreter';
+import type { computerInputSchema } from '../tool/computer';
 import type { fileSearchOutputSchema } from '../tool/file-search';
 import type { imageGenerationOutputSchema } from '../tool/image-generation';
 import type { localShellInputSchema } from '../tool/local-shell';
@@ -60,6 +61,7 @@ import {
   type OpenAIResponsesWebSearchAction,
   type OpenAIResponsesApplyPatchOperationDiffDeltaChunk,
   type OpenAIResponsesApplyPatchOperationDiffDoneChunk,
+  type OpenAIResponsesComputerAction,
 } from './openai-responses-api';
 import {
   openaiLanguageModelResponsesOptionsSchema,
@@ -99,8 +101,94 @@ function extractApprovalRequestIdToToolCallIdMapping(
   return mapping;
 }
 
+<<<<<<< HEAD
 export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
   readonly specificationVersion = 'v3';
+=======
+function mapComputerAction(
+  action: OpenAIResponsesComputerAction,
+): InferSchema<typeof computerInputSchema>['actions'][number] {
+  switch (action.type) {
+    case 'click':
+      return {
+        type: 'click',
+        button: action.button,
+        x: action.x,
+        y: action.y,
+        ...(action.keys != null && { keys: action.keys }),
+      };
+    case 'double_click':
+      return {
+        type: 'double_click',
+        x: action.x,
+        y: action.y,
+        ...(action.keys != null && { keys: action.keys }),
+      };
+    case 'drag':
+      return {
+        type: 'drag',
+        path: action.path,
+        ...(action.keys != null && { keys: action.keys }),
+      };
+    case 'keypress':
+      return action;
+    case 'move':
+      return {
+        type: 'move',
+        x: action.x,
+        y: action.y,
+        ...(action.keys != null && { keys: action.keys }),
+      };
+    case 'screenshot':
+      return action;
+    case 'scroll':
+      return {
+        type: 'scroll',
+        x: action.x,
+        y: action.y,
+        scrollX: action.scroll_x,
+        scrollY: action.scroll_y,
+        ...(action.keys != null && { keys: action.keys }),
+      };
+    case 'type':
+      return action;
+    case 'wait':
+      return action;
+  }
+}
+
+function mapComputerCallInput({
+  action,
+  actions,
+  pending_safety_checks,
+  status,
+}: {
+  action?: OpenAIResponsesComputerAction | null;
+  actions?: OpenAIResponsesComputerAction[] | null;
+  pending_safety_checks?: Array<{
+    id: string;
+    code?: string | null;
+    message?: string | null;
+  }> | null;
+  status: 'in_progress' | 'completed' | 'incomplete';
+}): InferSchema<typeof computerInputSchema> {
+  return {
+    actions: (actions ?? (action != null ? [action] : [])).map(
+      mapComputerAction,
+    ),
+    pendingSafetyChecks:
+      pending_safety_checks?.map(safetyCheck => ({
+        id: safetyCheck.id,
+        ...(safetyCheck.code != null && { code: safetyCheck.code }),
+        ...(safetyCheck.message != null && { message: safetyCheck.message }),
+      })) ?? [],
+    status,
+  };
+}
+
+export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
+>>>>>>> 0063c2d35 (feat: add OpenAI Responses API computer tool support (#17290))
 
   readonly modelId: OpenAIResponsesModelId;
 
@@ -190,6 +278,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       tools,
       providerToolNames: {
         'openai.code_interpreter': 'code_interpreter',
+        'openai.computer': 'computer',
         'openai.file_search': 'file_search',
         'openai.image_generation': 'image_generation',
         'openai.local_shell': 'local_shell',
@@ -238,6 +327,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
         hasLocalShellTool: hasOpenAITool('openai.local_shell'),
         hasShellTool: hasOpenAITool('openai.shell'),
         hasApplyPatchTool: hasOpenAITool('openai.apply_patch'),
+        hasComputerTool: hasOpenAITool('openai.computer'),
         customProviderToolNames:
           customProviderToolNames.size > 0
             ? customProviderToolNames
@@ -923,21 +1013,39 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
         }
 
         case 'computer_call': {
-          content.push({
-            type: 'tool-call',
-            toolCallId: part.id,
-            toolName: toolNameMapping.toCustomToolName('computer_use'),
-            input: '',
-            providerExecuted: true,
-          });
+          if (part.call_id == null) {
+            content.push({
+              type: 'tool-call',
+              toolCallId: part.id,
+              toolName: toolNameMapping.toCustomToolName('computer_use'),
+              input: '',
+              providerExecuted: true,
+            });
+
+            content.push({
+              type: 'tool-result',
+              toolCallId: part.id,
+              toolName: toolNameMapping.toCustomToolName('computer_use'),
+              result: {
+                type: 'computer_use_tool_result',
+                status: part.status,
+              },
+            });
+            break;
+          }
+
+          hasFunctionCall = true;
+          const toolName = toolNameMapping.toCustomToolName('computer');
 
           content.push({
-            type: 'tool-result',
-            toolCallId: part.id,
-            toolName: toolNameMapping.toCustomToolName('computer_use'),
-            result: {
-              type: 'computer_use_tool_result',
-              status: part.status || 'completed',
+            type: 'tool-call',
+            toolCallId: part.call_id,
+            toolName,
+            input: JSON.stringify(mapComputerCallInput(part)),
+            providerMetadata: {
+              [providerOptionsName]: {
+                itemId: part.id,
+              },
             },
           });
           break;
@@ -1254,16 +1362,16 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   providerExecuted: true,
                 });
               } else if (value.item.type === 'computer_call') {
+                const toolCallId = value.item.call_id ?? value.item.id;
                 ongoingToolCalls[value.output_index] = {
-                  toolName: toolNameMapping.toCustomToolName('computer_use'),
-                  toolCallId: value.item.id,
+                  toolName: toolNameMapping.toCustomToolName('computer'),
+                  toolCallId,
                 };
 
                 controller.enqueue({
                   type: 'tool-input-start',
-                  id: value.item.id,
-                  toolName: toolNameMapping.toCustomToolName('computer_use'),
-                  providerExecuted: true,
+                  id: toolCallId,
+                  toolName: toolNameMapping.toCustomToolName('computer'),
                 });
               } else if (value.item.type === 'code_interpreter_call') {
                 ongoingToolCalls[value.output_index] = {
@@ -1504,26 +1612,54 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               } else if (value.item.type === 'computer_call') {
                 ongoingToolCalls[value.output_index] = undefined;
 
+                if (value.item.call_id == null) {
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: value.item.id,
+                  });
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: value.item.id,
+                    toolName: toolNameMapping.toCustomToolName('computer_use'),
+                    input: '',
+                    providerExecuted: true,
+                  });
+                  controller.enqueue({
+                    type: 'tool-result',
+                    toolCallId: value.item.id,
+                    toolName: toolNameMapping.toCustomToolName('computer_use'),
+                    result: {
+                      type: 'computer_use_tool_result',
+                      status: value.item.status,
+                    },
+                  });
+                  return;
+                }
+
+                hasFunctionCall = true;
+                const toolName = toolNameMapping.toCustomToolName('computer');
+                const input = JSON.stringify(mapComputerCallInput(value.item));
+
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: value.item.call_id,
+                  delta: input,
+                });
+
                 controller.enqueue({
                   type: 'tool-input-end',
-                  id: value.item.id,
+                  id: value.item.call_id,
                 });
 
                 controller.enqueue({
                   type: 'tool-call',
-                  toolCallId: value.item.id,
-                  toolName: toolNameMapping.toCustomToolName('computer_use'),
-                  input: '',
-                  providerExecuted: true,
-                });
-
-                controller.enqueue({
-                  type: 'tool-result',
-                  toolCallId: value.item.id,
-                  toolName: toolNameMapping.toCustomToolName('computer_use'),
-                  result: {
-                    type: 'computer_use_tool_result',
-                    status: value.item.status || 'completed',
+                  toolCallId: value.item.call_id,
+                  toolName,
+                  input,
+                  providerMetadata: {
+                    [providerOptionsName]: {
+                      itemId: value.item.id,
+                    },
                   },
                 });
               } else if (value.item.type === 'file_search_call') {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1494,6 +1494,44 @@ describe('prepareResponsesTools', () => {
     });
   });
 
+  describe('computer', () => {
+    it('should prepare computer tool', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.computer',
+            name: 'computer',
+            args: {},
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toEqual({
+        tools: [{ type: 'computer' }],
+        toolChoice: undefined,
+        toolWarnings: [],
+      });
+    });
+
+    it('should handle computer tool choice', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.computer',
+            name: 'computer',
+            args: {},
+          },
+        ],
+        toolChoice: { type: 'tool', toolName: 'computer' },
+      });
+
+      expect(result.toolChoice).toEqual({ type: 'computer' });
+    });
+  });
+
   describe('apply_patch', () => {
     it('should prepare apply_patch tool', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -57,6 +57,7 @@ export async function prepareResponsesTools({
     | { type: 'mcp' }
     | { type: 'image_generation' }
     | { type: 'apply_patch' }
+    | { type: 'computer' }
     | {
         type: 'allowed_tools';
         mode: 'auto' | 'required';
@@ -163,6 +164,12 @@ export async function prepareResponsesTools({
           case 'openai.apply_patch': {
             openaiTools.push({
               type: 'apply_patch',
+            });
+            break;
+          }
+          case 'openai.computer': {
+            openaiTools.push({
+              type: 'computer',
             });
             break;
           }
@@ -369,7 +376,8 @@ export async function prepareResponsesTools({
           resolvedToolName === 'web_search_preview' ||
           resolvedToolName === 'web_search' ||
           resolvedToolName === 'mcp' ||
-          resolvedToolName === 'apply_patch'
+          resolvedToolName === 'apply_patch' ||
+          resolvedToolName === 'computer'
             ? { type: resolvedToolName }
             : resolvedCustomProviderToolNames.has(resolvedToolName)
               ? { type: 'custom', name: resolvedToolName }

--- a/packages/openai/src/tool/computer.test-d.ts
+++ b/packages/openai/src/tool/computer.test-d.ts
@@ -1,0 +1,21 @@
+import type { InferSchema, Tool } from '@ai-sdk/provider-utils';
+import { describe, expectTypeOf, it } from 'vitest';
+import {
+  computer,
+  type computerInputSchema,
+  type computerOutputSchema,
+} from './computer';
+
+describe('computer tool type', () => {
+  it('should have Tool type', () => {
+    const computerTool = computer();
+
+    expectTypeOf(computerTool).toExtend<
+      Tool<
+        InferSchema<typeof computerInputSchema>,
+        InferSchema<typeof computerOutputSchema>,
+        {}
+      >
+    >();
+  });
+});

--- a/packages/openai/src/tool/computer.test-d.ts
+++ b/packages/openai/src/tool/computer.test-d.ts
@@ -13,8 +13,7 @@ describe('computer tool type', () => {
     expectTypeOf(computerTool).toExtend<
       Tool<
         InferSchema<typeof computerInputSchema>,
-        InferSchema<typeof computerOutputSchema>,
-        {}
+        InferSchema<typeof computerOutputSchema>
       >
     >();
   });

--- a/packages/openai/src/tool/computer.ts
+++ b/packages/openai/src/tool/computer.ts
@@ -1,0 +1,147 @@
+import {
+  createProviderDefinedToolFactoryWithOutputSchema,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const safetyCheckSchema = z.object({
+  id: z.string(),
+  code: z.string().optional(),
+  message: z.string().optional(),
+});
+
+const computerActionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('click'),
+    button: z.enum(['left', 'right', 'wheel', 'back', 'forward']),
+    x: z.number(),
+    y: z.number(),
+    keys: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal('double_click'),
+    x: z.number(),
+    y: z.number(),
+    keys: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal('drag'),
+    path: z.array(z.object({ x: z.number(), y: z.number() })),
+    keys: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal('keypress'),
+    keys: z.array(z.string()),
+  }),
+  z.object({
+    type: z.literal('move'),
+    x: z.number(),
+    y: z.number(),
+    keys: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal('screenshot'),
+  }),
+  z.object({
+    type: z.literal('scroll'),
+    x: z.number(),
+    y: z.number(),
+    scrollX: z.number(),
+    scrollY: z.number(),
+    keys: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal('type'),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal('wait'),
+  }),
+]);
+
+export const computerInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      actions: z.array(computerActionSchema),
+      pendingSafetyChecks: z.array(safetyCheckSchema),
+      status: z.enum(['in_progress', 'completed', 'incomplete']),
+    }),
+  ),
+);
+
+export const computerOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      output: z.union([
+        z.object({
+          type: z.literal('computer_screenshot'),
+          imageUrl: z.string(),
+          fileId: z.string().optional(),
+          detail: z.enum(['auto', 'low', 'high', 'original']).optional(),
+        }),
+        z.object({
+          type: z.literal('computer_screenshot'),
+          fileId: z.string(),
+          imageUrl: z.string().optional(),
+          detail: z.enum(['auto', 'low', 'high', 'original']).optional(),
+        }),
+      ]),
+      acknowledgedSafetyChecks: z.array(safetyCheckSchema).optional(),
+    }),
+  ),
+);
+
+export type OpenAIComputerAction = z.infer<typeof computerActionSchema>;
+export type OpenAIComputerSafetyCheck = z.infer<typeof safetyCheckSchema>;
+
+const computerToolFactory = createProviderDefinedToolFactoryWithOutputSchema<
+  {
+    /**
+     * Ordered UI actions to execute.
+     */
+    actions: OpenAIComputerAction[];
+
+    /**
+     * Safety checks that must be acknowledged before continuing.
+     */
+    pendingSafetyChecks: OpenAIComputerSafetyCheck[];
+
+    /**
+     * Status of the computer call.
+     */
+    status: 'in_progress' | 'completed' | 'incomplete';
+  },
+  {
+    /**
+     * The screenshot captured after executing all actions.
+     */
+    output:
+      | {
+          type: 'computer_screenshot';
+          imageUrl: string;
+          fileId?: string;
+          detail?: 'auto' | 'low' | 'high' | 'original';
+        }
+      | {
+          type: 'computer_screenshot';
+          fileId: string;
+          imageUrl?: string;
+          detail?: 'auto' | 'low' | 'high' | 'original';
+        };
+
+    /**
+     * Safety checks that the application has reviewed and acknowledged.
+     */
+    acknowledgedSafetyChecks?: OpenAIComputerSafetyCheck[];
+  },
+  {}
+>({
+  id: 'openai.computer',
+  inputSchema: computerInputSchema,
+  outputSchema: computerOutputSchema,
+});
+
+export const computer = (
+  options: Parameters<typeof computerToolFactory>[0] = {},
+) => computerToolFactory(options);

--- a/packages/openai/src/tool/computer.ts
+++ b/packages/openai/src/tool/computer.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -95,7 +95,7 @@ export const computerOutputSchema = lazySchema(() =>
 export type OpenAIComputerAction = z.infer<typeof computerActionSchema>;
 export type OpenAIComputerSafetyCheck = z.infer<typeof safetyCheckSchema>;
 
-const computerToolFactory = createProviderDefinedToolFactoryWithOutputSchema<
+const computerToolFactory = createProviderToolFactoryWithOutputSchema<
   {
     /**
      * Ordered UI actions to execute.


### PR DESCRIPTION
## Background

Applications need typed access to OpenAI's GA computer-use tool so models can request UI actions and receive updated screenshots in multi-step workflows.

## Summary

Added openai.tools.computer(), typed batched actions and safety checks, tool-choice serialization, streaming and non-streaming decoding, and computer_call_output round-tripping for image URLs and file IDs.

## Testing

Added type and runtime tests covering every action variant, tool preparation and selection, streaming and non-streaming calls, safety checks, data URL and file ID screenshots, stored and stateless requests, and previousResponseId flows.

## End-to-end Validation

- Ran the updated ai-functions example against live OpenAI GPT-5.4; it requested a screenshot action, received the screenshot output, and completed with an accurate screen description.

### Documentation

Documented the computer tool API, action and safety-check types, execution loop, screenshot formats, persistence behavior, approvals, and security guidance in the OpenAI provider documentation.

## Related Issues

Fixes #13730

Backport of #17290

Co-authored-by: realglyph123 <124026881+realglyph123@users.noreply.github.com>