### PR TITLE
[v5.0] feat: add non-streaming Voxtral TTS to the Mistral provider

### DIFF
--- a/.changeset/strong-speech-smile.md
+++ b/.changeset/strong-speech-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Add non-streaming Voxtral text-to-speech generation with saved voice IDs and one-off reference audio.

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -149,12 +149,12 @@ try {
 
 ## Speech Models
 
-<<<<<<< HEAD
 | Provider                                                           | Model                    |
 | ------------------------------------------------------------------ | ------------------------ |
 | [OpenAI](/providers/ai-sdk-providers/openai#speech-models)         | `tts-1`                  |
 | [OpenAI](/providers/ai-sdk-providers/openai#speech-models)         | `tts-1-hd`               |
 | [OpenAI](/providers/ai-sdk-providers/openai#speech-models)         | `gpt-4o-mini-tts`        |
+| [Mistral](/providers/ai-sdk-providers/mistral#speech-models)       | `voxtral-mini-tts-2603`  |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models) | `eleven_v3`              |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models) | `eleven_multilingual_v2` |
 | [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models) | `eleven_flash_v2_5`      |
@@ -164,34 +164,5 @@ try {
 | [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)             | `aurora`                 |
 | [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)             | `blizzard`               |
 | [Hume](/providers/ai-sdk-providers/hume#speech-models)             | `default`                |
-=======
-| Provider                                                                 | Model                               |
-| ------------------------------------------------------------------------ | ----------------------------------- |
-| [OpenAI](/providers/ai-sdk-providers/openai#speech-models)               | `tts-1`                             |
-| [OpenAI](/providers/ai-sdk-providers/openai#speech-models)               | `tts-1-hd`                          |
-| [OpenAI](/providers/ai-sdk-providers/openai#speech-models)               | `gpt-4o-mini-tts`                   |
-| [Mistral](/providers/ai-sdk-providers/mistral#speech-models)             | `voxtral-mini-tts-2603`             |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_v3`                         |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_multilingual_v2`            |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_flash_v2_5`                 |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_flash_v2`                   |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_turbo_v2_5`                 |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_turbo_v2`                   |
-| [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)                   | `aurora`                            |
-| [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)                   | `blizzard`                          |
-| [Hume](/providers/ai-sdk-providers/hume#speech-models)                   | `default`                           |
-| [Google](/providers/ai-sdk-providers/google#speech-models)               | `gemini-2.5-flash-preview-tts`      |
-| [Google](/providers/ai-sdk-providers/google#speech-models)               | `gemini-2.5-pro-preview-tts`        |
-| [Google](/providers/ai-sdk-providers/google#speech-models)               | `gemini-3.1-flash-tts-preview`      |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-flash-tts`              |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-pro-tts`                |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-flash-lite-preview-tts` |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-3.1-flash-tts-preview`      |
-| [xAI](/providers/ai-sdk-providers/xai#speech-models)                     | `default`                           |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-3.5`                         |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-3`                           |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-2`                           |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-turbo`                       |
->>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 
 Above are a small subset of the speech models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -149,6 +149,7 @@ try {
 
 ## Speech Models
 
+<<<<<<< HEAD
 | Provider                                                           | Model                    |
 | ------------------------------------------------------------------ | ------------------------ |
 | [OpenAI](/providers/ai-sdk-providers/openai#speech-models)         | `tts-1`                  |
@@ -163,5 +164,34 @@ try {
 | [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)             | `aurora`                 |
 | [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)             | `blizzard`               |
 | [Hume](/providers/ai-sdk-providers/hume#speech-models)             | `default`                |
+=======
+| Provider                                                                 | Model                               |
+| ------------------------------------------------------------------------ | ----------------------------------- |
+| [OpenAI](/providers/ai-sdk-providers/openai#speech-models)               | `tts-1`                             |
+| [OpenAI](/providers/ai-sdk-providers/openai#speech-models)               | `tts-1-hd`                          |
+| [OpenAI](/providers/ai-sdk-providers/openai#speech-models)               | `gpt-4o-mini-tts`                   |
+| [Mistral](/providers/ai-sdk-providers/mistral#speech-models)             | `voxtral-mini-tts-2603`             |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_v3`                         |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_multilingual_v2`            |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_flash_v2_5`                 |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_flash_v2`                   |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_turbo_v2_5`                 |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#speech-models)       | `eleven_turbo_v2`                   |
+| [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)                   | `aurora`                            |
+| [LMNT](/providers/ai-sdk-providers/lmnt#speech-models)                   | `blizzard`                          |
+| [Hume](/providers/ai-sdk-providers/hume#speech-models)                   | `default`                           |
+| [Google](/providers/ai-sdk-providers/google#speech-models)               | `gemini-2.5-flash-preview-tts`      |
+| [Google](/providers/ai-sdk-providers/google#speech-models)               | `gemini-2.5-pro-preview-tts`        |
+| [Google](/providers/ai-sdk-providers/google#speech-models)               | `gemini-3.1-flash-tts-preview`      |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-flash-tts`              |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-pro-tts`                |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-2.5-flash-lite-preview-tts` |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#speech-models) | `gemini-3.1-flash-tts-preview`      |
+| [xAI](/providers/ai-sdk-providers/xai#speech-models)                     | `default`                           |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-3.5`                         |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-3`                           |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-2`                           |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#speech-models)           | `sonic-turbo`                       |
+>>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 
 Above are a small subset of the speech models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -5,7 +5,8 @@ description: Learn how to use Mistral.
 
 # Mistral AI Provider
 
-The [Mistral AI](https://mistral.ai/) provider contains language model support for the Mistral chat API.
+The [Mistral AI](https://mistral.ai/) provider contains language model,
+embedding model, and speech model support for Mistral APIs.
 
 ## Setup
 
@@ -298,6 +299,75 @@ const result = await generateObject({
   full list of available models. The table above lists popular models. You can
   also pass any available provider model ID as a string if needed.
 </Note>
+
+## Speech Models
+
+You can create models that call the
+[Mistral speech API](https://docs.mistral.ai/api/endpoint/audio/speech) using
+the `.speech()` factory method:
+
+```ts
+const model = mistral.speech('voxtral-mini-tts-2603');
+```
+
+Use a preset or saved voice ID with [`generateSpeech`](/docs/reference/ai-sdk-core/generate-speech):
+
+```ts
+import { mistral } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+
+const result = await generateSpeech({
+  model: mistral.speech('voxtral-mini-tts-2603'),
+  text: 'Hello from the AI SDK!',
+  voice: 'en_paul_neutral',
+  outputFormat: 'mp3',
+});
+
+const audio = result.audio.uint8Array;
+```
+
+The Mistral speech model maps `voice` to Mistral's `voice_id`. It supports
+`mp3`, `wav`, `pcm`, `flac`, and `opus` output formats and defaults to `mp3`.
+The `instructions`, `speed`, and `language` settings are not supported and
+produce warnings when provided.
+
+Mistral also supports one-off voice cloning with base64-encoded reference
+audio. Pass it through `providerOptions.mistral.refAudio` and use
+`MistralSpeechModelOptions` for type checking:
+
+```ts highlight="9-13"
+import { readFile } from 'node:fs/promises';
+import { mistral, type MistralSpeechModelOptions } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+
+const referenceAudio = await readFile('./reference.mp3');
+
+const result = await generateSpeech({
+  model: mistral.speech('voxtral-mini-tts-2603'),
+  text: 'Hello from the AI SDK!',
+  providerOptions: {
+    mistral: {
+      refAudio: referenceAudio.toString('base64'),
+    } satisfies MistralSpeechModelOptions,
+  },
+});
+```
+
+When `refAudio` is provided, it takes precedence over `voice`. Reference audio
+is redacted from request metadata and API call errors returned by the provider.
+
+<Note>
+  Only use reference audio with the speaker's explicit consent. Follow Mistral's
+  voice cloning usage policy and disclose AI-generated audio when required. This
+  provider integration supports non-streaming speech generation; Mistral's
+  streaming speech API is not exposed through `SpeechModelV4`.
+</Note>
+
+### Model Capabilities
+
+| Model                   | Saved Voices | Reference Audio | Non-Streaming |
+| ----------------------- | ------------ | --------------- | ------------- |
+| `voxtral-mini-tts-2603` | <Check />    | <Check />       | <Check />     |
 
 ## Embedding Models
 

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -360,7 +360,7 @@ is redacted from request metadata and API call errors returned by the provider.
   Only use reference audio with the speaker's explicit consent. Follow Mistral's
   voice cloning usage policy and disclose AI-generated audio when required. This
   provider integration supports non-streaming speech generation; Mistral's
-  streaming speech API is not exposed through `SpeechModelV4`.
+  streaming speech API is not exposed through `SpeechModelV2`.
 </Note>
 
 ### Model Capabilities

--- a/examples/ai-functions/src/generate-speech/mistral/basic.ts
+++ b/examples/ai-functions/src/generate-speech/mistral/basic.ts
@@ -1,0 +1,18 @@
+import { mistral } from '@ai-sdk/mistral';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: mistral.speech('voxtral-mini-tts-2603'),
+    text: 'Hello from the AI SDK!',
+    voice: 'en_paul_neutral',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+
+  await saveAudioFile(result.audio);
+});

--- a/packages/mistral/README.md
+++ b/packages/mistral/README.md
@@ -1,6 +1,6 @@
 # AI SDK - Mistral Provider
 
-The **[Mistral provider](https://ai-sdk.dev/providers/ai-sdk-providers/mistral)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the Mistral chat API.
+The **[Mistral provider](https://ai-sdk.dev/providers/ai-sdk-providers/mistral)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model, embedding model, and speech model support for Mistral APIs.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Mistral (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -3,18 +3,9 @@ export type {
   MistralProvider,
   MistralProviderSettings,
 } from './mistral-provider';
-<<<<<<< HEAD
 export type { MistralLanguageModelOptions } from './mistral-chat-options';
-=======
-export type {
-  MistralLanguageModelChatOptions,
-  /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
-  MistralLanguageModelChatOptions as MistralLanguageModelOptions,
-} from './mistral-chat-language-model-options';
-export type { MistralEmbeddingModelOptions } from './mistral-embedding-model-options';
 export type {
   MistralSpeechModelId,
   MistralSpeechModelOptions,
 } from './mistral-speech-model-options';
->>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 export { VERSION } from './version';

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -3,5 +3,18 @@ export type {
   MistralProvider,
   MistralProviderSettings,
 } from './mistral-provider';
+<<<<<<< HEAD
 export type { MistralLanguageModelOptions } from './mistral-chat-options';
+=======
+export type {
+  MistralLanguageModelChatOptions,
+  /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
+  MistralLanguageModelChatOptions as MistralLanguageModelOptions,
+} from './mistral-chat-language-model-options';
+export type { MistralEmbeddingModelOptions } from './mistral-embedding-model-options';
+export type {
+  MistralSpeechModelId,
+  MistralSpeechModelOptions,
+} from './mistral-speech-model-options';
+>>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 export { VERSION } from './version';

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -3,13 +3,7 @@ import {
   type LanguageModelV2,
   type ProviderV2,
   NoSuchModelError,
-<<<<<<< HEAD
-=======
-  type EmbeddingModelV4,
-  type LanguageModelV4,
-  type ProviderV4,
-  type SpeechModelV4,
->>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
+  type SpeechModelV2,
 } from '@ai-sdk/provider';
 import {
   type FetchFunction,
@@ -20,13 +14,9 @@ import {
 import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
-<<<<<<< HEAD
 import type { MistralEmbeddingModelId } from './mistral-embedding-options';
-=======
-import type { MistralEmbeddingModelId } from './mistral-embedding-model-options';
 import { MistralSpeechModel } from './mistral-speech-model';
 import type { MistralSpeechModelId } from './mistral-speech-model-options';
->>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV2 {
@@ -49,31 +39,19 @@ Creates a model for text generation.
 
   textEmbedding(modelId: MistralEmbeddingModelId): EmbeddingModelV2<string>;
 
-<<<<<<< HEAD
   textEmbeddingModel: (
     modelId: MistralEmbeddingModelId,
   ) => EmbeddingModelV2<string>;
-=======
-  /**
-   * Creates a model for speech generation (text-to-speech).
-   */
-  speech(modelId: MistralSpeechModelId): SpeechModelV4;
 
   /**
    * Creates a model for speech generation (text-to-speech).
    */
-  speechModel(modelId: MistralSpeechModelId): SpeechModelV4;
+  speech(modelId: MistralSpeechModelId): SpeechModelV2;
 
   /**
-   * @deprecated Use `embedding` instead.
+   * Creates a model for speech generation (text-to-speech).
    */
-  textEmbedding(modelId: MistralEmbeddingModelId): EmbeddingModelV4;
-
-  /**
-   * @deprecated Use `embeddingModel` instead.
-   */
-  textEmbeddingModel(modelId: MistralEmbeddingModelId): EmbeddingModelV4;
->>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
+  speechModel(modelId: MistralSpeechModelId): SpeechModelV2;
 }
 
 export interface MistralProviderSettings {

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -3,6 +3,13 @@ import {
   type LanguageModelV2,
   type ProviderV2,
   NoSuchModelError,
+<<<<<<< HEAD
+=======
+  type EmbeddingModelV4,
+  type LanguageModelV4,
+  type ProviderV4,
+  type SpeechModelV4,
+>>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 } from '@ai-sdk/provider';
 import {
   type FetchFunction,
@@ -13,7 +20,13 @@ import {
 import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
+<<<<<<< HEAD
 import type { MistralEmbeddingModelId } from './mistral-embedding-options';
+=======
+import type { MistralEmbeddingModelId } from './mistral-embedding-model-options';
+import { MistralSpeechModel } from './mistral-speech-model';
+import type { MistralSpeechModelId } from './mistral-speech-model-options';
+>>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV2 {
@@ -36,9 +49,31 @@ Creates a model for text generation.
 
   textEmbedding(modelId: MistralEmbeddingModelId): EmbeddingModelV2<string>;
 
+<<<<<<< HEAD
   textEmbeddingModel: (
     modelId: MistralEmbeddingModelId,
   ) => EmbeddingModelV2<string>;
+=======
+  /**
+   * Creates a model for speech generation (text-to-speech).
+   */
+  speech(modelId: MistralSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates a model for speech generation (text-to-speech).
+   */
+  speechModel(modelId: MistralSpeechModelId): SpeechModelV4;
+
+  /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: MistralEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: MistralEmbeddingModelId): EmbeddingModelV4;
+>>>>>>> ba433f72e (feat: add non-streaming Voxtral TTS to the Mistral provider (#17286))
 }
 
 export interface MistralProviderSettings {
@@ -107,6 +142,14 @@ export function createMistral(
       fetch: options.fetch,
     });
 
+  const createSpeechModel = (modelId: MistralSpeechModelId) =>
+    new MistralSpeechModel(modelId, {
+      provider: 'mistral.speech',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const provider = function (modelId: MistralChatModelId) {
     if (new.target) {
       throw new Error(
@@ -122,6 +165,8 @@ export function createMistral(
   provider.embedding = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
+  provider.speech = createSpeechModel;
+  provider.speechModel = createSpeechModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });

--- a/packages/mistral/src/mistral-speech-model-options.ts
+++ b/packages/mistral/src/mistral-speech-model-options.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod/v4';
+
+export type MistralSpeechModelId = 'voxtral-mini-tts-2603' | (string & {});
+
+export const mistralSpeechModelOptions = z.object({
+  /**
+   * Base64-encoded reference audio for one-off voice cloning.
+   *
+   * When provided, this takes precedence over the standard `voice` option.
+   */
+  refAudio: z.string().min(1).optional(),
+});
+
+export type MistralSpeechModelOptions = z.infer<
+  typeof mistralSpeechModelOptions
+>;

--- a/packages/mistral/src/mistral-speech-model.test.ts
+++ b/packages/mistral/src/mistral-speech-model.test.ts
@@ -1,0 +1,346 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createMistral } from './mistral-provider';
+import { MistralSpeechModel } from './mistral-speech-model';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const modelId = 'voxtral-mini-tts-2603';
+const url = 'https://api.mistral.ai/v1/audio/speech';
+const provider = createMistral({ apiKey: 'test-api-key' });
+const model = provider.speech(modelId);
+
+const server = createTestServer({
+  [url]: {},
+});
+
+describe('MistralSpeechModel', () => {
+  it('should expose correct provider and model information', () => {
+    expect(model.provider).toBe('mistral.speech');
+    expect(model.modelId).toBe(modelId);
+    expect(model.specificationVersion).toBe('v4');
+  });
+
+  it('should create speech models through both provider factories', () => {
+    expect(provider.speech(modelId)).toBeInstanceOf(MistralSpeechModel);
+    expect(provider.speechModel(modelId)).toBeInstanceOf(MistralSpeechModel);
+  });
+});
+
+describe('doGenerate', () => {
+  function prepareJsonResponse({
+    audioData = 'SUQzBAAAAAAA',
+    headers,
+  }: {
+    audioData?: string;
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls[url].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        audio_data: audioData,
+      },
+    };
+  }
+
+  it('should send a non-streaming request with default mp3 output', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: modelId,
+      input: 'Hello from the AI SDK!',
+      response_format: 'mp3',
+      stream: false,
+    });
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestUrl).toBe(url);
+  });
+
+  it('should map the voice to voice_id', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'voice-id',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      voice_id: 'voice-id',
+    });
+  });
+
+  it('should map refAudio to ref_audio and prefer it over voice', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'voice-id',
+      providerOptions: {
+        mistral: {
+          refAudio: 'cmVmZXJlbmNlLWF1ZGlv',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: modelId,
+      input: 'Hello from the AI SDK!',
+      ref_audio: 'cmVmZXJlbmNlLWF1ZGlv',
+      response_format: 'mp3',
+      stream: false,
+    });
+  });
+
+  it.each(['pcm', 'wav', 'mp3', 'flac', 'opus'])(
+    'should accept the %s output format',
+    async outputFormat => {
+      prepareJsonResponse();
+
+      await model.doGenerate({
+        text: 'Hello from the AI SDK!',
+        outputFormat,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        response_format: outputFormat,
+      });
+    },
+  );
+
+  it('should warn and use mp3 for unsupported output formats', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      outputFormat: 'aac',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      response_format: 'mp3',
+    });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'outputFormat',
+      }),
+    );
+  });
+
+  it('should warn for unsupported standard speech options', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      instructions: 'Speak cheerfully',
+      speed: 1.2,
+      language: 'en',
+    });
+
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'instructions',
+      }),
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'speed',
+      }),
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'language',
+      }),
+    ]);
+  });
+
+  it('should pass headers and the Mistral user agent', async () => {
+    prepareJsonResponse();
+
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      headers: {
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await customProvider.speech(modelId).doGenerate({
+      text: 'Hello from the AI SDK!',
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain(
+      'ai-sdk/mistral/0.0.0-test',
+    );
+  });
+
+  it('should use a custom base URL', async () => {
+    const customUrl = 'https://custom.mistral.example/v2/audio/speech';
+    const customFetch = vi.fn<typeof globalThis.fetch>(async () => {
+      return new Response(JSON.stringify({ audio_data: 'SUQzBAAAAAAA' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      baseURL: 'https://custom.mistral.example/v2/',
+      fetch: customFetch,
+    });
+
+    await customProvider.speech(modelId).doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(customFetch.mock.calls[0]![0]).toBe(customUrl);
+  });
+
+  it('should use a custom fetch implementation', async () => {
+    const customFetch = vi.fn<typeof globalThis.fetch>(async () => {
+      return new Response(JSON.stringify({ audio_data: 'SUQzBAAAAAAA' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      fetch: customFetch,
+    });
+
+    await customProvider.speech(modelId).doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(customFetch).toHaveBeenCalledOnce();
+    expect(customFetch.mock.calls[0]![0]).toBe(url);
+  });
+
+  it('should return base64 audio data', async () => {
+    prepareJsonResponse({ audioData: 'YXVkaW8=' });
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.audio).toBe('YXVkaW8=');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should include response data with timestamp, model id, and headers', async () => {
+    prepareJsonResponse({
+      headers: { 'x-request-id': 'test-request-id' },
+    });
+    const testDate = new Date(0);
+    const customModel = new MistralSpeechModel(modelId, {
+      provider: 'mistral.speech',
+      baseURL: 'https://api.mistral.ai/v1',
+      headers: () => ({ Authorization: 'Bearer test-api-key' }),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId,
+      headers: expect.objectContaining({
+        'x-request-id': 'test-request-id',
+      }),
+      body: {
+        audio_data: 'SUQzBAAAAAAA',
+      },
+    });
+  });
+
+  it('should redact reference audio from request metadata', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      providerOptions: {
+        mistral: {
+          refAudio: 'sensitive-reference-audio',
+        },
+      },
+    });
+
+    expect(result.request?.body).toBe(
+      JSON.stringify({
+        model: modelId,
+        input: 'Hello from the AI SDK!',
+        ref_audio: '[redacted]',
+        response_format: 'mp3',
+        stream: false,
+      }),
+    );
+    expect(result.request?.body).not.toContain('sensitive-reference-audio');
+  });
+
+  it('should redact reference audio from API errors', async () => {
+    server.urls[url].response = {
+      type: 'error',
+      status: 400,
+      body: JSON.stringify({
+        object: 'error',
+        message: 'The request was rejected.',
+        type: 'invalid_request_error',
+        param: 'ref_audio',
+        code: 'invalid_reference_audio',
+      }),
+    };
+
+    await expect(
+      model.doGenerate({
+        text: 'Hello from the AI SDK!',
+        providerOptions: {
+          mistral: {
+            refAudio: 'sensitive-reference-audio',
+          },
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: 'The request was rejected.',
+      statusCode: 400,
+      requestBodyValues: expect.objectContaining({
+        ref_audio: '[redacted]',
+      }),
+    });
+  });
+
+  it('should forward the abort signal', async () => {
+    const abortController = new AbortController();
+    const customFetch = vi.fn<typeof globalThis.fetch>(async (_url, init) => {
+      expect(init?.signal).toBe(abortController.signal);
+      return new Response(JSON.stringify({ audio_data: 'YXVkaW8=' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      fetch: customFetch,
+    });
+
+    await customProvider.speech(modelId).doGenerate({
+      text: 'Hello from the AI SDK!',
+      abortSignal: abortController.signal,
+    });
+
+    expect(customFetch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mistral/src/mistral-speech-model.test.ts
+++ b/packages/mistral/src/mistral-speech-model.test.ts
@@ -20,7 +20,7 @@ describe('MistralSpeechModel', () => {
   it('should expose correct provider and model information', () => {
     expect(model.provider).toBe('mistral.speech');
     expect(model.modelId).toBe(modelId);
-    expect(model.specificationVersion).toBe('v4');
+    expect(model.specificationVersion).toBe('v2');
   });
 
   it('should create speech models through both provider factories', () => {
@@ -127,8 +127,8 @@ describe('doGenerate', () => {
     });
     expect(result.warnings).toContainEqual(
       expect.objectContaining({
-        type: 'unsupported',
-        feature: 'outputFormat',
+        type: 'unsupported-setting',
+        setting: 'outputFormat',
       }),
     );
   });
@@ -145,16 +145,16 @@ describe('doGenerate', () => {
 
     expect(result.warnings).toEqual([
       expect.objectContaining({
-        type: 'unsupported',
-        feature: 'instructions',
+        type: 'unsupported-setting',
+        setting: 'instructions',
       }),
       expect.objectContaining({
-        type: 'unsupported',
-        feature: 'speed',
+        type: 'unsupported-setting',
+        setting: 'speed',
       }),
       expect.objectContaining({
-        type: 'unsupported',
-        feature: 'language',
+        type: 'unsupported-setting',
+        setting: 'language',
       }),
     ]);
   });

--- a/packages/mistral/src/mistral-speech-model.ts
+++ b/packages/mistral/src/mistral-speech-model.ts
@@ -1,0 +1,179 @@
+import type { SharedV4Warning, SpeechModelV4 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { mistralFailedResponseHandler } from './mistral-error';
+import {
+  mistralSpeechModelOptions,
+  type MistralSpeechModelId,
+} from './mistral-speech-model-options';
+
+interface MistralSpeechModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+type MistralSpeechOutputFormat = 'pcm' | 'wav' | 'mp3' | 'flac' | 'opus';
+
+export class MistralSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: MistralSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: MistralSpeechModelId;
+    config: MistralSpeechModelConfig;
+  }) {
+    return new MistralSpeechModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: MistralSpeechModelId,
+    private readonly config: MistralSpeechModelConfig,
+  ) {}
+
+  private async getArgs({
+    text,
+    voice,
+    outputFormat = 'mp3',
+    instructions,
+    speed,
+    language,
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+    const mistralOptions = await parseProviderOptions({
+      provider: 'mistral',
+      providerOptions,
+      schema: mistralSpeechModelOptions,
+    });
+
+    let responseFormat: MistralSpeechOutputFormat = 'mp3';
+    if (['pcm', 'wav', 'mp3', 'flac', 'opus'].includes(outputFormat)) {
+      responseFormat = outputFormat as MistralSpeechOutputFormat;
+    } else {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'outputFormat',
+        details: `Unsupported output format: ${outputFormat}. Using mp3 instead.`,
+      });
+    }
+
+    if (instructions != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'Mistral speech models do not support the `instructions` option. ' +
+          'Use a reference audio clip to guide delivery.',
+      });
+    }
+
+    if (speed != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'speed',
+        details:
+          'Mistral speech models do not support the `speed` option. It was ignored.',
+      });
+    }
+
+    if (language != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'language',
+        details:
+          'Mistral speech models do not support the `language` option. ' +
+          'Language is inferred from the input text and voice.',
+      });
+    }
+
+    const refAudio = mistralOptions?.refAudio;
+    const requestBody = {
+      model: this.modelId,
+      input: text,
+      voice_id: refAudio == null ? voice : undefined,
+      ref_audio: refAudio,
+      response_format: responseFormat,
+      stream: false,
+    };
+
+    const requestBodyValues = {
+      ...requestBody,
+      ref_audio: refAudio == null ? undefined : '[redacted]',
+    };
+
+    return { requestBody, requestBodyValues, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestBody, requestBodyValues, warnings } =
+      await this.getArgs(options);
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postToApi({
+      url: `${this.config.baseURL}/audio/speech`,
+      headers: combineHeaders(
+        { 'Content-Type': 'application/json' },
+        this.config.headers?.(),
+        options.headers,
+      ),
+      body: {
+        content: JSON.stringify(requestBody),
+        values: requestBodyValues,
+      },
+      failedResponseHandler: mistralFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        mistralSpeechResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      audio: response.audio_data,
+      warnings,
+      request: {
+        body: JSON.stringify(requestBodyValues),
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}
+
+const mistralSpeechResponseSchema = z.object({
+  audio_data: z.string(),
+});

--- a/packages/mistral/src/mistral-speech-model.ts
+++ b/packages/mistral/src/mistral-speech-model.ts
@@ -1,12 +1,9 @@
-import type { SharedV4Warning, SpeechModelV4 } from '@ai-sdk/provider';
+import type { SpeechModelV2, SpeechModelV2CallWarning } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonResponseHandler,
   parseProviderOptions,
   postToApi,
-  serializeModelOptions,
-  WORKFLOW_DESERIALIZE,
-  WORKFLOW_SERIALIZE,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
@@ -28,22 +25,8 @@ interface MistralSpeechModelConfig {
 
 type MistralSpeechOutputFormat = 'pcm' | 'wav' | 'mp3' | 'flac' | 'opus';
 
-export class MistralSpeechModel implements SpeechModelV4 {
-  readonly specificationVersion = 'v4';
-
-  static [WORKFLOW_SERIALIZE](model: MistralSpeechModel) {
-    return serializeModelOptions({
-      modelId: model.modelId,
-      config: model.config,
-    });
-  }
-
-  static [WORKFLOW_DESERIALIZE](options: {
-    modelId: MistralSpeechModelId;
-    config: MistralSpeechModelConfig;
-  }) {
-    return new MistralSpeechModel(options.modelId, options.config);
-  }
+export class MistralSpeechModel implements SpeechModelV2 {
+  readonly specificationVersion = 'v2';
 
   get provider(): string {
     return this.config.provider;
@@ -62,8 +45,8 @@ export class MistralSpeechModel implements SpeechModelV4 {
     speed,
     language,
     providerOptions,
-  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
-    const warnings: SharedV4Warning[] = [];
+  }: Parameters<SpeechModelV2['doGenerate']>[0]) {
+    const warnings: SpeechModelV2CallWarning[] = [];
     const mistralOptions = await parseProviderOptions({
       provider: 'mistral',
       providerOptions,
@@ -75,16 +58,16 @@ export class MistralSpeechModel implements SpeechModelV4 {
       responseFormat = outputFormat as MistralSpeechOutputFormat;
     } else {
       warnings.push({
-        type: 'unsupported',
-        feature: 'outputFormat',
+        type: 'unsupported-setting',
+        setting: 'outputFormat',
         details: `Unsupported output format: ${outputFormat}. Using mp3 instead.`,
       });
     }
 
     if (instructions != null) {
       warnings.push({
-        type: 'unsupported',
-        feature: 'instructions',
+        type: 'unsupported-setting',
+        setting: 'instructions',
         details:
           'Mistral speech models do not support the `instructions` option. ' +
           'Use a reference audio clip to guide delivery.',
@@ -93,8 +76,8 @@ export class MistralSpeechModel implements SpeechModelV4 {
 
     if (speed != null) {
       warnings.push({
-        type: 'unsupported',
-        feature: 'speed',
+        type: 'unsupported-setting',
+        setting: 'speed',
         details:
           'Mistral speech models do not support the `speed` option. It was ignored.',
       });
@@ -102,8 +85,8 @@ export class MistralSpeechModel implements SpeechModelV4 {
 
     if (language != null) {
       warnings.push({
-        type: 'unsupported',
-        feature: 'language',
+        type: 'unsupported-setting',
+        setting: 'language',
         details:
           'Mistral speech models do not support the `language` option. ' +
           'Language is inferred from the input text and voice.',
@@ -129,8 +112,8 @@ export class MistralSpeechModel implements SpeechModelV4 {
   }
 
   async doGenerate(
-    options: Parameters<SpeechModelV4['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    options: Parameters<SpeechModelV2['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV2['doGenerate']>>> {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { requestBody, requestBodyValues, warnings } =
       await this.getArgs(options);


### PR DESCRIPTION
## Background

Users need first-class Mistral Voxtral text-to-speech support so they can generate audio with saved voices or one-off reference audio through generateSpeech.

## Summary

Added a SpeechModelV4 implementation, speech and speechModel factories, public MistralSpeechModelId and MistralSpeechModelOptions types, supported output-format mapping, warnings, base64 response handling, and sensitive reference-audio redaction.

## Testing

Added 20 focused speech-model tests covering factories, request mapping, voice cloning, formats, warnings, headers, custom configuration, abort signals, responses, errors, and reference-audio privacy in Node and Edge runtimes.

## End-to-end Validation

- Ran the Mistral generateSpeech example against the live API and produced valid MP3 audio.
- Live-validated one-off cloning using synthetic reference audio; generated valid MP3 audio without warnings.
- Removed generated output artifacts after validation.

### Documentation

Updated the Mistral provider documentation with speech factories, saved and preset voices, reference audio, formats, unsupported settings, privacy and consent guidance, and non-streaming constraints; also added Voxtral to the core speech model list.

## Related Issues

Fixes #14245

Backport of #17286

Co-authored-by: sovetski <13520683+sovetski@users.noreply.github.com>