### PR TITLE
docs: document removal of the `tool()` `name` property in AI SDK 6

### DIFF
--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -301,6 +301,40 @@ const someTool = tool({
   codebase.
 </Note>
 
+### `tool()` `name` Property Removal
+
+AI SDK 6 no longer accepts a `name` property in `tool()` definitions. Remove the
+property when migrating. The tool name comes from its key in the `tools` object.
+
+```tsx filename="AI SDK 5"
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  weather: tool({
+    name: 'weather',
+    description: 'Get the weather',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+  }),
+};
+```
+
+```tsx filename="AI SDK 6"
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  weather: tool({
+    description: 'Get the weather',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+  }),
+};
+```
+
 ### `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` Deprecation
 
 `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` have been deprecated.


### PR DESCRIPTION
## Background

Issue #12213 reports that AI SDK 6 rejects `name` inside `tool()` definitions, but the 5.x-to-6.0 migration guide omitted this change. The public `Tool` type excludes `name`, and tool preparation derives each name from its key in the `tools` object. 

## Summary

Added an AI SDK 6 migration section explaining that `name` must be removed from `tool()` definitions and showing before-and-after examples that use the `tools` object key as the name.

## Testing

Formatting, documentation validation, repository checks, diff validation, and a focused TypeScript sample check all passed.

## Related Issues

Fixes #12213

Co-authored-by: dylanmoz <4955191+dylanmoz@users.noreply.github.com>