### PR TITLE
feat: handle empty HTTP 202 responses while polling xAI videos

### DIFF
--- a/.changeset/silly-zebras-poll.md
+++ b/.changeset/silly-zebras-poll.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Treat empty HTTP 202 xAI video status responses as pending while polling generation and editing requests.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -1226,7 +1226,9 @@ You can validate the provider options using the `XaiVideoModelOptions` type.
   images. Used with `mode: 'reference-to-video'`.
 
 <Note>
-  Video generation is an asynchronous process that can take several minutes.
+  Video generation is an asynchronous process that can take several minutes. The
+  provider treats HTTP 202 status responses as still processing, including when
+  the response body is empty, and continues polling at `pollIntervalMs`.
   Consider setting `pollTimeoutMs` to at least 10 minutes (600000ms) for
   reliable operation. Generated video URLs are ephemeral and should be
   downloaded promptly.

--- a/examples/ai-functions/src/generate-video/xai/basic.ts
+++ b/examples/ai-functions/src/generate-video/xai/basic.ts
@@ -15,6 +15,7 @@ run(async () => {
         duration: 5,
         providerOptions: {
           xai: {
+            pollIntervalMs: 5000, // HTTP 202 responses continue polling
             pollTimeoutMs: 600000, // 10 minutes
           } satisfies XaiVideoModelOptions,
         },

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -1385,6 +1385,142 @@ describe('XaiVideoModel', () => {
         body: doneStatusResponse,
       };
     });
+
+    it('should treat an empty HTTP 202 generation response as pending', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+        callNumber,
+      }) =>
+        callNumber === 1
+          ? { type: 'empty', status: 202 }
+          : { type: 'json-value', body: doneStatusResponse };
+
+      const model = createModel();
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(server.calls).toHaveLength(3);
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://vidgen.x.ai/output/video-001.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+
+    it('should treat an empty HTTP 202 edit response as pending', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+        callNumber,
+      }) =>
+        callNumber === 1
+          ? { type: 'empty', status: 202 }
+          : { type: 'json-value', body: doneStatusResponse };
+
+      const model = createModel();
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'edit-video',
+            videoUrl: 'https://example.com/source-video.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(`${TEST_BASE_URL}/videos/edits`);
+      expect(server.calls).toHaveLength(3);
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://vidgen.x.ai/output/video-001.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+
+    it('should time out while receiving empty HTTP 202 responses', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'empty',
+        status: 202,
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              pollIntervalMs: 10,
+              pollTimeoutMs: 30,
+            },
+          },
+        }),
+      ).rejects.toThrow('timed out');
+
+      expect(server.calls.length).toBeGreaterThan(1);
+    });
+
+    it('should preserve abort behavior after an empty HTTP 202 response', async () => {
+      const abortController = new AbortController();
+
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = () => {
+        setTimeout(() => abortController.abort(), 0);
+        return { type: 'empty', status: 202 };
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          abortSignal: abortController.signal,
+          providerOptions: {
+            xai: {
+              pollIntervalMs: 50,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+
+      expect(server.calls).toHaveLength(2);
+    });
+
+    it('should preserve unsuccessful polling response handling', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'Video status request failed',
+          },
+        }),
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({ ...defaultOptions }),
+      ).rejects.toMatchObject({
+        message: 'Video status request failed',
+        statusCode: 500,
+      });
+    });
+
+    it('should reject malformed HTTP 200 completion responses', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 200,
+        body: 'not-json',
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({ ...defaultOptions }),
+      ).rejects.toMatchObject({
+        message: 'Invalid JSON response',
+        statusCode: 200,
+      });
+    });
   });
 
   describe('providerMetadata edge cases', () => {

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -5,6 +5,7 @@ import {
   type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
+  cancelResponseBody,
   combineHeaders,
   convertUint8ArrayToBase64,
   createJsonResponseHandler,
@@ -14,6 +15,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
   type FetchFunction,
+  type ResponseHandler,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { xaiFailedResponseHandler } from './xai-error';
@@ -430,9 +432,7 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           url: `${baseURL}/videos/${requestId}`,
           validateUrl: false,
           headers: combineHeaders(this.config.headers(), options.headers),
-          successfulResponseHandler: createJsonResponseHandler(
-            xaiVideoStatusResponseSchema,
-          ),
+          successfulResponseHandler: xaiVideoStatusResponseHandler,
           failedResponseHandler: xaiFailedResponseHandler,
           abortSignal: options.abortSignal,
           fetch: this.config.fetch,
@@ -538,3 +538,22 @@ const xaiVideoStatusResponseSchema = z.object({
     })
     .nullish(),
 });
+
+const xaiCompletedVideoStatusResponseHandler = createJsonResponseHandler(
+  xaiVideoStatusResponseSchema,
+);
+
+const xaiVideoStatusResponseHandler: ResponseHandler<
+  z.infer<typeof xaiVideoStatusResponseSchema>
+> = async options => {
+  if (options.response.status === 202) {
+    await cancelResponseBody(options.response);
+
+    return {
+      value: { status: 'pending' },
+      responseHeaders: Object.fromEntries(options.response.headers),
+    };
+  }
+
+  return xaiCompletedVideoStatusResponseHandler(options);
+};


### PR DESCRIPTION
## Background

xAI video polling must continue when the status endpoint returns HTTP 202 with an empty body instead of failing JSON parsing.

## Summary

Added an xAI-specific status-aware polling handler that treats HTTP 202 as pending, safely discards its body, and retains schema validation for completed responses. No public API or type changes were required.

## Testing

Added generation and editing regression tests for empty 202 responses, plus timeout, abort, unsuccessful-status, and malformed HTTP 200 coverage.

## End-to-end Validation

- Ran the updated xAI basic video example against the live provider and successfully generated and downloaded an MP4; the generated artifact was removed afterward.

## Documentation

Updated the xAI provider documentation and basic video example to describe HTTP 202 polling behavior and the polling interval.

## Related Issues

Fixes #17308

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>