### PR TITLE
feat (provider/gateway): transcription client-secret minting via gateway.experimental_transcription.getToken

### DIFF
--- a/.changeset/loud-donkeys-attend.md
+++ b/.changeset/loud-donkeys-attend.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+feat (provider/gateway): add `gateway.experimental_transcription.getToken` for minting transcription-bound client secrets

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -36,7 +36,10 @@ import { GatewayImageModel } from './gateway-image-model';
 import { GatewayVideoModel } from './gateway-video-model';
 import { GatewayRerankingModel } from './gateway-reranking-model';
 import { GatewaySpeechModel } from './gateway-speech-model';
-import { GatewayTranscriptionModel } from './gateway-transcription-model';
+import {
+  GatewayTranscriptionModel,
+  toGatewayTranscriptionUrl,
+} from './gateway-transcription-model';
 import { GatewayRealtimeModel } from './gateway-realtime-model';
 import type { GatewayEmbeddingModelId } from './gateway-embedding-model-settings';
 import type { GatewayImageModelId } from './gateway-image-model-settings';
@@ -175,9 +178,47 @@ export interface GatewayProvider extends ProviderV4 {
   experimental_realtime: RealtimeFactoryV4;
 
   /**
+   * Experimental streaming-transcription entry point. Callable like
+   * `transcription(modelId)`, plus `getToken` for minting a short-lived
+   * client secret (`vcst_`) a browser can use to open the streaming
+   * transcription WebSocket without holding the Gateway credential.
+   */
+  experimental_transcription: GatewayTranscriptionFactory;
+
+  /**
    * Gateway-specific tools executed server-side.
    */
   tools: typeof gatewayTools;
+}
+
+export type GatewayTranscriptionFactoryGetTokenOptions = {
+  model: GatewayTranscriptionModelId;
+  /** Token lifetime in seconds. Gateway default is 60s (max 300s). */
+  expiresAfterSeconds?: number;
+};
+
+export type GatewayTranscriptionFactoryGetTokenResult = {
+  /** The minted `vcst_` client secret. */
+  token: string;
+  /** WebSocket URL of the streaming transcription surface for this model. */
+  url: string;
+  /** Token expiry, epoch seconds. */
+  expiresAt?: number;
+};
+
+/**
+ * Streaming-transcription factory: callable like `transcription(modelId)`,
+ * plus a server-side `getToken` that mints a transcription-bound short-lived
+ * client secret (`vcst_`). The browser connects with
+ * `createGateway({ apiKey: token }).transcription(modelId)` — the token rides
+ * the same auth subprotocol an API key does, without exposing the credential.
+ */
+export interface GatewayTranscriptionFactory {
+  (modelId: GatewayTranscriptionModelId): TranscriptionModelV4;
+
+  getToken(
+    options: GatewayTranscriptionFactoryGetTokenOptions,
+  ): Promise<GatewayTranscriptionFactoryGetTokenResult>;
 }
 
 export interface GatewayProviderSettings {
@@ -297,18 +338,21 @@ export function createGateway(
     }
   };
 
-  // Mints a short-lived realtime client secret (`vcst_`) via the Gateway's
+  // Mints a short-lived client secret (`vcst_`) via the Gateway's
   // `/v1/realtime/client-secrets` route, authenticated with the long-lived
   // Gateway credential. Server-side only (asserted) — the credential never
   // belongs in a browser; the browser receives only the minted token. The
   // mint route lives at the gateway origin's `/v1/realtime/client-secrets`,
-  // not under the realtime `baseURL` path (which targets `/v4/ai`), so the
-  // URL is resolved against the origin.
-  const mintRealtimeClientSecret = async (params: {
+  // not under the `baseURL` path (which targets `/v4/ai`), so the URL is
+  // resolved against the origin. `routeKind` binds the token to a WebSocket
+  // surface; it is omitted for realtime (the gateway default) so older
+  // gateway deployments keep accepting realtime mints.
+  const mintClientSecret = async (params: {
     modelId: string;
     expiresAfterSeconds?: number;
+    routeKind?: 'transcription';
   }): Promise<{ token: string; expiresAt?: number }> => {
-    assertGatewayRealtimeServerEnvironment();
+    assertGatewayClientSecretServerEnvironment();
     const auth = await getRealtimeAuthToken();
     const headers = createAuthHeaders(auth);
     const url = new URL('/v1/realtime/client-secrets', baseURL).toString();
@@ -318,6 +362,7 @@ export function createGateway(
         headers,
         body: {
           model: params.modelId,
+          ...(params.routeKind != null && { routeKind: params.routeKind }),
           ...(params.expiresAfterSeconds != null && {
             expiresIn: params.expiresAfterSeconds,
           }),
@@ -530,18 +575,42 @@ export function createGateway(
   };
   provider.transcriptionModel = createTranscriptionModel;
   provider.transcription = createTranscriptionModel;
+  // Callable like `transcription(modelId)`; `getToken` mints a
+  // transcription-bound client secret (server-side only) the browser uses to
+  // connect via `createGateway({ apiKey: token }).transcription(modelId)`.
+  provider.experimental_transcription = Object.assign(
+    (modelId: GatewayTranscriptionModelId) => createTranscriptionModel(modelId),
+    {
+      getToken: async (
+        tokenOptions: GatewayTranscriptionFactoryGetTokenOptions,
+      ): Promise<GatewayTranscriptionFactoryGetTokenResult> => {
+        const secret = await mintClientSecret({
+          modelId: tokenOptions.model,
+          routeKind: 'transcription',
+          ...(tokenOptions.expiresAfterSeconds != null && {
+            expiresAfterSeconds: tokenOptions.expiresAfterSeconds,
+          }),
+        });
+        return {
+          token: secret.token,
+          url: toGatewayTranscriptionUrl(baseURL, tokenOptions.model),
+          ...(secret.expiresAt != null && { expiresAt: secret.expiresAt }),
+        };
+      },
+    },
+  ) as GatewayTranscriptionFactory;
 
   // No server-environment guard here: building the realtime model is just the
   // event codec + WebSocket-config helper, which the browser legitimately
   // needs to drive the transport with a server-minted client secret. The
-  // server-only boundary is enforced on minting itself
-  // (`mintRealtimeClientSecret`), which requires the Gateway credential.
+  // server-only boundary is enforced on minting itself (`mintClientSecret`),
+  // which requires the Gateway credential.
   const createRealtimeModel = (modelId: GatewayRealtimeModelId) =>
     new GatewayRealtimeModel(modelId, {
       provider: 'gateway.realtime',
       baseURL,
       teamIdOrSlug: options.teamIdOrSlug,
-      createClientSecret: mintRealtimeClientSecret,
+      createClientSecret: mintClientSecret,
     });
   provider.experimental_realtime = Object.assign(
     (modelId: GatewayRealtimeModelId) => createRealtimeModel(modelId),
@@ -591,10 +660,10 @@ export async function getGatewayAuthToken(
   };
 }
 
-function assertGatewayRealtimeServerEnvironment(): void {
+function assertGatewayClientSecretServerEnvironment(): void {
   if (typeof globalThis.window !== 'undefined') {
     throw new Error(
-      'AI Gateway realtime client secrets must be minted server-side: minting needs your Gateway credential, which must never reach the browser. Call gateway.experimental_realtime.getToken() from your server and pass the returned token to the client.',
+      'AI Gateway client secrets must be minted server-side: minting needs your Gateway credential, which must never reach the browser. Call gateway.experimental_realtime.getToken() or gateway.experimental_transcription.getToken() from your server and pass the returned token to the client.',
     );
   }
 }

--- a/packages/gateway/src/gateway-realtime-model.test.ts
+++ b/packages/gateway/src/gateway-realtime-model.test.ts
@@ -205,12 +205,16 @@ describe('gateway.experimental_realtime', () => {
         'https://ai-gateway.vercel.sh/v1/realtime/client-secrets',
       );
 
-      // The request body forwarded the model and the TTL.
+      // The request body forwarded the model and the TTL. `routeKind` is
+      // omitted for realtime mints (the gateway default) so older gateway
+      // deployments keep accepting them.
       const init = fetch.mock.calls[0]?.[1] as RequestInit;
-      expect(JSON.parse(init.body as string)).toMatchObject({
+      const sentBody = JSON.parse(init.body as string);
+      expect(sentBody).toMatchObject({
         model: 'openai/gpt-realtime',
         expiresIn: 120,
       });
+      expect('routeKind' in sentBody).toBe(false);
       // Authenticated with the long-lived key.
       const sentHeaders = new Headers(init.headers);
       expect(sentHeaders.get('authorization')).toBe('Bearer vck_test-token');

--- a/packages/gateway/src/gateway-transcription-model.test.ts
+++ b/packages/gateway/src/gateway-transcription-model.test.ts
@@ -914,3 +914,106 @@ describe('GatewayTranscriptionModel', () => {
     });
   });
 });
+
+describe('gateway.experimental_transcription', () => {
+  const serverOnlyIt = typeof globalThis.window === 'undefined' ? it : it.skip;
+  const MODEL = 'openai/gpt-realtime-whisper';
+
+  serverOnlyIt('creates a transcription model from a model id', async () => {
+    const { createGateway } = await import('./gateway-provider');
+    const gateway = createGateway({ apiKey: 'vck_test-token' });
+    const model = gateway.experimental_transcription(MODEL);
+    expect(model.specificationVersion).toBe('v4');
+    expect(model.modelId).toBe(MODEL);
+    expect(model.provider).toBe('gateway');
+  });
+
+  serverOnlyIt(
+    'mints a transcription-bound vcst_ client secret and returns it with the wss url',
+    async () => {
+      const { createGateway } = await import('./gateway-provider');
+      let capturedMintUrl = '';
+      const fetch = vi.fn(
+        async (input: string | URL | Request, _init?: RequestInit) => {
+          const url = input instanceof Request ? input.url : input.toString();
+          capturedMintUrl = url;
+          return new Response(
+            JSON.stringify({ token: 'vcst_minted', expiresAt: 1_700_000_060 }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        },
+      );
+      const mintGateway = createGateway({ apiKey: 'vck_test-token', fetch });
+
+      const result = await mintGateway.experimental_transcription.getToken({
+        model: MODEL,
+        expiresAfterSeconds: 120,
+      });
+
+      // Minted token (not the raw key), and the mint hit the v1 route on the
+      // gateway origin — not the transcription baseURL path (/v4/ai).
+      expect(result.token).toBe('vcst_minted');
+      expect(result.expiresAt).toBe(1_700_000_060);
+      expect(result.url).toBe(
+        'wss://ai-gateway.vercel.sh/v4/ai/transcription-model?ai-model-id=openai%2Fgpt-realtime-whisper',
+      );
+      expect(capturedMintUrl).toBe(
+        'https://ai-gateway.vercel.sh/v1/realtime/client-secrets',
+      );
+
+      // The body binds the token to the transcription surface.
+      const init = fetch.mock.calls[0]?.[1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        model: MODEL,
+        routeKind: 'transcription',
+        expiresIn: 120,
+      });
+      // Authenticated with the long-lived key.
+      const sentHeaders = new Headers(init.headers);
+      expect(sentHeaders.get('authorization')).toBe('Bearer vck_test-token');
+    },
+  );
+
+  serverOnlyIt(
+    'tolerates a null expiresAt from the mint endpoint and omits it from the result',
+    async () => {
+      const { createGateway } = await import('./gateway-provider');
+      const fetch = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ token: 'vcst_minted', expiresAt: null }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      );
+      const mintGateway = createGateway({ apiKey: 'vck_test-token', fetch });
+
+      const result = await mintGateway.experimental_transcription.getToken({
+        model: MODEL,
+      });
+
+      expect(result.token).toBe('vcst_minted');
+      expect('expiresAt' in result).toBe(false);
+    },
+  );
+
+  it('rejects minting (getToken) in browsers — the credential must stay server-side', async () => {
+    const { createGateway } = await import('./gateway-provider');
+    const gateway = createGateway({ apiKey: 'vck_test-token' });
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {},
+    });
+    try {
+      await expect(
+        gateway.experimental_transcription.getToken({ model: MODEL }),
+      ).rejects.toThrow(/must be minted server-side/);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'window', descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
+  });
+});

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -181,7 +181,10 @@ export class GatewayTranscriptionModel implements TranscriptionModelV4 {
  * WS(S), model id in `?ai-model-id=` (browser `WebSocket` cannot set headers;
  * slash-safe for qualified ids like `openai/gpt-realtime-whisper`).
  */
-function toGatewayTranscriptionUrl(baseURL: string, modelId: string): string {
+export function toGatewayTranscriptionUrl(
+  baseURL: string,
+  modelId: string,
+): string {
   const url = new URL(`${baseURL.replace(/^http/, 'ws')}/transcription-model`);
   url.searchParams.set('ai-model-id', modelId);
   return url.toString();


### PR DESCRIPTION
## Summary

Server-side DX parity with `gateway.experimental_realtime.getToken` for the streaming transcription surface (vercel/ai-gateway#2509): mints a short-lived, **transcription-bound** `vcst_` client secret so a browser can open the streaming transcription WebSocket without ever holding the long-lived Gateway credential.

```ts
// server
const { token, url, expiresAt } = await gateway.experimental_transcription.getToken({
  model: 'openai/gpt-realtime-whisper',
  expiresAfterSeconds: 120,
});

// browser — the token rides the same auth subprotocol an API key does
const client = createGateway({ apiKey: token });
experimental_streamTranscribe({
  model: client.transcription('openai/gpt-realtime-whisper'),
  audio,
  inputAudioFormat: { type: 'audio/pcm', rate: 24_000 },
});
```

## Design

- `gateway.experimental_transcription` is callable like `transcription(modelId)`, plus `getToken` — mirroring the `experimental_realtime` factory shape. No spec changes: the factory type is gateway-local since transcription streaming is a gateway-owned experimental envelope.
- Minting posts `routeKind: 'transcription'` to the Gateway's `/v1/realtime/client-secrets` route (supported since vercel/ai-gateway#2509; redemption enforces the binding — a transcription token cannot open realtime sessions and vice versa).
- `routeKind` is **omitted** for realtime mints (the gateway default) so older gateway deployments keep accepting them — pinned by test.
- Server-only assertion on minting (shared with realtime); building models stays browser-safe.
- No client transport changes needed: `GatewayTranscriptionModel` already sends whatever bearer it holds over the auth subprotocol.

## Verification

- 145 gateway package tests green (4 new: mint body/URL/auth, transcription `wss` URL in the result, null `expiresAt`, browser-mint rejection) + realtime back-compat pin
- `turbo build`, `type-check`, full `@ai-sdk/gateway` test task green
- Server behavior verified end-to-end in production against the deployed gateway (mint → redeem → live session; cross-surface 403; replay 401) as part of vercel/ai-gateway#2509

## Related

- Linear: KDA-204
- Gateway server side: vercel/ai-gateway#2509 (merged)