### PR TITLE
docs: fix 'to to' typo in openai-compatible-provider.test.ts

### DIFF
--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -275,7 +275,7 @@ describe('OpenAICompatibleProvider', () => {
   });
 
   describe('supportsStructuredOutputs setting', () => {
-    it('should pass supportsStructuredOutputs to to .chatModel() and .languageModel() only', () => {
+    it('should pass supportsStructuredOutputs to .chatModel() and .languageModel() only', () => {
       const options = {
         baseURL: 'https://api.example.com',
         name: 'test-provider',


### PR DESCRIPTION
Fixes a minor typo ('to to' -> 'to') in the test description for the OpenAI compatible provider.