### PR TITLE
chore(docs): remove canary naming from Geistdocs site

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -13,8 +13,8 @@ pnpm --filter ai-sdk-docs dev:site
 
 The content sync generates `apps/docs/content/` from two reviewed sources:
 
-- Canary documentation from this checkout's `content/docs/` directory.
-- Stable v6 documentation from the commit pinned in
+- v7 documentation from this checkout's `content/docs/` directory.
+- v6 documentation from the commit pinned in
   `scripts/sync-content.mjs`.
 
 Generated content, Fumadocs source files, and Next.js output are ignored by

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -2,20 +2,20 @@ import { createSearchRoute } from '@vercel/geistdocs/routes/search';
 import { config } from '@/lib/geistdocs/config';
 import { v6Source, v7Source } from '@/lib/geistdocs/source';
 
-const stableSearch = createSearchRoute({ config, source: v6Source });
-const canarySearch = createSearchRoute({ config, source: v7Source });
+const v6Search = createSearchRoute({ config, source: v6Source });
+const v7Search = createSearchRoute({ config, source: v7Source });
 
 export const GET = async (request: Request) => {
   const referer = request.headers.get('referer');
-  let isCanary = false;
+  let isV7 = false;
   if (referer) {
     try {
-      isCanary = new URL(referer).pathname.startsWith('/v7/');
+      isV7 = new URL(referer).pathname.startsWith('/v7/');
     } catch {
-      // Invalid or synthetic Referer headers fall back to stable docs search.
+      // Invalid or synthetic Referer headers fall back to v6 docs search.
     }
   }
-  const response = await (isCanary ? canarySearch : stableSearch)(request);
+  const response = await (isV7 ? v7Search : v6Search)(request);
   response.headers.append('Vary', 'Referer');
   return response;
 };

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -14,8 +14,8 @@ export const content: NonNullable<GeistdocsConfig['content']> = [
   { id: 'v6', label: 'v6', dir: 'content/v6/docs', route: '/docs' },
   {
     id: 'v7',
-    label: 'v7 (Canary)',
-    dir: 'content/canary/docs',
+    label: 'v7',
+    dir: 'content/v7/docs',
     route: '/v7/docs',
   },
 ];
@@ -26,13 +26,13 @@ export const versions: NonNullable<GeistdocsConfig['versions']> = {
     {
       id: 'v6',
       label: 'v6',
-      description: 'Current stable documentation',
+      description: 'v6 documentation',
       routePrefix: '',
     },
     {
       id: 'v7',
-      label: 'v7 (Canary)',
-      description: 'Prerelease documentation',
+      label: 'v7',
+      description: 'Latest documentation',
       routePrefix: '/v7',
     },
   ],

--- a/apps/docs/lib/geistdocs/source.ts
+++ b/apps/docs/lib/geistdocs/source.ts
@@ -1,5 +1,5 @@
 import { createVersionedSources } from '@vercel/geistdocs/source';
-import { docsCanary, docsV6 } from '@/.source/server';
+import { docsV6, docsV7 } from '@/.source/server';
 import { config } from './config';
 
 export const versions = createVersionedSources({
@@ -15,8 +15,8 @@ export const versions = createVersionedSources({
     },
     {
       id: 'v7',
-      label: 'v7 (Canary)',
-      docs: docsCanary,
+      label: 'v7',
+      docs: docsV7,
       baseUrl: '/v7/docs',
       routePrefix: '/v7',
     },

--- a/apps/docs/lib/geistdocs/version-paths.ts
+++ b/apps/docs/lib/geistdocs/version-paths.ts
@@ -1,13 +1,11 @@
 import { v6Source, v7Source } from './source';
 
-const stablePaths = new Set(
-  v6Source.source.getPages('en').map(page => page.url),
-);
-const canaryPaths = new Set(
+const v6Paths = new Set(v6Source.source.getPages('en').map(page => page.url));
+const v7Paths = new Set(
   v7Source.source.getPages('en').map(page => page.url.replace(/^\/v7/, '')),
 );
 
 export const missingVersionPaths = {
-  v6: [...canaryPaths].filter(path => !stablePaths.has(path)),
-  v7: [...stablePaths].filter(path => !canaryPaths.has(path)),
+  v6: [...v7Paths].filter(path => !v6Paths.has(path)),
+  v7: [...v6Paths].filter(path => !v7Paths.has(path)),
 };

--- a/apps/docs/scripts/sync-content.mjs
+++ b/apps/docs/scripts/sync-content.mjs
@@ -3,9 +3,9 @@
  * Syncs and transforms docs content into apps/docs/content/.
  *
  * Sources:
- *   - canary: ../../content/docs (this repo's working tree, i.e. `main`)
- *   - v6:     content/docs from a reviewed `release-v6.0` commit (git, with
- *             a GitHub tarball fallback for environments without git access)
+ *   - v7: ../../content/docs (this repo's working tree, i.e. `main`)
+ *   - v6: content/docs from a reviewed `release-v6.0` commit (git, with
+ *         a GitHub tarball fallback for environments without git access)
  *
  * Transforms (content authored with `NN-` ordering prefixes -> fumadocs):
  *   1. Strips `NN-` numeric prefixes from every path segment.
@@ -39,7 +39,7 @@ const force = process.argv.includes("--force");
 
 /** Version definitions. `ref: null` means the local working tree. */
 const versions = [
-  { id: "canary", ref: null },
+  { id: "v7", ref: null },
   // Update this SHA explicitly when stable v6 documentation changes should
   // ship. Pinning keeps builds reproducible and content changes reviewable.
   { id: "v6", ref: "31e168b16f71a2abc03a1fae69176886577337f4" },

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -23,7 +23,7 @@ const createDocsCollection = (dir: string) =>
   });
 
 export const docsV6 = createDocsCollection('content/v6/docs');
-export const docsCanary = createDocsCollection('content/canary/docs');
+export const docsV7 = createDocsCollection('content/v7/docs');
 
 export default defineGeistdocsSourceConfig({
   mdxOptions: {


### PR DESCRIPTION
Follow-up to #17311.

v7 is stable now and there is currently no canary version, so this removes the "canary" checks and naming from the Geistdocs app:

- `geistdocs.tsx`: version label `v7 (Canary)` → `v7`, description `Prerelease documentation` → `Latest documentation`, content dir `content/canary/docs` → `content/v7/docs`
- `source.config.ts`: `docsCanary` collection → `docsV7`
- `lib/geistdocs/source.ts`: updated import and label
- `app/api/search/route.ts`: `canarySearch`/`isCanary` → `v7Search`/`isV7` (referer-based source selection is unchanged)
- `lib/geistdocs/version-paths.ts`: `canaryPaths` → `v7Paths` (and `stablePaths` → `v6Paths`)
- `scripts/sync-content.mjs`: sync version id `canary` → `v7`, so generated content lands in `content/v7/`
- `README.md`: wording

No changeset: `ai-sdk-docs` is a private app. Verified with `pnpm --filter ai-sdk-docs validate:site` (tests + build pass; v7 routes prerender from `content/v7`).