### PR TITLE
fix(docs): fix incorrect highlighted line numbers

### DIFF
--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -311,7 +311,7 @@ This will install the [AI SDK](/docs) and the AI SDK's React hooks.
 
 Let’s add a function to generate embeddings. Copy the following code into your `lib/ai/embedding.ts` file.
 
-```tsx filename="lib/ai/embedding.ts" highlight="1-2,4,13-21"
+```tsx filename="lib/ai/embedding.ts" highlight="1,3,12-21"
 import { embedMany } from 'ai';
 
 const embeddingModel = 'openai/text-embedding-ada-002';

--- a/content/cookbook/01-next/77-track-agent-token-usage.mdx
+++ b/content/cookbook/01-next/77-track-agent-token-usage.mdx
@@ -100,7 +100,7 @@ export default function Chat() {
 
 To track token usage, attach it to each message using the `messageMetadata` callback. First, define a metadata type and pass it as a second generic to `InferAgentUIMessage`.
 
-```typescript filename='ai/agent.ts' highlight="1,15-16"
+```typescript filename='ai/agent.ts' highlight="2-3,20-21"
 import {
   type InferAgentUIMessage,
   type LanguageModelUsage,

--- a/content/cookbook/05-node/45-stream-object-record-token-usage.mdx
+++ b/content/cookbook/05-node/45-stream-object-record-token-usage.mdx
@@ -14,7 +14,7 @@ you may want to record the token usage for billing purposes.
 You can use the `onEnd` callback to record token usage.
 It is called when the stream is finished.
 
-```ts file='index.ts' highlight={"15-17"}
+```ts file='index.ts' highlight={"16-18"}
 import { streamText, Output } from 'ai';
 import { z } from 'zod';
 

--- a/content/cookbook/05-node/46-stream-object-record-final-object.mdx
+++ b/content/cookbook/05-node/46-stream-object-record-final-object.mdx
@@ -12,7 +12,7 @@ When you're streaming structured data, you may want to record the final object f
 
 Use `onEnd` for metadata like token usage and await `result.output` for the final structured object.
 
-```ts file='index.ts' highlight={"15-29"}
+```ts file='index.ts' highlight={"16-18,24-29"}
 import { streamText, Output } from 'ai';
 import { z } from 'zod';
 
@@ -49,7 +49,7 @@ try {
 The `streamText` result contains an `output` promise that resolves to the final object.
 The object is fully typed. When the type validation according to the schema fails, the promise will be rejected with a `TypeValidationError`.
 
-```ts file='index.ts' highlight={"17-26"}
+```ts file='index.ts' highlight={"21-26"}
 import { streamText, Output } from 'ai';
 import { z } from 'zod';
 

--- a/content/cookbook/15-api-servers/40-fastify.mdx
+++ b/content/cookbook/15-api-servers/40-fastify.mdx
@@ -51,7 +51,7 @@ fastify.listen({ port: 8080 });
 
 `createUIMessageStream` can be used to send custom data to the client.
 
-```ts filename='index.ts' highlight="8-11,18"
+```ts filename='index.ts' highlight="12-17"
 import { createUIMessageStream, streamText, toUIMessageStream } from 'ai';
 import Fastify from 'fastify';
 
@@ -98,7 +98,7 @@ fastify.listen({ port: 8080 });
 
 You can use the `textStream` property to get a text stream from the result and then pipe it to the response.
 
-```ts filename='index.ts' highlight="15"
+```ts filename='index.ts' highlight="14"
 import { streamText } from 'ai';
 import Fastify from 'fastify';
 

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -417,7 +417,7 @@ By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 
 
 Update your `app/api/chat/route.ts` file to add a new tool to convert the temperature from Fahrenheit to Celsius:
 
-```tsx filename="app/api/chat/route.ts" highlight="33-48"
+```tsx filename="app/api/chat/route.ts" highlight="34-47"
 import {
   streamText,
   UIMessage,

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -402,7 +402,7 @@ By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 
 
 Update your `app/api/chat/route.ts` file to add a new tool to convert the temperature from Fahrenheit to Celsius:
 
-```tsx filename="app/api/chat/route.ts" highlight="33-48"
+```tsx filename="app/api/chat/route.ts" highlight="34-47"
 import {
   streamText,
   UIMessage,

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -250,7 +250,7 @@ Try asking something like "What's the weather in New York?" and see how the agen
 
 Notice the blank "assistant" response? This is because instead of generating a text response, the agent generated a tool call. You can access the tool call and subsequent tool result in the `toolCall` and `toolResult` keys of the result object.
 
-```typescript highlight="46-47"
+```typescript highlight="50-51"
 import { ModelMessage, streamText, tool } from 'ai';
 __PROVIDER_IMPORT__;
 import 'dotenv/config';

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -331,7 +331,7 @@ When using `streamText`, you can provide an `onEnd` callback that is triggered w
 ).
 It contains the text, usage information, finish reason, messages, steps, total usage, and more:
 
-```tsx highlight="7-9"
+```tsx highlight="7-10"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -97,7 +97,7 @@ When using `generateText`, you can provide an `onEnd` callback that is triggered
 ).
 It contains the text, usage information, finish reason, messages, steps, total usage, and more:
 
-```tsx highlight="6-8"
+```tsx highlight="7-10"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -262,7 +262,7 @@ Errors become part of the stream and are not thrown to prevent e.g. servers from
 
 To log errors, you can provide an `onError` callback that is triggered when an error occurs.
 
-```tsx highlight="6-8"
+```tsx highlight="7-9"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -308,7 +308,7 @@ It receives all stream part types from `stream`, including:
 - `error`
 - `raw`
 
-```tsx highlight="6-11"
+```tsx highlight="7-12"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -331,7 +331,7 @@ When using `streamText`, you can provide an `onEnd` callback that is triggered w
 ).
 It contains the text, usage information, finish reason, messages, steps, total usage, and more:
 
-```tsx highlight="6-8"
+```tsx highlight="7-9"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -28,9 +28,9 @@ Use `generateText` with `Output.object()` to generate structured data from a pro
 The schema is also used to validate the generated data, ensuring type safety and correctness.
 
 ```ts
-import { generateText, Output } from 'ai';
+import { generateText, Output } from "ai";
 __PROVIDER_IMPORT__;
-import { z } from 'zod';
+import { z } from "zod";
 
 const { output } = await generateText({
   model: __MODEL__,
@@ -45,7 +45,7 @@ const { output } = await generateText({
       }),
     }),
   }),
-  prompt: 'Generate a lasagna recipe.',
+  prompt: "Generate a lasagna recipe.",
 });
 ```
 
@@ -63,7 +63,7 @@ e.g. to access some provider-specific headers or body content.
 You can access the raw response headers and body using the `response` property:
 
 ```ts
-import { generateText, Output } from 'ai';
+import { generateText, Output } from "ai";
 
 const result = await generateText({
   // ...
@@ -80,9 +80,9 @@ Given the added complexity of returning structured data, model response time can
 With `streamText` and `output`, you can stream the model's structured response as it is generated.
 
 ```ts
-import { streamText, Output } from 'ai';
+import { streamText, Output } from "ai";
 __PROVIDER_IMPORT__;
-import { z } from 'zod';
+import { z } from "zod";
 
 const { partialOutputStream } = streamText({
   model: __MODEL__,
@@ -97,7 +97,7 @@ const { partialOutputStream } = streamText({
       }),
     }),
   }),
-  prompt: 'Generate a lasagna recipe.',
+  prompt: "Generate a lasagna recipe.",
 });
 
 // use partialOutputStream as an async iterable
@@ -115,7 +115,7 @@ You can consume the structured output on the client with the [`useObject`](/docs
 To handle errors, provide an `onError` callback:
 
 ```tsx highlight="5-7"
-import { streamText, Output } from 'ai';
+import { streamText, Output } from "ai";
 
 const result = streamText({
   // ...
@@ -137,12 +137,12 @@ The AI SDK supports multiple ways of specifying the expected structure of genera
 Use `Output.text()` to generate plain text from a model. This option doesn't enforce any schema on the result: you simply receive the model's text as a string. This is the default behavior when no `output` is specified.
 
 ```ts
-import { generateText, Output } from 'ai';
+import { generateText, Output } from "ai";
 
 const { output } = await generateText({
   // ...
   output: Output.text(),
-  prompt: 'Tell me a joke.',
+  prompt: "Tell me a joke.",
 });
 // output will be a string (the joke)
 ```
@@ -152,8 +152,8 @@ const { output } = await generateText({
 Use `Output.object({ schema })` to generate a structured object based on a schema (for example, a Zod schema). The output is type-validated to ensure the returned result matches the schema.
 
 ```ts
-import { generateText, Output } from 'ai';
-import { z } from 'zod';
+import { generateText, Output } from "ai";
+import { z } from "zod";
 
 const { output } = await generateText({
   // ...
@@ -164,7 +164,7 @@ const { output } = await generateText({
       labels: z.array(z.string()),
     }),
   }),
-  prompt: 'Generate information for a test user.',
+  prompt: "Generate information for a test user.",
 });
 // output will be an object matching the schema above
 ```
@@ -180,8 +180,8 @@ const { output } = await generateText({
 Use `Output.array({ element })` to specify that you expect an array of typed objects from the model, where each element should conform to a schema (defined in the `element` property).
 
 ```ts
-import { generateText, Output } from 'ai';
-import { z } from 'zod';
+import { generateText, Output } from "ai";
+import { z } from "zod";
 
 const { output } = await generateText({
   // ...
@@ -192,7 +192,7 @@ const { output } = await generateText({
       condition: z.string(),
     }),
   }),
-  prompt: 'List the weather for San Francisco and Paris.',
+  prompt: "List the weather for San Francisco and Paris.",
 });
 // output will be an array of objects like:
 // [
@@ -204,8 +204,8 @@ const { output } = await generateText({
 When streaming arrays with `streamText`, you can use `elementStream` to receive each completed element as it is generated:
 
 ```ts
-import { streamText, Output } from 'ai';
-import { z } from 'zod';
+import { streamText, Output } from "ai";
+import { z } from "zod";
 
 const { elementStream } = streamText({
   // ...
@@ -216,7 +216,7 @@ const { elementStream } = streamText({
       description: z.string(),
     }),
   }),
-  prompt: 'Generate 3 hero descriptions for a fantasy role playing game.',
+  prompt: "Generate 3 hero descriptions for a fantasy role playing game.",
 });
 
 for await (const hero of elementStream) {
@@ -235,14 +235,14 @@ for await (const hero of elementStream) {
 Use `Output.choice({ options })` when you expect the model to choose from a specific set of string options, such as for classification or fixed-enum answers.
 
 ```ts
-import { generateText, Output } from 'ai';
+import { generateText, Output } from "ai";
 
 const { output } = await generateText({
   // ...
   output: Output.choice({
-    options: ['sunny', 'rainy', 'snowy'],
+    options: ["sunny", "rainy", "snowy"],
   }),
-  prompt: 'Is the weather sunny, rainy, or snowy today?',
+  prompt: "Is the weather sunny, rainy, or snowy today?",
 });
 // output will be one of: 'sunny', 'rainy', or 'snowy'
 ```
@@ -256,13 +256,13 @@ This is especially useful for making classification-style generations or forcing
 Use `Output.json()` when you want to generate and parse unstructured JSON values from the model, without enforcing a specific schema. This is useful if you want to capture arbitrary objects, flexible structures, or when you want to rely on the model's natural output rather than rigid validation.
 
 ```ts
-import { generateText, Output } from 'ai';
+import { generateText, Output } from "ai";
 
 const { output } = await generateText({
   // ...
   output: Output.json(),
   prompt:
-    'For each city, return the current temperature and weather condition as a JSON object.',
+    "For each city, return the current temperature and weather condition as a JSON object.",
 });
 
 // output could be any valid JSON, for example:
@@ -281,19 +281,19 @@ For more advanced validation or different structures, see [the Output API refere
 One of the key advantages of using structured output with `generateText` and `streamText` is the ability to combine it with tool calling.
 
 ```ts
-import { generateText, Output, tool, isStepCount } from 'ai';
+import { generateText, Output, tool, isStepCount } from "ai";
 __PROVIDER_IMPORT__;
-import { z } from 'zod';
+import { z } from "zod";
 
 const { output } = await generateText({
   model: __MODEL__,
   tools: {
     weather: tool({
-      description: 'Get the weather for a location',
+      description: "Get the weather for a location",
       inputSchema: z.object({ location: z.string() }),
       execute: async ({ location }) => {
         // fetch weather data
-        return { temperature: 72, condition: 'sunny' };
+        return { temperature: 72, condition: "sunny" };
       },
     }),
   },
@@ -304,7 +304,7 @@ const { output } = await generateText({
     }),
   }),
   stopWhen: isStepCount(5),
-  prompt: 'What should I wear in San Francisco today?',
+  prompt: "What should I wear in San Francisco today?",
 });
 ```
 
@@ -318,30 +318,30 @@ const { output } = await generateText({
 
 You can add `.describe("...")` to individual schema properties to give the model hints about what each property is for. This helps improve the quality and accuracy of generated structured data:
 
-```ts highlight="5,9"
-import { generateText, Output } from 'ai';
+```ts highlight="9,16,19-20"
+import { generateText, Output } from "ai";
 __PROVIDER_IMPORT__;
-import { z } from 'zod';
+import { z } from "zod";
 
 const { output } = await generateText({
   model: __MODEL__,
   output: Output.object({
     schema: z.object({
-      name: z.string().describe('The name of the recipe'),
+      name: z.string().describe("The name of the recipe"),
       ingredients: z
         .array(
           z.object({
             name: z.string(),
             amount: z
               .string()
-              .describe('The amount of the ingredient (grams or ml)'),
+              .describe("The amount of the ingredient (grams or ml)"),
           }),
         )
-        .describe('List of ingredients with amounts'),
-      steps: z.array(z.string()).describe('Step-by-step cooking instructions'),
+        .describe("List of ingredients with amounts"),
+      steps: z.array(z.string()).describe("Step-by-step cooking instructions"),
     }),
   }),
-  prompt: 'Generate a lasagna recipe.',
+  prompt: "Generate a lasagna recipe.",
 });
 ```
 
@@ -355,23 +355,23 @@ Property descriptions are particularly useful for:
 
 You can optionally specify a `name` and `description` for the output. These are used by some providers for additional LLM guidance, e.g. via tool or schema name.
 
-```ts highlight="6-7"
-import { generateText, Output } from 'ai';
+```ts highlight="8-9"
+import { generateText, Output } from "ai";
 __PROVIDER_IMPORT__;
-import { z } from 'zod';
+import { z } from "zod";
 
 const { output } = await generateText({
   model: __MODEL__,
   output: Output.object({
-    name: 'Recipe',
-    description: 'A recipe for a dish.',
+    name: "Recipe",
+    description: "A recipe for a dish.",
     schema: z.object({
       name: z.string(),
       ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
       steps: z.array(z.string()),
     }),
   }),
-  prompt: 'Generate a lasagna recipe.',
+  prompt: "Generate a lasagna recipe.",
 });
 ```
 
@@ -387,9 +387,9 @@ This works with all output types that support structured generation:
 You can access the reasoning used by the language model to generate the object via the `reasoning` property on the result. This property contains a string with the model's thought process, if available.
 
 ```ts
-import { generateText, Output } from 'ai';
+import { generateText, Output } from "ai";
 __PROVIDER_IMPORT__;
-import { z } from 'zod';
+import { z } from "zod";
 
 const result = await generateText({
   model: __MODEL__, // must be a reasoning model
@@ -407,7 +407,7 @@ const result = await generateText({
       }),
     }),
   }),
-  prompt: 'Generate a lasagna recipe.',
+  prompt: "Generate a lasagna recipe.",
 });
 
 console.log(result.reasoningText);
@@ -432,7 +432,7 @@ The error preserves the following information to help you log the issue:
 - `cause`: The cause of the error (e.g. a JSON parsing error). You can use this for more detailed error handling.
 
 ```ts
-import { generateText, Output, NoObjectGeneratedError } from 'ai';
+import { generateText, Output, NoObjectGeneratedError } from "ai";
 
 try {
   await generateText({
@@ -442,11 +442,11 @@ try {
   });
 } catch (error) {
   if (NoObjectGeneratedError.isInstance(error)) {
-    console.log('NoObjectGeneratedError');
-    console.log('Cause:', error.cause);
-    console.log('Text:', error.text);
-    console.log('Response:', error.response);
-    console.log('Usage:', error.usage);
+    console.log("NoObjectGeneratedError");
+    console.log("Cause:", error.cause);
+    console.log("Text:", error.text);
+    console.log("Response:", error.response);
+    console.log("Usage:", error.usage);
   }
 }
 ```
@@ -460,18 +460,18 @@ You can see structured output generation in action using various frameworks in t
 <ExampleLinks
   examples={[
     {
-      title: 'Learn to generate structured data in Node.js',
-      link: '/examples/node/generating-structured-data/generate-object',
+      title: "Learn to generate structured data in Node.js",
+      link: "/examples/node/generating-structured-data/generate-object",
     },
     {
       title:
-        'Learn to generate structured data in Next.js with Route Handlers (AI SDK UI)',
-      link: '/examples/next-pages/basics/generating-object',
+        "Learn to generate structured data in Next.js with Route Handlers (AI SDK UI)",
+      link: "/examples/next-pages/basics/generating-object",
     },
     {
       title:
-        'Learn to generate structured data in Next.js with Server Actions (AI SDK RSC)',
-      link: '/examples/next-app/basics/generating-object',
+        "Learn to generate structured data in Next.js with Server Actions (AI SDK RSC)",
+      link: "/examples/next-app/basics/generating-object",
     },
   ]}
 />
@@ -481,18 +481,18 @@ You can see structured output generation in action using various frameworks in t
 <ExampleLinks
   examples={[
     {
-      title: 'Learn to stream structured data in Node.js',
-      link: '/examples/node/streaming-structured-data/stream-object',
+      title: "Learn to stream structured data in Node.js",
+      link: "/examples/node/streaming-structured-data/stream-object",
     },
     {
       title:
-        'Learn to stream structured data in Next.js with Route Handlers (AI SDK UI)',
-      link: '/examples/next-pages/basics/streaming-object-generation',
+        "Learn to stream structured data in Next.js with Route Handlers (AI SDK UI)",
+      link: "/examples/next-pages/basics/streaming-object-generation",
     },
     {
       title:
-        'Learn to stream structured data in Next.js with Server Actions (AI SDK RSC)',
-      link: '/examples/next-app/basics/streaming-object-generation',
+        "Learn to stream structured data in Next.js with Server Actions (AI SDK RSC)",
+      link: "/examples/next-app/basics/streaming-object-generation",
     },
   ]}
 />

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -114,7 +114,7 @@ You can consume the structured output on the client with the [`useObject`](/docs
 
 To handle errors, provide an `onError` callback:
 
-```tsx highlight="5-7"
+```tsx highlight="6-8"
 import { streamText, Output } from "ai";
 
 const result = streamText({

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -28,9 +28,9 @@ Use `generateText` with `Output.object()` to generate structured data from a pro
 The schema is also used to validate the generated data, ensuring type safety and correctness.
 
 ```ts
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 __PROVIDER_IMPORT__;
-import { z } from "zod";
+import { z } from 'zod';
 
 const { output } = await generateText({
   model: __MODEL__,
@@ -45,7 +45,7 @@ const { output } = await generateText({
       }),
     }),
   }),
-  prompt: "Generate a lasagna recipe.",
+  prompt: 'Generate a lasagna recipe.',
 });
 ```
 
@@ -63,7 +63,7 @@ e.g. to access some provider-specific headers or body content.
 You can access the raw response headers and body using the `response` property:
 
 ```ts
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 
 const result = await generateText({
   // ...
@@ -80,9 +80,9 @@ Given the added complexity of returning structured data, model response time can
 With `streamText` and `output`, you can stream the model's structured response as it is generated.
 
 ```ts
-import { streamText, Output } from "ai";
+import { streamText, Output } from 'ai';
 __PROVIDER_IMPORT__;
-import { z } from "zod";
+import { z } from 'zod';
 
 const { partialOutputStream } = streamText({
   model: __MODEL__,
@@ -97,7 +97,7 @@ const { partialOutputStream } = streamText({
       }),
     }),
   }),
-  prompt: "Generate a lasagna recipe.",
+  prompt: 'Generate a lasagna recipe.',
 });
 
 // use partialOutputStream as an async iterable
@@ -115,7 +115,7 @@ You can consume the structured output on the client with the [`useObject`](/docs
 To handle errors, provide an `onError` callback:
 
 ```tsx highlight="6-8"
-import { streamText, Output } from "ai";
+import { streamText, Output } from 'ai';
 
 const result = streamText({
   // ...
@@ -137,12 +137,12 @@ The AI SDK supports multiple ways of specifying the expected structure of genera
 Use `Output.text()` to generate plain text from a model. This option doesn't enforce any schema on the result: you simply receive the model's text as a string. This is the default behavior when no `output` is specified.
 
 ```ts
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 
 const { output } = await generateText({
   // ...
   output: Output.text(),
-  prompt: "Tell me a joke.",
+  prompt: 'Tell me a joke.',
 });
 // output will be a string (the joke)
 ```
@@ -152,8 +152,8 @@ const { output } = await generateText({
 Use `Output.object({ schema })` to generate a structured object based on a schema (for example, a Zod schema). The output is type-validated to ensure the returned result matches the schema.
 
 ```ts
-import { generateText, Output } from "ai";
-import { z } from "zod";
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
 
 const { output } = await generateText({
   // ...
@@ -164,7 +164,7 @@ const { output } = await generateText({
       labels: z.array(z.string()),
     }),
   }),
-  prompt: "Generate information for a test user.",
+  prompt: 'Generate information for a test user.',
 });
 // output will be an object matching the schema above
 ```
@@ -180,8 +180,8 @@ const { output } = await generateText({
 Use `Output.array({ element })` to specify that you expect an array of typed objects from the model, where each element should conform to a schema (defined in the `element` property).
 
 ```ts
-import { generateText, Output } from "ai";
-import { z } from "zod";
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
 
 const { output } = await generateText({
   // ...
@@ -192,7 +192,7 @@ const { output } = await generateText({
       condition: z.string(),
     }),
   }),
-  prompt: "List the weather for San Francisco and Paris.",
+  prompt: 'List the weather for San Francisco and Paris.',
 });
 // output will be an array of objects like:
 // [
@@ -204,8 +204,8 @@ const { output } = await generateText({
 When streaming arrays with `streamText`, you can use `elementStream` to receive each completed element as it is generated:
 
 ```ts
-import { streamText, Output } from "ai";
-import { z } from "zod";
+import { streamText, Output } from 'ai';
+import { z } from 'zod';
 
 const { elementStream } = streamText({
   // ...
@@ -216,7 +216,7 @@ const { elementStream } = streamText({
       description: z.string(),
     }),
   }),
-  prompt: "Generate 3 hero descriptions for a fantasy role playing game.",
+  prompt: 'Generate 3 hero descriptions for a fantasy role playing game.',
 });
 
 for await (const hero of elementStream) {
@@ -235,14 +235,14 @@ for await (const hero of elementStream) {
 Use `Output.choice({ options })` when you expect the model to choose from a specific set of string options, such as for classification or fixed-enum answers.
 
 ```ts
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 
 const { output } = await generateText({
   // ...
   output: Output.choice({
-    options: ["sunny", "rainy", "snowy"],
+    options: ['sunny', 'rainy', 'snowy'],
   }),
-  prompt: "Is the weather sunny, rainy, or snowy today?",
+  prompt: 'Is the weather sunny, rainy, or snowy today?',
 });
 // output will be one of: 'sunny', 'rainy', or 'snowy'
 ```
@@ -256,13 +256,13 @@ This is especially useful for making classification-style generations or forcing
 Use `Output.json()` when you want to generate and parse unstructured JSON values from the model, without enforcing a specific schema. This is useful if you want to capture arbitrary objects, flexible structures, or when you want to rely on the model's natural output rather than rigid validation.
 
 ```ts
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 
 const { output } = await generateText({
   // ...
   output: Output.json(),
   prompt:
-    "For each city, return the current temperature and weather condition as a JSON object.",
+    'For each city, return the current temperature and weather condition as a JSON object.',
 });
 
 // output could be any valid JSON, for example:
@@ -281,19 +281,19 @@ For more advanced validation or different structures, see [the Output API refere
 One of the key advantages of using structured output with `generateText` and `streamText` is the ability to combine it with tool calling.
 
 ```ts
-import { generateText, Output, tool, isStepCount } from "ai";
+import { generateText, Output, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
-import { z } from "zod";
+import { z } from 'zod';
 
 const { output } = await generateText({
   model: __MODEL__,
   tools: {
     weather: tool({
-      description: "Get the weather for a location",
+      description: 'Get the weather for a location',
       inputSchema: z.object({ location: z.string() }),
       execute: async ({ location }) => {
         // fetch weather data
-        return { temperature: 72, condition: "sunny" };
+        return { temperature: 72, condition: 'sunny' };
       },
     }),
   },
@@ -304,7 +304,7 @@ const { output } = await generateText({
     }),
   }),
   stopWhen: isStepCount(5),
-  prompt: "What should I wear in San Francisco today?",
+  prompt: 'What should I wear in San Francisco today?',
 });
 ```
 
@@ -319,29 +319,29 @@ const { output } = await generateText({
 You can add `.describe("...")` to individual schema properties to give the model hints about what each property is for. This helps improve the quality and accuracy of generated structured data:
 
 ```ts highlight="9,16,19-20"
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 __PROVIDER_IMPORT__;
-import { z } from "zod";
+import { z } from 'zod';
 
 const { output } = await generateText({
   model: __MODEL__,
   output: Output.object({
     schema: z.object({
-      name: z.string().describe("The name of the recipe"),
+      name: z.string().describe('The name of the recipe'),
       ingredients: z
         .array(
           z.object({
             name: z.string(),
             amount: z
               .string()
-              .describe("The amount of the ingredient (grams or ml)"),
+              .describe('The amount of the ingredient (grams or ml)'),
           }),
         )
-        .describe("List of ingredients with amounts"),
-      steps: z.array(z.string()).describe("Step-by-step cooking instructions"),
+        .describe('List of ingredients with amounts'),
+      steps: z.array(z.string()).describe('Step-by-step cooking instructions'),
     }),
   }),
-  prompt: "Generate a lasagna recipe.",
+  prompt: 'Generate a lasagna recipe.',
 });
 ```
 
@@ -356,22 +356,22 @@ Property descriptions are particularly useful for:
 You can optionally specify a `name` and `description` for the output. These are used by some providers for additional LLM guidance, e.g. via tool or schema name.
 
 ```ts highlight="8-9"
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 __PROVIDER_IMPORT__;
-import { z } from "zod";
+import { z } from 'zod';
 
 const { output } = await generateText({
   model: __MODEL__,
   output: Output.object({
-    name: "Recipe",
-    description: "A recipe for a dish.",
+    name: 'Recipe',
+    description: 'A recipe for a dish.',
     schema: z.object({
       name: z.string(),
       ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
       steps: z.array(z.string()),
     }),
   }),
-  prompt: "Generate a lasagna recipe.",
+  prompt: 'Generate a lasagna recipe.',
 });
 ```
 
@@ -387,9 +387,9 @@ This works with all output types that support structured generation:
 You can access the reasoning used by the language model to generate the object via the `reasoning` property on the result. This property contains a string with the model's thought process, if available.
 
 ```ts
-import { generateText, Output } from "ai";
+import { generateText, Output } from 'ai';
 __PROVIDER_IMPORT__;
-import { z } from "zod";
+import { z } from 'zod';
 
 const result = await generateText({
   model: __MODEL__, // must be a reasoning model
@@ -407,7 +407,7 @@ const result = await generateText({
       }),
     }),
   }),
-  prompt: "Generate a lasagna recipe.",
+  prompt: 'Generate a lasagna recipe.',
 });
 
 console.log(result.reasoningText);
@@ -432,7 +432,7 @@ The error preserves the following information to help you log the issue:
 - `cause`: The cause of the error (e.g. a JSON parsing error). You can use this for more detailed error handling.
 
 ```ts
-import { generateText, Output, NoObjectGeneratedError } from "ai";
+import { generateText, Output, NoObjectGeneratedError } from 'ai';
 
 try {
   await generateText({
@@ -442,11 +442,11 @@ try {
   });
 } catch (error) {
   if (NoObjectGeneratedError.isInstance(error)) {
-    console.log("NoObjectGeneratedError");
-    console.log("Cause:", error.cause);
-    console.log("Text:", error.text);
-    console.log("Response:", error.response);
-    console.log("Usage:", error.usage);
+    console.log('NoObjectGeneratedError');
+    console.log('Cause:', error.cause);
+    console.log('Text:', error.text);
+    console.log('Response:', error.response);
+    console.log('Usage:', error.usage);
   }
 }
 ```
@@ -460,18 +460,18 @@ You can see structured output generation in action using various frameworks in t
 <ExampleLinks
   examples={[
     {
-      title: "Learn to generate structured data in Node.js",
-      link: "/examples/node/generating-structured-data/generate-object",
+      title: 'Learn to generate structured data in Node.js',
+      link: '/examples/node/generating-structured-data/generate-object',
     },
     {
       title:
-        "Learn to generate structured data in Next.js with Route Handlers (AI SDK UI)",
-      link: "/examples/next-pages/basics/generating-object",
+        'Learn to generate structured data in Next.js with Route Handlers (AI SDK UI)',
+      link: '/examples/next-pages/basics/generating-object',
     },
     {
       title:
-        "Learn to generate structured data in Next.js with Server Actions (AI SDK RSC)",
-      link: "/examples/next-app/basics/generating-object",
+        'Learn to generate structured data in Next.js with Server Actions (AI SDK RSC)',
+      link: '/examples/next-app/basics/generating-object',
     },
   ]}
 />
@@ -481,18 +481,18 @@ You can see structured output generation in action using various frameworks in t
 <ExampleLinks
   examples={[
     {
-      title: "Learn to stream structured data in Node.js",
-      link: "/examples/node/streaming-structured-data/stream-object",
+      title: 'Learn to stream structured data in Node.js',
+      link: '/examples/node/streaming-structured-data/stream-object',
     },
     {
       title:
-        "Learn to stream structured data in Next.js with Route Handlers (AI SDK UI)",
-      link: "/examples/next-pages/basics/streaming-object-generation",
+        'Learn to stream structured data in Next.js with Route Handlers (AI SDK UI)',
+      link: '/examples/next-pages/basics/streaming-object-generation',
     },
     {
       title:
-        "Learn to stream structured data in Next.js with Server Actions (AI SDK RSC)",
-      link: "/examples/next-app/basics/streaming-object-generation",
+        'Learn to stream structured data in Next.js with Server Actions (AI SDK RSC)',
+      link: '/examples/next-app/basics/streaming-object-generation',
     },
   ]}
 />

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -20,7 +20,7 @@ Function tools and dynamic tools contain several core elements:
 
 The `tools` parameter of `generateText` and `streamText` is an object that has the tool names as keys and the tools as values:
 
-```ts highlight="6-17"
+```ts highlight="7-18"
 import { z } from 'zod';
 import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
@@ -413,7 +413,7 @@ In the following example, there are two steps:
    1. The tool result is sent to the model.
    1. The model generates a response considering the tool result.
 
-```ts highlight="18-19"
+```ts highlight="19-20"
 import { z } from 'zod';
 import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
@@ -447,7 +447,7 @@ It contains all the text, tool calls, tool results, per-step `performance`, and 
 
 #### Example: Extract tool results from all steps
 
-```ts highlight="3,9-10"
+```ts highlight="4,10-11"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -772,7 +772,7 @@ It supports the following settings:
 - `none`: the model must not call tools
 - `{ type: 'tool', toolName: string (typed) }`: the model must call the specified tool
 
-```ts highlight="18"
+```ts highlight="19"
 import { z } from 'zod';
 import { generateText, tool } from 'ai';
 __PROVIDER_IMPORT__;
@@ -877,7 +877,7 @@ const result = await generateText({
 The abort signals from `generateText` and `streamText` are forwarded to the tool execution.
 You can access them in the second parameter of the `execute` function and e.g. abort long-running computations or forward them to fetch calls inside tools.
 
-```ts highlight="6,11,14"
+```ts highlight="7,12,15"
 import { z } from 'zod';
 import { generateText, tool } from 'ai';
 __PROVIDER_IMPORT__;
@@ -1047,7 +1047,7 @@ The following tool input lifecycle hooks are available:
 
 ### Example
 
-```ts highlight="15-23"
+```ts highlight="16-24"
 import { streamText, tool } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -1334,7 +1334,7 @@ the AI SDK provides the `activeTools` property.
 It is an array of tool names that are currently active.
 By default, the value is `undefined` and all tools are active.
 
-```ts highlight="7"
+```ts highlight="8"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
@@ -1357,7 +1357,7 @@ debugging. The list can be partial: tools listed in `toolOrder` are sent first
 in that order, and any remaining tools are sent afterwards in alphabetical
 order. Tool names are typed from your `tools` object.
 
-```ts highlight="9"
+```ts highlight="7"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -63,7 +63,7 @@ model for each generation step. It receives the matching tool `context` from
 `toolsContext` and the current `experimental_sandbox`, if one was provided. If `prepareStep`
 updates `toolsContext` or `experimental_sandbox`, the next step uses those updated values.
 
-```ts highlight="6-14,28-33"
+```ts highlight="5-16,32-35"
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 
@@ -1397,7 +1397,7 @@ that converts the tool result into a content part.
 
 Here is an example for converting a screenshot into a content part:
 
-```ts highlight="22-27"
+```ts highlight="23-38"
 const result = await generateText({
   model: __MODEL__,
   tools: {

--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -109,7 +109,7 @@ Google's `gemini-embedding-2` model (also available as `gemini-embedding-2-previ
 
 The `embedMany` function now supports parallel processing with configurable `maxParallelCalls` to optimize performance:
 
-```ts highlight={"3"}
+```ts highlight={"4"}
 import { embedMany } from 'ai';
 
 const { embeddings, usage } = await embedMany({

--- a/content/docs/03-ai-sdk-core/31-reranking.mdx
+++ b/content/docs/03-ai-sdk-core/31-reranking.mdx
@@ -101,7 +101,7 @@ Each item in the `ranking` array contains:
 
 Use `topN` to limit the number of results returned. This is useful for retrieving only the most relevant documents:
 
-```ts highlight={"7"}
+```ts highlight={"8"}
 import { cohere } from '@ai-sdk/cohere';
 import { rerank } from 'ai';
 
@@ -139,7 +139,7 @@ The `rerank` function accepts an optional `maxRetries` parameter of type `number
 that you can use to set the maximum number of retries for the reranking process.
 It defaults to `2` retries (3 attempts in total). You can set it to `0` to disable retries.
 
-```ts highlight={"7"}
+```ts highlight={"8"}
 import { cohere } from '@ai-sdk/cohere';
 import { rerank } from 'ai';
 
@@ -157,7 +157,7 @@ The `rerank` function accepts an optional `abortSignal` parameter of
 type [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 that you can use to abort the reranking process or set a timeout.
 
-```ts highlight={"7"}
+```ts highlight={"8"}
 import { cohere } from '@ai-sdk/cohere';
 import { rerank } from 'ai';
 
@@ -174,7 +174,7 @@ const { ranking } = await rerank({
 The `rerank` function accepts an optional `headers` parameter of type `Record<string, string>`
 that you can use to add custom headers to the reranking request.
 
-```ts highlight={"7"}
+```ts highlight={"8"}
 import { cohere } from '@ai-sdk/cohere';
 import { rerank } from 'ai';
 

--- a/content/docs/03-ai-sdk-core/35-image-generation.mdx
+++ b/content/docs/03-ai-sdk-core/35-image-generation.mdx
@@ -119,7 +119,7 @@ You can pass such settings to the `generateImage` function
 using the `providerOptions` parameter. The options for the provider
 (`openai` in the example below) become request body properties.
 
-```tsx highlight={"12"}
+```tsx highlight={"8-13"}
 import { generateImage } from 'ai';
 import { openai, type OpenAIImageModelGenerationOptions } from '@ai-sdk/openai';
 

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -154,7 +154,7 @@ const transcript = await transcribe({
 When `audio` is a URL, the SDK downloads the file with a default **2 GiB** size limit.
 You can customize this using `createDownload`:
 
-```ts highlight="1,8"
+```ts highlight="1,7"
 import { transcribe, createDownload } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -167,7 +167,7 @@ const transcript = await transcribe({
 
 You can also provide a fully custom download function:
 
-```ts highlight="6-12"
+```ts highlight="7-13"
 import { transcribe } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -210,7 +210,7 @@ that you can use to abort the transcription process or set a timeout.
 
 This is particularly useful when combined with URL downloads to prevent long-running requests:
 
-```ts highlight="8"
+```ts highlight="7"
 import { openai } from '@ai-sdk/openai';
 import { transcribe } from 'ai';
 

--- a/content/docs/03-ai-sdk-core/38-video-generation.mdx
+++ b/content/docs/03-ai-sdk-core/38-video-generation.mdx
@@ -146,7 +146,7 @@ const { videos } = await generateVideo({
 
 Some video models support generating videos from an input image. You can provide an image using the prompt object:
 
-```tsx highlight={"7-10"}
+```tsx highlight={"6-9"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -177,7 +177,7 @@ Some video models support first-last-frame generation, where you provide the
 starting and/or ending frames of the video. Use the `frameImages` option to pass
 role-tagged images in a provider-agnostic way:
 
-```tsx highlight={"5-16"}
+```tsx highlight={"4-13"}
 const { video } = await generateVideo({
   model: __VIDEO_MODEL__,
   prompt: 'The cat walks across the scene and transforms into a dog by the end',
@@ -200,7 +200,7 @@ Some video models support reference-to-video generation, where you provide one o
 more reference images or videos that the model incorporates into the generated video. Use the `inputReferences` option to pass
 these inputs in a provider-agnostic way:
 
-```tsx highlight={"5-8"}
+```tsx highlight={"4-7"}
 const { video } = await generateVideo({
   model: __VIDEO_MODEL__,
   prompt: 'The two characters meet in a bustling market',
@@ -213,7 +213,7 @@ const { video } = await generateVideo({
 
 For URL-based video references, use the object form with an explicit `mediaType`:
 
-```tsx highlight={"5-10"}
+```tsx highlight={"4-9"}
 const { video } = await generateVideo({
   model: __VIDEO_MODEL__,
   prompt: 'Match the motion in the reference clip',
@@ -295,7 +295,7 @@ Video generation is an asynchronous process that can take several minutes to com
 
 You can configure the polling timeout using provider-specific options. Each provider exports a type for its options that you can use with `satisfies` for type safety:
 
-```tsx highlight={"10-12"}
+```tsx highlight={"8-12"}
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { fal, type FalVideoModelOptions } from '@ai-sdk/fal';
 

--- a/content/docs/03-ai-sdk-core/50-error-handling.mdx
+++ b/content/docs/03-ai-sdk-core/50-error-handling.mdx
@@ -9,7 +9,7 @@ description: Learn how to handle errors in the AI SDK Core
 
 Regular errors are thrown and can be handled using the `try/catch` block.
 
-```ts highlight="3,8-10"
+```ts highlight="4,9-11"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -31,7 +31,7 @@ When errors occur during streams that do not support error chunks,
 the error is thrown as a regular error.
 You can handle these errors using the `try/catch` block.
 
-```ts highlight="3,12-14"
+```ts highlight="4,13-15"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -56,7 +56,7 @@ You can handle those parts similar to other parts.
 It is recommended to also add a try-catch block for errors that
 happen outside of the streaming.
 
-```ts highlight="13-21"
+```ts highlight="14-22"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -99,7 +99,7 @@ When streams are aborted (e.g., via chat stop button), you may want to perform c
 
 The `onAbort` callback is called when a stream is aborted via `AbortSignal`, but `onEnd` is not called. This ensures you can still update your UI state appropriately.
 
-```ts highlight="5-9"
+```ts highlight="6-10"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -127,7 +127,7 @@ The `onAbort` callback receives:
 
 You can also handle abort events directly in the stream:
 
-```ts highlight="10-13"
+```ts highlight="11-14"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/docs/03-ai-sdk-core/65-lifecycle-callbacks.mdx
+++ b/content/docs/03-ai-sdk-core/65-lifecycle-callbacks.mdx
@@ -55,7 +55,7 @@ Because callbacks run as part of the lifecycle, keep them fast or enqueue expens
 Use `onStart` and `onEnd` to record one application log for the beginning and end of a call.
 The `callId` is available across lifecycle events, so you can correlate logs from the same request.
 
-```tsx highlight="8-20"
+```tsx highlight="8-23"
 import { generateText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -124,7 +124,7 @@ Use step events when you want timing that includes SDK-managed work such as loca
 When you use tools with `generateText` or `streamText`, a single user request can involve multiple model calls.
 Each model call is a step. The model may call a tool in one step, receive the tool result, and then produce a final answer in the next step.
 
-```tsx highlight="10-29"
+```tsx highlight="17-31"
 import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 __PROVIDER_IMPORT__;
@@ -171,7 +171,7 @@ This helps answer questions such as:
 Tool execution callbacks run around the tool's `execute` function.
 Use them to record tool usage, latency, successful results, and tool errors.
 
-```tsx highlight="17-35"
+```tsx highlight="19-36"
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 __PROVIDER_IMPORT__;
@@ -293,7 +293,7 @@ This distinction matters when the step includes local tool execution: the step d
 Lifecycle callbacks receive the full `runtimeContext` and `toolsContext` values that flow through the call.
 This makes callbacks useful for attaching application context without changing prompts or tool inputs.
 
-```tsx highlight="8-17,23-28"
+```tsx highlight="8-24,26-39"
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 __PROVIDER_IMPORT__;

--- a/content/docs/03-ai-sdk-core/65-lifecycle-callbacks.mdx
+++ b/content/docs/03-ai-sdk-core/65-lifecycle-callbacks.mdx
@@ -218,7 +218,7 @@ const result = await generateText({
 Embedding and reranking callbacks are simpler: they expose `onStart` and `onEnd` around the operation.
 This is useful for retrieval pipelines where you want to understand how often you are embedding, how many values you embed, and how reranking changes result sets.
 
-```tsx highlight="10-23"
+```tsx highlight="10-24,32-37"
 import { embedMany, rerank } from 'ai';
 import { cohere } from '@ai-sdk/cohere';
 

--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -96,7 +96,7 @@ When processing messages on the server that contain tool calls, custom metadata,
 
 When your messages include tool calls, validate them against your tool definitions:
 
-```tsx filename="app/api/chat/route.ts" highlight="9-27,34-39"
+```tsx filename="app/api/chat/route.ts" highlight="7-8,14-27,35-45"
 import {
   convertToModelMessages,
   createUIMessageStreamResponse,
@@ -416,7 +416,7 @@ export async function POST(req: Request) {
 
 Alternatively, you can use `createUIMessageStream` to control the message ID by writing a start message part:
 
-```tsx filename="app/api/chat/route.ts" highlight="9-19"
+```tsx filename="app/api/chat/route.ts" highlight="14-18,25-27"
 import {
   generateId,
   streamText,

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -14,7 +14,7 @@ The `dynamicTool` function creates tools where the input and output types are no
 
 Unlike the regular `tool` function, `dynamicTool` accepts and returns `unknown` types, allowing you to work with tools that have runtime-determined schemas.
 
-```ts highlight={"1,4,9,10,11"}
+```ts highlight={"1,4,9,11"}
 import { dynamicTool } from 'ai';
 import { z } from 'zod';
 

--- a/content/docs/09-troubleshooting/15-stream-text-not-working.mdx
+++ b/content/docs/09-troubleshooting/15-stream-text-not-working.mdx
@@ -19,7 +19,7 @@ Errors become part of the stream and are not thrown to prevent e.g. servers from
 
 To log errors, you can provide an `onError` callback that is triggered when an error occurs.
 
-```tsx highlight="6-8"
+```tsx highlight="7-9"
 import { streamText } from 'ai';
 __PROVIDER_IMPORT__;
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -300,7 +300,7 @@ The following OpenAI-specific metadata may be returned:
 
 For reasoning models like `gpt-5`, you can enable reasoning summaries to see the model's thought process. Different models support different summarizers—for example, `o4-mini` supports detailed summaries. Set `reasoningSummary: "auto"` to automatically receive the richest level available. When `reasoningEffort` is set to a value other than `'none'`, the OpenAI Responses provider defaults `reasoningSummary` to `'detailed'`; set `reasoningSummary: null` to omit reasoning summaries.
 
-```ts highlight="8-9,16"
+```ts highlight="10-14,17-23"
 import {
   openai,
   type OpenAILanguageModelResponsesOptions,
@@ -1943,7 +1943,7 @@ They support additional settings and response metadata:
 
 - You can use the response `usage` to access the number of reasoning tokens that the model generated via `usage.outputTokenDetails.reasoningTokens`.
 
-```ts highlight="4,7-11,17"
+```ts highlight="4,7-11,15"
 import { openai, type OpenAILanguageModelChatOptions } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
@@ -2201,7 +2201,7 @@ const result = streamText({
 OpenAI provides usage information for predicted outputs (`acceptedPredictionTokens` and `rejectedPredictionTokens`).
 You can access it in the `providerMetadata` object.
 
-```ts highlight="11"
+```ts highlight="3-4"
 const openaiMetadata = (await result.providerMetadata)?.openai;
 
 const acceptedPredictionTokens = openaiMetadata?.acceptedPredictionTokens;
@@ -2296,7 +2296,7 @@ including `gpt-4o` and `gpt-4o-mini`.
 - For GPT-5.6 and later models, `usage.inputTokenDetails.cacheWriteTokens` reports tokens written to the cache.
 - For GPT-5.6 and later models, `promptCacheOptions.ttl` sets a minimum cache lifetime of 30 minutes. Earlier models generally retain in-memory prefixes for 5-10 minutes of inactivity, up to one hour.
 
-```ts highlight="11"
+```ts highlight="9"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -1489,7 +1489,7 @@ To use skills, you need to:
 1. Enable the code execution tool
 2. Specify the container with skills in `providerOptions`
 
-```ts highlight="4,9-17,19-23"
+```ts highlight="6-8,10-23"
 import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
@@ -1519,7 +1519,7 @@ const result = await generateText({
 
 You can also use custom skills by specifying `type: 'custom'`:
 
-```ts highlight="9-11"
+```ts highlight="11-15"
 const result = await generateText({
   model: anthropic('claude-sonnet-4-5'),
   tools: {

--- a/content/providers/01-ai-sdk-providers/110-deepgram.mdx
+++ b/content/providers/01-ai-sdk-providers/110-deepgram.mdx
@@ -167,7 +167,7 @@ const model = deepgram.transcription('nova-3');
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `summarize` option will enable summaries for sections of content.
 
-```ts highlight="6"
+```ts highlight="11-15"
 import { transcribe } from 'ai';
 import {
   deepgram,

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -498,7 +498,7 @@ The response will contain the tool calls and results from the code execution.
 With [Google Search grounding](https://ai.google.dev/gemini-api/docs/google-search),
 the model has access to the latest information using Google Search.
 
-```ts highlight="8,17-20"
+```ts highlight="8,17-19"
 import { google } from '@ai-sdk/google';
 import { GoogleProviderMetadata } from '@ai-sdk/google';
 import { generateText } from 'ai';
@@ -657,7 +657,7 @@ Google provides a provider-defined URL context tool.
 
 The URL context tool allows you to provide specific URLs that you want the model to analyze directly in from the prompt.
 
-```ts highlight="9,13-17"
+```ts highlight="9,13-15"
 import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
@@ -818,7 +818,7 @@ This enables the model to provide answers based on your specific data sources an
   Google provider (`@ai-sdk/google`) to use this feature.
 </Note>
 
-```ts highlight="8,17-20"
+```ts highlight="5-8,13-17,25-27"
 import { createGoogleVertex } from '@ai-sdk/google-vertex';
 import { GoogleProviderMetadata } from '@ai-sdk/google';
 import { generateText } from 'ai';
@@ -2024,7 +2024,7 @@ spoken text, so `instructions: 'Say cheerfully'` with `text: 'Hello'` speaks `Sa
 For multi-speaker dialogue, pass a `multiSpeakerVoiceConfig` through `providerOptions`. Each speaker
 name must match a name used in the input text. When set, it overrides the top-level `voice`.
 
-```ts highlight="8-23"
+```ts highlight="7-22"
 import { generateSpeech } from 'ai';
 import { google, type GoogleSpeechModelOptions } from '@ai-sdk/google';
 

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -176,7 +176,7 @@ const model = elevenLabs.transcription('scribe_v1');
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format can sometimes improve transcription performance if known beforehand.
 
-```ts highlight="6"
+```ts highlight="10-14"
 import { transcribe } from 'ai';
 import {
   elevenLabs,

--- a/content/providers/01-ai-sdk-providers/95-cartesia.mdx
+++ b/content/providers/01-ai-sdk-providers/95-cartesia.mdx
@@ -281,7 +281,7 @@ const result = await transcribe({
 
 You can also pass additional provider-specific options using the `providerOptions` argument:
 
-```ts highlight="6"
+```ts highlight="11-15"
 import { transcribe } from 'ai';
 import {
   cartesia,

--- a/content/providers/03-observability/langsmith.mdx
+++ b/content/providers/03-observability/langsmith.mdx
@@ -39,7 +39,7 @@ export OPENAI_API_KEY=<your-openai-api-key> # The examples use OpenAI (replace w
 
 To start tracing, you will need to import and call the `wrapAISDK` method at the start of your code:
 
-```ts highlight="6-7"
+```ts highlight="6"
 import { openai } from '@ai-sdk/openai';
 import * as ai from 'ai';
 

--- a/content/providers/03-observability/raindrop.mdx
+++ b/content/providers/03-observability/raindrop.mdx
@@ -53,7 +53,7 @@ Raindrop records an event once a `userId` is available, so set the Raindrop `con
 
 If Raindrop event fields such as `userId`, `convoId`, or `eventName` change per request, pass a Raindrop integration through `telemetry.integrations` for that call:
 
-```ts highlight="12-22"
+```ts highlight="8-10,15-19,21"
 import { generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { raindrop } from '@raindrop-ai/ai-sdk';

--- a/content/providers/06-adapters/02-llamaindex.mdx
+++ b/content/providers/06-adapters/02-llamaindex.mdx
@@ -13,7 +13,7 @@ Here is a basic example that uses both AI SDK and LlamaIndex together with the [
 
 The AI SDK `@ai-sdk/llamaindex` package uses the stream result from calling the `chat` method on a [LlamaIndex ChatEngine](https://ts.llamaindex.ai/modules/chat_engine) or the `query` method on a [LlamaIndex QueryEngine](https://ts.llamaindex.ai/modules/query_engines) to pipe text to the client.
 
-```tsx filename="app/api/completion/route.ts" highlight="17"
+```tsx filename="app/api/completion/route.ts" highlight="18-20"
 import { OpenAI, SimpleChatEngine } from 'llamaindex';
 import { toUIMessageStream } from '@ai-sdk/llamaindex';
 import { createUIMessageStreamResponse } from 'ai';


### PR DESCRIPTION
## Background

highlighted line numbers in docs were misaligned from what was actually supposed to be highlighted.

some of this was because selecting the Gateway provider in interactive code snippets removed the `__PROVIDER_IMPORT__` line, but highlighted lines weren't updated so they were offset. https://github.com/vercel/ai-studio/pull/2084 fixes that bug.

## Summary

fixed highlighted line numbers across docs

## Contributor Credit

@joshualipman123 

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

https://github.com/vercel/ai/pull/16967
