### PR TITLE
fix(examples/nuxt-openai): add explicit tailwind css file to fix build

### DIFF
--- a/examples/nuxt-openai/assets/css/tailwind.css
+++ b/examples/nuxt-openai/assets/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Background

CI is failing on `main` since the Version Packages merge (#17324): the `Build Examples (other-frameworks)` job fails building `@example/nuxt-openai` with:

```
Rollup failed to resolve import ".../node_modules/.pnpm/tailwindcss@4.3.0/node_modules/tailwindcss/tailwind.css"
```

## Root cause

The example pins `tailwindcss@3.4.15` (and the lockfile agrees), but `@nuxtjs/tailwindcss@6.12.2` finds no `assets/css/tailwind.css` in the app, so it falls back to `tryResolveModule('tailwindcss/package.json')` resolved from the *nuxt module's* context — not the example's. Since nuxt doesn't declare tailwindcss as a dependency, resolution falls through to pnpm's hidden hoist fallback (`node_modules/.pnpm/node_modules/tailwindcss`).

#17311 (Geistdocs site) added `tailwindcss@4.3.0` to the monorepo. On a fresh install that version now wins the hoist-fallback slot, and Tailwind v4 no longer ships a `tailwind.css` entry file → the build fails. It didn't surface on #17311's own CI because of turbo caching; the Version Packages merge invalidated the example's build cache on a fresh runner.

## Fix

Add the standard Tailwind v3 entry file at `examples/nuxt-openai/assets/css/tailwind.css`. The module prefers the app-local file over its fragile default resolution, decoupling the example from whichever tailwind version happens to be hoisted.

Verified locally: the build now logs `Using Tailwind CSS from ~/assets/css/tailwind.css` and completes successfully.

No changeset — example-only change.