### PR TITLE
ci: bump @ai-sdk/openai max load time to 75ms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,7 @@ jobs:
           - module: 'ai'
             max-load-time: 105
           - module: '@ai-sdk/openai'
-            max-load-time: 70
+            max-load-time: 75
           - module: '@ai-sdk/openai-compatible'
             max-load-time: 70
           - module: '@ai-sdk/anthropic'


### PR DESCRIPTION
## Background

`Load Time Check (@ai-sdk/openai, 70)` failed on `main` in the CI run for the Version Packages merge (#17324), measuring **70.5ms against the 70ms threshold** — on a commit that only bumps version numbers and changelogs. That's runner variance sitting right at the ceiling, not a load-time regression.

## Change

Bump the `@ai-sdk/openai` `max-load-time` from 70ms to 75ms to give the check headroom against runner noise. The other module thresholds are unchanged.

No changeset — CI-only change.