### PR TITLE
fix(ai): preserve tool metadata from output chunks

### DIFF
--- a/.changeset/slow-bugs-notice.md
+++ b/.changeset/slow-bugs-notice.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix: preserve tool metadata from tool output chunks in UI message streams

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -5822,7 +5822,7 @@ describe('processUIMessageStream', () => {
       });
     });
 
-    it('should preserve tool metadata on dynamic tool parts', async () => {
+    it('should apply output metadata to dynamic tool parts', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
@@ -5839,6 +5839,7 @@ describe('processUIMessageStream', () => {
           toolCallId: 'tool-call-1',
           output: { result: 'provider-result' },
           dynamic: true,
+          toolMetadata: { downloadable: true },
         },
         { type: 'finish-step' },
         { type: 'finish' },
@@ -5879,7 +5880,7 @@ describe('processUIMessageStream', () => {
           "title": undefined,
           "toolCallId": "tool-call-1",
           "toolMetadata": {
-            "clientName": "MyMCPClient",
+            "downloadable": true,
           },
           "toolName": "tool-name",
           "type": "dynamic-tool",

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -766,7 +766,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
+                  toolMetadata:
+                    chunk.toolMetadata ?? toolInvocation.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -779,7 +780,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   preliminary: chunk.preliminary,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
+                  toolMetadata:
+                    chunk.toolMetadata ?? toolInvocation.toolMetadata,
                 });
               }
 
@@ -800,7 +802,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
+                  toolMetadata:
+                    chunk.toolMetadata ?? toolInvocation.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -813,7 +816,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
+                  toolMetadata:
+                    chunk.toolMetadata ?? toolInvocation.toolMetadata,
                 });
               }
 


### PR DESCRIPTION
## Summary

- Preserve `toolMetadata` supplied by `tool-output-available` and `tool-output-error` chunks.
- Retain the input-phase metadata when output metadata is absent.
- Add a regression test that verifies output metadata replaces earlier input metadata on dynamic tool parts.

The UI stream processor previously passed the stale metadata from the existing tool part into every output update, ignoring metadata carried by the output chunk itself.

Fixes #16930.

## Validation

- `vitest run --config packages/ai/vitest.node.config.js packages/ai/src/ui/process-ui-message-stream.test.ts` (103 passed)
- `git diff --check`
