### PR TITLE
Fix Agents next link

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -4,6 +4,24 @@ import { getMdxComponents } from '@/components/mdx-components';
 import { config } from '@/lib/geistdocs/config';
 import { v6Source } from '@/lib/geistdocs/source';
 
+const pageSource = {
+  ...v6Source,
+  source: {
+    ...v6Source.source,
+    getPageTree: (...args: Parameters<typeof v6Source.source.getPageTree>) => {
+      const tree = v6Source.source.getPageTree(...args);
+      return {
+        ...tree,
+        children: tree.children.map(item =>
+          item.type === 'folder' && item.index?.url === '/docs/agents'
+            ? { ...item, index: { ...item.index, external: true } }
+            : item,
+        ),
+      };
+    },
+  },
+};
+
 const docsPage = createDocsPage({
   config,
   mdx: ({ link }) => getMdxComponents({ link, versionPrefix: '' }),
@@ -15,7 +33,7 @@ const docsPage = createDocsPage({
     },
   }),
   renderTop: ({ data }) => <MobileDocsBar toc={data.toc} />,
-  source: v6Source,
+  source: pageSource,
   tableOfContentPopover: {
     enabled: false,
   },


### PR DESCRIPTION
Fixes the Agents pagination link to skip the section index and open Overview.

The section index was included as the next page, producing a self-link in production.

Validated with `pnpm check`, docs tests, type-checking, and a production build.
