### PR TITLE
fix(mcp): treat code_challenge_methods_supported as optional

### DIFF
--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -69,7 +69,7 @@ export const OAuthMetadataSchema = z.looseObject({
   scopes_supported: z.array(z.string()).optional(),
   response_types_supported: z.array(z.string()),
   grant_types_supported: z.array(z.string()).optional(),
-  code_challenge_methods_supported: z.array(z.string()),
+  code_challenge_methods_supported: z.array(z.string()).optional(),
   token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
   token_endpoint_auth_signing_alg_values_supported: z
     .array(z.string())

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -576,6 +576,27 @@ describe('discoverAuthorizationServerMetadata', () => {
     expect(metadata).toEqual(tenantMetadata);
   });
 
+  it('accepts OAuth metadata without code_challenge_methods_supported', async () => {
+    const metadataWithoutPkceMethods = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      response_types_supported: ['code'],
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => metadataWithoutPkceMethods,
+    });
+
+    const metadata = await discoverAuthorizationServerMetadata(
+      'https://auth.example.com',
+    );
+
+    expect(metadata).toEqual(metadataWithoutPkceMethods);
+  });
+
   it('tries URLs in order and returns first successful metadata', async () => {
     // First OAuth URL fails with 404
     mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

`OAuthMetadataSchema` required `code_challenge_methods_supported`, but RFC 8414 marks that field as optional. Servers like AWS Sign-In omit it, so metadata discovery failed before the OAuth flow could start.

This makes the field optional in the schema and adds a test for metadata responses without it.

Fixes #17334

## Test plan

- [x] `pnpm --filter @ai-sdk/mcp test:node -- src/tool/oauth.test.ts -t "accepts OAuth metadata without code_challenge_methods_supported"`