### PR TITLE
feat: add a per-step first-content timeout for streaming generations

### DIFF
--- a/.changeset/tidy-rivers-stream.md
+++ b/.changeset/tidy-rivers-stream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add a per-step `firstChunkMs` timeout for streaming generations that waits for parsed content-bearing output independently from the timeout between later chunks.

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -142,7 +142,8 @@ You can specify the timeout either as a number (milliseconds) or as an object wi
 
 - `totalMs`: The total timeout for the entire call including all steps.
 - `stepMs`: The timeout for each individual step (LLM call). This is useful for multi-step generations where you want to limit the time spent on each step independently.
-- `chunkMs`: The timeout between stream chunks (streaming only). The call will abort if no new chunk is received within this duration. This is useful for detecting stalled streams.
+- `firstChunkMs`: The timeout for receiving the first content-bearing output chunk in each model-call step (streaming only). Text deltas, reasoning deltas, tool-input deltas, tool calls, and generated files satisfy the timeout. Response metadata, stream-start parts, empty deltas, raw chunks, and transport activity do not.
+- `chunkMs`: The timeout between content-bearing output chunks (streaming only). It starts after the first output chunk and aborts the call if no subsequent output chunk is received within this duration. This is useful for detecting stalled streams after output begins.
 - `toolMs`: The default timeout for all tool executions. If a tool takes longer, it aborts and returns a tool-error so the model can respond or retry.
 - `tools`: Per-tool timeout overrides using `{toolName}Ms` keys (e.g. `weatherMs`, `slowApiMs`). Takes precedence over `toolMs`. Tool names are type-checked for autocomplete.
 
@@ -189,15 +190,20 @@ const result = await generateText({
 });
 ```
 
-#### Example: Per-chunk timeout for streaming (streamText only)
+#### Example: First-content and per-chunk timeouts for streaming (streamText only)
 
 ```ts
 const result = streamText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
-  timeout: { chunkMs: 5000 }, // abort if no chunk received for 5 seconds
+  timeout: {
+    firstChunkMs: 10000, // wait up to 10 seconds for the first output chunk
+    chunkMs: 5000, // then wait up to 5 seconds between output chunks
+  },
 });
 ```
+
+`firstChunkMs` is re-armed independently for every model-call step in a multi-step generation. It begins after that step's response stream starts, so response setup time remains governed by `stepMs` or `totalMs`.
 
 #### Example: Tool execution timeout
 

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -477,10 +477,10 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, chunkMs, toolMs, and/or tools properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call). chunkMs sets the timeout between stream chunks - the call will abort if no new chunk is received within this duration. toolMs sets the default timeout for all tool executions. tools sets per-tool timeout overrides using the pattern {toolName}Ms (e.g. weatherMs, slowApiMs) that take precedence over toolMs - tool names are type-checked for autocomplete. If a tool takes longer than its timeout, it aborts and returns a tool-error so the model can respond or retry. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or tools properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call). firstChunkMs sets the per-step timeout for the first content-bearing output chunk and ignores response metadata, stream-start parts, empty deltas, raw chunks, and transport activity. chunkMs starts after the first output chunk and sets the timeout between subsequent content-bearing output chunks. toolMs sets the default timeout for all tool executions. tools sets per-tool timeout overrides using the pattern {toolName}Ms (e.g. weatherMs, slowApiMs) that take precedence over toolMs - tool names are type-checked for autocomplete. If a tool takes longer than its timeout, it aborts and returns a tool-error so the model can respond or retry. Can be used alongside abortSignal.',
     },
     {
       name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -63,11 +63,19 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
      */
     abortSignal?: AbortSignal;
     /**
-     * Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property.
-     * The call will be aborted if it takes longer than the specified timeout.
-     * Can be used alongside abortSignal.
+     * Timeout in milliseconds. Streaming agents can also configure per-step
+     * first-content and chunk timeouts. Can be used alongside abortSignal.
      */
-    timeout?: number | { totalMs?: number };
+    timeout?:
+      | number
+      | {
+          totalMs?: number;
+          stepMs?: number;
+          firstChunkMs?: number;
+          chunkMs?: number;
+          toolMs?: number;
+          tools?: Partial<Record<`${string}Ms`, number>>;
+        };
     /**
      * Experimental sandbox environment that is passed through to tool execution.
      */
@@ -180,7 +188,7 @@ Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS, TO
 - `messages` (optional): An array of `ModelMessage` objects (mutually exclusive with `prompt`)
 - `options` (optional): Additional call options when `CALL_OPTIONS` is not `never`
 - `abortSignal` (optional): An `AbortSignal` to cancel the operation
-- `timeout` (optional): A timeout in milliseconds. Can be specified as a number or as an object with a `totalMs` property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside `abortSignal`.
+- `timeout` (optional): A timeout in milliseconds. Can be specified as a number or as an object with `totalMs`, `stepMs`, `firstChunkMs`, `chunkMs`, `toolMs`, and per-tool timeout properties. For streaming agents, `firstChunkMs` is re-armed for each model-call step and waits for parsed content-bearing output, while `chunkMs` governs gaps after output begins. Can be used alongside `abortSignal`.
 - `experimental_sandbox` (optional): An experimental sandbox environment forwarded to tool execution.
 - `onStart` (optional): Callback invoked when the agent operation begins, before any LLM calls.
 - `onStepStart` (optional): Callback invoked when a step (LLM call) begins, before the provider is called.

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -246,7 +246,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } } | undefined',
               description: 'Timeout configuration for the generation.',
             },
             {
@@ -360,7 +360,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } } | undefined',
               description: 'Timeout configuration for the generation.',
             },
             {
@@ -712,10 +712,10 @@ const result = await agent.generate({
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or per-tool properties. For streaming calls, firstChunkMs is re-armed for each model-call step and waits for parsed content-bearing output, while chunkMs governs gaps after output begins. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',
@@ -828,10 +828,10 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or per-tool properties. For streaming calls, firstChunkMs is re-armed for each model-call step and waits for parsed content-bearing output, while chunkMs governs gaps after output begins. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -68,10 +68,10 @@ export async function* streamAgent(
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isRequired: false,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or per-tool properties. firstChunkMs is re-armed for each model-call step and waits for parsed content-bearing output, while chunkMs governs gaps after output begins. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -69,10 +69,10 @@ export async function POST(request: Request) {
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isRequired: false,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or per-tool properties. firstChunkMs is re-armed for each model-call step and waits for parsed content-bearing output, while chunkMs governs gaps after output begins. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -70,10 +70,10 @@ export async function handler(req, res) {
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isRequired: false,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or per-tool properties. firstChunkMs is re-armed for each model-call step and waits for parsed content-bearing output, while chunkMs governs gaps after output begins. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/examples/ai-functions/src/stream-text/openai/timeout-chunk.ts
+++ b/examples/ai-functions/src/stream-text/openai/timeout-chunk.ts
@@ -8,7 +8,10 @@ run(async () => {
   const result = streamText({
     model: openai('gpt-4o'),
     prompt: 'Write a short poem about the ocean.',
-    timeout: { chunkMs: 500 },
+    timeout: {
+      firstChunkMs: 10000, // first content-bearing output for each step
+      chunkMs: 5000, // gaps between content-bearing output chunks
+    },
   });
 
   printFullStream({ result });

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -70,7 +70,8 @@ export type AgentCallParameters<
     abortSignal?: AbortSignal;
 
     /**
-     * Timeout in milliseconds. Can be specified as a number or as an object with `totalMs`.
+     * Timeout configuration. Streaming agents can separately limit time to
+     * first content-bearing output and gaps between later output chunks.
      */
     timeout?: TimeoutConfiguration<TOOLS>;
 

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -56,7 +56,7 @@ export type GenerateTextStartEvent<
 
   /**
    * Timeout configuration for the generation.
-   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs, toolMs, and per-tool overrides via tools.
+   * Can be a number (milliseconds) or an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and per-tool overrides via tools.
    */
   readonly timeout: TimeoutConfiguration<TOOLS> | undefined;
 

--- a/packages/ai/src/generate-text/stream-text-first-chunk-timeout.test.ts
+++ b/packages/ai/src/generate-text/stream-text-first-chunk-timeout.test.ts
@@ -1,0 +1,426 @@
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import { DelayedPromise } from '@ai-sdk/provider-utils';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { isStepCount } from './stop-condition';
+import { streamText } from './stream-text';
+
+const testUsage: LanguageModelV4Usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+describe('streamText firstChunkMs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should arm only after the provider response stream starts', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    const responsePromise = new DelayedPromise<void>();
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+          await responsePromise.promise;
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    responsePromise.resolve(undefined);
+    await consumePromise;
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+  });
+
+  it('should not arm after the call is aborted during response setup', async () => {
+    const abortController = new AbortController();
+    const responsePromise = new DelayedPromise<void>();
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async () => {
+          await responsePromise.promise;
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      abortSignal: abortController.signal,
+      timeout: { firstChunkMs: 50 },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+    abortController.abort();
+    responsePromise.resolve(undefined);
+    await consumePromise;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('should ignore non-output parts and empty deltas', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-id',
+                });
+                controller.enqueue({
+                  type: 'raw',
+                  rawValue: { type: 'ping' },
+                });
+                controller.enqueue({ type: 'text-start', id: '1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: '1',
+                  delta: '',
+                });
+
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      include: { rawChunks: true },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+    await vi.advanceTimersByTimeAsync(100);
+    await consumePromise;
+
+    expect(receivedAbortSignal?.aborted).toBe(true);
+    expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
+    expect((receivedAbortSignal?.reason as Error)?.message).toBe(
+      'First chunk timeout of 50ms exceeded',
+    );
+  });
+
+  it.each<{
+    name: string;
+    chunks: LanguageModelV4StreamPart[];
+  }>([
+    {
+      name: 'text delta',
+      chunks: [
+        { type: 'text-start', id: '1' },
+        { type: 'text-delta', id: '1', delta: 'Hello' },
+        { type: 'text-end', id: '1' },
+      ],
+    },
+    {
+      name: 'reasoning delta',
+      chunks: [
+        { type: 'reasoning-start', id: '1' },
+        { type: 'reasoning-delta', id: '1', delta: 'Thinking' },
+        { type: 'reasoning-end', id: '1' },
+      ],
+    },
+    {
+      name: 'tool input delta',
+      chunks: [
+        { type: 'tool-input-start', id: 'call-1', toolName: 'tool1' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '{"value":',
+        },
+        { type: 'tool-input-end', id: 'call-1' },
+      ],
+    },
+    {
+      name: 'tool call',
+      chunks: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: '{"value":"test"}',
+        },
+      ],
+    },
+    {
+      name: 'generated file',
+      chunks: [
+        {
+          type: 'file',
+          data: { type: 'data', data: 'Hello World' },
+          mediaType: 'text/plain',
+        },
+      ],
+    },
+  ])('should disarm for a $name', async ({ chunks }) => {
+    let receivedAbortSignal: AbortSignal | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+          return {
+            stream: convertArrayToReadableStream([
+              ...chunks,
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+        },
+      },
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      onError: () => {},
+    });
+
+    await result.consumeStream();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+  });
+
+  it('should clear before forwarding the first output part', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    let wasAbortedDuringOnChunk: boolean | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      onChunk: async ({ chunk }) => {
+        if (chunk.type === 'text-delta') {
+          await vi.advanceTimersByTimeAsync(100);
+          wasAbortedDuringOnChunk = receivedAbortSignal?.aborted;
+        }
+      },
+      onError: () => {},
+    });
+
+    await result.consumeStream();
+
+    expect(wasAbortedDuringOnChunk).toBe(false);
+    expect(receivedAbortSignal?.aborted).toBe(false);
+  });
+
+  it('should re-arm for later model-call steps', async () => {
+    const receivedAbortSignals: (AbortSignal | undefined)[] = [];
+    let stepCount = 0;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignals.push(abortSignal);
+          stepCount++;
+
+          if (stepCount === 1) {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: '{"value":"test"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: {
+                    unified: 'tool-calls',
+                    raw: 'tool-calls',
+                  },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          }
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-id',
+                });
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+              },
+            }),
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+          execute: async () => 'tool result',
+        },
+      },
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      stopWhen: isStepCount(2),
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+    await vi.waitFor(() => expect(stepCount).toBe(2));
+    await vi.advanceTimersByTimeAsync(100);
+    await consumePromise;
+
+    expect(receivedAbortSignals).toHaveLength(2);
+    expect(receivedAbortSignals[1]?.aborted).toBe(true);
+    expect((receivedAbortSignals[1]?.reason as Error)?.message).toBe(
+      'First chunk timeout of 50ms exceeded',
+    );
+  });
+
+  it('should use chunkMs only after the first output chunk', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    const firstOutputPromise = new DelayedPromise<void>();
+    const finishPromise = new DelayedPromise<void>();
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+          return {
+            stream: new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-id',
+                });
+
+                await firstOutputPromise.promise;
+                controller.enqueue({ type: 'text-start', id: '1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: '1',
+                  delta: 'Hello',
+                });
+
+                await finishPromise.promise;
+                controller.enqueue({ type: 'text-end', id: '1' });
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 100, chunkMs: 25 },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    firstOutputPromise.resolve(undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(30);
+    expect(receivedAbortSignal?.aborted).toBe(true);
+    expect((receivedAbortSignal?.reason as Error)?.message).toBe(
+      'Chunk timeout of 25ms exceeded',
+    );
+
+    finishPromise.resolve(undefined);
+    await consumePromise;
+  });
+});

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -22,6 +22,14 @@ import type { ResponseMessage } from './response-message';
 import type { StepResult } from './step-result';
 
 describe('streamText types', () => {
+  it('should accept a first content chunk timeout', () => {
+    streamText({
+      model: new MockLanguageModelV4(),
+      prompt: 'Hello',
+      timeout: { firstChunkMs: 1000 },
+    });
+  });
+
   describe('onEnd', () => {
     it('should expose end event properties', () => {
       streamText({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -34,6 +34,7 @@ import { prepareTools } from '../prompt/prepare-tools';
 import type { Prompt } from '../prompt/prompt';
 import {
   getChunkTimeoutMs,
+  getFirstChunkTimeoutMs,
   getStepTimeoutMs,
   getTotalTimeoutMs,
   type RequestOptions,
@@ -157,28 +158,29 @@ const originalGenerateCallId = createIdGenerator({
   size: 24,
 });
 
-// chunk types that count as model output; used to distinguish empty
-// incomplete streams from incomplete streams with partial results.
+// chunk types that count as content-bearing model output; used for first
+// content and chunk timeouts and to distinguish empty incomplete streams from
+// incomplete streams with partial results.
 // exhaustive so that new chunk types must be classified explicitly:
 const isOutputChunkType = {
   file: true,
-  custom: true,
-  source: true,
-  'text-start': true,
-  'text-end': true,
+  custom: false,
+  source: false,
+  'text-start': false,
+  'text-end': false,
   'text-delta': true,
-  'reasoning-start': true,
-  'reasoning-end': true,
+  'reasoning-start': false,
+  'reasoning-end': false,
   'reasoning-delta': true,
   'reasoning-file': true,
-  'tool-input-start': true,
-  'tool-input-end': true,
+  'tool-input-start': false,
+  'tool-input-end': false,
   'tool-input-delta': true,
-  'tool-approval-request': true,
-  'tool-approval-response': true,
+  'tool-approval-request': false,
+  'tool-approval-response': false,
   'tool-call': true,
-  'tool-result': true,
-  'tool-error': true,
+  'tool-result': false,
+  'tool-error': false,
   'tool-execution-end': false,
   'model-call-start': false,
   'model-call-response-metadata': false,
@@ -299,7 +301,7 @@ export type StreamTextOnAbortCallback<
  *
  * @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
  * @param abortSignal - An optional abort signal that can be used to cancel the call.
- * @param timeout - An optional timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout.
+ * @param timeout - Optional timeout configuration. Streaming timeouts can separately limit total duration, each step, time to first content-bearing output, and gaps between later output chunks.
  * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
  *
  * @param experimental_sandbox - The sandbox environment that is passed through to tool execution.
@@ -716,9 +718,12 @@ export function streamText<
   }): StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
+  const firstChunkTimeoutMs = getFirstChunkTimeoutMs(timeout);
   const chunkTimeoutMs = getChunkTimeoutMs(timeout);
   const stepAbortController =
     stepTimeoutMs != null ? new AbortController() : undefined;
+  const firstChunkAbortController =
+    firstChunkTimeoutMs != null ? new AbortController() : undefined;
   const chunkAbortController =
     chunkTimeoutMs != null ? new AbortController() : undefined;
   const resolvedOnStart = onStart ?? experimental_onStart;
@@ -742,10 +747,13 @@ export function streamText<
       abortSignal,
       totalTimeoutMs,
       stepAbortController?.signal,
+      firstChunkAbortController?.signal,
       chunkAbortController?.signal,
     ),
     stepTimeoutMs,
     stepAbortController,
+    firstChunkTimeoutMs,
+    firstChunkAbortController,
     chunkTimeoutMs,
     chunkAbortController,
     instructions,
@@ -951,6 +959,8 @@ class DefaultStreamTextResult<
     abortSignal,
     stepTimeoutMs,
     stepAbortController,
+    firstChunkTimeoutMs,
+    firstChunkAbortController,
     chunkTimeoutMs,
     chunkAbortController,
     instructions,
@@ -1000,6 +1010,8 @@ class DefaultStreamTextResult<
     abortSignal: AbortSignal | undefined;
     stepTimeoutMs: number | undefined;
     stepAbortController: AbortController | undefined;
+    firstChunkTimeoutMs: number | undefined;
+    firstChunkAbortController: AbortController | undefined;
     chunkTimeoutMs: number | undefined;
     chunkAbortController: AbortController | undefined;
     toolsContext: InferToolSetContext<TOOLS>;
@@ -1764,7 +1776,32 @@ class DefaultStreamTextResult<
           timeoutMs: stepTimeoutMs,
         });
 
-        // Set up chunk timeout tracking (will be reset on each chunk)
+        // The first-content timeout is armed after the provider response stream
+        // starts. It is cleared by the first content-bearing output chunk.
+        let firstChunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
+          undefined;
+
+        function startFirstChunkTimeout() {
+          if (abortSignal?.aborted) {
+            return;
+          }
+
+          firstChunkTimeoutId = setAbortTimeout({
+            abortController: firstChunkAbortController,
+            label: 'First chunk',
+            timeoutMs: firstChunkTimeoutMs,
+          });
+        }
+
+        function clearFirstChunkTimeout() {
+          if (firstChunkTimeoutId != null) {
+            clearTimeout(firstChunkTimeoutId);
+            firstChunkTimeoutId = undefined;
+          }
+        }
+
+        // Set up chunk timeout tracking. It is armed by the first
+        // content-bearing output chunk and reset by subsequent output chunks.
         let chunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
           undefined;
 
@@ -1792,12 +1829,21 @@ class DefaultStreamTextResult<
           }
         }
 
+        function clearStepTimeouts() {
+          clearStepTimeout();
+          clearFirstChunkTimeout();
+          clearChunkTimeout();
+          abortSignal?.removeEventListener('abort', clearStepTimeouts);
+        }
+
         // The step's stream is registered lazily and consumed long after this
         // function returns, so the step timer must stay armed past setup. When
-        // the merged abort signal fires (any step/chunk/total timeout or caller
-        // abort), drop both step-scoped timers so neither outlives the step.
-        abortSignal?.addEventListener('abort', clearStepTimeout);
-        abortSignal?.addEventListener('abort', clearChunkTimeout);
+        // the merged abort signal fires (any step/first-chunk/chunk/total
+        // timeout or caller abort), drop all step-scoped timers so none
+        // outlives the step.
+        abortSignal?.addEventListener('abort', clearStepTimeouts, {
+          once: true,
+        });
 
         try {
           stepFinish = new DelayedPromise<void>();
@@ -1960,6 +2006,8 @@ class DefaultStreamTextResult<
             ),
           );
 
+          startFirstChunkTimeout();
+
           const streamAfterToolCallbackInvocation =
             invokeToolCallbacksFromStream({
               stream: languageModelStream,
@@ -2069,11 +2117,30 @@ class DefaultStreamTextResult<
                 TextStreamPart<TOOLS>
               >({
                 async transform(chunk, controller): Promise<void> {
-                  resetChunkTimeout();
-
                   if (chunk.type === 'model-call-start') {
                     warnings = chunk.warnings;
                     return; // stream start chunks are sent immediately and do not count as first chunk
+                  }
+
+                  const chunkType = chunk.type;
+                  const isOutputChunk =
+                    isOutputChunkType[chunkType] &&
+                    !(
+                      (chunkType === 'text-delta' ||
+                        chunkType === 'reasoning-delta') &&
+                      chunk.text.length === 0
+                    ) &&
+                    !(
+                      chunkType === 'tool-input-delta' &&
+                      chunk.delta.length === 0
+                    );
+
+                  if (isOutputChunk) {
+                    if (!hasReceivedOutputChunk) {
+                      clearFirstChunkTimeout();
+                    }
+                    hasReceivedOutputChunk = true;
+                    resetChunkTimeout();
                   }
 
                   if (stepFirstChunk) {
@@ -2085,12 +2152,6 @@ class DefaultStreamTextResult<
                       request: stepRequest,
                       warnings: warnings ?? [],
                     });
-                  }
-
-                  const chunkType = chunk.type;
-
-                  if (isOutputChunkType[chunkType]) {
-                    hasReceivedOutputChunk = true;
                   }
 
                   switch (chunkType) {
@@ -2210,8 +2271,7 @@ class DefaultStreamTextResult<
                       }),
                     });
 
-                    clearStepTimeout();
-                    clearChunkTimeout();
+                    clearStepTimeouts();
                     self.closeStream();
                     return;
                   }
@@ -2291,9 +2351,8 @@ class DefaultStreamTextResult<
                     }
                   }
 
-                  // Clear the step and chunk timeouts before the next step is started
-                  clearStepTimeout();
-                  clearChunkTimeout();
+                  // Clear the step timeouts before the next step is started.
+                  clearStepTimeouts();
 
                   if (
                     // Continue if:
@@ -2342,8 +2401,7 @@ class DefaultStreamTextResult<
         } catch (error) {
           // Setup failed before the stream was registered, so neither the
           // stream's flush nor an abort will clear the timers — clear them here.
-          clearStepTimeout();
-          clearChunkTimeout();
+          clearStepTimeouts();
           throw error;
         }
       }

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -10,6 +10,7 @@ export type CallSettings = LanguageModelCallOptions &
 export {
   getTotalTimeoutMs,
   getStepTimeoutMs,
+  getFirstChunkTimeoutMs,
   getChunkTimeoutMs,
   getToolTimeoutMs,
 } from './request-options';

--- a/packages/ai/src/prompt/prepare-language-model-call-options.test.ts
+++ b/packages/ai/src/prompt/prepare-language-model-call-options.test.ts
@@ -1,6 +1,7 @@
 import { InvalidArgumentError } from '../error/invalid-argument-error';
 import { prepareLanguageModelCallOptions } from './prepare-language-model-call-options';
 import {
+  getFirstChunkTimeoutMs,
   getToolTimeoutMs,
   getTotalTimeoutMs,
   getStepTimeoutMs,
@@ -279,6 +280,20 @@ describe('timeout helpers (from request-options)', () => {
 
     it('should return chunkMs from an object', () => {
       expect(getChunkTimeoutMs({ chunkMs: 2000 })).toBe(2000);
+    });
+  });
+
+  describe('getFirstChunkTimeoutMs', () => {
+    it('should return undefined when timeout is undefined', () => {
+      expect(getFirstChunkTimeoutMs(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when timeout is a number', () => {
+      expect(getFirstChunkTimeoutMs(5000)).toBeUndefined();
+    });
+
+    it('should return firstChunkMs from an object', () => {
+      expect(getFirstChunkTimeoutMs({ firstChunkMs: 1500 })).toBe(1500);
     });
   });
 });

--- a/packages/ai/src/prompt/request-options.ts
+++ b/packages/ai/src/prompt/request-options.ts
@@ -5,6 +5,7 @@ import type { ToolSet } from '@ai-sdk/provider-utils';
  * - A number representing milliseconds
  * - An object with `totalMs` property for the total timeout in milliseconds
  * - An object with `stepMs` property for the timeout of each step in milliseconds
+ * - An object with `firstChunkMs` property for the timeout until the first content chunk (streaming only)
  * - An object with `chunkMs` property for the timeout between stream chunks (streaming only)
  * - An object with `toolMs` property for the default timeout for all tool executions
  * - An object with `tools` property for per-tool timeout overrides using `{toolName}Ms` keys
@@ -14,6 +15,7 @@ export type TimeoutConfiguration<TOOLS extends ToolSet> =
   | {
       totalMs?: number;
       stepMs?: number;
+      firstChunkMs?: number;
       chunkMs?: number;
       toolMs?: number;
       tools?: Partial<Record<`${keyof TOOLS & string}Ms`, number>>;
@@ -50,6 +52,22 @@ export function getStepTimeoutMs(
     return undefined;
   }
   return timeout.stepMs;
+}
+
+/**
+ * Extracts the first content chunk timeout value in milliseconds from a TimeoutConfiguration.
+ * This timeout is for streaming only - it aborts if no content-bearing output chunk is received within the specified duration.
+ *
+ * @param timeout - The timeout configuration.
+ * @returns The first content chunk timeout in milliseconds, or undefined if no first content chunk timeout is configured.
+ */
+export function getFirstChunkTimeoutMs(
+  timeout: TimeoutConfiguration<any> | undefined,
+): number | undefined {
+  if (timeout == null || typeof timeout === 'number') {
+    return undefined;
+  }
+  return timeout.firstChunkMs;
 }
 
 /**


### PR DESCRIPTION
## Background

Streaming responses can deliver headers or non-content framing and then stall indefinitely; a parsed first-content deadline lets applications detect and safely retry these pre-output failures.

## Summary

Added public `firstChunkMs` timeout configuration and extraction, per-step timeout enforcement in `streamText`, semantic output classification, dedicated provider abort signaling, and post-output `chunkMs` handling.

## Testing

Added Node and Edge coverage for timeout extraction, public typing, delayed response setup, non-output framing, empty deltas, supported output types, later tool-calling steps, cleanup races, clear-before-forward ordering, and `chunkMs` interaction.

## End-to-end Validation

- Built `ai` and ran the updated OpenAI streaming-timeout example against the live API; content streamed successfully with a `stop` finish reason.

## Documentation

Updated timeout settings, `streamText` and agent references, and the existing OpenAI timeout example to document per-step first-content behavior and its distinction from between-chunk inactivity.

## Related Issues

Fixes #17315

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>