### PR TITLE
reproduction: could not reproduce Issue: UnsupportedModelVersionError thrown when using LanguageModelV4 providers with

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-17327-openrouter-v4.ts
+++ b/examples/ai-functions/src/reproduction/issue-17327-openrouter-v4.ts
@@ -1,0 +1,90 @@
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import assert from 'node:assert/strict';
+import { streamText as streamTextCurrent } from 'ai';
+import { streamText as streamTextReported } from 'ai-7-0-22';
+
+const modelId = 'minimax/minimax-m2.7';
+const expectedText = 'compatibility-ok';
+
+const openrouter = createOpenRouter({
+  apiKey: 'test-api-key',
+  fetch: async (_input, init) => {
+    const body = JSON.parse(String(init?.body));
+
+    assert.equal(body.model, modelId);
+    assert.equal(body.stream, true);
+
+    const chunks = [
+      {
+        id: 'chatcmpl-issue-17327',
+        model: modelId,
+        choices: [
+          {
+            index: 0,
+            delta: { role: 'assistant', content: expectedText },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-issue-17327',
+        model: modelId,
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+      },
+    ];
+
+    return new Response(
+      `${chunks.map(chunk => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`,
+      {
+        headers: { 'content-type': 'text/event-stream' },
+        status: 200,
+      },
+    );
+  },
+});
+
+async function runReportedVersion(): Promise<void> {
+  const model = openrouter(modelId);
+
+  assert.equal(model.specificationVersion, 'v4');
+
+  const result = streamTextReported({
+    model,
+    prompt: 'Reply with compatibility-ok.',
+  });
+  const text = await result.text;
+
+  assert.equal(text, expectedText);
+  console.log(`ai@7.0.22 accepted OpenRouter LanguageModelV4: ${text}`);
+}
+
+async function runCurrentVersion(): Promise<void> {
+  const model = openrouter(modelId);
+
+  assert.equal(model.specificationVersion, 'v4');
+
+  const result = streamTextCurrent({
+    model,
+    prompt: 'Reply with compatibility-ok.',
+  });
+  const text = await result.text;
+
+  assert.equal(text, expectedText);
+  console.log(`ai@7.0.29 accepted OpenRouter LanguageModelV4: ${text}`);
+}
+
+async function main(): Promise<void> {
+  await runReportedVersion();
+  await runCurrentVersion();
+  console.log('Issue #17327 could not be reproduced.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Issue: UnsupportedModelVersionError thrown when using LanguageModelV4 providers with AI SDK v7

## Reproduction

- The reported bug would prevent `streamText` from executing with a supported LanguageModelV4 provider.
- The reproduction artifact is `examples/ai-functions/src/reproduction/issue-17327-openrouter-v4.ts`.
- The artifact observed both `ai@7.0.22` and the current `ai@7.0.29` accepting `@openrouter/ai-sdk-provider@3.0.0` and producing the expected streamed text instead of throwing `UnsupportedModelVersionError`.
- Published package metadata declares `@openrouter/ai-sdk-provider@3.0.0` compatible with `ai@^7.0.0`.
- Both the published `ai@7.0.22` build and current `packages/ai/src/model/resolve-model.ts` explicitly accept specification versions `v4`, `v3`, and `v2`.
- `packages/ai/src/error/unsupported-model-version-error.ts` retains stale AI SDK `5/v2` wording, but that error was not thrown for the reported v4 model.
- The reported runtime error is consistent with a different or partially upgraded `ai` build being resolved at runtime, but the issue provides no lockfile or module-resolution evidence to verify that inference.
- A live OpenRouter request was not evaluated because OpenRouter live-service checks are skipped by policy; the pre-transport compatibility check and complete stream consumption were exercised with an intercepted valid SSE response.

## Relevant Documentation

- https://www.npmjs.com/package/%40openrouter/ai-sdk-provider?activeTab=versions
- https://openrouter.ai/docs/community/frameworks
- https://ai-sdk.dev/docs/foundations/providers-and-models

## Related Issues

Could not reproduce #17327