### PR TITLE
reproduction: @ai-sdk/anthropic: disableParallelToolUse: true is hardcoded when structuredOutputMode: 'jsonTool',

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 15652,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-15652.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-15652.ts",
+    "packages/anthropic/src/__fixtures__/anthropic-issue-15652.chunks.txt",
+    "packages/anthropic/src/__fixtures__/anthropic-issue-15652-false.chunks.txt"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #15652 reproduced: expected 3 parallel searchDocs calls, but received 1 because disable_parallel_tool_use was true."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-15652.ts
+++ b/examples/ai-functions/src/reproduction/issue-15652.ts
@@ -1,0 +1,97 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { Output, streamText, tool } from 'ai';
+import { readFile } from 'node:fs/promises';
+import { z } from 'zod';
+
+type AnthropicRequestBody = {
+  tool_choice?: {
+    disable_parallel_tool_use?: boolean;
+  };
+};
+
+async function loadLiveResponseFixture(disableParallelToolUse: boolean) {
+  const filename = disableParallelToolUse
+    ? 'anthropic-issue-15652.chunks.txt'
+    : 'anthropic-issue-15652-false.chunks.txt';
+  const chunks = await readFile(
+    new URL(
+      `../../../../packages/anthropic/src/__fixtures__/${filename}`,
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  return `${chunks
+    .trim()
+    .split('\n')
+    .map(line => `data: ${line}\n\n`)
+    .join('')}data: [DONE]\n\n`;
+}
+
+async function main() {
+  let requestBody: AnthropicRequestBody | undefined;
+
+  const anthropic = createAnthropic({
+    apiKey: 'test-api-key',
+    fetch: async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as AnthropicRequestBody;
+      const disableParallelToolUse =
+        requestBody.tool_choice?.disable_parallel_tool_use === true;
+
+      return new Response(
+        await loadLiveResponseFixture(disableParallelToolUse),
+        {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      );
+    },
+  });
+
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    tools: {
+      searchDocs: tool({
+        description: 'Search documentation for one query.',
+        inputSchema: z.object({ query: z.string() }),
+      }),
+    },
+    output: Output.object({
+      schema: z.object({ items: z.array(z.string()) }),
+    }),
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'jsonTool',
+        disableParallelToolUse: false,
+      },
+    },
+    prompt:
+      'Call searchDocs exactly 3 times in parallel in this response, with the distinct queries alpha, beta, and gamma. Do not call the json tool yet.',
+  });
+
+  const toolCalls: string[] = [];
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'tool-call') {
+      toolCalls.push(chunk.toolName);
+    }
+  }
+
+  if (toolCalls.length !== 3) {
+    console.error(
+      'Issue #15652 reproduced: expected 3 parallel searchDocs calls, but received 1 because disable_parallel_tool_use was true.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (requestBody?.tool_choice?.disable_parallel_tool_use !== false) {
+    throw new Error(
+      'Expected disableParallelToolUse=false to serialize as disable_parallel_tool_use=false.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-15652-false.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-15652-false.chunks.txt
@@ -1,0 +1,19 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd5Uz3EsW7t2zRF3zZGJL","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":798,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard","inference_geo":"not_available"}}            }
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01LtEf4h1QW7KCKLsYMuhTNB","name":"searchDocs","input":{},"caller":{"type":"direct"}}  }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}        }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\": \"alpha"}       }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}           }
+{"type":"content_block_stop","index":0  }
+{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_016tfZE7otAFSBjhc67wu189","name":"searchDocs","input":{},"caller":{"type":"direct"}}           }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}               }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\": \"beta"}          }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}   }
+{"type":"content_block_stop","index":1   }
+{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01XkU35z8BVWqqc9tijDuLrA","name":"searchDocs","input":{},"caller":{"type":"direct"}}      }
+{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}      }
+{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"query\": \"gamma"}   }
+{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\"}"}        }
+{"type":"content_block_stop","index":2       }
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":798,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":110}    }
+{"type":"message_stop"     }

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-15652.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-15652.chunks.txt
@@ -1,0 +1,9 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd5UukmomryrtuTzjWdSU","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":799,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard","inference_geo":"not_available"}}        }
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01FyLTSWHevzHgjqxfx6RFaC","name":"searchDocs","input":{},"caller":{"type":"direct"}}     }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}           }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\": \"alpha"}           }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}     }
+{"type":"content_block_stop","index":0       }
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":799,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":29}              }
+{"type":"message_stop"              }

--- a/packages/anthropic/src/anthropic-issue-15652.test.ts
+++ b/packages/anthropic/src/anthropic-issue-15652.test.ts
@@ -1,0 +1,101 @@
+import {
+  convertReadableStreamToArray,
+  mockId,
+} from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import type { AnthropicLanguageModelOptions } from './anthropic-language-model-options';
+import { createAnthropic } from './anthropic-provider';
+
+type AnthropicRequestBody = {
+  tool_choice?: {
+    disable_parallel_tool_use?: boolean;
+  };
+};
+
+function loadLiveResponseFixture(disableParallelToolUse: boolean) {
+  const filename = disableParallelToolUse
+    ? 'anthropic-issue-15652.chunks.txt'
+    : 'anthropic-issue-15652-false.chunks.txt';
+  const chunks = fs.readFileSync(
+    new URL(`./__fixtures__/${filename}`, import.meta.url),
+    'utf8',
+  );
+
+  return `${chunks
+    .trim()
+    .split('\n')
+    .map(line => `data: ${line}\n\n`)
+    .join('')}data: [DONE]\n\n`;
+}
+
+it('respects disableParallelToolUse=false with jsonTool structured output', async () => {
+  let requestBody: AnthropicRequestBody | undefined;
+  const provider = createAnthropic({
+    apiKey: 'test-api-key',
+    generateId: mockId({ prefix: 'id' }),
+    fetch: async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as AnthropicRequestBody;
+      const disableParallelToolUse =
+        requestBody.tool_choice?.disable_parallel_tool_use === true;
+
+      return new Response(loadLiveResponseFixture(disableParallelToolUse), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    },
+  });
+
+  const { stream } = await provider('claude-sonnet-4-5').doStream({
+    prompt: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Call searchDocs exactly 3 times in parallel in this response, with the distinct queries alpha, beta, and gamma. Do not call the json tool yet.',
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        type: 'function',
+        name: 'searchDocs',
+        description: 'Search documentation for one query.',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    responseFormat: {
+      type: 'json',
+      schema: {
+        type: 'object',
+        properties: {
+          items: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['items'],
+        additionalProperties: false,
+      },
+    },
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'jsonTool',
+        disableParallelToolUse: false,
+      } satisfies AnthropicLanguageModelOptions,
+    },
+  });
+
+  const chunks = await convertReadableStreamToArray(stream);
+  const toolCalls = chunks.filter(chunk => chunk.type === 'tool-call');
+
+  expect(
+    toolCalls,
+    'The live false-option fixture contains three parallel searchDocs calls',
+  ).toHaveLength(3);
+  expect(requestBody?.tool_choice?.disable_parallel_tool_use).toBe(false);
+});


### PR DESCRIPTION
## Bug

@ai-sdk/anthropic: `disableParallelToolUse: true` is hardcoded when `structuredOutputMode: 'jsonTool'`, ignores user override

## Reproduction

- `@ai-sdk/anthropic@4.0.15` still serializes `disable_parallel_tool_use: true` when `structuredOutputMode: 'jsonTool'` and the user explicitly sets `disableParallelToolUse: false`.
- The live `claude-sonnet-4-5` request produced only one `searchDocs` call; changing only the serialized flag to `false` produced all three requested parallel calls.
- `examples/ai-functions/src/reproduction/issue-15652.ts` replays the captured live responses and exits with code 1 because one call is received instead of the expected three.
- Live response fixtures are stored in `packages/anthropic/src/__fixtures__/anthropic-issue-15652.chunks.txt` and `packages/anthropic/src/__fixtures__/anthropic-issue-15652-false.chunks.txt`; the failing provider regression test is `packages/anthropic/src/anthropic-issue-15652.test.ts`.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic

## Related Issues

Reproduces #15652