### PR TITLE
[v6.0] reproduction: @ai-sdk/anthropic: disableParallelToolUse: true is hardcoded when structuredOutputMode: 'jsonTool',

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 15652,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-15652-anthropic-json-tool-parallel.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-15652-anthropic-json-tool-parallel.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "BUG: disableParallelToolUse:false did not allow three parallel searchDocs calls with structuredOutputMode:jsonTool"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-15652-anthropic-json-tool-parallel.ts
+++ b/examples/ai-functions/src/reproduction/issue-15652-anthropic-json-tool-parallel.ts
@@ -1,0 +1,77 @@
+import 'dotenv/config';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { Output, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+type AnthropicRequest = {
+  tool_choice?: {
+    type?: string;
+    disable_parallel_tool_use?: boolean;
+  };
+};
+
+async function main() {
+  let requestBody: AnthropicRequest | undefined;
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBody = JSON.parse(init.body) as AnthropicRequest;
+      }
+
+      return fetch(input, init);
+    },
+  });
+
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    maxOutputTokens: 1024,
+    output: Output.object({
+      schema: z.object({ items: z.array(z.string()) }),
+    }),
+    tools: {
+      searchDocs: tool({
+        description:
+          'Search documentation. Call this once for each requested query.',
+        inputSchema: z.object({ query: z.string() }),
+      }),
+    },
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'jsonTool',
+        disableParallelToolUse: false,
+      },
+    },
+    prompt:
+      'Call searchDocs exactly 3 times in parallel in this response, with the distinct queries alpha, beta, and gamma. Do not call the json tool yet.',
+  });
+
+  const searchCalls: string[] = [];
+
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'tool-call' && chunk.toolName === 'searchDocs') {
+      searchCalls.push((chunk.input as { query: string }).query);
+    }
+  }
+
+  const serializedValue = requestBody?.tool_choice?.disable_parallel_tool_use;
+
+  console.log(
+    JSON.stringify({
+      requestedDisableParallelToolUse: false,
+      serializedDisableParallelToolUse: serializedValue,
+      searchCalls,
+    }),
+  );
+
+  if (serializedValue !== false || searchCalls.length !== 3) {
+    throw new Error(
+      'BUG: disableParallelToolUse:false did not allow three parallel searchDocs calls with structuredOutputMode:jsonTool',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-15652-json-tool-parallel.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-15652-json-tool-parallel.chunks.txt
@@ -1,0 +1,9 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd5UwYJGcvy1r1hrycUKx","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":804,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard","inference_geo":"not_available"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01GjFujkZhVEfe2hDvhJLy1Q","name":"searchDocs","input":{},"caller":{"type":"direct"}}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\": \"alpha"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}}
+{"type":"content_block_stop","index":0}
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":804,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":29}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/anthropic-messages-language-model.issue-15652.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.issue-15652.test.ts
@@ -1,0 +1,87 @@
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import type { AnthropicLanguageModelOptions } from './anthropic-messages-options';
+import { createAnthropic } from './anthropic-provider';
+
+describe('issue #15652', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+
+  it('replays the live response with only one real tool call', async () => {
+    const chunks = fs
+      .readFileSync(
+        'src/__fixtures__/anthropic-issue-15652-json-tool-parallel.chunks.txt',
+        'utf8',
+      )
+      .split('\n')
+      .map(line => `data: ${line}\n\n`);
+
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+
+    const provider = createAnthropic({ apiKey: 'test-api-key' });
+    const { stream } = await provider('claude-sonnet-4-5').doStream({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Call searchDocs exactly 3 times in parallel in this response, with the distinct queries alpha, beta, and gamma. Do not call the json tool yet.',
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: 'function',
+          name: 'searchDocs',
+          description:
+            'Search documentation. Call this once for each requested query.',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            items: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['items'],
+        },
+      },
+      providerOptions: {
+        anthropic: {
+          structuredOutputMode: 'jsonTool',
+          disableParallelToolUse: false,
+        } satisfies AnthropicLanguageModelOptions,
+      },
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+    const toolCalls = parts.filter(part => part.type === 'tool-call');
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toMatchObject({
+      type: 'tool-call',
+      toolName: 'searchDocs',
+      input: '{"query": "alpha"}',
+    });
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      tool_choice: {
+        type: 'any',
+        disable_parallel_tool_use: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/anthropic: `disableParallelToolUse: true` is hardcoded when `structuredOutputMode: 'jsonTool'`, ignores user override

## Reproduction

- `@ai-sdk/anthropic@3.0.97` reproduces the override mismatch: `disableParallelToolUse: false` is serialized as `tool_choice.disable_parallel_tool_use: true` with `structuredOutputMode: 'jsonTool'`.
- The live Claude Sonnet 4.5 response contained only one `searchDocs` call (`alpha`) instead of the three parallel calls requested.
- Expected behavior is for the explicit `false` value to be preserved, allowing the model to issue multiple real-tool calls in one response.
- The runnable reproduction at `examples/ai-functions/src/reproduction/issue-15652-anthropic-json-tool-parallel.ts` exits non-zero when the override is ignored or three parallel calls are not emitted.
- The live response is recorded in `packages/anthropic/src/__fixtures__/anthropic-issue-15652-json-tool-parallel.chunks.txt` and replayed by `packages/anthropic/src/anthropic-messages-language-model.issue-15652.test.ts`.

## Relevant Documentation

- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use

## Related Issues

Reproduces #15652