### PR TITLE
[v5.0] reproduction: @ai-sdk/anthropic: disableParallelToolUse: true is hardcoded when structuredOutputMode: 'jsonTool',

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "issueId": 15652,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/anthropic-json-tool-parallel-use.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/anthropic-json-tool-parallel-use.ts",
+    "packages/anthropic/src/__fixtures__/issue-15652.chunks.txt",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #15652 REPRODUCED: expected 3 parallel searchDocs calls with disableParallelToolUse=false, but observed 0 calls and serialized disable_parallel_tool_use=true."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/anthropic-json-tool-parallel-use.ts
+++ b/examples/ai-functions/src/reproduction/anthropic-json-tool-parallel-use.ts
@@ -1,0 +1,75 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { Output, stepCountIs, streamText, tool } from 'ai';
+import fs from 'node:fs/promises';
+import { z } from 'zod';
+
+async function main() {
+  const fixture = await fs.readFile(
+    '../../packages/anthropic/src/__fixtures__/issue-15652.chunks.txt',
+    'utf8',
+  );
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const model = createAnthropic({
+    apiKey: 'test-api-key',
+    fetch: async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+      return new Response(
+        `${fixture
+          .trim()
+          .split('\n')
+          .map(line => `data: ${line}\n\n`)
+          .join('')}data: [DONE]\n\n`,
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+    },
+  })('claude-sonnet-4-5');
+
+  let searchCount = 0;
+  const result = streamText({
+    model,
+    tools: {
+      searchDocs: tool({
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }) => {
+          searchCount += 1;
+          return { query, result: `Result for ${query}` };
+        },
+      }),
+    },
+    experimental_output: Output.object({
+      schema: z.object({ items: z.array(z.string()) }),
+    }),
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'jsonTool',
+        disableParallelToolUse: false,
+      },
+    },
+    stopWhen: stepCountIs(3),
+    prompt:
+      'Call searchDocs exactly 3 times in parallel with distinct queries, then return the query names as items.',
+  });
+
+  for await (const _part of result.fullStream) {
+    // Consume the live-provider fixture so tool executions can run.
+  }
+
+  const request = requestBodies[0];
+  const toolChoice = request.tool_choice as
+    | { disable_parallel_tool_use?: boolean }
+    | undefined;
+  const tools = request.tools as Array<{ name?: string }> | undefined;
+  const ignoredOverride = toolChoice?.disable_parallel_tool_use === true;
+  const searchToolWasRemoved = !tools?.some(tool => tool.name === 'searchDocs');
+
+  if (ignoredOverride && searchToolWasRemoved && searchCount === 0) {
+    throw new Error(
+      'ISSUE #15652 REPRODUCED: expected 3 parallel searchDocs calls with disableParallelToolUse=false, but observed 0 calls and serialized disable_parallel_tool_use=true.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/anthropic/src/__fixtures__/issue-15652.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/issue-15652.chunks.txt
@@ -1,0 +1,14 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd5V17nzF1TYk1CdtpT1P","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":711,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"service_tier":"standard","inference_geo":"not_available"}}      }
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01K4GY9uwhsreuBs4rEVCbAL","name":"json","input":{},"caller":{"type":"direct"}}             }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}           }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"items\":"}   }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" [\"qu"}    }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ery1\",\"q"}          }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uery2\",\""}             }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"quer"}           }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"y3"}          }
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"]}"}               }
+{"type":"content_block_stop","index":0      }
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":711,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":35}     }
+{"type":"message_stop"           }

--- a/packages/anthropic/src/issue-15652.test.ts
+++ b/packages/anthropic/src/issue-15652.test.ts
@@ -1,0 +1,74 @@
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs/promises';
+import { expect, it } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+it('respects disableParallelToolUse false in jsonTool mode (issue #15652)', async () => {
+  const fixture = await fs.readFile(
+    'src/__fixtures__/issue-15652.chunks.txt',
+    'utf8',
+  );
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const model = createAnthropic({
+    apiKey: 'test-api-key',
+    fetch: async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+      return new Response(
+        `${fixture
+          .trim()
+          .split('\n')
+          .map(line => `data: ${line}\n\n`)
+          .join('')}data: [DONE]\n\n`,
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+    },
+  })('claude-sonnet-4-5');
+
+  const { stream } = await model.doStream({
+    prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+    tools: [
+      {
+        type: 'function',
+        name: 'searchDocs',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+          $schema: 'http://json-schema.org/draft-07/schema#',
+        },
+      },
+    ],
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'jsonTool',
+        disableParallelToolUse: false,
+      },
+    },
+    responseFormat: {
+      type: 'json',
+      schema: {
+        type: 'object',
+        properties: {
+          items: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['items'],
+        additionalProperties: false,
+        $schema: 'http://json-schema.org/draft-07/schema#',
+      },
+    },
+  });
+
+  await convertReadableStreamToArray(stream);
+
+  const requestBody = requestBodies[0];
+  expect(requestBody.tool_choice).toMatchObject({
+    disable_parallel_tool_use: false,
+  });
+  expect(requestBody.tools).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ name: 'searchDocs' }),
+      expect.objectContaining({ name: 'json' }),
+    ]),
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,25 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -27396,7 +27415,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -36840,7 +36859,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:
@@ -38497,6 +38516,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -38699,7 +38727,7 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   ts-node@10.9.2(@types/node@20.17.24)(typescript@5.4.5):
     dependencies:
@@ -40035,6 +40063,38 @@ snapshots:
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Bug

@ai-sdk/anthropic: `disableParallelToolUse: true` is hardcoded when `structuredOutputMode: 'jsonTool'`, ignores user override

## Reproduction

- `examples/ai-functions/src/reproduction/anthropic-json-tool-parallel-use.ts` sets `disableParallelToolUse: false`; expected three parallel `searchDocs` calls, but the request serialized `disable_parallel_tool_use: true`, removed `searchDocs`, and executed zero calls.
- A live Claude Sonnet 4.5 response exhibiting the failure is recorded in `packages/anthropic/src/__fixtures__/issue-15652.chunks.txt`.
- `packages/anthropic/src/issue-15652.test.ts` expects the override to remain `false`, but observes the hardcoded `true` value.
- The checkout contains `@ai-sdk/anthropic@2.0.86`, rather than the reported 3.0.80, but reproduces the same ignored override; the separate native structured-output streaming-delay claim was not evaluated.

## Relevant Documentation

- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://ai-sdk.dev/docs/troubleshooting/tool-calling-with-structured-outputs
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use
- https://platform.claude.com/docs/en/build-with-claude/structured-outputs

## Related Issues

Reproduces #15652