### PR TITLE
reproduction: experimentaltranscribe mis-detects m4a/mp4 files and sends them to

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 14721,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-14721-transcribe-mp4.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-14721-transcribe-mp4.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_14721_REPRODUCED: transcribe uploaded MP4 bytes as audio/wav and OpenAI rejected them with 400 unsupported_format while direct audio/mp4 transcription succeeded"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-14721-transcribe-mp4.ts
+++ b/examples/ai-functions/src/reproduction/issue-14721-transcribe-mp4.ts
@@ -1,0 +1,112 @@
+import { APICallError } from '@ai-sdk/provider';
+import { createOpenAI } from '@ai-sdk/openai';
+import { transcribe } from 'ai';
+
+type RequestObservation = {
+  fileName: string;
+  fileSize: number;
+  mediaType: string;
+  responseBody: string;
+  status: number;
+};
+
+async function main() {
+  const fixtureResponse = await fetch(
+    'https://raw.githubusercontent.com/aamikus/ai-sdk-transcribe-m4a-repro/650167f52d6c1fe427ffd7ba8fbed622ef312010/fixture/sample.m4a',
+  );
+  if (!fixtureResponse.ok) {
+    throw new Error(
+      `Failed to download the issue fixture: ${fixtureResponse.status}`,
+    );
+  }
+  const audio = new Uint8Array(await fixtureResponse.arrayBuffer());
+  const observations: RequestObservation[] = [];
+
+  const openai = createOpenAI({
+    fetch: async (input, init) => {
+      if (!(init?.body instanceof FormData)) {
+        throw new Error('Expected the OpenAI request body to be FormData.');
+      }
+      const file = init.body.get('file');
+      if (!(file instanceof File)) {
+        throw new Error('Expected the OpenAI request to contain a file.');
+      }
+
+      const response = await fetch(input, init);
+      observations.push({
+        fileName: file.name,
+        fileSize: file.size,
+        mediaType: file.type,
+        responseBody: await response.clone().text(),
+        status: response.status,
+      });
+      return response;
+    },
+  });
+  const model = openai.transcription('gpt-4o-mini-transcribe');
+
+  const directResult = await model.doGenerate({
+    audio,
+    mediaType: 'audio/mp4',
+  });
+
+  let wrapperError: unknown;
+  try {
+    await transcribe({
+      model,
+      audio,
+      maxRetries: 0,
+    });
+  } catch (error) {
+    wrapperError = error;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        bytes0To15: Array.from(audio.subarray(0, 16)),
+        directText: directResult.text,
+        observations,
+        wrapperError: APICallError.isInstance(wrapperError)
+          ? {
+              responseBody: wrapperError.responseBody,
+              statusCode: wrapperError.statusCode,
+            }
+          : wrapperError instanceof Error
+            ? {
+                message: wrapperError.message,
+                name: wrapperError.name,
+              }
+            : wrapperError,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const directRequest = observations[0];
+  const wrapperRequest = observations[1];
+  if (
+    directResult.text &&
+    directRequest?.mediaType === 'audio/mp4' &&
+    directRequest.fileName === 'audio.m4a' &&
+    wrapperRequest?.mediaType === 'audio/wav' &&
+    wrapperRequest.fileName === 'audio.wav' &&
+    APICallError.isInstance(wrapperError) &&
+    wrapperError.statusCode === 400 &&
+    wrapperError.responseBody?.includes('unsupported_format')
+  ) {
+    throw new Error(
+      'ISSUE_14721_REPRODUCED: transcribe uploaded MP4 bytes as audio/wav and OpenAI rejected them with 400 unsupported_format while direct audio/mp4 transcription succeeded',
+    );
+  }
+
+  throw new Error(
+    'ISSUE_14721_NOT_REPRODUCED: the observed final OpenAI behavior did not match the report',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/transcription/__fixtures__/openai-transcription-issue-14721-audio-mp4.json
+++ b/packages/openai/src/transcription/__fixtures__/openai-transcription-issue-14721-audio-mp4.json
@@ -1,0 +1,13 @@
+{
+  "text": "Honestly, it was a pretty steep learning curve at first. I spent most of the first week just trying to figure out the query syntax, but after a while, things started to click and now I'm much faster with it.",
+  "usage": {
+    "type": "tokens",
+    "total_tokens": 169,
+    "input_tokens": 122,
+    "input_token_details": {
+      "text_tokens": 0,
+      "audio_tokens": 122
+    },
+    "output_tokens": 47
+  }
+}

--- a/packages/openai/src/transcription/__fixtures__/openai-transcription-issue-14721-audio-wav-error.json
+++ b/packages/openai/src/transcription/__fixtures__/openai-transcription-issue-14721-audio-wav-error.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "This model does not support the format you provided.",
+    "type": "invalid_request_error",
+    "param": "messages",
+    "code": "unsupported_format"
+  }
+}

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -98,6 +98,54 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send explicit audio/mp4 input as an m4a file', async () => {
+    prepareJsonFixtureResponse('openai-transcription-issue-14721-audio-mp4');
+
+    const result = await provider
+      .transcription('gpt-4o-mini-transcribe')
+      .doGenerate({
+        audio: new Uint8Array([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70]),
+        mediaType: 'audio/mp4',
+      });
+
+    const requestBody = await server.calls[0].requestBodyMultipart;
+    expect(requestBody?.file).toBeInstanceOf(File);
+    expect(requestBody?.file).toMatchObject({
+      name: 'audio.m4a',
+      type: 'audio/mp4',
+    });
+    expect(result.text).toContain('steep learning curve');
+  });
+
+  it('should surface the live unsupported-format response for m4a bytes mislabeled as wav', async () => {
+    server.urls['https://api.openai.com/v1/audio/transcriptions'].response = {
+      type: 'error',
+      status: 400,
+      body: fs.readFileSync(
+        'src/transcription/__fixtures__/openai-transcription-issue-14721-audio-wav-error.json',
+        'utf8',
+      ),
+    };
+
+    await expect(
+      provider.transcription('gpt-4o-mini-transcribe').doGenerate({
+        audio: new Uint8Array([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70]),
+        mediaType: 'audio/wav',
+      }),
+    ).rejects.toMatchObject({
+      message: 'This model does not support the format you provided.',
+      responseBody: expect.stringContaining('unsupported_format'),
+      statusCode: 400,
+    });
+
+    const requestBody = await server.calls[0].requestBodyMultipart;
+    expect(requestBody?.file).toBeInstanceOf(File);
+    expect(requestBody?.file).toMatchObject({
+      name: 'audio.wav',
+      type: 'audio/wav',
+    });
+  });
+
   it('should default whisper-1 to verbose_json response format', async () => {
     prepareJsonFixtureResponse('openai-transcription');
 


### PR DESCRIPTION
## Bug

experimental_transcribe mis-detects m4a/mp4 files and sends them to OpenAI as audio/wav

## Reproduction

- `examples/ai-functions/src/reproduction/issue-14721-transcribe-mp4.ts` reproduced the user-visible failure: `transcribe()` uploaded the 215,332-byte M4A fixture as `audio.wav` with `audio/wav`, and OpenAI returned HTTP 400 `unsupported_format`.
- The expected behavior was confirmed by sending the same bytes directly as `audio/mp4`; OpenAI accepted `audio.m4a` with HTTP 200 and returned the reported transcript.
- The aligned current workspace versions, `ai` 7.0.29 and `@ai-sdk/openai` 4.0.15, reproduce the issue without a partial-upgrade or peer-dependency mismatch.
- Live responses are recorded in `packages/openai/src/transcription/__fixtures__/openai-transcription-issue-14721-audio-mp4.json` and `packages/openai/src/transcription/__fixtures__/openai-transcription-issue-14721-audio-wav-error.json`, with provider coverage in `packages/openai/src/transcription/openai-transcription-model.test.ts`.

## Relevant Documentation

- https://platform.openai.com/docs/api-reference/audio/createTranscription

## Related Issues

Reproduces #14721