### PR TITLE
[v6.0] feat: pass end-user identifiers to xAI video generation and editing requests

### DIFF
--- a/.changeset/tidy-videos-identify.md
+++ b/.changeset/tidy-videos-identify.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): support end-user identifiers for video generation and editing

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -992,6 +992,7 @@ const { video } = await generateVideo({
   duration: 5,
   providerOptions: {
     xai: {
+      user: 'user-123',
       pollTimeoutMs: 600000, // 10 minutes
     } satisfies XaiVideoModelOptions,
   },
@@ -1253,6 +1254,14 @@ You can validate the provider options using the `XaiVideoModelOptions` type.
   Video resolution. When using the SDK's standard `resolution` parameter,
   `1280x720` maps to `720p` and `854x480` maps to `480p`.
   Use this provider option to pass the native format directly.
+
+- **user** _string_
+
+  Optional identifier for the end user responsible for the request. xAI uses
+  this value for abuse monitoring. It is sent unchanged for video generation
+  (including reference-to-video) and video editing requests, and is omitted
+  when not configured. It is not sent for video extension requests. Use an
+  opaque stable identifier and avoid sending unnecessary personal information.
 
 - **mode** _'edit-video' | 'extend-video' | 'reference-to-video'_
 

--- a/examples/ai-functions/src/generate-video/xai/basic.ts
+++ b/examples/ai-functions/src/generate-video/xai/basic.ts
@@ -15,6 +15,7 @@ run(async () => {
         duration: 5,
         providerOptions: {
           xai: {
+            user: 'example-user-123',
             pollTimeoutMs: 600000, // 10 minutes
           } satisfies XaiVideoModelOptions,
         },

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -114,6 +114,102 @@ describe('XaiVideoModel', () => {
       });
     });
 
+    it('should pass user unchanged to the video generation endpoint', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            user: 'tenant/user:123',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/generations`,
+      );
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'grok-imagine-video',
+        prompt,
+        user: 'tenant/user:123',
+      });
+    });
+
+    it('should omit user when it is not configured', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty('user');
+    });
+
+    it('should pass user unchanged to the video editing endpoint', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'edit-video',
+            videoUrl: 'https://example.com/source-video.mp4',
+            user: 'tenant/user:123',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(`${TEST_BASE_URL}/videos/edits`);
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'grok-imagine-video',
+        prompt,
+        video: { url: 'https://example.com/source-video.mp4' },
+        user: 'tenant/user:123',
+      });
+    });
+
+    it('should not pass user to the video extension endpoint', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'extend-video',
+            videoUrl: 'https://example.com/source-video.mp4',
+            user: 'tenant/user:123',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/extensions`,
+      );
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty('user');
+    });
+
+    it('should reject non-string user values', async () => {
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              user: 123,
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow(InvalidArgumentError);
+    });
+
     it('should poll the correct status URL', async () => {
       const model = createModel();
 

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -363,6 +363,10 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
       });
     }
 
+    if (!isExtension && xaiOptions?.user !== undefined) {
+      body.user = xaiOptions.user;
+    }
+
     if (xaiOptions != null) {
       for (const [key, value] of Object.entries(xaiOptions)) {
         if (
@@ -373,6 +377,7 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
             'resolution',
             'videoUrl',
             'referenceImageUrls',
+            'user',
           ].includes(key)
         ) {
           body[key] = value;

--- a/packages/xai/src/xai-video-options.test-d.ts
+++ b/packages/xai/src/xai-video-options.test-d.ts
@@ -54,6 +54,7 @@ describe('XaiVideoModelOptions type', () => {
     const options = {
       pollIntervalMs: 1000,
       resolution: '480p',
+      user: 'user-123',
     } satisfies XaiVideoModelOptions;
 
     expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
@@ -71,6 +72,7 @@ describe('XaiVideoModelOptions type', () => {
   it('should allow videoUrl without mode for backward compatibility', () => {
     const options = {
       videoUrl: 'https://example.com/video.mp4',
+      user: 'user-123',
     } satisfies XaiVideoModelOptions;
 
     expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
@@ -79,6 +81,7 @@ describe('XaiVideoModelOptions type', () => {
   it('should allow referenceImageUrls without mode for backward compatibility', () => {
     const options = {
       referenceImageUrls: ['https://example.com/ref.png'],
+      user: 'user-123',
     } satisfies XaiVideoModelOptions;
 
     expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
@@ -106,6 +109,43 @@ describe('XaiVideoModelOptions type', () => {
 
     expectTypeOf(editOptions).toMatchTypeOf<XaiVideoModelOptions>();
     expectTypeOf(referenceOptions).toMatchTypeOf<XaiVideoModelOptions>();
+  });
+
+  it('should allow user for explicit generation and editing endpoint modes', () => {
+    const editOptions = {
+      mode: 'edit-video',
+      videoUrl: 'https://example.com/video.mp4',
+      user: 'user-123',
+    } satisfies XaiVideoModelOptions;
+
+    const referenceOptions = {
+      mode: 'reference-to-video',
+      referenceImageUrls: ['https://example.com/ref.png'],
+      user: 'user-123',
+    } satisfies XaiVideoModelOptions;
+
+    expectTypeOf(editOptions).toMatchTypeOf<XaiVideoModelOptions>();
+    expectTypeOf(referenceOptions).toMatchTypeOf<XaiVideoModelOptions>();
+  });
+
+  it('should not allow user for video extension', () => {
+    const options: XaiVideoModelOptions = {
+      mode: 'extend-video',
+      videoUrl: 'https://example.com/video.mp4',
+      // @ts-expect-error - the xAI extension endpoint does not support user
+      user: 'user-123',
+    };
+
+    options;
+  });
+
+  it('should require user to be a string', () => {
+    const options: XaiVideoModelOptions = {
+      // @ts-expect-error - user must be a string
+      user: 123,
+    };
+
+    options;
   });
 
   // ── Discriminated union: illegal combos rejected ───────────────────

--- a/packages/xai/src/xai-video-options.ts
+++ b/packages/xai/src/xai-video-options.ts
@@ -14,7 +14,15 @@ interface XaiVideoSharedOptions {
   resolution?: XaiVideoResolution | null;
 }
 
-interface XaiVideoEditModeOptions extends XaiVideoSharedOptions {
+interface XaiVideoUserOptions {
+  /**
+   * A unique identifier representing the end user, for abuse monitoring.
+   */
+  user?: string;
+}
+
+interface XaiVideoEditModeOptions
+  extends XaiVideoSharedOptions, XaiVideoUserOptions {
   /**
    * Select edit-video mode explicitly for best autocomplete and narrowing.
    */
@@ -32,7 +40,8 @@ interface XaiVideoExtendModeOptions extends XaiVideoSharedOptions {
   videoUrl: string;
 }
 
-interface XaiVideoReferenceToVideoOptions extends XaiVideoSharedOptions {
+interface XaiVideoReferenceToVideoOptions
+  extends XaiVideoSharedOptions, XaiVideoUserOptions {
   /**
    * Select reference-to-video mode explicitly for best autocomplete and narrowing.
    */
@@ -41,13 +50,15 @@ interface XaiVideoReferenceToVideoOptions extends XaiVideoSharedOptions {
   referenceImageUrls: string[];
 }
 
-interface XaiVideoGenerationOptions extends XaiVideoSharedOptions {
+interface XaiVideoGenerationOptions
+  extends XaiVideoSharedOptions, XaiVideoUserOptions {
   mode?: undefined;
   videoUrl?: undefined;
   referenceImageUrls?: undefined;
 }
 
-interface XaiLegacyEditVideoOptions extends XaiVideoSharedOptions {
+interface XaiLegacyEditVideoOptions
+  extends XaiVideoSharedOptions, XaiVideoUserOptions {
   /**
    * Legacy backward-compatible shape: omitting `mode` while providing
    * `videoUrl` behaves like edit-video.
@@ -56,7 +67,8 @@ interface XaiLegacyEditVideoOptions extends XaiVideoSharedOptions {
   videoUrl: string;
 }
 
-interface XaiLegacyReferenceToVideoOptions extends XaiVideoSharedOptions {
+interface XaiLegacyReferenceToVideoOptions
+  extends XaiVideoSharedOptions, XaiVideoUserOptions {
   /**
    * Legacy backward-compatible shape: omitting `mode` while providing
    * `referenceImageUrls` behaves like reference-to-video.
@@ -94,8 +106,13 @@ const baseFields = {
   resolution: resolutionSchema.nullish(),
 };
 
+const userField = {
+  user: z.string().optional(),
+};
+
 const editVideoSchema = z.object({
   ...baseFields,
+  ...userField,
   mode: z.literal('edit-video'),
   videoUrl: nonEmptyStringSchema,
   referenceImageUrls: z.undefined().optional(),
@@ -110,6 +127,7 @@ const extendVideoSchema = z.object({
 
 const referenceToVideoSchema = z.object({
   ...baseFields,
+  ...userField,
   mode: z.literal('reference-to-video'),
   referenceImageUrls: z.array(nonEmptyStringSchema).min(1).max(7),
   videoUrl: z.undefined().optional(),
@@ -117,6 +135,7 @@ const referenceToVideoSchema = z.object({
 
 const autoDetectSchema = z.object({
   ...baseFields,
+  ...userField,
   mode: z.undefined().optional(),
   videoUrl: nonEmptyStringSchema.optional(),
   referenceImageUrls: z.array(nonEmptyStringSchema).min(1).max(7).optional(),
@@ -129,6 +148,7 @@ export const xaiVideoModelOptions = z.union([
   autoDetectSchema,
 ]);
 
+<<<<<<< HEAD:packages/xai/src/xai-video-options.ts
 const runtimeSchema = z
   .object({
     mode: modeSchema.optional(),
@@ -137,6 +157,15 @@ const runtimeSchema = z
     ...baseFields,
   })
   .passthrough();
+=======
+const runtimeSchema = z.looseObject({
+  mode: modeSchema.optional(),
+  videoUrl: nonEmptyStringSchema.optional(),
+  referenceImageUrls: z.array(nonEmptyStringSchema).min(1).max(7).optional(),
+  user: z.string().optional(),
+  ...baseFields,
+});
+>>>>>>> 91a3d6e9f (feat: pass end-user identifiers to xAI video generation and editing requests (#17312)):packages/xai/src/xai-video-model-options.ts
 
 export type XaiParsedVideoModelOptions = z.infer<typeof runtimeSchema>;
 

--- a/packages/xai/src/xai-video-options.ts
+++ b/packages/xai/src/xai-video-options.ts
@@ -148,24 +148,15 @@ export const xaiVideoModelOptions = z.union([
   autoDetectSchema,
 ]);
 
-<<<<<<< HEAD:packages/xai/src/xai-video-options.ts
 const runtimeSchema = z
   .object({
     mode: modeSchema.optional(),
     videoUrl: nonEmptyStringSchema.optional(),
     referenceImageUrls: z.array(nonEmptyStringSchema).min(1).max(7).optional(),
+    user: z.string().optional(),
     ...baseFields,
   })
   .passthrough();
-=======
-const runtimeSchema = z.looseObject({
-  mode: modeSchema.optional(),
-  videoUrl: nonEmptyStringSchema.optional(),
-  referenceImageUrls: z.array(nonEmptyStringSchema).min(1).max(7).optional(),
-  user: z.string().optional(),
-  ...baseFields,
-});
->>>>>>> 91a3d6e9f (feat: pass end-user identifiers to xAI video generation and editing requests (#17312)):packages/xai/src/xai-video-model-options.ts
 
 export type XaiParsedVideoModelOptions = z.infer<typeof runtimeSchema>;
 


### PR DESCRIPTION
## Background

Applications need to identify the end user responsible for xAI video requests so xAI can perform abuse monitoring and attribution.

## Summary

Added an optional typed and runtime-validated `user` option to `XaiVideoModelOptions` for generation and editing, forwarding it unchanged as a top-level request field while omitting it for undefined values and video extensions. Added a patch changeset.

## Testing

Added runtime tests for generation and editing forwarding, omission, extension exclusion, and invalid values, plus type tests covering supported option variants and extension rejection.

## End-to-end Validation

- Ran the updated xAI basic video example against the live API with `user: 'example-user-123'`; generation completed successfully and produced a valid MP4.

### Documentation

Updated the xAI provider documentation and basic video example with typed `user` usage, supported operations, omission behavior, and privacy guidance.

## Related Issues

Fixes #17307

Backport of #17312

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>