### PR TITLE
fix(otel): record system instructions on model spans

### DIFF
--- a/.changeset/clean-spans-instruct.md
+++ b/.changeset/clean-spans-instruct.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/otel': patch
+---
+
+fix(otel): record system instructions on language model spans

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -578,6 +578,31 @@ describe('OpenTelemetry', () => {
       `);
     });
 
+    it('sets system_instructions on the language model span', () => {
+      integration.onStart!(
+        makeOnStartEvent({ instructions: 'You are helpful' }),
+      );
+      integration.onStepStart!(makeStepStartEvent());
+      integration.onLanguageModelCallStart!(
+        makeLanguageModelCallStartEvent({
+          instructions: 'You are helpful',
+        }),
+      );
+
+      const attrs = getStartSpanAttributes(tracer, 2);
+      expect(parseJsonAttributes(attrs, 'gen_ai.system_instructions'))
+        .toMatchInlineSnapshot(`
+        {
+          "gen_ai.system_instructions": [
+            {
+              "content": "You are helpful",
+              "type": "text",
+            },
+          ],
+        }
+      `);
+    });
+
     it('sets gen_ai.tool.definitions when tools provided', () => {
       const tools = [
         { type: 'function', name: 'get_weather', description: 'Get weather' },

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -687,6 +687,12 @@ export class OpenTelemetry implements Telemetry {
         | undefined,
       'gen_ai.request.top_k': state.settings.topK as number | undefined,
       'gen_ai.request.top_p': state.settings.topP as number | undefined,
+      'gen_ai.system_instructions': event.instructions
+        ? {
+            input: () =>
+              JSON.stringify(formatSystemInstructions(event.instructions!)),
+          }
+        : undefined,
       'gen_ai.input.messages': {
         input: () => {
           const formattedMessages = formatModelMessages({


### PR DESCRIPTION
## Background

AI SDK includes standardized instructions on every `LanguageModelCallStartEvent`, but the OpenTelemetry integration only records them on the outer `invoke_agent` span. The child `chat` span records messages, tools, response data, and token usage without `gen_ai.system_instructions`.

This makes model-call traces incomplete, especially in multi-step tool loops where each provider execution should show the instructions used for that call.

## Summary

- Record `event.instructions` as `gen_ai.system_instructions` on language model spans.
- Reuse the same `formatSystemInstructions` conversion already used by the parent operation span.
- Add regression coverage for the child `chat` span.
- Add a patch changeset for `@ai-sdk/otel`.

## End-to-End Verification

The emitted child span now contains the same semantic-convention system-instructions representation as the parent operation span. No provider request behavior changes; this only completes the telemetry emitted from the existing model-call event.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Testing

- `pnpm --filter @ai-sdk/otel test`
- `pnpm --filter @ai-sdk/otel type-check`
- `pnpm --filter '@ai-sdk/otel...' build`
- `pnpm check`
