### PR TITLE
reproduction: tool.onInputAvailable can be called without onInputStart being called

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11043,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11043-tool-input-callback-order.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_11043_REPRODUCED: onInputAvailable was called without prior onInputStart; sequence=onInputAvailable"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts
+++ b/examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts
@@ -1,0 +1,74 @@
+import type { LanguageModelV4 } from '@ai-sdk/provider';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const toolCallId = 'call-1';
+const callbackSequence: string[] = [];
+
+const model: LanguageModelV4 = {
+  specificationVersion: 'v4',
+  provider: 'issue-11043-reproduction',
+  modelId: 'complete-tool-call',
+  supportedUrls: {},
+  async doGenerate() {
+    return {
+      content: [
+        {
+          type: 'tool-call' as const,
+          toolCallType: 'function' as const,
+          toolCallId,
+          toolName: 'weather',
+          input: '{"location":"San Francisco"}',
+        },
+      ],
+      finishReason: { unified: 'tool-calls' as const, raw: undefined },
+      usage: {
+        inputTokens: {
+          total: 1,
+          noCache: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        outputTokens: {
+          total: 1,
+          text: 0,
+          reasoning: 0,
+        },
+      },
+      warnings: [],
+    };
+  },
+  async doStream() {
+    throw new Error('This reproduction only uses non-streaming generation.');
+  },
+};
+
+async function main() {
+  await generateText({
+    model,
+    prompt: 'What is the weather in San Francisco?',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        onInputStart() {
+          callbackSequence.push('onInputStart');
+        },
+        onInputAvailable() {
+          callbackSequence.push('onInputAvailable');
+        },
+      }),
+    },
+  });
+
+  const expectedSequence = ['onInputStart', 'onInputAvailable'];
+  if (callbackSequence.join(',') !== expectedSequence.join(',')) {
+    throw new Error(
+      `ISSUE_11043_REPRODUCED: onInputAvailable was called without prior onInputStart; sequence=${callbackSequence.join(',')}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

tool.onInputAvailable can be called without onInputStart being called

## Reproduction

- On the current checkout using `ai` 7.0.29, `generateText` invoked `onInputAvailable` without invoking `onInputStart`; the observed callback sequence was only `onInputAvailable`.
- The expected lifecycle is for `onInputStart` to precede `onInputAvailable`, including when the complete tool input arrives in one operation; otherwise consumers must handle uninitialized callback state.
- The runnable reproduction at `examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts` fails specifically when the expected callback ordering is absent.
- The behavior persists beyond the reported `ai` 5.0.107, so upgrading to the current checkout does not provide the requested all-cases callback ordering.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/tool

## Related Issues

Reproduces #11043