### PR TITLE
[v6.0] reproduction: Handle empty HTTP 202 responses while polling xAI

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17308,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/xai-empty-202-polling.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/xai-empty-202-polling.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE 17308 REPRODUCED: empty HTTP 202 stopped xAI video polling for generation and editing instead of returning the completed video"
+  }
+}

--- a/examples/ai-functions/src/reproduction/xai-empty-202-polling.ts
+++ b/examples/ai-functions/src/reproduction/xai-empty-202-polling.ts
@@ -1,0 +1,105 @@
+import { createXai } from '@ai-sdk/xai';
+
+const baseURL = 'https://xai.example.test/v1';
+const completedVideoUrl = 'https://vidgen.x.ai/example/completed.mp4';
+
+function createPollingFetch() {
+  let pollCount = 0;
+
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    if (init?.method === 'POST') {
+      return Response.json({ request_id: 'request-123' });
+    }
+
+    if (url === `${baseURL}/videos/request-123`) {
+      pollCount++;
+
+      if (pollCount === 1) {
+        return new Response(null, { status: 202 });
+      }
+
+      return Response.json({
+        status: 'done',
+        video: {
+          url: completedVideoUrl,
+          duration: 1,
+          respect_moderation: true,
+        },
+        model: 'grok-imagine-video',
+        progress: 100,
+      });
+    }
+
+    return Response.json({ error: 'unexpected request' }, { status: 500 });
+  };
+}
+
+async function runScenario(mode: 'generation' | 'editing') {
+  const xai = createXai({
+    apiKey: 'test-api-key',
+    baseURL,
+    fetch: createPollingFetch(),
+  });
+
+  const xaiOptions =
+    mode === 'editing'
+      ? {
+          mode: 'edit-video' as const,
+          videoUrl: 'https://example.com/input.mp4',
+          pollIntervalMs: 1,
+          pollTimeoutMs: 1000,
+        }
+      : {
+          pollIntervalMs: 1,
+          pollTimeoutMs: 1000,
+        };
+
+  const result = await xai.video('grok-imagine-video').doGenerate({
+    prompt: `Reproduction for xAI video ${mode}`,
+    n: 1,
+    image: undefined,
+    frameImages: undefined,
+    inputReferences: undefined,
+    aspectRatio: undefined,
+    resolution: undefined,
+    duration: undefined,
+    fps: undefined,
+    seed: undefined,
+    generateAudio: undefined,
+    providerOptions: { xai: { ...xaiOptions } },
+  });
+
+  const video = result.videos[0];
+  if (video?.type !== 'url' || video.url !== completedVideoUrl) {
+    throw new Error(`${mode} did not return the completed video`);
+  }
+}
+
+async function main() {
+  const scenarios = ['generation', 'editing'] as const;
+  const results = await Promise.allSettled(scenarios.map(runScenario));
+  const failedScenarios = results.flatMap((result, index) =>
+    result.status === 'rejected' ? [scenarios[index]] : [],
+  );
+
+  if (failedScenarios.length > 0) {
+    throw new Error(
+      `ISSUE 17308 REPRODUCED: empty HTTP 202 stopped xAI video polling for ${failedScenarios.join(
+        ' and ',
+      )} instead of returning the completed video`,
+    );
+  }
+
+  console.log(
+    'Empty HTTP 202 responses were treated as in progress for generation and editing.',
+  );
+}
+
+main();

--- a/packages/xai/src/__fixtures__/xai-video-status-done.1.json
+++ b/packages/xai/src/__fixtures__/xai-video-status-done.1.json
@@ -1,0 +1,13 @@
+{
+  "status": "done",
+  "video": {
+    "url": "https://vidgen.x.ai/xai-vidgen-bucket/xai-video-52a79ffe-80a5-9cd4-8ece-a8a24d6f267f.mp4",
+    "duration": 1,
+    "respect_moderation": true
+  },
+  "model": "grok-imagine-video",
+  "usage": {
+    "cost_in_usd_ticks": 500000000
+  },
+  "progress": 100
+}

--- a/packages/xai/src/__fixtures__/xai-video-status-pending.1.json
+++ b/packages/xai/src/__fixtures__/xai-video-status-pending.1.json
@@ -1,0 +1,4 @@
+{
+  "status": "pending",
+  "progress": 0
+}

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -1,5 +1,6 @@
 import { InvalidArgumentError } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import * as fs from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { XaiVideoModel } from './xai-video-model';
 
@@ -21,6 +22,14 @@ const doneStatusResponse = {
   model: 'grok-imagine-video',
   progress: 100,
 };
+
+const liveDoneStatusResponse = JSON.parse(
+  fs.readFileSync('src/__fixtures__/xai-video-status-done.1.json', 'utf8'),
+);
+
+const livePendingStatusResponse = JSON.parse(
+  fs.readFileSync('src/__fixtures__/xai-video-status-pending.1.json', 'utf8'),
+);
 
 const defaultOptions = {
   prompt,
@@ -762,6 +771,44 @@ describe('XaiVideoModel', () => {
   });
 
   describe('error handling', () => {
+    it('should preserve unsuccessful polling status handling', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'status endpoint failed',
+            type: null,
+            param: null,
+            code: null,
+          },
+        }),
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({ ...defaultOptions }),
+      ).rejects.toMatchObject({
+        message: 'status endpoint failed',
+        statusCode: 500,
+      });
+    });
+
+    it('should preserve malformed HTTP 200 completion handling', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 200,
+        body: '{',
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        'Invalid JSON response',
+      );
+    });
+
     it('should throw when status is expired', async () => {
       server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
         type: 'json-value',
@@ -1443,6 +1490,84 @@ describe('XaiVideoModel', () => {
   });
 
   describe('polling behaviour', () => {
+    it.each([
+      {
+        mode: 'generation',
+        providerOptions: {
+          xai: { pollIntervalMs: 10, pollTimeoutMs: 5000 },
+        },
+      },
+      {
+        mode: 'editing',
+        providerOptions: {
+          xai: {
+            mode: 'edit-video' as const,
+            videoUrl: 'https://example.com/input.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      },
+    ])(
+      'should treat an empty HTTP 202 as pending for $mode',
+      async ({ providerOptions }) => {
+        server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+          callNumber,
+        }) =>
+          callNumber === 1
+            ? { type: 'empty', status: 202 }
+            : { type: 'json-value', body: liveDoneStatusResponse };
+
+        const model = createModel();
+        const result = await model.doGenerate({
+          ...defaultOptions,
+          providerOptions,
+        });
+
+        expect(result.videos[0]).toStrictEqual({
+          type: 'url',
+          url: liveDoneStatusResponse.video.url,
+          mediaType: 'video/mp4',
+        });
+        expect(server.calls).toHaveLength(3);
+      },
+    );
+
+    it('should time out while repeatedly receiving empty HTTP 202 responses', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'empty',
+        status: 202,
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: { pollIntervalMs: 10, pollTimeoutMs: 30 },
+          },
+        }),
+      ).rejects.toThrow('timed out');
+    });
+
+    it('should honor abort after an empty HTTP 202 response', async () => {
+      const abortController = new AbortController();
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = () => {
+        queueMicrotask(() => abortController.abort());
+        return { type: 'empty', status: 202 };
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow(/aborted/i);
+    });
+
     it('should retry polling on pending before resolving done', async () => {
       // callNumber is global across all URLs in the test.
       // Call 0 = POST /generations. Polls start at callNumber 1.
@@ -1453,7 +1578,7 @@ describe('XaiVideoModel', () => {
         if (callNumber < 3) {
           return {
             type: 'json-value',
-            body: { status: 'pending', model: 'grok-imagine-video' },
+            body: livePendingStatusResponse,
           };
         }
         return { type: 'json-value', body: doneStatusResponse };


### PR DESCRIPTION
## Bug

Handle empty HTTP 202 responses while polling xAI videos

## Reproduction

- `@ai-sdk/xai` 3.0.108 parses every successful polling response as JSON, so an empty HTTP 202 raises `AI_APICallError: Invalid JSON response` instead of continuing.
- `examples/ai-functions/src/reproduction/xai-empty-202-polling.ts` reproduced the user-visible failure for both video generation and editing; each should poll through the empty 202 and return the subsequent completed video.
- `packages/xai/src/xai-video-model.test.ts` adds generation, editing, timeout, abort, unsuccessful-status, and malformed-completion coverage for the reported behavior.
- `packages/xai/src/__fixtures__/xai-video-status-pending.1.json` and `packages/xai/src/__fixtures__/xai-video-status-done.1.json` record live xAI polling responses.

## Relevant Documentation

- https://docs.x.ai/developers/model-capabilities/video/generation
- https://docs.x.ai/developers/rest-api-reference/inference/videos
- https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.3

## Related Issues

Reproduces #17308