### PR TITLE
[v5.0] reproduction: convertToOpenAIChatMessages sends content: "" instead of content: null

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 12389,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12389-openai-tool-call-content.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_12389_REPRODUCED: tool-call-only assistant content was \"\" instead of null"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts
+++ b/examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts
@@ -1,0 +1,126 @@
+import {
+  createOpenAI,
+  VERSION,
+} from '../../../../packages/openai/dist/index.mjs';
+
+type OpenAIRequest = {
+  messages: Array<{
+    role: string;
+    content?: unknown;
+    tool_calls?: unknown[];
+  }>;
+};
+
+async function main() {
+  let request: OpenAIRequest | undefined;
+
+  const provider = createOpenAI({
+    apiKey: 'test-api-key',
+    baseURL: 'http://local.test/v1',
+    fetch: async (_url, init) => {
+      request = JSON.parse(String(init?.body)) as OpenAIRequest;
+
+      return new Response(
+        JSON.stringify({
+          id: 'chatcmpl-reproduction',
+          object: 'chat.completion',
+          created: 1,
+          model: 'qwen3-coder:latest',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'File created.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+          },
+        }),
+        {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
+      );
+    },
+  });
+
+  await provider.chat('qwen3-coder:latest').doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Inspect the workspace.' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call_1',
+            toolName: 'lookup',
+            input: { path: '.' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_1',
+            toolName: 'lookup',
+            output: { type: 'text', value: 'README.md' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Now create the file.' }],
+      },
+    ],
+  });
+
+  const assistantToolCallMessage = request?.messages.find(
+    message =>
+      message.role === 'assistant' &&
+      Array.isArray(message.tool_calls) &&
+      message.tool_calls.length > 0,
+  );
+  const observedContent = assistantToolCallMessage?.content;
+
+  console.log(
+    JSON.stringify(
+      {
+        openaiProviderVersion: VERSION,
+        expectedAssistantToolCallContent: 'null or omitted',
+        observedAssistantToolCallContent: observedContent,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (assistantToolCallMessage == null) {
+    throw new Error(
+      'REPRODUCTION_HARNESS_ERROR: assistant tool-call message was not sent',
+    );
+  }
+
+  if (observedContent !== null && observedContent !== undefined) {
+    throw new Error(
+      `ISSUE_12389_REPRODUCED: tool-call-only assistant content was ${JSON.stringify(
+        observedContent,
+      )} instead of null`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

convertToOpenAIChatMessages sends content: "" instead of content: null for tool-call-only assistant messages

## Reproduction

- Added runnable reproduction at `examples/ai-functions/src/reproduction/issue-12389-openai-tool-call-content.ts` with workspace manifest `examples/ai-functions/package.json`.
- The checked-out `@ai-sdk/openai` v2.0.112 serialized a tool-call-only assistant message with `content: ""`; the expected value was `null` or an omitted field.
- The checkout uses `ai` v5.0.214 and `@ai-sdk/openai` v2.0.112 rather than the reporter's v6.0.41 and v3.0.12, but exhibits the same reported serialization failure.
- The downstream qwen3-coder text-markup switch was not live-verified because no Ollama service was listening on `localhost:11434`.

## Relevant Documentation

- https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
- https://docs.ollama.com/api/openai-compatibility
- https://registry.ollama.com/library/qwen3-coder

## Related Issues

Reproduces #12389