### PR TITLE
[v6.0] reproduction: Cannot catch errors from writeToServerResponse

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11023,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11023-write-to-server-response-error.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #11023 REPRODUCED: pipeTextStreamToResponse returned before the stream failed, so the caller's catch was bypassed and AI_InvalidResponseDataError became an unhandled rejection."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts
@@ -1,0 +1,96 @@
+import type { ServerResponse } from 'node:http';
+import { InvalidResponseDataError, pipeTextStreamToResponse } from 'ai';
+
+const errorMessage = "Expected 'function.name' to be a string.";
+const failureSignal =
+  "ISSUE #11023 REPRODUCED: pipeTextStreamToResponse returned before the stream failed, so the caller's catch was bypassed and AI_InvalidResponseDataError became an unhandled rejection.";
+
+function createResponse(): ServerResponse {
+  return {
+    writeHead() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {
+      return this;
+    },
+  } as unknown as ServerResponse;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error);
+}
+
+async function main() {
+  let resolveUnhandled: (reason: unknown) => void;
+  const unhandledPromise = new Promise<unknown>(resolve => {
+    resolveUnhandled = resolve;
+  });
+  const onUnhandledRejection = (reason: unknown) => resolveUnhandled(reason);
+
+  process.once('unhandledRejection', onUnhandledRejection);
+
+  let caughtByCaller: unknown;
+
+  try {
+    await pipeTextStreamToResponse({
+      response: createResponse(),
+      textStream: new ReadableStream<string>({
+        start(controller) {
+          queueMicrotask(() => {
+            controller.error(
+              new InvalidResponseDataError({
+                data: { function: {} },
+                message: errorMessage,
+              }),
+            );
+          });
+        },
+      }),
+    });
+  } catch (error) {
+    caughtByCaller = error;
+  }
+
+  const outcome = await Promise.race([
+    unhandledPromise.then(reason => ({ type: 'unhandled' as const, reason })),
+    new Promise<{ type: 'timeout' }>(resolve =>
+      setTimeout(() => resolve({ type: 'timeout' }), 1000),
+    ),
+  ]);
+
+  process.removeListener('unhandledRejection', onUnhandledRejection);
+
+  if (caughtByCaller !== undefined) {
+    console.log(
+      `Caller caught the stream error: ${formatError(caughtByCaller)}`,
+    );
+    return;
+  }
+
+  if (
+    outcome.type === 'unhandled' &&
+    InvalidResponseDataError.isInstance(outcome.reason) &&
+    outcome.reason.message === errorMessage
+  ) {
+    console.error(failureSignal);
+    console.error(`Unhandled rejection: ${formatError(outcome.reason)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  throw new Error(
+    outcome.type === 'unhandled'
+      ? `Unexpected unhandled rejection: ${formatError(outcome.reason)}`
+      : 'The stream error was neither caught by the caller nor emitted as an unhandled rejection.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Cannot catch errors from `writeToServerResponse`

## Reproduction

- `examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts` demonstrates that an awaited piping call cannot catch a stream-side `AI_InvalidResponseDataError`; the error instead becomes an unhandled rejection.
- The expected behavior is for the piping operation to reject so the caller's `catch` can handle the stream read failure.
- The behavior occurs with both the reported `ai@5.0.76` and the checkout's `ai@6.0.228`, so upgrading to the current target branch does not resolve it.
- `writeToServerResponse` invokes its asynchronous `read()` operation without returning its promise, while the public piping helpers return `void`.

## Related Issues

Reproduces #11023