### PR TITLE
docs: fix Google provider documentation links

### DIFF
--- a/.changeset/brave-plums-add.md
+++ b/.changeset/brave-plums-add.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+docs: update link to Google provider documentation

--- a/.changeset/brave-plums-add.md
+++ b/.changeset/brave-plums-add.md
@@ -1,5 +1,0 @@
----
-"@ai-sdk/google": patch
----
-
-docs: update link to Google provider documentation

--- a/apps/docs/components/docs/marketing-cards.tsx
+++ b/apps/docs/components/docs/marketing-cards.tsx
@@ -71,7 +71,7 @@ const providers = [
   ['AI Gateway', '/providers/ai-sdk-providers/ai-gateway'],
   ['OpenAI', '/providers/ai-sdk-providers/openai'],
   ['Anthropic', '/providers/ai-sdk-providers/anthropic'],
-  ['Google', '/providers/ai-sdk-providers/google-generative-ai'],
+  ['Google', '/providers/ai-sdk-providers/google'],
   ['Amazon Bedrock', '/providers/ai-sdk-providers/amazon-bedrock'],
   ['Azure', '/providers/ai-sdk-providers/azure'],
 ] as const;

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -1065,7 +1065,7 @@ The following gateway provider options are available:
   per-provider option each provider expects, and overrides any tier
   also set in the per-provider options. Leave unset for provider
   default. See the [OpenAI](/providers/ai-sdk-providers/openai),
-  [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai),
+  [Google Generative AI](/providers/ai-sdk-providers/google),
   and [Google Vertex AI](/providers/ai-sdk-providers/google-vertex)
   provider docs for tier semantics, model availability, and graceful
   downgrade behavior on each provider.

--- a/packages/google/README.md
+++ b/packages/google/README.md
@@ -1,6 +1,6 @@
 # AI SDK - Google Provider
 
-The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
+The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Google (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 
@@ -42,4 +42,4 @@ const { text } = await generateText({
 
 ## Documentation
 
-Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for more information.
+Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for more information.


### PR DESCRIPTION
## Background

Following the v7 package rename from `@ai-sdk/google-generative-ai` to `@ai-sdk/google`, several links across the documentation site, provider content, and package READMEs still pointed to the old `/providers/ai-sdk-providers/google-generative-ai` URL. This PR updates all remaining occurrences to the correct `/providers/ai-sdk-providers/google` path to resolve dead/broken links.

## Summary

- **marketing-cards.tsx**: Corrected the Google provider link in the documentation home page cards.
- **00-ai-gateway.mdx**: Updated the Google provider link target in the AI Gateway guide.
- **packages/google/README.md**: Updated references to point to the correct documentation page.
- **Changeset**: Added a patch changeset for `@ai-sdk/google` to trigger documentation updates on npm.

## Contributor Credit

- Kushal Rathod (Issue reporter & PR author)

## End-to-End Verification

*(Not needed / Docs change)*

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17365 