### PR TITLE
ci: add backported label to issues

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -661,6 +661,7 @@ jobs:
 
       - name: Label linked issues for the backported version
         if: steps.check-existing.outputs.existing-pr || steps.create-pr.outputs.backport-pr-url
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -681,32 +682,39 @@ jobs:
               ;;
           esac
 
-          gh api graphql \
-            -f query='
-              query($owner: String!, $name: String!, $number: Int!) {
-                repository(owner: $owner, name: $name) {
-                  pullRequest(number: $number) {
-                    closingIssuesReferences(first: 100) {
-                      nodes {
-                        number
-                        repository {
-                          nameWithOwner
+          if ! LINKED_ISSUES=$(gh api graphql \
+              -f query='
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      closingIssuesReferences(first: 100) {
+                        nodes {
+                          number
+                          repository {
+                            nameWithOwner
+                          }
                         }
                       }
                     }
                   }
                 }
-              }
-            ' \
-            -f owner="$OWNER" \
-            -f name="$NAME" \
-            -F number="$PR_NUMBER" \
-            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[] | [.repository.nameWithOwner, .number] | @tsv' |
-            while IFS=$'\t' read -r ISSUE_REPO ISSUE_NUMBER; do
-              if [ "$ISSUE_REPO" = "$REPO" ]; then
-                gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$ISSUE_LABEL"
-              fi
-            done
+              ' \
+              -f owner="$OWNER" \
+              -f name="$NAME" \
+              -F number="$PR_NUMBER" \
+              --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[] | [.repository.nameWithOwner, .number] | @tsv'); then
+            echo "::warning::Could not fetch linked issues for PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          [ -n "$LINKED_ISSUES" ] || exit 0
+
+          while IFS=$'\t' read -r ISSUE_REPO ISSUE_NUMBER; do
+            [ "$ISSUE_REPO" = "$REPO" ] || continue
+
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$ISSUE_LABEL" \
+              || echo "::warning::Could not add ${ISSUE_LABEL} to issue #${ISSUE_NUMBER}"
+          done <<< "$LINKED_ISSUES"
 
       - name: Remove backport label from original PR
         if: '!steps.check-existing.outputs.existing-pr && steps.create-pr.outputs.backport-pr-url'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -659,6 +659,55 @@ jobs:
             ${{ steps.cherry-pick.outputs.git-output }}
             ```
 
+      - name: Label linked issues for the backported version
+        if: steps.check-existing.outputs.existing-pr || steps.create-pr.outputs.backport-pr-url
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
+          BASE_REF: ${{ needs.resolve-pr.outputs.base-ref }}
+        run: |
+          set -euo pipefail
+
+          OWNER="${REPO%%/*}"
+          NAME="${REPO#*/}"
+
+          case "$BASE_REF" in
+            main) ISSUE_LABEL="backported-v6" ;;
+            release-v6.0) ISSUE_LABEL="backported-v5" ;;
+            *)
+              echo "::warning::No backported issue label is configured for base branch ${BASE_REF}"
+              exit 0
+              ;;
+          esac
+
+          gh api graphql \
+            -f query='
+              query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 100) {
+                      nodes {
+                        number
+                        repository {
+                          nameWithOwner
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ' \
+            -f owner="$OWNER" \
+            -f name="$NAME" \
+            -F number="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[] | [.repository.nameWithOwner, .number] | @tsv' |
+            while IFS=$'\t' read -r ISSUE_REPO ISSUE_NUMBER; do
+              if [ "$ISSUE_REPO" = "$REPO" ]; then
+                gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$ISSUE_LABEL"
+              fi
+            done
+
       - name: Remove backport label from original PR
         if: '!steps.check-existing.outputs.existing-pr && steps.create-pr.outputs.backport-pr-url'
         run: |


### PR DESCRIPTION
## Background

adding labels for if the issue has been backported or not, will help in the factory's UI to see if the bug repro and fix should be available to run or not

## Summary

based on the PR target branch:
- main PR → linked issue gets backported-v6
- release-v6.0 PR → linked issue gets backported-v5

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)