### PR TITLE
feat: add a per-step first-content timeout for streaming generations

### DIFF
--- a/.changeset/bright-spoons-stream.md
+++ b/.changeset/bright-spoons-stream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add a per-step `firstChunkMs` timeout for streaming generations

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -142,9 +142,12 @@ You can specify the timeout either as a number (milliseconds) or as an object wi
 
 - `totalMs`: The total timeout for the entire call including all steps.
 - `stepMs`: The timeout for each individual step (LLM call). This is useful for multi-step generations where you want to limit the time spent on each step independently.
-- `chunkMs`: The timeout between stream chunks (streaming only). The call will abort if no new chunk is received within this duration. This is useful for detecting stalled streams.
+- `firstChunkMs`: The timeout from the start of each model response stream until the first content-bearing output part (streaming only). Response metadata, stream-start parts, raw chunks, and empty text or reasoning starts do not satisfy or reset this timeout. It is applied independently to every model-call step.
+- `chunkMs`: The timeout between content-bearing output chunks after output has started (streaming only). The call will abort if no new output chunk is received within this duration. This is useful for detecting streams that stall after generation begins.
 - `toolMs`: The default timeout for all tool executions. If a tool takes longer, it aborts and returns a tool-error so the model can respond or retry.
 - `tools`: Per-tool timeout overrides using `{toolName}Ms` keys (e.g. `weatherMs`, `slowApiMs`). Takes precedence over `toolMs`. Tool names are type-checked for autocomplete.
+
+All timeout object properties are optional and unset by default.
 
 #### Example: 5 second timeout (number format)
 
@@ -198,6 +201,21 @@ const result = streamText({
   timeout: { chunkMs: 5000 }, // abort if no chunk received for 5 seconds
 });
 ```
+
+#### Example: First-content timeout for streaming (streamText only)
+
+```ts
+const result = streamText({
+  model: __MODEL__,
+  prompt: 'Invent a new holiday and describe its traditions.',
+  timeout: {
+    firstChunkMs: 10000, // allow up to 10 seconds for the first output
+    chunkMs: 5000, // then allow up to 5 seconds between output chunks
+  },
+});
+```
+
+`firstChunkMs` is armed after each streaming model call returns its response stream. The first non-empty text delta, reasoning delta, tool-input delta, tool call, or other content-bearing output part disarms it before that part is forwarded. Transport bytes, HTTP headers, SSE comments, keep-alive framing, response metadata, and raw stream parts do not affect it.
 
 #### Example: Tool execution timeout
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1107,9 +1107,9 @@ To see `generateText` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
               description:
-                'Timeout configuration for the generation. Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs.',
+                'Timeout configuration for the generation. Can be a number (milliseconds) or an object with totalMs, stepMs, firstChunkMs, chunkMs. firstChunkMs and chunkMs apply to streaming generations.',
             },
             {
               name: 'headers',
@@ -1227,9 +1227,9 @@ To see `generateText` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
               description:
-                'Timeout configuration for the generation. Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs.',
+                'Timeout configuration for the generation. Can be a number (milliseconds) or an object with totalMs, stepMs, firstChunkMs, chunkMs. firstChunkMs and chunkMs apply to streaming generations.',
             },
             {
               name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -477,10 +477,10 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, chunkMs, toolMs, and/or tools properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call). chunkMs sets the timeout between stream chunks - the call will abort if no new chunk is received within this duration. toolMs sets the default timeout for all tool executions. tools sets per-tool timeout overrides using the pattern {toolName}Ms (e.g. weatherMs, slowApiMs) that take precedence over toolMs - tool names are type-checked for autocomplete. If a tool takes longer than its timeout, it aborts and returns a tool-error so the model can respond or retry. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or tools properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call). firstChunkMs sets a per-step timeout from the start of the response stream until the first content-bearing output part; metadata, raw parts, and transport activity do not satisfy or reset it. chunkMs sets the timeout between content-bearing output chunks after output has started. toolMs sets the default timeout for all tool executions. tools sets per-tool timeout overrides using the pattern {toolName}Ms (e.g. weatherMs, slowApiMs) that take precedence over toolMs - tool names are type-checked for autocomplete. If a tool takes longer than its timeout, it aborts and returns a tool-error so the model can respond or retry. Can be used alongside abortSignal.',
     },
     {
       name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -246,7 +246,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
               description: 'Timeout configuration for the generation.',
             },
             {
@@ -360,7 +360,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
               description: 'Timeout configuration for the generation.',
             },
             {
@@ -712,10 +712,10 @@ const result = await agent.generate({
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, and/or chunkMs properties. For streamed agent runs, firstChunkMs limits the wait for the first content-bearing output of every model-call step, while chunkMs limits gaps between later output chunks. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',
@@ -828,10 +828,10 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, and/or chunkMs properties. For streamed agent runs, firstChunkMs limits the wait for the first content-bearing output of every model-call step, while chunkMs limits gaps between later output chunks. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/examples/ai-functions/src/stream-text/openai/timeout-first-chunk.ts
+++ b/examples/ai-functions/src/stream-text/openai/timeout-first-chunk.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+import { print } from '../../lib/print';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-5-nano'),
+    prompt: 'Write a short poem about the ocean.',
+    timeout: {
+      firstChunkMs: 10_000,
+      chunkMs: 5_000,
+    },
+  });
+
+  printFullStream({ result });
+
+  print('Usage:', await result.usage);
+  print('Finish reason:', await result.finishReason);
+});

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -56,7 +56,7 @@ export type GenerateTextStartEvent<
 
   /**
    * Timeout configuration for the generation.
-   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs, toolMs, and per-tool overrides via tools.
+   * Can be a number (milliseconds) or an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and per-tool overrides via tools.
    */
   readonly timeout: TimeoutConfiguration<TOOLS> | undefined;
 

--- a/packages/ai/src/generate-text/stream-text-first-chunk-timeout.test.ts
+++ b/packages/ai/src/generate-text/stream-text-first-chunk-timeout.test.ts
@@ -1,0 +1,297 @@
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import { DelayedPromise } from '@ai-sdk/provider-utils';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { isStepCount } from './stop-condition';
+import { streamText } from './stream-text';
+
+const testUsage: LanguageModelV4Usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+describe('streamText firstChunkMs timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts when only non-content parts arrive before the deadline', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-id',
+                });
+                controller.enqueue({ type: 'raw', rawValue: ': ping' });
+                controller.enqueue({ type: 'text-start', id: '1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: '1',
+                  delta: '',
+                });
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      onError: () => {},
+    });
+
+    const textExpectation = expect(result.text).rejects.toHaveProperty(
+      'name',
+      'TimeoutError',
+    );
+    await vi.advanceTimersByTimeAsync(100);
+
+    await textExpectation;
+    expect(receivedAbortSignal?.aborted).toBe(true);
+    expect((receivedAbortSignal!.reason as Error).message).toBe(
+      'First chunk timeout of 50ms exceeded',
+    );
+  });
+
+  it.each([
+    {
+      name: 'text delta',
+      chunks: [
+        { type: 'text-start', id: '1' },
+        { type: 'text-delta', id: '1', delta: 'Hello' },
+      ] satisfies LanguageModelV4StreamPart[],
+    },
+    {
+      name: 'reasoning delta',
+      chunks: [
+        { type: 'reasoning-start', id: '1' },
+        { type: 'reasoning-delta', id: '1', delta: 'Thinking' },
+      ] satisfies LanguageModelV4StreamPart[],
+    },
+    {
+      name: 'tool input delta',
+      chunks: [
+        {
+          type: 'tool-input-start',
+          id: 'call-1',
+          toolName: 'tool1',
+        },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '{"value":"test"}',
+        },
+      ] satisfies LanguageModelV4StreamPart[],
+    },
+    {
+      name: 'tool call',
+      chunks: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: '{"value":"test"}',
+        },
+      ] satisfies LanguageModelV4StreamPart[],
+    },
+  ])('disarms before forwarding the first $name', async ({ chunks }) => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    const continueStream = new DelayedPromise<void>();
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              async start(controller) {
+                for (const chunk of chunks) {
+                  controller.enqueue(chunk);
+                }
+
+                await continueStream.promise;
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+        },
+      },
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    continueStream.resolve(undefined);
+    await consumePromise;
+  });
+
+  it('re-arms the deadline for later model-call steps', async () => {
+    const receivedAbortSignals: AbortSignal[] = [];
+    let stepCount = 0;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignals.push(abortSignal!);
+          stepCount++;
+
+          if (stepCount === 1) {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: '{"value":"test"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          }
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'second-step',
+                });
+              },
+            }),
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+          execute: async () => 'tool result',
+        },
+      },
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      stopWhen: isStepCount(2),
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+    await vi.waitFor(() => expect(stepCount).toBe(2));
+    await vi.advanceTimersByTimeAsync(100);
+    await consumePromise;
+
+    expect(receivedAbortSignals).toHaveLength(2);
+    expect(receivedAbortSignals[1].aborted).toBe(true);
+    expect((receivedAbortSignals[1].reason as Error).name).toBe('TimeoutError');
+  });
+
+  it('starts chunkMs only after the first content-bearing output', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    const sendFirstOutput = new DelayedPromise<void>();
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              async start(controller) {
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-id',
+                });
+
+                await sendFirstOutput.promise;
+
+                controller.enqueue({ type: 'text-start', id: '1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: '1',
+                  delta: 'Hello',
+                });
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 100, chunkMs: 20 },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    sendFirstOutput.resolve(undefined);
+    await vi.advanceTimersByTimeAsync(30);
+    await consumePromise;
+
+    expect(receivedAbortSignal?.aborted).toBe(true);
+    expect((receivedAbortSignal!.reason as Error).message).toBe(
+      'Chunk timeout of 20ms exceeded',
+    );
+  });
+});

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -34,6 +34,7 @@ import { prepareTools } from '../prompt/prepare-tools';
 import type { Prompt } from '../prompt/prompt';
 import {
   getChunkTimeoutMs,
+  getFirstChunkTimeoutMs,
   getStepTimeoutMs,
   getTotalTimeoutMs,
   type RequestOptions,
@@ -164,15 +165,15 @@ const isOutputChunkType = {
   file: true,
   custom: true,
   source: true,
-  'text-start': true,
-  'text-end': true,
+  'text-start': false,
+  'text-end': false,
   'text-delta': true,
-  'reasoning-start': true,
-  'reasoning-end': true,
+  'reasoning-start': false,
+  'reasoning-end': false,
   'reasoning-delta': true,
   'reasoning-file': true,
-  'tool-input-start': true,
-  'tool-input-end': true,
+  'tool-input-start': false,
+  'tool-input-end': false,
   'tool-input-delta': true,
   'tool-approval-request': true,
   'tool-approval-response': true,
@@ -186,6 +187,22 @@ const isOutputChunkType = {
   error: false,
   raw: false,
 } as const satisfies Record<ExecuteToolsStreamPart['type'], boolean>;
+
+function isOutputChunk(chunk: ExecuteToolsStreamPart): boolean {
+  if (!isOutputChunkType[chunk.type]) {
+    return false;
+  }
+
+  switch (chunk.type) {
+    case 'text-delta':
+    case 'reasoning-delta':
+      return chunk.text.length > 0;
+    case 'tool-input-delta':
+      return chunk.delta.length > 0;
+    default:
+      return true;
+  }
+}
 
 export type StreamTextInclude = {
   /**
@@ -716,11 +733,14 @@ export function streamText<
   }): StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
+  const firstChunkTimeoutMs = getFirstChunkTimeoutMs(timeout);
   const chunkTimeoutMs = getChunkTimeoutMs(timeout);
   const stepAbortController =
     stepTimeoutMs != null ? new AbortController() : undefined;
   const chunkAbortController =
     chunkTimeoutMs != null ? new AbortController() : undefined;
+  const firstChunkAbortController =
+    firstChunkTimeoutMs != null ? new AbortController() : undefined;
   const resolvedOnStart = onStart ?? experimental_onStart;
   const resolvedOnStepStart = onStepStart ?? experimental_onStepStart;
   const resolvedOnLanguageModelCallStart =
@@ -742,10 +762,13 @@ export function streamText<
       abortSignal,
       totalTimeoutMs,
       stepAbortController?.signal,
+      firstChunkAbortController?.signal,
       chunkAbortController?.signal,
     ),
     stepTimeoutMs,
     stepAbortController,
+    firstChunkTimeoutMs,
+    firstChunkAbortController,
     chunkTimeoutMs,
     chunkAbortController,
     instructions,
@@ -951,6 +974,8 @@ class DefaultStreamTextResult<
     abortSignal,
     stepTimeoutMs,
     stepAbortController,
+    firstChunkTimeoutMs,
+    firstChunkAbortController,
     chunkTimeoutMs,
     chunkAbortController,
     instructions,
@@ -1000,6 +1025,8 @@ class DefaultStreamTextResult<
     abortSignal: AbortSignal | undefined;
     stepTimeoutMs: number | undefined;
     stepAbortController: AbortController | undefined;
+    firstChunkTimeoutMs: number | undefined;
+    firstChunkAbortController: AbortController | undefined;
     chunkTimeoutMs: number | undefined;
     chunkAbortController: AbortController | undefined;
     toolsContext: InferToolSetContext<TOOLS>;
@@ -1764,9 +1791,32 @@ class DefaultStreamTextResult<
           timeoutMs: stepTimeoutMs,
         });
 
-        // Set up chunk timeout tracking (will be reset on each chunk)
+        // Set up first-output and chunk timeout tracking. The first-output
+        // timeout is armed after doStream returns; chunkMs starts with the
+        // first content-bearing output and governs subsequent output gaps.
+        let firstChunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
+          undefined;
         let chunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
           undefined;
+
+        function armFirstChunkTimeout() {
+          if (abortSignal?.aborted) {
+            return;
+          }
+          firstChunkTimeoutId = setAbortTimeout({
+            abortController: firstChunkAbortController,
+            label: 'First chunk',
+            timeoutMs: firstChunkTimeoutMs,
+          });
+        }
+
+        function clearFirstChunkTimeout() {
+          if (firstChunkTimeoutId != null) {
+            clearTimeout(firstChunkTimeoutId);
+            firstChunkTimeoutId = undefined;
+          }
+          abortSignal?.removeEventListener('abort', clearFirstChunkTimeout);
+        }
 
         function resetChunkTimeout() {
           if (chunkTimeoutId != null) {
@@ -1784,19 +1834,22 @@ class DefaultStreamTextResult<
             clearTimeout(chunkTimeoutId);
             chunkTimeoutId = undefined;
           }
+          abortSignal?.removeEventListener('abort', clearChunkTimeout);
         }
 
         function clearStepTimeout() {
           if (stepTimeoutId != null) {
             clearTimeout(stepTimeoutId);
           }
+          abortSignal?.removeEventListener('abort', clearStepTimeout);
         }
 
         // The step's stream is registered lazily and consumed long after this
         // function returns, so the step timer must stay armed past setup. When
         // the merged abort signal fires (any step/chunk/total timeout or caller
-        // abort), drop both step-scoped timers so neither outlives the step.
+        // abort), drop all step-scoped timers so none outlive the step.
         abortSignal?.addEventListener('abort', clearStepTimeout);
+        abortSignal?.addEventListener('abort', clearFirstChunkTimeout);
         abortSignal?.addEventListener('abort', clearChunkTimeout);
 
         try {
@@ -1960,6 +2013,10 @@ class DefaultStreamTextResult<
             ),
           );
 
+          // The provider has returned its response stream. Start the semantic
+          // first-output deadline before consuming any parsed stream parts.
+          armFirstChunkTimeout();
+
           const streamAfterToolCallbackInvocation =
             invokeToolCallbacksFromStream({
               stream: languageModelStream,
@@ -2069,8 +2126,6 @@ class DefaultStreamTextResult<
                 TextStreamPart<TOOLS>
               >({
                 async transform(chunk, controller): Promise<void> {
-                  resetChunkTimeout();
-
                   if (chunk.type === 'model-call-start') {
                     warnings = chunk.warnings;
                     return; // stream start chunks are sent immediately and do not count as first chunk
@@ -2089,8 +2144,14 @@ class DefaultStreamTextResult<
 
                   const chunkType = chunk.type;
 
-                  if (isOutputChunkType[chunkType]) {
+                  if (isOutputChunk(chunk)) {
+                    // Clear before forwarding so the timeout cannot win a race
+                    // after generated output has become visible.
+                    if (!hasReceivedOutputChunk) {
+                      clearFirstChunkTimeout();
+                    }
                     hasReceivedOutputChunk = true;
+                    resetChunkTimeout();
                   }
 
                   switch (chunkType) {
@@ -2211,6 +2272,7 @@ class DefaultStreamTextResult<
                     });
 
                     clearStepTimeout();
+                    clearFirstChunkTimeout();
                     clearChunkTimeout();
                     self.closeStream();
                     return;
@@ -2291,8 +2353,9 @@ class DefaultStreamTextResult<
                     }
                   }
 
-                  // Clear the step and chunk timeouts before the next step is started
+                  // Clear step-scoped timeouts before the next step is started.
                   clearStepTimeout();
+                  clearFirstChunkTimeout();
                   clearChunkTimeout();
 
                   if (
@@ -2343,6 +2406,7 @@ class DefaultStreamTextResult<
           // Setup failed before the stream was registered, so neither the
           // stream's flush nor an abort will clear the timers — clear them here.
           clearStepTimeout();
+          clearFirstChunkTimeout();
           clearChunkTimeout();
           throw error;
         }

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -10,6 +10,7 @@ export type CallSettings = LanguageModelCallOptions &
 export {
   getTotalTimeoutMs,
   getStepTimeoutMs,
+  getFirstChunkTimeoutMs,
   getChunkTimeoutMs,
   getToolTimeoutMs,
 } from './request-options';

--- a/packages/ai/src/prompt/prepare-language-model-call-options.test.ts
+++ b/packages/ai/src/prompt/prepare-language-model-call-options.test.ts
@@ -4,6 +4,7 @@ import {
   getToolTimeoutMs,
   getTotalTimeoutMs,
   getStepTimeoutMs,
+  getFirstChunkTimeoutMs,
   getChunkTimeoutMs,
 } from './request-options';
 import { describe, it, expect } from 'vitest';
@@ -279,6 +280,20 @@ describe('timeout helpers (from request-options)', () => {
 
     it('should return chunkMs from an object', () => {
       expect(getChunkTimeoutMs({ chunkMs: 2000 })).toBe(2000);
+    });
+  });
+
+  describe('getFirstChunkTimeoutMs', () => {
+    it('should return undefined when timeout is undefined', () => {
+      expect(getFirstChunkTimeoutMs(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when timeout is a number', () => {
+      expect(getFirstChunkTimeoutMs(5000)).toBeUndefined();
+    });
+
+    it('should return firstChunkMs from an object', () => {
+      expect(getFirstChunkTimeoutMs({ firstChunkMs: 2000 })).toBe(2000);
     });
   });
 });

--- a/packages/ai/src/prompt/request-options.ts
+++ b/packages/ai/src/prompt/request-options.ts
@@ -5,7 +5,8 @@ import type { ToolSet } from '@ai-sdk/provider-utils';
  * - A number representing milliseconds
  * - An object with `totalMs` property for the total timeout in milliseconds
  * - An object with `stepMs` property for the timeout of each step in milliseconds
- * - An object with `chunkMs` property for the timeout between stream chunks (streaming only)
+ * - An object with `firstChunkMs` property for the timeout until the first output chunk (streaming only)
+ * - An object with `chunkMs` property for the timeout between output chunks after output starts (streaming only)
  * - An object with `toolMs` property for the default timeout for all tool executions
  * - An object with `tools` property for per-tool timeout overrides using `{toolName}Ms` keys
  */
@@ -14,6 +15,7 @@ export type TimeoutConfiguration<TOOLS extends ToolSet> =
   | {
       totalMs?: number;
       stepMs?: number;
+      firstChunkMs?: number;
       chunkMs?: number;
       toolMs?: number;
       tools?: Partial<Record<`${keyof TOOLS & string}Ms`, number>>;
@@ -53,8 +55,24 @@ export function getStepTimeoutMs(
 }
 
 /**
+ * Extracts the first chunk timeout value in milliseconds from a TimeoutConfiguration.
+ * This timeout is for streaming only - it aborts if no output chunk is received within the specified duration.
+ *
+ * @param timeout - The timeout configuration.
+ * @returns The first chunk timeout in milliseconds, or undefined if no first chunk timeout is configured.
+ */
+export function getFirstChunkTimeoutMs(
+  timeout: TimeoutConfiguration<any> | undefined,
+): number | undefined {
+  if (timeout == null || typeof timeout === 'number') {
+    return undefined;
+  }
+  return timeout.firstChunkMs;
+}
+
+/**
  * Extracts the chunk timeout value in milliseconds from a TimeoutConfiguration.
- * This timeout is for streaming only - it aborts if no new chunk is received within the specified duration.
+ * This timeout is for streaming only - after output starts, it aborts if no new output chunk is received within the specified duration.
  *
  * @param timeout - The timeout configuration.
  * @returns The chunk timeout in milliseconds, or undefined if no chunk timeout is configured.


### PR DESCRIPTION
## Background

Streaming providers can return headers and non-content framing promptly but then stall indefinitely; a semantic first-content timeout lets applications abort these stalled steps safely before visible output begins.

## Summary

Added the optional public `firstChunkMs` timeout, extractor, per-step stream enforcement, dedicated abort signal, content-aware timeout classification, cleanup, and post-first-output `chunkMs` handling.

## Testing

Added focused Node and Edge tests covering non-content stalls, text and reasoning deltas, tool-input and tool-call output, later multi-step calls, timeout surfacing, extraction, and `chunkMs` interaction.

## End-to-end Validation

- Ran the new OpenAI `timeout-first-chunk.ts` example against the live API and successfully streamed a complete response with combined `firstChunkMs` and `chunkMs` settings.

## Documentation

Updated timeout settings, `streamText`, `generateText` event types, and ToolLoopAgent references with the new API, per-step semantics, ignored non-content parts, examples, and timeout interactions.

## Related Issues

Fixes #17315

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>