### PR TITLE
[v6.0] docs: document AI SDK 6 removal of `name` from function tool definitions

### DIFF
--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -301,6 +301,42 @@ const someTool = tool({
   codebase.
 </Note>
 
+### Remove `name` from Function Tool Definitions
+
+Function tool names come from their keys in the `tools` object. In AI SDK 5, a
+`name` property could pass type checking because it was part of the
+provider-defined member of the `Tool` type, but it did not set the name of a
+function tool. The AI SDK 6 types no longer accept the property in a function
+tool definition.
+
+Remove `name` from `tool()` and use the intended name as the key in the `tools`
+object:
+
+```tsx filename="AI SDK 5"
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  getWeather: tool({
+    name: 'getWeather',
+    inputSchema: z.object({}),
+    outputSchema: z.any(),
+  }),
+};
+```
+
+```tsx filename="AI SDK 6"
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  getWeather: tool({
+    inputSchema: z.object({}),
+    outputSchema: z.any(),
+  }),
+};
+```
+
 ### `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` Deprecation
 
 `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` have been deprecated.


### PR DESCRIPTION
## Background

## Scope and reader problem

Issue #12213 reports that a function tool containing `name: 'getWeather'` compiled with AI SDK 5 but produces an unclear TypeScript overload error after upgrading to AI SDK 6. The linked reproduction uses `ai@6.0.68`, and its source matches the screenshot: `tool({ name, inputSchema, outputSchema })`. Its README states that changing to `ai@5.0.125` makes the build succeed.  The requested outcome is migration guidance explaining why removing `name` resolves the error and where a tool's name should be declared.

## Behavior verification

The report is valid as a migration problem, but the title's characterization of `name` as a deprecated function-tool field is not technically exact:

- In AI SDK 5, the `Tool` union in `packages/provider-utils/src/types/tool.ts` did not define `name` for ordinary function tools. It defined `name` only on the provider-defined member of the union. That union shape could nevertheless allow the reporter's function-tool object to pass generic `tool()` type inference. 
- AI SDK 5's `packages/ai/src/prompt/prepare-tools-and-tool-choice.ts` derived the model-visible tool name from each entry's key in the `tools` object for both function and provider-defined tools. It did not read a `name` property from a function tool, so the reporter's property was redundant and did not determine runtime behavior. 
- In AI SDK 6, the `Tool` union no longer contains that `name` property, so the redundant property causes the reported type-inference failure. 
- Current `main` remains consistent with this behavior: `packages/provider-utils/src/types/tool.ts` has no `name` property on tool definitions, while `packages/ai/src/prompt/prepare-tools.ts` obtains names from `ToolSet` entries.

## Existing documentation audit

The current conceptual documentation is correct for new code. `content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx` explicitly says that the `tools` object has tool names as keys and tool definitions as values. `content/docs/02-foundations/04-tools.mdx` demonstrates the same structure, and `content/docs/07-reference/01-ai-sdk-core/20-tool.mdx` correctly omits `name` from the `tool()` API properties.

However, `content/docs/08-migration-guides/24-migration-guide-6-0.mdx` covered several adjacent tool changes—such as `Tool.toModelOutput`, `ToolCallOptions`, and per-tool strict mode—but did not explain this source-compatible-looking type change. Consequently, readers upgrading code that happened to compile under AI SDK 5 could encounter an error reported against `inputSchema` without discovering that the redundant `name` property must be removed.

## Decision

A documentation change improves migration task completion without duplicating general tool documentation. The fix belongs in the AI SDK 6 migration guide and should clarify both the practical migration and the historical nuance: `name` was not a functional naming field for function tools, even though the AI SDK 5 union could allow it through type checking. The authoritative naming mechanism is the key in the `tools` object.

## Summary

Updated `content/docs/08-migration-guides/24-migration-guide-6-0.mdx` with a focused migration section explaining that function tool names come from `tools` object keys, why `name` could compile under AI SDK 5, and that AI SDK 6 users should remove it. Added matching AI SDK 5 and AI SDK 6 before-and-after examples.

## Testing

`pnpm check` passed with zero warnings or errors. `pnpm type-check:full` passed on a standalone rerun; some accidentally duplicated concurrent invocations were killed with exit code 137 due resource contention. `pnpm validate:docs` passed for all 500 MDX files. The focused `oxfmt` check and `git diff --check` passed. No unit tests were run because the change is documentation-only.

## Related Issues

Fixes #12213

Backport of #17316

Co-authored-by: dylanmoz <4955191+dylanmoz@users.noreply.github.com>