### PR TITLE
reproduction: Gemini may return multiple codeExecutionResult per executableCode part

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 11485,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/google-multiple-code-execution-results.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts",
+    "packages/google/src/__fixtures__/google-code-execution-multiple-results.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_11485_REPRODUCED: Tool call undefined not found."
+  }
+}

--- a/examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts
+++ b/examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts
@@ -1,0 +1,43 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { readFile } from 'node:fs/promises';
+
+async function main() {
+  const response = await readFile(
+    new URL(
+      '../../../../packages/google/src/__fixtures__/google-code-execution-multiple-results.json',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  const google = createGoogleGenerativeAI({
+    apiKey: 'reproduction-api-key',
+    generateId: () => 'code-execution-call',
+    fetch: async () =>
+      new Response(response, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  });
+
+  await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      code_execution: google.tools.codeExecution({}),
+    },
+    prompt:
+      "use code execution to execute the following code snippet:\nprint('ok')\nprint(1/0)",
+  });
+
+  console.log('Issue #11485 did not reproduce.');
+}
+
+main().catch(error => {
+  console.error(
+    `ISSUE_11485_REPRODUCED: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/google-code-execution-multiple-results.json
+++ b/packages/google/src/__fixtures__/google-code-execution-multiple-results.json
@@ -1,0 +1,56 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "executableCode": {
+              "language": "PYTHON",
+              "code": "print('ok')\nprint(1/0)"
+            },
+            "thoughtSignature": "EjQKMgFyyNp8VRG2uDen0QENDjUJEy6ZQlvEGUhI8VcgTgNaspEC3M5Cao6lhYRGpmCcClR1"
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_OK",
+              "output": "ok\n"
+            }
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_FAILED",
+              "output": "division by zero\nTraceback (most recent call last):\n  File \"/usr/bin/entry/entry_point\", line 109, in _run_python\n    exec(code, exec_scope)  # pylint: disable=exec-used\n    ^^^^^^^^^^^^^^^^^^^^^^\n  File \"<string>\", line 2, in <module>\nZeroDivisionError: division by zero\n"
+            }
+          },
+          {
+            "text": "The code execution resulted in the following output:\n\n```\nok\n```\n\nFollowed by an error:\n\n```python\nZeroDivisionError: division by zero\n```",
+            "thoughtSignature": "EjQKMgFyyNp8EcK2k/joUmmIxJlqtIvdJP/1F+ziwsCn9P4uyk2ZNeBiYz2Um4GXD4IEGlE9"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 23,
+    "candidatesTokenCount": 35,
+    "totalTokenCount": 347,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 23
+      }
+    ],
+    "toolUsePromptTokenCount": 289,
+    "toolUsePromptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 289
+      }
+    ]
+  },
+  "modelVersion": "gemini-3-flash-preview",
+  "responseId": "x7hVadT9OdKT_uMP792-mAc"
+}

--- a/packages/google/src/__fixtures__/google-code-execution-single-combined-result-live-2026-07-16.json
+++ b/packages/google/src/__fixtures__/google-code-execution-single-combined-result-live-2026-07-16.json
@@ -1,0 +1,53 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "executableCode": {
+              "language": "PYTHON",
+              "code": "print('ok')\nprint(1/0)",
+              "id": "g4hwl40j"
+            },
+            "thoughtSignature": "EjQKMgERTTIPJbXZCCCgJVDkqkNB3ZcD1nlkWgNDb00fmgwldMSSQYRL6JoIRBawIPL7JyWW"
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_FAILED",
+              "output": "stdout: ok\n\nstderr: OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k\ndivision by zero\nTraceback (most recent call last):\n  File \"/usr/bin/entry/named_interpreters/python/interpreter\", line 98, in _run_python\n    exec(code, exec_scope)  # pylint: disable=exec-used\n    ^^^^^^^^^^^^^^^^^^^^^^\n  File \"<string>\", line 2, in <module>\nZeroDivisionError: division by zero\n",
+              "id": "g4hwl40j"
+            }
+          },
+          {
+            "text": "The execution of the code snippet produced the following output:\n\n```\nok\nTraceback (most recent call last):\n  File \"<string>\", line 2, in <module>\nZeroDivisionError: division by zero\n```\n\nAs expected, the code printed `ok` and then raised a `ZeroDivisionError` when attempting to divide by zero.",
+            "thoughtSignature": "EjQKMgERTTIPCBKomITVvJS4t+JVmtQVE9tLS9rbZNQkyKRyC0yXtz2biz5GCv3KzPcQd5bw"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 23,
+    "candidatesTokenCount": 98,
+    "totalTokenCount": 282,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 23
+      }
+    ],
+    "toolUsePromptTokenCount": 161,
+    "toolUsePromptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 161
+      }
+    ],
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3-flash-preview",
+  "responseId": "VAlZaoe8H8zj7M8P6ui9AQ"
+}

--- a/packages/google/src/google-language-model.issue-11485.test.ts
+++ b/packages/google/src/google-language-model.issue-11485.test.ts
@@ -1,0 +1,52 @@
+import * as fs from 'node:fs';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { expect, it } from 'vitest';
+import { createGoogle } from './google-provider';
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: "use code execution to execute:\nprint('ok')\nprint(1/0)",
+      },
+    ],
+  },
+];
+
+it('associates multiple code execution results with the same tool call', async () => {
+  const response = fs.readFileSync(
+    'src/__fixtures__/google-code-execution-multiple-results.json',
+    'utf8',
+  );
+
+  const provider = createGoogle({
+    apiKey: 'test-api-key',
+    generateId: () => 'test-id',
+    fetch: async () =>
+      new Response(response, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  });
+
+  const model = provider.languageModel('gemini-3-flash-preview');
+  const { content } = await model.doGenerate({
+    tools: [
+      {
+        type: 'provider',
+        id: 'google.code_execution',
+        name: 'code_execution',
+        args: {},
+      },
+    ],
+    prompt: TEST_PROMPT,
+  });
+
+  expect(
+    content
+      .filter(part => part.type === 'tool-result')
+      .map(part => part.toolCallId),
+  ).toEqual(['test-id', 'test-id']);
+});


### PR DESCRIPTION
## Bug

Gemini may return multiple codeExecutionResult per executableCode part

## Reproduction

- Replaying the recorded Gemini response with one `executableCode` and two `codeExecutionResult` parts makes `generateText` throw `Tool call undefined not found.` instead of returning both results.
- The current checkout (`ai` 7.0.29 and `@ai-sdk/google` 4.0.17) assigns the second result an undefined tool-call ID, so upgrading from the reported versions does not resolve this response shape.
- `examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts`, `packages/google/src/__fixtures__/google-code-execution-multiple-results.json`, and `packages/google/src/google-language-model.issue-11485.test.ts` reproduce the user-visible error and underlying ID mismatch.
- `packages/google/src/__fixtures__/google-code-execution-single-combined-result-live-2026-07-16.json` records that the exact live request on July 16, 2026 returned one combined failed result and succeeded, confirming the provider response shape is variable.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/code-execution
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview

## Related Issues

Reproduces #11485