### PR TITLE
reproduction: @ai-sdk/xai: responses converter silently drops image parts in

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17381,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17381-xai-tool-result-image.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17381_REPRODUCED: xAI could not read the code because the tool-result image was dropped."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts
+++ b/examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts
@@ -1,0 +1,231 @@
+import 'dotenv/config';
+import { createXai } from '@ai-sdk/xai';
+import { generateText, isStepCount, tool } from 'ai';
+import { writeFile } from 'node:fs/promises';
+import sharp from 'sharp';
+import { z } from 'zod';
+
+const EXPECTED_CODE = 'ZXQ-731';
+const LIVE_FIXTURE_PATH =
+  '../../packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.json';
+
+async function createTestImage(): Promise<string> {
+  return (
+    await sharp({
+      create: {
+        width: 800,
+        height: 400,
+        channels: 3,
+        background: 'white',
+      },
+    })
+      .composite([
+        {
+          input: Buffer.from(`
+            <svg width="800" height="400" xmlns="http://www.w3.org/2000/svg">
+              <rect width="800" height="400" fill="white"/>
+              <text
+                x="400"
+                y="235"
+                text-anchor="middle"
+                font-family="Arial, sans-serif"
+                font-size="120"
+                font-weight="bold"
+                fill="black"
+              >${EXPECTED_CODE}</text>
+            </svg>
+          `),
+        },
+      ])
+      .png()
+      .toBuffer()
+  ).toString('base64');
+}
+
+async function callRawXai(imageData: string) {
+  const headers = {
+    Authorization: `Bearer ${process.env.XAI_API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+  const tools = [
+    {
+      type: 'function',
+      name: 'inspect_image',
+      description: 'Returns the image whose code must be read.',
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  ];
+
+  const toolCallResponse = await fetch('https://api.x.ai/v1/responses', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: 'grok-4.5',
+      input:
+        'Call inspect_image exactly once so you can read its image and then reply with only the exact uppercase code shown in the image.',
+      tools,
+      tool_choice: { type: 'function', name: 'inspect_image' },
+    }),
+  });
+  const toolCallBody = (await toolCallResponse.json()) as {
+    id?: string;
+    output?: Array<{ type?: string; call_id?: string }>;
+  };
+
+  if (!toolCallResponse.ok) {
+    throw new Error(
+      `Raw xAI tool-call request failed: ${JSON.stringify(toolCallBody)}`,
+    );
+  }
+
+  const callId = toolCallBody.output?.find(
+    item => item.type === 'function_call',
+  )?.call_id;
+  if (toolCallBody.id == null || callId == null) {
+    throw new Error(
+      `Raw xAI response did not contain a function call: ${JSON.stringify(toolCallBody)}`,
+    );
+  }
+
+  const imageResponse = await fetch('https://api.x.ai/v1/responses', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: 'grok-4.5',
+      previous_response_id: toolCallBody.id,
+      input: [
+        {
+          type: 'function_call_output',
+          call_id: callId,
+          output: [
+            {
+              type: 'input_text',
+              text: 'The requested image is attached.',
+            },
+            {
+              type: 'input_image',
+              image_url: `data:image/png;base64,${imageData}`,
+            },
+          ],
+        },
+      ],
+      tools,
+    }),
+  });
+  const imageResponseBody = (await imageResponse.json()) as {
+    output?: Array<{
+      type?: string;
+      content?: Array<{ type?: string; text?: string }>;
+    }>;
+  };
+
+  if (!imageResponse.ok) {
+    throw new Error(
+      `Raw xAI image tool-result request failed: ${JSON.stringify(imageResponseBody)}`,
+    );
+  }
+
+  if (process.env.RECORD_LIVE_FIXTURE === '1') {
+    await writeFile(
+      LIVE_FIXTURE_PATH,
+      `${JSON.stringify(imageResponseBody, null, 2)}\n`,
+    );
+  }
+
+  const text = imageResponseBody.output
+    ?.flatMap(item => item.content ?? [])
+    .find(item => item.type === 'output_text')?.text;
+
+  return { response: imageResponseBody, text };
+}
+
+async function main() {
+  const requestBodies: unknown[] = [];
+  const xai = createXai({
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBodies.push(JSON.parse(init.body));
+      }
+      return fetch(input, init);
+    },
+  });
+
+  const imageData = await createTestImage();
+  const rawApiResult = await callRawXai(imageData);
+
+  const result = await generateText({
+    model: xai.responses('grok-4.5'),
+    prompt:
+      'Call inspectImage exactly once, read the image returned by the tool, and reply with only the exact uppercase code shown in the image.',
+    tools: {
+      inspectImage: tool({
+        description: 'Returns the image whose code must be read.',
+        inputSchema: z.object({}),
+        execute: async () => ({ imageData }),
+        toModelOutput: ({ output }) => ({
+          type: 'content',
+          value: [
+            {
+              type: 'text',
+              text: 'The requested image is attached.',
+            },
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: { type: 'data', data: output.imageData },
+            },
+          ],
+        }),
+      }),
+    },
+    stopWhen: isStepCount(3),
+  });
+
+  const toolResultRequest = requestBodies.find(body => {
+    if (body == null || typeof body !== 'object' || !('input' in body)) {
+      return false;
+    }
+    return (
+      Array.isArray(body.input) &&
+      body.input.some(
+        item =>
+          item != null &&
+          typeof item === 'object' &&
+          'type' in item &&
+          item.type === 'function_call_output',
+      )
+    );
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        assistantText: result.text,
+        rawApiText: rawApiResult.text,
+        toolResultRequest,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!rawApiResult.text?.toUpperCase().includes(EXPECTED_CODE)) {
+    throw new Error(
+      `Raw xAI API did not read the expected code: ${JSON.stringify(rawApiResult.response)}`,
+    );
+  }
+
+  if (!result.text.toUpperCase().includes(EXPECTED_CODE)) {
+    throw new Error(
+      'ISSUE_17381_REPRODUCED: xAI could not read the code because the tool-result image was dropped.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.json
+++ b/packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.json
@@ -1,0 +1,97 @@
+{
+  "created_at": 1784220440,
+  "completed_at": 1784220441,
+  "id": "085e6f04-c447-94b0-aef1-e2f35d8f697e",
+  "max_output_tokens": null,
+  "model": "grok-4.5",
+  "object": "response",
+  "output": [
+    {
+      "id": "rs_085e6f04-c447-94b0-aef1-e2f35d8f697e",
+      "summary": [
+        {
+          "text": "The image shows \"ZXQ-731\" in uppercase.\n",
+          "type": "summary_text"
+        }
+      ],
+      "type": "reasoning",
+      "status": "completed"
+    },
+    {
+      "content": [
+        {
+          "type": "output_text",
+          "text": "ZXQ-731",
+          "logprobs": [],
+          "annotations": []
+        }
+      ],
+      "id": "msg_085e6f04-c447-94b0-aef1-e2f35d8f697e",
+      "role": "assistant",
+      "type": "message",
+      "status": "completed"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "previous_response_id": "502676b2-297f-9b0e-a747-9b676d54a61f",
+  "reasoning": {
+    "effort": "high",
+    "summary": "detailed"
+  },
+  "temperature": 0.7,
+  "text": {
+    "format": {
+      "type": "text"
+    }
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "Returns the image whose code must be read.",
+      "name": "inspect_image",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "strict": false
+    }
+  ],
+  "top_p": 0.95,
+  "usage": {
+    "input_tokens": 893,
+    "input_tokens_details": {
+      "cached_tokens": 256
+    },
+    "output_tokens": 64,
+    "output_tokens_details": {
+      "reasoning_tokens": 60
+    },
+    "total_tokens": 957,
+    "num_sources_used": 0,
+    "num_server_side_tools_used": 0,
+    "cost_in_usd_ticks": 17860000,
+    "context_details": {
+      "input_tokens": 893,
+      "output_tokens": 64
+    }
+  },
+  "user": null,
+  "incomplete_details": null,
+  "status": "completed",
+  "store": true,
+  "metadata": {
+    "system_fingerprint": "fp_a39489019fa99b6e"
+  },
+  "background": false,
+  "service_tier": "default",
+  "truncation": "disabled",
+  "top_logprobs": 0,
+  "presence_penalty": 0,
+  "frequency_penalty": 0,
+  "prompt_cache_key": null,
+  "max_tool_calls": null,
+  "safety_identifier": null,
+  "error": null,
+  "instructions": null
+}

--- a/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
@@ -420,6 +420,57 @@ describe('convertToXaiResponsesInput', () => {
         ]
       `);
     });
+
+    it('should preserve image URLs in content output', async () => {
+      const result = await convertToXaiResponsesInput({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'inspectImage',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'text',
+                      text: 'The requested image is attached.',
+                    },
+                    {
+                      type: 'file',
+                      mediaType: 'image/png',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/image.png'),
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: [
+            {
+              type: 'input_text',
+              text: 'The requested image is attached.',
+            },
+            {
+              type: 'input_image',
+              image_url: 'https://example.com/image.png',
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('multi-turn conversations', () => {

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1026,6 +1026,76 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      it('should send image data in function call output', async () => {
+        prepareJsonFixtureResponse('issue-17381-tool-result-image');
+
+        const result = await createModel('grok-4.5').doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Read the tool image.' }],
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_123',
+                  toolName: 'inspectImage',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_123',
+                  toolName: 'inspectImage',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'text',
+                        text: 'The requested image is attached.',
+                      },
+                      {
+                        type: 'file',
+                        mediaType: 'image/png',
+                        data: {
+                          type: 'data',
+                          data: Buffer.from([0, 1, 2, 3]),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        expect(result.content).toContainEqual({
+          type: 'text',
+          text: 'ZXQ-731',
+        });
+        expect((await server.calls[0].requestBodyJson).input).toContainEqual({
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: [
+            {
+              type: 'input_text',
+              text: 'The requested image is attached.',
+            },
+            {
+              type: 'input_image',
+              image_url: 'data:image/png;base64,AAECAw==',
+            },
+          ],
+        });
+      });
+
       it('should warn about unsupported stopSequences', async () => {
         prepareJsonResponse({
           id: 'resp_123',


### PR DESCRIPTION
## Bug

@ai-sdk/xai: responses converter silently drops image parts in tool results (xAI API supports them)

## Reproduction

- `examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts` reproduced the live user-visible failure with `grok-4.5`: the raw xAI API read `ZXQ-731`, while `generateText` returned `WVER84K` after the SDK request omitted the image and sent only the accompanying text.
- Expected behavior is for inline-data and URL image parts to become `input_image` entries inside `function_call_output`, allowing the model to inspect the tool-returned image.
- `packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.json` records the successful live xAI response identifying `ZXQ-731` from an image-bearing tool result.
- Failing assertions in `packages/xai/src/responses/xai-responses-language-model.test.ts` and `packages/xai/src/responses/convert-to-xai-responses-input.test.ts` cover inline image data and image URLs; both observe that the converter retains text but drops the image.
- The checkout uses `@ai-sdk/xai@4.0.14`, matching a reported affected version without requiring a configuration or dependency mismatch.

## Relevant Documentation

- https://docs.x.ai/developers/tools/function-calling
- https://docs.x.ai/developers/model-capabilities/images/understanding

## Related Issues

Reproduces #17381