### PR TITLE
[v6.0] reproduction: Anthropic: invalid provider-executed tool call synthesizes a tool-error

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17366,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17366-anthropic-invalid-provider-tool.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17366-anthropic-invalid-provider-tool.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #17366: generateText and streamText sent orphaned srvtoolu_ tool_result blocks that Anthropic rejected."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17366-anthropic-invalid-provider-tool.ts
+++ b/examples/ai-functions/src/reproduction/issue-17366-anthropic-invalid-provider-tool.ts
@@ -1,0 +1,242 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type {
+  LanguageModelV3,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamResult,
+} from '@ai-sdk/provider';
+import { generateText, stepCountIs, streamText } from 'ai';
+
+const invalidToolCallId = 'srvtoolu_issue_17366_invalid';
+const deferredToolCallId = 'srvtoolu_issue_17366_deferred';
+
+const usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 1,
+    text: 1,
+    reasoning: undefined,
+  },
+};
+
+type CapturedCall = {
+  requestBody: unknown;
+  responseStatus?: number;
+  responseBody?: unknown;
+};
+
+function createLiveHarness() {
+  const calls: CapturedCall[] = [];
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const call: CapturedCall = {
+        requestBody:
+          typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.responseStatus = response.status;
+      call.responseBody = await response
+        .clone()
+        .json()
+        .catch(() => undefined);
+      return response;
+    },
+  });
+
+  return {
+    anthropic,
+    calls,
+    liveModel: anthropic('claude-sonnet-4-5'),
+  };
+}
+
+function isExpectedRejection(call: CapturedCall | undefined) {
+  const responseMessage = JSON.stringify(call?.responseBody);
+  return (
+    call?.responseStatus === 400 &&
+    responseMessage.includes('unexpected `tool_use_id`') &&
+    responseMessage.includes(invalidToolCallId)
+  );
+}
+
+async function reproduceGenerateText() {
+  const { anthropic, calls, liveModel } = createLiveHarness();
+  let callCount = 0;
+  const model: LanguageModelV3 = {
+    specificationVersion: 'v3',
+    provider: liveModel.provider,
+    modelId: liveModel.modelId,
+    supportedUrls: liveModel.supportedUrls,
+    doStream: options => liveModel.doStream(options),
+    doGenerate: async options => {
+      if (callCount++ > 0) {
+        return liveModel.doGenerate(options);
+      }
+
+      return {
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: invalidToolCallId,
+            toolName: 'web_search',
+            input: '{}',
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: invalidToolCallId,
+            toolName: 'web_search',
+            result: {
+              type: 'web_search_tool_result_error',
+              errorCode: 'invalid_tool_input',
+            },
+            isError: true,
+          },
+          {
+            type: 'tool-call',
+            toolCallId: deferredToolCallId,
+            toolName: 'web_search',
+            input: '{"query":"AI SDK"}',
+            providerExecuted: true,
+          },
+        ],
+        finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+        usage,
+        warnings: [],
+      } satisfies LanguageModelV3GenerateResult;
+    },
+  };
+
+  try {
+    await generateText({
+      model,
+      prompt: 'Reproduce issue #17366.',
+      tools: {
+        web_search: anthropic.tools.webSearch_20250305(),
+      },
+      stopWhen: stepCountIs(2),
+    });
+  } catch {
+    if (isExpectedRejection(calls[0])) {
+      return calls[0];
+    }
+  }
+
+  throw new Error(
+    'Expected Anthropic to reject the generateText follow-up request for issue #17366.',
+  );
+}
+
+async function reproduceStreamText() {
+  const { anthropic, calls, liveModel } = createLiveHarness();
+  let callCount = 0;
+  const model: LanguageModelV3 = {
+    specificationVersion: 'v3',
+    provider: liveModel.provider,
+    modelId: liveModel.modelId,
+    supportedUrls: liveModel.supportedUrls,
+    doGenerate: options => liveModel.doGenerate(options),
+    doStream: async options => {
+      if (callCount++ > 0) {
+        return liveModel.doStream(options);
+      }
+
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'tool-call',
+              toolCallId: invalidToolCallId,
+              toolName: 'web_search',
+              input: '{}',
+              providerExecuted: true,
+            });
+            controller.enqueue({
+              type: 'tool-result',
+              toolCallId: invalidToolCallId,
+              toolName: 'web_search',
+              result: {
+                type: 'web_search_tool_result_error',
+                errorCode: 'invalid_tool_input',
+              },
+              isError: true,
+            });
+            controller.enqueue({
+              type: 'tool-call',
+              toolCallId: deferredToolCallId,
+              toolName: 'web_search',
+              input: '{"query":"AI SDK"}',
+              providerExecuted: true,
+            });
+            controller.enqueue({
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+              usage,
+            });
+            controller.close();
+          },
+        }),
+      } satisfies LanguageModelV3StreamResult;
+    },
+  };
+
+  try {
+    const result = streamText({
+      model,
+      prompt: 'Reproduce issue #17366.',
+      tools: {
+        web_search: anthropic.tools.webSearch_20250305(),
+      },
+      stopWhen: stepCountIs(2),
+      onError: () => {},
+    });
+    await result.consumeStream();
+  } catch {}
+
+  if (isExpectedRejection(calls[0])) {
+    return calls[0];
+  }
+
+  throw new Error(
+    'Expected Anthropic to reject the streamText follow-up request for issue #17366.',
+  );
+}
+
+async function main() {
+  const generateTextCall = await reproduceGenerateText();
+  const streamTextCall = await reproduceStreamText();
+
+  console.log(
+    JSON.stringify(
+      {
+        generateText: {
+          request: generateTextCall?.requestBody,
+          responseStatus: generateTextCall?.responseStatus,
+          response: generateTextCall?.responseBody,
+        },
+        streamText: {
+          request: streamTextCall?.requestBody,
+          responseStatus: streamTextCall?.responseStatus,
+          response: streamTextCall?.responseBody,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  throw new Error(
+    'Reproduced issue #17366: generateText and streamText sent orphaned srvtoolu_ tool_result blocks that Anthropic rejected.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-17366-error.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-17366-error.json
@@ -1,0 +1,8 @@
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "messages.2.content.0: unexpected `tool_use_id` found in `tool_result` blocks: srvtoolu_issue_17366_invalid. Each `tool_result` block must have a corresponding `tool_use` block in the previous message."
+  },
+  "request_id": "req_011Cd65WVh8Zrvno3NunpJ73"
+}

--- a/packages/anthropic/src/issue-17366.test.ts
+++ b/packages/anthropic/src/issue-17366.test.ts
@@ -1,0 +1,121 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+it('surfaces the live API rejection for an orphaned tool_result that references a server_tool_use', async () => {
+  const responseBody = fs.readFileSync(
+    'src/__fixtures__/anthropic-issue-17366-error.json',
+    'utf8',
+  );
+  server.urls['https://api.anthropic.com/v1/messages'].response = {
+    type: 'error',
+    status: 400,
+    body: responseBody,
+  };
+
+  const prompt: LanguageModelV3Prompt = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Reproduce issue #17366.' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'srvtoolu_issue_17366_invalid',
+          toolName: 'web_search',
+          input: {},
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'srvtoolu_issue_17366_invalid',
+          toolName: 'web_search',
+          output: {
+            type: 'error-json',
+            value: {
+              type: 'web_search_tool_result_error',
+              errorCode: 'invalid_tool_input',
+            },
+          },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'srvtoolu_issue_17366_deferred',
+          toolName: 'web_search',
+          input: { query: 'AI SDK' },
+          providerExecuted: true,
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'srvtoolu_issue_17366_invalid',
+          toolName: 'web_search',
+          output: {
+            type: 'error-text',
+            value: 'Invalid input for tool web_search',
+          },
+        },
+      ],
+    },
+  ];
+
+  const provider = createAnthropic({ apiKey: 'test-api-key' });
+
+  await expect(
+    provider('claude-sonnet-4-5').doGenerate({
+      prompt,
+      tools: [
+        {
+          type: 'provider',
+          id: 'anthropic.web_search_20250305',
+          name: 'web_search',
+          args: {},
+        },
+      ],
+    }),
+  ).rejects.toMatchObject({
+    statusCode: 400,
+    message:
+      'messages.2.content.0: unexpected `tool_use_id` found in `tool_result` blocks: srvtoolu_issue_17366_invalid. Each `tool_result` block must have a corresponding `tool_use` block in the previous message.',
+  });
+
+  expect(await server.calls[0].requestBodyJson).toMatchObject({
+    messages: [
+      expect.anything(),
+      {
+        role: 'assistant',
+        content: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'server_tool_use',
+            id: 'srvtoolu_issue_17366_invalid',
+          }),
+          expect.objectContaining({
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_issue_17366_invalid',
+          }),
+        ]),
+      },
+      {
+        role: 'user',
+        content: [
+          expect.objectContaining({
+            type: 'tool_result',
+            tool_use_id: 'srvtoolu_issue_17366_invalid',
+          }),
+        ],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Bug

Anthropic: invalid provider-executed tool call synthesizes a tool-error without providerExecuted — orphaned srvtoolu_ tool_result 400s the next request

## Reproduction

- `examples/ai-functions/src/reproduction/issue-17366-anthropic-invalid-provider-tool.ts` reproduced the bug in both `generateText` and `streamText`: each generated an orphaned user `tool_result` for the invalid provider-executed `srvtoolu_` call, and live Anthropic returned HTTP 400.
- Expected behavior is for the synthetic error to remain provider-executed or be suppressed, avoiding a client `tool_result` for an Anthropic `server_tool_use`.
- `packages/anthropic/src/__fixtures__/anthropic-issue-17366-error.json` records the live Anthropic rejection, and `packages/anthropic/src/issue-17366.test.ts` verifies the malformed serialization and resulting API error.
- The issue remains present with the checkout's `ai@6.0.228`, `@ai-sdk/anthropic@3.0.97`, and live `claude-sonnet-4-5`; upgrading from the reporter's `@ai-sdk/anthropic@3.0.81` does not resolve it.

## Relevant Documentation

- https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview
- https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/implement-tool-use

## Related Issues

Reproduces #17366