### PR TITLE
reproduction: Anthropic: invalid provider-executed tool call synthesizes a tool-error

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17366,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17366-anthropic-orphaned-server-tool-result.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17366-anthropic-orphaned-server-tool-result.ts",
+    "packages/anthropic/src/__fixtures__/anthropic-issue-17366-orphan-tool-result.1.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #17366: messages.2.content.0: unexpected `tool_use_id` found in `tool_result` blocks: srvtoolu_01FvCG2mjosttzrL4Lnb5mHy. Each `tool_result` block must have a corresponding `tool_use` block in the previous message."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17366-anthropic-orphaned-server-tool-result.ts
+++ b/examples/ai-functions/src/reproduction/issue-17366-anthropic-orphaned-server-tool-result.ts
@@ -1,0 +1,313 @@
+import { readFile } from 'node:fs/promises';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText, isStepCount, streamText, tool, type ToolSet } from 'ai';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod';
+
+const serverToolCallId = 'srvtoolu_01FvCG2mjosttzrL4Lnb5mHy';
+const deferredServerToolCallId = 'srvtoolu_01Issue17366Deferred';
+const clientToolCallId = 'toolu_01Issue17366ClientTool';
+
+const usage = {
+  inputTokens: {
+    total: 10,
+    noCache: 10,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 20,
+    text: 20,
+    reasoning: undefined,
+  },
+};
+
+type Fixture = {
+  response: {
+    status: number;
+    body: {
+      error: {
+        message: string;
+      };
+    };
+  };
+};
+
+type RequestBody = {
+  messages?: Array<{
+    role?: string;
+    content?: Array<Record<string, unknown>> | string;
+  }>;
+};
+
+type ScenarioResult = {
+  error: string;
+  request: RequestBody | undefined;
+  hasServerToolUse: boolean;
+  hasServerToolResult: boolean;
+  hasOrphanedClientToolResult: boolean;
+};
+
+function inspectRequest(request: RequestBody | undefined) {
+  const content = request?.messages?.flatMap(message =>
+    Array.isArray(message.content) ? message.content : [],
+  );
+
+  return {
+    hasServerToolUse:
+      content?.some(
+        part =>
+          part.type === 'server_tool_use' &&
+          part.id === serverToolCallId &&
+          part.name === 'web_search',
+      ) === true,
+    hasServerToolResult:
+      content?.some(
+        part =>
+          part.type === 'web_search_tool_result' &&
+          part.tool_use_id === serverToolCallId,
+      ) === true,
+    hasOrphanedClientToolResult:
+      request?.messages?.some(
+        message =>
+          message.role === 'user' &&
+          Array.isArray(message.content) &&
+          message.content.some(
+            part =>
+              part.type === 'tool_result' &&
+              part.tool_use_id === serverToolCallId,
+          ),
+      ) === true,
+  };
+}
+
+function createTools(anthropic: ReturnType<typeof createAnthropic>): ToolSet {
+  return {
+    web_search: anthropic.tools.webSearch_20250305(),
+    client_tool: tool({
+      inputSchema: z.object({}),
+      execute: async () => 'client tool completed',
+    }),
+  };
+}
+
+function createGenerateModel() {
+  return new MockLanguageModelV4({
+    doGenerate: async () => ({
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: serverToolCallId,
+          toolName: 'web_search',
+          input: '{}',
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: serverToolCallId,
+          toolName: 'web_search',
+          result: {
+            type: 'web_search_tool_result_error',
+            errorCode: 'invalid_tool_input',
+          },
+          isError: true,
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-call',
+          toolCallId: clientToolCallId,
+          toolName: 'client_tool',
+          input: '{}',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: deferredServerToolCallId,
+          toolName: 'web_search',
+          input: '{"query":"continue after the client tool"}',
+          providerExecuted: true,
+        },
+      ],
+      finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+      usage,
+      warnings: [],
+    }),
+  });
+}
+
+function createStreamModel() {
+  return new MockLanguageModelV4({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'tool-call',
+          toolCallId: serverToolCallId,
+          toolName: 'web_search',
+          input: '{}',
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: serverToolCallId,
+          toolName: 'web_search',
+          result: {
+            type: 'web_search_tool_result_error',
+            errorCode: 'invalid_tool_input',
+          },
+          isError: true,
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-call',
+          toolCallId: clientToolCallId,
+          toolName: 'client_tool',
+          input: '{}',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: deferredServerToolCallId,
+          toolName: 'web_search',
+          input: '{"query":"continue after the client tool"}',
+          providerExecuted: true,
+        },
+        {
+          type: 'finish',
+          finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+          usage,
+        },
+      ]),
+    }),
+  });
+}
+
+function createFixtureProvider(fixture: Fixture) {
+  let request: RequestBody | undefined;
+
+  const anthropic = createAnthropic({
+    apiKey: 'fixture-api-key',
+    fetch: async (_input, init) => {
+      request =
+        typeof init?.body === 'string'
+          ? (JSON.parse(init.body) as RequestBody)
+          : undefined;
+
+      return new Response(JSON.stringify(fixture.response.body), {
+        status: fixture.response.status,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  return {
+    anthropic,
+    getRequest: () => request,
+  };
+}
+
+async function runGenerateScenario(fixture: Fixture): Promise<ScenarioResult> {
+  const provider = createFixtureProvider(fixture);
+  let error = '';
+
+  try {
+    await generateText({
+      model: provider.anthropic('claude-sonnet-4-6'),
+      prompt: 'Use web search and the client tool.',
+      tools: createTools(provider.anthropic),
+      stopWhen: isStepCount(2),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber === 0 ? { model: createGenerateModel() } : undefined,
+    });
+  } catch (caught) {
+    error = String(caught);
+  }
+
+  return {
+    error,
+    request: provider.getRequest(),
+    ...inspectRequest(provider.getRequest()),
+  };
+}
+
+async function runStreamScenario(fixture: Fixture): Promise<ScenarioResult> {
+  const provider = createFixtureProvider(fixture);
+  let error = '';
+
+  try {
+    const result = streamText({
+      model: provider.anthropic('claude-sonnet-4-6'),
+      prompt: 'Use web search and the client tool.',
+      tools: createTools(provider.anthropic),
+      stopWhen: isStepCount(2),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber === 0 ? { model: createStreamModel() } : undefined,
+      onError: event => {
+        error = String(event.error);
+      },
+    });
+
+    await result.text;
+  } catch (caught) {
+    error = String(caught);
+  }
+
+  return {
+    error,
+    request: provider.getRequest(),
+    ...inspectRequest(provider.getRequest()),
+  };
+}
+
+async function main() {
+  const fixture = JSON.parse(
+    await readFile(
+      new URL(
+        '../../../../packages/anthropic/src/__fixtures__/anthropic-issue-17366-orphan-tool-result.1.json',
+        import.meta.url,
+      ),
+      'utf8',
+    ),
+  ) as Fixture;
+
+  const generateTextResult = await runGenerateScenario(fixture);
+  const streamTextResult = await runStreamScenario(fixture);
+  const expectedError = fixture.response.body.error.message;
+
+  console.log(
+    JSON.stringify(
+      {
+        expectedAnthropicError: expectedError,
+        generateText: generateTextResult,
+        streamText: streamTextResult,
+      },
+      null,
+      2,
+    ),
+  );
+
+  for (const [name, result] of [
+    ['generateText', generateTextResult],
+    ['streamText', streamTextResult],
+  ] as const) {
+    if (
+      !result.hasServerToolUse ||
+      !result.hasServerToolResult ||
+      !result.hasOrphanedClientToolResult
+    ) {
+      throw new Error(
+        `${name} did not produce the malformed Anthropic follow-up request reported in issue #17366.`,
+      );
+    }
+
+    if (!result.error.includes(expectedError)) {
+      throw new Error(
+        `${name} did not surface the recorded Anthropic 400 for the malformed follow-up request.`,
+      );
+    }
+  }
+
+  throw new Error(`Reproduced issue #17366: ${expectedError}`);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-17366-orphan-tool-result.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-17366-orphan-tool-result.1.json
@@ -1,0 +1,94 @@
+{
+  "request": {
+    "model": "claude-sonnet-4-6",
+    "max_tokens": 32,
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Use web search and the client tool."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "server_tool_use",
+            "id": "srvtoolu_01FvCG2mjosttzrL4Lnb5mHy",
+            "name": "web_search",
+            "input": {}
+          },
+          {
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_01FvCG2mjosttzrL4Lnb5mHy",
+            "content": {
+              "type": "web_search_tool_result_error",
+              "error_code": "invalid_tool_input"
+            }
+          },
+          {
+            "type": "server_tool_use",
+            "id": "srvtoolu_01Issue17366Deferred",
+            "name": "web_search",
+            "input": {
+              "query": "continue after the client tool"
+            }
+          },
+          {
+            "type": "tool_use",
+            "id": "toolu_01Issue17366ClientTool",
+            "name": "client_tool",
+            "input": {}
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "srvtoolu_01FvCG2mjosttzrL4Lnb5mHy",
+            "content": "SDK local input validation failed",
+            "is_error": true
+          },
+          {
+            "type": "tool_result",
+            "tool_use_id": "toolu_01Issue17366ClientTool",
+            "content": "client tool completed"
+          }
+        ]
+      }
+    ],
+    "tools": [
+      {
+        "type": "web_search_20250305",
+        "name": "web_search"
+      },
+      {
+        "name": "client_tool",
+        "input_schema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+      }
+    ],
+    "tool_choice": {
+      "type": "auto"
+    }
+  },
+  "response": {
+    "status": 400,
+    "body": {
+      "type": "error",
+      "error": {
+        "type": "invalid_request_error",
+        "message": "messages.2.content.0: unexpected `tool_use_id` found in `tool_result` blocks: srvtoolu_01FvCG2mjosttzrL4Lnb5mHy. Each `tool_result` block must have a corresponding `tool_use` block in the previous message."
+      },
+      "request_id": "req_011Cd65sEszHNbYYRoYTMjZU"
+    }
+  }
+}

--- a/packages/anthropic/src/issue-17366.test.ts
+++ b/packages/anthropic/src/issue-17366.test.ts
@@ -1,0 +1,83 @@
+import { readFile } from 'node:fs/promises';
+import { createToolNameMapping } from '@ai-sdk/provider-utils';
+import { describe, it } from 'vitest';
+import { convertToAnthropicPrompt } from './convert-to-anthropic-prompt';
+
+const serverToolCallId = 'srvtoolu_01FvCG2mjosttzrL4Lnb5mHy';
+
+describe('issue #17366', () => {
+  it('does not serialize a synthetic error for a provider-executed call as a client tool_result', async () => {
+    const fixture = JSON.parse(
+      await readFile(
+        new URL(
+          './__fixtures__/anthropic-issue-17366-orphan-tool-result.1.json',
+          import.meta.url,
+        ),
+        'utf8',
+      ),
+    );
+
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: serverToolCallId,
+              toolName: 'web_search',
+              input: {},
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: serverToolCallId,
+              toolName: 'web_search',
+              output: {
+                type: 'error-json',
+                value: {
+                  type: 'web_search_tool_result_error',
+                  errorCode: 'invalid_tool_input',
+                },
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: serverToolCallId,
+              toolName: 'web_search',
+              output: {
+                type: 'error-text',
+                value: 'SDK local input validation failed',
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings: [],
+      toolNameMapping: createToolNameMapping({
+        tools: [],
+        providerToolNames: {},
+      }),
+    });
+
+    const orphanedToolResult = result.prompt.messages
+      .filter(message => message.role === 'user')
+      .flatMap(message => message.content)
+      .find(
+        part =>
+          part.type === 'tool_result' && part.tool_use_id === serverToolCallId,
+      );
+
+    if (orphanedToolResult != null) {
+      throw new Error(
+        `Reproduced issue #17366: ${fixture.response.body.error.message}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Bug

Anthropic: invalid provider-executed tool call synthesizes a tool-error without providerExecuted — orphaned srvtoolu_ tool_result 400s the next request

## Reproduction

- `examples/ai-functions/src/reproduction/issue-17366-anthropic-orphaned-server-tool-result.ts` reproduces both `generateText` and `streamText` serializing the synthetic error as an orphaned user `tool_result`, causing an `AI_APICallError`; expected behavior is to keep it provider-executed or suppress it.
- `packages/anthropic/src/__fixtures__/anthropic-issue-17366-orphan-tool-result.1.json` records a live Claude API request and its HTTP 400 response for the malformed follow-up message.
- `packages/anthropic/src/issue-17366.test.ts` fails when Anthropic prompt conversion emits the orphaned `srvtoolu_` result instead of omitting it from the client tool-results message.
- Reproduced on the checkout's `ai@7.0.29` and `@ai-sdk/anthropic@4.0.15`.
- A client tool alone did not advance the current loop because the synthetic error increases the client-output count; the reproduction includes a valid deferred server call to force the reported follow-up request.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls

## Related Issues

Reproduces #17366