### PR TITLE
feat: add kimi-k3 model and `reasoningEffort` provider option

### DIFF
--- a/.changeset/curvy-kimis-reason.md
+++ b/.changeset/curvy-kimis-reason.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/moonshotai': patch
+'@ai-sdk/gateway': patch
+---
+
+feat: add kimi-k3 model and `reasoningEffort` provider option

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -62,7 +62,7 @@ import { moonshotai } from '@ai-sdk/moonshotai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: moonshotai('kimi-k2.5'),
+  model: moonshotai('kimi-k3'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -70,9 +70,9 @@ const { text } = await generateText({
 You can also use the `.chatModel()` or `.languageModel()` factory methods:
 
 ```ts
-const model = moonshotai.chatModel('kimi-k2.5');
+const model = moonshotai.chatModel('kimi-k3');
 // or
-const model = moonshotai.languageModel('kimi-k2.5');
+const model = moonshotai.languageModel('kimi-k3');
 ```
 
 Moonshot AI language models can be used in the `streamText` function
@@ -87,6 +87,30 @@ For other Moonshot models, object generation falls back to JSON mode instead of 
 For best reliability, it is strongly recommended to include your schema requirements in your prompt in addition to passing the schema through `Output`.
 
 ### Reasoning Models
+
+Kimi K3 always reasons. It currently supports only the `max` reasoning effort,
+which you can configure through provider options:
+
+```ts
+import {
+  moonshotai,
+  type MoonshotAILanguageModelOptions,
+} from '@ai-sdk/moonshotai';
+import { generateText } from 'ai';
+
+const { text, reasoningText } = await generateText({
+  model: moonshotai('kimi-k3'),
+  providerOptions: {
+    moonshotai: {
+      reasoningEffort: 'max',
+    } satisfies MoonshotAILanguageModelOptions,
+  },
+  prompt: 'How many "r"s are in the word "strawberry"?',
+});
+
+console.log(reasoningText);
+console.log(text);
+```
 
 Moonshot AI offers thinking models like `kimi-k2-thinking` that generate intermediate reasoning tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
 
@@ -118,6 +142,10 @@ See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details on 
 
 The following optional provider options are available for Moonshot AI language models:
 
+- **reasoningEffort** _'max'_
+
+  Reasoning effort for Kimi K3. Currently, only `'max'` is supported.
+
 - **thinking** _object_
 
   Configuration for thinking/reasoning models like Kimi K2 Thinking.
@@ -148,6 +176,7 @@ The following optional provider options are available for Moonshot AI language m
 | `kimi-k2-thinking`       | <Cross />   | <Check />         | <Check />  | <Check />      |
 | `kimi-k2-thinking-turbo` | <Cross />   | <Check />         | <Check />  | <Check />      |
 | `kimi-k2-turbo`          | <Cross />   | <Check />         | <Check />  | <Check />      |
+| `kimi-k3`                | <Check />   | <Check />         | <Check />  | <Check />      |
 
 <Note>
   Please see the [Moonshot AI docs](https://platform.moonshot.ai/docs/intro) for

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -74,6 +74,7 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-chat`                                     | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-reasoner`                                 | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Moonshot AI](/providers/ai-sdk-providers/moonshotai)      | `kimi-k2.5`                                         | <Check />   | <Check />         | <Check />  | <Check />      |
+| [Moonshot AI](/providers/ai-sdk-providers/moonshotai)      | `kimi-k3`                                           | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Moonshot AI](/providers/ai-sdk-providers/moonshotai)      | `kimi-k2-thinking`                                  | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)                   | `meta-llama/llama-4-scout-17b-16e-instruct`         | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)                   | `llama-3.3-70b-versatile`                           | <Cross />   | <Check />         | <Check />  | <Check />      |

--- a/examples/ai-functions/src/generate-text/moonshot/basic.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/basic.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: moonshotai('kimi-k2.5'),
+    model: moonshotai('kimi-k3'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/moonshot/cache.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/cache.ts
@@ -8,7 +8,7 @@ run(async () => {
   const largeContext = errorMessage.repeat(100);
 
   const result = await generateText({
-    model: moonshotai('kimi-k2.5'),
+    model: moonshotai('kimi-k3'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/moonshot/structured-outputs.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/structured-outputs.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: moonshotai('kimi-k2.5'),
+    model: moonshotai('kimi-k3'),
     output: Output.object({
       schema: z.object({
         holiday: z.string(),

--- a/examples/ai-functions/src/generate-text/moonshot/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/tool-call.ts
@@ -5,7 +5,7 @@ import { weatherTool } from '../../tools/weather-tool';
 
 run(async () => {
   const result = await generateText({
-    model: moonshotai('kimi-k2.5'),
+    model: moonshotai('kimi-k3'),
     tools: { weather: weatherTool },
     stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',

--- a/examples/ai-functions/src/stream-text/gateway/kimi-k3-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/kimi-k3-tool-call.ts
@@ -1,4 +1,4 @@
-import type { FireworksLanguageModelOptions } from '@ai-sdk/fireworks';
+import type { MoonshotAILanguageModelOptions } from '@ai-sdk/moonshotai';
 import { gateway } from '@ai-sdk/gateway';
 import { isStepCount, streamText } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -7,17 +7,16 @@ import { weatherTool } from '../../tools/weather-tool';
 
 run(async () => {
   const result = streamText({
-    model: gateway('moonshotai/kimi-k2.5'),
+    model: gateway('moonshotai/kimi-k3'),
     providerOptions: {
-      fireworks: {
-        thinking: { type: 'enabled', budgetTokens: 4096 },
-        reasoningHistory: 'interleaved',
-      } satisfies FireworksLanguageModelOptions,
+      moonshotai: {
+        reasoningEffort: 'max',
+      } satisfies MoonshotAILanguageModelOptions,
     },
     tools: { weather: weatherTool },
     stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 
-  printFullStream({ result });
+  await printFullStream({ result });
 });

--- a/examples/ai-functions/src/stream-text/moonshot/basic.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/basic.ts
@@ -1,18 +1,16 @@
 import { moonshotai } from '@ai-sdk/moonshotai';
 import { streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: moonshotai('kimi-k2.5'),
+    model: moonshotai('kimi-k3'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  for await (const textPart of result.textStream) {
-    process.stdout.write(textPart);
-  }
+  await printFullStream({ result });
 
-  console.log();
   console.log('Token usage:', await result.usage);
   console.log('Finish reason:', await result.finishReason);
 });

--- a/examples/ai-functions/src/stream-text/moonshot/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/tool-call.ts
@@ -2,11 +2,12 @@ import { moonshotai } from '@ai-sdk/moonshotai';
 import { weatherTool } from '../../tools/weather-tool';
 import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
+import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: moonshotai('kimi-k2.5'),
+    model: moonshotai('kimi-k3'),
     stopWhen: isStepCount(5),
     tools: {
       currentLocation: tool({
@@ -24,34 +25,7 @@ run(async () => {
     prompt: 'What is the weather in my current location?',
   });
 
-  for await (const chunk of result.stream) {
-    switch (chunk.type) {
-      case 'text-delta': {
-        process.stdout.write(chunk.text);
-        break;
-      }
-
-      case 'tool-call': {
-        console.log(
-          `TOOL CALL ${chunk.toolName} ${JSON.stringify(chunk.input)}`,
-        );
-        break;
-      }
-
-      case 'tool-result': {
-        console.log(
-          `TOOL RESULT ${chunk.toolName} ${JSON.stringify(chunk.output)}`,
-        );
-        break;
-      }
-
-      case 'finish-step': {
-        console.log();
-        console.log();
-        break;
-      }
-    }
-  }
+  await printFullStream({ result });
 
   console.log('Token usage:', await result.usage);
   console.log('Finish reason:', await result.finishReason);

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -117,6 +117,7 @@ export type GatewayModelId =
   | 'moonshotai/kimi-k2.6'
   | 'moonshotai/kimi-k2.7-code'
   | 'moonshotai/kimi-k2.7-code-highspeed'
+  | 'moonshotai/kimi-k3'
   | 'morph/morph-v3-fast'
   | 'morph/morph-v3-large'
   | 'nvidia/nemotron-3-nano-30b-a3b'

--- a/packages/moonshotai/README.md
+++ b/packages/moonshotai/README.md
@@ -35,7 +35,7 @@ import { moonshotai } from '@ai-sdk/moonshotai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: moonshotai('kimi-k2.5'),
+  model: moonshotai('kimi-k3'),
   prompt: 'Write a JavaScript function that sorts a list:',
 });
 ```

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -8,9 +8,15 @@ export type MoonshotAIChatModelId =
   | 'kimi-k2.6'
   | 'kimi-k2.7-code'
   | 'kimi-k2.7-code-highspeed'
+  | 'kimi-k3'
   | (string & {});
 
 export const moonshotaiLanguageModelOptions = z.object({
+  /**
+   * Reasoning effort for Kimi K3. Currently, only `max` is supported.
+   */
+  reasoningEffort: z.literal('max').optional(),
+
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),

--- a/packages/moonshotai/src/moonshotai-provider.test.ts
+++ b/packages/moonshotai/src/moonshotai-provider.test.ts
@@ -174,6 +174,7 @@ describe('getMoonshotAILanguageModelCapabilities', () => {
     ['kimi-k2.5', true],
     ['kimi-k2.6', true],
     ['kimi-k2.7-code', true],
+    ['kimi-k3', true],
     ['moonshot-v1-8k', false],
     ['moonshot-v1-32k', false],
     ['moonshot-v1-128k', false],


### PR DESCRIPTION
## Background

`kimi-k3` was released:
* https://platform.kimi.ai/docs/pricing/chat-k3
* https://platform.kimi.ai/docs/api/models-overview#parameter-comparison

AI Gateway has it too:
* https://vercel.com/ai-gateway/models/kimi-k3

## Summary

* Add `kimi-k3` model to `@ai-sdk/moonshotai`
* Add `moonshotai/kimi-k3` model to `@ai-sdk/gateway`
* Add `reasoningEffort` provider option to `@ai-sdk/moonshotai` and document
* Update examples

## End-to-End Verification

Tested `basic.ts` (in both moonshot and gateway) and `structured-outputs.ts` examples using `kimi-k3`.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
