### PR TITLE
docs: fix broken google provider links

### DIFF
--- a/apps/docs/components/docs/marketing-cards.tsx
+++ b/apps/docs/components/docs/marketing-cards.tsx
@@ -71,7 +71,7 @@ const providers = [
   ['AI Gateway', '/providers/ai-sdk-providers/ai-gateway'],
   ['OpenAI', '/providers/ai-sdk-providers/openai'],
   ['Anthropic', '/providers/ai-sdk-providers/anthropic'],
-  ['Google', '/providers/ai-sdk-providers/google-generative-ai'],
+  ['Google', '/providers/ai-sdk-providers/google'],
   ['Amazon Bedrock', '/providers/ai-sdk-providers/amazon-bedrock'],
   ['Azure', '/providers/ai-sdk-providers/azure'],
 ] as const;

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -1065,7 +1065,7 @@ The following gateway provider options are available:
   per-provider option each provider expects, and overrides any tier
   also set in the per-provider options. Leave unset for provider
   default. See the [OpenAI](/providers/ai-sdk-providers/openai),
-  [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai),
+  [Google Generative AI](/providers/ai-sdk-providers/google),
   and [Google Vertex AI](/providers/ai-sdk-providers/google-vertex)
   provider docs for tier semantics, model availability, and graceful
   downgrade behavior on each provider.

--- a/packages/google/README.md
+++ b/packages/google/README.md
@@ -1,6 +1,6 @@
 # AI SDK - Google Provider
 
-The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
+The **[Google provider](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Google Generative AI](https://ai.google/discover/generativeai/) APIs.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access Google (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 
@@ -42,4 +42,4 @@ const { text } = await generateText({
 
 ## Documentation
 
-Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)** for more information.
+Please check out the **[Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google)** for more information.


### PR DESCRIPTION
Fixes #17365. Updated outdated links pointing to `/providers/ai-sdk-providers/google-generative-ai` to point to `/providers/ai-sdk-providers/google` after the package rename in v7. Affected files were `marketing-cards.tsx`, `00-ai-gateway.mdx`, and the Google provider `README.md`.