### PR TITLE
[v6.0] reproduction: could not reproduce generateText doesn't work with AWS Bedrock application inference

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-14117-bedrock-application-inference-profile-arn.ts
+++ b/examples/ai-functions/src/reproduction/issue-14117-bedrock-application-inference-profile-arn.ts
@@ -1,0 +1,62 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+
+const modelId =
+  'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
+const expectedUrl =
+  `https://bedrock-runtime.us-east-1.amazonaws.com/model/` +
+  `${encodeURIComponent(modelId)}/converse`;
+
+async function main() {
+  const fixture = fs.readFileSync(
+    new URL(
+      '../../../../packages/amazon-bedrock/src/__fixtures__/issue-14117-application-inference-profile-success.json',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  let requestUrl: string | undefined;
+
+  const bedrock = createAmazonBedrock({
+    region: 'us-east-1',
+    accessKeyId: 'test-access-key',
+    secretAccessKey: 'test-secret-key',
+    fetch: async input => {
+      requestUrl =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+
+      return new Response(fixture, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  const result = await generateText({
+    model: bedrock(modelId),
+    prompt: 'Reply with exactly: hello',
+    maxOutputTokens: 10,
+    maxRetries: 0,
+  });
+
+  if (requestUrl !== expectedUrl) {
+    throw new Error(
+      `Unexpected Bedrock application inference profile URL: ${requestUrl}`,
+    );
+  }
+  if (result.text !== 'hello') {
+    throw new Error(`Expected generateText to return "hello": ${result.text}`);
+  }
+
+  console.log(
+    'Issue #14117 not reproduced: generateText returned "hello" for an application inference profile ARN.',
+  );
+  console.log(`Request URL: ${requestUrl}`);
+}
+
+main();

--- a/packages/amazon-bedrock/src/__fixtures__/issue-14117-application-inference-profile-success.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-14117-application-inference-profile-success.json
@@ -1,0 +1,26 @@
+{
+  "metrics": {
+    "latencyMs": 1331
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "hello"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 12,
+    "outputTokens": 4,
+    "serverToolUsage": {},
+    "totalTokens": 16
+  }
+}

--- a/packages/amazon-bedrock/src/issue-14117-application-inference-profile.test.ts
+++ b/packages/amazon-bedrock/src/issue-14117-application-inference-profile.test.ts
@@ -1,0 +1,45 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+const modelId =
+  'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const expectedUrl = `${baseUrl}/model/${encodeURIComponent(modelId)}/converse`;
+const prompt: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Say hello' }] },
+];
+
+describe('issue 14117', () => {
+  it('generates text with an application inference profile ARN', async () => {
+    const fixture = fs.readFileSync(
+      'src/__fixtures__/issue-14117-application-inference-profile-success.json',
+      'utf8',
+    );
+    let requestUrl: string | undefined;
+    const model = new BedrockChatLanguageModel(modelId, {
+      baseUrl: () => baseUrl,
+      headers: {},
+      fetch: async input => {
+        requestUrl =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+
+        return new Response(fixture, {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+      generateId: () => 'test-id',
+    });
+
+    const result = await model.doGenerate({ prompt });
+
+    expect(requestUrl).toBe(expectedUrl);
+    expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+});


### PR DESCRIPTION
## Bug

generateText doesn't work with AWS Bedrock application inference profile ARNs

## Reproduction

- A live, temporary AWS Bedrock application inference profile returned HTTP 200 and `hello` through `generateText`; the request used the reported percent-encoded ARN URL rather than producing the expected `400 The provided model identifier is invalid`.
- The live invocation succeeded with both `@ai-sdk/amazon-bedrock` 4.0.136 and the reported 4.0.85, so no product-code upgrade was required in the tested configuration.
- `examples/ai-functions/src/reproduction/issue-14117-bedrock-application-inference-profile-arn.ts` replays the recorded response and confirms that `generateText` returns `hello` instead of the reported error.
- The live response is recorded in `packages/amazon-bedrock/src/__fixtures__/issue-14117-application-inference-profile-success.json` and covered by `packages/amazon-bedrock/src/issue-14117-application-inference-profile.test.ts`.
- The original 400 may depend on inference-profile status, region, model, or IAM configuration not present in the tested AWS account.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-application-inference-profiles.html

## Related Issues

Could not reproduce #14117