### PR TITLE
chore: verify PR commit signatures in GitHub Action

### DIFF
--- a/.github/workflows/verify-commit-signatures.yml
+++ b/.github/workflows/verify-commit-signatures.yml
@@ -1,0 +1,105 @@
+name: Verify Commit Signatures
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify Commit Signatures
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # pull_request_target keeps this workflow on the trusted default branch.
+      # Do not check out or execute code from the pull request in this job.
+      - name: Verify every commit signature
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    commits(first: 100, after: $cursor) {
+                      nodes {
+                        commit {
+                          abbreviatedOid
+                          signature {
+                            isValid
+                            signer {
+                              login
+                            }
+                            state
+                          }
+                          url
+                        }
+                      }
+                      pageInfo {
+                        endCursor
+                        hasNextPage
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const commits = [];
+            let cursor = null;
+
+            do {
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: context.payload.pull_request.number,
+                cursor,
+              });
+
+              const connection = result.repository.pullRequest.commits;
+              commits.push(...connection.nodes.map(node => node.commit));
+              cursor = connection.pageInfo.hasNextPage
+                ? connection.pageInfo.endCursor
+                : null;
+            } while (cursor != null);
+
+            const unverifiedCommits = commits.filter(
+              commit =>
+                commit.signature?.isValid !== true ||
+                commit.signature.signer == null,
+            );
+
+            if (unverifiedCommits.length === 0) {
+              await core.summary
+                .addHeading('Commit signature verification passed')
+                .addRaw(
+                  `All ${commits.length} commit${commits.length === 1 ? '' : 's'} have GitHub-verified signatures.`,
+                )
+                .write();
+              return;
+            }
+
+            const failures = unverifiedCommits.map(commit => {
+              const reason =
+                commit.signature == null
+                  ? 'unsigned'
+                  : commit.signature.isValid !== true
+                    ? commit.signature.state.toLowerCase()
+                    : 'signature is not linked to a GitHub user';
+
+              return `- [\`${commit.abbreviatedOid}\`](${commit.url}): ${reason}`;
+            });
+
+            await core.summary
+              .addHeading('Commit signature verification failed')
+              .addRaw(failures.join('\n'))
+              .addRaw(
+                '\n\nSign or re-sign these commits with a key linked to your GitHub account, then force-push the rewritten commits.',
+              )
+              .write();
+
+            core.setFailed(
+              `${unverifiedCommits.length} of ${commits.length} commits do not have a GitHub-verified signature.`,
+            );


### PR DESCRIPTION
## Background

AI SDK requires pull requests to have every commit signed. But GitHub rulesets can only require this on pushes to `vercel/ai`, not forks. So it required us to manually check that all commits were verified before merging a PR from an outside contributor.

## Summary

Add a GitHub Action that runs on PRs to verify that all commits are signed with a verified signature (not just *any* signature)

## End-to-End Verification

Tested the action on my fork:
* https://github.com/n1ckoates/ai/pull/1
* https://github.com/n1ckoates/ai/pull/2
* https://github.com/n1ckoates/ai/pull/3

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
