### PR TITLE
reproduction: could not reproduce generateText doesn't work with AWS Bedrock application inference

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-14117-bedrock-inference-profile-arn.ts
+++ b/examples/ai-functions/src/reproduction/issue-14117-bedrock-inference-profile-arn.ts
@@ -1,0 +1,57 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+
+async function main() {
+  const inferenceProfileArn = process.env.ISSUE_14117_INFERENCE_PROFILE_ARN;
+
+  if (inferenceProfileArn == null) {
+    throw new Error(
+      'Set ISSUE_14117_INFERENCE_PROFILE_ARN to an active Amazon Bedrock application inference profile ARN.',
+    );
+  }
+
+  const arnMatch = inferenceProfileArn.match(
+    /^arn:aws:bedrock:([^:]+):\d{12}:application-inference-profile\/.+$/,
+  );
+
+  if (arnMatch == null) {
+    throw new Error(
+      'ISSUE_14117_INFERENCE_PROFILE_ARN must be an Amazon Bedrock application inference profile ARN.',
+    );
+  }
+
+  let requestUrl: string | undefined;
+  const captureFetch: typeof fetch = async (input, init) => {
+    requestUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    return fetch(input, init);
+  };
+
+  const bedrock = createAmazonBedrock({
+    region: arnMatch[1],
+    fetch: captureFetch,
+  });
+
+  const result = await generateText({
+    model: bedrock(inferenceProfileArn),
+    prompt: 'Say hello in one word.',
+  });
+
+  if (result.text.length === 0) {
+    throw new Error(
+      'ISSUE_14117_REPRODUCED: generateText returned no text for the application inference profile ARN.',
+    );
+  }
+
+  console.log(
+    'ISSUE_14117_COULD_NOT_REPRODUCE: generateText succeeded with an application inference profile ARN.',
+  );
+  console.log(`Request URL: ${requestUrl}`);
+  console.log(`Generated text: ${result.text}`);
+}
+
+main();


### PR DESCRIPTION
## Bug

generateText doesn't work with AWS Bedrock application inference profile ARNs

## Reproduction

- Live `generateText` calls using an active AWS Bedrock application inference profile ARN succeeded and returned text instead of the reported `400 The provided model identifier is invalid` error.
- The current `@ai-sdk/amazon-bedrock` v5.0.23 request still percent-encoded the ARN delimiters in the URL, but AWS Bedrock accepted that URL; the suspected intermediate URL shape did not cause the reported user-visible failure.
- A comparison using the reported `@ai-sdk/amazon-bedrock` v4.0.85 also succeeded against the same live application inference profile.
- Added `examples/ai-functions/src/reproduction/issue-14117-bedrock-inference-profile-arn.ts`; it invokes a supplied application inference profile ARN, captures the request URL, and verifies that text is generated.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateInferenceProfile.html

## Related Issues

Could not reproduce #14117