### PR TITLE
fix(bedrock): support application inference profile ARNs

### DIFF
--- a/.changeset/thin-bees-own.md
+++ b/.changeset/thin-bees-own.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(bedrock): support application inference profile ARNs

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -235,6 +235,53 @@ describe('doGenerate request metadata', () => {
   });
 });
 
+describe('request URL', () => {
+  it('should preserve application inference profile ARN delimiters', async () => {
+    const inferenceProfileArn =
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
+    const fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          output: {
+            message: {
+              role: 'assistant',
+              content: [{ text: 'hello' }],
+            },
+          },
+          stopReason: 'end_turn',
+          usage: {
+            inputTokens: 1,
+            outputTokens: 1,
+            totalTokens: 2,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    const inferenceProfileModel = new AmazonBedrockChatLanguageModel(
+      inferenceProfileArn,
+      {
+        baseUrl: () => baseUrl,
+        headers: {},
+        fetch,
+        generateId: () => 'test-id',
+      },
+    );
+
+    await inferenceProfileModel.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/model/${inferenceProfileArn}/converse`,
+      expect.any(Object),
+    );
+  });
+});
+
 describe('doStream', () => {
   beforeEach(() => {
     mockOptions = { success: true, errorValue: undefined };

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -1097,7 +1097,9 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = modelId.startsWith('arn:')
+      ? encodeURIComponent(modelId).replace(/%3A/g, ':').replace(/%2F/g, '/')
+      : encodeURIComponent(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}`;
   }
 }


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/14117

the provider applied `encodeURIComponent` to the entire ARN, encoding required : and / delimiters. Bedrock then received an invalid model identifier and returned HTTP 400.

## Summary

Preserve `:` and `/` delimiters when constructing request URLs from Bedrock ARN model IDs.

## End-to-End Verification

verified by running the following repro:

<details>
<summary>repro:</summary>

```ts
import assert from 'node:assert/strict';
import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
import { generateText } from 'ai';
import { run } from '../../lib/run';

const inferenceProfileArn =
  'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
const baseURL = 'https://bedrock-runtime.us-east-1.amazonaws.com';

run(async () => {
  let observedUrl: string | undefined;

  const bedrock = createAmazonBedrock({
    region: 'us-east-1',
    apiKey: 'dummy-token-for-url-reproduction',
    fetch: async input => {
      observedUrl =
        typeof input === 'string'
          ? input
          : input instanceof URL
            ? input.href
            : input.url;

      return new Response(
        JSON.stringify({
          output: {
            message: {
              role: 'assistant',
              content: [{ text: 'hello' }],
            },
          },
          stopReason: 'end_turn',
          usage: {
            inputTokens: 1,
            outputTokens: 1,
            totalTokens: 2,
          },
        }),
        {
          status: 200,
          headers: { 'content-type': 'application/json' },
        },
      );
    },
  });

  await generateText({
    model: bedrock(inferenceProfileArn),
    prompt: 'Say hello',
  });

  const expectedUrl = `${baseURL}/model/${inferenceProfileArn}/converse`;

  console.log(`Observed Bedrock Converse URL: ${observedUrl}`);
  console.log(`Expected ARN-preserving URL: ${expectedUrl}`);

  assert.equal(
    observedUrl,
    expectedUrl,
    'Bug reproduced: the Bedrock provider percent-encoded the inference profile ARN.',
  );
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14117