### PR TITLE
fix(openai): preserve tool_search function history

### DIFF
--- a/.changeset/calm-tools-search.md
+++ b/.changeset/calm-tools-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Fix replaying regular functions named `tool_search` as provider-defined tool search calls.

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -3318,6 +3318,62 @@ describe('convertToOpenAIResponsesInput', () => {
     });
   });
 
+  it('should serialize a function named tool_search as a function call', async () => {
+    const result = await convertToOpenAIResponsesInput({
+      toolNameMapping: testToolNameMapping,
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName: 'tool_search',
+              input: {
+                query: 'synthetic query',
+                limit: 10,
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_123',
+              toolName: 'tool_search',
+              output: { type: 'json', value: { matches: [] } },
+            },
+          ],
+        },
+      ],
+      systemMessageMode: 'system',
+      providerOptionsName: 'openai',
+      store: false,
+    });
+
+    expect(result).toEqual({
+      input: [
+        {
+          type: 'function_call',
+          call_id: 'call_123',
+          name: 'tool_search',
+          arguments: JSON.stringify({
+            query: 'synthetic query',
+            limit: 10,
+          }),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: JSON.stringify({ matches: [] }),
+        },
+      ],
+      warnings: [],
+    });
+  });
+
   describe('provider-defined tools', () => {
     it('should convert single provider-executed tool call and result into item reference with store: true', async () => {
       const result = await convertToOpenAIResponsesInput({
@@ -3367,6 +3423,7 @@ describe('convertToOpenAIResponsesInput', () => {
     it('should reconstruct hosted tool search call and output with store: false', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,
+        hasToolSearchTool: true,
         prompt: [
           {
             role: 'assistant',
@@ -3448,6 +3505,7 @@ describe('convertToOpenAIResponsesInput', () => {
     it('should use distinct item references for hosted tool search call and output with store: true', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,
+        hasToolSearchTool: true,
         prompt: [
           {
             role: 'assistant',
@@ -3514,6 +3572,7 @@ describe('convertToOpenAIResponsesInput', () => {
     it('should serialize client tool search output with call_id from tool role', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,
+        hasToolSearchTool: true,
         prompt: [
           {
             role: 'assistant',
@@ -3609,6 +3668,7 @@ describe('convertToOpenAIResponsesInput', () => {
     it('should use call_id (not item id) for client tool search call serialization', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,
+        hasToolSearchTool: true,
         prompt: [
           {
             role: 'assistant',

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -79,6 +79,7 @@ export async function convertToOpenAIResponsesInput({
   hasShellTool = false,
   hasApplyPatchTool = false,
   hasComputerTool = false,
+  hasToolSearchTool = false,
   customProviderToolNames,
 }: {
   prompt: LanguageModelV4Prompt;
@@ -95,6 +96,7 @@ export async function convertToOpenAIResponsesInput({
   hasShellTool?: boolean;
   hasApplyPatchTool?: boolean;
   hasComputerTool?: boolean;
+  hasToolSearchTool?: boolean;
   customProviderToolNames?: Set<string>;
 }): Promise<{
   input: OpenAIResponsesInput;
@@ -359,7 +361,7 @@ export async function convertToOpenAIResponsesInput({
                 part.toolName,
               );
 
-              if (resolvedToolName === 'tool_search') {
+              if (hasToolSearchTool && resolvedToolName === 'tool_search') {
                 if (store && id != null) {
                   input.push({ type: 'item_reference', id });
                   break;
@@ -580,7 +582,10 @@ export async function convertToOpenAIResponsesInput({
                 part.toolName,
               );
 
-              if (resolvedResultToolName === 'tool_search') {
+              if (
+                hasToolSearchTool &&
+                resolvedResultToolName === 'tool_search'
+              ) {
                 const itemId =
                   (
                     part.providerOptions?.[providerOptionsName] as
@@ -841,7 +846,11 @@ export async function convertToOpenAIResponsesInput({
             part.toolName,
           );
 
-          if (resolvedToolName === 'tool_search' && output.type === 'json') {
+          if (
+            hasToolSearchTool &&
+            resolvedToolName === 'tool_search' &&
+            output.type === 'json'
+          ) {
             const parsedOutput = await validateTypes({
               value: output.value,
               schema: toolSearchOutputSchema,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -349,6 +349,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
         hasShellTool: hasOpenAITool('openai.shell'),
         hasApplyPatchTool: hasOpenAITool('openai.apply_patch'),
         hasComputerTool: hasOpenAITool('openai.computer'),
+        hasToolSearchTool: hasOpenAITool('openai.tool_search'),
         customProviderToolNames:
           customProviderToolNames.size > 0
             ? customProviderToolNames


### PR DESCRIPTION
## Background

A regular function named `tool_search` is sent correctly in the initial OpenAI Responses request, but replaying its call in a later turn changes it into a provider-defined `tool_search_call`. Its ordinary function arguments no longer match that wire format, and a JSON function result is also validated against the native tool-search output schema.

## Summary

- Gate native tool-search call and output replay on the presence of the `openai.tool_search` provider tool.
- Preserve ordinary `function_call` and `function_call_output` serialization for a regular function named `tool_search`.
- Add focused regression coverage for the regular-function collision while preserving the existing hosted and client tool-search behavior.
- Add a patch changeset for `@ai-sdk/openai`.

## Contributor Credit

Thanks @guitard0g for the report and reproduction.

## End-to-End Verification

Replayed the reported two-turn flow with a regular `tool_search` function. The follow-up request retained `function_call` and `function_call_output`, including the original JSON arguments and result, while configured provider-defined tool search continued to use its native call and output forms.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17402
