### PR TITLE
feat(langchain): add lifecycle chunk options

### DIFF
--- a/.changeset/calm-rivers-stream.md
+++ b/.changeset/calm-rivers-stream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+add options to omit start and finish UI message chunks

--- a/content/providers/06-adapters/01-langchain.mdx
+++ b/content/providers/06-adapters/01-langchain.mdx
@@ -462,7 +462,7 @@ const langchainMessages = convertModelMessages(modelMessages);
 
 **Returns:** `BaseMessage[]`
 
-### `toUIMessageStream(stream)`
+### `toUIMessageStream(stream, options?)`
 
 Converts a LangChain/LangGraph stream to an AI SDK `UIMessageStream`. Automatically detects the stream type and handles direct model streams, LangGraph streams, and `streamEvents()` output.
 
@@ -492,9 +492,24 @@ return createUIMessageStreamResponse({
 });
 ```
 
+When composing the adapter output into a caller-owned `UIMessageStream`, you
+can omit the outer lifecycle chunks:
+
+```ts
+const uiMessageStream = toUIMessageStream(graphStream, {
+  sendStart: false,
+  sendFinish: false,
+});
+```
+
 **Parameters:**
 
 - `stream`: `AsyncIterable<AIMessageChunk> | ReadableStream` - LangChain model stream, LangGraph stream, or `streamEvents()` output
+- `options.sendStart`: Whether to send the message start event. Defaults to `true`.
+- `options.sendFinish`: Whether to send the finish event. Defaults to `true`.
+
+These options only control the outer message lifecycle. LangGraph `start-step`
+and `finish-step` chunks are unchanged.
 
 **Returns:** `ReadableStream<UIMessageChunk>`
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -221,14 +221,16 @@ Converts AI SDK `ModelMessage` objects to LangChain `BaseMessage` objects.
 
 **Returns:** `BaseMessage[]`
 
-### `toUIMessageStream(stream, callbacks?)`
+### `toUIMessageStream(stream, options?)`
 
 Converts a LangChain/LangGraph stream to an AI SDK `UIMessageStream`.
 
 **Parameters:**
 
 - `stream`: `AsyncIterable | ReadableStream` - A stream from LangChain `model.stream()`, LangGraph `graph.stream()`, or `streamEvents()`
-- `callbacks?`: `StreamCallbacks<TState>` - Optional lifecycle callbacks:
+- `options?`: `ToUIMessageStreamOptions<TState>` - Optional stream options and lifecycle callbacks:
+  - `sendStart` - Send the message start event. Defaults to `true`.
+  - `sendFinish` - Send the finish event. Defaults to `true`.
   - `onStart()` - Called when stream initializes
   - `onToken(token)` - Called for each token
   - `onText(text)` - Called for each text chunk
@@ -236,6 +238,9 @@ Converts a LangChain/LangGraph stream to an AI SDK `UIMessageStream`.
   - `onFinish(state)` - Called on success with LangGraph state (or `undefined` for other streams)
   - `onError(error)` - Called when stream errors
   - `onAbort()` - Called when stream is aborted
+
+`sendStart` and `sendFinish` only control the outer message lifecycle. LangGraph
+`start-step` and `finish-step` chunks are unchanged.
 
 **Returns:** `ReadableStream<UIMessageChunk>`
 

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -33,6 +33,26 @@ describe('toUIMessageStream', () => {
     expect(result[0]).toEqual({ type: 'start' });
   });
 
+  it('should omit the start event when sendStart is false', async () => {
+    const inputStream = convertArrayToReadableStream([['values', {}]]);
+
+    const result = await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { sendStart: false }),
+    );
+
+    expect(result).toEqual([{ type: 'finish' }]);
+  });
+
+  it('should omit the finish event when sendFinish is false', async () => {
+    const inputStream = convertArrayToReadableStream([['values', {}]]);
+
+    const result = await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { sendFinish: false }),
+    );
+
+    expect(result).toEqual([{ type: 'start' }]);
+  });
+
   it('should handle text streaming from messages', async () => {
     // Create actual AIMessageChunk instances
     const chunk1 = new AIMessage({ content: 'Hello', id: 'msg-1' });

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -22,7 +22,7 @@ import {
   emitSourceChunks,
 } from './utils';
 import type { LangGraphEventState } from './types';
-import type { StreamCallbacks } from './stream-callbacks';
+import type { ToUIMessageStreamOptions } from './stream-callbacks';
 
 /**
  * Converts AI SDK UIMessages to LangChain BaseMessage objects.
@@ -352,7 +352,7 @@ function isAbortError(error: unknown): boolean {
  * - streamEvents streams (from `agent.streamEvents()` or `model.streamEvents()`)
  *
  * @param stream - A stream from LangChain model.stream(), graph.stream(), or streamEvents().
- * @param callbacks - Optional callbacks for stream lifecycle events.
+ * @param options - Optional UI message stream options and lifecycle callbacks.
  * @returns A ReadableStream of UIMessageChunk objects.
  *
  * @example
@@ -402,8 +402,10 @@ function isAbortError(error: unknown): boolean {
  */
 export function toUIMessageStream<TState = unknown>(
   stream: AsyncIterable<AIMessageChunk> | ReadableStream,
-  callbacks?: StreamCallbacks<TState>,
+  options?: ToUIMessageStreamOptions<TState>,
 ): ReadableStream<UIMessageChunk> {
+  const { sendStart = true, sendFinish = true } = options ?? {};
+
   /**
    * Track text chunks for onFinal callback
    */
@@ -486,10 +488,14 @@ export function toUIMessageStream<TState = unknown>(
         /**
          * Intercept text-delta chunks for callbacks
          */
-        if (callbacks && chunk.type === 'text-delta' && chunk.delta) {
+        if (
+          (options?.onFinal || options?.onText || options?.onToken) &&
+          chunk.type === 'text-delta' &&
+          chunk.delta
+        ) {
           textChunks.push(chunk.delta);
-          callbacks.onToken?.(chunk.delta);
-          callbacks.onText?.(chunk.delta);
+          options.onToken?.(chunk.delta);
+          options.onText?.(chunk.delta);
         }
         originalController.enqueue(chunk);
       },
@@ -498,10 +504,12 @@ export function toUIMessageStream<TState = unknown>(
 
   return new ReadableStream<UIMessageChunk>({
     async start(controller) {
-      await callbacks?.onStart?.();
+      await options?.onStart?.();
 
       const wrappedController = createCallbackController(controller);
-      controller.enqueue({ type: 'start' });
+      if (sendStart) {
+        controller.enqueue({ type: 'start' });
+      }
 
       try {
         while (true) {
@@ -576,7 +584,6 @@ export function toUIMessageStream<TState = unknown>(
               id: modelState.textMessageId ?? modelState.messageId,
             });
           }
-          controller.enqueue({ type: 'finish' });
         } else if (streamType === 'langgraph') {
           /**
            * Close any open text/reasoning parts before finishing.
@@ -598,24 +605,27 @@ export function toUIMessageStream<TState = unknown>(
           if (langGraphState.currentStep !== null) {
             controller.enqueue({ type: 'finish-step' });
           }
+        }
+
+        if (streamType !== null && sendFinish) {
           controller.enqueue({ type: 'finish' });
         }
 
         /**
          * Call onFinal callback with aggregated text
          */
-        await callbacks?.onFinal?.(textChunks.join(''));
-        await callbacks?.onFinish?.(lastValuesData);
+        await options?.onFinal?.(textChunks.join(''));
+        await options?.onFinish?.(lastValuesData);
       } catch (error) {
         const errorObj =
           error instanceof Error ? error : new Error(String(error));
 
-        await callbacks?.onFinal?.(textChunks.join(''));
+        await options?.onFinal?.(textChunks.join(''));
 
         if (isAbortError(error)) {
-          await callbacks?.onAbort?.();
+          await options?.onAbort?.();
         } else {
-          await callbacks?.onError?.(errorObj);
+          await options?.onError?.(errorObj);
         }
 
         controller.enqueue({

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -9,4 +9,7 @@ export {
   type LangSmithDeploymentTransportOptions,
 } from './transport';
 
-export { type StreamCallbacks } from './stream-callbacks';
+export {
+  type StreamCallbacks,
+  type ToUIMessageStreamOptions,
+} from './stream-callbacks';

--- a/packages/langchain/src/stream-callbacks.ts
+++ b/packages/langchain/src/stream-callbacks.ts
@@ -28,6 +28,25 @@ export interface StreamCallbacks<TState = unknown> {
 }
 
 /**
+ * Options for converting a LangChain stream to an AI SDK UIMessageStream.
+ */
+export interface ToUIMessageStreamOptions<
+  TState = unknown,
+> extends StreamCallbacks<TState> {
+  /**
+   * Send the message start event.
+   * Default to true.
+   */
+  sendStart?: boolean;
+
+  /**
+   * Send the finish event.
+   * Default to true.
+   */
+  sendFinish?: boolean;
+}
+
+/**
  * Creates a transform stream that invokes callbacks during text stream processing.
  *
  * Lifecycle:


### PR DESCRIPTION
## Background

`@ai-sdk/langchain` always emits outer `start` and `finish` chunks. Consumers
that compose the adapter output into a caller-owned `UIMessageStream` therefore
have to filter duplicate lifecycle chunks themselves.

AI SDK Core already supports the same composition use case with `sendStart`
and `sendFinish`.

## Summary

- add a backward-compatible `ToUIMessageStreamOptions` type that extends the
  existing lifecycle callbacks
- add `sendStart` and `sendFinish`, both defaulting to `true`
- keep LangGraph step, text, reasoning, tool, and data chunks unchanged
- document the options and add a patch changeset
- add exact-output regression tests for each option

## Validation

- `pnpm test` in `packages/langchain` (225 Node and 225 Edge tests)
- `pnpm type-check:full`
- `pnpm check`
- `pnpm validate:docs`
- `pnpm exec turbo build --filter=@ai-sdk/langchain...`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17412
