### PR TITLE
fix(langchain): close reasoning before text

### DIFF
--- a/.changeset/fuzzy-dots-think.md
+++ b/.changeset/fuzzy-dots-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+close LangGraph reasoning before streaming text

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -715,7 +715,7 @@ describe('toUIMessageStream', () => {
     expect(startIds.has('msg_test-002')).toBe(true);
   });
 
-  it('should handle reasoning followed by text content', async () => {
+  it('should close reasoning before starting text content', async () => {
     // Reasoning chunk
     const reasoningChunk = new AIMessageChunk({
       id: 'msg-1',
@@ -754,6 +754,10 @@ describe('toUIMessageStream', () => {
         },
         {
           "id": "msg-1",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "msg-1",
           "type": "text-start",
         },
         {
@@ -764,10 +768,6 @@ describe('toUIMessageStream', () => {
         {
           "id": "msg-1",
           "type": "text-end",
-        },
-        {
-          "id": "msg-1",
-          "type": "reasoning-end",
         },
         {
           "type": "finish",

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -1504,10 +1504,16 @@ export function processLangGraphEvent(
          */
         const text = getMessageText(msg);
         if (text) {
-          const seen = messageSeen.get(msgId);
-          if (!seen?.text) {
+          const seen = getOrCreateMessageSeen(messageSeen, msgId);
+
+          if (seen.reasoning) {
+            controller.enqueue({ type: 'reasoning-end', id: msgId });
+            seen.reasoning = false;
+          }
+
+          if (!seen.text) {
             controller.enqueue({ type: 'text-start', id: msgId });
-            getOrCreateMessageSeen(messageSeen, msgId).text = true;
+            seen.text = true;
           }
 
           controller.enqueue({


### PR DESCRIPTION
## Background

The LangGraph `messages` path can emit `text-start` while the reasoning part
for the same message is still open. The resulting overlapping lifecycle differs
from the direct-model and `streamEvents` paths and can leave both parts active
in UI message consumers.

## Summary

- close an open LangGraph reasoning part before emitting `text-start`
- mark that reasoning part closed so `values` finalization does not emit a
  duplicate `reasoning-end`
- update the existing reasoning-then-text regression test to assert the exact
  lifecycle order
- add a patch changeset

No public API changes are introduced.

## Validation

- `pnpm test` in `packages/langchain` (223 Node and 223 Edge tests)
- `pnpm type-check:full`
- `pnpm check`
- `pnpm exec turbo build --filter=@ai-sdk/langchain...`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17413
