### PR TITLE
fix(harness-pi): block workspace symlink escapes in file tools

### DIFF
--- a/.changeset/warm-shrimps-destroy.md
+++ b/.changeset/warm-shrimps-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+fix(harness-pi): block workspace symlink escapes in file tools

--- a/packages/harness-pi/src/pi-paths.ts
+++ b/packages/harness-pi/src/pi-paths.ts
@@ -17,6 +17,13 @@ export interface PiPathMapper {
    * allows explicitly configured sandbox roots such as `$HOME/.agents/skills`.
    */
   toReadableSandboxPath(inputPath: string): string;
+  /** Verify that a sandbox-side path is still inside `sandboxWorkDir`. */
+  assertSandboxPath(inputPath: string): string;
+  /**
+   * Verify that a sandbox-side path is inside `sandboxWorkDir` or an
+   * explicitly configured readable root.
+   */
+  assertReadableSandboxPath(inputPath: string): string;
   /** Translate any path to its POSIX-relative form under `sandboxWorkDir`. */
   toRelativePath(inputPath: string): string;
 }
@@ -73,11 +80,34 @@ export function createPiPathMapper(
       sandboxDir: path.posix.normalize(root.sandboxDir),
     })) ?? [];
 
+  const assertWorkspaceSandboxPath = (inputPath: string): string => {
+    const normalizedInput = path.posix.normalize(inputPath);
+    if (!isInsidePosixPath(normalizedSandbox, normalizedInput)) {
+      throw new Error(`Pi path escapes the workspace: ${inputPath}`);
+    }
+    return normalizedInput;
+  };
+
+  const assertReadableSandboxPath = (inputPath: string): string => {
+    const normalizedInput = path.posix.normalize(inputPath);
+    if (
+      !isInsidePosixPath(normalizedSandbox, normalizedInput) &&
+      !readableRoots.some(root =>
+        isInsidePosixPath(root.sandboxDir, normalizedInput),
+      )
+    ) {
+      throw new Error(`Pi path escapes the readable roots: ${inputPath}`);
+    }
+    return normalizedInput;
+  };
+
   const toWorkspaceSandboxPath = (inputPath: string): string => {
     if (path.posix.isAbsolute(inputPath)) {
       const normalizedInput = path.posix.normalize(inputPath);
-      if (isInsidePosixPath(normalizedSandbox, normalizedInput)) {
-        return normalizedInput;
+      try {
+        return assertWorkspaceSandboxPath(normalizedInput);
+      } catch {
+        // Absolute host paths are handled below.
       }
     }
 
@@ -110,17 +140,20 @@ export function createPiPathMapper(
     toReadableSandboxPath(inputPath: string) {
       if (path.posix.isAbsolute(inputPath)) {
         const normalizedInput = path.posix.normalize(inputPath);
-        if (
-          isInsidePosixPath(normalizedSandbox, normalizedInput) ||
-          readableRoots.some(root =>
-            isInsidePosixPath(root.sandboxDir, normalizedInput),
-          )
-        ) {
-          return normalizedInput;
+        try {
+          return assertReadableSandboxPath(normalizedInput);
+        } catch {
+          // Absolute host paths are handled by workspace mapping below.
         }
       }
 
       return toWorkspaceSandboxPath(inputPath);
+    },
+    assertSandboxPath(inputPath: string) {
+      return assertWorkspaceSandboxPath(inputPath);
+    },
+    assertReadableSandboxPath(inputPath: string) {
+      return assertReadableSandboxPath(inputPath);
     },
     toRelativePath(inputPath: string) {
       const sandboxPath = path.posix.isAbsolute(inputPath)

--- a/packages/harness-pi/src/pi-remote-ops.test.ts
+++ b/packages/harness-pi/src/pi-remote-ops.test.ts
@@ -16,6 +16,7 @@ function makeMockSandbox(behaviors: {
     stderr?: string;
     exitCode?: number;
   };
+  realpath?: (path: string) => string | null;
   readBinary?: (path: string) => Uint8Array | null;
 }): {
   sandbox: Experimental_SandboxSession;
@@ -38,7 +39,10 @@ function makeMockSandbox(behaviors: {
         workingDirectory?: string;
       }) => {
         runCalls.push({ command, workingDirectory });
-        const result = behaviors.run?.(command) ?? {};
+        const result =
+          mockRealpathCommand(command, behaviors.realpath) ??
+          behaviors.run?.(command) ??
+          {};
         return {
           exitCode: result.exitCode ?? 0,
           stdout: result.stdout ?? '',
@@ -63,6 +67,26 @@ function makeMockSandbox(behaviors: {
   } as unknown as Experimental_SandboxSession;
 
   return { sandbox, runCalls, readCalls, writeCalls };
+}
+
+function mockRealpathCommand(
+  command: string,
+  resolvePath: ((path: string) => string | null) | undefined,
+): { stdout?: string; stderr?: string; exitCode?: number } | undefined {
+  if (!command.includes('realpath')) {
+    return undefined;
+  }
+
+  const target = command.match(/target='([^']+)'/)?.[1];
+  if (!target) {
+    return undefined;
+  }
+
+  const resolvedPath = resolvePath?.(target) ?? target;
+  if (resolvedPath === null) {
+    return { stdout: '__PI_REALPATH_NOT_FOUND__\n', exitCode: 2 };
+  }
+  return { stdout: `${resolvedPath}\n` };
 }
 
 const hostWorkDir = '/tmp/pi-test-host';
@@ -108,14 +132,33 @@ describe('createPiRemoteOps.readBuffer', () => {
     const buf = await env.ops.readBuffer(skillPath);
     expect(buf.toString('utf8')).toBe('skill');
   });
+
+  it('rejects workspace symlinks that resolve outside readable roots', async () => {
+    const outsideSecretPath = '/home/vercel-sandbox/CODEX_API_KEY';
+    const env = makeOps({
+      realpath: p =>
+        p === `${sandboxWorkDir}/repo-controlled-secret-link`
+          ? outsideSecretPath
+          : p,
+      readBinary: p =>
+        p === outsideSecretPath
+          ? new TextEncoder().encode('CODEX_API_KEY=secret')
+          : null,
+    });
+
+    await expect(
+      env.ops.readBuffer('repo-controlled-secret-link'),
+    ).rejects.toThrow(/escapes the readable roots/);
+    expect(env.readCalls).toEqual([]);
+  });
 });
 
 describe('createPiRemoteOps.writeFile', () => {
   it('mkdir -p the parent and writes via writeTextFile', async () => {
     const env = makeOps({ readBinary: () => null });
     await env.ops.writeFile('src/new.ts', 'export {};');
-    expect(env.runCalls[0]?.command).toContain('mkdir -p');
-    expect(env.runCalls[0]?.command).toContain(`'${sandboxWorkDir}/src'`);
+    expect(env.runCalls[1]?.command).toContain('mkdir -p');
+    expect(env.runCalls[1]?.command).toContain(`'${sandboxWorkDir}/src'`);
     expect(env.writeCalls).toEqual([
       { path: `${sandboxWorkDir}/src/new.ts`, content: 'export {};' },
     ]);
@@ -152,6 +195,26 @@ describe('createPiRemoteOps.writeFile', () => {
       'modify',
       'a.txt',
       expect.anything(),
+    );
+  });
+
+  it('rejects workspace symlinks that resolve outside the workspace', async () => {
+    const outsideConfigPath = '/home/vercel-sandbox/victim-config.json';
+    const env = makeOps({
+      realpath: p =>
+        p === `${sandboxWorkDir}/repo-controlled-write-link`
+          ? outsideConfigPath
+          : p,
+      readBinary: p =>
+        p === outsideConfigPath ? new TextEncoder().encode('{}') : null,
+    });
+
+    await expect(
+      env.ops.writeFile('repo-controlled-write-link', '{"owned":true}\n'),
+    ).rejects.toThrow(/escapes the workspace/);
+    expect(env.writeCalls).toEqual([]);
+    expect(env.runCalls.some(call => call.command.includes('mkdir -p'))).toBe(
+      false,
     );
   });
 });
@@ -191,7 +254,10 @@ describe('createPiRemoteOps.listDirectory', () => {
     });
     const names = await env.ops.listDirectory('.');
     expect(names).toEqual(['node_modules/', 'README.md', 'src/']);
-    expect(env.runCalls[0]?.command).toContain('ls -1Ap');
+    const cmd =
+      env.runCalls.find(call => call.command.includes('ls -1Ap'))?.command ??
+      '';
+    expect(cmd).toContain('ls -1Ap');
   });
 
   it('throws on __PI_LS_NOT_FOUND__ sentinel', async () => {
@@ -220,7 +286,8 @@ describe('createPiRemoteOps.grepFiles', () => {
     // The inner command is wrapped in `bash -lc '...'`, so its single quotes
     // get escaped to `'\''` in the outer string. We just look for the
     // signature substrings without quoting.
-    const cmd = env.runCalls[0]?.command ?? '';
+    const cmd =
+      env.runCalls.find(call => call.command.includes('grep '))?.command ?? '';
     expect(cmd).toContain('grep');
     expect(cmd).toContain('-R');
     expect(cmd).toContain('-i');
@@ -235,6 +302,27 @@ describe('createPiRemoteOps.grepFiles', () => {
     const env = makeOps({ run: () => ({ stdout: '' }) });
     const out = await env.ops.grepFiles('x', {});
     expect(out).toBe('No matches found');
+  });
+
+  it('rejects workspace symlinks before running grep outside readable roots', async () => {
+    const outsideSecretPath = '/home/vercel-sandbox/CODEX_API_KEY';
+    const env = makeOps({
+      realpath: p =>
+        p === `${sandboxWorkDir}/repo-controlled-secret-link`
+          ? outsideSecretPath
+          : p,
+      run: () => ({ stdout: 'CODEX_API_KEY=secret\n' }),
+    });
+
+    await expect(
+      env.ops.grepFiles('secret', {
+        path: 'repo-controlled-secret-link',
+        literal: true,
+      }),
+    ).rejects.toThrow(/escapes the readable roots/);
+    expect(env.runCalls.some(call => call.command.includes('grep '))).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/harness-pi/src/pi-remote-ops.ts
+++ b/packages/harness-pi/src/pi-remote-ops.ts
@@ -65,6 +65,10 @@ interface RunShellResult {
   output: Buffer;
 }
 
+function lastOutputLine(output: Buffer): string | undefined {
+  return output.toString('utf8').trim().split('\n').filter(Boolean).at(-1);
+}
+
 export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
   const runShell = async (
     command: string,
@@ -94,9 +98,83 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     };
   };
 
+  const resolveExistingSandboxPath = async (
+    remotePath: string,
+    inputPath: string,
+  ): Promise<string> => {
+    const result = await runShell(
+      [
+        `target=${shellQuote(remotePath)}`,
+        `if [ ! -e "$target" ]; then echo "__PI_REALPATH_NOT_FOUND__"; exit 2; fi`,
+        `resolved=$(realpath "$target" 2>/dev/null) || { echo "__PI_REALPATH_FAILED__"; exit 3; }`,
+        `printf '%s\\n' "$resolved"`,
+      ].join('; '),
+    );
+
+    const output = result.output.toString('utf8');
+    if (output.includes('__PI_REALPATH_NOT_FOUND__')) {
+      throw new Error(`Path not found: ${inputPath}`);
+    }
+    if (output.includes('__PI_REALPATH_FAILED__') || result.exitCode !== 0) {
+      throw new Error(`Unable to resolve path: ${inputPath}`);
+    }
+
+    const resolvedPath = lastOutputLine(result.output);
+    if (!resolvedPath) {
+      throw new Error(`Unable to resolve path: ${inputPath}`);
+    }
+    return resolvedPath;
+  };
+
+  const resolveReadableSandboxPath = async (
+    remotePath: string,
+    inputPath: string,
+  ): Promise<string> =>
+    options.paths.assertReadableSandboxPath(
+      await resolveExistingSandboxPath(remotePath, inputPath),
+    );
+
+  const resolveWritableSandboxPath = async (
+    remotePath: string,
+    inputPath: string,
+  ): Promise<string> => {
+    const result = await runShell(
+      [
+        `target=${shellQuote(remotePath)}`,
+        `if [ -e "$target" ] || [ -L "$target" ]; then resolved=$(realpath "$target" 2>/dev/null) || { echo "__PI_REALPATH_FAILED__"; exit 3; }; printf '%s\\n' "$resolved"; exit 0; fi`,
+        `dir=$(dirname "$target")`,
+        `base=$(basename "$target")`,
+        `missing="$base"`,
+        `while [ ! -e "$dir" ] && [ ! -L "$dir" ]; do parent=$(dirname "$dir"); if [ "$parent" = "$dir" ]; then echo "__PI_REALPATH_NOT_FOUND__"; exit 2; fi; missing="$(basename "$dir")/$missing"; dir="$parent"; done`,
+        `resolved_dir=$(realpath "$dir" 2>/dev/null) || { echo "__PI_REALPATH_FAILED__"; exit 3; }`,
+        `printf '%s/%s\\n' "$resolved_dir" "$missing"`,
+      ].join('; '),
+    );
+
+    const output = result.output.toString('utf8');
+    if (
+      output.includes('__PI_REALPATH_NOT_FOUND__') ||
+      output.includes('__PI_REALPATH_FAILED__') ||
+      result.exitCode !== 0
+    ) {
+      throw new Error(`Unable to resolve path: ${inputPath}`);
+    }
+
+    const resolvedPath = lastOutputLine(result.output);
+    if (!resolvedPath) {
+      throw new Error(`Unable to resolve path: ${inputPath}`);
+    }
+    return options.paths.assertSandboxPath(resolvedPath);
+  };
+
   const readBuffer = async (inputPath: string): Promise<Buffer> => {
+    const remotePath = options.paths.toReadableSandboxPath(inputPath);
+    const resolvedPath = await resolveReadableSandboxPath(
+      remotePath,
+      inputPath,
+    );
     const bytes = await options.sandbox.readBinaryFile({
-      path: options.paths.toReadableSandboxPath(inputPath),
+      path: resolvedPath,
     });
     if (!bytes) {
       throw new Error(`Path not found: ${inputPath}`);
@@ -109,12 +187,18 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     content: string,
   ): Promise<void> => {
     const remotePath = options.paths.toSandboxPath(inputPath);
-    const previous = await options.sandbox.readBinaryFile({ path: remotePath });
-    await runShell(`mkdir -p ${shellQuote(path.posix.dirname(remotePath))}`);
-    await options.sandbox.writeTextFile({ path: remotePath, content });
+    const resolvedPath = await resolveWritableSandboxPath(
+      remotePath,
+      inputPath,
+    );
+    const previous = await options.sandbox.readBinaryFile({
+      path: resolvedPath,
+    });
+    await runShell(`mkdir -p ${shellQuote(path.posix.dirname(resolvedPath))}`);
+    await options.sandbox.writeTextFile({ path: resolvedPath, content });
     options.onFileChange?.(
       previous ? 'modify' : 'create',
-      options.paths.toRelativePath(remotePath),
+      options.paths.toRelativePath(resolvedPath),
       Buffer.from(content, 'utf8'),
     );
   };
@@ -141,11 +225,15 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     limit: number = 500,
   ): Promise<string[]> => {
     const remotePath = options.paths.toReadableSandboxPath(inputPath);
+    const resolvedPath = await resolveReadableSandboxPath(
+      remotePath,
+      inputPath,
+    );
     const result = await runShell(
       [
-        `if [ ! -e ${shellQuote(remotePath)} ]; then echo "__PI_LS_NOT_FOUND__"; exit 2; fi`,
-        `if [ ! -d ${shellQuote(remotePath)} ]; then echo "__PI_LS_NOT_DIR__"; exit 3; fi`,
-        `cd ${shellQuote(remotePath)}`,
+        `if [ ! -e ${shellQuote(resolvedPath)} ]; then echo "__PI_LS_NOT_FOUND__"; exit 2; fi`,
+        `if [ ! -d ${shellQuote(resolvedPath)} ]; then echo "__PI_LS_NOT_DIR__"; exit 3; fi`,
+        `cd ${shellQuote(resolvedPath)}`,
         'ls -1Ap',
       ].join('; '),
     );
@@ -174,10 +262,14 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     limit: number = 1_000,
   ): Promise<string[]> => {
     const remotePath = options.paths.toReadableSandboxPath(inputPath);
+    const resolvedPath = await resolveReadableSandboxPath(
+      remotePath,
+      inputPath,
+    );
     const result = await runShell(
       [
-        `if [ ! -e ${shellQuote(remotePath)} ]; then echo "__PI_FIND_NOT_FOUND__"; exit 2; fi`,
-        `if [ -d ${shellQuote(remotePath)} ]; then find ${shellQuote(remotePath)} -type f -print; else printf '%s\\n' ${shellQuote(remotePath)}; fi`,
+        `if [ ! -e ${shellQuote(resolvedPath)} ]; then echo "__PI_FIND_NOT_FOUND__"; exit 2; fi`,
+        `if [ -d ${shellQuote(resolvedPath)} ]; then find ${shellQuote(resolvedPath)} -type f -print; else printf '%s\\n' ${shellQuote(resolvedPath)}; fi`,
       ].join('; '),
     );
 
@@ -186,7 +278,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
       throw new Error(`Path not found: ${inputPath}`);
     }
 
-    const searchRoot = remotePath;
+    const searchRoot = resolvedPath;
     return output
       .split('\n')
       .filter(Boolean)
@@ -218,10 +310,14 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     },
   ): Promise<string> => {
     const remotePath = options.paths.toReadableSandboxPath(input.path ?? '.');
-    const relativeTarget = options.paths.toRelativePath(remotePath);
+    const resolvedPath = await resolveReadableSandboxPath(
+      remotePath,
+      input.path ?? '.',
+    );
+    const relativeTarget = options.paths.toRelativePath(resolvedPath);
     const targetPath =
       relativeTarget.startsWith('../') || path.posix.isAbsolute(relativeTarget)
-        ? remotePath
+        ? resolvedPath
         : relativeTarget;
     const flags = [
       '-R',
@@ -237,7 +333,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     const limit = Math.max(1, input.limit ?? 100);
     const result = await runShell(
       [
-        `if [ ! -e ${shellQuote(remotePath)} ]; then echo "__PI_GREP_NOT_FOUND__"; exit 2; fi`,
+        `if [ ! -e ${shellQuote(resolvedPath)} ]; then echo "__PI_GREP_NOT_FOUND__"; exit 2; fi`,
         `cd ${shellQuote(options.paths.sandboxWorkDir)}`,
         `grep ${flags.map(shellQuote).join(' ')} -- ${shellQuote(pattern)} ${shellQuote(targetPath)} 2>/dev/null | head -n ${limit}`,
       ].join('; '),


### PR DESCRIPTION
## Background

currently, `harness-pi` validated that the requested path string was inside the sandbox workspace, but it did not resolve the sandbox-side realpath before reading, grepping, or writing. so an attacker-controlled workspace symlink could look safe, while actually pointing outside the workspace to a secret/config file.

## Summary

harness-pi now resolves the real path first and then it checks that resolved target.

## End-to-End Verification

the fix was verified against the repro in the vuln report - VULN-13166

what the repro did: 

1. Create fake workspace: sandbox-workspace/
2. Create fake secret outside it: sandbox-home/CODEX_API_KEY
3. Put a symlink inside the workspace:
```
sandbox-workspace/repo-controlled-secret-link -> sandbox-home/CODEX_API_KEY
```
4. Ask harness-pi to read repo-controlled-secret-link.

--

before the fix, `harness-pi` only checked the string path:

`sandbox-workspace/repo-controlled-secret-link`

That string looks safe because it is inside the workspace. Then the filesystem followed the symlink and leaked the outside secret. So the repro passed.
<img width="954" height="298" alt="Screenshot 2026-07-17 at 12 25 54 AM" src="https://github.com/user-attachments/assets/afede896-9ae5-4f26-be31-2624afbf901e" />


After the fix, `harness-pi` resolves the real path first:
```
sandbox-workspace/repo-controlled-secret-link
realpath -> sandbox-home/CODEX_API_KEY
```
Then it checks that resolved target. Since `sandbox-home/CODEX_API_KEY` is outside the workspace/readable roots, it throws:
`Pi path escapes the readable roots`

<img width="963" height="500" alt="Screenshot 2026-07-17 at 12 26 30 AM" src="https://github.com/user-attachments/assets/801b4943-d1f5-4651-9755-6cf3c6b4cd5e" />

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)