### PR TITLE
[v6.0] reproduction: tool.onInputAvailable can be called without onInputStart being called

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11043,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11043-tool-input-callback-order.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_11043_REPRODUCED: expected onInputStart -> onInputAvailable, observed onInputAvailable"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts
+++ b/examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts
@@ -1,0 +1,66 @@
+import { generateText, tool } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+async function main() {
+  const callbacks: string[] = [];
+
+  await generateText({
+    model: new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [
+          {
+            type: 'tool-call',
+            toolCallType: 'function',
+            toolCallId: 'call-1',
+            toolName: 'testTool',
+            input: '{"value":"ready"}',
+          },
+        ],
+        finishReason: { raw: 'tool-calls', unified: 'tool-calls' },
+        usage: {
+          inputTokens: {
+            total: 1,
+            noCache: 1,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 1,
+            text: 1,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      }),
+    }),
+    prompt: 'Call the test tool.',
+    tools: {
+      testTool: tool({
+        inputSchema: z.object({ value: z.string() }),
+        onInputStart: () => {
+          callbacks.push('onInputStart');
+        },
+        onInputAvailable: () => {
+          callbacks.push('onInputAvailable');
+        },
+      }),
+    },
+    toolChoice: 'required',
+  });
+
+  const expected = ['onInputStart', 'onInputAvailable'];
+
+  if (JSON.stringify(callbacks) !== JSON.stringify(expected)) {
+    throw new Error(
+      `ISSUE_11043_REPRODUCED: expected ${expected.join(' -> ')}, observed ${callbacks.join(' -> ') || '(no callbacks)'}`,
+    );
+  }
+
+  console.log(`Callback order: ${callbacks.join(' -> ')}`);
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

tool.onInputAvailable can be called without onInputStart being called

## Reproduction

- On the current checkout using `ai` 6.0.229, `generateText` invoked only `onInputAvailable` for a valid completed tool call.
- The expected lifecycle is `onInputStart` followed by `onInputAvailable`, including when the complete input arrives in one operation; otherwise callback state initialized by `onInputStart` is unavailable.
- The reproduction at `examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts` observed `onInputAvailable` without a preceding `onInputStart` and failed on that callback-order mismatch.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/tool

## Related Issues

Reproduces #11043