### PR TITLE
reproduction: Cannot catch errors from writeToServerResponse

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11023,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11023-write-to-server-response-error.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #11023: the caller's catch was bypassed and AI_InvalidResponseDataError became an unhandled rejection."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from 'node:events';
+import type { ServerResponse } from 'node:http';
+import { InvalidResponseDataError, pipeTextStreamToResponse } from 'ai';
+
+class MockServerResponse extends EventEmitter {
+  writeHead(): this {
+    return this;
+  }
+
+  write(): boolean {
+    return true;
+  }
+
+  end(): this {
+    return this;
+  }
+}
+
+async function main() {
+  let resolveUnhandledRejection: (reason: unknown) => void;
+  const unhandledRejection = new Promise<unknown>(resolve => {
+    resolveUnhandledRejection = resolve;
+  });
+  const onUnhandledRejection = (reason: unknown) => {
+    resolveUnhandledRejection(reason);
+  };
+  process.once('unhandledRejection', onUnhandledRejection);
+
+  const stream = new ReadableStream<string>({
+    pull() {
+      throw new InvalidResponseDataError({
+        data: { function: { arguments: '{}' } },
+        message: `Expected 'function.name' to be a string.`,
+      });
+    },
+  });
+
+  let caughtByCaller: unknown;
+  try {
+    await pipeTextStreamToResponse({
+      response: new MockServerResponse() as unknown as ServerResponse,
+      stream,
+    });
+  } catch (error) {
+    caughtByCaller = error;
+  }
+
+  const observedUnhandledRejection = await Promise.race([
+    unhandledRejection,
+    new Promise<undefined>(resolve =>
+      setTimeout(() => resolve(undefined), 250),
+    ),
+  ]);
+  process.removeListener('unhandledRejection', onUnhandledRejection);
+
+  if (caughtByCaller != null) {
+    console.log('The stream read error was caught by the caller.');
+    return;
+  }
+
+  if (
+    !InvalidResponseDataError.isInstance(observedUnhandledRejection) ||
+    observedUnhandledRejection.message !==
+      `Expected 'function.name' to be a string.`
+  ) {
+    throw new Error(
+      'The piping call returned without rejecting, but the expected unhandled AI_InvalidResponseDataError was not observed.',
+    );
+  }
+
+  throw new Error(
+    "Reproduced issue #11023: the caller's catch was bypassed and AI_InvalidResponseDataError became an unhandled rejection.",
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Cannot catch errors from `writeToServerResponse`

## Reproduction

- On the current `ai@7.0.30` checkout, `examples/ai-functions/src/reproduction/issue-11023-write-to-server-response-error.ts` shows that an awaited piping call bypasses the caller's catch and produces an unhandled `AI_InvalidResponseDataError`.
- Expected behavior is for the piping operation to reject so applications can catch stream-read failures instead of receiving unhandled rejections.
- `writeToServerResponse` returns `void` and starts its asynchronous `read()` operation without returning its promise; the public text piping helper also returns `void`.
- The issue remains present after upgrading from the reported `ai@5.0.76` to the checkout's `ai@7.0.30`.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/reference/ai-sdk-errors/ai-invalid-response-data-error

## Related Issues

Reproduces #11023