### PR TITLE
[v5.0] reproduction: @ai-sdk/xai: responses converter silently drops image parts in

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17381,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17381-xai-tool-result-image.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17381_REPRODUCED: corrected xAI request read BANANA, but generateText received \"NO_IMAGE\" after the SDK omitted the tool-result image."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts
+++ b/examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts
@@ -1,0 +1,242 @@
+import { createXai } from '../../../ai-core/node_modules/@ai-sdk/xai/dist/index.mjs';
+import {
+  generateText,
+  stepCountIs,
+  tool,
+} from '../../../ai-core/node_modules/ai/dist/index.mjs';
+import { deflateSync } from 'node:zlib';
+import { z } from '../../../ai-core/node_modules/zod/index.js';
+
+const EXPECTED_CODE = 'BANANA';
+
+const glyphs: Record<string, string[]> = {
+  A: ['01110', '10001', '10001', '11111', '10001', '10001', '10001'],
+  B: ['11110', '10001', '10001', '11110', '10001', '10001', '11110'],
+  N: ['10001', '11001', '11001', '10101', '10011', '10011', '10001'],
+};
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const typeBuffer = Buffer.from(type);
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])));
+  return Buffer.concat([length, typeBuffer, data, checksum]);
+}
+
+function createCodePng(): Buffer {
+  const width = 900;
+  const height = 260;
+  const scale = 24;
+  const glyphWidth = 5 * scale;
+  const gap = scale;
+  const textWidth =
+    EXPECTED_CODE.length * glyphWidth + (EXPECTED_CODE.length - 1) * gap;
+  const xOffset = Math.floor((width - textWidth) / 2);
+  const yOffset = Math.floor((height - 7 * scale) / 2);
+  const rows = Buffer.alloc(height * (1 + width * 3), 255);
+
+  for (let y = 0; y < height; y++) {
+    rows[y * (1 + width * 3)] = 0;
+  }
+
+  for (const [characterIndex, character] of [...EXPECTED_CODE].entries()) {
+    const glyph = glyphs[character];
+    for (const [glyphY, row] of glyph.entries()) {
+      for (const [glyphX, pixel] of [...row].entries()) {
+        if (pixel !== '1') {
+          continue;
+        }
+        for (let dy = 0; dy < scale; dy++) {
+          for (let dx = 0; dx < scale; dx++) {
+            const x =
+              xOffset +
+              characterIndex * (glyphWidth + gap) +
+              glyphX * scale +
+              dx;
+            const y = yOffset + glyphY * scale + dy;
+            const offset = y * (1 + width * 3) + 1 + x * 3;
+            rows[offset] = 0;
+            rows[offset + 1] = 0;
+            rows[offset + 2] = 0;
+          }
+        }
+      }
+    }
+  }
+
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 2;
+
+  return Buffer.concat([
+    Buffer.from('89504e470d0a1a0a', 'hex'),
+    pngChunk('IHDR', header),
+    pngChunk('IDAT', deflateSync(rows)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+function responseText(response: any): string {
+  return (response.output ?? [])
+    .flatMap((item: any) => item.content ?? [])
+    .filter((part: any) => part.type === 'output_text')
+    .map((part: any) => part.text)
+    .join('');
+}
+
+async function main() {
+  const apiKey = process.env.XAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'XAI_API_KEY is required for this live-provider reproduction',
+    );
+  }
+
+  const imageBase64 = createCodePng().toString('base64');
+  const requestBodies: any[] = [];
+  const responseBodies: any[] = [];
+  const trackedFetch: typeof fetch = async (input, init) => {
+    if (typeof init?.body === 'string') {
+      requestBodies.push(JSON.parse(init.body));
+    }
+    const response = await fetch(input, init);
+    responseBodies.push(await response.clone().json());
+    return response;
+  };
+  const xai = createXai({ apiKey, fetch: trackedFetch });
+
+  const sdkResult = await generateText({
+    model: xai.responses('grok-4.5'),
+    prompt:
+      'Call inspectImage once. Then read the exact code shown in the returned image. If no image is visible, answer exactly NO_IMAGE.',
+    tools: {
+      inspectImage: tool({
+        description: 'Returns an image containing a code that must be read.',
+        inputSchema: z.object({}),
+        execute: async () => ({ imageBase64 }),
+        toModelOutput: () => ({
+          type: 'content',
+          value: [
+            {
+              type: 'text',
+              text: 'Read the exact code in the attached image. If there is no attached image, answer exactly NO_IMAGE.',
+            },
+            {
+              type: 'media',
+              mediaType: 'image/png',
+              data: imageBase64,
+            },
+          ],
+        }),
+      }),
+    },
+    prepareStep: ({ stepNumber }) =>
+      stepNumber === 0
+        ? {
+            activeTools: ['inspectImage'],
+            toolChoice: { type: 'tool', toolName: 'inspectImage' },
+          }
+        : { activeTools: [], toolChoice: 'none' },
+    stopWhen: stepCountIs(2),
+    temperature: 0,
+    maxOutputTokens: 100,
+  });
+
+  const sdkSecondRequest = requestBodies.find(body =>
+    body.input?.some((item: any) => item.type === 'function_call_output'),
+  );
+  if (!sdkSecondRequest) {
+    throw new Error('Live SDK call did not produce a tool-result request');
+  }
+
+  const correctedRequest = structuredClone(sdkSecondRequest);
+  const correctedOutput = correctedRequest.input.find(
+    (item: any) => item.type === 'function_call_output',
+  );
+  correctedOutput.output = [
+    {
+      type: 'input_text',
+      text: 'Read the exact code in the attached image. If there is no attached image, answer exactly NO_IMAGE.',
+    },
+    {
+      type: 'input_image',
+      image_url: `data:image/png;base64,${imageBase64}`,
+    },
+  ];
+
+  const correctedHttpResponse = await fetch('https://api.x.ai/v1/responses', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(correctedRequest),
+  });
+  const correctedResponse = await correctedHttpResponse.json();
+  if (!correctedHttpResponse.ok) {
+    throw new Error(
+      `Corrected live xAI request failed with ${correctedHttpResponse.status}: ${JSON.stringify(correctedResponse)}`,
+    );
+  }
+
+  const correctedText = responseText(correctedResponse);
+  const sdkFunctionCallOutput = sdkSecondRequest.input.find(
+    (item: any) => item.type === 'function_call_output',
+  )?.output;
+
+  console.log(
+    `ISSUE_17381_LIVE_FIXTURE=${JSON.stringify({
+      model: 'grok-4.5',
+      sdkText: sdkResult.text,
+      correctedText,
+      sdkFunctionCallOutput,
+      correctedFunctionCallOutput: correctedOutput.output.map((part: any) =>
+        part.type === 'input_image'
+          ? {
+              type: 'input_image',
+              image_url: '<data:image/png;base64,...>',
+            }
+          : part,
+      ),
+      sdkFinalResponse: responseBodies.at(-1),
+      correctedResponse,
+    })}`,
+  );
+
+  if (!correctedText.includes(EXPECTED_CODE)) {
+    throw new Error(
+      `Corrected xAI request did not read ${EXPECTED_CODE}; received: ${correctedText}`,
+    );
+  }
+
+  if (sdkResult.text.includes(EXPECTED_CODE)) {
+    console.log(
+      `Issue not reproduced: the SDK-delivered tool image was read as ${EXPECTED_CODE}.`,
+    );
+    return;
+  }
+
+  console.error(
+    `ISSUE_17381_REPRODUCED: corrected xAI request read ${EXPECTED_CODE}, but generateText received "${sdkResult.text}" after the SDK omitted the tool-result image.`,
+  );
+  process.exitCode = 1;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.live.json
+++ b/packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.live.json
@@ -1,0 +1,166 @@
+{
+  "model": "grok-4.5",
+  "sdkText": "NO_IMAGE",
+  "correctedText": "BANANA",
+  "sdkFunctionCallOutput": "Read the exact code in the attached image. If there is no attached image, answer exactly NO_IMAGE.",
+  "correctedFunctionCallOutput": [
+    {
+      "type": "input_text",
+      "text": "Read the exact code in the attached image. If there is no attached image, answer exactly NO_IMAGE."
+    },
+    {
+      "type": "input_image",
+      "image_url": "<data:image/png;base64,...>"
+    }
+  ],
+  "sdkFinalResponse": {
+    "created_at": 1784267145,
+    "completed_at": 1784267145,
+    "id": "9a215677-f489-9b9f-b547-6e249ba27001",
+    "max_output_tokens": 100,
+    "model": "grok-4.5",
+    "object": "response",
+    "output": [
+      {
+        "content": [
+          {
+            "type": "output_text",
+            "text": "NO_IMAGE",
+            "logprobs": [],
+            "annotations": []
+          }
+        ],
+        "id": "msg_9a215677-f489-9b9f-b547-6e249ba27001",
+        "role": "assistant",
+        "type": "message",
+        "status": "completed"
+      }
+    ],
+    "parallel_tool_calls": true,
+    "previous_response_id": null,
+    "reasoning": {
+      "effort": "high",
+      "summary": "detailed"
+    },
+    "temperature": 0,
+    "text": {
+      "format": {
+        "type": "text"
+      }
+    },
+    "tool_choice": "auto",
+    "tools": [],
+    "top_p": 0.95,
+    "usage": {
+      "input_tokens": 267,
+      "input_tokens_details": {
+        "cached_tokens": 256
+      },
+      "output_tokens": 3,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 270,
+      "num_sources_used": 0,
+      "num_server_side_tools_used": 0,
+      "cost_in_usd_ticks": 1680000,
+      "context_details": {
+        "input_tokens": 267,
+        "output_tokens": 3
+      }
+    },
+    "user": null,
+    "incomplete_details": null,
+    "status": "completed",
+    "store": true,
+    "metadata": {
+      "system_fingerprint": "fp_a39489019fa99b6e"
+    },
+    "background": false,
+    "service_tier": "default",
+    "truncation": "disabled",
+    "top_logprobs": 0,
+    "presence_penalty": 0,
+    "frequency_penalty": 0,
+    "prompt_cache_key": null,
+    "max_tool_calls": null,
+    "safety_identifier": null,
+    "error": null,
+    "instructions": null
+  },
+  "correctedResponse": {
+    "created_at": 1784267146,
+    "completed_at": 1784267146,
+    "id": "b21fea47-0dd2-9d8c-9c51-819a18911112",
+    "max_output_tokens": 100,
+    "model": "grok-4.5",
+    "object": "response",
+    "output": [
+      {
+        "content": [
+          {
+            "type": "output_text",
+            "text": "BANANA",
+            "logprobs": [],
+            "annotations": []
+          }
+        ],
+        "id": "msg_b21fea47-0dd2-9d8c-9c51-819a18911112",
+        "role": "assistant",
+        "type": "message",
+        "status": "completed"
+      }
+    ],
+    "parallel_tool_calls": true,
+    "previous_response_id": null,
+    "reasoning": {
+      "effort": "high",
+      "summary": "detailed"
+    },
+    "temperature": 0,
+    "text": {
+      "format": {
+        "type": "text"
+      }
+    },
+    "tool_choice": "auto",
+    "tools": [],
+    "top_p": 0.95,
+    "usage": {
+      "input_tokens": 532,
+      "input_tokens_details": {
+        "cached_tokens": 128
+      },
+      "output_tokens": 2,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 534,
+      "num_sources_used": 0,
+      "num_server_side_tools_used": 0,
+      "cost_in_usd_ticks": 8840000,
+      "context_details": {
+        "input_tokens": 532,
+        "output_tokens": 2
+      }
+    },
+    "user": null,
+    "incomplete_details": null,
+    "status": "completed",
+    "store": true,
+    "metadata": {
+      "system_fingerprint": "fp_a39489019fa99b6e"
+    },
+    "background": false,
+    "service_tier": "default",
+    "truncation": "disabled",
+    "top_logprobs": 0,
+    "presence_penalty": 0,
+    "frequency_penalty": 0,
+    "prompt_cache_key": null,
+    "max_tool_calls": null,
+    "safety_identifier": null,
+    "error": null,
+    "instructions": null
+  }
+}

--- a/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
@@ -405,6 +405,54 @@ describe('convertToXaiResponsesInput', () => {
         ]
       `);
     });
+
+    it('should preserve image media in content tool output', async () => {
+      const result = await convertToXaiResponsesInput({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'inspectImage',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'text',
+                      text: 'Figure attached.',
+                    },
+                    {
+                      type: 'media',
+                      mediaType: 'image/png',
+                      data: 'base64_image_data',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: [
+            {
+              type: 'input_text',
+              text: 'Figure attached.',
+            },
+            {
+              type: 'input_image',
+              image_url: 'data:image/png;base64,base64_image_data',
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('multi-turn conversations', () => {

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -66,6 +66,90 @@ describe('XaiResponsesLanguageModel', () => {
   }
 
   describe('doGenerate', () => {
+    it('should let the model inspect an image returned by a tool', async () => {
+      const fixture = JSON.parse(
+        fs.readFileSync(
+          'src/responses/__fixtures__/issue-17381-tool-result-image.live.json',
+          'utf8',
+        ),
+      );
+      prepareJsonResponse(fixture.sdkFinalResponse);
+
+      const result = await createModel('grok-4.5').doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Read the exact code in the image returned by the tool.',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_123',
+                toolName: 'inspectImage',
+                input: {},
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'inspectImage',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'text',
+                      text: 'Read the exact code in the attached image. If there is no attached image, answer exactly NO_IMAGE.',
+                    },
+                    {
+                      type: 'media',
+                      mediaType: 'image/png',
+                      data: 'base64_image_data',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect.soft(result.content).toEqual([
+        {
+          type: 'text',
+          text: fixture.correctedText,
+        },
+      ]);
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect
+        .soft(
+          requestBody.input.find(
+            (item: { type: string }) => item.type === 'function_call_output',
+          ).output,
+        )
+        .toEqual([
+          {
+            type: 'input_text',
+            text: 'Read the exact code in the attached image. If there is no attached image, answer exactly NO_IMAGE.',
+          },
+          {
+            type: 'input_image',
+            image_url: 'data:image/png;base64,base64_image_data',
+          },
+        ]);
+    });
+
     describe('basic text generation', () => {
       it('should generate text content', async () => {
         prepareJsonResponse({


### PR DESCRIPTION
## Bug

@ai-sdk/xai: responses converter silently drops image parts in tool results (xAI API supports them)

## Reproduction

- Live `generateText` with `xai.responses('grok-4.5')` returned `NO_IMAGE`; the equivalent corrected xAI request preserved the image and returned `BANANA`.
- Expected behavior is for tool-result image media to become an `input_image` part in `function_call_output`, allowing Grok to inspect it.
- `examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts` and `examples/ai-functions/package.json` provide the runnable live reproduction.
- `packages/xai/src/responses/__fixtures__/issue-17381-tool-result-image.live.json` records the failing SDK response and successful corrected response.
- `packages/xai/src/responses/convert-to-xai-responses-input.test.ts` and `packages/xai/src/responses/xai-responses-language-model.test.ts` demonstrate that only tool-result text is sent and the model consequently returns `NO_IMAGE` instead of `BANANA`.
- The checkout contains `@ai-sdk/xai@2.0.80`; its tool-result type supports inline base64 media but cannot represent the separately reported image-URL variant.

## Relevant Documentation

- https://docs.x.ai/developers/tools/function-calling
- https://docs.x.ai/developers/model-capabilities/images/understanding

## Related Issues

Reproduces #17381