### PR TITLE
reproduction: @ai-sdk/langchain: close LangGraph reasoning before text starts

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17413,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17413 REPRODUCED: reasoning and text lifecycles overlap; observed reasoning-start -> reasoning-delta -> text-start -> text-delta -> text-end -> reasoning-end"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts
+++ b/examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts
@@ -1,0 +1,56 @@
+import { AIMessageChunk } from '../../../../packages/langchain/node_modules/@langchain/core/messages';
+import { toUIMessageStream } from '../../../../packages/langchain/dist/index.js';
+
+async function main() {
+  const reasoning = new AIMessageChunk({
+    id: 'message-1',
+    content: [{ type: 'reasoning', reasoning: 'Thinking...' }],
+  });
+
+  const text = new AIMessageChunk({
+    id: 'message-1',
+    content: 'Answer',
+  });
+
+  const input = new ReadableStream({
+    start(controller) {
+      controller.enqueue(['messages', [reasoning]]);
+      controller.enqueue(['messages', [text]]);
+      controller.enqueue(['values', {}]);
+      controller.close();
+    },
+  });
+
+  const chunks = [];
+  const reader = toUIMessageStream(input).getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const lifecycle = chunks
+    .map(chunk => chunk.type)
+    .filter(type => type !== 'start' && type !== 'finish');
+  const expected = [
+    'reasoning-start',
+    'reasoning-delta',
+    'reasoning-end',
+    'text-start',
+    'text-delta',
+    'text-end',
+  ];
+
+  if (lifecycle.join(',') !== expected.join(',')) {
+    throw new Error(
+      `ISSUE #17413 REPRODUCED: reasoning and text lifecycles overlap; observed ${lifecycle.join(
+        ' -> ',
+      )}; expected ${expected.join(' -> ')}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

@ai-sdk/langchain: close LangGraph reasoning before text starts

## Reproduction

- Reproduction artifact `examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts` observes `reasoning-start → reasoning-delta → text-start → text-delta → text-end → reasoning-end`.
- The expected lifecycle is `reasoning-start → reasoning-delta → reasoning-end → text-start → text-delta → text-end`, preventing reasoning and text parts from being active simultaneously.
- The current checkout uses `@ai-sdk/langchain` 3.0.30 with compatible `@langchain/core` 1.1.46 and `@langchain/langgraph` 1.3.0, ruling out the reported setup being an unsupported version combination.
- `packages/langchain/src/adapter.test.ts` records the same overlapping lifecycle, while the direct-model and `streamEvents` paths close reasoning before starting text.

## Relevant Documentation

- https://docs.langchain.com/oss/javascript/langgraph/streaming
- https://reference.langchain.com/javascript/langchain-core/messages/AIMessageChunk
- https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol

## Related Issues

Reproduces #17413