### PR TITLE
[v6.0] reproduction: could not reproduce user-denied tool approval never reaches output-denied — tool

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-17136-denied-tool-approval.ts
+++ b/examples/ai-functions/src/reproduction/issue-17136-denied-tool-approval.ts
@@ -1,0 +1,274 @@
+import {
+  AbstractChat,
+  type ChatInit,
+  type ChatState,
+  type ChatStatus,
+  type ChatTransport,
+  DirectChatTransport,
+  isToolUIPart,
+  ToolLoopAgent,
+  type ToolUIPart,
+  type UIMessage,
+  type UIMessageChunk,
+  tool,
+} from 'ai';
+import { convertArrayToReadableStream, MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+const failureSignal =
+  'ISSUE #17136 REPRODUCED: denied tool part remained approval-responded after resubmission; expected output-denied';
+
+class MemoryChatState implements ChatState<UIMessage> {
+  status: ChatStatus = 'ready';
+  error: Error | undefined;
+  messages: UIMessage[] = [];
+
+  pushMessage = (message: UIMessage) => {
+    this.messages.push(message);
+  };
+
+  popMessage = () => {
+    this.messages.pop();
+  };
+
+  replaceMessage = (index: number, message: UIMessage) => {
+    this.messages[index] = message;
+  };
+
+  snapshot = <T>(value: T): T => structuredClone(value);
+}
+
+class MemoryChat extends AbstractChat<UIMessage> {
+  constructor(init: ChatInit<UIMessage>) {
+    super({ ...init, state: new MemoryChatState() });
+  }
+}
+
+function usage() {
+  return {
+    inputTokens: {
+      total: 1,
+      noCache: 1,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: 1,
+      text: 1,
+      reasoning: undefined,
+    },
+  };
+}
+
+function textResponse(text: string) {
+  return [
+    { type: 'text-start' as const, id: 'text-1' },
+    { type: 'text-delta' as const, id: 'text-1', delta: text },
+    { type: 'text-end' as const, id: 'text-1' },
+    {
+      type: 'finish' as const,
+      finishReason: { unified: 'stop' as const, raw: 'stop' },
+      usage: usage(),
+    },
+  ];
+}
+
+function toolCallResponse() {
+  return [
+    {
+      type: 'tool-call' as const,
+      toolCallType: 'function' as const,
+      toolCallId: 'call-1',
+      toolName: 'delete_file',
+      input: JSON.stringify({ path: '/tmp/x' }),
+    },
+    {
+      type: 'finish' as const,
+      finishReason: {
+        unified: 'tool-calls' as const,
+        raw: 'tool-calls',
+      },
+      usage: usage(),
+    },
+  ];
+}
+
+function findToolPart(messages: UIMessage[]): ToolUIPart | undefined {
+  for (const part of messages.flatMap(message => message.parts)) {
+    if (
+      isToolUIPart(part) &&
+      part.type === 'tool-delete_file' &&
+      part.toolCallId === 'call-1'
+    ) {
+      return part;
+    }
+  }
+
+  return undefined;
+}
+
+async function runScenario(approved: boolean) {
+  let modelSawExecutionDenied = false;
+  const onFinishSnapshots: UIMessage[][] = [];
+  const wireChunksByRequest: UIMessageChunk[][] = [];
+
+  const model = new MockLanguageModelV3({
+    doStream: async ({ prompt }) => {
+      const serializedPrompt = JSON.stringify(prompt);
+      modelSawExecutionDenied ||= serializedPrompt.includes('execution-denied');
+
+      const responseParts = serializedPrompt.includes('execution-denied')
+        ? textResponse('Understood, I will not delete the file.')
+        : serializedPrompt.includes('deleted /tmp/x')
+          ? textResponse('The file was deleted.')
+          : toolCallResponse();
+
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          {
+            type: 'response-metadata' as const,
+            id: 'response-1',
+            modelId: 'mock-model',
+            timestamp: new Date(0),
+          },
+          ...responseParts,
+        ]),
+      };
+    },
+  });
+
+  const agent = new ToolLoopAgent({
+    model,
+    tools: {
+      delete_file: tool({
+        description: 'Delete a file',
+        inputSchema: z.object({ path: z.string() }),
+        execute: async ({ path }) => `deleted ${path}`,
+        needsApproval: true,
+      }),
+    },
+  });
+
+  const directTransport = new DirectChatTransport({ agent });
+  const recordingTransport: ChatTransport<UIMessage> = {
+    sendMessages: async options => {
+      const chunks: UIMessageChunk[] = [];
+      wireChunksByRequest.push(chunks);
+      const stream = await directTransport.sendMessages(
+        options as Parameters<typeof directTransport.sendMessages>[0],
+      );
+
+      return stream.pipeThrough(
+        new TransformStream<UIMessageChunk, UIMessageChunk>({
+          transform(chunk, controller) {
+            chunks.push(structuredClone(chunk));
+            controller.enqueue(chunk);
+          },
+        }),
+      );
+    },
+    reconnectToStream: async () => null,
+  };
+
+  const chat = new MemoryChat({
+    transport: recordingTransport,
+    onFinish: ({ messages }) => {
+      onFinishSnapshots.push(structuredClone(messages));
+    },
+  });
+
+  await chat.sendMessage({ text: 'Please delete /tmp/x' });
+  const stateAfterTurn1 = findToolPart(chat.messages)?.state;
+  const approvalId = findToolPart(chat.messages)?.approval?.id;
+
+  if (approvalId == null) {
+    throw new Error('Reproduction setup failed: approval id was not emitted');
+  }
+
+  await chat.addToolApprovalResponse({
+    id: approvalId,
+    approved,
+    reason: approved ? 'user approved' : 'user declined',
+  });
+  const stateAfterResponse = findToolPart(chat.messages)?.state;
+
+  await chat.sendMessage();
+
+  return {
+    stateAfterTurn1,
+    stateAfterResponse,
+    finalState: findToolPart(chat.messages)?.state,
+    persistedFinalState: findToolPart(onFinishSnapshots.at(-1) ?? [])?.state,
+    secondRequestWireChunks: wireChunksByRequest.at(-1) ?? [],
+    modelSawExecutionDenied,
+    finalText: chat.messages
+      .at(-1)
+      ?.parts.filter(part => part.type === 'text')
+      .map(part => part.text)
+      .join(''),
+  };
+}
+
+async function main() {
+  const denied = await runScenario(false);
+  const approved = await runScenario(true);
+
+  console.log('denied scenario:', JSON.stringify(denied, null, 2));
+  console.log('approved final state:', approved.finalState);
+
+  if (denied.stateAfterTurn1 !== 'approval-requested') {
+    throw new Error(
+      `Reproduction setup failed: first state was ${denied.stateAfterTurn1}`,
+    );
+  }
+
+  if (denied.stateAfterResponse !== 'approval-responded') {
+    throw new Error(
+      `Reproduction setup failed: local denial state was ${denied.stateAfterResponse}`,
+    );
+  }
+
+  if (!denied.modelSawExecutionDenied) {
+    throw new Error(
+      'Reproduction setup failed: model did not receive execution-denied',
+    );
+  }
+
+  if (denied.finalText !== 'Understood, I will not delete the file.') {
+    throw new Error(
+      `Reproduction setup failed: model response was ${denied.finalText}`,
+    );
+  }
+
+  if (approved.finalState !== 'output-available') {
+    throw new Error(
+      `Control failed: approved tool state was ${approved.finalState}`,
+    );
+  }
+
+  const emittedDeniedChunk = denied.secondRequestWireChunks.some(
+    chunk => chunk.type === 'tool-output-denied',
+  );
+
+  if (
+    denied.finalState === 'approval-responded' &&
+    denied.persistedFinalState === 'approval-responded' &&
+    !emittedDeniedChunk
+  ) {
+    throw new Error(failureSignal);
+  }
+
+  if (denied.finalState !== 'output-denied') {
+    throw new Error(
+      `Unexpected denied tool state: ${denied.finalState}; expected output-denied`,
+    );
+  }
+
+  console.log('Issue #17136 did not reproduce.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

user-denied tool approval never reaches `output-denied` — tool part stuck in `approval-responded` (synthetic execution-denied result defeats collectToolApprovals)

## Reproduction

- Added `examples/ai-functions/src/reproduction/issue-17136-denied-tool-approval.ts`; on the target checkout, denial emits `tool-output-denied` and both UI and persisted states become the expected `output-denied` rather than remaining `approval-responded`.
- The model received `execution-denied` and responded correctly, while the approved control reached `output-available`.
- An isolated comparison with the reported `ai@7.0.22` reproduced the stale `approval-responded` state, but the target checkout (`ai@6.0.229`) no longer exhibits the bug; this conclusion applies to the checked-out branch.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-tool-usage
- https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat
- https://ai-sdk.dev/docs/reference/ai-sdk-core/model-message

## Related Issues

Could not reproduce #17136