### PR TITLE
[v6.0] fix: preserve Anthropic web search citations across multi-turn assistant message replay

### DIFF
--- a/.changeset/lucky-mice-cite.md
+++ b/.changeset/lucky-mice-cite.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): preserve web search citations when replaying assistant messages

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -1477,6 +1477,19 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > web search tool > with fi
     "type": "text",
   },
   {
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Daily Tech News 26 September 2024 · Top Story Caroline Ellison, Sam Bankman-Fried&#x27;s right-hand woman in the FTX kerfuffle, has been sentenced to ...",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDDULr5oJyZTXVnDn8RoMK4nGlIB5/8KPBQftIjBoGwKgdBO0xPobCWf4FMQZeJZTexZ2PVubA2Jakj1ei+PHwsUHeXLU+KWVSskeWpEqE9LEcU8cVMZsafx5pIdH1s4Fzo8YBA==",
+            "title": "Daily Tech News 26 September 2024",
+            "type": "web_search_result_location",
+            "url": "https://acecomments.mu.nu/?post=411647",
+          },
+        ],
+      },
+    },
     "text": "Caroline Ellison, Sam Bankman-Fried's right-hand woman in the FTX kerfuffle, has been sentenced to two years in prison for her part in the fuffling and ordered to pay $11 billion in restitution.",
     "type": "text",
   },
@@ -1503,6 +1516,19 @@ Unfortunately, the search results don't show many other specific breaking tech n
     "type": "text",
   },
   {
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Date: August 26, 2025 Summary: Anthropic has launched a Chrome extension enabling its Claude AI agent to interact directly with the browser, manipulat...",
+            "encrypted_index": "EpMBCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDH/NVmfefWyzakcthBoMkqoT8aytDBV0FvAFIjClSipbNID/zEFscAaakdLn5Z6i5W8sJbYqg4XzUNd6572B59pBEvD8haJbwNgojhoqF8z5/oae4RSDzdKPWa4FX1t3q5E8tYfPGAQ=",
+            "title": "The Latest AI News and AI Breakthroughs that Matter Most: 2025 | News",
+            "type": "web_search_result_location",
+            "url": "https://www.crescendo.ai/news/latest-ai-news-and-updates",
+          },
+        ],
+      },
+    },
     "text": "Anthropic has launched a Chrome extension enabling its Claude AI agent to interact directly with the browser, manipulating webpages, retrieving content, and automating tasks. This marks the company's first move toward agentic AI with real-time web control.",
     "type": "text",
   },
@@ -1526,6 +1552,19 @@ Unfortunately, the search results don't show many other specific breaking tech n
     "type": "text",
   },
   {
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Date: September 19, 2025 Summary: Chinese AI firm DeepSeek has unveiled its R1 model, a significant leap in AI performance trained at a cost 70% lower...",
+            "encrypted_index": "EpMBCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDBWUYk1OFyII3dq4JRoM0dCF2bTcT1OwCwSqIjBvViA7Pv/gvLgQlu7pNnhAHjHaThPZ1V7eor1hdefQF/ibzwrZ5o6VFZrPznm3pbEqF8cYd5F85vVDLY++URAQ//xwtev9Lt3kGAQ=",
+            "title": "The Latest AI News and AI Breakthroughs that Matter Most: 2025 | News",
+            "type": "web_search_result_location",
+            "url": "https://www.crescendo.ai/news/latest-ai-news-and-updates",
+          },
+        ],
+      },
+    },
     "text": "Chinese AI firm DeepSeek has unveiled its R1 model, a significant leap in AI performance trained at a cost 70% lower than comparable U.S. models. The company attributes its efficiency to custom hardware, proprietary optimization techniques, and low energy costs in China. Analysts see this as a direct challenge to Western dominance in large language models, especially OpenAI and Anthropic.",
     "type": "text",
   },
@@ -18054,6 +18093,33 @@ exports[`AnthropicMessagesLanguageModel > doStream > web search tool > should st
   },
   {
     "id": "3",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Apple today announced the grand reopening of Apple Ginza on Friday, September 26, located in the vibrant Ginza district.",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDN+3yPep8hrW9WwANxoMO/sEZvNTf/xpoyVuIjDRoNaRlBo0z68VAiTpUeOWF+P5edPT3/3i60mbhvTMOTWMAyGiNjnSf0/ceg9FvmcqE5T//6pWT15OO5PH9g/jQaotEHkYBA==",
+            "title": "The all-new Apple Ginza opens this Friday, September 26, in Tokyo - Apple",
+            "type": "web_search_result_location",
+            "url": "https://www.apple.com/newsroom/2025/09/the-all-new-apple-ginza-opens-this-friday-september-26-in-tokyo/",
+          },
+          {
+            "cited_text": "TOKYO Apple today announced the grand reopening of Apple Ginza on Friday, September 26, located in the vibrant Ginza district where Apple’s retail jou...",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDPhQNm231kpbwvo5GxoM7h/deBh9okrXVy+0IjCF8Fu6pVDoxH5kEHYnDxHcXjYGxUWsqPa7zWJj63JvpbcAnqR54Fuu/j7sEf52c3gqE4+wq/aNt50hD3nwsq0nGX7XZFoYBA==",
+            "title": "The all-new Apple Ginza opens this Friday, September 26, in Tokyo - Apple",
+            "type": "web_search_result_location",
+            "url": "https://www.apple.com/newsroom/2025/09/the-all-new-apple-ginza-opens-this-friday-september-26-in-tokyo/",
+          },
+          {
+            "cited_text": "Apple Ginza opens to customers Friday, September 26, at 10 a.m. JST. ",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDLbB+GC68MPUyjdjEBoMxbiOu598WzwdiRCJIjAAhTSlAu9Es/ErWBtEgie/Mp5VktMqh/JvZ//uprZEXDRnbmLUPROzgt7MC+BHPFcqE4mv+hJs7CQQtjFEovk32MFh4QIYBA==",
+            "title": "The all-new Apple Ginza opens this Friday, September 26, in Tokyo - Apple",
+            "type": "web_search_result_location",
+            "url": "https://www.apple.com/newsroom/2025/09/the-all-new-apple-ginza-opens-this-friday-september-26-in-tokyo/",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18126,6 +18192,26 @@ exports[`AnthropicMessagesLanguageModel > doStream > web search tool > should st
   },
   {
     "id": "5",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Opened in 2003 as Apple’s first store outside the U.S., Apple Ginza now returns in an all-new four-story design that brings together the best of Apple...",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDInhmZCA7JQw90CQiBoMZdhuGlh0urSfikIlIjAOfQluExdSLykntVUY5/QUlAIPpun6DAqXn9jxHbTB/GTMr7QuGMGbT+5fwdMk/U0qEwvQELJf9hlOYKENgMoheizRBfgYBA==",
+            "title": "The all-new Apple Ginza opens this Friday, September 26, in Tokyo - Apple",
+            "type": "web_search_result_location",
+            "url": "https://www.apple.com/newsroom/2025/09/the-all-new-apple-ginza-opens-this-friday-september-26-in-tokyo/",
+          },
+          {
+            "cited_text": "Opened in 2003 as Apple’s first store outside the U.S., Apple Ginza now returns in an all-new four-story design that brings together the best of Apple...",
+            "encrypted_index": "EpABCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDPdYUCIhgQkfi58EphoMC8P48MQ3sQFlcnfKIjDPwLNXEt13Rqsgkakpa0pFH+se7uElXxWFBumPnCSJebZSZBCdBelu8VeP32khIMAqFLCf9j+bfA9UCuOfz3TCRcqVUYbnGAQ=",
+            "title": "The all-new Apple Ginza opens this Friday, September 26, in Tokyo - Apple",
+            "type": "web_search_result_location",
+            "url": "https://www.apple.com/newsroom/2025/09/the-all-new-apple-ginza-opens-this-friday-september-26-in-tokyo/",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18193,6 +18279,19 @@ exports[`AnthropicMessagesLanguageModel > doStream > web search tool > should st
   },
   {
     "id": "7",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Apple is considering building a pilot production line for a foldable iPhone in Taiwan, with plans to launch the new foldable iPhone in 2026. Currently...",
+            "encrypted_index": "EpEBCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDN9RRNtj1Qp6RaNu1xoM99Hpd9h5/iiAHVV1IjACHitA/CndYvvQF5mFfD37nMJCc2Dt9+WarXhj7MOp0SULX1XGU/UsFAkp+LFUxWwqFUTSJ7/UKDtvO7kikg9WL6iVvVicxhgE",
+            "title": "Fang Junyu's Technology Weekly - September 26, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/junyu_fang_a216509a97501d/fang-junyus-technology-weekly-september-26-2025-2ndd",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18279,6 +18378,19 @@ exports[`AnthropicMessagesLanguageModel > doStream > web search tool > should st
   },
   {
     "id": "9",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "OpenAI launches ChatGPT Pulse, proactively writing your morning briefing. OpenAI is rolling out a new feature in ChatGPT called Pulse, which generates...",
+            "encrypted_index": "EpMBCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDLi26WjvZzuqNWkZGBoMN2xRMzTInXpgc+N0IjBV5WkXoe+qIbxhn3ZuE4vKJxW1DxkaVK1FOzOsZl5XK9Wl2IRhbEGLpqKsJF2uSNgqF8CAJjYkYVTQUPqU4JKD7jE6ZgE6NwvhGAQ=",
+            "title": "Fang Junyu's Technology Weekly - September 26, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/junyu_fang_a216509a97501d/fang-junyus-technology-weekly-september-26-2025-2ndd",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18345,6 +18457,26 @@ exports[`AnthropicMessagesLanguageModel > doStream > web search tool > should st
   },
   {
     "id": "11",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "On September 25, 2025, headlines were dominated by seismic shifts in AI infrastructure, potential blockbuster partnerships between legacy chip giants,...",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDOQ/NQu+nnBHHIkVuhoMXqvV+iEabI/JvCcEIjDan9SLf1kUDEjapUM3Tstq5f3nrHJSMRj+XdWWzrlUVfLX4K6afVpgOK6pZzKJ8/4qEwZgT6oJF/sGnrdCPAA8mlKGdxkYBA==",
+            "title": "📰 Major Tech News: September 25, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/om_shree_0709/major-tech-news-september-25-2025-5h38",
+          },
+          {
+            "cited_text": "On September 25, 2025, headlines were dominated by seismic shifts in AI infrastructure, potential blockbuster partnerships between legacy chip giants,...",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDPTNFSUt4rkCaRmBiBoM8HcdQPJstID+PCGGIjBLhIRYpaD2k2EGRa++jM2pLq1TF7VFh2pj20i5gpPW7qKG8awi0bxnbUHJh6kI7hcqE63MfpB43d2a081kYEEtnpCMjDkYBA==",
+            "title": "📰 Major Tech News: September 25, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/om_shree_0709/major-tech-news-september-25-2025-5h38",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18392,6 +18524,19 @@ Key highlights include:
   },
   {
     "id": "13",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Microsoft shook up its AI stack by integrating Anthropic's models into Copilot for Microsoft 365, reducing OpenAI dependency and boosting productivity...",
+            "encrypted_index": "EpABCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDAC88THJtPYWws/AnRoM9vnyF6Cv1kG0w+zfIjABi6xlH9yl/cfwW1kVKxEww0QSITFKBixiNoGIEoEOPy/unW0Jt1KgaQ5X8sdVDBwqFB1AfiWedfrXpRtEghZYy+a3LIanGAQ=",
+            "title": "📰 Major Tech News: September 25, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/om_shree_0709/major-tech-news-september-25-2025-5h38",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18432,6 +18577,19 @@ Key highlights include:
   },
   {
     "id": "15",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Oracle followed with a $15 billion bond raise for cloud expansion, riding AI demand waves. ",
+            "encrypted_index": "EpABCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDFusGSC0EOZjZBGgARoMfOwWDOch04HX9MVdIjBZ3DN9EtoEgYz3dKM+oRWK2bhrg/5/O0JBbumO0HMXLjwnoFzD25fvVr3ic1VLcB8qFL0kqPObH+ugPBuuh8a/3gCs5xApGAQ=",
+            "title": "📰 Major Tech News: September 25, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/om_shree_0709/major-tech-news-september-25-2025-5h38",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18477,6 +18635,19 @@ Key highlights include:
   },
   {
     "id": "17",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "Google launched Mixboard, an AI mood board app with Gemini-powered suggestions for designers, and rolled conversational editing to more Android phones...",
+            "encrypted_index": "EpABCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDKTAT7cc6BiCx6BdmRoMkVcS4u/F+dWR3K8bIjCBixw1ZX30TadhFVj+NE2sUZLJjkKxJtNtYPIyQBhIpZoOhTIvkp2lsbwkzR/CtWMqFIABgH01yvhMEvw4JGr9mx6g+XhBGAQ=",
+            "title": "📰 Major Tech News: September 25, 2025 - Future",
+            "type": "web_search_result_location",
+            "url": "https://future.forem.com/om_shree_0709/major-tech-news-september-25-2025-5h38",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {
@@ -18547,6 +18718,26 @@ Key highlights include:
   },
   {
     "id": "19",
+    "providerMetadata": {
+      "anthropic": {
+        "citations": [
+          {
+            "cited_text": "With iOS 26 officially launched, Apple is moving forward with iOS 26.1. ",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDIPB/AN3fJlbLwK8RhoMuar7jkDtGlWf2zAqIjDhSubMgOqlu9mQga+JzkQPW2Kq/+Lc2PPJarWoWOwpvAhd0wEkDbe+tvffGYUvH0gqE2r0uwM2Ab9FL7pYWlhK9dXq7NYYBA==",
+            "title": "Apple releases first iOS 26.1 developer beta for iPhone - 9to5Mac",
+            "type": "web_search_result_location",
+            "url": "https://9to5mac.com/2025/09/22/ios-26-1-beta-1/",
+          },
+          {
+            "cited_text": "Apple released iOS 26 on September 15, bringing the Liquid Glass redesign to the iPhone. ",
+            "encrypted_index": "Eo8BCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDKwFwl13npJwcmRCphoM51Qmc4OrGRffab8VIjD6jLriOpBhiA1tmErisXQlR3pDvzabIE/sUXyiW8bv5d+URlUm8GQRQOGdMY82kscqE7REcFDzGjDki9CZFMNYpjMkKXIYBA==",
+            "title": "Apple releases first iOS 26.1 developer beta for iPhone - 9to5Mac",
+            "type": "web_search_result_location",
+            "url": "https://9to5mac.com/2025/09/22/ios-26-1-beta-1/",
+          },
+        ],
+      },
+    },
     "type": "text-end",
   },
   {

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -66,6 +66,7 @@ export interface AnthropicCompactionContent {
 export interface AnthropicTextContent {
   type: 'text';
   text: string;
+  citations?: Citation[];
   cache_control: AnthropicCacheControl | undefined;
 }
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -873,7 +873,22 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       switch (part.type) {
         case 'text': {
           if (!usesJsonResponseTool) {
-            content.push({ type: 'text', text: part.text });
+            const webSearchCitations = part.citations?.filter(
+              citation => citation.type === 'web_search_result_location',
+            );
+
+            content.push({
+              type: 'text',
+              text: part.text,
+              ...(webSearchCitations != null &&
+                webSearchCitations.length > 0 && {
+                  providerMetadata: {
+                    anthropic: {
+                      citations: webSearchCitations,
+                    },
+                  },
+                }),
+            });
 
             // Process citations if present
             if (part.citations) {
@@ -1456,7 +1471,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             toolId?: string;
           };
         }
-      | { type: 'text' | 'reasoning' }
+      | { type: 'text'; citations: Citation[] }
+      | { type: 'reasoning' }
     > = {};
     const mcpToolCalls: Record<string, LanguageModelV3ToolCall> = {};
     const serverToolCalls: Record<string, string> = {}; // tool_use_id -> provider tool name
@@ -1538,7 +1554,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                     return;
                   }
 
-                  contentBlocks[value.index] = { type: 'text' };
+                  contentBlocks[value.index] = {
+                    type: 'text',
+                    citations: [],
+                  };
                   controller.enqueue({
                     type: 'text-start',
                     id: String(value.index),
@@ -1570,7 +1589,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                 }
 
                 case 'compaction': {
-                  contentBlocks[value.index] = { type: 'text' };
+                  contentBlocks[value.index] = {
+                    type: 'text',
+                    citations: [],
+                  };
                   controller.enqueue({
                     type: 'text-start',
                     id: String(value.index),
@@ -1590,7 +1612,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                   if (isJsonResponseTool) {
                     isJsonResponseFromTool = true;
 
-                    contentBlocks[value.index] = { type: 'text' };
+                    contentBlocks[value.index] = {
+                      type: 'text',
+                      citations: [],
+                    };
 
                     controller.enqueue({
                       type: 'text-start',
@@ -2049,6 +2074,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                     controller.enqueue({
                       type: 'text-end',
                       id: String(value.index),
+                      ...(contentBlock.citations.length > 0 && {
+                        providerMetadata: {
+                          anthropic: {
+                            citations: contentBlock.citations,
+                          },
+                        },
+                      }),
                     });
                     break;
                   }
@@ -2239,6 +2271,15 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
                 case 'citations_delta': {
                   const citation = value.delta.citation;
+                  const contentBlock = contentBlocks[value.index];
+
+                  if (
+                    contentBlock?.type === 'text' &&
+                    citation.type === 'web_search_result_location'
+                  ) {
+                    contentBlock.citations.push(citation);
+                  }
+
                   const source = createCitationSource(
                     citation,
                     citationDocuments,

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -883,7 +883,7 @@ describe('tool messages', () => {
 
 describe('assistant messages', () => {
   it('should preserve citations on assistant text', async () => {
-    const result = await convertToAnthropicPrompt({
+    const result = await convertToAnthropicMessagesPrompt({
       prompt: [
         {
           role: 'assistant',

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -882,6 +882,76 @@ describe('tool messages', () => {
 });
 
 describe('assistant messages', () => {
+  it('should preserve citations on assistant text', async () => {
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'The Federal Reserve held rates steady.',
+              providerOptions: {
+                anthropic: {
+                  citations: [
+                    {
+                      type: 'web_search_result_location',
+                      cited_text: 'The Committee decided to maintain the rate.',
+                      url: 'https://example.com/fed-decision',
+                      title: 'Federal Reserve decision',
+                      encrypted_index: 'encrypted-index',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What happened before that?' }],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result.prompt.messages).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "cache_control": undefined,
+              "citations": [
+                {
+                  "cited_text": "The Committee decided to maintain the rate.",
+                  "encrypted_index": "encrypted-index",
+                  "title": "Federal Reserve decision",
+                  "type": "web_search_result_location",
+                  "url": "https://example.com/fed-decision",
+                },
+              ],
+              "text": "The Federal Reserve held rates steady.",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "cache_control": undefined,
+              "text": "What happened before that?",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should remove trailing whitespace from last assistant message when there is no further user message', async () => {
     const result = await convertToAnthropicMessagesPrompt({
       prompt: [

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -23,8 +23,14 @@ import {
   type AnthropicToolResultContent,
   type AnthropicUserMessage,
   type AnthropicWebFetchToolResultContent,
+<<<<<<< HEAD:packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
 } from './anthropic-messages-api';
 import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
+=======
+  type Citation,
+} from './anthropic-api';
+import { anthropicFilePartProviderOptions } from './anthropic-language-model-options';
+>>>>>>> afcf19c40 (fix: preserve Anthropic web search citations across multi-turn assistant message replay (#17398)):packages/anthropic/src/convert-to-anthropic-prompt.ts
 import { CacheControlValidator } from './get-cache-control';
 import { advisor_20260301OutputSchema } from './tool/advisor_20260301';
 import { codeExecution_20250522OutputSchema } from './tool/code-execution_20250522';
@@ -507,7 +513,7 @@ export async function convertToAnthropicMessagesPrompt({
               case 'text': {
                 // Check if this is a compaction block (via providerMetadata)
                 const textMetadata = part.providerOptions?.anthropic as
-                  | { type?: string }
+                  | { type?: string; citations?: Citation[] }
                   | undefined;
 
                 if (textMetadata?.type === 'compaction') {
@@ -526,7 +532,9 @@ export async function convertToAnthropicMessagesPrompt({
                       isLastBlock && isLastMessage && isLastContentPart
                         ? part.text.trim()
                         : part.text,
-
+                    ...(textMetadata?.citations != null && {
+                      citations: textMetadata.citations,
+                    }),
                     cache_control: cacheControl,
                   });
                 }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -23,14 +23,9 @@ import {
   type AnthropicToolResultContent,
   type AnthropicUserMessage,
   type AnthropicWebFetchToolResultContent,
-<<<<<<< HEAD:packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+  type Citation,
 } from './anthropic-messages-api';
 import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
-=======
-  type Citation,
-} from './anthropic-api';
-import { anthropicFilePartProviderOptions } from './anthropic-language-model-options';
->>>>>>> afcf19c40 (fix: preserve Anthropic web search citations across multi-turn assistant message replay (#17398)):packages/anthropic/src/convert-to-anthropic-prompt.ts
 import { CacheControlValidator } from './get-cache-control';
 import { advisor_20260301OutputSchema } from './tool/advisor_20260301';
 import { codeExecution_20250522OutputSchema } from './tool/code-execution_20250522';


### PR DESCRIPTION
## Background

Multi-turn Anthropic web-search conversations replayed previously cited assistant text without citations or encrypted indices, losing citation context.

## Root Cause

Anthropic citation deltas were emitted only as source parts, which response history excludes, while assistant text serialization ignored citation metadata; this was confirmed by the failing replay reproduction and the converter and response-history code paths.

## Summary

Stored web_search_result_location data on generated text metadata and serialized it back into Anthropic assistant text citation arrays.

## Testing

Added inline-snapshot converter coverage and updated Anthropic generate and stream snapshots to verify citation metadata preservation.

## End-to-end Validation

- `cd examples/ai-functions && pnpm tsx src/reproduction/anthropic-web-search-citation-replay.ts` — live two-turn Anthropic request passed and preserved `web_search_result_location` citations.

## Related Issues

Fixes #17379

Closes #17392

Backport of #17398

Co-authored-by: flovouin <5155149+flovouin@users.noreply.github.com>