### PR TITLE
[v6.0] reproduction: @ai-sdk/langchain: close LangGraph reasoning before text starts

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17413,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #17413 reproduced: reasoning-end occurred after text-end, so reasoning and text lifecycles overlapped"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts
+++ b/examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts
@@ -1,0 +1,59 @@
+const expectedLifecycle = [
+  'reasoning-start',
+  'reasoning-delta',
+  'reasoning-end',
+  'text-start',
+  'text-delta',
+  'text-end',
+];
+
+async function main() {
+  const [{ AIMessageChunk }, { toUIMessageStream }] = await Promise.all([
+    import('../../../../packages/langchain/node_modules/@langchain/core/messages.js'),
+    import('../../../../packages/langchain/dist/index.mjs'),
+  ]);
+
+  const reasoning = new AIMessageChunk({
+    id: 'message-1',
+    content: [{ type: 'reasoning', reasoning: 'Thinking...' }],
+  });
+
+  const text = new AIMessageChunk({
+    id: 'message-1',
+    content: 'Answer',
+  });
+
+  const input = new ReadableStream({
+    start(controller) {
+      controller.enqueue(['messages', [reasoning]]);
+      controller.enqueue(['messages', [text]]);
+      controller.enqueue(['values', {}]);
+      controller.close();
+    },
+  });
+
+  const chunks: Array<{ type: string }> = [];
+  const reader = toUIMessageStream(input).getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+  }
+
+  const lifecycle = chunks
+    .map(chunk => chunk.type)
+    .filter(type => type.startsWith('reasoning-') || type.startsWith('text-'));
+
+  console.log(`Expected lifecycle: ${expectedLifecycle.join(' -> ')}`);
+  console.log(`Observed lifecycle: ${lifecycle.join(' -> ')}`);
+
+  if (lifecycle.join(',') !== expectedLifecycle.join(',')) {
+    throw new Error(
+      'Issue #17413 reproduced: reasoning-end occurred after text-end, so reasoning and text lifecycles overlapped',
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## Bug

@ai-sdk/langchain: close LangGraph reasoning before text starts

## Reproduction

- Reproduction artifact `examples/ai-functions/src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts` observed `reasoning-start → reasoning-delta → text-start → text-delta → text-end → reasoning-end`, leaving reasoning and text active simultaneously.
- The expected non-overlapping lifecycle is `reasoning-start → reasoning-delta → reasoning-end → text-start → text-delta → text-end`.
- The active checkout uses `@ai-sdk/langchain` 2.0.237 with compatible `@langchain/core` 1.1.29 and `@langchain/langgraph` 1.2.0; the issue reports `@ai-sdk/langchain` 3.0.30, but the same primary failure is present on this target branch.
- The existing snapshot in `packages/langchain/src/adapter.test.ts` records the same overlapping lifecycle, while the direct-model and `streamEvents` implementations close reasoning before starting text.

## Relevant Documentation

- https://docs.langchain.com/oss/javascript/langgraph/streaming
- https://reference.langchain.com/javascript/langchain-core/messages/AIMessageChunk
- https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol

## Related Issues

Reproduces #17413