### PR TITLE
[v6.0] reproduction: @ai-sdk/openai: function named toolsearch is replayed as native

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17402,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17402-tool-search-name-collision.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17402-tool-search-name-collision.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17402_REPRODUCED: regular function tool_search was replayed as tool_search_call without arguments and OpenAI rejected the request"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17402-tool-search-name-collision.ts
+++ b/examples/ai-functions/src/reproduction/issue-17402-tool-search-name-collision.ts
@@ -1,0 +1,126 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  let requestBody: Record<string, unknown> | undefined;
+  let responseBody: unknown;
+
+  const openai = createOpenAI({
+    fetch: async (url, init) => {
+      requestBody = JSON.parse(String(init?.body));
+      const response = await fetch(url, init);
+      try {
+        responseBody = await response.clone().json();
+      } catch {
+        responseBody = await response.clone().text();
+      }
+
+      return response;
+    },
+  });
+
+  try {
+    await generateText({
+      model: openai.responses('gpt-5.4-mini'),
+      tools: {
+        tool_search: tool({
+          description: 'Search synthetic records',
+          inputSchema: z.object({
+            query: z.string(),
+            limit: z.number(),
+          }),
+          execute: async () => 'No matches',
+        }),
+      },
+      messages: [
+        {
+          role: 'user',
+          content: 'Search the synthetic records.',
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName: 'tool_search',
+              input: {
+                query: 'synthetic query',
+                limit: 10,
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_123',
+              toolName: 'tool_search',
+              output: {
+                type: 'json',
+                value: { tools: [] },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  } catch (error) {
+    const input = requestBody?.input;
+    const tools = requestBody?.tools;
+    const toolDefinition = Array.isArray(tools)
+      ? tools.find(
+          item =>
+            typeof item === 'object' &&
+            item != null &&
+            'name' in item &&
+            item.name === 'tool_search',
+        )
+      : undefined;
+    const replayedCall = Array.isArray(input)
+      ? input.find(
+          item =>
+            typeof item === 'object' &&
+            item != null &&
+            'type' in item &&
+            item.type === 'tool_search_call',
+        )
+      : undefined;
+    const responseText = JSON.stringify(responseBody);
+
+    if (
+      typeof toolDefinition === 'object' &&
+      toolDefinition != null &&
+      'type' in toolDefinition &&
+      toolDefinition.type === 'function' &&
+      typeof replayedCall === 'object' &&
+      replayedCall != null &&
+      !('arguments' in replayedCall) &&
+      responseText.includes('Missing required parameter') &&
+      responseText.includes('arguments')
+    ) {
+      console.error(
+        'ISSUE_17402_REPRODUCED: regular function tool_search was replayed as tool_search_call without arguments and OpenAI rejected the request',
+      );
+      console.error(
+        JSON.stringify({ toolDefinition, replayedCall, responseBody }, null, 2),
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  throw new Error(
+    `ISSUE_17402_NOT_REPRODUCED: request completed; body=${JSON.stringify(requestBody)}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/responses/__fixtures__/openai-issue-17402-error.1.json
+++ b/packages/openai/src/responses/__fixtures__/openai-issue-17402-error.1.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Missing required parameter: 'input[1].arguments'.",
+    "type": "invalid_request_error",
+    "param": "input[1].arguments",
+    "code": "missing_required_parameter"
+  }
+}

--- a/packages/openai/src/responses/issue-17402.reproduction.test.ts
+++ b/packages/openai/src/responses/issue-17402.reproduction.test.ts
@@ -1,0 +1,120 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { OpenAIResponsesLanguageModel } from './openai-responses-language-model';
+
+const prompt: LanguageModelV3Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Search the synthetic records.' }],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'call_123',
+        toolName: 'tool_search',
+        input: {
+          query: 'synthetic query',
+          limit: 10,
+        },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'call_123',
+        toolName: 'tool_search',
+        output: {
+          type: 'json',
+          value: { tools: [] },
+        },
+      },
+    ],
+  },
+];
+
+const server = createTestServer({
+  'https://api.openai.com/v1/responses': {},
+});
+
+it('replays a regular function named tool_search as a function call', async () => {
+  const liveErrorFixture = fs.readFileSync(
+    'src/responses/__fixtures__/openai-issue-17402-error.1.json',
+    'utf8',
+  );
+
+  server.urls['https://api.openai.com/v1/responses'].response = {
+    type: 'error',
+    status: 400,
+    body: liveErrorFixture,
+  };
+
+  const model = new OpenAIResponsesLanguageModel('gpt-5.4-mini', {
+    provider: 'openai',
+    url: ({ path }) => `https://api.openai.com/v1${path}`,
+    headers: () => ({ Authorization: 'Bearer APIKEY' }),
+    generateId: mockId(),
+  });
+
+  let apiError: unknown;
+  try {
+    await model.doGenerate({
+      prompt,
+      tools: [
+        {
+          type: 'function',
+          name: 'tool_search',
+          description: 'Search synthetic records',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              limit: { type: 'number' },
+            },
+            required: ['query', 'limit'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+  } catch (error) {
+    apiError = error;
+  }
+
+  const requestBody = await server.calls[0].requestBodyJson;
+  expect(requestBody.tools[0]).toMatchObject({
+    type: 'function',
+    name: 'tool_search',
+  });
+
+  const replayedCall = requestBody.input.find(
+    (item: { type?: string }) => item.type === 'tool_search_call',
+  );
+  const errorMessage =
+    apiError instanceof Error ? apiError.message : String(apiError);
+
+  if (
+    replayedCall != null &&
+    !('arguments' in replayedCall) &&
+    errorMessage.includes('Missing required parameter') &&
+    errorMessage.includes('arguments')
+  ) {
+    throw new Error(
+      'ISSUE_17402_REPRODUCED: regular function tool_search was replayed as tool_search_call without arguments and OpenAI rejected the request',
+    );
+  }
+
+  expect(replayedCall).toEqual({
+    type: 'function_call',
+    call_id: 'call_123',
+    name: 'tool_search',
+    arguments: '{"query":"synthetic query","limit":10}',
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/openai: function named tool_search is replayed as native tool search

## Reproduction

- Live reproduction `examples/ai-functions/src/reproduction/issue-17402-tool-search-name-collision.ts` defined `tool_search` as a regular function but observed history serialized as `tool_search_call` without `arguments`.
- OpenAI returned HTTP 400 with `Missing required parameter: 'input[1].arguments'.`, preventing the subsequent Responses generation.
- Expected history serialization is `function_call` with `call_id`, `name`, and JSON-encoded `arguments`, followed by `function_call_output`.
- Recorded live-provider error fixture: `packages/openai/src/responses/__fixtures__/openai-issue-17402-error.1.json`.
- Failing provider regression test: `packages/openai/src/responses/issue-17402.reproduction.test.ts`.

## Relevant Documentation

- https://platform.openai.com/docs/api-reference/responses
- https://developers.openai.com/api/docs/guides/function-calling
- https://developers.openai.com/api/docs/guides/tools-tool-search

## Related Issues

Reproduces #17402