### PR TITLE
fix(google): cast fileBytes to BodyInit in google-files upload

### DIFF
--- a/.changeset/fix-google-files-body-type.md
+++ b/.changeset/fix-google-files-body-type.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix: cast `Uint8Array` to `BodyInit` in google-files upload to resolve TypeScript compilation error

--- a/packages/google/src/google-files.ts
+++ b/packages/google/src/google-files.ts
@@ -107,7 +107,7 @@ export class GoogleFiles implements FilesV4 {
         'X-Goog-Upload-Offset': '0',
         'X-Goog-Upload-Command': 'upload, finalize',
       },
-      body: fileBytes,
+      body: fileBytes as BodyInit,
     });
 
     if (!uploadResponse.ok) {


### PR DESCRIPTION
## Background

In `packages/google/src/google-files.ts`, `fileBytes` (a `Uint8Array`) is passed directly to the `body` parameter of the fetch options. In strict TypeScript environments, this throws a `ts(2769)` compilation error because the compiler cannot implicitly assign the typed array to the `BodyInit` type.

This PR fixes the type mismatch by explicitly casting `fileBytes` to `BodyInit`.

## Summary

- Cast `fileBytes` to `BodyInit` in the resumable file upload call in `google-files.ts`.
- Added a patch changeset for `@ai-sdk/google`.

## Contributor Credit

- Kushal Rathod (Issue reporter & PR author)

## End-to-End Verification

Verified that the TypeScript compiler / editor type checks pass cleanly on `google-files.ts` with the cast applied.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17441