### PR TITLE
reproduction: buggoogle: TypeScript type compatibility issue in google-files.ts fetch

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17441,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/google-files-fetch-body-type-compatibility.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/google-files-fetch-body-type-compatibility.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 2,
+    "signal": "packages/google/src/google-files.ts(110,7): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BodyInit | null | undefined'."
+  }
+}

--- a/examples/ai-functions/src/reproduction/google-files-fetch-body-type-compatibility.ts
+++ b/examples/ai-functions/src/reproduction/google-files-fetch-body-type-compatibility.ts
@@ -1,0 +1,66 @@
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const expectedFailure =
+  "packages/google/src/google-files.ts(110,7): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BodyInit | null | undefined'.";
+
+async function main() {
+  const repositoryRoot = resolve(process.cwd(), '../..');
+  const typescriptCompiler = resolve(
+    repositoryRoot,
+    'node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/bin/tsc',
+  );
+
+  const compiler = spawn(
+    process.execPath,
+    [
+      typescriptCompiler,
+      'packages/google/src/google-files.ts',
+      '--noEmit',
+      '--strict',
+      '--target',
+      'ES2018',
+      '--module',
+      'ESNext',
+      '--moduleResolution',
+      'Bundler',
+      '--lib',
+      'dom,dom.iterable,ES2018',
+      '--skipLibCheck',
+      '--pretty',
+      'false',
+    ],
+    {
+      cwd: repositoryRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  let output = '';
+  compiler.stdout.on('data', chunk => {
+    output += chunk;
+  });
+  compiler.stderr.on('data', chunk => {
+    output += chunk;
+  });
+
+  const exitCode = await new Promise<number>((resolveExitCode, reject) => {
+    compiler.on('error', reject);
+    compiler.on('close', code => resolveExitCode(code ?? 1));
+  });
+
+  process.stderr.write(output);
+
+  if (!output.includes(expectedFailure)) {
+    throw new Error(
+      `Expected the Google Files fetch body type error, but it was not found (tsc exit code ${exitCode}).`,
+    );
+  }
+
+  process.exitCode = exitCode;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

bug(google): TypeScript type compatibility issue in google-files.ts fetch body

## Reproduction

- `packages/google/src/google-files.ts` passes a `Uint8Array<ArrayBufferLike>` directly to the fetch body, which TypeScript 5.9's DOM types reject as `BodyInit`.
- Strict TypeScript 5.9.3 compilation fails at `packages/google/src/google-files.ts:110` with TS2322 instead of compiling cleanly, blocking builds that type-check this source with TypeScript 5.9.
- `examples/ai-functions/src/reproduction/google-files-fetch-body-type-compatibility.ts` reproduces the reported incompatibility and exits with code 2.
- The repository-pinned TypeScript 5.8.3 configuration still compiles successfully; the failure begins with the documented TypeScript 5.9 `lib.d.ts` changes.

## Relevant Documentation

- https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html

## Related Issues

Reproduces #17441