### PR TITLE
[v5.0] reproduction: tool.onInputAvailable can be called without onInputStart being called

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 11043,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11043-tool-input-callback-order.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts",
+    "examples/ai-functions/package.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #11043 REPRODUCED: onInputAvailable was called without a preceding onInputStart"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts
+++ b/examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts
@@ -1,0 +1,94 @@
+import {
+  generateText,
+  jsonSchema,
+  tool,
+} from '../../../../packages/ai/dist/index.mjs';
+
+async function main() {
+  const callbackSequence: string[] = [];
+  let inputStarted = false;
+  let inputAvailableBeforeStart = false;
+
+  await generateText({
+    model: {
+      specificationVersion: 'v2',
+      provider: 'reproduction',
+      modelId: 'issue-11043',
+      supportedUrls: {},
+      doGenerate: async () => ({
+        content: [
+          {
+            type: 'tool-call',
+            toolCallType: 'function',
+            toolCallId: 'call-1',
+            toolName: 'test-tool',
+            input: '{"value":"available-in-one-go"}',
+          },
+        ],
+        finishReason: 'tool-calls',
+        usage: {
+          inputTokens: 3,
+          outputTokens: 10,
+          totalTokens: 13,
+        },
+        warnings: [],
+      }),
+      doStream: async () => {
+        throw new Error('Streaming is not used by this reproduction.');
+      },
+    },
+    tools: {
+      'test-tool': tool({
+        inputSchema: jsonSchema<{ value: string }>({
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+          },
+          required: ['value'],
+          additionalProperties: false,
+        }),
+        onInputStart: () => {
+          inputStarted = true;
+          callbackSequence.push('onInputStart');
+        },
+        onInputAvailable: () => {
+          if (!inputStarted) {
+            inputAvailableBeforeStart = true;
+          }
+          callbackSequence.push('onInputAvailable');
+        },
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Call test-tool.',
+  });
+
+  if (inputAvailableBeforeStart) {
+    console.error(
+      'ISSUE #11043 REPRODUCED: onInputAvailable was called without a preceding onInputStart',
+    );
+    console.error(
+      `Observed callback sequence: ${callbackSequence.join(' -> ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const expectedSequence = ['onInputStart', 'onInputAvailable'];
+  if (callbackSequence.join(',') !== expectedSequence.join(',')) {
+    console.error(
+      `Unexpected callback sequence: ${callbackSequence.join(' -> ') || '(none)'}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Expected callback sequence observed: ${callbackSequence.join(' -> ')}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,12 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':


### PR DESCRIPTION
## Bug

tool.onInputAvailable can be called without onInputStart being called

## Reproduction

- On target `ai@5.0.215`, `generateText` invoked `onInputAvailable` for a valid completed tool call without invoking `onInputStart`; the observed sequence was only `onInputAvailable`.
- The issue's expected sequence is `onInputStart` followed by `onInputAvailable`, allowing consumers to initialize callback state before receiving validated input.
- The behavior persists beyond the reported `ai@5.0.107`, so upgrading within the tested v5 release line does not resolve it.
- Added the runnable reproduction at `examples/ai-functions/src/reproduction/issue-11043-tool-input-callback-order.ts`, with workspace setup in `examples/ai-functions/package.json` and `pnpm-lock.yaml`.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/tool

## Related Issues

Reproduces #11043