### PR TITLE
[v6.0] fix: xAI video polling fails on empty HTTP 202 responses

### DIFF
--- a/.changeset/quiet-videos-poll.md
+++ b/.changeset/quiet-videos-poll.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): handle empty HTTP 202 responses while polling videos

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -762,6 +762,50 @@ describe('XaiVideoModel', () => {
   });
 
   describe('error handling', () => {
+    it('should preserve unsuccessful polling status handling', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          code: 'status_error',
+          error: 'status endpoint failed',
+        }),
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({ ...defaultOptions }),
+      ).rejects.toMatchObject({
+        message: 'status_error: status endpoint failed',
+        statusCode: 500,
+      });
+
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
+    it('should preserve malformed HTTP 200 completion handling', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 200,
+        body: '{',
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        'Invalid JSON response',
+      );
+
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
     it('should throw when status is expired', async () => {
       server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
         type: 'json-value',
@@ -1443,6 +1487,84 @@ describe('XaiVideoModel', () => {
   });
 
   describe('polling behaviour', () => {
+    it.each([
+      {
+        mode: 'generation',
+        providerOptions: {
+          xai: { pollIntervalMs: 10, pollTimeoutMs: 5000 },
+        },
+      },
+      {
+        mode: 'editing',
+        providerOptions: {
+          xai: {
+            mode: 'edit-video' as const,
+            videoUrl: 'https://example.com/input.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      },
+    ])(
+      'should treat an empty HTTP 202 as pending for $mode',
+      async ({ providerOptions }) => {
+        server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+          callNumber,
+        }) =>
+          callNumber === 1
+            ? { type: 'empty', status: 202 }
+            : { type: 'json-value', body: doneStatusResponse };
+
+        const model = createModel();
+        const result = await model.doGenerate({
+          ...defaultOptions,
+          providerOptions,
+        });
+
+        expect(result.videos[0]).toMatchInlineSnapshot(`
+          {
+            "mediaType": "video/mp4",
+            "type": "url",
+            "url": "https://vidgen.x.ai/output/video-001.mp4",
+          }
+        `);
+        expect(server.calls).toHaveLength(3);
+      },
+    );
+
+    it('should time out while repeatedly receiving empty HTTP 202 responses', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'empty',
+        status: 202,
+      };
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: { pollIntervalMs: 10, pollTimeoutMs: 30 },
+          },
+        }),
+      ).rejects.toThrow('timed out');
+    });
+
+    it('should honor abort after an empty HTTP 202 response', async () => {
+      const abortController = new AbortController();
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = () => {
+        queueMicrotask(() => abortController.abort());
+        return { type: 'empty', status: 202 };
+      };
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow(/aborted/i);
+    });
+
     it('should retry polling on pending before resolving done', async () => {
       // callNumber is global across all URLs in the test.
       // Call 0 = POST /generations. Polls start at callNumber 1.

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -10,19 +10,12 @@ import {
   convertUint8ArrayToBase64,
   createJsonResponseHandler,
   delay,
-<<<<<<< HEAD
-  type FetchFunction,
-=======
   extractResponseHeaders,
->>>>>>> 1e2ae1f81 (fix: xAI video polling fails on empty HTTP 202 responses (#17435))
+  type FetchFunction,
   getFromApi,
   parseProviderOptions,
   postJsonToApi,
-<<<<<<< HEAD
-=======
-  type FetchFunction,
   type ResponseHandler,
->>>>>>> 1e2ae1f81 (fix: xAI video polling fails on empty HTTP 202 responses (#17435))
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { xaiFailedResponseHandler } from './xai-error';

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -5,14 +5,24 @@ import {
   type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
+  cancelResponseBody,
   combineHeaders,
   convertUint8ArrayToBase64,
   createJsonResponseHandler,
   delay,
+<<<<<<< HEAD
   type FetchFunction,
+=======
+  extractResponseHeaders,
+>>>>>>> 1e2ae1f81 (fix: xAI video polling fails on empty HTTP 202 responses (#17435))
   getFromApi,
   parseProviderOptions,
   postJsonToApi,
+<<<<<<< HEAD
+=======
+  type FetchFunction,
+  type ResponseHandler,
+>>>>>>> 1e2ae1f81 (fix: xAI video polling fails on empty HTTP 202 responses (#17435))
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { xaiFailedResponseHandler } from './xai-error';
@@ -438,9 +448,7 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
         await getFromApi({
           url: `${baseURL}/videos/${requestId}`,
           headers: combineHeaders(this.config.headers(), options.headers),
-          successfulResponseHandler: createJsonResponseHandler(
-            xaiVideoStatusResponseSchema,
-          ),
+          successfulResponseHandler: xaiVideoStatusResponseHandler,
           failedResponseHandler: xaiFailedResponseHandler,
           abortSignal: options.abortSignal,
           fetch: this.config.fetch,
@@ -546,3 +554,23 @@ const xaiVideoStatusResponseSchema = z.object({
     })
     .nullish(),
 });
+
+const xaiVideoStatusJsonResponseHandler = createJsonResponseHandler(
+  xaiVideoStatusResponseSchema,
+);
+
+const xaiVideoStatusResponseHandler: ResponseHandler<
+  z.infer<typeof xaiVideoStatusResponseSchema>
+> = async options => {
+  if (options.response.status === 202) {
+    const responseHeaders = extractResponseHeaders(options.response);
+    await cancelResponseBody(options.response);
+
+    return {
+      responseHeaders,
+      value: { status: 'pending' },
+    };
+  }
+
+  return xaiVideoStatusJsonResponseHandler(options);
+};


### PR DESCRIPTION
## Background

xAI video generation and editing stopped polling with an Invalid JSON response when the status endpoint returned a valid empty HTTP 202 response.

## Root Cause

The polling path sent every successful response through the JSON schema handler, causing empty HTTP 202 bodies to fail parsing before the polling loop could continue.

## Summary

Added a status-aware xAI polling handler that treats HTTP 202 as pending, discards its body, and retains JSON validation for completed responses.

## Testing

Added regression coverage for generation and editing through empty HTTP 202 responses, timeout and abort behavior, unsuccessful statuses, and malformed HTTP 200 responses.

## End-to-end Validation

- `cd examples/ai-functions && pnpm tsx src/generate-video/xai/basic.ts` — successfully generated and downloaded a 3.28 MB MP4 using the live xAI API; the artifact was removed afterward.

## Related Issues

Fixes #17308

Closes #17428

Backport of #17435

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>