### PR TITLE
[v6.0] fix: close LangGraph reasoning before text starts

### DIFF
--- a/.changeset/tidy-graphs-reason.md
+++ b/.changeset/tidy-graphs-reason.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/langchain": patch
+---
+
+fix(langchain): close LangGraph reasoning before starting text

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -715,7 +715,7 @@ describe('toUIMessageStream', () => {
     expect(startIds.has('msg_test-002')).toBe(true);
   });
 
-  it('should handle reasoning followed by text content', async () => {
+  it('should close reasoning before starting text content', async () => {
     // Reasoning chunk
     const reasoningChunk = new AIMessageChunk({
       id: 'msg-1',
@@ -754,6 +754,10 @@ describe('toUIMessageStream', () => {
         },
         {
           "id": "msg-1",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "msg-1",
           "type": "text-start",
         },
         {
@@ -764,10 +768,6 @@ describe('toUIMessageStream', () => {
         {
           "id": "msg-1",
           "type": "text-end",
-        },
-        {
-          "id": "msg-1",
-          "type": "reasoning-end",
         },
         {
           "type": "finish",

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -1446,6 +1446,11 @@ export function processLangGraphEvent(
         const text = getMessageText(msg);
         if (text) {
           const seen = messageSeen.get(msgId);
+          if (seen?.reasoning && !seen.text) {
+            controller.enqueue({ type: 'reasoning-end', id: msgId });
+            seen.reasoning = false;
+          }
+
           if (!seen?.text) {
             controller.enqueue({ type: 'text-start', id: msgId });
             getOrCreateMessageSeen(messageSeen, msgId).text = true;


### PR DESCRIPTION
## Background

LangGraph message streams could leave reasoning active after text began, causing overlapping reasoning and text lifecycles for consumers.

## Root Cause

The LangGraph messages handler started text without ending and clearing the tracked reasoning lifecycle; the reproduction and regression snapshot confirmed reasoning-end was deferred until values finalization.

## Summary

Updated LangGraph message processing to emit reasoning-end and clear the reasoning state before starting text.

## Testing

Updated the existing adapter regression test and inline snapshot to assert reasoning ends before text starts.

## End-to-end Validation

- `pnpm -C packages/langchain build && pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17413-langgraph-reasoning-text-overlap.ts` completed successfully and observed the expected non-overlapping lifecycle.

## Related Issues

Fixes #17413

Closes #17429

Backport of #17437

Co-authored-by: Ives7 <24537993+Ives7@users.noreply.github.com>