### PR TITLE
reproduction: generateText silently swallows AbortError in multi-step tool loop

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 12878,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12878-generate-text-abort.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_REPRODUCED: generateText returned normally after aborting a multi-step tool loop"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts
+++ b/examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts
@@ -1,0 +1,117 @@
+import { generateText, isStepCount, tool } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod';
+
+const reproducedSignal =
+  'ISSUE_REPRODUCED: generateText returned normally after aborting a multi-step tool loop';
+
+const zeroUsage = {
+  inputTokens: {
+    total: 0,
+    noCache: 0,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 0,
+    text: 0,
+    reasoning: undefined,
+  },
+};
+
+async function main() {
+  const abortController = new AbortController();
+  let modelCallCount = 0;
+
+  const model = new MockLanguageModelV4({
+    doGenerate: async ({ abortSignal }) => {
+      modelCallCount++;
+
+      if (modelCallCount === 1) {
+        return {
+          content: [
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'slow-tool-call',
+              toolName: 'slowTool',
+              input: JSON.stringify({ query: 'first query' }),
+            },
+          ],
+          finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+          usage: zeroUsage,
+          warnings: [],
+        };
+      }
+
+      if (!abortSignal?.aborted) {
+        throw new Error(
+          'Reproduction setup failed: second call was not aborted',
+        );
+      }
+
+      // Model the partial response reported for an HTTP call made with an
+      // already-aborted signal.
+      return {
+        content: [],
+        finishReason: { unified: 'other', raw: 'unknown' },
+        usage: zeroUsage,
+        warnings: [],
+      };
+    },
+  });
+
+  const slowTool = tool({
+    description: 'A tool that waits until the operation is aborted',
+    inputSchema: z.object({ query: z.string() }),
+    execute: async (_input, { abortSignal }) => {
+      setTimeout(() => abortController.abort(), 10);
+
+      await new Promise<never>((_resolve, reject) => {
+        abortSignal?.addEventListener(
+          'abort',
+          () => reject(abortSignal.reason),
+          { once: true },
+        );
+      });
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model,
+      prompt: 'Call the slow tool, then summarize.',
+      tools: { slowTool },
+      stopWhen: isStepCount(10),
+      abortSignal: abortController.signal,
+      maxRetries: 0,
+    });
+
+    console.error(
+      JSON.stringify({
+        finishReason: result.finishReason,
+        steps: result.steps.length,
+        lastStepUsage: result.steps.at(-1)?.usage,
+        signalAborted: abortController.signal.aborted,
+        modelCallCount,
+      }),
+    );
+    throw new Error(reproducedSignal);
+  } catch (error) {
+    if (error instanceof Error && error.message === reproducedSignal) {
+      throw error;
+    }
+
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      console.log('Expected behavior: generateText propagated AbortError');
+      return;
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

generateText() silently swallows AbortError in multi-step tool loop

## Reproduction

- The reproduction at `examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts` aborts during tool execution in a multi-step `generateText()` loop on `ai` 7.0.30.
- `generateText()` returned normally with an aborted signal, two steps, final finish reason `other`, and zero final-step tokens instead of propagating `AbortError`.
- `packages/ai/src/generate-text/execute-tool-call.ts` converts the tool's abort exception into a `tool-error`, while `packages/ai/src/generate-text/generate-text.ts` does not check the aborted signal before the next step.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://nodejs.org/api/globals.html

## Related Issues

Reproduces #12878