### PR TITLE
reproduction: OAuthMetadataSchema requires codechallengemethodssupported, but RFC 8414 marks it

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17334,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17334.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17334.ts",
+    "packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17334_REPRODUCED: OAuth metadata without code_challenge_methods_supported was rejected before Dynamic Client Registration"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17334.ts
+++ b/examples/ai-functions/src/reproduction/issue-17334.ts
@@ -1,0 +1,127 @@
+import {
+  auth,
+  type OAuthClientInformation,
+  type OAuthClientProvider,
+  type OAuthTokens,
+} from '@ai-sdk/mcp';
+import fs from 'node:fs';
+import { ZodError } from 'zod/v4';
+
+const serverUrl = new URL('https://aws-mcp.us-east-1.api.aws/mcp');
+const resourceMetadataUrl = new URL(
+  'https://aws-mcp.us-east-1.api.aws/.well-known/oauth-protected-resource',
+);
+const authorizationServerUrl = new URL('https://us-east-1.oauth.signin.aws');
+const registrationEndpoint = new URL('/v1/register', authorizationServerUrl)
+  .href;
+const dcrReached = new Error('DCR_REACHED');
+
+const awsSignInMetadata = JSON.parse(
+  fs.readFileSync(
+    new URL(
+      '../../../../packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+);
+
+const provider: OAuthClientProvider = {
+  redirectUrl: 'http://localhost:8090/oauth/callback',
+  clientMetadata: {
+    redirect_uris: ['http://localhost:8090/oauth/callback'],
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    client_name: 'issue-17334-reproduction',
+  },
+  tokens(): OAuthTokens | undefined {
+    return undefined;
+  },
+  saveTokens() {},
+  clientInformation(): OAuthClientInformation | undefined {
+    return undefined;
+  },
+  saveClientInformation() {},
+  saveCodeVerifier() {},
+  codeVerifier() {
+    return '';
+  },
+  redirectToAuthorization() {},
+};
+
+function createFixtureFetch(): typeof fetch {
+  return async input => {
+    const url = new URL(String(input));
+
+    if (url.href === resourceMetadataUrl.href) {
+      return Response.json({
+        resource: serverUrl.href,
+        authorization_servers: [`${authorizationServerUrl.href}/`],
+      });
+    }
+
+    if (
+      url.href ===
+      new URL('/.well-known/oauth-authorization-server', authorizationServerUrl)
+        .href
+    ) {
+      return Response.json(awsSignInMetadata);
+    }
+
+    if (url.href === registrationEndpoint) {
+      throw dcrReached;
+    }
+
+    return new Response(null, { status: 404 });
+  };
+}
+
+function createLiveFetch(): typeof fetch {
+  return async (input, init) => {
+    if (new URL(String(input)).href === registrationEndpoint) {
+      throw dcrReached;
+    }
+
+    return fetch(input, init);
+  };
+}
+
+async function main() {
+  const fetchFn =
+    process.env.ISSUE_17334_LIVE === '1'
+      ? createLiveFetch()
+      : createFixtureFetch();
+
+  try {
+    await auth(provider, {
+      serverUrl,
+      resourceMetadataUrl,
+      fetchFn,
+    });
+  } catch (error) {
+    if (error === dcrReached) {
+      console.log(
+        'OAuth metadata was accepted and Dynamic Client Registration was reached.',
+      );
+      return;
+    }
+
+    if (
+      error instanceof ZodError &&
+      error.issues.some(issue =>
+        issue.path.includes('code_challenge_methods_supported'),
+      )
+    ) {
+      console.error(
+        'ISSUE_17334_REPRODUCED: OAuth metadata without code_challenge_methods_supported was rejected before Dynamic Client Registration',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+}
+
+main();

--- a/packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json
+++ b/packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json
@@ -1,0 +1,9 @@
+{
+  "issuer": "https://us-east-1.oauth.signin.aws",
+  "authorization_endpoint": "https://us-east-1.oauth.signin.aws/v1/authorize",
+  "token_endpoint": "https://us-east-1.oauth.signin.aws/v1/token",
+  "registration_endpoint": "https://us-east-1.oauth.signin.aws/v1/register",
+  "token_endpoint_auth_methods_supported": ["none"],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"]
+}

--- a/packages/mcp/src/tool/oauth.issue-17334.test.ts
+++ b/packages/mcp/src/tool/oauth.issue-17334.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { discoverAuthorizationServerMetadata } from './oauth';
+
+const awsSignInMetadata = JSON.parse(
+  fs.readFileSync(
+    'src/tool/__fixtures__/aws-signin-oauth-metadata.json',
+    'utf8',
+  ),
+);
+
+describe('issue #17334', () => {
+  it('accepts AWS Sign-In OAuth metadata without the optional PKCE metadata field', async () => {
+    await expect(
+      discoverAuthorizationServerMetadata(
+        'https://us-east-1.oauth.signin.aws',
+        {
+          fetchFn: async () => Response.json(awsSignInMetadata),
+        },
+      ),
+    ).resolves.toEqual(awsSignInMetadata);
+  });
+});


### PR DESCRIPTION
## Bug

OAuthMetadataSchema requires code_challenge_methods_supported, but RFC 8414 marks it optional, breaking DCR against spec-compliant servers (e.g. AWS Sign-In)

## Reproduction

- Live AWS Sign-In metadata omitted `code_challenge_methods_supported`, and `@ai-sdk/mcp` 2.0.14 on `main` threw a ZodError in `packages/mcp/src/tool/oauth-types.ts` before Dynamic Client Registration.
- RFC 8414 defines the field as optional; discovery should accept the metadata and leave PKCE compatibility handling to the OAuth flow.
- `examples/ai-functions/src/reproduction/issue-17334.ts` expected to reach DCR but exited 1 after reproducing the premature metadata rejection.
- `packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json` records the live AWS response observed on July 17, 2026.
- `packages/mcp/src/tool/oauth.issue-17334.test.ts` failed because `discoverAuthorizationServerMetadata()` rejected the recorded response with `Invalid input: expected array, received undefined`.
- The current MCP authorization specification requires clients to refuse authorization when the field is absent, so making the schema optional would expose the existing compatibility error but would not alone enable the complete AWS flow.
- The reported post-injection interactive AWS authorization, token exchange, and authenticated tool call were not rerun; the reproduced status is based on the primary pre-DCR failure.

## Relevant Documentation

- https://www.rfc-editor.org/rfc/rfc8414.html#section-2
- https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
- https://docs.aws.amazon.com/signin/latest/userguide/oauth-sign-in-overview.html
- https://ts.sdk.modelcontextprotocol.io/v2/functions/_modelcontextprotocol_client.client_auth.discoverOAuthMetadata.html

## Related Issues

Reproduces #17334