### PR TITLE
[v5.0] fix: ensure tool input lifecycle callbacks start before input becomes available

### DIFF
--- a/.changeset/calm-tools-start.md
+++ b/.changeset/calm-tools-start.md
@@ -1,0 +1,6 @@
+---
+'ai': patch
+'@ai-sdk/provider-utils': patch
+---
+
+fix(ai): call `onInputStart` before `onInputAvailable` during non-streaming tool calls

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -489,7 +489,7 @@ The following tool input lifecycle hooks are available:
 - **`onInputDelta`**: Called for each chunk of text as the input is streamed
 - **`onInputAvailable`**: Called when the complete input is available and validated
 
-`onInputStart` and `onInputDelta` are only called in streaming contexts (when using `streamText`). They are not called when using `generateText`.
+`onInputStart` is always called before `onInputAvailable`, including when using `generateText`. `onInputDelta` is only called in streaming contexts (when using `streamText`).
 
 ### Example
 

--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -119,7 +119,7 @@ export const weatherTool = tool({
               isOptional: true,
               type: '(options: ToolCallOptions) => void | PromiseLike<void>',
               description:
-                'Optional function that is called when the argument streaming starts. Only called when the tool is used in a streaming context.',
+                'Optional function that is called when the model starts generating the tool input. In non-streaming contexts, it is called immediately before onInputAvailable.',
             },
             {
               name: 'onInputDelta',

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -100,30 +100,6 @@ export const customTool = dynamicTool({
               description: 'Optional conversion function that maps the tool result to an output that can be used by the language model.'
             },
             {
-<<<<<<< HEAD
-=======
-              name: 'onInputStart',
-              isOptional: true,
-              type: '(options: ToolExecutionOptions<Context>) => void | PromiseLike<void>',
-              description:
-                'Optional function that is called when the model starts generating the tool input. In non-streaming contexts, it is called immediately before onInputAvailable.'
-            },
-            {
-              name: 'onInputDelta',
-              isOptional: true,
-              type: '(options: { inputTextDelta: string } & ToolExecutionOptions<Context>) => void | PromiseLike<void>',
-              description:
-                'Optional function that is called when an argument streaming delta is available. Only called when the tool is used in a streaming context.'
-            },
-            {
-              name: 'onInputAvailable',
-              isOptional: true,
-              type: '(options: { input: unknown } & ToolExecutionOptions<Context>) => void | PromiseLike<void>',
-              description:
-                'Optional function that is called when a tool call can be started, even if the execute function is not provided.'
-            },
-            {
->>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
               name: 'providerOptions',
               isOptional: true,
               type: 'ProviderOptions',

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -100,6 +100,30 @@ export const customTool = dynamicTool({
               description: 'Optional conversion function that maps the tool result to an output that can be used by the language model.'
             },
             {
+<<<<<<< HEAD
+=======
+              name: 'onInputStart',
+              isOptional: true,
+              type: '(options: ToolExecutionOptions<Context>) => void | PromiseLike<void>',
+              description:
+                'Optional function that is called when the model starts generating the tool input. In non-streaming contexts, it is called immediately before onInputAvailable.'
+            },
+            {
+              name: 'onInputDelta',
+              isOptional: true,
+              type: '(options: { inputTextDelta: string } & ToolExecutionOptions<Context>) => void | PromiseLike<void>',
+              description:
+                'Optional function that is called when an argument streaming delta is available. Only called when the tool is used in a streaming context.'
+            },
+            {
+              name: 'onInputAvailable',
+              isOptional: true,
+              type: '(options: { input: unknown } & ToolExecutionOptions<Context>) => void | PromiseLike<void>',
+              description:
+                'Optional function that is called when a tool call can be started, even if the execute function is not provided.'
+            },
+            {
+>>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
               name: 'providerOptions',
               isOptional: true,
               type: 'ProviderOptions',

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2148,10 +2148,7 @@ describe('generateText', () => {
           {
             "options": {
               "abortSignal": undefined,
-<<<<<<< HEAD
               "experimental_context": undefined,
-=======
-              "context": {},
               "messages": [
                 {
                   "content": "test-input",
@@ -2165,8 +2162,7 @@ describe('generateText', () => {
           {
             "options": {
               "abortSignal": undefined,
-              "context": {},
->>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
+              "experimental_context": undefined,
               "input": {
                 "value": "value",
               },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2148,7 +2148,25 @@ describe('generateText', () => {
           {
             "options": {
               "abortSignal": undefined,
+<<<<<<< HEAD
               "experimental_context": undefined,
+=======
+              "context": {},
+              "messages": [
+                {
+                  "content": "test-input",
+                  "role": "user",
+                },
+              ],
+              "toolCallId": "call-1",
+            },
+            "type": "onInputStart",
+          },
+          {
+            "options": {
+              "abortSignal": undefined,
+              "context": {},
+>>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
               "input": {
                 "value": "value",
               },

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -452,7 +452,6 @@ A function that attempts to repair a tool call that failed to parse.
             }),
           );
 
-<<<<<<< HEAD
           // parse tool calls:
           const stepToolCalls: TypedToolCall<TOOLS>[] = await Promise.all(
             currentModelResponse.content
@@ -462,30 +461,6 @@ A function that attempts to repair a tool call that failed to parse.
               )
               .map(toolCall =>
                 parseToolCall({
-=======
-                if (tool.onInputStart != null) {
-                  await tool.onInputStart({
-                    toolCallId: toolCall.toolCallId,
-                    messages: stepMessages,
-                    abortSignal: mergedAbortSignal,
-                    context: runtimeContext,
-                  });
-                }
-
-                if (tool?.onInputAvailable != null) {
-                  await tool.onInputAvailable({
-                    input: toolCall.input,
-                    toolCallId: toolCall.toolCallId,
-                    messages: stepMessages,
-                    abortSignal: mergedAbortSignal,
-                    context: runtimeContext,
-                  });
-                }
-
-                const toolApprovalStatus = await resolveToolApproval({
-                  tools,
-                  toolApproval,
->>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
                   toolCall,
                   tools,
                   repairToolCall,
@@ -502,6 +477,15 @@ A function that attempts to repair a tool call that failed to parse.
             }
 
             const tool = tools![toolCall.toolName];
+            if (tool.onInputStart != null) {
+              await tool.onInputStart({
+                toolCallId: toolCall.toolCallId,
+                messages: stepInputMessages,
+                abortSignal,
+                experimental_context,
+              });
+            }
+
             if (tool?.onInputAvailable != null) {
               await tool.onInputAvailable({
                 input: toolCall.input,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -452,6 +452,7 @@ A function that attempts to repair a tool call that failed to parse.
             }),
           );
 
+<<<<<<< HEAD
           // parse tool calls:
           const stepToolCalls: TypedToolCall<TOOLS>[] = await Promise.all(
             currentModelResponse.content
@@ -461,6 +462,30 @@ A function that attempts to repair a tool call that failed to parse.
               )
               .map(toolCall =>
                 parseToolCall({
+=======
+                if (tool.onInputStart != null) {
+                  await tool.onInputStart({
+                    toolCallId: toolCall.toolCallId,
+                    messages: stepMessages,
+                    abortSignal: mergedAbortSignal,
+                    context: runtimeContext,
+                  });
+                }
+
+                if (tool?.onInputAvailable != null) {
+                  await tool.onInputAvailable({
+                    input: toolCall.input,
+                    toolCallId: toolCall.toolCallId,
+                    messages: stepMessages,
+                    abortSignal: mergedAbortSignal,
+                    context: runtimeContext,
+                  });
+                }
+
+                const toolApprovalStatus = await resolveToolApproval({
+                  tools,
+                  toolApproval,
+>>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
                   toolCall,
                   tools,
                   repairToolCall,

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -101,32 +101,8 @@ Use descriptions to make the input understandable for the language model.
   inputSchema: FlexibleSchema<INPUT>;
 
   /**
-<<<<<<< HEAD
-   * Optional function that is called when the argument streaming starts.
-   * Only called when the tool is used in a streaming context.
-=======
-   * An optional schema describing the context that the tool expects.
-   *
-   * The context is passed to execute function as part of the execution options.
-   */
-  contextSchema?: FlexibleSchema<CONTEXT>;
-
-  /**
-   * Whether the tool needs approval before it can be executed.
-   *
-   * @deprecated Tool approval is handled on a `generateText` / `streamText` level now.
-   */
-  needsApproval?:
-    | boolean
-    | ToolNeedsApprovalFunction<
-        [INPUT] extends [never] ? unknown : INPUT,
-        NoInfer<CONTEXT>
-      >;
-
-  /**
    * Optional function that is called when the model starts generating the tool input.
    * In non-streaming contexts, it is called immediately before `onInputAvailable`.
->>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
    */
   onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
 

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -101,8 +101,32 @@ Use descriptions to make the input understandable for the language model.
   inputSchema: FlexibleSchema<INPUT>;
 
   /**
+<<<<<<< HEAD
    * Optional function that is called when the argument streaming starts.
    * Only called when the tool is used in a streaming context.
+=======
+   * An optional schema describing the context that the tool expects.
+   *
+   * The context is passed to execute function as part of the execution options.
+   */
+  contextSchema?: FlexibleSchema<CONTEXT>;
+
+  /**
+   * Whether the tool needs approval before it can be executed.
+   *
+   * @deprecated Tool approval is handled on a `generateText` / `streamText` level now.
+   */
+  needsApproval?:
+    | boolean
+    | ToolNeedsApprovalFunction<
+        [INPUT] extends [never] ? unknown : INPUT,
+        NoInfer<CONTEXT>
+      >;
+
+  /**
+   * Optional function that is called when the model starts generating the tool input.
+   * In non-streaming contexts, it is called immediately before `onInputAvailable`.
+>>>>>>> cd064585a (fix: ensure tool input lifecycle callbacks start before input becomes available (#17393))
    */
   onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
 


### PR DESCRIPTION
## Background

Non-streaming tool calls could invoke onInputAvailable without first invoking onInputStart, forcing consumers to handle inconsistent lifecycle state.

## Root Cause

generateText directly invoked onInputAvailable for completed tool calls but omitted the corresponding onInputStart invocation, as confirmed by the reproduction and existing callback snapshot.

## Summary

generateText now invokes onInputStart immediately before onInputAvailable for valid non-streaming tool calls.

## Testing

Updated the existing generateText callback regression test and inline snapshot to assert the onInputStart, onInputAvailable sequence.

## End-to-end Validation

- `pnpm -C packages/ai build && pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11043-tool-input-callback-order.ts` — exited successfully with onInputStart preceding onInputAvailable.

## Related Issues

Fixes #11043

Closes #17360

Backport of #17393

Co-authored-by: SamyPesse <845425+SamyPesse@users.noreply.github.com>