### PR TITLE
reproduction: could not reproduce Page refreshes itself when submit is called when

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-5795.ts
+++ b/examples/ai-functions/src/reproduction/issue-5795.ts
@@ -1,0 +1,167 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+const port = 35795;
+const baseUrl = `http://127.0.0.1:${port}`;
+const reproductionPath = '/reproduction/issue-5795';
+const attemptsPerScenario = 25;
+
+async function waitForServer(process: ChildProcess) {
+  const deadline = Date.now() + 60_000;
+
+  while (Date.now() < deadline) {
+    if (process.exitCode != null) {
+      throw new Error(`Next.js exited early with code ${process.exitCode}.`);
+    }
+
+    try {
+      const response = await fetch(`${baseUrl}${reproductionPath}`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // The development server is still starting.
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 250));
+  }
+
+  throw new Error('Timed out waiting for the Next.js reproduction server.');
+}
+
+async function stopServer(process: ChildProcess) {
+  if (process.exitCode != null) {
+    return;
+  }
+
+  process.kill('SIGTERM');
+
+  await Promise.race([
+    new Promise<void>(resolve => process.once('exit', () => resolve())),
+    new Promise<void>(resolve =>
+      setTimeout(() => {
+        process.kill('SIGKILL');
+        resolve();
+      }, 5_000),
+    ),
+  ]);
+}
+
+async function main() {
+  const server = spawn(
+    'pnpm',
+    [
+      '-C',
+      'examples/next-openai-pages',
+      'exec',
+      'next',
+      'dev',
+      '--hostname',
+      '127.0.0.1',
+      '--port',
+      String(port),
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        NEXT_TELEMETRY_DISABLED: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  let serverOutput = '';
+  server.stdout.on('data', chunk => {
+    serverOutput += String(chunk);
+  });
+  server.stderr.on('data', chunk => {
+    serverOutput += String(chunk);
+  });
+
+  try {
+    await waitForServer(server);
+
+    const browser = await chromium.launch({ headless: true });
+
+    try {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      let documentRequests = 0;
+
+      page.on('request', request => {
+        if (request.resourceType() === 'document') {
+          documentRequests += 1;
+        }
+      });
+
+      await page.goto(`${baseUrl}${reproductionPath}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.getByTestId('page-load-count').waitFor();
+
+      for (let index = 1; index <= attemptsPerScenario; index++) {
+        await page.getByTestId('direct-submit').click();
+        await page
+          .getByTestId('completed-count')
+          .getByText(String(index), { exact: true })
+          .waitFor();
+      }
+
+      for (let index = 1; index <= attemptsPerScenario; index++) {
+        const expectedCount = attemptsPerScenario + index;
+        await page.getByTestId('form-submit').click();
+        await page
+          .getByTestId('completed-count')
+          .getByText(String(expectedCount), { exact: true })
+          .waitFor();
+      }
+
+      const result = {
+        directSubmitAttempts: attemptsPerScenario,
+        preventedFormSubmitAttempts: attemptsPerScenario,
+        completedRequests: Number(
+          await page.getByTestId('completed-count').textContent(),
+        ),
+        pageLoadCount: Number(
+          await page.getByTestId('page-load-count').textContent(),
+        ),
+        documentRequests,
+        finalObject: await page.getByTestId('object').textContent(),
+        error: await page.getByTestId('error').textContent(),
+      };
+
+      console.log(JSON.stringify(result, null, 2));
+
+      if (result.pageLoadCount !== 1 || documentRequests !== 1) {
+        throw new Error(
+          `Reproduced issue #5795: useObject().submit() reloaded the page (pageLoadCount=${result.pageLoadCount}, documentRequests=${documentRequests}).`,
+        );
+      }
+
+      if (result.completedRequests !== attemptsPerScenario * 2) {
+        throw new Error(
+          `Expected ${attemptsPerScenario * 2} completed requests, received ${result.completedRequests}.`,
+        );
+      }
+
+      if (result.error !== '') {
+        throw new Error(`useObject reported an error: ${result.error}`);
+      }
+    } finally {
+      await browser.close();
+    }
+  } catch (error) {
+    console.error(serverOutput);
+    throw error;
+  } finally {
+    await stopServer(server);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/next-openai-pages/app/api/reproduction/issue-5795/route.ts
+++ b/examples/next-openai-pages/app/api/reproduction/issue-5795/route.ts
@@ -1,0 +1,20 @@
+const encoder = new TextEncoder();
+
+export async function POST(request: Request) {
+  const input = (await request.json()) as { sequence: number };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(encoder.encode('{"sequence":'));
+      await new Promise(resolve => setTimeout(resolve, 5));
+      controller.enqueue(encoder.encode(`${input.sequence}}`));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/examples/next-openai-pages/pages/reproduction/issue-5795.tsx
+++ b/examples/next-openai-pages/pages/reproduction/issue-5795.tsx
@@ -1,0 +1,68 @@
+import { useObject } from '@ai-sdk/react';
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+
+const schema = z.object({
+  sequence: z.number(),
+});
+
+export default function Issue5795Page() {
+  const [completedCount, setCompletedCount] = useState(0);
+  const [pageLoadCount, setPageLoadCount] = useState<number>();
+  const [sequence, setSequence] = useState(0);
+
+  const { submit, isLoading, object, error } = useObject({
+    api: '/api/reproduction/issue-5795',
+    schema,
+    onFinish({ object }) {
+      if (object != null) {
+        setCompletedCount(count => count + 1);
+      }
+    },
+  });
+
+  useEffect(() => {
+    const storageKey = 'ai-sdk-issue-5795-page-load-count';
+    const nextCount = Number(sessionStorage.getItem(storageKey) ?? 0) + 1;
+    sessionStorage.setItem(storageKey, String(nextCount));
+    setPageLoadCount(nextCount);
+  }, []);
+
+  const submitNext = () => {
+    setSequence(current => {
+      const next = current + 1;
+      submit({ sequence: next });
+      return next;
+    });
+  };
+
+  return (
+    <main>
+      <p data-testid="page-load-count">{pageLoadCount}</p>
+      <p data-testid="completed-count">{completedCount}</p>
+      <p data-testid="object">{JSON.stringify(object)}</p>
+      <p data-testid="error">{error?.message}</p>
+
+      <button
+        data-testid="direct-submit"
+        type="button"
+        disabled={isLoading}
+        onClick={submitNext}
+      >
+        Direct submit
+      </button>
+
+      <form
+        onSubmit={event => {
+          event.preventDefault();
+          submitNext();
+        }}
+      >
+        <input data-testid="form-input" defaultValue="issue 5795" />
+        <button data-testid="form-submit" type="submit" disabled={isLoading}>
+          Form submit
+        </button>
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## Bug

Page refreshes itself when submit() is called when using useObject()

## Reproduction

- Expected behavior: `useObject().submit()` should stream an object without reloading the document and resetting client state.
- Added `examples/ai-functions/src/reproduction/issue-5795.ts`, `examples/next-openai-pages/pages/reproduction/issue-5795.tsx`, and `examples/next-openai-pages/app/api/reproduction/issue-5795/route.ts` to test a Pages Router page calling an App Router endpoint under Next.js 15.5.18.
- All 25 direct submissions and 25 form submissions with `preventDefault()` completed successfully; the browser recorded one page load and one document request, rather than the additional document navigation expected from the reported issue.
- Mixing a Pages Router page with an App Router API endpoint did not produce the reported reload on the current `main` branch.
- The issue did not provide package versions or a runnable snippet, so its exact historical configuration could not be reconstructed.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-object
- https://nextjs.org/docs/app/getting-started/route-handlers
- https://nextjs.org/docs/pages/guides/migrating/app-router-migration
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button

## Related Issues

Could not reproduce #5795