### PR TITLE
feat: add accumulated UI message callbacks at agent step boundaries

### DIFF
--- a/.changeset/bright-pandas-persist.md
+++ b/.changeset/bright-pandas-persist.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add per-step UI message callbacks to UI message stream conversion and `onUIMessageStepEnd` to agent UI stream helpers for inspecting or persisting the accumulated response message.

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -3955,6 +3955,19 @@ To see `streamText` in action, check out [these examples](#examples).
               description: 'The original messages.',
             },
             {
+              name: 'onStepEnd',
+              type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; }) => PromiseLike<void> | void',
+              isOptional: true,
+              description:
+                'Callback function called after each step is converted to UI message parts. Provides the updated messages, whether the response is a continuation, and the accumulated response message.',
+            },
+            {
+              name: 'onStepFinish',
+              type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; }) => PromiseLike<void> | void',
+              isOptional: true,
+              description: 'Deprecated alias for `onStepEnd`.',
+            },
+            {
               name: 'onEnd',
               type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; isAborted: boolean; }) => void',
               isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -109,11 +109,18 @@ export async function* streamAgent(
         'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
-      name: '...UIMessageStreamOptions',
-      type: 'UIMessageStreamOptions',
+      name: 'onUIMessageStepEnd',
+      type: 'UIMessageStreamOnStepEndCallback',
       isRequired: false,
       description:
-        'Additional options to control the output stream, such as including sources or usage data.',
+        'Callback invoked after each UI message step is assembled. It receives `messages`, `isContinuation`, and the accumulated `responseMessage`, making it suitable for persisting intermediate UI message state.',
+    },
+    {
+      name: '...AgentUIMessageStreamOptions',
+      type: 'AgentUIMessageStreamOptions',
+      isRequired: false,
+      description:
+        'Additional options to control the UI message stream, including message IDs, metadata, final callbacks, sources, and reasoning.',
     },
   ]}
 />
@@ -146,6 +153,32 @@ for await (const chunk of stream) {
 // Call controller.abort() to cancel the agent operation early.
 ```
 
+## Persisting the UI Message After Each Step
+
+Use `onUIMessageStepEnd` when you need the accumulated [`UIMessage`](/docs/reference/ai-sdk-core/ui-message) after each agent step:
+
+```ts
+const stream = await createAgentUIStream({
+  agent,
+  uiMessages,
+  onUIMessageStepEnd: async ({ messages, responseMessage, isContinuation }) => {
+    await upsertConversation({
+      messages,
+      responseMessage,
+      isContinuation,
+    });
+  },
+});
+
+for await (const chunk of stream) {
+  // Consume or forward the stream so the callback can run.
+}
+```
+
+`onStepEnd` and `onUIMessageStepEnd` serve different layers. `onStepEnd` receives the low-level generation step result, including usage, finish reason, and tool call details. `onUIMessageStepEnd` runs after that step has been converted to UI message parts and receives the response message accumulated so far.
+
+The callback is awaited before the `finish-step` chunk continues through the stream. If it throws, the error is passed to `onError` and streaming continues. Use idempotent writes because each callback contains a growing snapshot of the same response message. UI messages can contain model output, reasoning, tool inputs, and tool outputs, so apply the same access controls and sensitive-data handling that you use for final conversation persistence.
+
 ## How It Works
 
 1. **UI Message Validation:** The input `uiMessages` array is validated and normalized using the agent's `tools` definition. Any invalid messages cause an error.
@@ -158,7 +191,8 @@ for await (const chunk of stream) {
 - The agent **must** implement the `.stream({ prompt, ... })` method and define its supported `tools` property.
 - This utility returns an async iterable for maximal streaming flexibility. For HTTP responses, see [`createAgentUIStreamResponse`](/docs/reference/ai-sdk-core/create-agent-ui-stream-response) (Web) or [`pipeAgentUIStreamToResponse`](/docs/reference/ai-sdk-core/pipe-agent-ui-stream-to-response) (Node.js).
 - The `uiMessages` parameter is named `uiMessages`, **not** just `messages`.
-- You can provide advanced options via `UIMessageStreamOptions` (for example, to include sources or usage).
+- You can provide advanced options via `AgentUIMessageStreamOptions` (for example, to include sources or message metadata).
+- Use `onUIMessageStepEnd` for per-step UI message persistence. Use `onStepEnd` for low-level generation telemetry and step details.
 - To cancel the stream, pass an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) via the `abortSignal` parameter.
 - Pass `experimental_sandbox` when your agent tools need an experimental sandbox environment during execution.
 

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -110,11 +110,18 @@ export async function POST(request: Request) {
         'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
-      name: '...UIMessageStreamOptions',
-      type: 'UIMessageStreamOptions',
+      name: 'onUIMessageStepEnd',
+      type: 'UIMessageStreamOnStepEndCallback',
       isRequired: false,
       description:
-        'Other UI message output options—such as `sendSources` and more.',
+        'Callback invoked after each UI message step is assembled. It receives `messages`, `isContinuation`, and the accumulated `responseMessage` for intermediate persistence.',
+    },
+    {
+      name: '...AgentUIMessageStreamOptions',
+      type: 'AgentUIMessageStreamOptions',
+      isRequired: false,
+      description:
+        'Other UI message output options, including message IDs, metadata, final callbacks, sources, and reasoning.',
     },
     {
       name: 'headers',
@@ -147,6 +154,8 @@ export async function POST(request: Request) {
 ## Returns
 
 A `Promise<Response>` whose `body` is a streaming UI message output from the agent. Use this as the return value of API/server handlers in serverless, Next.js, Express, Hono, or edge runtime contexts.
+
+Use `onUIMessageStepEnd` to persist the accumulated UI response after every agent step. The callback is awaited before the corresponding `finish-step` chunk continues. Use idempotent writes and protect model output, reasoning, tool inputs, and tool outputs as sensitive conversation data. The existing `onStepEnd` callback remains the low-level generation callback for usage, finish reasons, and raw step details.
 
 ## Example: Next.js API Route Handler
 

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -111,7 +111,14 @@ export async function handler(req, res) {
         'Deprecated. Use `onStepEnd` instead. This alias is only used as a fallback when `onStepEnd` is not provided.',
     },
     {
-      name: '...UIMessageStreamResponseInit & UIMessageStreamOptions',
+      name: 'onUIMessageStepEnd',
+      type: 'UIMessageStreamOnStepEndCallback',
+      isRequired: false,
+      description:
+        'Callback invoked after each UI message step is assembled. It receives `messages`, `isContinuation`, and the accumulated `responseMessage` for intermediate persistence.',
+    },
+    {
+      name: '...UIMessageStreamResponseInit & AgentUIMessageStreamOptions',
       type: 'object',
       isRequired: false,
       description:
@@ -123,6 +130,8 @@ export async function handler(req, res) {
 ## Returns
 
 A `Promise<void>`. The function completes when the UI message stream has been fully sent to the provided ServerResponse.
+
+Use `onUIMessageStepEnd` to persist the accumulated UI response after every agent step. It is awaited before the corresponding `finish-step` chunk is piped. Use idempotent writes and protect model output, reasoning, tool inputs, and tool outputs as sensitive conversation data. Use the existing `onStepEnd` callback when you need low-level generation usage, finish reasons, or raw step details instead.
 
 ## Example: Express Route Handler
 

--- a/examples/ai-functions/src/agent/openai/stream-ui-message-step-end.ts
+++ b/examples/ai-functions/src/agent/openai/stream-ui-message-step-end.ts
@@ -1,0 +1,60 @@
+import { openai } from '@ai-sdk/openai';
+import { createAgentUIStream, tool, ToolLoopAgent } from 'ai';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-5.6'),
+  instructions: 'Use the weather tool, then answer the user.',
+  tools: {
+    weather: tool({
+      description: 'Get the current weather for a location.',
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72,
+        condition: 'sunny',
+      }),
+    }),
+  },
+  prepareStep: ({ stepNumber }) => ({
+    toolChoice:
+      stepNumber === 0 ? { type: 'tool', toolName: 'weather' } : 'none',
+  }),
+});
+
+run(async () => {
+  const persistedSnapshots: unknown[] = [];
+
+  const stream = await createAgentUIStream({
+    agent,
+    uiMessages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'What is the weather in San Francisco?' },
+        ],
+      },
+    ],
+    generateMessageId: () => 'assistant-1',
+    onUIMessageStepEnd: async ({ responseMessage }) => {
+      // Replace this with an idempotent database upsert in production.
+      persistedSnapshots.push(responseMessage);
+      console.log(
+        `\nPersisting step ${persistedSnapshots.length}:`,
+        JSON.stringify(responseMessage, null, 2),
+      );
+    },
+  });
+
+  for await (const chunk of stream) {
+    if (chunk.type === 'text-delta') {
+      process.stdout.write(chunk.delta);
+    }
+  }
+
+  assert.equal(persistedSnapshots.length, 2);
+  console.log('\nPersisted both agent steps.');
+});

--- a/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
@@ -7,7 +7,7 @@ import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,
 } from '@ai-sdk/provider-utils/test';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockSandboxSessionFileStubs } from '../test/mock-sandbox';
 import { z } from 'zod/v4';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
@@ -266,6 +266,7 @@ describe('createAgentUIStreamResponse', () => {
     it('should call onFinish callback and complete stream without errors', async () => {
       let onFinishCalled = false;
       let finishMessages: unknown[] | undefined;
+      const onUIMessageStepEnd = vi.fn();
 
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV4({
@@ -343,6 +344,7 @@ describe('createAgentUIStreamResponse', () => {
           onFinishCalled = true;
           finishMessages = messages;
         },
+        onUIMessageStepEnd,
       });
 
       // Consume the response to trigger onFinish
@@ -360,6 +362,16 @@ describe('createAgentUIStreamResponse', () => {
       expect(onFinishCalled).toBe(true);
       expect(finishMessages).toBeDefined();
       expect(finishMessages!.length).toBe(2);
+      expect(onUIMessageStepEnd).toHaveBeenCalledTimes(1);
+      expect(onUIMessageStepEnd.mock.calls[0][0].responseMessage).toMatchObject(
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          parts: expect.arrayContaining([
+            expect.objectContaining({ type: 'text', text: 'Done!' }),
+          ]),
+        },
+      );
     });
   });
 

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -4,19 +4,17 @@ import type {
   Experimental_SandboxSession as SandboxSession,
   ToolSet,
 } from '@ai-sdk/provider-utils';
-import type {
-  GenerateTextOnStepEndCallback,
-  GenerateTextOnStepFinishCallback,
-} from '../generate-text/generate-text-events';
 import type { Output } from '../generate-text/output';
 import type { StreamTextTransform } from '../generate-text/stream-text';
-import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
 import type { TimeoutConfiguration } from '../prompt/request-options';
 import { createUIMessageStreamResponse } from '../ui-message-stream';
 import type { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import type { InferUITools, UIMessage } from '../ui/ui-messages';
 import type { Agent } from './agent';
-import { createAgentUIStream } from './create-agent-ui-stream';
+import {
+  createAgentUIStream,
+  type AgentUIMessageStreamOptions,
+} from './create-agent-ui-stream';
 
 /**
  * Runs the agent and returns a response object with a UI message stream.
@@ -30,6 +28,7 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  * @param experimental_transform - Stream transformations. Optional.
  * @param onStepEnd - Callback that is called when each step ends. Optional.
  * @param onStepFinish - Deprecated alias for `onStepEnd`. Optional.
+ * @param onUIMessageStepEnd - Callback that is called with the accumulated UI message when each step ends. Optional.
  * @param headers - Additional headers for the response. Optional.
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
@@ -57,11 +56,9 @@ export async function createAgentUIStreamResponse<
   experimental_sandbox?: SandboxSession;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
-  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
-  /** @deprecated Use `onStepEnd` instead. */
-  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
-  UIMessageStreamOptions<
+  AgentUIMessageStreamOptions<
+    TOOLS,
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
   >): Promise<Response> {
   return createUIMessageStreamResponse({

--- a/packages/ai/src/agent/create-agent-ui-stream.test-d.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.test-d.ts
@@ -1,0 +1,37 @@
+import { tool } from '@ai-sdk/provider-utils';
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import type { UIMessage } from '../ui/ui-messages';
+import type { UIMessageStreamOnStepEndCallback } from '../ui-message-stream';
+import type { GenerateTextStepEndEvent } from '../generate-text/generate-text-events';
+import { createAgentUIStream } from './create-agent-ui-stream';
+import { ToolLoopAgent } from './tool-loop-agent';
+
+describe('createAgentUIStream types', () => {
+  it('separates generation and UI message step callbacks', () => {
+    const agent = new ToolLoopAgent({
+      model: new MockLanguageModelV4(),
+      tools: {
+        weather: tool({
+          inputSchema: z.object({ location: z.string() }),
+          execute: async ({ location }) => ({ location, temperature: 72 }),
+        }),
+      },
+    });
+
+    void createAgentUIStream({
+      agent,
+      uiMessages: [],
+      onStepEnd: event => {
+        expectTypeOf(event).toMatchTypeOf<GenerateTextStepEndEvent>();
+      },
+      onUIMessageStepEnd: event => {
+        expectTypeOf(event).toMatchTypeOf<
+          Parameters<UIMessageStreamOnStepEndCallback<UIMessage>>[0]
+        >();
+        expectTypeOf(event.responseMessage).toMatchTypeOf<UIMessage>();
+      },
+    });
+  });
+});

--- a/packages/ai/src/agent/create-agent-ui-stream.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.test.ts
@@ -1,0 +1,182 @@
+import { tool } from '@ai-sdk/provider-utils';
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import type { UIMessage } from '../ui/ui-messages';
+import { createAgentUIStream } from './create-agent-ui-stream';
+import { ToolLoopAgent } from './tool-loop-agent';
+
+describe('createAgentUIStream', () => {
+  it('provides accumulated UI messages after every agent step', async () => {
+    let modelCallCount = 0;
+    const onStepEnd = vi.fn();
+    const onUIMessageStepEnd = vi.fn();
+
+    const agent = new ToolLoopAgent({
+      model: new MockLanguageModelV4({
+        doStream: async () => {
+          modelCallCount++;
+
+          if (modelCallCount === 1) {
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'response-1',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  input: '{"location":"San Francisco"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: {
+                    unified: 'tool-calls' as const,
+                    raw: 'tool-calls',
+                  },
+                  usage: {
+                    inputTokens: {
+                      total: 3,
+                      noCache: 3,
+                      cacheRead: undefined,
+                      cacheWrite: undefined,
+                    },
+                    outputTokens: {
+                      total: 4,
+                      text: 4,
+                      reasoning: undefined,
+                    },
+                  },
+                  providerMetadata: {},
+                },
+              ]),
+            };
+          }
+
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'response-2',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'reasoning-start', id: 'reasoning-1' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'The tool returned 72°F.',
+              },
+              { type: 'reasoning-end', id: 'reasoning-1' },
+              { type: 'text-start', id: 'text-1' },
+              {
+                type: 'text-delta',
+                id: 'text-1',
+                delta: 'It is 72°F in San Francisco.',
+              },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop' as const, raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 5,
+                    noCache: 5,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: {
+                    total: 8,
+                    text: 6,
+                    reasoning: 2,
+                  },
+                },
+                providerMetadata: {},
+              },
+            ]),
+          };
+        },
+      }),
+      tools: {
+        weather: tool({
+          inputSchema: z.object({ location: z.string() }),
+          execute: async ({ location }) => ({
+            location,
+            temperature: 72,
+          }),
+        }),
+      },
+    });
+
+    const uiMessages: UIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'What is the weather in San Francisco?' },
+        ],
+      },
+    ];
+
+    const stream = await createAgentUIStream({
+      agent,
+      uiMessages,
+      generateMessageId: () => 'assistant-1',
+      messageMetadata: ({ part }) => ({ partType: part.type }),
+      onStepEnd,
+      onUIMessageStepEnd,
+    });
+
+    await convertReadableStreamToArray(stream);
+
+    expect(onStepEnd).toHaveBeenCalledTimes(2);
+    expect(onStepEnd.mock.calls[0][0]).not.toHaveProperty('responseMessage');
+
+    expect(onUIMessageStepEnd).toHaveBeenCalledTimes(2);
+    expect(onUIMessageStepEnd.mock.calls[0][0]).toMatchObject({
+      isContinuation: false,
+      messages: [uiMessages[0], expect.any(Object)],
+      responseMessage: {
+        id: 'assistant-1',
+        role: 'assistant',
+        metadata: { partType: 'tool-result' },
+        parts: [
+          { type: 'step-start' },
+          {
+            type: 'tool-weather',
+            toolCallId: 'call-1',
+            state: 'output-available',
+            input: { location: 'San Francisco' },
+            output: {
+              location: 'San Francisco',
+              temperature: 72,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(onUIMessageStepEnd.mock.calls[1][0].responseMessage).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      metadata: { partType: 'text-end' },
+      parts: [
+        { type: 'step-start' },
+        { type: 'tool-weather' },
+        { type: 'step-start' },
+        { type: 'reasoning', text: 'The tool returned 72°F.' },
+        { type: 'text', text: 'It is 72°F in San Francisco.' },
+      ],
+    });
+  });
+});

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -14,6 +14,7 @@ import type { StreamTextTransform } from '../generate-text/stream-text';
 import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
 import type { TimeoutConfiguration } from '../prompt/request-options';
 import type { InferUIMessageChunk } from '../ui-message-stream';
+import type { UIMessageStreamOnStepEndCallback } from '../ui-message-stream/ui-message-stream-on-step-end-callback';
 import { toUIMessageStream } from '../ui-message-stream/to-ui-message-stream';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
 import type {
@@ -29,6 +30,36 @@ import {
 import type { Agent } from './agent';
 
 /**
+ * Options for converting an agent stream to a UI message stream.
+ *
+ * `onStepEnd` receives the low-level generation step result. Use
+ * `onUIMessageStepEnd` to inspect or persist the accumulated UI message.
+ */
+export type AgentUIMessageStreamOptions<
+  TOOLS extends ToolSet,
+  UI_MESSAGE extends UIMessage,
+> = Omit<UIMessageStreamOptions<UI_MESSAGE>, 'onStepEnd' | 'onStepFinish'> & {
+  /**
+   * Callback that is called when each generation step ends.
+   */
+  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
+
+  /**
+   * Callback that is called when each generation step ends.
+   *
+   * @deprecated Use `onStepEnd` instead.
+   */
+  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
+
+  /**
+   * Callback that is called when each UI message step ends.
+   *
+   * Receives the accumulated response message and updated message list.
+   */
+  onUIMessageStepEnd?: UIMessageStreamOnStepEndCallback<UI_MESSAGE>;
+};
+
+/**
  * Runs the agent and stream the output as a UI message stream.
  *
  * @param agent - The agent to run.
@@ -40,6 +71,7 @@ import type { Agent } from './agent';
  * @param experimental_transform - The stream transformations. Optional.
  * @param onStepEnd - Callback that is called when each step ends. Optional.
  * @param onStepFinish - Deprecated alias for `onStepEnd`. Optional.
+ * @param onUIMessageStepEnd - Callback that is called with the accumulated UI message when each step ends. Optional.
  *
  * @returns The UI message stream.
  */
@@ -61,6 +93,7 @@ export async function createAgentUIStream<
   experimental_transform,
   onStepEnd,
   onStepFinish,
+  onUIMessageStepEnd,
   ...uiMessageStreamOptions
 }: {
   agent: Agent<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>;
@@ -70,11 +103,8 @@ export async function createAgentUIStream<
   experimental_sandbox?: SandboxSession;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
-  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
-  /** @deprecated Use `onStepEnd` instead. */
-  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
   // TODO `originalMessages` is part of this for bc, omit in v7
-} & UIMessageStreamOptions<UI_MESSAGE>): Promise<
+} & AgentUIMessageStreamOptions<TOOLS, UI_MESSAGE>): Promise<
   AsyncIterableStream<InferUIMessageChunk<UI_MESSAGE>>
 > {
   const validatedMessages = await validateUIMessages<UI_MESSAGE>({
@@ -111,6 +141,7 @@ export async function createAgentUIStream<
     toUIMessageStream({
       ...uiMessageStreamOptions,
       originalMessages,
+      onStepEnd: onUIMessageStepEnd,
       stream: result.stream,
       tools: agent.tools,
     }),

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -27,5 +27,8 @@ export {
   type InferAgentUIMessage,
 } from './infer-agent-ui-message';
 export { createAgentUIStreamResponse } from './create-agent-ui-stream-response';
-export { createAgentUIStream } from './create-agent-ui-stream';
+export {
+  createAgentUIStream,
+  type AgentUIMessageStreamOptions,
+} from './create-agent-ui-stream';
 export { pipeAgentUIStreamToResponse } from './pipe-agent-ui-stream-to-response';

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.test.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.test.ts
@@ -1,0 +1,71 @@
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockServerResponse } from '../test/mock-server-response';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { pipeAgentUIStreamToResponse } from './pipe-agent-ui-stream-to-response';
+import { ToolLoopAgent } from './tool-loop-agent';
+
+describe('pipeAgentUIStreamToResponse', () => {
+  it('calls onUIMessageStepEnd with the accumulated response message', async () => {
+    const agent = new ToolLoopAgent({
+      model: new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: 'response-1',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Hello!' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop' as const, raw: 'stop' },
+              usage: {
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+              providerMetadata: {},
+            },
+          ]),
+        }),
+      }),
+    });
+    const response = createMockServerResponse();
+    const onUIMessageStepEnd = vi.fn();
+
+    await pipeAgentUIStreamToResponse({
+      response,
+      agent,
+      uiMessages: [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Say hello.' }],
+        },
+      ],
+      generateMessageId: () => 'assistant-1',
+      onUIMessageStepEnd,
+    });
+    await response.waitForEnd();
+
+    expect(onUIMessageStepEnd).toHaveBeenCalledTimes(1);
+    expect(onUIMessageStepEnd.mock.calls[0][0].responseMessage).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{ type: 'step-start' }, { type: 'text', text: 'Hello!' }],
+    });
+  });
+});

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -5,19 +5,17 @@ import type {
   ToolSet,
 } from '@ai-sdk/provider-utils';
 import type { ServerResponse } from 'node:http';
-import type {
-  GenerateTextOnStepEndCallback,
-  GenerateTextOnStepFinishCallback,
-} from '../generate-text/generate-text-events';
 import type { Output } from '../generate-text/output';
 import type { StreamTextTransform } from '../generate-text/stream-text';
-import type { UIMessageStreamOptions } from '../generate-text/stream-text-result';
 import type { TimeoutConfiguration } from '../prompt/request-options';
 import { pipeUIMessageStreamToResponse } from '../ui-message-stream';
 import type { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import type { InferUITools, UIMessage } from '../ui/ui-messages';
 import type { Agent } from './agent';
-import { createAgentUIStream } from './create-agent-ui-stream';
+import {
+  createAgentUIStream,
+  type AgentUIMessageStreamOptions,
+} from './create-agent-ui-stream';
 
 /**
  * Pipes the agent UI message stream to a Node.js ServerResponse object.
@@ -32,6 +30,7 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  * @param experimental_transform - Stream transformations. Optional.
  * @param onStepEnd - Callback that is called when each step ends. Optional.
  * @param onStepFinish - Deprecated alias for `onStepEnd`. Optional.
+ * @param onUIMessageStepEnd - Callback that is called with the accumulated UI message when each step ends. Optional.
  * @param headers - Additional headers for the response. Optional.
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
@@ -59,11 +58,9 @@ export async function pipeAgentUIStreamToResponse<
   experimental_sandbox?: SandboxSession;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
-  onStepEnd?: GenerateTextOnStepEndCallback<TOOLS>;
-  /** @deprecated Use `onStepEnd` instead. */
-  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
-  UIMessageStreamOptions<
+  AgentUIMessageStreamOptions<
+    TOOLS,
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
   >): Promise<void> {
   pipeUIMessageStreamToResponse({

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -12,6 +12,8 @@ import type { LanguageModelResponseMetadata } from '../types/language-model-resp
 import type { LanguageModelUsage } from '../types/usage';
 import type { InferUIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import type { UIMessageStreamOnEndCallback } from '../ui-message-stream/ui-message-stream-on-end-callback';
+import type { UIMessageStreamOnStepEndCallback } from '../ui-message-stream/ui-message-stream-on-step-end-callback';
+import type { UIMessageStreamOnStepFinishCallback } from '../ui-message-stream/ui-message-stream-on-step-finish-callback';
 import type { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import type { InferUIMessageMetadata, UIMessage } from '../ui/ui-messages';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
@@ -56,6 +58,20 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
    * the original messages are provided and the last message is an assistant message).
    */
   generateMessageId?: IdGenerator;
+
+  /**
+   * Callback that is called when each step ends during multi-step runs.
+   * Useful for persisting intermediate UI messages.
+   */
+  onStepEnd?: UIMessageStreamOnStepEndCallback<UI_MESSAGE>;
+
+  /**
+   * Callback that is called when each step ends during multi-step runs.
+   * Useful for persisting intermediate UI messages.
+   *
+   * @deprecated Use `onStepEnd` instead.
+   */
+  onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
   onEnd?: UIMessageStreamOnEndCallback<UI_MESSAGE>;
 

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -14,6 +14,8 @@ import type { UIMessage } from '../ui';
 import type {
   UIMessageStreamOnEndCallback,
   UIMessageStreamOnFinishCallback,
+  UIMessageStreamOnStepEndCallback,
+  UIMessageStreamOnStepFinishCallback,
 } from '../ui-message-stream';
 import type { AsyncIterableStream } from '../util';
 import type { DeepPartial } from '../util/deep-partial';
@@ -79,10 +81,26 @@ describe('streamText types', () => {
   });
 
   describe('toUIMessageStream options', () => {
-    it('should support onEnd and deprecated onFinish', () => {
+    it('should support step and stream end callbacks', () => {
       const result = streamText({
         model: new MockLanguageModelV4(),
         prompt: 'Hello',
+      });
+
+      result.toUIMessageStream({
+        onStepEnd: event => {
+          expectTypeOf(event).toMatchTypeOf<
+            Parameters<UIMessageStreamOnStepEndCallback<UIMessage>>[0]
+          >();
+        },
+      });
+
+      result.toUIMessageStream({
+        onStepFinish: event => {
+          expectTypeOf(event).toMatchTypeOf<
+            Parameters<UIMessageStreamOnStepFinishCallback<UIMessage>>[0]
+          >();
+        },
       });
 
       result.toUIMessageStream({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2634,6 +2634,8 @@ class DefaultStreamTextResult<
   toUIMessageStream<UI_MESSAGE extends UIMessage>({
     originalMessages,
     generateMessageId,
+    onStepEnd,
+    onStepFinish,
     onEnd,
     onFinish,
     messageMetadata,
@@ -2651,6 +2653,7 @@ class DefaultStreamTextResult<
         tools: this.tools,
         originalMessages,
         generateMessageId,
+        onStepEnd: onStepEnd ?? onStepFinish,
         onEnd: onEnd ?? onFinish,
         messageMetadata,
         sendReasoning,
@@ -2667,6 +2670,8 @@ class DefaultStreamTextResult<
     {
       originalMessages,
       generateMessageId,
+      onStepEnd,
+      onStepFinish,
       onEnd,
       onFinish,
       messageMetadata,
@@ -2683,6 +2688,7 @@ class DefaultStreamTextResult<
       stream: this.toUIMessageStream({
         originalMessages,
         generateMessageId,
+        onStepEnd: onStepEnd ?? onStepFinish,
         onEnd: onEnd ?? onFinish,
         messageMetadata,
         sendReasoning,
@@ -2706,6 +2712,8 @@ class DefaultStreamTextResult<
   toUIMessageStreamResponse<UI_MESSAGE extends UIMessage>({
     originalMessages,
     generateMessageId,
+    onStepEnd,
+    onStepFinish,
     onEnd,
     onFinish,
     messageMetadata,
@@ -2721,6 +2729,7 @@ class DefaultStreamTextResult<
       stream: this.toUIMessageStream({
         originalMessages,
         generateMessageId,
+        onStepEnd: onStepEnd ?? onStepFinish,
         onEnd: onEnd ?? onFinish,
         messageMetadata,
         sendReasoning,

--- a/packages/ai/src/ui-message-stream/to-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-stream.test.ts
@@ -253,6 +253,104 @@ describe('toUIMessageStream', () => {
     });
   });
 
+  it('calls onStepEnd with the accumulated UI message', async () => {
+    const parts: TextStreamPart<{}>[] = [
+      { type: 'start' },
+      { type: 'start-step', request: {}, warnings: [] },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', text: 'First' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish-step',
+        response: { id: 'r1', modelId: 'm', timestamp: new Date(0) },
+        usage: testUsage,
+        performance: {
+          effectiveOutputTokensPerSecond: 0,
+          outputTokensPerSecond: 0,
+          inputTokensPerSecond: 0,
+          effectiveTotalTokensPerSecond: 0,
+          stepTimeMs: 0,
+          responseTimeMs: 0,
+          toolExecutionMs: {},
+          timeToFirstOutputMs: undefined,
+        },
+        finishReason: 'stop',
+        rawFinishReason: 'stop',
+        providerMetadata: undefined,
+      },
+      { type: 'start-step', request: {}, warnings: [] },
+      { type: 'text-start', id: 't2' },
+      { type: 'text-delta', id: 't2', text: 'Second' },
+      { type: 'text-end', id: 't2' },
+      {
+        type: 'finish-step',
+        response: { id: 'r2', modelId: 'm', timestamp: new Date(0) },
+        usage: testUsage,
+        performance: {
+          effectiveOutputTokensPerSecond: 0,
+          outputTokensPerSecond: 0,
+          inputTokensPerSecond: 0,
+          effectiveTotalTokensPerSecond: 0,
+          stepTimeMs: 0,
+          responseTimeMs: 0,
+          toolExecutionMs: {},
+          timeToFirstOutputMs: undefined,
+        },
+        finishReason: 'stop',
+        rawFinishReason: 'stop',
+        providerMetadata: undefined,
+      },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        rawFinishReason: 'stop',
+        totalUsage: testUsage,
+      },
+    ];
+    const originalMessages: UIMessage[] = [
+      {
+        id: 'user-msg-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hi' }],
+      },
+    ];
+    const onStepEnd = vi.fn();
+
+    await convertReadableStreamToArray(
+      toUIMessageStream({
+        stream: convertArrayToReadableStream(parts),
+        tools: undefined,
+        originalMessages,
+        generateMessageId: () => 'assistant-msg-1',
+        onStepEnd,
+      }),
+    );
+
+    expect(onStepEnd).toHaveBeenCalledTimes(2);
+    expect(onStepEnd.mock.calls[0][0]).toMatchObject({
+      isContinuation: false,
+      responseMessage: {
+        id: 'assistant-msg-1',
+        role: 'assistant',
+        parts: [{ type: 'step-start' }, { type: 'text', text: 'First' }],
+      },
+      messages: [
+        originalMessages[0],
+        {
+          id: 'assistant-msg-1',
+          role: 'assistant',
+          parts: [{ type: 'step-start' }, { type: 'text', text: 'First' }],
+        },
+      ],
+    });
+    expect(onStepEnd.mock.calls[1][0].responseMessage.parts).toMatchObject([
+      { type: 'step-start' },
+      { type: 'text', text: 'First' },
+      { type: 'step-start' },
+      { type: 'text', text: 'Second' },
+    ]);
+  });
+
   it('calls onEnd when stream finishes', async () => {
     const parts: TextStreamPart<{}>[] = [
       { type: 'start' },

--- a/packages/ai/src/ui-message-stream/to-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-stream.ts
@@ -13,7 +13,7 @@ import { toUIMessageChunk } from './to-ui-message-chunk';
  * Converts a stream of `TextStreamPart<TOOLS>` chunks (as emitted by
  * `streamText`'s `stream`) into a stream of `UIMessageChunk`s suitable for
  * UI message streaming, including response message ID injection and
- * `onEnd` handling.
+ * step/end callback handling.
  */
 export function toUIMessageStream<
   TOOLS extends ToolSet = ToolSet,
@@ -29,6 +29,8 @@ export function toUIMessageStream<
   messageMetadata,
   originalMessages,
   generateMessageId,
+  onStepEnd,
+  onStepFinish,
   onEnd,
   onFinish,
 }: {
@@ -85,6 +87,7 @@ export function toUIMessageStream<
     stream: uiMessageChunkStream,
     messageId: responseMessageId ?? generateMessageId?.(),
     originalMessages,
+    onStepEnd: onStepEnd ?? onStepFinish,
     onEnd: onEnd ?? onFinish,
     onError,
   });


### PR DESCRIPTION
## Background

Agent UI stream users need the accumulated UIMessage at every step boundary so they can inspect or persist intermediate conversation state without reconstructing it from generation results.

## Summary

Added shared per-step callbacks to UIMessageStreamOptions and introduced onUIMessageStepEnd across createAgentUIStream, createAgentUIStreamResponse, and pipeAgentUIStreamToResponse while preserving the existing low-level onStepEnd callback.

## Testing

Added runtime and type tests covering multi-step accumulated text, reasoning, tools, metadata, message IDs, callback type separation, response helpers, pipe helpers, and streamText UI conversion.

## End-to-end Validation

- Ran the new OpenAI gpt-5.6 example against the live API and verified two accumulated UIMessage snapshots were produced and persisted across the tool-call and final-answer steps.

## Documentation

Updated the agent UI stream and streamText references with callback APIs, persistence examples, lifecycle distinctions, backpressure and error behavior, idempotency guidance, and sensitive-data considerations.

## Related Issues

Fixes #12841

Co-authored-by: rovo89 <1573299+rovo89@users.noreply.github.com>