### PR TITLE
fix(ai): scope UI message tool parts to the current step

### DIFF
--- a/.changeset/ui-tool-part-step-scope.md
+++ b/.changeset/ui-tool-part-step-scope.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): scope UI message tool parts to the current step so a tool call id reused across steps creates a new tool part instead of overwriting the earlier one

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -9385,4 +9385,73 @@ describe('processUIMessageStream', () => {
       ]);
     });
   });
+
+  describe('tool call id reused across steps', () => {
+    // Reproduces https://github.com/vercel/ai/issues/17347: a provider (e.g. the
+    // OpenAI Responses API through Amazon Bedrock) may return the same
+    // response-scoped tool call id in more than one step. Each step is a
+    // distinct tool call, so it must become its own UI tool part instead of
+    // overwriting the earlier one.
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-1' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'call_0',
+          toolName: 'recordStep',
+          input: { step: 1 },
+          providerMetadata: { openai: { itemId: 'fc_step_1' } },
+        },
+        {
+          type: 'tool-output-available',
+          toolCallId: 'call_0',
+          output: { ok: 1 },
+        },
+        { type: 'finish-step' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'call_0',
+          toolName: 'recordStep',
+          input: { step: 2 },
+          providerMetadata: { openai: { itemId: 'fc_step_2' } },
+        },
+        {
+          type: 'tool-output-available',
+          toolCallId: 'call_0',
+          output: { ok: 2 },
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-1',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('keeps a separate tool part for each step', () => {
+      const toolParts = state!.message.parts.filter(
+        part => part.type === 'tool-recordStep',
+      );
+
+      expect(toolParts).toHaveLength(2);
+      expect(toolParts).toMatchObject([
+        { input: { step: 1 }, output: { ok: 1 } },
+        { input: { step: 2 }, output: { ok: 2 } },
+      ]);
+    });
+  });
 });

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -35,6 +35,10 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   message: UI_MESSAGE;
   activeTextParts: Record<string, TextUIPart>;
   activeReasoningParts: Record<string, ReasoningUIPart>;
+  activeToolParts: Record<
+    string,
+    ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | DynamicToolUIPart
+  >;
   partialToolCalls: Record<
     string,
     {
@@ -56,21 +60,38 @@ export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage: UI_MESSAGE | undefined;
   messageId: string;
 }): StreamingUIMessageState<UI_MESSAGE> {
+  const message =
+    lastMessage?.role === 'assistant'
+      ? lastMessage
+      : ({
+          id: messageId,
+          metadata: undefined,
+          role: 'assistant',
+          parts: [] as UIMessagePart<
+            InferUIMessageData<UI_MESSAGE>,
+            InferUIMessageTools<UI_MESSAGE>
+          >[],
+        } as UI_MESSAGE);
+
+  // Seed the active tool parts from the message being continued so that a
+  // resumed tool call (e.g. a tool executed after an approval that was carried
+  // over in lastMessage) updates the existing part instead of creating a
+  // duplicate. Parts created within the stream are added as they arrive, and
+  // the set is reset at each step boundary.
+  const activeToolParts: StreamingUIMessageState<UI_MESSAGE>['activeToolParts'] =
+    createIdMap();
+  for (const part of message.parts) {
+    if (isToolUIPart(part)) {
+      activeToolParts[part.toolCallId] =
+        part as (typeof activeToolParts)[string];
+    }
+  }
+
   return {
-    message:
-      lastMessage?.role === 'assistant'
-        ? lastMessage
-        : ({
-            id: messageId,
-            metadata: undefined,
-            role: 'assistant',
-            parts: [] as UIMessagePart<
-              InferUIMessageData<UI_MESSAGE>,
-              InferUIMessageTools<UI_MESSAGE>
-            >[],
-          } as UI_MESSAGE),
+    message,
     activeTextParts: createIdMap(),
     activeReasoningParts: createIdMap(),
+    activeToolParts,
     partialToolCalls: createIdMap(),
   };
 }
@@ -105,11 +126,14 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
       async transform(chunk, controller) {
         await runUpdateMessageJob(async ({ state, write }) => {
           function getToolInvocation(toolCallId: string) {
-            const toolInvocations = state.message.parts.filter(isToolUIPart);
-
-            const toolInvocation = toolInvocations.find(
-              invocation => invocation.toolCallId === toolCallId,
-            );
+            // Scope the lookup to the current step's active tool part: providers
+            // may reuse a response-scoped tool call id (e.g. `call_0`) across
+            // steps, so a global search by id would resolve to an earlier step's
+            // tool part.
+            const activePart = state.activeToolParts[toolCallId];
+            const toolInvocation = state.message.parts
+              .filter(isToolUIPart)
+              .find(invocation => invocation === activePart);
 
             if (toolInvocation == null) {
               throw new UIMessageStreamError({
@@ -178,11 +202,11 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 }
             ),
           ) {
-            const part = state.message.parts.find(
-              part =>
-                isStaticToolUIPart(part) &&
-                part.toolCallId === options.toolCallId,
-            ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined;
+            const activePart = state.activeToolParts[options.toolCallId];
+            const part =
+              activePart != null && isStaticToolUIPart(activePart)
+                ? (activePart as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>)
+                : undefined;
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -222,7 +246,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 }
               }
             } else {
-              state.message.parts.push({
+              const newPart = {
                 type: `tool-${options.toolName}`,
                 toolCallId: options.toolCallId,
                 state: options.state,
@@ -248,7 +272,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 )
                   ? { callProviderMetadata: anyOptions.providerMetadata }
                   : {}),
-              } as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>);
+              } as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>;
+              state.message.parts.push(newPart);
+              state.activeToolParts[options.toolCallId] = newPart;
             }
           }
 
@@ -285,11 +311,11 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 }
             ),
           ) {
-            const part = state.message.parts.find(
-              part =>
-                part.type === 'dynamic-tool' &&
-                part.toolCallId === options.toolCallId,
-            ) as DynamicToolUIPart | undefined;
+            const activePart = state.activeToolParts[options.toolCallId];
+            const part =
+              activePart?.type === 'dynamic-tool'
+                ? (activePart as DynamicToolUIPart)
+                : undefined;
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -330,7 +356,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 }
               }
             } else {
-              state.message.parts.push({
+              const newPart = {
                 type: 'dynamic-tool',
                 toolName: options.toolName,
                 toolCallId: options.toolCallId,
@@ -356,7 +382,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 )
                   ? { callProviderMetadata: anyOptions.providerMetadata }
                   : {}),
-              } as DynamicToolUIPart);
+              } as DynamicToolUIPart;
+              state.message.parts.push(newPart);
+              state.activeToolParts[options.toolCallId] = newPart;
             }
           }
 
@@ -828,9 +856,11 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'finish-step': {
-              // reset the current text and reasoning parts
+              // reset the current text, reasoning, and tool parts so the next
+              // step starts a fresh part even if a tool call id is reused
               state.activeTextParts = createIdMap();
               state.activeReasoningParts = createIdMap();
+              state.activeToolParts = createIdMap();
               break;
             }
 


### PR DESCRIPTION
## Background

Fixes #17347

When multiple model steps are aggregated into one `UIMessage`, a provider can return the same response-scoped tool call id in more than one step. This happens with the OpenAI-compatible Responses API through Amazon Bedrock, where each step restarts the tool call id at `call_0` while the provider item ids (`fc_...`) stay globally unique.

The UI message stream reducer resolved tool parts globally by `toolCallId` (`updateToolPart`, `updateDynamicToolPart`, and `getToolInvocation` all did a `find` over the whole message). So a later step's `call_0` updated the earlier step's tool part instead of appending a new one, and after `toUIMessageStream()` / `readUIMessageStream()` the final message kept a single merged tool part rather than one per step.

The reducer already treats a step boundary as a fresh scope for text and reasoning parts (`activeTextParts` and `activeReasoningParts` are reset on `finish-step`); tool parts were the exception. This change makes tool parts follow the same step-scoping rule, so it does not depend on providers producing globally unique ids.

## Summary

Tool parts are now tracked in a step-scoped `activeToolParts` map alongside `activeTextParts` and `activeReasoningParts`. `updateToolPart`, `updateDynamicToolPart`, and `getToolInvocation` resolve the current tool part through that map and register newly created parts in it, and the map is reset on `finish-step`. It is seeded from the message being continued so a resumed tool call (for example a tool executed after an approval carried over in `lastMessage`) still updates the existing part instead of duplicating it. Provider tool call ids are left untouched for protocol pairing.

## Contributor Credit

Thanks to @wangliang1996 for the detailed report and the self-contained reproduction in #17347.

## End-to-End Verification

Replaying the chunk sequence from the issue (two steps that both use `toolCallId: 'call_0'` with different inputs and outputs, separated by a `finish-step`) through `processUIMessageStream`: before the change the final message contains a single `tool-recordStep` part carrying only the second step's data; after the change it contains two distinct tool parts, one per step, each with its own input and output. The existing approval and resume flows (including tool execution after an approval carried over in `lastMessage`) still resolve their tool part and behave unchanged.
