### PR TITLE
[v6.0] reproduction: OAuthMetadataSchema requires codechallengemethodssupported, but RFC 8414 marks it

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17334,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17334.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17334.ts",
+    "packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue 17334 reproduced: valid OAuth metadata without code_challenge_methods_supported was rejected before DCR"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17334.ts
+++ b/examples/ai-functions/src/reproduction/issue-17334.ts
@@ -1,0 +1,142 @@
+import { readFile } from 'node:fs/promises';
+import {
+  auth,
+  type OAuthClientProvider,
+} from '../../../../packages/mcp/src/tool/oauth';
+
+type FetchFunction = typeof globalThis.fetch;
+
+const fixtureUrl = new URL(
+  '../../../../packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json',
+  import.meta.url,
+);
+
+const expectedSchemaMessage =
+  'Invalid input: expected array, received undefined';
+const reproductionSignal =
+  'Issue 17334 reproduced: valid OAuth metadata without code_challenge_methods_supported was rejected before DCR';
+
+function createProvider(): OAuthClientProvider {
+  return {
+    get redirectUrl() {
+      return 'http://localhost:8090/oauth/callback';
+    },
+    get clientMetadata() {
+      return {
+        redirect_uris: ['http://localhost:8090/oauth/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        client_name: 'issue-17334-reproduction',
+      };
+    },
+    tokens() {
+      return undefined;
+    },
+    saveTokens() {},
+    clientInformation() {
+      return undefined;
+    },
+    saveClientInformation() {},
+    saveCodeVerifier() {},
+    codeVerifier() {
+      return '';
+    },
+    redirectToAuthorization() {},
+  };
+}
+
+function createFetch({
+  metadata,
+  onRegistration,
+}: {
+  metadata: Record<string, unknown>;
+  onRegistration: () => void;
+}): FetchFunction {
+  return async input => {
+    const url = new URL(
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input
+          : input.url,
+    );
+
+    if (url.pathname === '/.well-known/oauth-protected-resource') {
+      return new Response(null, { status: 404 });
+    }
+
+    if (url.pathname === '/.well-known/oauth-authorization-server') {
+      return Response.json(metadata);
+    }
+
+    if (url.pathname === '/v1/register') {
+      onRegistration();
+      return Response.json({
+        client_id: 'recorded-fixture-client',
+        redirect_uris: ['http://localhost:8090/oauth/callback'],
+      });
+    }
+
+    throw new Error(`Unexpected reproduction request: ${url}`);
+  };
+}
+
+async function reachesDynamicClientRegistration(
+  metadata: Record<string, unknown>,
+): Promise<{ reached: boolean; error?: unknown }> {
+  let reached = false;
+
+  try {
+    await auth(createProvider(), {
+      serverUrl: String(metadata.issuer),
+      fetchFn: createFetch({
+        metadata,
+        onRegistration: () => {
+          reached = true;
+        },
+      }),
+    });
+    return { reached };
+  } catch (error) {
+    return { reached, error };
+  }
+}
+
+async function main() {
+  const metadata = JSON.parse(await readFile(fixtureUrl, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+
+  const reportedResult = await reachesDynamicClientRegistration(metadata);
+  const comparisonResult = await reachesDynamicClientRegistration({
+    ...metadata,
+    code_challenge_methods_supported: ['S256'],
+  });
+
+  const rejectedMissingField =
+    !reportedResult.reached &&
+    reportedResult.error instanceof Error &&
+    reportedResult.error.message.includes(expectedSchemaMessage) &&
+    reportedResult.error.message.includes('code_challenge_methods_supported');
+
+  if (rejectedMissingField && comparisonResult.reached) {
+    console.error(reproductionSignal);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (reportedResult.error && !reportedResult.reached) {
+    throw reportedResult.error;
+  }
+
+  console.log(
+    'Issue 17334 not reproduced: metadata discovery reached Dynamic Client Registration',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json
+++ b/packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json
@@ -1,0 +1,9 @@
+{
+  "issuer": "https://us-east-1.oauth.signin.aws",
+  "authorization_endpoint": "https://us-east-1.oauth.signin.aws/v1/authorize",
+  "token_endpoint": "https://us-east-1.oauth.signin.aws/v1/token",
+  "registration_endpoint": "https://us-east-1.oauth.signin.aws/v1/register",
+  "token_endpoint_auth_methods_supported": ["none"],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"]
+}

--- a/packages/mcp/src/tool/oauth.issue-17334.test.ts
+++ b/packages/mcp/src/tool/oauth.issue-17334.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import { discoverAuthorizationServerMetadata } from './oauth';
+
+const awsSignInMetadata = JSON.parse(
+  readFileSync(
+    new URL('./__fixtures__/aws-signin-oauth-metadata.json', import.meta.url),
+    'utf8',
+  ),
+);
+
+it('accepts RFC 8414 metadata that omits code challenge methods', async () => {
+  const fetchFn = vi.fn(async () =>
+    Response.json(awsSignInMetadata, { status: 200 }),
+  );
+
+  await expect(
+    discoverAuthorizationServerMetadata(awsSignInMetadata.issuer, { fetchFn }),
+  ).resolves.toEqual(awsSignInMetadata);
+});


### PR DESCRIPTION
## Bug

OAuthMetadataSchema requires code_challenge_methods_supported, but RFC 8414 marks it optional, breaking DCR against spec-compliant servers (e.g. AWS Sign-In)

## Reproduction

- Live AWS Sign-In metadata returned HTTP 200 without `code_challenge_methods_supported`; the recorded response is in `packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json`.
- On `release-v6.0`, `packages/mcp/src/tool/oauth-types.ts` requires the omitted field, causing metadata discovery to throw a ZodError before Dynamic Client Registration instead of accepting the RFC-valid document.
- `examples/ai-functions/src/reproduction/issue-17334.ts` reproduced the premature rejection; injecting `code_challenge_methods_supported: ["S256"]` into the same fixture allowed execution to reach Dynamic Client Registration.
- `packages/mcp/src/tool/oauth.issue-17334.test.ts` expects discovery to accept the recorded metadata but fails on `code_challenge_methods_supported` being undefined.
- RFC 8414 defines the field as optional, while the current MCP specification requires clients to refuse authorization later when PKCE support is not advertised; making the schema optional fixes the premature discovery failure but does not alone make the complete AWS authorization flow MCP-compatible.
- The target branch contains `@ai-sdk/mcp` 1.0.62 rather than the reported 2.0.13, but the affected API and required schema field are present and exhibit the same failure.
- The post-DCR interactive browser authorization, token exchange, and authenticated AWS tool call were not rerun; the reproduced primary outcome is the credential-free failure before DCR.

## Relevant Documentation

- https://www.rfc-editor.org/rfc/rfc8414.html#section-2
- https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
- https://docs.aws.amazon.com/signin/latest/userguide/oauth-sign-in-overview.html
- https://ts.sdk.modelcontextprotocol.io/v2/functions/_modelcontextprotocol_client.client_auth.discoverOAuthMetadata.html

## Related Issues

Reproduces #17334