### PR TITLE
[v6.0] reproduction: uiMessageChunkSchema strict validation breaks backward due to providerMetadata

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 13733,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/ui-message-chunk-forward-compatibility.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Forward compatibility failure: DefaultChatTransport rejected optionalFieldFromNewerServer with AI_TypeValidationError."
+  }
+}

--- a/examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts
+++ b/examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { DefaultChatTransport, type UIMessage } from 'ai';
+
+const encoder = new TextEncoder();
+
+async function parseServerChunk(chunk: unknown) {
+  const transport = new DefaultChatTransport<UIMessage>({
+    api: 'https://example.test/api/chat',
+    fetch: async () =>
+      new Response(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`), {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+  });
+
+  const stream = await transport.sendMessages({
+    trigger: 'submit-message',
+    chatId: 'reproduction',
+    messageId: undefined,
+    messages: [],
+    abortSignal: undefined,
+  });
+
+  return (await stream.getReader().read()).value;
+}
+
+async function main() {
+  const baselineChunk = {
+    type: 'tool-output-available',
+    toolCallId: 'call-1',
+    output: { temperature: 72 },
+  };
+
+  assert.deepEqual(await parseServerChunk(baselineChunk), baselineChunk);
+
+  const currentMetadataChunk = {
+    ...baselineChunk,
+    providerMetadata: { openai: { itemId: 'item-1' } },
+    toolMetadata: { clientName: 'ai-sdk-mcp-client' },
+  };
+
+  assert.deepEqual(
+    await parseServerChunk(currentMetadataChunk),
+    currentMetadataChunk,
+  );
+
+  const newerServerChunk = {
+    ...baselineChunk,
+    optionalFieldFromNewerServer: true,
+  };
+
+  try {
+    await parseServerChunk(newerServerChunk);
+  } catch (error) {
+    assert.ok(
+      error instanceof Error &&
+        error.name === 'AI_TypeValidationError' &&
+        error.message.includes('"code": "unrecognized_keys"') &&
+        error.message.includes('optionalFieldFromNewerServer'),
+      'Expected strict UI message chunk validation to reject the newer field',
+    );
+
+    throw new Error(
+      'Forward compatibility failure: DefaultChatTransport rejected optionalFieldFromNewerServer with AI_TypeValidationError.',
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## Bug

uiMessageChunkSchema strict validation breaks backward due to providerMetadata addition

## Reproduction

- `packages/ai/src/ui-message-stream/ui-message-chunks.ts` in `ai@6.0.230` still defines UI message chunk variants with `z.strictObject()`, rejecting fields unknown to the client schema.
- `examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts` confirms that baseline chunks and currently recognized `providerMetadata` and `toolMetadata` fields parse successfully, while a field added by a newer server causes `DefaultChatTransport` to throw `AI_TypeValidationError`.
- The expected behavior is for older clients to accept or ignore additional fields on known chunk types instead of terminating the UI message stream.
- Historical `ai@6.0.119` and `ai@6.0.140` bundles were not installed; the target `ai@6.0.230` branch reproduces the same forward-compatibility failure using an unknown newer-server field.

## Related Issues

Reproduces #13733