### PR TITLE
[v6.0] reproduction: activeTools still executes disabled tools and breaks prepareStep

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 13448,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-13448-active-tools-execution.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_13448_REPRODUCED: an activeTools-disabled tool execute function ran."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts
+++ b/examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts
@@ -1,0 +1,132 @@
+import { simulateReadableStream, stepCountIs, streamText, tool } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+const usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+function toolCallStream(toolCallId: string) {
+  return simulateReadableStream({
+    initialDelayInMs: 0,
+    chunkDelayInMs: 0,
+    chunks: [
+      {
+        type: 'tool-call' as const,
+        toolCallId,
+        toolName: 'weather',
+        input: JSON.stringify({ location: 'Basel' }),
+      },
+      {
+        type: 'finish' as const,
+        finishReason: { unified: 'tool-calls' as const, raw: undefined },
+        usage,
+      },
+    ],
+  });
+}
+
+async function runDirectActiveToolsScenario() {
+  let executionCount = 0;
+  let providerToolCount: number | undefined;
+
+  const result = streamText({
+    model: new MockLanguageModelV3({
+      doStream: async ({ tools }) => {
+        providerToolCount = tools?.length;
+        return { stream: toolCallStream('direct_call') };
+      },
+    }),
+    prompt: 'test',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executionCount++;
+          return `weather for ${location}`;
+        },
+      }),
+    },
+    activeTools: [],
+    stopWhen: stepCountIs(1),
+  });
+
+  await result.consumeStream();
+
+  return {
+    executionCount,
+    providerToolCount,
+    toolCalls: await result.toolCalls,
+    toolResults: await result.toolResults,
+  };
+}
+
+async function runPrepareStepScenario() {
+  let executionCount = 0;
+  const providerToolCounts: Array<number | undefined> = [];
+  let modelCallCount = 0;
+
+  const result = streamText({
+    model: new MockLanguageModelV3({
+      doStream: async ({ tools }) => {
+        providerToolCounts.push(tools?.length);
+        modelCallCount++;
+        return { stream: toolCallStream(`prepare_call_${modelCallCount}`) };
+      },
+    }),
+    prompt: 'test',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executionCount++;
+          return `weather for ${location}`;
+        },
+      }),
+    },
+    prepareStep: ({ stepNumber }) =>
+      stepNumber === 1 ? { activeTools: [] } : undefined,
+    stopWhen: stepCountIs(2),
+  });
+
+  await result.consumeStream();
+
+  return {
+    executionCount,
+    providerToolCounts,
+    stepToolCalls: (await result.steps).map(step => step.toolCalls),
+    stepToolResults: (await result.steps).map(step => step.toolResults),
+  };
+}
+
+async function main() {
+  const direct = await runDirectActiveToolsScenario();
+  const prepareStep = await runPrepareStepScenario();
+
+  console.log(
+    JSON.stringify(
+      {
+        direct,
+        prepareStep,
+        expected: {
+          directExecutionCount: 0,
+          prepareStepExecutionCount: 1,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (direct.executionCount !== 0 || prepareStep.executionCount !== 1) {
+    throw new Error(
+      'ISSUE_13448_REPRODUCED: an activeTools-disabled tool execute function ran.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

activeTools still executes disabled tools and breaks prepareStep tool disabling

## Reproduction

- Added `examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts` covering both direct `activeTools: []` and later-step disabling through `prepareStep`.
- On `ai@6.0.230`, the direct scenario sent zero tools to the provider, but the disabled `weather` tool executed once and produced a successful tool result.
- The `prepareStep` scenario sent one tool on step 1 and zero tools on step 2, but `weather` executed on both steps instead of only the enabled first step.
- Expected disabled tool calls to be treated as unavailable and their `execute` functions not to run; both reported behaviors were reproduced.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling

## Related Issues

Reproduces #13448