### PR TITLE
[v6.0] fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations

### DIFF
--- a/.changeset/olive-owls-listen.md
+++ b/.changeset/olive-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): accept OAuth metadata without code challenge methods

--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -63,6 +63,7 @@ export const OAuthProtectedResourceMetadataSchema = z
   })
   .passthrough();
 
+<<<<<<< HEAD
 export const OAuthMetadataSchema = z
   .object({
     issuer: z.string(),
@@ -79,6 +80,22 @@ export const OAuthMetadataSchema = z
       .optional(),
   })
   .passthrough();
+=======
+export const OAuthMetadataSchema = z.looseObject({
+  issuer: z.string(),
+  authorization_endpoint: SafeUrlSchema,
+  token_endpoint: SafeUrlSchema,
+  registration_endpoint: SafeUrlSchema.optional(),
+  scopes_supported: z.array(z.string()).optional(),
+  response_types_supported: z.array(z.string()),
+  grant_types_supported: z.array(z.string()).optional(),
+  code_challenge_methods_supported: z.array(z.string()).optional(),
+  token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
+  token_endpoint_auth_signing_alg_values_supported: z
+    .array(z.string())
+    .optional(),
+});
+>>>>>>> d84ea43de (fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations (#17462))
 
 /**
  * OpenID Connect Discovery 1.0 Provider Metadata

--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -63,7 +63,6 @@ export const OAuthProtectedResourceMetadataSchema = z
   })
   .passthrough();
 
-<<<<<<< HEAD
 export const OAuthMetadataSchema = z
   .object({
     issuer: z.string(),
@@ -73,29 +72,13 @@ export const OAuthMetadataSchema = z
     scopes_supported: z.array(z.string()).optional(),
     response_types_supported: z.array(z.string()),
     grant_types_supported: z.array(z.string()).optional(),
-    code_challenge_methods_supported: z.array(z.string()),
+    code_challenge_methods_supported: z.array(z.string()).optional(),
     token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
     token_endpoint_auth_signing_alg_values_supported: z
       .array(z.string())
       .optional(),
   })
   .passthrough();
-=======
-export const OAuthMetadataSchema = z.looseObject({
-  issuer: z.string(),
-  authorization_endpoint: SafeUrlSchema,
-  token_endpoint: SafeUrlSchema,
-  registration_endpoint: SafeUrlSchema.optional(),
-  scopes_supported: z.array(z.string()).optional(),
-  response_types_supported: z.array(z.string()),
-  grant_types_supported: z.array(z.string()).optional(),
-  code_challenge_methods_supported: z.array(z.string()).optional(),
-  token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
-  token_endpoint_auth_signing_alg_values_supported: z
-    .array(z.string())
-    .optional(),
-});
->>>>>>> d84ea43de (fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations (#17462))
 
 /**
  * OpenID Connect Discovery 1.0 Provider Metadata

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -576,6 +576,34 @@ describe('discoverAuthorizationServerMetadata', () => {
     expect(metadata).toEqual(tenantMetadata);
   });
 
+  it('accepts OAuth metadata when code challenge methods are omitted', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        registration_endpoint: 'https://auth.example.com/register',
+        response_types_supported: ['code'],
+      }),
+    });
+
+    expect(
+      await discoverAuthorizationServerMetadata('https://auth.example.com'),
+    ).toMatchInlineSnapshot(`
+      {
+        "authorization_endpoint": "https://auth.example.com/authorize",
+        "issuer": "https://auth.example.com",
+        "registration_endpoint": "https://auth.example.com/register",
+        "response_types_supported": [
+          "code",
+        ],
+        "token_endpoint": "https://auth.example.com/token",
+      }
+    `);
+  });
+
   it('tries URLs in order and returns first successful metadata', async () => {
     // First OAuth URL fails with 404
     mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Background

RFC 8414-compliant servers such as AWS Sign-In can omit PKCE method metadata, which caused MCP OAuth discovery to fail before Dynamic Client Registration.

## Root Cause

OAuthMetadataSchema incorrectly required code_challenge_methods_supported; the reproduction confirmed that its absence caused a Zod array validation error before registration.

## Summary

Made code_challenge_methods_supported optional in the MCP OAuth metadata schema.

## Testing

Added an inline-snapshot regression test to the existing OAuth test suite covering metadata that omits code challenge methods.

## End-to-end Validation

- `pnpm exec tsx -e "<live AWS OAuth auth probe>"` accepted the live AWS Sign-In metadata and reached Dynamic Client Registration.

## Related Issues

Fixes #17334

Closes #17453

Backport of #17462

Co-authored-by: rene84 <7099469+rene84@users.noreply.github.com>