### PR TITLE
reproduction: could not reproduce Cannot Access AI Gateway

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-7447-gateway-explicit-api-key.ts
+++ b/examples/ai-functions/src/reproduction/issue-7447-gateway-explicit-api-key.ts
@@ -1,0 +1,40 @@
+import 'dotenv/config';
+import { createGateway } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+async function main() {
+  const apiKey = process.env.AI_GATEWAY_API_KEY;
+  let explicitApiKeyWasForwarded = false;
+
+  const gateway = createGateway({
+    apiKey,
+    fetch: async (input, init) => {
+      explicitApiKeyWasForwarded =
+        new Headers(init?.headers).get('authorization') === `Bearer ${apiKey}`;
+      return fetch(input, init);
+    },
+  });
+
+  const result = await generateText({
+    model: gateway('openai/gpt-5-nano'),
+    prompt: 'Reply with exactly: OK',
+    maxOutputTokens: 10,
+  });
+
+  if (!explicitApiKeyWasForwarded) {
+    throw new Error(
+      'The explicit createGateway apiKey was not forwarded to AI Gateway.',
+    );
+  }
+
+  console.log('AI Gateway access succeeded with an explicit apiKey.');
+  console.log(`Finish reason: ${result.finishReason}`);
+}
+
+main().catch(error => {
+  console.error(
+    'Issue #7447: AI Gateway access failed with an explicit apiKey.',
+  );
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Cannot Access AI Gateway

## Reproduction

- The primary reported failure did not occur on `main`: a live `generateText` request through `createGateway({ apiKey })` completed successfully with `openai/gpt-5-nano`.
- `examples/ai-functions/src/reproduction/issue-7447-gateway-explicit-api-key.ts` reproduces the explicit-key setup and confirms the supplied key is forwarded as the bearer credential; it exits successfully instead of reporting “Vercel AI Gateway access failed.”
- `packages/ai/CHANGELOG.md` lists `@ai-sdk/gateway@1.0.0-beta.11` with `ai@5.0.0-beta.25`, so the reported beta versions were release-aligned rather than an unsupported combination.
- The reporter's SST `Resource.AIGatewayAPIKey.value` resolution was unavailable; the live check substituted `AI_GATEWAY_API_KEY` as the explicit value, leaving an SST secret-resolution or configuration issue outside this SDK reproduction.

## Relevant Documentation

- https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway
- https://vercel.com/docs/ai-gateway/authentication-and-byok

## Related Issues

Could not reproduce #7447