### PR TITLE
[v5.0] reproduction: could not reproduce Cannot Access AI Gateway

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-7447-gateway-explicit-api-key.ts
+++ b/examples/ai-functions/src/reproduction/issue-7447-gateway-explicit-api-key.ts
@@ -1,0 +1,44 @@
+import { createGateway, generateText } from 'ai';
+
+async function main() {
+  const apiKey = process.env.AI_GATEWAY_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('AI_GATEWAY_API_KEY is required for this reproduction.');
+  }
+
+  let forwardedAuthorization: string | null = null;
+
+  const gateway = createGateway({
+    apiKey,
+    fetch: async (input, init) => {
+      forwardedAuthorization = new Headers(init?.headers).get('authorization');
+      return fetch(input, init);
+    },
+  });
+
+  const result = await generateText({
+    model: gateway('openai/gpt-4.1-nano'),
+    prompt: 'Reply with exactly gateway-ok.',
+    maxOutputTokens: 20,
+  });
+
+  if (forwardedAuthorization !== `Bearer ${apiKey}`) {
+    throw new Error('The explicit AI Gateway API key was not forwarded.');
+  }
+
+  if (result.text.trim() !== 'gateway-ok') {
+    throw new Error(
+      `AI Gateway returned unexpected text: ${JSON.stringify(result.text)}`,
+    );
+  }
+
+  console.log(
+    'Issue #7447 could not be reproduced: the explicit API key was forwarded and AI Gateway returned gateway-ok.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/gateway/src/__fixtures__/issue-7447-live-generate-response.json
+++ b/packages/gateway/src/__fixtures__/issue-7447-live-generate-response.json
@@ -1,0 +1,58 @@
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "gateway-ok",
+      "providerMetadata": {
+        "openai": {
+          "itemId": "msg_0d0584ea56718fea016a5a30a3e2b08193ba202fe0c65832ac"
+        }
+      }
+    }
+  ],
+  "finishReason": "stop",
+  "usage": {
+    "inputTokens": 13,
+    "outputTokens": 3,
+    "totalTokens": 16,
+    "reasoningTokens": 0,
+    "cachedInputTokens": 0
+  },
+  "providerMetadata": {
+    "openai": {
+      "responseId": "resp_0d0584ea56718fea016a5a30a39bd88193972602f1baa52735",
+      "serviceTier": "default",
+      "usage": {
+        "cacheWriteTokens": 0
+      }
+    },
+    "gateway": {
+      "routing": {
+        "originalModelId": "openai/gpt-4.1-nano",
+        "resolvedProvider": "openai",
+        "canonicalSlug": "openai/gpt-4.1-nano",
+        "finalProvider": "openai",
+        "modelAttemptCount": 1,
+        "modelAttempts": [
+          {
+            "canonicalSlug": "openai/gpt-4.1-nano",
+            "success": true,
+            "providerAttemptCount": 1,
+            "providerAttempts": [
+              {
+                "provider": "openai",
+                "credentialType": "system",
+                "success": true,
+                "statusCode": 200
+              }
+            ]
+          }
+        ],
+        "totalProviderAttemptCount": 1
+      },
+      "cost": "0.0000025",
+      "generationId": "gen_01KXR4VZEFCK523D2YWVJJTJ8Y"
+    }
+  },
+  "warnings": []
+}

--- a/packages/gateway/src/issue-7447-explicit-api-key.test.ts
+++ b/packages/gateway/src/issue-7447-explicit-api-key.test.ts
@@ -1,0 +1,41 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { createGatewayProvider } from './gateway-provider';
+// @ts-ignore - Vitest loads the recorded JSON fixture.
+import liveResponse from './__fixtures__/issue-7447-live-generate-response.json';
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Reply with exactly gateway-ok.' }],
+  },
+];
+
+describe('issue #7447 explicit API key', () => {
+  it('forwards the explicit key and accepts the recorded live response', async () => {
+    let authorization: string | null = null;
+
+    const gateway = createGatewayProvider({
+      apiKey: 'sst-explicit-api-key',
+      baseURL: 'https://gateway.test',
+      fetch: async (_input, init) => {
+        authorization = new Headers(init?.headers).get('authorization');
+
+        return new Response(JSON.stringify(liveResponse), {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        });
+      },
+    });
+
+    const result = await gateway('openai/gpt-4.1-nano').doGenerate({
+      prompt,
+    });
+
+    expect(authorization).toBe('Bearer sst-explicit-api-key');
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: 'text', text: 'gateway-ok' }),
+    ]);
+    expect(result.finishReason).toBe('stop');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,16 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19630,7 +19640,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19644,13 +19654,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19658,22 +19668,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19683,7 +19693,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19713,7 +19723,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24963,7 +24973,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29439,7 +29449,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30208,7 +30218,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30305,7 +30315,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33789,7 +33799,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33817,7 +33827,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34896,7 +34906,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36436,7 +36446,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37393,7 +37403,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37830,7 +37840,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -40029,7 +40039,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

Cannot Access AI Gateway

## Reproduction

- On `release-v5.0`, the expected “Vercel AI Gateway access failed” error did not occur: a live `generateText` request using `createGateway({ apiKey })` returned `gateway-ok` through `openai/gpt-4.1-nano`.
- `examples/ai-functions/src/reproduction/issue-7447-gateway-explicit-api-key.ts` exited successfully and confirmed that the explicitly supplied key was forwarded as the bearer credential; `examples/ai-functions/package.json` and `pnpm-lock.yaml` provide its runnable workspace setup.
- `packages/gateway/src/__fixtures__/issue-7447-live-generate-response.json` records the successful live response, and `packages/gateway/src/issue-7447-explicit-api-key.test.ts` confirms the explicit key and recorded response work in Node and Edge runtimes.
- `packages/ai/CHANGELOG.md` associates `ai@5.0.0-beta.25` with `@ai-sdk/gateway@1.0.0-beta.11`, so the reported versions were release-aligned rather than an unsupported package combination.
- The reporter's SST `Resource.AIGatewayAPIKey.value` resolution was unavailable; the reproduction passed the configured `AI_GATEWAY_API_KEY` value explicitly, so an SST secret-resolution or account-key issue remains outside this SDK reproduction.

## Relevant Documentation

- https://v5.ai-sdk.dev/providers/ai-sdk-providers/ai-gateway
- https://vercel.com/docs/ai-gateway/authentication-and-byok

## Related Issues

Could not reproduce #7447