### PR TITLE
[v5.0] fix: preserve images returned by tools in xAI Responses API requests

### DIFF
--- a/.changeset/tame-dogs-smile.md
+++ b/.changeset/tame-dogs-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): preserve images in Responses API tool results

--- a/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
@@ -406,7 +406,7 @@ describe('convertToXaiResponsesInput', () => {
       `);
     });
 
-    it('should preserve image URLs in content output', async () => {
+    it('should preserve images in content output', async () => {
       const result = await convertToXaiResponsesInput({
         prompt: [
           {
@@ -424,12 +424,9 @@ describe('convertToXaiResponsesInput', () => {
                       text: 'The requested image is attached.',
                     },
                     {
-                      type: 'file',
+                      type: 'media',
                       mediaType: 'image/png',
-                      data: {
-                        type: 'url',
-                        url: new URL('https://example.com/image.png'),
-                      },
+                      data: 'AAECAw==',
                     },
                   ],
                 },
@@ -449,7 +446,7 @@ describe('convertToXaiResponsesInput', () => {
                 "type": "input_text",
               },
               {
-                "image_url": "https://example.com/image.png",
+                "image_url": "data:image/png;base64,AAECAw==",
                 "type": "input_image",
               },
             ],

--- a/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
@@ -405,6 +405,59 @@ describe('convertToXaiResponsesInput', () => {
         ]
       `);
     });
+
+    it('should preserve image URLs in content output', async () => {
+      const result = await convertToXaiResponsesInput({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'inspectImage',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'text',
+                      text: 'The requested image is attached.',
+                    },
+                    {
+                      type: 'file',
+                      mediaType: 'image/png',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/image.png'),
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "call_id": "call_123",
+            "output": [
+              {
+                "text": "The requested image is attached.",
+                "type": "input_text",
+              },
+              {
+                "image_url": "https://example.com/image.png",
+                "type": "input_image",
+              },
+            ],
+            "type": "function_call_output",
+          },
+        ]
+      `);
+    });
   });
 
   describe('multi-turn conversations', () => {

--- a/packages/xai/src/responses/convert-to-xai-responses-input.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.ts
@@ -182,26 +182,14 @@ export async function convertToXaiResponsesInput({
                     });
                     break;
                   }
-                  case 'file': {
-                    if (
-                      getTopLevelMediaType(item.mediaType) === 'image' &&
-                      (item.data.type === 'data' || item.data.type === 'url')
-                    ) {
+                  case 'media': {
+                    if (item.mediaType.startsWith('image/')) {
                       outputValue.push({
                         type: 'input_image',
-                        image_url:
-                          item.data.type === 'url'
-                            ? item.data.url.toString()
-                            : `data:${resolveFullMediaType({ part: item })};base64,${convertToBase64(item.data.data)}`,
+                        image_url: `data:${item.mediaType};base64,${item.data}`,
                       });
                     }
                     break;
-                  }
-                  case 'custom': {
-                    break;
-                  }
-                  default: {
-                    const _exhaustiveCheck: never = item;
                   }
                 }
               }

--- a/packages/xai/src/responses/convert-to-xai-responses-input.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
 import type {
+  XaiResponsesFunctionCallOutput,
   XaiResponsesInput,
   XaiResponsesUserMessageContentPart,
 } from './xai-responses-api';
@@ -160,7 +161,7 @@ export async function convertToXaiResponsesInput({
         for (const part of message.content) {
           const output = part.output;
 
-          let outputValue: string;
+          let outputValue: XaiResponsesFunctionCallOutput['output'];
           switch (output.type) {
             case 'text':
             case 'error-text':
@@ -171,14 +172,39 @@ export async function convertToXaiResponsesInput({
               outputValue = JSON.stringify(output.value);
               break;
             case 'content':
-              outputValue = output.value
-                .map(item => {
-                  if (item.type === 'text') {
-                    return item.text;
+              outputValue = [];
+              for (const item of output.value) {
+                switch (item.type) {
+                  case 'text': {
+                    outputValue.push({
+                      type: 'input_text',
+                      text: item.text,
+                    });
+                    break;
                   }
-                  return '';
-                })
-                .join('');
+                  case 'file': {
+                    if (
+                      getTopLevelMediaType(item.mediaType) === 'image' &&
+                      (item.data.type === 'data' || item.data.type === 'url')
+                    ) {
+                      outputValue.push({
+                        type: 'input_image',
+                        image_url:
+                          item.data.type === 'url'
+                            ? item.data.url.toString()
+                            : `data:${resolveFullMediaType({ part: item })};base64,${convertToBase64(item.data.data)}`,
+                      });
+                    }
+                    break;
+                  }
+                  case 'custom': {
+                    break;
+                  }
+                  default: {
+                    const _exhaustiveCheck: never = item;
+                  }
+                }
+              }
               break;
             default: {
               const _exhaustiveCheck: never = output;

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -34,7 +34,18 @@ export type XaiResponsesAssistantMessage = {
 export type XaiResponsesFunctionCallOutput = {
   type: 'function_call_output';
   call_id: string;
-  output: string;
+  output:
+    | string
+    | Array<
+        | {
+            type: 'input_text';
+            text: string;
+          }
+        | {
+            type: 'input_image';
+            image_url: string;
+          }
+      >;
 };
 
 export type XaiResponsesReasoning = {

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -514,12 +514,9 @@ describe('XaiResponsesLanguageModel', () => {
                         text: 'The requested image is attached.',
                       },
                       {
-                        type: 'file',
+                        type: 'media',
                         mediaType: 'image/png',
-                        data: {
-                          type: 'data',
-                          data: Buffer.from([0, 1, 2, 3]),
-                        },
+                        data: 'AAECAw==',
                       },
                     ],
                   },

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -472,6 +472,101 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      it('should send image data in function call output', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-4.5',
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        });
+
+        await createModel('grok-4.5').doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Read the tool image.' }],
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_123',
+                  toolName: 'inspectImage',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_123',
+                  toolName: 'inspectImage',
+                  output: {
+                    type: 'content',
+                    value: [
+                      {
+                        type: 'text',
+                        text: 'The requested image is attached.',
+                      },
+                      {
+                        type: 'file',
+                        mediaType: 'image/png',
+                        data: {
+                          type: 'data',
+                          data: Buffer.from([0, 1, 2, 3]),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        expect((await server.calls[0].requestBodyJson).input)
+          .toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "Read the tool image.",
+                  "type": "input_text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "arguments": "{}",
+              "call_id": "call_123",
+              "id": "call_123",
+              "name": "inspectImage",
+              "status": "completed",
+              "type": "function_call",
+            },
+            {
+              "call_id": "call_123",
+              "output": [
+                {
+                  "text": "The requested image is attached.",
+                  "type": "input_text",
+                },
+                {
+                  "image_url": "data:image/png;base64,AAECAw==",
+                  "type": "input_image",
+                },
+              ],
+              "type": "function_call_output",
+            },
+          ]
+        `);
+      });
+
       it('should warn about unsupported stopSequences', async () => {
         prepareJsonResponse({
           id: 'resp_123',


### PR DESCRIPTION
## Background

xAI models could not inspect images returned by tools because the SDK omitted those images from Responses API requests.

## Root Cause

The xAI Responses converter flattened content tool outputs into a text string and returned an empty string for file parts; the reproduced request retained the text but omitted the image while the equivalent raw xAI request succeeded.

## Summary

Updated xAI function-call outputs to serialize text and inline-data or URL images as input_text and input_image content parts.

## Testing

Added inline-snapshot regression coverage for URL and base64 image tool results in the existing converter and language-model tests, plus a patch changeset.

## End-to-end Validation

- `pnpm -C packages/xai build && git show HEAD:examples/ai-functions/src/reproduction/issue-17381-xai-tool-result-image.ts | pnpm -C examples/ai-functions exec tsx -` — the SDK request included the data-URL `input_image`, and both `generateText` and the raw xAI API returned `ZXQ-731`.

## Related Issues

Fixes #17381

Closes #17388

Backport of #17432

Co-authored-by: andrewdoro <17547035+andrewdoro@users.noreply.github.com>