### PR TITLE
[v5.0] reproduction: OAuthMetadataSchema requires codechallengemethodssupported, but RFC 8414 marks it

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 17334,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17334.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-17334.ts",
+    "packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #17334 reproduced: OAuth metadata without code_challenge_methods_supported was rejected before Dynamic Client Registration"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-17334.ts
+++ b/examples/ai-functions/src/reproduction/issue-17334.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs';
+import {
+  auth,
+  type OAuthClientProvider,
+} from '../../../../packages/mcp/src/tool/oauth';
+
+const awsSignInMetadata = JSON.parse(
+  readFileSync(
+    new URL(
+      '../../../../packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+);
+
+async function main() {
+  let dynamicClientRegistrationReached = false;
+  const metadata =
+    process.env.INJECT_PKCE === '1'
+      ? {
+          ...awsSignInMetadata,
+          code_challenge_methods_supported: ['S256'],
+        }
+      : awsSignInMetadata;
+
+  const provider: OAuthClientProvider = {
+    get redirectUrl() {
+      return 'http://localhost:8090/oauth/callback';
+    },
+    get clientMetadata() {
+      return {
+        redirect_uris: ['http://localhost:8090/oauth/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        client_name: 'issue-17334-reproduction',
+      };
+    },
+    tokens() {
+      return undefined;
+    },
+    saveTokens() {},
+    clientInformation() {
+      return undefined;
+    },
+    saveClientInformation() {},
+    saveCodeVerifier() {},
+    codeVerifier() {
+      return '';
+    },
+    redirectToAuthorization() {},
+  };
+
+  const fetchFn: typeof fetch = async (input, init) => {
+    const url = String(input);
+
+    if (url.includes('/.well-known/oauth-protected-resource')) {
+      return Response.json({
+        resource: 'https://aws-mcp.us-east-1.api.aws',
+        authorization_servers: [awsSignInMetadata.issuer],
+      });
+    }
+
+    if (url.endsWith('/.well-known/oauth-authorization-server')) {
+      return Response.json(metadata);
+    }
+
+    if (
+      url === awsSignInMetadata.registration_endpoint &&
+      init?.method === 'POST'
+    ) {
+      dynamicClientRegistrationReached = true;
+      return Response.json({
+        client_id: 'reproduction-client',
+      });
+    }
+
+    throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`);
+  };
+
+  try {
+    await auth(provider, {
+      serverUrl: 'https://aws-mcp.us-east-1.api.aws/mcp',
+      fetchFn,
+    });
+  } catch (error) {
+    if (!dynamicClientRegistrationReached) {
+      const issues =
+        typeof error === 'object' && error !== null && 'issues' in error
+          ? (error as { issues?: Array<{ path?: PropertyKey[] }> }).issues
+          : undefined;
+      const rejectedOptionalField = issues?.some(
+        issue => issue.path?.[0] === 'code_challenge_methods_supported',
+      );
+
+      if (rejectedOptionalField) {
+        throw new Error(
+          'Issue #17334 reproduced: OAuth metadata without code_challenge_methods_supported was rejected before Dynamic Client Registration',
+          { cause: error },
+        );
+      }
+    }
+
+    if (dynamicClientRegistrationReached) {
+      console.log(
+        'Metadata discovery accepted the document and reached Dynamic Client Registration.',
+      );
+      return;
+    }
+
+    throw error;
+  }
+
+  if (!dynamicClientRegistrationReached) {
+    throw new Error('Dynamic Client Registration was not reached');
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json
+++ b/packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json
@@ -1,0 +1,9 @@
+{
+  "issuer": "https://us-east-1.oauth.signin.aws",
+  "authorization_endpoint": "https://us-east-1.oauth.signin.aws/v1/authorize",
+  "token_endpoint": "https://us-east-1.oauth.signin.aws/v1/token",
+  "registration_endpoint": "https://us-east-1.oauth.signin.aws/v1/register",
+  "token_endpoint_auth_methods_supported": ["none"],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"]
+}

--- a/packages/mcp/src/tool/oauth.issue-17334.test.ts
+++ b/packages/mcp/src/tool/oauth.issue-17334.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { discoverAuthorizationServerMetadata } from './oauth';
+
+const awsSignInMetadata = JSON.parse(
+  readFileSync(
+    new URL('./__fixtures__/aws-signin-oauth-metadata.json', import.meta.url),
+    'utf8',
+  ),
+);
+
+describe('issue #17334', () => {
+  it('accepts RFC 8414 metadata that omits code challenge methods', async () => {
+    const fetchFn = vi.fn(async () => {
+      return new Response(JSON.stringify(awsSignInMetadata), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await expect(
+      discoverAuthorizationServerMetadata(
+        'https://us-east-1.oauth.signin.aws',
+        { fetchFn },
+      ),
+    ).resolves.toEqual(awsSignInMetadata);
+  });
+});


### PR DESCRIPTION
## Bug

OAuthMetadataSchema requires code_challenge_methods_supported, but RFC 8414 marks it optional, breaking DCR against spec-compliant servers (e.g. AWS Sign-In)

## Reproduction

- Live AWS Sign-In metadata returned HTTP 200 on July 17, 2026, omitted `code_challenge_methods_supported`, and exactly matched `packages/mcp/src/tool/__fixtures__/aws-signin-oauth-metadata.json`.
- The target branch contains `@ai-sdk/mcp` 0.0.25 rather than the reported 2.0.13, but `packages/mcp/src/tool/oauth-types.ts` has the same required field and rejects the metadata before Dynamic Client Registration.
- `examples/ai-functions/src/reproduction/issue-17334.ts` expected metadata discovery to reach Dynamic Client Registration but observed the reported Zod validation failure first; injecting `S256` made the comparison reach registration.
- `packages/mcp/src/tool/oauth.issue-17334.test.ts` reproduces the rejection against the recorded AWS fixture in both Node and edge runtimes.
- RFC 8414 permits the field to be absent, although the current MCP authorization specification requires the client to refuse authorization later when PKCE support is not advertised.
- The interactive browser authorization, token exchange, and authenticated AWS tool call were not rerun; reproduction covers the primary credential-free failure before registration.

## Relevant Documentation

- https://www.rfc-editor.org/rfc/rfc8414.html#section-2
- https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
- https://docs.aws.amazon.com/signin/latest/userguide/oauth-sign-in-overview.html
- https://ts.sdk.modelcontextprotocol.io/v2/functions/_modelcontextprotocol_client.client_auth.discoverOAuthMetadata.html

## Related Issues

Reproduces #17334