### PR TITLE
reproduction: could not reproduce activeTools still executes disabled tools and breaks prepareStep

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts
+++ b/examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts
@@ -1,0 +1,154 @@
+import {
+  NoSuchToolError,
+  simulateReadableStream,
+  stepCountIs,
+  streamText,
+  tool,
+} from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+const usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+function createToolCallStream(toolCallId: string) {
+  return simulateReadableStream({
+    initialDelayInMs: 0,
+    chunkDelayInMs: 0,
+    chunks: [
+      {
+        type: 'tool-call' as const,
+        toolCallId,
+        toolName: 'weather',
+        input: JSON.stringify({ location: 'Basel' }),
+      },
+      {
+        type: 'finish' as const,
+        finishReason: { unified: 'tool-calls' as const, raw: undefined },
+        usage,
+      },
+    ],
+  });
+}
+
+async function runDirectActiveToolsScenario() {
+  let executionCount = 0;
+
+  const model = new MockLanguageModelV3({
+    doStream: async () => ({
+      stream: createToolCallStream('direct-call'),
+    }),
+  });
+
+  const result = streamText({
+    model,
+    prompt: 'test',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executionCount++;
+          return `weather for ${location}`;
+        },
+      }),
+    },
+    activeTools: [],
+    stopWhen: stepCountIs(1),
+  });
+
+  await result.consumeStream();
+
+  return {
+    executionCount,
+    providerToolCounts: model.doStreamCalls.map(
+      call => call.tools?.length ?? 0,
+    ),
+    toolCalls: await result.toolCalls,
+    toolResults: await result.toolResults,
+  };
+}
+
+async function runPrepareStepScenario() {
+  let executionCount = 0;
+  let streamCallCount = 0;
+
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      streamCallCount++;
+      return {
+        stream: createToolCallStream(`prepare-step-call-${streamCallCount}`),
+      };
+    },
+  });
+
+  const result = streamText({
+    model,
+    prompt: 'test',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executionCount++;
+          return `weather for ${location}`;
+        },
+      }),
+    },
+    prepareStep: ({ stepNumber }) =>
+      stepNumber === 0 ? { activeTools: ['weather'] } : { activeTools: [] },
+    stopWhen: stepCountIs(2),
+  });
+
+  await result.consumeStream();
+
+  return {
+    executionCount,
+    providerToolCounts: model.doStreamCalls.map(
+      call => call.tools?.length ?? 0,
+    ),
+    steps: (await result.steps).map(step => ({
+      toolCalls: step.toolCalls,
+      toolResults: step.toolResults,
+    })),
+  };
+}
+
+async function main() {
+  const direct = await runDirectActiveToolsScenario();
+  const prepareStep = await runPrepareStepScenario();
+
+  console.log(JSON.stringify({ direct, prepareStep }, null, 2));
+
+  const directDisabledToolExecuted =
+    direct.executionCount !== 0 || direct.toolResults.length !== 0;
+  const directDisabledToolWasNotRejected =
+    direct.toolCalls[0]?.invalid !== true ||
+    !NoSuchToolError.isInstance(direct.toolCalls[0].error);
+  const prepareStepDisabledToolExecuted =
+    prepareStep.executionCount !== 1 ||
+    prepareStep.steps[1]?.toolResults.length !== 0;
+  const prepareStepDisabledToolWasNotRejected =
+    prepareStep.steps[1]?.toolCalls[0]?.invalid !== true ||
+    !NoSuchToolError.isInstance(prepareStep.steps[1].toolCalls[0].error);
+
+  if (directDisabledToolExecuted || prepareStepDisabledToolExecuted) {
+    throw new Error(
+      `Reproduced issue #13448: disabled tools executed (direct=${direct.executionCount}, prepareStep=${prepareStep.executionCount}).`,
+    );
+  }
+
+  if (
+    directDisabledToolWasNotRejected ||
+    prepareStepDisabledToolWasNotRejected
+  ) {
+    throw new Error(
+      'Disabled tool calls were not surfaced as NoSuchTool errors.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

activeTools still executes disabled tools and breaks prepareStep tool disabling

## Reproduction

- Could not reproduce issue #13448 on target `main`, which contains `ai@7.0.31` in `packages/ai/package.json`; the reported setup used `ai@6.0.116`.
- Added `examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts`, covering both direct `activeTools: []` and later-step disabling through `prepareStep`.
- With direct `activeTools: []`, the provider received zero tools, `weather.execute` ran zero times, no tool result was produced, and the attempted call surfaced as `AI_NoSuchToolError`.
- With `prepareStep`, the provider received one tool on step 1 and zero on step 2; `weather.execute` ran only for the enabled first step, while the disabled second-step call produced no result and surfaced as `AI_NoSuchToolError`.
- The expected behavior—disabled tools being unavailable and never executing—is working on `main`; upgrading to the current `ai@7.0.31` code resolves the reported outcome without product-code changes.
- The historical `ai@6.0.116` behavior was not rerun because the reproduction target is the checked-out `main` branch.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling

## Related Issues

Could not reproduce #13448