### PR TITLE
[v5.0] reproduction: generateText silently swallows AbortError in multi-step tool loop

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 12878,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12878-generate-text-abort.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "BUG REPRODUCED: generateText returned normally after abort during tool execution"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts
+++ b/examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts
@@ -1,0 +1,119 @@
+import {
+  generateText,
+  jsonSchema,
+  stepCountIs,
+  tool,
+} from '../../../../packages/ai/src/index';
+import { MockLanguageModelV2 } from '../../../../packages/ai/src/test/mock-language-model-v2';
+
+const responseMetadata = {
+  warnings: [],
+};
+
+async function main() {
+  const abortController = new AbortController();
+  let modelCallCount = 0;
+
+  const model = new MockLanguageModelV2({
+    doGenerate: async () => {
+      modelCallCount++;
+
+      if (modelCallCount === 1) {
+        return {
+          ...responseMetadata,
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'slowTool',
+              input: '{"query":"first"}',
+            },
+          ],
+          finishReason: 'tool-calls',
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+        };
+      }
+
+      return {
+        ...responseMetadata,
+        content: [],
+        finishReason: 'other',
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+      };
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model,
+      prompt: 'Call the slow tool three times, then summarize.',
+      tools: {
+        slowTool: tool({
+          description: 'A tool that aborts while it is running.',
+          inputSchema: jsonSchema<{ query: string }>({
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          }),
+          execute: async () => {
+            abortController.abort(
+              new DOMException('The operation was aborted.', 'AbortError'),
+            );
+            abortController.signal.throwIfAborted();
+            return { result: 'done' };
+          },
+        }),
+      },
+      stopWhen: stepCountIs(10),
+      abortSignal: abortController.signal,
+    });
+
+    const finalStep = result.steps.at(-1);
+    const firstToolError = result.steps[0]?.content.find(
+      part => part.type === 'tool-error',
+    );
+
+    console.error(
+      JSON.stringify({
+        signalAborted: abortController.signal.aborted,
+        modelCallCount,
+        steps: result.steps.length,
+        finishReason: result.finishReason,
+        finalStepTotalTokens: finalStep?.usage.totalTokens,
+        toolErrorName:
+          firstToolError?.type === 'tool-error' &&
+          firstToolError.error instanceof Error
+            ? firstToolError.error.name
+            : undefined,
+      }),
+    );
+    throw new Error(
+      'BUG REPRODUCED: generateText returned normally after abort during tool execution',
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('BUG REPRODUCED:')) {
+      throw error;
+    }
+
+    if (error instanceof Error && error.name === 'AbortError') {
+      console.log('AbortError propagated as expected.');
+      return;
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

generateText() silently swallows AbortError in multi-step tool loop

## Reproduction

- On `ai` 5.0.216, the supported v5 `stopWhen` and `inputSchema` APIs still reproduce the bug; the issue's `maxSteps` and `parameters` APIs are pre-v5 equivalents.
- `examples/ai-functions/src/reproduction/issue-12878-generate-text-abort.ts` observed `generateText()` return normally after an `AbortError` during tool execution, instead of rejecting with the abort exception.
- The returned result had an aborted signal, two model calls and steps, final finish reason `other`, and zero final-step tokens, so callers can mistake interrupted generation for success.
- `packages/ai/src/generate-text/generate-text.ts` converts the tool abort exception into a `tool-error` and continues the multi-step loop without checking the aborted operation signal.
- `examples/ai-functions/package.json` supplies the minimal workspace package required by the replay command.

## Relevant Documentation

- https://ai-sdk.dev/v5/docs/reference/ai-sdk-core/generate-text
- https://ai-sdk.dev/v5/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/v5/docs/migration-guides/migration-guide-5-0
- https://nodejs.org/api/globals.html

## Related Issues

Reproduces #12878