### PR TITLE
[v5.0] reproduction: uiMessageChunkSchema strict validation breaks backward due to providerMetadata

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 13733,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/ui-message-chunk-forward-compatibility.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts",
+    "examples/ai-functions/package.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "FORWARD_COMPATIBILITY_BUG: DefaultChatTransport rejected newer server fields on known chunk types: providerMetadata, toolMetadata."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts
+++ b/examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts
@@ -1,0 +1,118 @@
+import { DefaultChatTransport, type UIMessage } from 'ai';
+
+async function parseChunk(chunk: unknown) {
+  const transport = new DefaultChatTransport<UIMessage>({
+    fetch: async () =>
+      new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+  });
+
+  const stream = await transport.sendMessages({
+    trigger: 'submit-message',
+    chatId: 'reproduction',
+    messageId: undefined,
+    messages: [],
+    abortSignal: undefined,
+  });
+  const result = await stream.getReader().read();
+
+  if (result.done) {
+    throw new Error('Expected one UI message chunk, but the stream was empty.');
+  }
+
+  return result.value;
+}
+
+async function isRejectedAsUnknownKey(chunk: unknown, fieldName: string) {
+  try {
+    await parseChunk(chunk);
+    return false;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      error instanceof Error &&
+      error.name === 'AI_TypeValidationError' &&
+      message.includes(fieldName) &&
+      message.includes('unrecognized_keys')
+    ) {
+      return true;
+    }
+
+    throw error;
+  }
+}
+
+async function main() {
+  const baselineToolOutputChunk = {
+    type: 'tool-output-available',
+    toolCallId: 'tool-call-1',
+    output: { weather: 'sunny' },
+  };
+  const baselineToolOutputResult = await parseChunk(baselineToolOutputChunk);
+
+  if (
+    baselineToolOutputResult.type !== 'tool-output-available' ||
+    baselineToolOutputResult.toolCallId !== baselineToolOutputChunk.toolCallId
+  ) {
+    throw new Error('The baseline tool-output-available chunk did not parse.');
+  }
+
+  const baselineToolInputChunk = {
+    type: 'tool-input-available',
+    toolCallId: 'tool-call-2',
+    toolName: 'describe_entity',
+    input: { entity: 'weather' },
+    dynamic: true,
+  };
+  const baselineToolInputResult = await parseChunk(baselineToolInputChunk);
+
+  if (
+    baselineToolInputResult.type !== 'tool-input-available' ||
+    baselineToolInputResult.toolCallId !== baselineToolInputChunk.toolCallId
+  ) {
+    throw new Error('The baseline tool-input-available chunk did not parse.');
+  }
+
+  const providerMetadataChunk = {
+    ...baselineToolOutputChunk,
+    providerMetadata: {
+      openai: {
+        itemId: 'item-1',
+      },
+    },
+  };
+  const toolMetadataChunk = {
+    ...baselineToolInputChunk,
+    toolMetadata: {
+      clientName: 'ai-sdk-mcp-client',
+    },
+    title: 'Describe entity',
+  };
+  const rejectedFields: string[] = [];
+
+  if (await isRejectedAsUnknownKey(providerMetadataChunk, 'providerMetadata')) {
+    rejectedFields.push('providerMetadata');
+  }
+
+  if (await isRejectedAsUnknownKey(toolMetadataChunk, 'toolMetadata')) {
+    rejectedFields.push('toolMetadata');
+  }
+
+  if (rejectedFields.length > 0) {
+    throw new Error(
+      `FORWARD_COMPATIBILITY_BUG: DefaultChatTransport rejected newer server fields on known chunk types: ${rejectedFields.join(', ')}.`,
+    );
+  }
+
+  console.log(
+    'DefaultChatTransport accepted newer server fields on known chunk types.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,16 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':


### PR DESCRIPTION
## Bug

uiMessageChunkSchema strict validation breaks backward due to providerMetadata addition

## Reproduction

- Target `ai@5.0.216` uses `z.strictObject()` for UI message chunk variants in `packages/ai/src/ui-message-stream/ui-message-chunks.ts`.
- `examples/ai-functions/src/reproduction/ui-message-chunk-forward-compatibility.ts` confirmed baseline tool chunks parse, but `DefaultChatTransport` terminates parsing with `AI_TypeValidationError` when known chunk types contain the reported newer-server `providerMetadata` or `toolMetadata` fields.
- Expected behavior is to accept or ignore additional fields on known chunk types so cached older clients can continue consuming streams.
- The exact historical v6 package combinations were not evaluated because the mandated target is release-v5.0; the target's equivalent client-stream behavior reproduced with the reported payload shapes.
- `examples/ai-functions/package.json` and `pnpm-lock.yaml` provide the workspace setup required to replay the reproduction.

## Related Issues

Reproduces #13733