### PR TITLE
[v6.0] reproduction: Gemini may return multiple codeExecutionResult per executableCode part

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 11485,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/google-multiple-code-execution-results.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts",
+    "packages/google/src/__fixtures__/google-code-execution-multiple-results.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #11485: generateText threw \"Tool call undefined not found.\" for one executableCode with two codeExecutionResult parts."
+  }
+}

--- a/examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts
+++ b/examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts
@@ -1,0 +1,61 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { readFile } from 'node:fs/promises';
+
+async function main() {
+  const recordedResponse = JSON.parse(
+    await readFile(
+      new URL(
+        '../../../../packages/google/src/__fixtures__/google-code-execution-multiple-results.json',
+        import.meta.url,
+      ),
+      'utf8',
+    ),
+  );
+
+  const google = createGoogleGenerativeAI({
+    apiKey: 'test-api-key',
+    generateId: () => 'code-execution-call',
+    fetch: async () =>
+      new Response(JSON.stringify(recordedResponse), {
+        headers: { 'content-type': 'application/json' },
+      }),
+  });
+
+  try {
+    const result = await generateText({
+      model: google('gemini-3-flash-preview'),
+      prompt:
+        "use code execution to execute the following code snippet:\nprint('ok')\nprint(1/0)",
+      tools: {
+        code_execution: google.tools.codeExecution({}),
+      },
+    });
+
+    const toolResults = result.content.filter(
+      part => part.type === 'tool-result',
+    );
+
+    if (toolResults.length !== 2) {
+      throw new Error(
+        `Expected generateText to return both code execution results, but received ${toolResults.length}.`,
+      );
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === 'Tool call undefined not found.'
+    ) {
+      throw new Error(
+        'Reproduced issue #11485: generateText threw "Tool call undefined not found." for one executableCode with two codeExecutionResult parts.',
+      );
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/google/src/__fixtures__/google-code-execution-multiple-results.json
+++ b/packages/google/src/__fixtures__/google-code-execution-multiple-results.json
@@ -1,0 +1,56 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "executableCode": {
+              "language": "PYTHON",
+              "code": "print('ok')\nprint(1/0)"
+            },
+            "thoughtSignature": "EjQKMgFyyNp8VRG2uDen0QENDjUJEy6ZQlvEGUhI8VcgTgNaspEC3M5Cao6lhYRGpmCcClR1"
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_OK",
+              "output": "ok\n"
+            }
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_FAILED",
+              "output": "division by zero\nTraceback (most recent call last):\n  File \"/usr/bin/entry/entry_point\", line 109, in _run_python\n    exec(code, exec_scope)  # pylint: disable=exec-used\n    ^^^^^^^^^^^^^^^^^^^^^^\n  File \"<string>\", line 2, in <module>\nZeroDivisionError: division by zero\n"
+            }
+          },
+          {
+            "text": "The code execution resulted in the following output:\n\n```\nok\n```\n\nFollowed by an error:\n\n```python\nZeroDivisionError: division by zero\n```",
+            "thoughtSignature": "EjQKMgFyyNp8EcK2k/joUmmIxJlqtIvdJP/1F+ziwsCn9P4uyk2ZNeBiYz2Um4GXD4IEGlE9"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 23,
+    "candidatesTokenCount": 35,
+    "totalTokenCount": 347,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 23
+      }
+    ],
+    "toolUsePromptTokenCount": 289,
+    "toolUsePromptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 289
+      }
+    ]
+  },
+  "modelVersion": "gemini-3-flash-preview",
+  "responseId": "x7hVadT9OdKT_uMP792-mAc"
+}

--- a/packages/google/src/google-generative-ai-language-model.issue-11485.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.issue-11485.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { createGoogleGenerativeAI } from './google-provider';
+
+const response = JSON.parse(
+  readFileSync(
+    new URL(
+      './__fixtures__/google-code-execution-multiple-results.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+);
+
+describe('issue #11485', () => {
+  it('associates every code execution result with its executable code', async () => {
+    const google = createGoogleGenerativeAI({
+      apiKey: 'test-api-key',
+      generateId: () => 'code-execution-call',
+      fetch: async () =>
+        new Response(JSON.stringify(response), {
+          headers: { 'content-type': 'application/json' },
+        }),
+    });
+
+    const result = await google('gemini-3-flash-preview').doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: "use code execution to execute the following code snippet:\nprint('ok')\nprint(1/0)",
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.code_execution',
+          name: 'code_execution',
+          args: {},
+        },
+      ],
+    });
+
+    expect(
+      result.content
+        .filter(part => part.type === 'tool-result')
+        .map(part => part.toolCallId),
+    ).toEqual(['code-execution-call', 'code-execution-call']);
+  });
+});


### PR DESCRIPTION
## Bug

Gemini may return multiple codeExecutionResult per executableCode part

## Reproduction

- `examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts` replays the reported Gemini response and reproduces `generateText` throwing `Tool call undefined not found.` instead of returning both code-execution results.
- `packages/google/src/__fixtures__/google-code-execution-multiple-results.json` records the reported response containing one `executableCode` part followed by two `codeExecutionResult` parts.
- `packages/google/src/google-generative-ai-language-model.issue-11485.test.ts` observes result tool-call IDs `["code-execution-call", undefined]`; both results were expected to reference `code-execution-call`.
- The `release-v6.0` checkout contains `ai` 6.0.230 and `@ai-sdk/google` 3.0.95, so upgrading from the reported 6.0.5 and 3.0.2 versions within this release line does not resolve the bug.
- `packages/google/src/google-generative-ai-language-model.ts` clears the generated and streaming code-execution tool-call ID after the first result; the streaming path consequently drops a subsequent result.
- An exact live Gemini request on July 17, 2026 was blocked by HTTP 403 `PERMISSION_DENIED` because no registered caller identity was available, so current live response variability could not be reevaluated.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/code-execution
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview

## Related Issues

Reproduces #11485