### PR TITLE
[v5.0] reproduction: activeTools still executes disabled tools and breaks prepareStep

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 13448,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-13448-active-tools-execution.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts",
+    "examples/ai-functions/package.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_13448_REPRODUCED: disabled weather tools executed successfully in both activeTools and prepareStep scenarios"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts
+++ b/examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts
@@ -1,0 +1,140 @@
+import { simulateReadableStream, stepCountIs, streamText, tool } from 'ai';
+import { MockLanguageModelV2 } from 'ai/test';
+import { z } from 'zod';
+
+const usage = {
+  inputTokens: 1,
+  outputTokens: 1,
+  totalTokens: 2,
+};
+
+function createToolCallingModel(providerToolCounts: number[]) {
+  let callCount = 0;
+
+  return new MockLanguageModelV2({
+    doStream: async ({ tools }) => {
+      providerToolCounts.push(tools?.length ?? 0);
+      callCount += 1;
+
+      return {
+        stream: simulateReadableStream({
+          initialDelayInMs: 0,
+          chunkDelayInMs: 0,
+          chunks: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: `call_${callCount}`,
+              toolName: 'weather',
+              input: JSON.stringify({ location: 'Basel' }),
+            },
+            {
+              type: 'finish' as const,
+              finishReason: 'tool-calls' as const,
+              usage,
+            },
+          ],
+        }),
+      };
+    },
+  });
+}
+
+async function runDirectActiveToolsScenario() {
+  const providerToolCounts: number[] = [];
+  let executions = 0;
+
+  const result = streamText({
+    model: createToolCallingModel(providerToolCounts),
+    prompt: 'test',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executions += 1;
+          return `weather for ${location}`;
+        },
+      }),
+    },
+    activeTools: [],
+    stopWhen: stepCountIs(1),
+  });
+
+  await result.consumeStream();
+
+  return {
+    executions,
+    providerToolCounts,
+    toolCalls: await result.toolCalls,
+    toolResults: await result.toolResults,
+  };
+}
+
+async function runPrepareStepScenario() {
+  const providerToolCounts: number[] = [];
+  let executions = 0;
+
+  const result = streamText({
+    model: createToolCallingModel(providerToolCounts),
+    prompt: 'test',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executions += 1;
+          return `weather for ${location}`;
+        },
+      }),
+    },
+    stopWhen: stepCountIs(2),
+    prepareStep: ({ stepNumber }) => ({
+      activeTools: stepNumber === 0 ? ['weather'] : [],
+    }),
+  });
+
+  await result.consumeStream();
+  const steps = await result.steps;
+
+  return {
+    executions,
+    providerToolCounts,
+    stepToolCallCounts: steps.map(step => step.toolCalls.length),
+    stepToolResultCounts: steps.map(step => step.toolResults.length),
+  };
+}
+
+async function main() {
+  const direct = await runDirectActiveToolsScenario();
+  const prepareStep = await runPrepareStepScenario();
+
+  console.log(JSON.stringify({ direct, prepareStep }, null, 2));
+
+  const directBugReproduced =
+    direct.providerToolCounts[0] === 0 &&
+    direct.executions === 1 &&
+    direct.toolCalls.length === 1 &&
+    direct.toolResults.length === 1;
+
+  const prepareStepBugReproduced =
+    prepareStep.providerToolCounts.join(',') === '1,0' &&
+    prepareStep.executions === 2 &&
+    prepareStep.stepToolCallCounts.join(',') === '1,1' &&
+    prepareStep.stepToolResultCounts.join(',') === '1,1';
+
+  if (directBugReproduced && prepareStepBugReproduced) {
+    throw new Error(
+      'ISSUE_13448_REPRODUCED: disabled weather tools executed successfully in both activeTools and prepareStep scenarios',
+    );
+  }
+
+  if (direct.executions !== 0 || direct.toolResults.length !== 0) {
+    throw new Error(`Unexpected direct scenario: ${JSON.stringify(direct)}`);
+  }
+
+  if (prepareStep.executions !== 1) {
+    throw new Error(
+      `Unexpected prepareStep scenario: ${JSON.stringify(prepareStep)}`,
+    );
+  }
+}
+
+await main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,19 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':


### PR DESCRIPTION
## Bug

activeTools still executes disabled tools and breaks prepareStep tool disabling

## Reproduction

- Reproduced on the target `ai@5.0.216` branch using the equivalent `MockLanguageModelV2` API available in AI SDK 5.
- With `activeTools: []`, the provider received zero tools, but the disabled `weather` call was accepted, executed once, and produced a successful tool result instead of being rejected as unavailable.
- With `prepareStep`, the provider received one tool on step 1 and zero tools on step 2, but `weather` executed on both steps, preventing tool disabling from reliably forcing a final text response.
- Added the runnable reproduction at `examples/ai-functions/src/reproduction/issue-13448-active-tools-execution.ts`, with workspace setup in `examples/ai-functions/package.json` and `pnpm-lock.yaml`.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/v5/docs/migration-guides/migration-guide-5-0

## Related Issues

Reproduces #13448