### PR TITLE
reproduction: could not reproduce Unsupported tool part state: input-available

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-7258-input-available.ts
+++ b/examples/ai-functions/src/reproduction/issue-7258-input-available.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { convertToModelMessages, type UIMessage } from 'ai';
+
+const incompleteToolHistory: UIMessage[] = [
+  {
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: [
+      { type: 'step-start' },
+      {
+        type: 'tool-clientTool',
+        toolCallId: 'call-1',
+        state: 'input-available',
+        input: { value: 'test' },
+      },
+    ],
+  },
+  {
+    id: 'user-2',
+    role: 'user',
+    parts: [{ type: 'text', text: 'Continue' }],
+  },
+];
+
+const completedToolHistory: UIMessage[] = [
+  {
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: [
+      { type: 'step-start' },
+      {
+        type: 'tool-clientTool',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: { value: 'test' },
+        output: 'success',
+      },
+    ],
+  },
+  {
+    id: 'user-2',
+    role: 'user',
+    parts: [{ type: 'text', text: 'Continue' }],
+  },
+];
+
+async function main() {
+  const convertedIncompleteHistory = await convertToModelMessages(
+    incompleteToolHistory,
+  );
+
+  assert.equal(convertedIncompleteHistory.length, 2);
+  assert.deepEqual(convertedIncompleteHistory[0], {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'clientTool',
+        input: { value: 'test' },
+        providerExecuted: undefined,
+      },
+    ],
+  });
+  assert.deepEqual(convertedIncompleteHistory[1], {
+    role: 'user',
+    content: [{ type: 'text', text: 'Continue' }],
+  });
+
+  const convertedCompletedHistory =
+    await convertToModelMessages(completedToolHistory);
+
+  assert.equal(convertedCompletedHistory.length, 3);
+  assert.equal(convertedCompletedHistory[0].role, 'assistant');
+  assert.deepEqual(convertedCompletedHistory[1], {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'clientTool',
+        output: { type: 'text', value: 'success' },
+      },
+    ],
+  });
+  assert.equal(convertedCompletedHistory[2].role, 'user');
+
+  const ignoredIncompleteHistory = await convertToModelMessages(
+    incompleteToolHistory,
+    { ignoreIncompleteToolCalls: true },
+  );
+
+  assert.deepEqual(ignoredIncompleteHistory, [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Continue' }],
+    },
+  ]);
+
+  console.log(
+    'Issue #7258 not reproduced: input-available and completed client tool histories converted without an unsupported-state error.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Unsupported tool part state: input-available

## Reproduction

- The target branch uses `ai` 7.0.31 and `@ai-sdk/react` 4.0.34, rather than the reported beta.15 packages.
- `examples/ai-functions/src/reproduction/issue-7258-input-available.ts` converted an `input-available` tool part followed by a user message without throwing the expected `Unsupported tool part state: input-available` error.
- The artifact also confirmed that `output-available` produces a tool result and that `ignoreIncompleteToolCalls: true` filters incomplete calls.
- The current `onToolCall` contract returns `void`; client tool results must be recorded with `addToolOutput` rather than returned from the callback.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/convert-to-model-messages
- https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-tool-usage
- https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat

## Related Issues

Could not reproduce #7258