### PR TITLE
feat(openai-compat): add an extensible providerOptions type for image model requests and stop forcing response_format

### DIFF
--- a/.changeset/tidy-images-smile.md
+++ b/.changeset/tidy-images-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat(openai-compatible): add an extensible `providerOptions` type for image model requests and stop forcing `response_format`

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -103,8 +103,7 @@
             "packages/gateway/src/gateway-realtime-model.ts",
             "packages/gateway/src/gateway-reranking-model.ts",
             "packages/gateway/src/gateway-speech-model.ts",
-            "packages/gateway/src/gateway-transcription-model.ts",
-            "packages/openai-compatible/src/image/openai-compatible-image-model.ts"
+            "packages/gateway/src/gateway-transcription-model.ts"
           ]
         },
         {

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -214,7 +214,10 @@ const model = provider.imageModel('model-id');
 ### Basic Image Generation
 
 ```ts
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import {
+  createOpenAICompatible,
+  type OpenAICompatibleImageModelOptions,
+} from '@ai-sdk/openai-compatible';
 import { generateImage } from 'ai';
 
 const provider = createOpenAICompatible({
@@ -227,8 +230,49 @@ const { images } = await generateImage({
   model: provider.imageModel('model-id'),
   prompt: 'A futuristic cityscape at sunset',
   size: '1024x1024',
+  providerOptions: {
+    providerName: {
+      quality: 'high',
+      output_format: 'jpeg',
+      output_compression: 80,
+      background: 'opaque',
+    } satisfies OpenAICompatibleImageModelOptions,
+  },
 });
 ```
+
+### Image Model Options
+
+The following common provider options are available for image models:
+
+- **size** _string_
+
+  Dimensions of the generated image. Use the top-level `size` option for
+  standard dimensions, or this provider option for provider-specific values
+  such as `auto`.
+
+- **quality** _string_
+
+  Quality of the generated image. Supported values depend on the provider and
+  model.
+
+- **output_format** _string_
+
+  File format of the generated image.
+
+- **output_compression** _number_
+
+  Compression level from `0` to `100` for formats such as JPEG and WebP.
+
+- **background** _string_
+
+  Background behavior for the generated image. Supported values depend on the
+  provider and model.
+
+Providers and models may support `auto` for `size`, `quality`, or `background`.
+
+`OpenAICompatibleImageModelOptions` also accepts additional provider-specific
+options. These options are passed through to the provider API unchanged.
 
 ### Image Editing
 

--- a/examples/ai-functions/src/generate-image/openai/compatible-options.ts
+++ b/examples/ai-functions/src/generate-image/openai/compatible-options.ts
@@ -1,0 +1,28 @@
+import {
+  createOpenAICompatible,
+  type OpenAICompatibleImageModelOptions,
+} from '@ai-sdk/openai-compatible';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+const provider = createOpenAICompatible({
+  name: 'openai',
+  baseURL: 'https://api.openai.com/v1',
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+run(async () => {
+  const { images } = await generateImage({
+    model: provider.imageModel('gpt-image-2'),
+    prompt: 'A luminous glass greenhouse floating over a forest at dawn',
+    size: '1024x1024',
+    providerOptions: {
+      openai: {
+        quality: 'low',
+      } satisfies OpenAICompatibleImageModelOptions,
+    },
+  });
+
+  await presentImages(images);
+});

--- a/packages/openai-compatible/src/image/openai-compatible-image-model-options.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model-options.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod/v4';
+
+/**
+ * Common provider options for OpenAI-compatible image models.
+ *
+ * Additional provider-specific options are passed through to the API.
+ */
+export const openaiCompatibleImageModelOptions = z.looseObject({
+  /**
+   * Dimensions of the generated image.
+   *
+   * Supported values depend on the provider and model.
+   */
+  size: z.string().optional(),
+
+  /**
+   * Quality of the generated image.
+   *
+   * Supported values depend on the provider and model.
+   */
+  quality: z.string().optional(),
+
+  /**
+   * File format of the generated image.
+   *
+   * Supported values depend on the provider and model.
+   */
+  output_format: z.string().optional(),
+
+  /**
+   * Compression level for JPEG and WebP images.
+   */
+  output_compression: z.number().min(0).max(100).optional(),
+
+  /**
+   * Background behavior for the generated image.
+   *
+   * Supported values depend on the provider and model.
+   */
+  background: z.string().optional(),
+});
+
+export type OpenAICompatibleImageModelOptions = z.infer<
+  typeof openaiCompatibleImageModelOptions
+>;

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { OpenAICompatibleImageModel } from './openai-compatible-image-model';
+import type { OpenAICompatibleImageModelOptions } from './openai-compatible-image-model-options';
 import { z } from 'zod/v4';
 import type { ProviderErrorStructure } from '../openai-compatible-error';
 import type { ImageModelV4CallOptions } from '@ai-sdk/provider';
@@ -96,7 +97,11 @@ describe('OpenAICompatibleImageModel', () => {
       await model.doGenerate(
         createDefaultGenerateParams({
           n: 2,
-          providerOptions: { openaiCompatible: { quality: 'hd' } },
+          providerOptions: {
+            openaiCompatible: {
+              quality: 'hd',
+            } satisfies OpenAICompatibleImageModelOptions,
+          },
         }),
       );
 
@@ -106,7 +111,6 @@ describe('OpenAICompatibleImageModel', () => {
         n: 2,
         size: '1024x1024',
         quality: 'hd',
-        response_format: 'b64_json',
       });
     });
 
@@ -120,7 +124,11 @@ describe('OpenAICompatibleImageModel', () => {
       await recraftModel.doGenerate(
         createDefaultGenerateParams({
           prompt: 'A beautiful sunset',
-          providerOptions: { recraft: { style: 'vector_illustration' } },
+          providerOptions: {
+            recraft: {
+              style: 'vector_illustration',
+            } satisfies OpenAICompatibleImageModelOptions,
+          },
         }),
       );
 
@@ -130,7 +138,35 @@ describe('OpenAICompatibleImageModel', () => {
         n: 1,
         size: '1024x1024',
         style: 'vector_illustration',
-        response_format: 'b64_json',
+      });
+    });
+
+    it('should pass typed image output options', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate(
+        createDefaultGenerateParams({
+          providerOptions: {
+            openaiCompatible: {
+              size: 'auto',
+              quality: 'high',
+              output_format: 'jpeg',
+              output_compression: 80,
+              background: 'opaque',
+            } satisfies OpenAICompatibleImageModelOptions,
+          },
+        }),
+      );
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'dall-e-3',
+        prompt,
+        n: 1,
+        size: 'auto',
+        quality: 'high',
+        output_format: 'jpeg',
+        output_compression: 80,
+        background: 'opaque',
       });
     });
 
@@ -364,7 +400,6 @@ describe('OpenAICompatibleImageModel', () => {
         n: 1,
         size: '1024x1024',
         user: 'test-user-id',
-        response_format: 'b64_json',
       });
     });
 
@@ -385,7 +420,6 @@ describe('OpenAICompatibleImageModel', () => {
         prompt,
         n: 1,
         size: '1024x1024',
-        response_format: 'b64_json',
       });
       expect(requestBody).not.toHaveProperty('user');
     });

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.ts
@@ -173,7 +173,6 @@ export class OpenAICompatibleImageModel implements ImageModelV4 {
         n,
         size,
         ...args,
-        response_format: 'b64_json',
       },
       failedResponseHandler: createJsonErrorResponseHandler(
         this.config.errorStructure ?? defaultOpenAICompatibleErrorStructure,

--- a/packages/openai-compatible/src/index.ts
+++ b/packages/openai-compatible/src/index.ts
@@ -20,6 +20,7 @@ export type {
   OpenAICompatibleEmbeddingModelOptions as OpenAICompatibleEmbeddingProviderOptions,
 } from './embedding/openai-compatible-embedding-model-options';
 export { OpenAICompatibleImageModel } from './image/openai-compatible-image-model';
+export type { OpenAICompatibleImageModelOptions } from './image/openai-compatible-image-model-options';
 export type {
   OpenAICompatibleErrorData,
   ProviderErrorStructure,


### PR DESCRIPTION
## Background

highlighted in https://github.com/vercel/ai/issues/14859, there was a gap in consistnecy.

- Image providerOptions were passed through without an exported type.
- response_format: 'b64_json' was always injected, causing newer APIs to reject requests.
- Model was excluded from consistency checks
 
## Summary

- Added exported OpenAICompatibleImageModelOptions with size, quality, output_format, output_compression, and background.
- Additional provider-specific options remain supported.
- Removed the forced response_format

## End-to-End Verification

ran the example in `examples/ai-functions/src/generate-image/openai/compatible-options.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

towards #14859