### PR TITLE
[v5.0] fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations

### DIFF
--- a/.changeset/olive-owls-listen.md
+++ b/.changeset/olive-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): accept OAuth metadata without code challenge methods

--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -61,7 +61,6 @@ export const OAuthProtectedResourceMetadataSchema = z
   })
   .passthrough();
 
-<<<<<<< HEAD
 export const OAuthMetadataSchema = z
   .object({
     issuer: z.string(),
@@ -71,46 +70,13 @@ export const OAuthMetadataSchema = z
     scopes_supported: z.array(z.string()).optional(),
     response_types_supported: z.array(z.string()),
     grant_types_supported: z.array(z.string()).optional(),
-    code_challenge_methods_supported: z.array(z.string()),
+    code_challenge_methods_supported: z.array(z.string()).optional(),
     token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
     token_endpoint_auth_signing_alg_values_supported: z
       .array(z.string())
       .optional(),
   })
   .passthrough();
-=======
-export const OAuthProtectedResourceMetadataSchema = z.looseObject({
-  resource: z.string().url(),
-  authorization_servers: z.array(SafeUrlSchema).optional(),
-  jwks_uri: z.string().url().optional(),
-  scopes_supported: z.array(z.string()).optional(),
-  bearer_methods_supported: z.array(z.string()).optional(),
-  resource_signing_alg_values_supported: z.array(z.string()).optional(),
-  resource_name: z.string().optional(),
-  resource_documentation: z.string().optional(),
-  resource_policy_uri: z.string().url().optional(),
-  resource_tos_uri: z.string().url().optional(),
-  tls_client_certificate_bound_access_tokens: z.boolean().optional(),
-  authorization_details_types_supported: z.array(z.string()).optional(),
-  dpop_signing_alg_values_supported: z.array(z.string()).optional(),
-  dpop_bound_access_tokens_required: z.boolean().optional(),
-});
-
-export const OAuthMetadataSchema = z.looseObject({
-  issuer: z.string(),
-  authorization_endpoint: SafeUrlSchema,
-  token_endpoint: SafeUrlSchema,
-  registration_endpoint: SafeUrlSchema.optional(),
-  scopes_supported: z.array(z.string()).optional(),
-  response_types_supported: z.array(z.string()),
-  grant_types_supported: z.array(z.string()).optional(),
-  code_challenge_methods_supported: z.array(z.string()).optional(),
-  token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
-  token_endpoint_auth_signing_alg_values_supported: z
-    .array(z.string())
-    .optional(),
-});
->>>>>>> d84ea43de (fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations (#17462))
 
 /**
  * OpenID Connect Discovery 1.0 Provider Metadata

--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -61,6 +61,7 @@ export const OAuthProtectedResourceMetadataSchema = z
   })
   .passthrough();
 
+<<<<<<< HEAD
 export const OAuthMetadataSchema = z
   .object({
     issuer: z.string(),
@@ -77,6 +78,39 @@ export const OAuthMetadataSchema = z
       .optional(),
   })
   .passthrough();
+=======
+export const OAuthProtectedResourceMetadataSchema = z.looseObject({
+  resource: z.string().url(),
+  authorization_servers: z.array(SafeUrlSchema).optional(),
+  jwks_uri: z.string().url().optional(),
+  scopes_supported: z.array(z.string()).optional(),
+  bearer_methods_supported: z.array(z.string()).optional(),
+  resource_signing_alg_values_supported: z.array(z.string()).optional(),
+  resource_name: z.string().optional(),
+  resource_documentation: z.string().optional(),
+  resource_policy_uri: z.string().url().optional(),
+  resource_tos_uri: z.string().url().optional(),
+  tls_client_certificate_bound_access_tokens: z.boolean().optional(),
+  authorization_details_types_supported: z.array(z.string()).optional(),
+  dpop_signing_alg_values_supported: z.array(z.string()).optional(),
+  dpop_bound_access_tokens_required: z.boolean().optional(),
+});
+
+export const OAuthMetadataSchema = z.looseObject({
+  issuer: z.string(),
+  authorization_endpoint: SafeUrlSchema,
+  token_endpoint: SafeUrlSchema,
+  registration_endpoint: SafeUrlSchema.optional(),
+  scopes_supported: z.array(z.string()).optional(),
+  response_types_supported: z.array(z.string()),
+  grant_types_supported: z.array(z.string()).optional(),
+  code_challenge_methods_supported: z.array(z.string()).optional(),
+  token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
+  token_endpoint_auth_signing_alg_values_supported: z
+    .array(z.string())
+    .optional(),
+});
+>>>>>>> d84ea43de (fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations (#17462))
 
 /**
  * OpenID Connect Discovery 1.0 Provider Metadata

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -557,27 +557,6 @@ describe('discoverAuthorizationServerMetadata', () => {
     code_challenge_methods_supported: ['S256'],
   };
 
-<<<<<<< HEAD
-=======
-  it('returns OAuth metadata when issuer matches path-aware discovery issuer', async () => {
-    const tenantMetadata = {
-      ...validOAuthMetadata,
-      issuer: 'https://auth.example.com/tenant1',
-    };
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => tenantMetadata,
-    });
-
-    const metadata = await discoverAuthorizationServerMetadata(
-      'https://auth.example.com/tenant1',
-    );
-
-    expect(metadata).toEqual(tenantMetadata);
-  });
-
   it('accepts OAuth metadata when code challenge methods are omitted', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -606,7 +585,6 @@ describe('discoverAuthorizationServerMetadata', () => {
     `);
   });
 
->>>>>>> d84ea43de (fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations (#17462))
   it('tries URLs in order and returns first successful metadata', async () => {
     // First OAuth URL fails with 404
     mockFetch.mockResolvedValueOnce({

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -557,6 +557,56 @@ describe('discoverAuthorizationServerMetadata', () => {
     code_challenge_methods_supported: ['S256'],
   };
 
+<<<<<<< HEAD
+=======
+  it('returns OAuth metadata when issuer matches path-aware discovery issuer', async () => {
+    const tenantMetadata = {
+      ...validOAuthMetadata,
+      issuer: 'https://auth.example.com/tenant1',
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => tenantMetadata,
+    });
+
+    const metadata = await discoverAuthorizationServerMetadata(
+      'https://auth.example.com/tenant1',
+    );
+
+    expect(metadata).toEqual(tenantMetadata);
+  });
+
+  it('accepts OAuth metadata when code challenge methods are omitted', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        registration_endpoint: 'https://auth.example.com/register',
+        response_types_supported: ['code'],
+      }),
+    });
+
+    expect(
+      await discoverAuthorizationServerMetadata('https://auth.example.com'),
+    ).toMatchInlineSnapshot(`
+      {
+        "authorization_endpoint": "https://auth.example.com/authorize",
+        "issuer": "https://auth.example.com",
+        "registration_endpoint": "https://auth.example.com/register",
+        "response_types_supported": [
+          "code",
+        ],
+        "token_endpoint": "https://auth.example.com/token",
+      }
+    `);
+  });
+
+>>>>>>> d84ea43de (fix: OAuth discovery rejects RFC-compliant metadata without PKCE method declarations (#17462))
   it('tries URLs in order and returns first successful metadata', async () => {
     // First OAuth URL fails with 404
     mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Background

RFC 8414-compliant servers such as AWS Sign-In can omit PKCE method metadata, which caused MCP OAuth discovery to fail before Dynamic Client Registration.

## Root Cause

OAuthMetadataSchema incorrectly required code_challenge_methods_supported; the reproduction confirmed that its absence caused a Zod array validation error before registration.

## Summary

Made code_challenge_methods_supported optional in the MCP OAuth metadata schema.

## Testing

Added an inline-snapshot regression test to the existing OAuth test suite covering metadata that omits code challenge methods.

## End-to-end Validation

- `pnpm exec tsx -e "<live AWS OAuth auth probe>"` accepted the live AWS Sign-In metadata and reached Dynamic Client Registration.

## Related Issues

Fixes #17334

Closes #17453

Backport of #17462

Co-authored-by: rene84 <7099469+rene84@users.noreply.github.com>