### PR TITLE
[v5.0] reproduction: could not reproduce Unsupported tool part state: input-available

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-7258-input-available.ts
+++ b/examples/ai-functions/src/reproduction/issue-7258-input-available.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { convertToModelMessages } from '../../../../packages/ai/dist/index.mjs';
+import type { UIMessage } from '../../../../packages/ai/src/index';
+
+async function main() {
+  const incompleteAssistantMessage: UIMessage = {
+    id: 'assistant-incomplete',
+    role: 'assistant',
+    parts: [
+      { type: 'step-start' },
+      {
+        type: 'tool-clientTool',
+        toolCallId: 'call-1',
+        state: 'input-available',
+        input: {},
+      },
+    ],
+  };
+
+  const followingUserMessage: UIMessage = {
+    id: 'user-follow-up',
+    role: 'user',
+    parts: [{ type: 'text', text: 'Continue' }],
+  };
+
+  let converted;
+  try {
+    converted = convertToModelMessages([
+      incompleteAssistantMessage,
+      followingUserMessage,
+    ]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('Unsupported tool part state: input-available')) {
+      throw new Error(
+        `ISSUE #7258 REPRODUCED: ${message}`,
+        error instanceof Error ? { cause: error } : undefined,
+      );
+    }
+    throw error;
+  }
+
+  assert.deepEqual(converted, [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'clientTool',
+          input: {},
+          providerExecuted: undefined,
+        },
+      ],
+    },
+    { role: 'tool', content: [] },
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Continue' }],
+    },
+  ]);
+
+  const completed = convertToModelMessages([
+    {
+      ...incompleteAssistantMessage,
+      parts: [
+        { type: 'step-start' },
+        {
+          type: 'tool-clientTool',
+          toolCallId: 'call-1',
+          state: 'output-available',
+          input: {},
+          output: 'success',
+        },
+      ],
+    },
+    followingUserMessage,
+  ]);
+
+  assert.deepEqual(completed[1], {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'clientTool',
+        output: { type: 'text', value: 'success' },
+      },
+    ],
+  });
+
+  const ignored = convertToModelMessages(
+    [incompleteAssistantMessage, followingUserMessage],
+    { ignoreIncompleteToolCalls: true },
+  );
+
+  assert.deepEqual(ignored, [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Continue' }],
+    },
+  ]);
+
+  console.log(
+    'Issue #7258 not reproduced: input-available converted without throwing; output-available produced a tool result; ignoreIncompleteToolCalls filtered the incomplete call.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Unsupported tool part state: input-available

## Reproduction

- The `release-v5.0` target contains `ai` 5.0.216 and `@ai-sdk/react` 2.0.218, rather than the reported beta.15 versions.
- Runnable artifacts `examples/ai-functions/src/reproduction/issue-7258-input-available.ts` and `examples/ai-functions/package.json` expected the reported `Unsupported tool part state: input-available` failure, but conversion completed without throwing.
- The artifact confirmed that an `output-available` client-tool part produces a tool result and that `ignoreIncompleteToolCalls: true` filters an incomplete call.
- The current `onToolCall` contract in `packages/ai/src/ui/chat.ts` returns `void`; client-tool results must be recorded with `addToolOutput` rather than returned from the callback.

## Relevant Documentation

- https://v5.ai-sdk.dev/docs/reference/ai-sdk-ui/convert-to-model-messages
- https://v5.ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat
- https://v5.ai-sdk.dev/docs/ai-sdk-ui/chatbot-tool-usage

## Related Issues

Could not reproduce #7258