### PR TITLE
[v5.0] fix: prevent generateText from returning partial results after cancellation in multi-step tool loops

### DIFF
--- a/.changeset/swift-tools-abort.md
+++ b/.changeset/swift-tools-abort.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Propagate abort reasons when generation is cancelled during tool execution.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -50,9 +50,6 @@ const dummyResponseValues = {
   warnings: [],
 };
 
-<<<<<<< HEAD
-const modelWithSources = new MockLanguageModelV2({
-=======
 describe('abort signal handling', () => {
   it('should reject when the abort signal fires during tool execution', async () => {
     const abortController = new AbortController();
@@ -60,7 +57,7 @@ describe('abort signal handling', () => {
     let modelCallCount = 0;
 
     const result = generateText({
-      model: new MockLanguageModelV4({
+      model: new MockLanguageModelV2({
         doGenerate: async () => {
           modelCallCount++;
 
@@ -82,7 +79,7 @@ describe('abort signal handling', () => {
           return {
             ...dummyResponseValues,
             content: [],
-            finishReason: { unified: 'other', raw: 'unknown' },
+            finishReason: 'other',
           };
         },
       }),
@@ -97,7 +94,7 @@ describe('abort signal handling', () => {
       },
       prompt: 'test-input',
       abortSignal: abortController.signal,
-      stopWhen: isStepCount(10),
+      stopWhen: stepCountIs(10),
       maxRetries: 0,
     });
 
@@ -113,7 +110,7 @@ describe('abort signal handling', () => {
     let modelCallCount = 0;
 
     const result = generateText({
-      model: new MockLanguageModelV4({
+      model: new MockLanguageModelV2({
         doGenerate: async () => {
           modelCallCount++;
 
@@ -135,7 +132,7 @@ describe('abort signal handling', () => {
           return {
             ...dummyResponseValues,
             content: [],
-            finishReason: { unified: 'other', raw: 'unknown' },
+            finishReason: 'other',
           };
         },
       }),
@@ -150,7 +147,7 @@ describe('abort signal handling', () => {
       },
       prompt: 'test-input',
       abortSignal: abortController.signal,
-      stopWhen: isStepCount(10),
+      stopWhen: stepCountIs(10),
       maxRetries: 0,
     });
 
@@ -161,8 +158,7 @@ describe('abort signal handling', () => {
   });
 });
 
-const modelWithSources = new MockLanguageModelV4({
->>>>>>> a4eb3f37f (fix: prevent generateText from returning partial results after cancellation in multi-step tool loops (#17461))
+const modelWithSources = new MockLanguageModelV2({
   doGenerate: {
     ...dummyResponseValues,
     content: [

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -50,7 +50,119 @@ const dummyResponseValues = {
   warnings: [],
 };
 
+<<<<<<< HEAD
 const modelWithSources = new MockLanguageModelV2({
+=======
+describe('abort signal handling', () => {
+  it('should reject when the abort signal fires during tool execution', async () => {
+    const abortController = new AbortController();
+    const abortError = new DOMException('tool execution aborted', 'AbortError');
+    let modelCallCount = 0;
+
+    const result = generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: async () => {
+          modelCallCount++;
+
+          if (modelCallCount === 1) {
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: `{ "value": "value" }`,
+                },
+              ],
+            };
+          }
+
+          return {
+            ...dummyResponseValues,
+            content: [],
+            finishReason: { unified: 'other', raw: 'unknown' },
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+          execute: async (_input, { abortSignal }) => {
+            abortController.abort(abortError);
+            abortSignal?.throwIfAborted();
+          },
+        },
+      },
+      prompt: 'test-input',
+      abortSignal: abortController.signal,
+      stopWhen: isStepCount(10),
+      maxRetries: 0,
+    });
+
+    await expect(result).rejects.toMatchInlineSnapshot(
+      `[AbortError: tool execution aborted]`,
+    );
+    expect(modelCallCount).toBe(1);
+  });
+
+  it('should reject before another model call when a tool completes after cancellation', async () => {
+    const abortController = new AbortController();
+    const abortError = new DOMException('tool execution aborted', 'AbortError');
+    let modelCallCount = 0;
+
+    const result = generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: async () => {
+          modelCallCount++;
+
+          if (modelCallCount === 1) {
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: `{ "value": "value" }`,
+                },
+              ],
+            };
+          }
+
+          return {
+            ...dummyResponseValues,
+            content: [],
+            finishReason: { unified: 'other', raw: 'unknown' },
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+          execute: async () => {
+            abortController.abort(abortError);
+            return 'tool result';
+          },
+        },
+      },
+      prompt: 'test-input',
+      abortSignal: abortController.signal,
+      stopWhen: isStepCount(10),
+      maxRetries: 0,
+    });
+
+    await expect(result).rejects.toMatchInlineSnapshot(
+      `[AbortError: tool execution aborted]`,
+    );
+    expect(modelCallCount).toBe(1);
+  });
+});
+
+const modelWithSources = new MockLanguageModelV4({
+>>>>>>> a4eb3f37f (fix: prevent generateText from returning partial results after cancellation in multi-step tool loops (#17461))
   doGenerate: {
     ...dummyResponseValues,
     content: [

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -386,6 +386,7 @@ A function that attempts to repair a tool call that failed to parse.
                   'gen_ai.request.top_p': settings.topP,
                 },
               }),
+<<<<<<< HEAD
               tracer,
               fn: async span => {
                 const result = await stepModel.doGenerate({
@@ -398,6 +399,210 @@ A function that attempts to repair a tool call that failed to parse.
                   abortSignal,
                   headers: headersWithUserAgent,
                 });
+=======
+            },
+          });
+        }
+
+        initialResponseMessages.push({
+          role: 'tool',
+          content: toolContent,
+        });
+      }
+
+      const callSettings = prepareLanguageModelCallOptions(settings);
+
+      let currentModelResponse: LanguageModelV4GenerateResult & {
+        response: { id: string; timestamp: Date; modelId: string };
+      };
+      let clientToolCalls: Array<TypedToolCall<TOOLS>> = [];
+      let clientToolOutputs: Array<ToolOutput<TOOLS>> = [];
+      let toolApprovalResponses: Array<ToolApprovalResponseOutput<TOOLS>> = [];
+      let deniedToolApprovalResponses: Array<
+        ToolApprovalResponseOutput<TOOLS>
+      > = [];
+      const steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'] =
+        [];
+      let instructionsForNextStep = initialPrompt.instructions;
+      let messagesForNextStep = [
+        ...initialMessages,
+        ...initialResponseMessages,
+      ];
+
+      // Track provider-executed tool calls that support deferred results
+      // (e.g., code_execution in programmatic tool calling scenarios).
+      // These tools may not return their results in the same turn as their call.
+      const pendingDeferredToolCalls = new Map<string, { toolName: string }>();
+
+      do {
+        if (steps.length > 0) {
+          mergedAbortSignal?.throwIfAborted();
+        }
+
+        // Set up step timeout if configured
+        const stepTimeoutId = setAbortTimeout({
+          abortController: stepAbortController,
+          label: 'Step',
+          timeoutMs: stepTimeoutMs,
+        });
+        const stepNumber = steps.length;
+
+        try {
+          await runInTracingChannelSpan({
+            type: 'step',
+            event: { callId, stepNumber },
+            execute: async () => {
+              const accumulatedResponseMessages = [
+                ...initialResponseMessages,
+                ...steps.flatMap(step => step.response.messages),
+              ];
+              const stepInputMessages = messagesForNextStep;
+
+              const prepareStepResult = await prepareStep?.({
+                model,
+                steps,
+                stepNumber: steps.length,
+                instructions: instructionsForNextStep,
+                initialInstructions: initialPrompt.instructions,
+                messages: stepInputMessages,
+                initialMessages,
+                responseMessages: accumulatedResponseMessages,
+                runtimeContext,
+                toolsContext,
+                experimental_sandbox: sandbox,
+              });
+
+              const stepSandbox =
+                prepareStepResult?.experimental_sandbox ?? sandbox;
+
+              const stepModel = resolveLanguageModel(
+                prepareStepResult?.model ?? model,
+              );
+
+              const stepInstructions =
+                prepareStepResult?.instructions ??
+                prepareStepResult?.system ??
+                instructionsForNextStep;
+
+              const promptMessages = await convertToLanguageModelPrompt({
+                prompt: {
+                  instructions: stepInstructions,
+                  messages: prepareStepResult?.messages ?? stepInputMessages,
+                },
+                supportedUrls: await stepModel.supportedUrls,
+                download,
+                provider: stepModel.provider.split('.')[0],
+              });
+
+              runtimeContext =
+                prepareStepResult?.runtimeContext ?? runtimeContext;
+              toolsContext = prepareStepResult?.toolsContext ?? toolsContext;
+
+              const stepActiveTools = filterActiveTools({
+                tools,
+                activeTools: prepareStepResult?.activeTools ?? activeTools,
+              });
+              const stepToolOrder = prepareStepResult?.toolOrder ?? toolOrder;
+
+              const stepTools = await prepareTools({
+                tools: stepActiveTools,
+                toolOrder: stepToolOrder as ToolOrder<
+                  ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
+                >,
+                // active tools context is a subset of the tools context, so we can cast to the unknown type
+                toolsContext: toolsContext as unknown as InferToolSetContext<
+                  ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
+                >,
+                experimental_sandbox: stepSandbox,
+              });
+
+              const stepToolChoice = prepareToolChoice({
+                toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
+              });
+
+              const stepMessages =
+                prepareStepResult?.messages ?? stepInputMessages;
+
+              const stepProviderOptions = mergeObjects(
+                providerOptions,
+                prepareStepResult?.providerOptions,
+              );
+
+              await notify({
+                event: {
+                  callId,
+                  provider: stepModel.provider,
+                  modelId: stepModel.modelId,
+                  stepNumber,
+                  instructions: stepInstructions,
+                  messages: stepMessages,
+                  tools,
+                  toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
+                  activeTools: prepareStepResult?.activeTools ?? activeTools,
+                  toolOrder: stepToolOrder,
+                  steps: [...steps],
+                  providerOptions: stepProviderOptions,
+                  output,
+                  runtimeContext,
+                  promptMessages,
+                  stepTools,
+                  stepToolChoice,
+                  toolsContext,
+                },
+                callbacks: [
+                  resolvedOnStepStart,
+                  telemetryDispatcher.onStepStart,
+                ],
+              });
+
+              const languageModelCallContext = {
+                provider: stepModel.provider,
+                modelId: stepModel.modelId,
+                instructions: stepInstructions,
+                messages: stepMessages,
+                tools: stepTools,
+                ...callSettings,
+              };
+              const languageModelCallStartEvent = {
+                callId,
+                ...languageModelCallContext,
+              };
+
+              const stepStartTimestampMs = now();
+
+              await notify({
+                event: languageModelCallStartEvent,
+                callbacks: [
+                  resolvedOnLanguageModelCallStart,
+                  telemetryDispatcher.onLanguageModelCallStart as
+                    | undefined
+                    | OnLanguageModelCallStartCallback,
+                ],
+              });
+
+              const executeLanguageModelCallInTelemetryContext =
+                telemetryDispatcher.executeLanguageModelCall ??
+                (async <T>({ execute }: { execute: () => PromiseLike<T> }) =>
+                  await execute());
+
+              currentModelResponse = await retry(async () => {
+                const result = await executeLanguageModelCallInTelemetryContext(
+                  {
+                    ...languageModelCallStartEvent,
+                    execute: async () =>
+                      await stepModel.doGenerate({
+                        ...callSettings,
+                        tools: stepTools,
+                        toolChoice: stepToolChoice,
+                        responseFormat: await output?.responseFormat,
+                        prompt: promptMessages,
+                        providerOptions: stepProviderOptions,
+                        abortSignal: mergedAbortSignal,
+                        headers: headersWithUserAgent,
+                      }),
+                  },
+                );
+>>>>>>> a4eb3f37f (fix: prevent generateText from returning partial results after cancellation in multi-step tool loops (#17461))
 
                 // Fill in default values:
                 const responseData = {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -312,6 +312,10 @@ A function that attempts to repair a tool call that failed to parse.
         const steps: GenerateTextResult<TOOLS, OUTPUT>['steps'] = [];
 
         do {
+          if (steps.length > 0) {
+            abortSignal?.throwIfAborted();
+          }
+
           const stepInputMessages = [
             ...initialPrompt.messages,
             ...responseMessages,
@@ -386,7 +390,6 @@ A function that attempts to repair a tool call that failed to parse.
                   'gen_ai.request.top_p': settings.topP,
                 },
               }),
-<<<<<<< HEAD
               tracer,
               fn: async span => {
                 const result = await stepModel.doGenerate({
@@ -399,210 +402,6 @@ A function that attempts to repair a tool call that failed to parse.
                   abortSignal,
                   headers: headersWithUserAgent,
                 });
-=======
-            },
-          });
-        }
-
-        initialResponseMessages.push({
-          role: 'tool',
-          content: toolContent,
-        });
-      }
-
-      const callSettings = prepareLanguageModelCallOptions(settings);
-
-      let currentModelResponse: LanguageModelV4GenerateResult & {
-        response: { id: string; timestamp: Date; modelId: string };
-      };
-      let clientToolCalls: Array<TypedToolCall<TOOLS>> = [];
-      let clientToolOutputs: Array<ToolOutput<TOOLS>> = [];
-      let toolApprovalResponses: Array<ToolApprovalResponseOutput<TOOLS>> = [];
-      let deniedToolApprovalResponses: Array<
-        ToolApprovalResponseOutput<TOOLS>
-      > = [];
-      const steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'] =
-        [];
-      let instructionsForNextStep = initialPrompt.instructions;
-      let messagesForNextStep = [
-        ...initialMessages,
-        ...initialResponseMessages,
-      ];
-
-      // Track provider-executed tool calls that support deferred results
-      // (e.g., code_execution in programmatic tool calling scenarios).
-      // These tools may not return their results in the same turn as their call.
-      const pendingDeferredToolCalls = new Map<string, { toolName: string }>();
-
-      do {
-        if (steps.length > 0) {
-          mergedAbortSignal?.throwIfAborted();
-        }
-
-        // Set up step timeout if configured
-        const stepTimeoutId = setAbortTimeout({
-          abortController: stepAbortController,
-          label: 'Step',
-          timeoutMs: stepTimeoutMs,
-        });
-        const stepNumber = steps.length;
-
-        try {
-          await runInTracingChannelSpan({
-            type: 'step',
-            event: { callId, stepNumber },
-            execute: async () => {
-              const accumulatedResponseMessages = [
-                ...initialResponseMessages,
-                ...steps.flatMap(step => step.response.messages),
-              ];
-              const stepInputMessages = messagesForNextStep;
-
-              const prepareStepResult = await prepareStep?.({
-                model,
-                steps,
-                stepNumber: steps.length,
-                instructions: instructionsForNextStep,
-                initialInstructions: initialPrompt.instructions,
-                messages: stepInputMessages,
-                initialMessages,
-                responseMessages: accumulatedResponseMessages,
-                runtimeContext,
-                toolsContext,
-                experimental_sandbox: sandbox,
-              });
-
-              const stepSandbox =
-                prepareStepResult?.experimental_sandbox ?? sandbox;
-
-              const stepModel = resolveLanguageModel(
-                prepareStepResult?.model ?? model,
-              );
-
-              const stepInstructions =
-                prepareStepResult?.instructions ??
-                prepareStepResult?.system ??
-                instructionsForNextStep;
-
-              const promptMessages = await convertToLanguageModelPrompt({
-                prompt: {
-                  instructions: stepInstructions,
-                  messages: prepareStepResult?.messages ?? stepInputMessages,
-                },
-                supportedUrls: await stepModel.supportedUrls,
-                download,
-                provider: stepModel.provider.split('.')[0],
-              });
-
-              runtimeContext =
-                prepareStepResult?.runtimeContext ?? runtimeContext;
-              toolsContext = prepareStepResult?.toolsContext ?? toolsContext;
-
-              const stepActiveTools = filterActiveTools({
-                tools,
-                activeTools: prepareStepResult?.activeTools ?? activeTools,
-              });
-              const stepToolOrder = prepareStepResult?.toolOrder ?? toolOrder;
-
-              const stepTools = await prepareTools({
-                tools: stepActiveTools,
-                toolOrder: stepToolOrder as ToolOrder<
-                  ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
-                >,
-                // active tools context is a subset of the tools context, so we can cast to the unknown type
-                toolsContext: toolsContext as unknown as InferToolSetContext<
-                  ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
-                >,
-                experimental_sandbox: stepSandbox,
-              });
-
-              const stepToolChoice = prepareToolChoice({
-                toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
-              });
-
-              const stepMessages =
-                prepareStepResult?.messages ?? stepInputMessages;
-
-              const stepProviderOptions = mergeObjects(
-                providerOptions,
-                prepareStepResult?.providerOptions,
-              );
-
-              await notify({
-                event: {
-                  callId,
-                  provider: stepModel.provider,
-                  modelId: stepModel.modelId,
-                  stepNumber,
-                  instructions: stepInstructions,
-                  messages: stepMessages,
-                  tools,
-                  toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
-                  activeTools: prepareStepResult?.activeTools ?? activeTools,
-                  toolOrder: stepToolOrder,
-                  steps: [...steps],
-                  providerOptions: stepProviderOptions,
-                  output,
-                  runtimeContext,
-                  promptMessages,
-                  stepTools,
-                  stepToolChoice,
-                  toolsContext,
-                },
-                callbacks: [
-                  resolvedOnStepStart,
-                  telemetryDispatcher.onStepStart,
-                ],
-              });
-
-              const languageModelCallContext = {
-                provider: stepModel.provider,
-                modelId: stepModel.modelId,
-                instructions: stepInstructions,
-                messages: stepMessages,
-                tools: stepTools,
-                ...callSettings,
-              };
-              const languageModelCallStartEvent = {
-                callId,
-                ...languageModelCallContext,
-              };
-
-              const stepStartTimestampMs = now();
-
-              await notify({
-                event: languageModelCallStartEvent,
-                callbacks: [
-                  resolvedOnLanguageModelCallStart,
-                  telemetryDispatcher.onLanguageModelCallStart as
-                    | undefined
-                    | OnLanguageModelCallStartCallback,
-                ],
-              });
-
-              const executeLanguageModelCallInTelemetryContext =
-                telemetryDispatcher.executeLanguageModelCall ??
-                (async <T>({ execute }: { execute: () => PromiseLike<T> }) =>
-                  await execute());
-
-              currentModelResponse = await retry(async () => {
-                const result = await executeLanguageModelCallInTelemetryContext(
-                  {
-                    ...languageModelCallStartEvent,
-                    execute: async () =>
-                      await stepModel.doGenerate({
-                        ...callSettings,
-                        tools: stepTools,
-                        toolChoice: stepToolChoice,
-                        responseFormat: await output?.responseFormat,
-                        prompt: promptMessages,
-                        providerOptions: stepProviderOptions,
-                        abortSignal: mergedAbortSignal,
-                        headers: headersWithUserAgent,
-                      }),
-                  },
-                );
->>>>>>> a4eb3f37f (fix: prevent generateText from returning partial results after cancellation in multi-step tool loops (#17461))
 
                 // Fill in default values:
                 const responseData = {


### PR DESCRIPTION
## Background

Callers relying on cancellation could receive an apparently successful partial result when an abort occurred during tool execution in a multi-step generation.

## Root Cause

Tool execution could normalize an abort exception into a tool-error, or ignore cancellation and return successfully, while `generateText` failed to check the aborted merged signal before starting the next loop iteration.

## Summary

The multi-step `generateText` loop now throws the merged abort signal's reason before beginning any continuation step, independently of the preceding tool result type.

## Testing

Added inline-snapshot regression tests confirming cancellation propagation for both abort-aware throwing tools and abort-insensitive successful tools, with assertions that no second model call occurs. The focused test file and full repository test suite passed.

## End-to-end Validation

- `pnpm -C examples/ai-functions exec tsx src/reproduction/issue-12878-generate-text-abort.ts` — the original reproduction exited successfully after observing propagated `AbortError`; its temporary artifact was removed afterward.

## Related Issues

Fixes #12878

Closes #17450

Backport of #17461

Co-authored-by: wkusnierczyk <2981661+wkusnierczyk@users.noreply.github.com>
Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>