### PR TITLE
[v6.0] fix: handle multiple Gemini code execution results for one executable code part

### DIFF
--- a/.changeset/bright-ravens-execute.md
+++ b/.changeset/bright-ravens-execute.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): associate multiple code execution results with their tool call

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -340,6 +340,157 @@ describe('urlContextMetadata', () => {
 });
 
 describe('doGenerate', () => {
+  it('should associate multiple generated and streamed code execution results with the same tool call', async () => {
+    const response = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                executableCode: {
+                  language: 'PYTHON',
+                  code: "print('ok')\nprint(1/0)",
+                },
+              },
+              {
+                codeExecutionResult: {
+                  outcome: 'OUTCOME_OK',
+                  output: 'ok\n',
+                },
+              },
+              {
+                codeExecutionResult: {
+                  outcome: 'OUTCOME_FAILED',
+                  output: 'ZeroDivisionError: division by zero\n',
+                },
+              },
+            ],
+            role: 'model',
+          },
+          finishReason: 'STOP',
+        },
+      ],
+    };
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(`data: ${JSON.stringify(response)}\n\n`, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+      );
+    const testProvider = createGoogle({
+      apiKey: 'test-api-key',
+      fetch,
+      generateId: () => 'test-id',
+    });
+
+    const { content } = await testProvider
+      .languageModel('gemini-2.0-pro')
+      .doGenerate({
+        tools: [
+          {
+            type: 'provider',
+            id: 'google.code_execution',
+            name: 'code_execution',
+            args: {},
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{"language":"PYTHON","code":"print('ok')\\nprint(1/0)"}",
+          "providerExecuted": true,
+          "toolCallId": "test-id",
+          "toolName": "code_execution",
+          "type": "tool-call",
+        },
+        {
+          "result": {
+            "outcome": "OUTCOME_OK",
+            "output": "ok
+      ",
+          },
+          "toolCallId": "test-id",
+          "toolName": "code_execution",
+          "type": "tool-result",
+        },
+        {
+          "result": {
+            "outcome": "OUTCOME_FAILED",
+            "output": "ZeroDivisionError: division by zero
+      ",
+          },
+          "toolCallId": "test-id",
+          "toolName": "code_execution",
+          "type": "tool-result",
+        },
+      ]
+    `);
+
+    const { stream } = await testProvider
+      .languageModel('gemini-2.0-pro')
+      .doStream({
+        tools: [
+          {
+            type: 'provider',
+            id: 'google.code_execution',
+            name: 'code_execution',
+            args: {},
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+    const events = await convertReadableStreamToArray(stream);
+    const toolEvents = events.filter(
+      event => event.type === 'tool-call' || event.type === 'tool-result',
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(toolEvents).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{"language":"PYTHON","code":"print('ok')\\nprint(1/0)"}",
+          "providerExecuted": true,
+          "toolCallId": "test-id",
+          "toolName": "code_execution",
+          "type": "tool-call",
+        },
+        {
+          "result": {
+            "outcome": "OUTCOME_OK",
+            "output": "ok
+      ",
+          },
+          "toolCallId": "test-id",
+          "toolName": "code_execution",
+          "type": "tool-result",
+        },
+        {
+          "result": {
+            "outcome": "OUTCOME_FAILED",
+            "output": "ZeroDivisionError: division by zero
+      ",
+          },
+          "toolCallId": "test-id",
+          "toolName": "code_execution",
+          "type": "tool-result",
+        },
+      ]
+    `);
+  });
+
   const TEST_URL_GEMINI_PRO =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
 

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -385,7 +385,7 @@ describe('doGenerate', () => {
           headers: { 'content-type': 'text/event-stream' },
         }),
       );
-    const testProvider = createGoogle({
+    const testProvider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
       fetch,
       generateId: () => 'test-id',

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -375,7 +375,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
 
     const usageMetadata = response.usageMetadata;
 
-    // Associates a code execution result with its preceding call.
+    // Associates code execution results with their preceding call.
     let lastCodeExecutionToolCallId: string | undefined;
     // Associates a server-side tool response with its preceding call (tool combination).
     let lastServerToolCallId: string | undefined;
@@ -396,7 +396,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       } else if ('codeExecutionResult' in part && part.codeExecutionResult) {
         content.push({
           type: 'tool-result',
-          // Assumes a result directly follows its corresponding call part.
+          // Results correspond to the most recent executable code part.
           toolCallId: lastCodeExecutionToolCallId!,
           toolName: 'code_execution',
           result: {
@@ -404,8 +404,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
             output: part.codeExecutionResult.output ?? '',
           },
         });
-        // Clear the ID after use to avoid accidental reuse.
-        lastCodeExecutionToolCallId = undefined;
       } else if ('text' in part && part.text != null) {
         const thoughtSignatureMetadata = part.thoughtSignature
           ? {
@@ -600,7 +598,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
 
     // Track emitted sources to prevent duplicates
     const emittedSourceUrls = new Set<string>();
-    // Associates a code execution result with its preceding call.
+    // Associates code execution results with their preceding call.
     let lastCodeExecutionToolCallId: string | undefined;
     // Associates a server-side tool response with its preceding call (tool combination).
     let lastServerToolCallId: string | undefined;
@@ -728,7 +726,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                   'codeExecutionResult' in part &&
                   part.codeExecutionResult
                 ) {
-                  // Assumes a result directly follows its corresponding call part.
+                  // Results correspond to the most recent executable code part.
                   const toolCallId = lastCodeExecutionToolCallId;
 
                   if (toolCallId) {
@@ -741,8 +739,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                         output: part.codeExecutionResult.output ?? '',
                       },
                     });
-                    // Clear the ID after use.
-                    lastCodeExecutionToolCallId = undefined;
                   }
                 } else if ('text' in part && part.text != null) {
                   const thoughtSignatureMetadata = part.thoughtSignature


### PR DESCRIPTION
## Background

Gemini responses containing multiple code execution results for one executable code part caused generateText to throw instead of returning the results.

## Root Cause

The Google provider cleared the most recent code-execution tool-call ID after the first result, leaving subsequent generated results with an undefined ID and dropping subsequent streamed results; the recorded response reproduced both the ID mismatch and generateText failure.

## Summary

Retained the most recent code-execution tool-call ID across all associated results in generated and streamed responses.

## Testing

Added inline-snapshot regression coverage to the existing Google language model test for generated and streamed responses containing two results associated with one tool call.

## End-to-end Validation

- `RESPONSE="$(git show 9c220d331:packages/google/src/__fixtures__/google-code-execution-multiple-results.json)" pnpm -C examples/ai-functions exec tsx -e ...` — recorded-response replay completed without throwing and returned both results with `code-execution-call`.
- `pnpm -C examples/ai-functions exec tsx src/generate-text/google/code-execution-tool-object.ts` — live Gemini code execution completed successfully and returned the structured answer `5117`.

## Related Issues

Fixes #11485

Closes #17387

Backport of #17399

Co-authored-by: cllu <677398+cllu@users.noreply.github.com>