### PR TITLE
fix(ai): use injective serialization for tool approval HMAC payload

### DIFF
--- a/.changeset/tool-approval-injective-payload.md
+++ b/.changeset/tool-approval-injective-payload.md
@@ -11,3 +11,8 @@ serialize to identical bytes, allowing a signed approval to verify against a
 different tuple. The payload is now serialized with `JSON.stringify` (with a
 versioned domain-separation prefix), which escapes delimiter/control characters
 and makes the encoding injective.
+
+Verification remains backwards compatible: a signature in the old format still
+verifies, but only when no field contains the `\n` delimiter (the condition
+that made the old format ambiguous), so a pending approval that straddles an
+upgrade is not rejected while the collision stays closed.

--- a/.changeset/tool-approval-injective-payload.md
+++ b/.changeset/tool-approval-injective-payload.md
@@ -1,0 +1,13 @@
+---
+'ai': patch
+---
+
+fix(ai): use injective serialization for tool approval HMAC payload
+
+The tool approval signature (`experimental_toolApprovalSecret`) built its HMAC
+payload by joining fields with `\n`. Because fields such as `toolName` and
+`toolCallId` can themselves contain a newline, distinct field tuples could
+serialize to identical bytes, allowing a signed approval to verify against a
+different tuple. The payload is now serialized with `JSON.stringify` (with a
+versioned domain-separation prefix), which escapes delimiter/control characters
+and makes the encoding injective.

--- a/packages/ai/src/generate-text/tool-approval-signature.test.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.test.ts
@@ -94,4 +94,72 @@ describe('signToolApproval + verifyToolApprovalSignature', () => {
     });
     expect(sig1).toBe(sig2);
   });
+
+  // A newline in toolName must not be retupleable into toolCallId to forge a
+  // matching signature for a different tool.
+  it('should not collide when a newline in toolName is retupled into toolCallId', async () => {
+    const signed = {
+      approvalId: 'approval-1',
+      toolCallId: 'call-1',
+      toolName: 'searchDocs\ndeleteFile',
+      input: { path: '/tmp/target' },
+    };
+    const retupled = {
+      approvalId: 'approval-1',
+      toolCallId: 'call-1\nsearchDocs',
+      toolName: 'deleteFile',
+      input: { path: '/tmp/target' },
+    };
+
+    const signature = await signToolApproval({ secret, ...signed });
+
+    // The signature issued for the newline-bearing tool must NOT verify against
+    // the retupled tuple that targets a different registered tool.
+    expect(
+      await verifyToolApprovalSignature({ secret, signature, ...retupled }),
+    ).toBe(false);
+
+    // The two tuples must produce distinct signatures.
+    const retupledSignature = await signToolApproval({ secret, ...retupled });
+    expect(signature).not.toBe(retupledSignature);
+
+    // Sanity: each signature still verifies against its own tuple.
+    expect(
+      await verifyToolApprovalSignature({ secret, signature, ...signed }),
+    ).toBe(true);
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature: retupledSignature,
+        ...retupled,
+      }),
+    ).toBe(true);
+  });
+
+  // Any delimiter/control character shifted across a field boundary must fail.
+  it.each([
+    ['newline', '\n'],
+    ['carriage return', '\r'],
+    ['tab', '\t'],
+    ['null byte', '\0'],
+    ['json quote', '"'],
+    ['json backslash', '\\'],
+  ])('should not collide across the %s delimiter', async (_label, delim) => {
+    const signed = {
+      approvalId: 'approval-1',
+      toolCallId: 'call-1',
+      toolName: `alpha${delim}beta`,
+      input: { path: '/tmp/target' },
+    };
+    const retupled = {
+      approvalId: 'approval-1',
+      toolCallId: `call-1${delim}alpha`,
+      toolName: 'beta',
+      input: { path: '/tmp/target' },
+    };
+    const signature = await signToolApproval({ secret, ...signed });
+    expect(
+      await verifyToolApprovalSignature({ secret, signature, ...retupled }),
+    ).toBe(false);
+  });
 });

--- a/packages/ai/src/generate-text/tool-approval-signature.test.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.test.ts
@@ -1,10 +1,39 @@
 import { describe, expect, it } from 'vitest';
+import { hashCanonical, toBase64url } from '../util/canonical-hash';
 import {
   signToolApproval,
   verifyToolApprovalSignature,
 } from './tool-approval-signature';
 
 const secret = 'test-secret-key-for-hmac-signing';
+
+// Produces a signature in the legacy newline-joined payload format that the
+// pre-JSON version emitted, so the backwards-compat fallback can be tested.
+async function signLegacy({
+  approvalId,
+  toolCallId,
+  toolName,
+  input,
+}: {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+}): Promise<string> {
+  const inputDigest = await hashCanonical(input);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const payload = new TextEncoder().encode(
+    `${approvalId}\n${toolCallId}\n${toolName}\n${inputDigest}`,
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, payload);
+  return toBase64url(new Uint8Array(sig));
+}
 
 describe('signToolApproval + verifyToolApprovalSignature', () => {
   const baseParams = {
@@ -160,6 +189,40 @@ describe('signToolApproval + verifyToolApprovalSignature', () => {
     const signature = await signToolApproval({ secret, ...signed });
     expect(
       await verifyToolApprovalSignature({ secret, signature, ...retupled }),
+    ).toBe(false);
+  });
+
+  // Backwards compatibility with pre-JSON signatures.
+  it('should still verify a legacy newline-format signature when no field contains a newline', async () => {
+    const legacy = await signLegacy(baseParams);
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature: legacy,
+        ...baseParams,
+      }),
+    ).toBe(true);
+  });
+
+  // The legacy fallback must not reopen the collision: a legacy signature over
+  // a newline-bearing tool cannot be reused for a retupled tuple, because the
+  // retupled tuple has a newline in a field and the fallback is refused.
+  it('should not accept a legacy signature through the retupling collision', async () => {
+    const legacy = await signLegacy({
+      approvalId: 'approval-1',
+      toolCallId: 'call-1',
+      toolName: 'searchDocs\ndeleteFile',
+      input: { path: '/tmp/target' },
+    });
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature: legacy,
+        approvalId: 'approval-1',
+        toolCallId: 'call-1\nsearchDocs',
+        toolName: 'deleteFile',
+        input: { path: '/tmp/target' },
+      }),
     ).toBe(false);
   });
 });

--- a/packages/ai/src/generate-text/tool-approval-signature.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.ts
@@ -18,6 +18,9 @@ async function importKey(secret: string | Uint8Array): Promise<CryptoKey> {
   );
 }
 
+// Serialize with JSON so the encoding is injective: fields may contain any
+// character (including newlines), and escaping + array structure keeps field
+// boundaries unambiguous. The version prefix provides domain separation.
 function buildPayload(
   approvalId: string,
   toolCallId: string,
@@ -25,7 +28,13 @@ function buildPayload(
   inputDigest: string,
 ): Uint8Array {
   return encoder.encode(
-    `${approvalId}\n${toolCallId}\n${toolName}\n${inputDigest}`,
+    JSON.stringify([
+      'ai-sdk-tool-approval-v1',
+      approvalId,
+      toolCallId,
+      toolName,
+      inputDigest,
+    ]),
   );
 }
 

--- a/packages/ai/src/generate-text/tool-approval-signature.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.ts
@@ -41,8 +41,9 @@ function buildPayload(
 // Legacy newline-joined payload. Ambiguous when any field contains the `\n`
 // delimiter, which is why it was replaced; only used as a verify-time fallback
 // guarded on delimiter-free fields.
-// TODO: remove in v8 when backwards compatibility with pre-JSON signatures
-// (approvals signed before the injective format) is no longer needed.
+// TODO(#17494): remove in v8 when backwards compatibility with pre-JSON
+// signatures (approvals signed before the injective format) is no longer
+// needed.
 function buildLegacyPayload(
   approvalId: string,
   toolCallId: string,
@@ -104,7 +105,7 @@ export async function verifyToolApprovalSignature({
   // retupling collision closed (the attack requires a newline in a field)
   // while still verifying benign approvals signed by an older version, e.g. a
   // pending approval that straddles an upgrade.
-  // TODO: remove in v8 (drop buildLegacyPayload and this fallback).
+  // TODO(#17494): remove in v8 (drop buildLegacyPayload and this fallback).
   if (
     !approvalId.includes('\n') &&
     !toolCallId.includes('\n') &&

--- a/packages/ai/src/generate-text/tool-approval-signature.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.ts
@@ -38,6 +38,22 @@ function buildPayload(
   );
 }
 
+// Legacy newline-joined payload. Ambiguous when any field contains the `\n`
+// delimiter, which is why it was replaced; only used as a verify-time fallback
+// guarded on delimiter-free fields.
+// TODO: remove in v8 when backwards compatibility with pre-JSON signatures
+// (approvals signed before the injective format) is no longer needed.
+function buildLegacyPayload(
+  approvalId: string,
+  toolCallId: string,
+  toolName: string,
+  inputDigest: string,
+): Uint8Array {
+  return encoder.encode(
+    `${approvalId}\n${toolCallId}\n${toolName}\n${inputDigest}`,
+  );
+}
+
 export async function signToolApproval({
   secret,
   approvalId,
@@ -75,9 +91,35 @@ export async function verifyToolApprovalSignature({
 }): Promise<boolean> {
   const key = await importKey(secret);
   const inputDigest = await hashCanonical(input);
-  const payload = buildPayload(approvalId, toolCallId, toolName, inputDigest);
   const sigBytes = fromBase64url(signature);
-  return crypto.subtle.verify('HMAC', key, sigBytes, payload);
+
+  const payload = buildPayload(approvalId, toolCallId, toolName, inputDigest);
+  if (await crypto.subtle.verify('HMAC', key, sigBytes, payload)) {
+    return true;
+  }
+
+  // Backwards compatibility: accept a signature produced by the legacy
+  // newline-joined format, but only when no field contains the `\n` delimiter
+  // — the exact condition that made that format ambiguous. This keeps the
+  // retupling collision closed (the attack requires a newline in a field)
+  // while still verifying benign approvals signed by an older version, e.g. a
+  // pending approval that straddles an upgrade.
+  // TODO: remove in v8 (drop buildLegacyPayload and this fallback).
+  if (
+    !approvalId.includes('\n') &&
+    !toolCallId.includes('\n') &&
+    !toolName.includes('\n')
+  ) {
+    const legacyPayload = buildLegacyPayload(
+      approvalId,
+      toolCallId,
+      toolName,
+      inputDigest,
+    );
+    return crypto.subtle.verify('HMAC', key, sigBytes, legacyPayload);
+  }
+
+  return false;
 }
 
 export async function maybeSignApproval({


### PR DESCRIPTION
The tool approval signature payload was built by joining fields with `\n`. Because fields like `toolName` and `toolCallId` can contain a newline, two different field tuples could serialize to identical bytes — so a signature issued for one tuple could verify against a different one. The payload is now serialized with `JSON.stringify` (with a constant domain-separation prefix), which escapes delimiter/control characters and makes the encoding injective.

Verification stays backwards compatible: it falls back to the old newline format only when no signed field contains a `\n`, so approvals signed by an older version still verify across an upgrade. This legacy fallback is marked `TODO: remove in v8`.

**Happy path**
- A valid approval signs and verifies for its own `(approvalId, toolCallId, toolName, input)` tuple.
- Input key ordering is still normalized, so equivalent inputs produce the same signature.
- A signature in the old newline format still verifies (delimiter-free fields), so a pending approval that straddles an upgrade is not rejected.

**Unhappy path**
- A tuple whose `toolName` contains a newline can no longer be retupled into `toolCallId` to reuse the same signature for a different tool — in both the new and the legacy fallback paths.
- Any delimiter/control character (`\n`, `\r`, `\t`, `\0`, `"`, `\\`) shifted across a field boundary fails verification.
- A legacy signature over a newline-bearing field no longer verifies (the fallback is refused when a field contains `\n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #17832