### PR TITLE
chore: standardize `target` to ES2022

### DIFF
--- a/examples/ai-e2e-next/tsconfig.json
+++ b/examples/ai-e2e-next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": [
       "es2022",
       "dom"

--- a/examples/angular/tsconfig.app.json
+++ b/examples/angular/tsconfig.app.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "module": "esnext",
-    "target": "esnext",
+    "target": "ES2022",
     "useDefineForClassFields": false
   },
   "angularCompilerOptions": {

--- a/examples/angular/tsconfig.server.json
+++ b/examples/angular/tsconfig.server.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": ["es2022", "dom"],
     "module": "esnext",
     "types": ["node"],

--- a/examples/express/tsconfig.json
+++ b/examples/express/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": ["es2022", "dom"],
     "module": "nodenext",
     "types": ["node"],

--- a/examples/fastify/tsconfig.json
+++ b/examples/fastify/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": ["es2022", "dom"],
     "module": "esnext",
     "types": ["node"],

--- a/examples/harness-e2e-next/tsconfig.json
+++ b/examples/harness-e2e-next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/harness-e2e-tui/tsconfig.json
+++ b/examples/harness-e2e-tui/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": [
       "es2022",
       "dom"

--- a/examples/hono/tsconfig.json
+++ b/examples/hono/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": ["es2022", "dom"],
     "module": "esnext",
     "types": ["node"],

--- a/examples/mcp/tsconfig.json
+++ b/examples/mcp/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": [
       "es2022",
       "dom"

--- a/examples/nest/tsconfig.json
+++ b/examples/nest/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",

--- a/examples/next-agent/tsconfig.json
+++ b/examples/next-agent/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-fastapi/tsconfig.json
+++ b/examples/next-fastapi/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-google-vertex/tsconfig.json
+++ b/examples/next-google-vertex/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-langchain/tsconfig.json
+++ b/examples/next-langchain/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-openai-kasada-bot-protection/tsconfig.json
+++ b/examples/next-openai-kasada-bot-protection/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-openai-pages/tsconfig.json
+++ b/examples/next-openai-pages/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-openai-telemetry-sentry/tsconfig.json
+++ b/examples/next-openai-telemetry-sentry/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-openai-telemetry/tsconfig.json
+++ b/examples/next-openai-telemetry/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-openai-upstash-rate-limits/tsconfig.json
+++ b/examples/next-openai-upstash-rate-limits/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next-workflow/tsconfig.json
+++ b/examples/next-workflow/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
       "dom",
       "dom.iterable",

--- a/examples/next/tsconfig.json
+++ b/examples/next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/examples/node-http-server/tsconfig.json
+++ b/examples/node-http-server/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "declaration": true,
     "sourceMap": true,
-    "target": "es2022",
+    "target": "ES2022",
     "lib": [
       "es2022",
       "dom"

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2022",
     "stripInternal": true,
     "lib": [
       "dom",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/react-library.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2022",
     "stripInternal": true,
     "composite": true,
     "rootDir": "src",

--- a/packages/rsc/tsconfig.json
+++ b/packages/rsc/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/react-library.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2022",
     "stripInternal": true,
     "rootDir": "src",
     "composite": true,

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "moduleResolution": "bundler",
     "module": "esnext",
-    "target": "esnext",
+    "target": "ES2022",
     "declaration": true,
     "declarationMap": true,
     "stripInternal": true,

--- a/tools/tsconfig/react-library.json
+++ b/tools/tsconfig/react-library.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["dom", "ES2015"],
     "module": "ESNext",
-    "target": "es6"
+    "target": "ES2022"
   }
 }

--- a/tools/tsconfig/ts-library.json
+++ b/tools/tsconfig/ts-library.json
@@ -9,7 +9,7 @@
             "ES2018"
         ],
         "module": "ESNext",
-        "target": "ES2018",
+        "target": "ES2022",
         "stripInternal": true
     },
 }


### PR DESCRIPTION
## Background

* TypeScript 6 deprecates `target: 'es5'` and TypeScript 7 fully removes it.
* We currently use `es5` for some packages and a variety of other targets for others
* Node 22 is already our minimum supported Node version

## Summary

Standardize all `target` to `ES2022` (and normalized casing)

## End-to-End Verification

<!--
For features & bugfixes.
Remove the section if it's not needed (e.g. for docs).
Please explain how you verified that the change works end-to-end as expected.
Do not include integration/unit tests or linting
-->

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

- typescript 6
- typescript 7
