### PR TITLE
feat(xai): add support for video output.upload_url delivery

### DIFF
--- a/.changeset/xai-video-upload-url.md
+++ b/.changeset/xai-video-upload-url.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): add support for video output.upload_url delivery

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -1204,6 +1204,12 @@ You can validate the provider options using the `XaiVideoModelOptions` type.
   `1280x720` maps to `720p` and `854x480` maps to `480p`.
   Use this provider option to pass the native format directly.
 
+- **output** _object_
+  Configure delivery settings. Currently supports direct upload to a user-managed destination (like an S3 presigned URL). When configured, the video is uploaded via HTTP PUT to the target destination, and the final response completes successfully without returning a downloadable video URL.
+
+- **uploadUrl** _string_ (required)
+  The signed URL where the completed video will be uploaded.
+
 - **user** _string_
 
   Optional identifier for the end user responsible for the request. xAI uses

--- a/packages/xai/src/xai-video-model-options.ts
+++ b/packages/xai/src/xai-video-model-options.ts
@@ -12,6 +12,9 @@ interface XaiVideoSharedOptions {
   pollIntervalMs?: number | null;
   pollTimeoutMs?: number | null;
   resolution?: XaiVideoResolution | null;
+  output?: {
+    uploadUrl: string;
+  } | null;
 }
 
 interface XaiVideoUserOptions {
@@ -104,6 +107,11 @@ const baseFields = {
   pollIntervalMs: z.number().positive().nullish(),
   pollTimeoutMs: z.number().positive().nullish(),
   resolution: resolutionSchema.nullish(),
+  output: z
+    .object({
+      uploadUrl: z.string().min(1),
+    })
+    .nullish(),
 };
 
 const userField = {

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -1763,5 +1763,98 @@ describe('XaiVideoModel', () => {
         expect.objectContaining({ feature: 'aspectRatio' }),
       );
     });
+
+    it('should send output.upload_url in request body', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            output: {
+              uploadUrl: 'https://example.com/dest.mp4',
+            },
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        output: { upload_url: 'https://example.com/dest.mp4' },
+      });
+    });
+
+    it('should complete successfully without video URL when output.uploadUrl is configured', async () => {
+      const model = createModel();
+
+      // Mock status poll response to not have a video object
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          status: 'done',
+          video: null,
+          model: 'grok-imagine-video',
+          progress: 100,
+        },
+      };
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            output: {
+              uploadUrl: 'https://example.com/dest.mp4',
+            },
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.videos).toStrictEqual([]);
+
+      // Restore standard response
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
+    it('should throw error if video URL is missing and output.uploadUrl is NOT configured', async () => {
+      const model = createModel();
+
+      // Mock status poll response to not have a video object
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          status: 'done',
+          video: null,
+          model: 'grok-imagine-video',
+          progress: 100,
+        },
+      };
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow(
+        /Video generation completed but no video URL was returned/,
+      );
+
+      // Restore standard response
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
   });
 });

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -260,6 +260,12 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
       prompt: options.prompt,
     };
 
+    if (xaiOptions?.output?.uploadUrl != null) {
+      body.output = {
+        upload_url: xaiOptions.output.uploadUrl,
+      };
+    }
+
     const allowDuration = !isEdit;
     const allowAspectRatio = !isEdit && !isExtension;
     const allowResolution = !isEdit && !isExtension;
@@ -377,6 +383,7 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
             'videoUrl',
             'referenceImageUrls',
             'user',
+            'output',
           ].includes(key)
         ) {
           body[key] = value;
@@ -420,6 +427,7 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
     // Step 2: Poll for completion
     const pollIntervalMs = xaiOptions?.pollIntervalMs ?? 5000;
     const pollTimeoutMs = xaiOptions?.pollTimeoutMs ?? 600000;
+    const hasUploadUrl = xaiOptions?.output?.uploadUrl != null;
     const startTime = Date.now();
     let responseHeaders: Record<string, string> | undefined;
 
@@ -458,7 +466,7 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           });
         }
 
-        if (!statusResponse.video?.url) {
+        if (!hasUploadUrl && !statusResponse.video?.url) {
           throw new AISDKError({
             name: 'XAI_VIDEO_GENERATION_ERROR',
             message:
@@ -467,13 +475,15 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         }
 
         return {
-          videos: [
-            {
-              type: 'url' as const,
-              url: statusResponse.video.url,
-              mediaType: 'video/mp4',
-            },
-          ],
+          videos: statusResponse.video?.url
+            ? [
+                {
+                  type: 'url' as const,
+                  url: statusResponse.video.url,
+                  mediaType: 'video/mp4',
+                },
+              ]
+            : [],
           warnings,
           response: {
             timestamp: currentDate,
@@ -483,8 +493,10 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           providerMetadata: {
             xai: {
               requestId,
-              videoUrl: statusResponse.video.url,
-              ...(statusResponse.video.duration != null
+              ...(statusResponse.video?.url
+                ? { videoUrl: statusResponse.video.url }
+                : {}),
+              ...(statusResponse.video?.duration != null
                 ? { duration: statusResponse.video.duration }
                 : {}),
               ...(statusResponse.usage?.cost_in_usd_ticks != null
@@ -525,7 +537,7 @@ const xaiVideoStatusResponseSchema = z.object({
   status: z.string().nullish(),
   video: z
     .object({
-      url: z.string(),
+      url: z.string().nullish(),
       duration: z.number().nullish(),
       respect_moderation: z.boolean().nullish(),
     })

--- a/packages/xai/src/xai-video-options.test-d.ts
+++ b/packages/xai/src/xai-video-options.test-d.ts
@@ -221,4 +221,25 @@ describe('XaiVideoModelOptions type', () => {
 
     options;
   });
+
+  it('should allow output options with uploadUrl', () => {
+    const options = {
+      output: {
+        uploadUrl: 'https://example.com/upload',
+      },
+    } satisfies XaiVideoModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
+  });
+
+  it('should require output.uploadUrl to be a string', () => {
+    const options: XaiVideoModelOptions = {
+      output: {
+        // @ts-expect-error - uploadUrl must be a string
+        uploadUrl: 123,
+      },
+    };
+
+    options;
+  });
 });


### PR DESCRIPTION
## Background

The xAI video generation and editing endpoints allow delivering the completed video directly to a caller-managed storage (such as an AWS S3 presigned URL) via an HTTP PUT upload instead of returning a downloadable video URL. The current xAI provider implementation assumes every completed request supplies a downloadable video URL, which throws a missing-video-URL error and prevents storage-routing workflows.

## Summary

- **TypeScript Options & Zod Schemas**: Added `output` and `uploadUrl` to `XaiVideoSharedOptions` and Zod schemas to support static typing and runtime validation.
- **Request Payload**: Serialized `output.uploadUrl` to snake_case `output.upload_url` in the request body for video generation and video editing.
- **Polling & Validation**: Updated `xaiVideoStatusResponseSchema` to allow a nullish `video.url`.
- **Completion Check**: Bypassed the missing video URL check during status polling when an upload URL is configured, returning successfully with `videos: []`.
- **Testing**: Added unit and type tests covering serialization, polling success, and missing-URL error preservation.
- **Documentation**: Updated `content/providers/01-ai-sdk-providers/01-xai.mdx` to include the new options.
- **Changeset**: Created a patch changeset for `@ai-sdk/xai`.

## Contributor Credit

`@lgrammel` for the issue #17306 

## End-to-End Verification

Verified using mock API status poll responses corresponding to a completed direct upload (where `video.url` is absent). Asserts that the model generation completes successfully with an empty `videos` array without raising a `NoVideoGeneratedError`. Also confirmed that standard request paths (where no upload URL is specified) preserve the error if `video.url` is missing.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17306