### PR TITLE
feat(speechify): add Speechify speech provider

### DIFF
--- a/.changeset/speechify-provider-initial.md
+++ b/.changeset/speechify-provider-initial.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/speechify': major
+---
+
+feat(speechify): add Speechify speech provider

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -159,5 +159,9 @@ try {
 | [Fish Audio](/providers/ai-sdk-providers/fish-audio#speech-models)       | `s1`                                |
 | [Fish Audio](/providers/ai-sdk-providers/fish-audio#speech-models)       | `s2-pro`                            |
 | [Fish Audio](/providers/ai-sdk-providers/fish-audio#speech-models)       | `s2.1-pro`                          |
+| [Speechify](/providers/ai-sdk-providers/speechify#speech-models)         | `simba-3.2`                         |
+| [Speechify](/providers/ai-sdk-providers/speechify#speech-models)         | `simba-english`                     |
+| [Speechify](/providers/ai-sdk-providers/speechify#speech-models)         | `simba-multilingual`                |
+| [Speechify](/providers/ai-sdk-providers/speechify#speech-models)         | `simba-3.0`                         |
 
 Above are a small subset of the speech models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/145-speechify.mdx
+++ b/content/providers/01-ai-sdk-providers/145-speechify.mdx
@@ -1,0 +1,147 @@
+---
+title: Speechify
+description: Learn how to use the Speechify provider for the AI SDK.
+---
+
+# Speechify Provider
+
+The [Speechify](https://speechify.ai/) provider contains speech model support for the Speechify text-to-speech API, including word- and sentence-level speech marks (timing metadata) with every generation.
+
+## Setup
+
+The Speechify provider is available in the `@ai-sdk/speechify` module. You can install it with
+
+<InstallPackages packages="@ai-sdk/speechify" />
+
+## Provider Instance
+
+You can import the default provider instance `speechify` from `@ai-sdk/speechify`:
+
+```ts
+import { speechify } from '@ai-sdk/speechify';
+```
+
+If you need a customized setup, you can import `createSpeechify` from `@ai-sdk/speechify` and create a provider instance with your settings:
+
+```ts
+import { createSpeechify } from '@ai-sdk/speechify';
+
+const speechify = createSpeechify({
+  // custom settings, e.g.
+  fetch: customFetch,
+});
+```
+
+You can use the following optional settings to customize the Speechify provider instance:
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header.
+  It defaults to the `SPEECHIFY_API_KEY` environment variable.
+
+- **baseURL** _string_
+
+  Base URL for the API calls. Defaults to `https://api.sws.speechify.com`.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
+## Speech Models
+
+You can create models that call the [Speechify speech API](https://docs.speechify.ai)
+using the `.speech()` factory method.
+
+The first argument is the model id e.g. `simba-3.2`.
+
+```ts
+const model = speechify.speech('simba-3.2');
+```
+
+The `voice` parameter takes a Speechify voice ID, including cloned voices. It defaults to `geffen_32`.
+
+```ts highlight="7"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { speechify } from '@ai-sdk/speechify';
+
+const result = await generateSpeech({
+  model: speechify.speech('simba-3.2'),
+  text: 'Hello from Speechify!',
+  voice: 'geffen_32',
+});
+```
+
+The `outputFormat` option accepts simple names (`mp3`, `wav`, `ogg`, `aac`, `pcm`) or Speechify codec strings with sample rate and bitrate such as `mp3_24000_128`, `pcm_16000`, and `ulaw_8000` (for telephony). It defaults to `mp3`.
+
+The standard `speed` option is implemented via [SSML](https://docs.speechify.ai) prosody. Text that is already SSML (starting with `<speak`) is passed through unchanged, so you can control rate, pitch, and emotion directly in your markup.
+
+You can also pass additional provider-specific options using the `providerOptions` argument:
+
+```ts highlight="10-15"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { speechify } from '@ai-sdk/speechify';
+import { type SpeechifySpeechModelOptions } from '@ai-sdk/speechify';
+
+const result = await generateSpeech({
+  model: speechify.speech('simba-3.2'),
+  text: 'Hello from Speechify!',
+  voice: 'geffen_32',
+  providerOptions: {
+    speechify: {
+      outputFormat: 'mp3_24000_128',
+      loudnessNormalization: true,
+      textNormalization: true,
+    } satisfies SpeechifySpeechModelOptions,
+  },
+});
+```
+
+### Provider Options
+
+The Speechify provider accepts the following options via `providerOptions.speechify`:
+
+- **ssml** _boolean_
+
+  Treat the input text as SSML. When enabled, the input is sent unchanged and the standard `speed` option is ignored (control rate via SSML instead).
+
+- **outputFormat** _string_
+
+  A Speechify codec output format string, e.g. `mp3_24000_128`, `pcm_16000`, or `ulaw_8000`. Takes precedence over the standard `outputFormat` option.
+
+- **loudnessNormalization** _boolean_
+
+  Normalize the loudness of the generated audio.
+
+- **textNormalization** _boolean_
+
+  Apply text normalization (e.g. expanding numbers and abbreviations).
+
+### Speech Marks
+
+Speechify returns word- and sentence-level timing data with every generation via provider metadata:
+
+```ts
+const result = await generateSpeech({
+  model: speechify.speech('simba-3.2'),
+  text: 'Timed speech.',
+});
+
+const { speechMarks, billableCharactersCount } =
+  result.providerMetadata.speechify;
+```
+
+### Model Capabilities
+
+| Model                | Instructions |
+| -------------------- | ------------ |
+| `simba-3.2`          | <Cross />    |
+| `simba-english`      | <Cross />    |
+| `simba-multilingual` | <Cross />    |
+| `simba-3.0`          | <Cross />    |

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -64,6 +64,7 @@
     "@ai-sdk/revai": "workspace:*",
     "@ai-sdk/sandbox-just-bash": "workspace:*",
     "@ai-sdk/sandbox-vercel": "workspace:*",
+    "@ai-sdk/speechify": "workspace:*",
     "@ai-sdk/togetherai": "workspace:*",
     "@ai-sdk/tui": "workspace:*",
     "@ai-sdk/valibot": "workspace:*",

--- a/examples/ai-functions/src/generate-speech/speechify/basic.ts
+++ b/examples/ai-functions/src/generate-speech/speechify/basic.ts
@@ -1,0 +1,19 @@
+import { speechify } from '@ai-sdk/speechify';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: speechify.speech('simba-3.2'),
+    text: 'Hello from Speechify!',
+    voice: 'geffen_32',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/generate-speech/speechify/output-format.ts
+++ b/examples/ai-functions/src/generate-speech/speechify/output-format.ts
@@ -1,0 +1,20 @@
+import { speechify } from '@ai-sdk/speechify';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: speechify.speech('simba-3.2'),
+    text: 'This audio is generated as 8kHz u-law for telephony.',
+    outputFormat: 'ulaw_8000',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+  console.log('Output format: u-law at 8kHz');
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/generate-speech/speechify/voice.ts
+++ b/examples/ai-functions/src/generate-speech/speechify/voice.ts
@@ -1,0 +1,19 @@
+import { speechify } from '@ai-sdk/speechify';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: speechify.speech('simba-3.0'),
+    text: 'This uses a specific Speechify voice, including cloned voices.',
+    voice: 'geffen_32',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -202,6 +202,9 @@
       "path": "../../packages/sandbox-vercel"
     },
     {
+      "path": "../../packages/speechify"
+    },
+    {
       "path": "../../packages/togetherai"
     },
     {

--- a/packages/speechify/CHANGELOG.md
+++ b/packages/speechify/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ai-sdk/speechify

--- a/packages/speechify/README.md
+++ b/packages/speechify/README.md
@@ -1,0 +1,45 @@
+# AI SDK - Speechify Provider
+
+The **[Speechify provider](https://ai-sdk.dev/providers/ai-sdk-providers/speechify)** for the [AI SDK](https://ai-sdk.dev/docs)
+contains speech model support for the Speechify text-to-speech API, including word- and sentence-level speech marks with every generation.
+
+## Setup
+
+The Speechify provider is available in the `@ai-sdk/speechify` module. You can install it with
+
+```bash
+npm i @ai-sdk/speechify
+```
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the AI SDK skill to your repository:
+
+```shell
+npx skills add vercel/ai
+```
+
+## Provider Instance
+
+You can import the default provider instance `speechify` from `@ai-sdk/speechify`:
+
+```ts
+import { speechify } from '@ai-sdk/speechify';
+```
+
+## Example
+
+```ts
+import { speechify } from '@ai-sdk/speechify';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+
+const { audio } = await generateSpeech({
+  model: speechify.speech('simba-3.2'),
+  text: 'Hello from Speechify!',
+  voice: 'geffen_32',
+});
+```
+
+## Documentation
+
+Please check out the **[Speechify provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/speechify)** for more information.

--- a/packages/speechify/package.json
+++ b/packages/speechify/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@ai-sdk/speechify",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "tsup --tsconfig tsconfig.build.json",
+    "build:watch": "tsup --tsconfig tsconfig.build.json --watch",
+    "clean": "del-cli dist docs",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/145-speechify.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "type-check": "tsc --noEmit",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:watch": "vitest --config vitest.node.config.js --watch",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run",
+    "test:node:watch": "vitest --config vitest.node.config.js --watch"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.6.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/speechify"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/speechify/src/index.ts
+++ b/packages/speechify/src/index.ts
@@ -1,0 +1,11 @@
+export { createSpeechify, speechify } from './speechify-provider';
+export type {
+  SpeechifyProvider,
+  SpeechifyProviderSettings,
+} from './speechify-provider';
+export type {
+  SpeechifySpeechModelId,
+  SpeechifySpeechVoiceId,
+} from './speechify-speech-options';
+export type { SpeechifySpeechModelOptions } from './speechify-speech-model-options';
+export { VERSION } from './version';

--- a/packages/speechify/src/speechify-api-types.ts
+++ b/packages/speechify/src/speechify-api-types.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod/v4';
+
+export type SpeechifySpeechAudioFormat = 'mp3' | 'wav' | 'ogg' | 'aac' | 'pcm';
+
+export type SpeechifySpeechRequest = {
+  input: string;
+  voice_id: string;
+  model: string;
+  language?: string;
+  audio_format?: SpeechifySpeechAudioFormat;
+  output_format?: string;
+  options?: {
+    loudness_normalization?: boolean;
+    text_normalization?: boolean;
+  };
+};
+
+export const speechifySpeechResponseSchema = z.object({
+  audio_data: z.string(),
+  audio_format: z.string().nullish(),
+  speech_marks: z.unknown().nullish(),
+  billable_characters_count: z.number().nullish(),
+});
+
+export type SpeechifySpeechResponse = z.infer<
+  typeof speechifySpeechResponseSchema
+>;

--- a/packages/speechify/src/speechify-config.ts
+++ b/packages/speechify/src/speechify-config.ts
@@ -1,0 +1,9 @@
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+
+export type SpeechifyConfig = {
+  provider: string;
+  url: (options: { modelId: string; path: string }) => string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  generateId?: () => string;
+};

--- a/packages/speechify/src/speechify-error.test.ts
+++ b/packages/speechify/src/speechify-error.test.ts
@@ -1,0 +1,46 @@
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+import { speechifyErrorDataSchema } from './speechify-error';
+import { describe, it, expect } from 'vitest';
+
+describe('speechifyErrorDataSchema', () => {
+  it('should parse a Speechify validation error', async () => {
+    const error = `{"error":{"code":"validation_failed","message":"voice_id is required"},"request_id":"req_123"}`;
+
+    const result = await safeParseJSON({
+      text: error,
+      schema: speechifyErrorDataSchema,
+    });
+
+    expect(result).toStrictEqual({
+      success: true,
+      value: {
+        error: {
+          code: 'validation_failed',
+          message: 'voice_id is required',
+        },
+        request_id: 'req_123',
+      },
+      rawValue: {
+        error: {
+          code: 'validation_failed',
+          message: 'voice_id is required',
+        },
+        request_id: 'req_123',
+      },
+    });
+  });
+
+  it('should parse an error without a code or request_id', async () => {
+    const error = `{"error":{"message":"Internal server error"}}`;
+
+    const result = await safeParseJSON({
+      text: error,
+      schema: speechifyErrorDataSchema,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.error.message).toBe('Internal server error');
+    }
+  });
+});

--- a/packages/speechify/src/speechify-error.ts
+++ b/packages/speechify/src/speechify-error.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod/v4';
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+
+export const speechifyErrorDataSchema = z.object({
+  error: z.object({
+    code: z.string().nullish(),
+    message: z.string(),
+  }),
+  request_id: z.string().nullish(),
+});
+
+export type SpeechifyErrorData = z.infer<typeof speechifyErrorDataSchema>;
+
+export const speechifyFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: speechifyErrorDataSchema,
+  errorToMessage: data => data.error.message,
+});

--- a/packages/speechify/src/speechify-provider.ts
+++ b/packages/speechify/src/speechify-provider.ts
@@ -1,0 +1,121 @@
+import {
+  NoSuchModelError,
+  type SpeechModelV4,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  loadApiKey,
+  withUserAgentSuffix,
+  withoutTrailingSlash,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { SpeechifySpeechModel } from './speechify-speech-model';
+import type { SpeechifySpeechModelId } from './speechify-speech-options';
+import { VERSION } from './version';
+
+const DEFAULT_BASE_URL = 'https://api.sws.speechify.com';
+
+export interface SpeechifyProvider extends ProviderV4 {
+  (modelId: SpeechifySpeechModelId): {
+    speech: SpeechifySpeechModel;
+  };
+
+  /**
+   * Creates a model for speech synthesis.
+   */
+  speech(modelId: SpeechifySpeechModelId): SpeechModelV4;
+}
+
+export interface SpeechifyProviderSettings {
+  /**
+   * API key for authenticating requests.
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for the API calls. Defaults to `https://api.sws.speechify.com`.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+/**
+ * Create a Speechify provider instance.
+ */
+export function createSpeechify(
+  options: SpeechifyProviderSettings = {},
+): SpeechifyProvider {
+  const baseURL = withoutTrailingSlash(options.baseURL) ?? DEFAULT_BASE_URL;
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'SPEECHIFY_API_KEY',
+          description: 'Speechify',
+        })}`,
+        ...options.headers,
+      },
+      `ai-sdk/speechify/${VERSION}`,
+    );
+
+  const createSpeechModel = (modelId: SpeechifySpeechModelId) =>
+    new SpeechifySpeechModel(modelId, {
+      provider: `speechify.speech`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const provider = function (modelId: SpeechifySpeechModelId) {
+    return {
+      speech: createSpeechModel(modelId),
+    };
+  };
+
+  provider.specificationVersion = 'v4' as const;
+  provider.speech = createSpeechModel;
+  provider.speechModel = createSpeechModel;
+
+  provider.languageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'languageModel',
+      message: 'Speechify does not provide language models',
+    });
+  };
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+      message: 'Speechify does not provide embedding models',
+    });
+  };
+
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'imageModel',
+      message: 'Speechify does not provide image models',
+    });
+  };
+
+  return provider as SpeechifyProvider;
+}
+
+/**
+ * Default Speechify provider instance.
+ */
+export const speechify = createSpeechify();

--- a/packages/speechify/src/speechify-provider.ts
+++ b/packages/speechify/src/speechify-provider.ts
@@ -65,6 +65,7 @@ export function createSpeechify(
           environmentVariableName: 'SPEECHIFY_API_KEY',
           description: 'Speechify',
         })}`,
+        'Speechify-Caller': 'vercel',
         ...options.headers,
       },
       `ai-sdk/speechify/${VERSION}`,

--- a/packages/speechify/src/speechify-provider.ts
+++ b/packages/speechify/src/speechify-provider.ts
@@ -65,7 +65,11 @@ export function createSpeechify(
           environmentVariableName: 'SPEECHIFY_API_KEY',
           description: 'Speechify',
         })}`,
-        'Speechify-Caller': 'vercel',
+        // Attribute every request to this integration per its release; the
+        // caller is the installable artifact's slug. A consumer's own headers
+        // still override.
+        'Speechify-Caller': 'vercel-ai-sdk',
+        'Speechify-Caller-Version': VERSION,
         ...options.headers,
       },
       `ai-sdk/speechify/${VERSION}`,

--- a/packages/speechify/src/speechify-speech-model-options.ts
+++ b/packages/speechify/src/speechify-speech-model-options.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod/v4';
+
+export const speechifySpeechModelOptionsSchema = z.object({
+  /**
+   * Treat the input text as SSML. When enabled, the input is sent unchanged and
+   * the standard `speed` option is ignored (control rate via SSML instead).
+   */
+  ssml: z.boolean().nullish(),
+
+  /**
+   * Speechify codec output format string, e.g. `mp3_24000_128`, `pcm_16000`,
+   * `ulaw_8000`. Takes precedence over the standard `outputFormat` option.
+   */
+  outputFormat: z.string().nullish(),
+
+  /**
+   * Normalize the loudness of the generated audio.
+   */
+  loudnessNormalization: z.boolean().nullish(),
+
+  /**
+   * Apply text normalization (e.g. expanding numbers and abbreviations).
+   */
+  textNormalization: z.boolean().nullish(),
+});
+
+export type SpeechifySpeechModelOptions = z.infer<
+  typeof speechifySpeechModelOptionsSchema
+>;

--- a/packages/speechify/src/speechify-speech-model.test.ts
+++ b/packages/speechify/src/speechify-speech-model.test.ts
@@ -1,0 +1,311 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
+import { SpeechifySpeechModel } from './speechify-speech-model';
+import { createSpeechify } from './speechify-provider';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createSpeechify({ apiKey: 'test-api-key' });
+const model = provider.speech('simba-3.2');
+
+const audioBase64 = convertUint8ArrayToBase64(new Uint8Array([1, 2, 3, 4]));
+
+const server = createTestServer({
+  'https://api.sws.speechify.com/v1/audio/speech': {},
+});
+
+describe('doGenerate', () => {
+  function prepareAudioResponse({
+    headers,
+    audio_format = 'mp3',
+    speech_marks = { type: 'word', start: 0, end: 5 },
+    billable_characters_count = 12,
+  }: {
+    headers?: Record<string, string>;
+    audio_format?: string;
+    speech_marks?: unknown;
+    billable_characters_count?: number;
+  } = {}) {
+    server.urls['https://api.sws.speechify.com/v1/audio/speech'].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        audio_data: audioBase64,
+        audio_format,
+        speech_marks,
+        billable_characters_count,
+      },
+    };
+  }
+
+  it('should pass the model, text and default voice', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      input: 'Hello from the AI SDK!',
+      voice_id: 'geffen_32',
+      model: 'simba-3.2',
+    });
+  });
+
+  it('should pass headers and authorization', async () => {
+    prepareAudioResponse();
+
+    const provider = createSpeechify({
+      apiKey: 'test-api-key',
+      headers: {
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await provider.speech('simba-3.2').doGenerate({
+      text: 'Hello from the AI SDK!',
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain(
+      `ai-sdk/speechify/0.0.0-test`,
+    );
+  });
+
+  it('should pass the voice and language', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'custom-voice',
+      language: 'en',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      input: 'Hello from the AI SDK!',
+      voice_id: 'custom-voice',
+      model: 'simba-3.2',
+      language: 'en',
+    });
+  });
+
+  it('should map a simple output format to audio_format', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      outputFormat: 'wav',
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.audio_format).toBe('wav');
+    expect(body.output_format).toBeUndefined();
+  });
+
+  it('should pass a codec output format through as output_format', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      outputFormat: 'ulaw_8000',
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.output_format).toBe('ulaw_8000');
+    expect(body.audio_format).toBeUndefined();
+  });
+
+  it('should warn on an unsupported output format', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      outputFormat: 'flac',
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.audio_format).toBeUndefined();
+    expect(body.output_format).toBeUndefined();
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'outputFormat',
+      details: expect.stringContaining('flac'),
+    });
+  });
+
+  it('should wrap text in SSML prosody when speed is set', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello',
+      speed: 1.5,
+    });
+
+    expect((await server.calls[0].requestBodyJson).input).toBe(
+      '<speak><prosody rate="150%">Hello</prosody></speak>',
+    );
+  });
+
+  it('should pass SSML input through unchanged and warn when speed is also set', async () => {
+    prepareAudioResponse();
+
+    const ssml = '<speak>Already SSML</speak>';
+    const result = await model.doGenerate({
+      text: ssml,
+      speed: 2,
+    });
+
+    expect((await server.calls[0].requestBodyJson).input).toBe(ssml);
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'speed',
+      details: expect.any(String),
+    });
+  });
+
+  it('should map provider options', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      providerOptions: {
+        speechify: {
+          outputFormat: 'mp3_24000_128',
+          loudnessNormalization: true,
+          textNormalization: false,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      output_format: 'mp3_24000_128',
+      options: {
+        loudness_normalization: true,
+        text_normalization: false,
+      },
+    });
+  });
+
+  it('should send SSML unchanged when the ssml provider option is set', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: '<speak>hi</speak>',
+      speed: 1.2,
+      providerOptions: {
+        speechify: {
+          ssml: true,
+        },
+      },
+    });
+
+    expect((await server.calls[0].requestBodyJson).input).toBe(
+      '<speak>hi</speak>',
+    );
+  });
+
+  it('should warn when instructions are provided', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      instructions: 'Speak slowly',
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'instructions',
+      details: expect.any(String),
+    });
+  });
+
+  it('should return the base64 audio data', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.audio).toStrictEqual(audioBase64);
+  });
+
+  it('should expose speech marks and billable characters in provider metadata', async () => {
+    prepareAudioResponse({
+      audio_format: 'mp3',
+      speech_marks: { type: 'word', start: 0, end: 4, value: 'Hi' },
+      billable_characters_count: 2,
+    });
+
+    const result = await model.doGenerate({
+      text: 'Hi',
+    });
+
+    expect(result.providerMetadata?.speechify).toStrictEqual({
+      audioFormat: 'mp3',
+      billableCharactersCount: 2,
+      speechMarks: { type: 'word', start: 0, end: 4, value: 'Hi' },
+    });
+  });
+
+  it('should include response data with timestamp, modelId and headers', async () => {
+    prepareAudioResponse({
+      headers: {
+        'x-request-id': 'test-request-id',
+      },
+    });
+
+    const testDate = new Date(0);
+    const customModel = new SpeechifySpeechModel('simba-3.2', {
+      provider: 'test-provider',
+      url: () => 'https://api.sws.speechify.com/v1/audio/speech',
+      headers: () => ({}),
+      _internal: {
+        currentDate: () => testDate,
+      },
+    });
+
+    const result = await customModel.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId: 'simba-3.2',
+      headers: {
+        'x-request-id': 'test-request-id',
+      },
+    });
+  });
+
+  it('should use real date when no custom date provider is specified', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.response.timestamp.getTime()).toBeGreaterThan(0);
+    expect(result.response.modelId).toBe('simba-3.2');
+  });
+
+  it('should not include warnings for a plain generation', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/packages/speechify/src/speechify-speech-model.test.ts
+++ b/packages/speechify/src/speechify-speech-model.test.ts
@@ -157,6 +157,19 @@ describe('doGenerate', () => {
     );
   });
 
+  it('should XML-escape text when wrapping it in SSML for speed', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Tom & Jerry <3 "quotes"',
+      speed: 1.2,
+    });
+
+    expect((await server.calls[0].requestBodyJson).input).toBe(
+      '<speak><prosody rate="120%">Tom &amp; Jerry &lt;3 &quot;quotes&quot;</prosody></speak>',
+    );
+  });
+
   it('should pass SSML input through unchanged and warn when speed is also set', async () => {
     prepareAudioResponse();
 

--- a/packages/speechify/src/speechify-speech-model.test.ts
+++ b/packages/speechify/src/speechify-speech-model.test.ts
@@ -312,6 +312,47 @@ describe('doGenerate', () => {
     expect(result.response.modelId).toBe('simba-3.2');
   });
 
+  it('should warn when a simba-3.2 voice is used with a non-simba-3.2 model', async () => {
+    prepareAudioResponse();
+
+    const nonSimba32Model = provider.speech('simba-english');
+
+    const result = await nonSimba32Model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'geffen_32',
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'voice',
+      details: expect.stringContaining('geffen_32'),
+    });
+  });
+
+  it('should NOT warn when a simba-3.2 voice is used with simba-3.2 model', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'geffen_32',
+    });
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should NOT warn when a non-simba-3.2 voice is used with a non-simba-3.2 model', async () => {
+    prepareAudioResponse();
+
+    const nonSimba32Model = provider.speech('simba-english');
+
+    const result = await nonSimba32Model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      voice: 'some-other-voice',
+    });
+
+    expect(result.warnings).toEqual([]);
+  });
+
   it('should not include warnings for a plain generation', async () => {
     prepareAudioResponse();
 

--- a/packages/speechify/src/speechify-speech-model.test.ts
+++ b/packages/speechify/src/speechify-speech-model.test.ts
@@ -77,6 +77,8 @@ describe('doGenerate', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+      'speechify-caller': 'vercel-ai-sdk',
+      'speechify-caller-version': '0.0.0-test',
     });
     expect(server.calls[0].requestUserAgent).toContain(
       `ai-sdk/speechify/0.0.0-test`,

--- a/packages/speechify/src/speechify-speech-model.ts
+++ b/packages/speechify/src/speechify-speech-model.ts
@@ -40,6 +40,18 @@ function isSimpleAudioFormat(
 // Speechify codec output formats, e.g. `mp3_24000_128`, `pcm_16000`, `ulaw_8000`.
 const CODEC_OUTPUT_FORMAT_REGEX = /^(mp3|pcm|ogg|aac|ulaw|wav)_\d+(_\d+)?$/;
 
+const XML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+function escapeXml(value: string): string {
+  return value.replace(/[&<>"']/g, char => XML_ESCAPES[char]);
+}
+
 interface SpeechifySpeechModelConfig extends SpeechifyConfig {
   _internal?: {
     currentDate?: () => Date;
@@ -102,7 +114,7 @@ export class SpeechifySpeechModel implements SpeechModelV4 {
             'The speed setting is ignored because the input is SSML. Use an SSML <prosody rate="..."> tag to control rate.',
         });
       } else {
-        input = `<speak><prosody rate="${Math.round(speed * 100)}%">${text}</prosody></speak>`;
+        input = `<speak><prosody rate="${Math.round(speed * 100)}%">${escapeXml(text)}</prosody></speak>`;
       }
     }
 

--- a/packages/speechify/src/speechify-speech-model.ts
+++ b/packages/speechify/src/speechify-speech-model.ts
@@ -1,0 +1,211 @@
+import type { SpeechModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+} from '@ai-sdk/provider-utils';
+import type { SpeechifyConfig } from './speechify-config';
+import { speechifyFailedResponseHandler } from './speechify-error';
+import { speechifySpeechModelOptionsSchema } from './speechify-speech-model-options';
+import {
+  type SpeechifySpeechAudioFormat,
+  type SpeechifySpeechRequest,
+  speechifySpeechResponseSchema,
+} from './speechify-api-types';
+import type {
+  SpeechifySpeechModelId,
+  SpeechifySpeechVoiceId,
+} from './speechify-speech-options';
+
+const DEFAULT_VOICE_ID: SpeechifySpeechVoiceId = 'geffen_32';
+
+const SIMPLE_AUDIO_FORMATS: readonly SpeechifySpeechAudioFormat[] = [
+  'mp3',
+  'wav',
+  'ogg',
+  'aac',
+  'pcm',
+];
+
+function isSimpleAudioFormat(
+  value: string,
+): value is SpeechifySpeechAudioFormat {
+  return (SIMPLE_AUDIO_FORMATS as readonly string[]).includes(value);
+}
+
+// Speechify codec output formats, e.g. `mp3_24000_128`, `pcm_16000`, `ulaw_8000`.
+const CODEC_OUTPUT_FORMAT_REGEX = /^(mp3|pcm|ogg|aac|ulaw|wav)_\d+(_\d+)?$/;
+
+interface SpeechifySpeechModelConfig extends SpeechifyConfig {
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+export class SpeechifySpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  static [WORKFLOW_SERIALIZE](model: SpeechifySpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: SpeechifySpeechModelId;
+    config: SpeechifySpeechModelConfig;
+  }) {
+    return new SpeechifySpeechModel(options.modelId, options.config);
+  }
+
+  constructor(
+    readonly modelId: SpeechifySpeechModelId,
+    private readonly config: SpeechifySpeechModelConfig,
+  ) {}
+
+  private async getArgs({
+    text,
+    voice = DEFAULT_VOICE_ID,
+    outputFormat,
+    instructions,
+    speed,
+    language,
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+
+    const speechifyOptions = await parseProviderOptions({
+      provider: 'speechify',
+      providerOptions,
+      schema: speechifySpeechModelOptionsSchema,
+    });
+
+    const isSsmlInput =
+      speechifyOptions?.ssml === true || text.trimStart().startsWith('<speak');
+
+    let input = text;
+    if (speed != null) {
+      if (isSsmlInput) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'speed',
+          details:
+            'The speed setting is ignored because the input is SSML. Use an SSML <prosody rate="..."> tag to control rate.',
+        });
+      } else {
+        input = `<speak><prosody rate="${Math.round(speed * 100)}%">${text}</prosody></speak>`;
+      }
+    }
+
+    const requestBody: SpeechifySpeechRequest = {
+      input,
+      voice_id: voice,
+      model: this.modelId,
+    };
+
+    if (language != null) {
+      requestBody.language = language;
+    }
+
+    if (speechifyOptions?.outputFormat != null) {
+      requestBody.output_format = speechifyOptions.outputFormat;
+    } else if (outputFormat != null) {
+      if (CODEC_OUTPUT_FORMAT_REGEX.test(outputFormat)) {
+        requestBody.output_format = outputFormat;
+      } else if (isSimpleAudioFormat(outputFormat)) {
+        requestBody.audio_format = outputFormat;
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'outputFormat',
+          details: `Unsupported output format: ${outputFormat}. Using the provider default instead.`,
+        });
+      }
+    }
+
+    if (
+      speechifyOptions?.loudnessNormalization != null ||
+      speechifyOptions?.textNormalization != null
+    ) {
+      requestBody.options = {};
+      if (speechifyOptions.loudnessNormalization != null) {
+        requestBody.options.loudness_normalization =
+          speechifyOptions.loudnessNormalization;
+      }
+      if (speechifyOptions.textNormalization != null) {
+        requestBody.options.text_normalization =
+          speechifyOptions.textNormalization;
+      }
+    }
+
+    if (instructions != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'Speechify speech models do not support instructions. The instructions parameter was ignored.',
+      });
+    }
+
+    return {
+      requestBody,
+      warnings,
+    };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestBody, warnings } = await this.getArgs(options);
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: this.config.url({
+        path: '/v1/audio/speech',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body: requestBody,
+      failedResponseHandler: speechifyFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        speechifySpeechResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      audio: response.audio_data,
+      warnings,
+      request: {
+        body: JSON.stringify(requestBody),
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      providerMetadata: {
+        speechify: {
+          audioFormat: response.audio_format ?? null,
+          billableCharactersCount: response.billable_characters_count ?? null,
+          speechMarks: (response.speech_marks ?? null) as never,
+        },
+      },
+    };
+  }
+}

--- a/packages/speechify/src/speechify-speech-model.ts
+++ b/packages/speechify/src/speechify-speech-model.ts
@@ -16,9 +16,10 @@ import {
   type SpeechifySpeechRequest,
   speechifySpeechResponseSchema,
 } from './speechify-api-types';
-import type {
-  SpeechifySpeechModelId,
-  SpeechifySpeechVoiceId,
+import {
+  type SpeechifySpeechModelId,
+  type SpeechifySpeechVoiceId,
+  SIMBA_3_2_VOICES,
 } from './speechify-speech-options';
 
 const DEFAULT_VOICE_ID: SpeechifySpeechVoiceId = 'geffen_32';
@@ -94,6 +95,18 @@ export class SpeechifySpeechModel implements SpeechModelV4 {
     providerOptions,
   }: Parameters<SpeechModelV4['doGenerate']>[0]) {
     const warnings: SharedV4Warning[] = [];
+
+    // Warn when a simba-3.2 curated voice is used with a non-simba-3.2 model
+    if (
+      (SIMBA_3_2_VOICES as readonly string[]).includes(voice) &&
+      this.modelId !== 'simba-3.2'
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'voice',
+        details: `The voice "${voice}" is a simba-3.2 curated voice and may not be available on the ${this.modelId} model. Use a voice from the model's supported voice set.`,
+      });
+    }
 
     const speechifyOptions = await parseProviderOptions({
       provider: 'speechify',

--- a/packages/speechify/src/speechify-speech-options.ts
+++ b/packages/speechify/src/speechify-speech-options.ts
@@ -6,3 +6,16 @@ export type SpeechifySpeechModelId =
   | (string & {});
 
 export type SpeechifySpeechVoiceId = string;
+
+export const SIMBA_3_2_VOICES = [
+  'beatrice_32',
+  'dominic_32',
+  'edmund_32',
+  'geffen_32',
+  'harper_32',
+  'hugh_32',
+  'imogen_32',
+  'wyatt_32',
+] as const;
+
+export type Simba32Voice = (typeof SIMBA_3_2_VOICES)[number];

--- a/packages/speechify/src/speechify-speech-options.ts
+++ b/packages/speechify/src/speechify-speech-options.ts
@@ -1,0 +1,8 @@
+export type SpeechifySpeechModelId =
+  | 'simba-3.2'
+  | 'simba-english'
+  | 'simba-multilingual'
+  | 'simba-3.0'
+  | (string & {});
+
+export type SpeechifySpeechVoiceId = string;

--- a/packages/speechify/src/version.ts
+++ b/packages/speechify/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/speechify/tsconfig.build.json
+++ b/packages/speechify/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/speechify/tsconfig.json
+++ b/packages/speechify/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/speechify/tsup.config.ts
+++ b/packages/speechify/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/speechify/turbo.json
+++ b/packages/speechify/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/speechify/vitest.edge.config.js
+++ b/packages/speechify/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/speechify/vitest.node.config.js
+++ b/packages/speechify/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
       '@ai-sdk/sandbox-vercel':
         specifier: workspace:*
         version: link:../../packages/sandbox-vercel
+      '@ai-sdk/speechify':
+        specifier: workspace:*
+        version: link:../../packages/speechify
       '@ai-sdk/togetherai':
         specifier: workspace:*
         version: link:../../packages/togetherai
@@ -4055,6 +4058,34 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+
+  packages/speechify:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.0)(typescript@5.6.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   packages/svelte:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4079,7 +4079,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(typescript@5.6.3)(yaml@2.9.0)
       typescript:
         specifier: 5.6.3
         version: 5.6.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -202,6 +202,9 @@
       "path": "packages/sandbox-vercel"
     },
     {
+      "path": "packages/speechify"
+    },
+    {
       "path": "packages/svelte"
     },
     {


### PR DESCRIPTION
Adds a first-party `@ai-sdk/speechify` speech (TTS) provider, mirroring `@ai-sdk/lmnt` / `@ai-sdk/elevenlabs`.

Closes #17497.
Supersedes #16844 (docs-only community page for `@speechify/vercel`). Please do not close #16844 yet — @vrishab-jpg will close it in favour of this once this is accepted.

Speechify (the vendor) is contributing this and will maintain it. There is an existing community package, `@speechify/vercel`; this first-party package reimplements the same API against `@ai-sdk/provider` + `@ai-sdk/provider-utils` using raw `fetch` (no vendor-SDK dependency).

## What it covers

- `speechify.speech(modelId)` implementing `SpeechModelV4`
- `POST /v1/audio/speech` at `https://api.sws.speechify.com` (configurable `baseURL`)
- models: `simba-3.2` (default), `simba-english`, `simba-multilingual`, `simba-3.0`
- default voice `geffen_32`
- `outputFormat`: simple names (`mp3`, `wav`, `ogg`, `aac`, `pcm`) and codec strings (`mp3_24000_128`, `pcm_16000`, `ulaw_8000`, …)
- `speed` implemented via SSML `<prosody rate>`; SSML input passed through unchanged (with a warning if `speed` is also set)
- `providerOptions.speechify`: `ssml`, `outputFormat`, `loudnessNormalization`, `textNormalization`
- `speechMarks` and `billableCharactersCount` surfaced via `providerMetadata.speechify`
- Attribution: every request sends `Speechify-Caller: vercel-ai-sdk` and `Speechify-Caller-Version` (the package release); a consumer's own headers still override
- `unsupported` warnings for `instructions` and unknown output formats
- API key from `SPEECHIFY_API_KEY`; `baseURL`, `headers`, `fetch` overrides

## Docs & examples

- `content/providers/01-ai-sdk-providers/145-speechify.mdx`
- Speechify rows added to the Speech core docs model table
- `examples/ai-functions/src/generate-speech/speechify/{basic,voice,output-format}.ts`

## Tests

Node + edge suites: happy path, model/voice/output-format mapping, speed→SSML wrapping, SSML passthrough + warning, provider options, warnings for unsupported settings, error parsing, attribution + user-agent + authorization header assertions, response metadata. Also validated end-to-end against the live API (default model, a specific voice on `simba-3.0`, and `ulaw_8000`), confirming `providerMetadata.speechify.speechMarks` is populated.

## Snippet

```ts
import { speechify } from '@ai-sdk/speechify';
import { experimental_generateSpeech as generateSpeech } from 'ai';

const { audio } = await generateSpeech({
  model: speechify.speech('simba-3.2'),
  text: 'Hello from Speechify!',
  voice: 'geffen_32',
});
```

API docs: https://docs.speechify.ai