### PR TITLE
fix: emit terminal finish part when streamText terminates on an error

### DIFF
--- a/.changeset/tidy-errors-finish.md
+++ b/.changeset/tidy-errors-finish.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix: emit a terminal finish part with `finishReason: 'error'` when `streamText` terminates on an error (failed follow-up step request, failed initial request, or a model stream that produced no output), so `result.finishReason`, `fullStream`, and UI message stream `onEnd`/`onFinish` observe the error termination instead of a stream that ends without a finish event

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -45,6 +45,7 @@ import { z } from 'zod/v4';
 import { Output, type LanguageModelCallEndEvent, type Telemetry } from '..';
 import * as logWarningsModule from '../logger/log-warnings';
 import type { Instructions } from '../prompt';
+import { NoOutputGeneratedError } from '../error/no-output-generated-error';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import { createMockServerResponse } from '../test/mock-server-response';
 import { mockValues } from '../test/mock-values';
@@ -2382,6 +2383,12 @@ describe('streamText', () => {
           type: 'error',
           error: new Error('test error'),
         },
+        {
+          type: 'finish',
+          finishReason: 'error',
+          rawFinishReason: undefined,
+          totalUsage: createNullLanguageModelUsage(),
+        },
       ]);
     });
 
@@ -2582,6 +2589,173 @@ describe('streamText', () => {
       expect(onError).toHaveBeenCalledWith({
         error: new Error('test error'),
       });
+    });
+
+    it('should terminate the stream with an error finish part when the 2nd step fails', async () => {
+      let responseCount = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            if (responseCount++ === 0) {
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'response-metadata',
+                    id: 'id-0',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    input: `{ "value": "value" }`,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: { unified: 'tool-calls', raw: undefined },
+                    usage: testUsage,
+                  },
+                ]),
+                response: { headers: { call: '1' } },
+              };
+            }
+
+            throw new Error('test error');
+          },
+        }),
+        prompt: 'test-input',
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => 'result1',
+          },
+        },
+        stopWhen: isStepCount(3),
+        onError: () => {},
+      });
+
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+
+      expect(parts.map(part => part.type)).toContain('error');
+      const lastPart = parts[parts.length - 1];
+      expect(lastPart).toMatchObject({
+        type: 'finish',
+        finishReason: 'error',
+      });
+      expect(await result.finishReason).toBe('error');
+    });
+
+    it('should report an error finish reason to the ui message stream when the 2nd step fails', async () => {
+      let responseCount = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            if (responseCount++ === 0) {
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'response-metadata',
+                    id: 'id-0',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    input: `{ "value": "value" }`,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: { unified: 'tool-calls', raw: undefined },
+                    usage: testUsage,
+                  },
+                ]),
+                response: { headers: { call: '1' } },
+              };
+            }
+
+            throw new Error('test error');
+          },
+        }),
+        prompt: 'test-input',
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => 'result1',
+          },
+        },
+        stopWhen: isStepCount(3),
+        onError: () => {},
+      });
+
+      const onEnd = vi.fn();
+      await convertReadableStreamToArray(
+        result.toUIMessageStream({ onEnd, onError: () => 'error' }),
+      );
+
+      expect(onEnd).toHaveBeenCalledTimes(1);
+      expect(onEnd.mock.calls[0][0].finishReason).toBe('error');
+      expect(onEnd.mock.calls[0][0].isAborted).toBe(false);
+    });
+
+    it('should terminate the stream with an error finish part when the first request fails', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            throw new Error('test error');
+          },
+        }),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+
+      expect(parts.map(part => part.type)).toEqual(['start', 'error', 'finish']);
+      expect(parts[2]).toMatchObject({
+        type: 'finish',
+        finishReason: 'error',
+      });
+    });
+
+    it('should terminate the stream with an error finish part when the model stream produces no output', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'stream-start',
+              warnings: [],
+            },
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+
+      const lastPart = parts[parts.length - 1];
+      expect(lastPart).toMatchObject({
+        type: 'finish',
+        finishReason: 'error',
+      });
+      expect(
+        parts.some(
+          part =>
+            part.type === 'error' &&
+            part.error instanceof NoOutputGeneratedError,
+        ),
+      ).toBe(true);
     });
 
     it('should reject text promise when error is thrown', async () => {
@@ -11259,6 +11433,12 @@ describe('streamText', () => {
         {
           type: 'error',
           error: new Error('test error'),
+        },
+        {
+          type: 'finish',
+          finishReason: 'error',
+          rawFinishReason: undefined,
+          totalUsage: createNullLanguageModelUsage(),
         },
       ]);
     });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2217,6 +2217,17 @@ class DefaultStreamTextResult<
                       }),
                     });
 
+                    // terminate the stream with a proper finish part so
+                    // consumers (fullStream, UI message stream onEnd) observe
+                    // the error termination instead of a stream that ends
+                    // without a finish event:
+                    controller.enqueue({
+                      type: 'finish',
+                      finishReason: 'error',
+                      rawFinishReason: undefined,
+                      totalUsage: addLanguageModelUsage(usage, stepUsage),
+                    });
+
                     clearStepTimeout();
                     clearChunkTimeout();
                     self.closeStream();
@@ -2330,6 +2341,17 @@ class DefaultStreamTextResult<
                         error,
                       });
 
+                      // terminate the stream with a proper finish part so
+                      // consumers (finishReason promise, fullStream,
+                      // UI message stream onEnd) observe the error termination
+                      // instead of a stream that ends without a finish event:
+                      controller.enqueue({
+                        type: 'finish',
+                        finishReason: 'error',
+                        rawFinishReason: undefined,
+                        totalUsage: combinedUsage,
+                      });
+
                       self.closeStream();
                     }
                   } else {
@@ -2367,11 +2389,20 @@ class DefaultStreamTextResult<
       self._initialResponseMessages.reject(error);
       markPromiseAsHandled(self._initialResponseMessages.promise);
 
-      // add an error stream part and close the streams:
+      // add an error stream part, a terminal finish part, and close the
+      // streams. The finish part keeps the stream protocol intact so
+      // consumers (finishReason promise, fullStream, UI message stream
+      // onEnd) observe the error termination:
       self.addStream(
         new ReadableStream({
           start(controller) {
             controller.enqueue({ type: 'error', error });
+            controller.enqueue({
+              type: 'finish',
+              finishReason: 'error',
+              rawFinishReason: undefined,
+              totalUsage: createNullLanguageModelUsage(),
+            });
             controller.close();
           },
         }),

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -475,6 +475,40 @@ describe('createUIMessageStream', () => {
     });
   });
 
+  it('should keep the main stream finish reason when a merged stream errors', async () => {
+    const recordedOptions: any[] = [];
+
+    const stream = createUIMessageStream({
+      execute: ({ writer }) => {
+        writer.write({ type: 'text-start', id: '1' });
+        writer.write({ type: 'text-delta', id: '1', delta: '1a' });
+        writer.write({ type: 'text-end', id: '1' });
+        writer.write({ type: 'finish', finishReason: 'stop' });
+
+        // auxiliary merged stream that fails after the main stream finished;
+        // its failure becomes an error chunk without terminating the others
+        writer.merge(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error('auxiliary stream failure'));
+            },
+          }),
+        );
+      },
+      onError: () => 'auxiliary stream failure',
+      onEnd: options => {
+        recordedOptions.push(options);
+      },
+      generateId: () => 'response-message-id',
+    });
+
+    await consumeStream({ stream });
+
+    expect(recordedOptions).toHaveLength(1);
+    expect(recordedOptions[0].finishReason).toBe('stop');
+    expect(recordedOptions[0].isAborted).toBe(false);
+  });
+
   it('should handle onFinish with messages', async () => {
     const recordedOptions: any[] = [];
 

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
@@ -456,6 +456,132 @@ describe('handleUIMessageStreamFinish', () => {
     });
   });
 
+  describe('finish reason', () => {
+    it('should report the finish reason from the finish chunk', async () => {
+      const onEndCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-1' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream(inputChunks),
+        messageId: 'msg-1',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onEnd: onEndCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onEndCallback).toHaveBeenCalledTimes(1);
+      expect(onEndCallback.mock.calls[0][0].finishReason).toBe('stop');
+    });
+
+    it('should report the finish reason from an error termination finish chunk', async () => {
+      const onEndCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-1' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Partial' },
+        { type: 'text-end', id: 'text-1' },
+        // terminal error termination from streamText: an error chunk followed
+        // by a finish chunk that carries the error finish reason
+        { type: 'error', errorText: 'Internal server error' },
+        { type: 'finish', finishReason: 'error' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream(inputChunks),
+        messageId: 'msg-1',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onEnd: onEndCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onEndCallback).toHaveBeenCalledTimes(1);
+      expect(onEndCallback.mock.calls[0][0].finishReason).toBe('error');
+      expect(onEndCallback.mock.calls[0][0].isAborted).toBe(false);
+    });
+
+    it('should keep the finish reason undefined when an error chunk arrives without a finish chunk', async () => {
+      const onEndCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-1' },
+        { type: 'error', errorText: 'Custom stream error' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream(inputChunks),
+        messageId: 'msg-1',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onEnd: onEndCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      // error chunks are not finish events: the finish reason only comes from
+      // finish chunks, so custom streams that error without finishing report
+      // no finish reason.
+      expect(onEndCallback).toHaveBeenCalledTimes(1);
+      expect(onEndCallback.mock.calls[0][0].finishReason).toBeUndefined();
+    });
+
+    it('should not let an auxiliary error chunk overwrite a successful finish reason', async () => {
+      const onEndCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-1' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Done' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop' },
+        // e.g. a merged auxiliary stream failing after the main stream finished
+        { type: 'error', errorText: 'Auxiliary stream failure' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream(inputChunks),
+        messageId: 'msg-1',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onEnd: onEndCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onEndCallback).toHaveBeenCalledTimes(1);
+      expect(onEndCallback.mock.calls[0][0].finishReason).toBe('stop');
+    });
+
+    it('should keep the previous finish reason when a later finish chunk has none', async () => {
+      const onEndCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-1' },
+        { type: 'error', errorText: 'Recovered stream error' },
+        { type: 'finish' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream(inputChunks),
+        messageId: 'msg-1',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onEnd: onEndCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onEndCallback).toHaveBeenCalledTimes(1);
+      expect(onEndCallback.mock.calls[0][0].finishReason).toBeUndefined();
+    });
+  });
+
   describe('onStepFinish callback', () => {
     it('should call onStepEnd when finish-step chunk is encountered', async () => {
       const onStepEndCallback = vi.fn();


### PR DESCRIPTION
## Background

`onEnd`/`onFinish` get `finishReason` from the UI message state, and only `finish` chunks write it:

```ts
// packages/ai/src/ui/process-ui-message-stream.ts
case 'finish': {
  if (chunk.finishReason != null) {
    state.finishReason = chunk.finishReason;   // ← the only assignment
  }
  ...
}
```

But three `streamText` paths end the stream with an `error` part and never emit a `finish` part:

```ts
// packages/ai/src/generate-text/stream-text.ts (step continuation)
try {
  await streamStep({ currentStep: currentStep + 1, ... });
} catch (error) {
  controller.enqueue({ type: 'error', error });
  self.closeStream();                          // ← no { type: 'finish' } is ever emitted
}
```

The initial-request catch and the no-output flush path do the same. Mid-step errors are fine: they set `stepFinishReason = 'error'` and the terminal `finish` part carries it.

So on those paths the stream ends `… → error → (close)`: `result.finishReason` resolves `'other'`, `fullStream` has no terminal event, and `onEnd` reports `finishReason: undefined` for a stream that failed. Timing from a production trace (relative to stream start):

| t | Event |
|---|---|
| ~176 ms | follow-up step request rejected → `error` part enqueued, source closes with no `finish` part |
| ~210 ms | `onEnd` fires with `finishReason: undefined` — the consumer persists the response as **completed** |
| ~218 ms | the terminal `error` chunk drains through downstream transforms and reaches the client |

This isn't a race the consumer can win. `onEnd` runs in the stream's terminal `flush()`, before the error chunk clears downstream buffering, so the callback never sees the error no matter how it's written.

Today you have to track error chunks out of band and join the two signals:

```ts
let sawErrorChunk = false;

const uiStream = result.toUIMessageStream({
  onEnd: ({ isAborted, finishReason }) => {
    const failed = sawErrorChunk || finishReason === 'error';
    persistOutcome(isAborted ? 'interrupted' : failed ? 'failed' : 'completed');
  },
});

for await (const chunk of uiStream) {
  if (chunk.type === 'error') sawErrorChunk = true;
  send(chunk);
}
```

With the fix, `onEnd` alone is enough:

```ts
const uiStream = result.toUIMessageStream({
  onEnd: ({ isAborted, finishReason }) => {
    persistOutcome(
      isAborted ? 'interrupted' : finishReason === 'error' ? 'failed' : 'completed',
    );
  },
});
```

## Summary

Fix the producer instead of reinterpreting error chunks: the three terminating paths now emit a proper terminal `finish` part before closing.

```ts
} catch (error) {
  controller.enqueue({ type: 'error', error });

  // terminate the stream with a proper finish part so consumers
  // (finishReason promise, fullStream, UI message stream onEnd)
  // observe the error termination instead of a stream that ends
  // without a finish event:
  controller.enqueue({
    type: 'finish',
    finishReason: 'error',
    rawFinishReason: undefined,
    totalUsage: combinedUsage,
  });

  self.closeStream();
}
```

`'error'` is already part of the `FinishReason` vocabulary ("the model stopped because of an error"), and these paths are model-call failures, so the reported reason stays within the documented contract. Error chunks remain non-finish events everywhere.

What changes:

- follow-up step failure: `result.finishReason` resolves `'error'` (was `'other'`), `fullStream` ends with a `finish` part, UI `onEnd` reports `finishReason: 'error'` (was `undefined`/stale)
- initial request failure: the stream is `start → error → finish(error)`; result promises still reject exactly as before (the event processor's no-steps guard runs first)
- no-output stream: same terminal `finish(error)`; result promises still reject as before

What deliberately does not change (each pinned by a new test):

- an `error` chunk without a `finish` chunk does not invent a finish reason
- a successful `finish(stop)` followed by an auxiliary error chunk (e.g. a merged side stream failing) keeps `finishReason: 'stop'`
- a merged stream failing in `createUIMessageStream` does not affect the main stream's finish reason
- a later reason-less `finish` chunk does not overwrite anything
- client `Chat` behavior: its error handler throws, so processing stops at the error chunk — `isError` and `finishReason` keep their documented, separate meanings

## End-to-End Verification

Drove the three failure shapes through `streamText` with mock models: each now ends `fullStream` with `finish(finishReason: 'error')`, the follow-up-step case resolves `result.finishReason` to `'error'`, and `toUIMessageStream`'s `onEnd` reports `'error'` end to end. Success, recovery, and abort paths are unchanged across the full package suite (3,254 node + edge tests).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

`streamText`'s own `onEnd` callback event still reports `finalStep.finishReason` (the last recorded step's reason, e.g. `'tool-calls'`) rather than the overall termination reason — worth aligning with `result.finishReason` separately, since changing that event shape has its own compatibility questions.

## Related Issues

Fixes #17500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
