### PR TITLE
feat: add experimental_streamMode 'single-consumer' to streamText

### DIFF
--- a/.changeset/honest-pillows-tap.md
+++ b/.changeset/honest-pillows-tap.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat: add experimental_streamMode: 'single-consumer' to streamText to avoid tee() buffering for single-reader streams

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5221,6 +5221,51 @@ describe('streamText', () => {
     });
   });
 
+  describe('options.experimental_streamMode', () => {
+    it('should allow textStream to be consumed in single-consumer mode', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        experimental_streamMode: 'single-consumer',
+      });
+      expect(
+        await convertAsyncIterableToArray(result.textStream),
+      ).toStrictEqual(['Hello', ', ', 'world!']);
+    });
+    it('should allow a single final-result getter to be read in single-consumer mode', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        experimental_streamMode: 'single-consumer',
+      });
+      expect(await result.usage).toMatchObject({
+        inputTokens: 3,
+        outputTokens: 10,
+        totalTokens: 13,
+      });
+    });
+    it('should throw when a second stream getter is accessed before the first has been read', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        experimental_streamMode: 'single-consumer',
+      });
+      const textStreamPromise = convertAsyncIterableToArray(result.textStream);
+      expect(() => result.stream).toThrow(/already been consumed/);
+      await textStreamPromise;
+    });
+    it('should throw synchronously when the stream getter is accessed a second time', () => {
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        experimental_streamMode: 'single-consumer',
+      });
+      // biome-ignore lint: accessing the getter is the point of the test
+      result.stream;
+      expect(() => result.stream).toThrow(/already been consumed/);
+    });
+  });
+
   describe('multiple stream consumption', () => {
     it('should support text stream, ai stream, full stream on single result object', async () => {
       const result = streamText({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1,4 +1,5 @@
 import {
+  AISDKError,
   getErrorMessage,
   UnsupportedFunctionalityError,
   type LanguageModelV4,
@@ -387,6 +388,7 @@ export function streamText<
   toolsContext = {} as InferToolSetContext<TOOLS>,
   experimental_include,
   include = experimental_include,
+  experimental_streamMode,
   _internal: {
     now = originalNow,
     generateId = originalGenerateId,
@@ -704,6 +706,21 @@ export function streamText<
      * @deprecated Use `include` instead.
      */
     experimental_include?: StreamTextInclude;
+    /**
+     * Enables a low-retention streaming mode for callers that only need to
+     * read the stream once (e.g. just `textStream`, or just `consumeStream()`).
+     *
+     * When set to `'single-consumer'`, the internal stream is not split via
+     * `ReadableStream.tee()`, which avoids the server-side buffering that
+     * tee() introduces for large/long-running streams. Only one of
+     * `textStream`, `stream`/`fullStream`, `consumeStream()`,
+     * `partialOutputStream`, `elementStream`, or the final-result getters
+     * (e.g. `usage`, `steps`, `finishReason`) may be accessed -- accessing a
+     * second one throws, since there is no buffered copy left to read.
+     *
+     * @experimental This API is experimental and may change without notice.
+     */
+    experimental_streamMode?: 'single-consumer';
 
     /**
      * Internal. For test use only. May change without notice.
@@ -770,6 +787,7 @@ export function streamText<
     providerOptions,
     prepareStep,
     timeout,
+    mode: experimental_streamMode,
     onChunk,
     onError,
     onEnd,
@@ -942,6 +960,10 @@ class DefaultStreamTextResult<
 
   private tools: TOOLS | undefined;
 
+  private singleConsumer: boolean;
+
+  private streamConsumed = false;
+
   constructor({
     model,
     telemetry,
@@ -991,6 +1013,7 @@ class DefaultStreamTextResult<
     toolsContext,
     download,
     include,
+    mode,
   }: {
     model: LanguageModelV4;
     telemetry: TelemetryOptions<RUNTIME_CONTEXT, TOOLS> | undefined;
@@ -1033,6 +1056,7 @@ class DefaultStreamTextResult<
     timeout: TimeoutConfiguration<TOOLS> | undefined;
     download: DownloadFunction | undefined;
     include: Required<StreamTextInclude>;
+    mode: 'single-consumer' | undefined;
 
     // callbacks:
     onChunk: undefined | StreamTextOnChunkCallback<TOOLS>;
@@ -1072,6 +1096,7 @@ class DefaultStreamTextResult<
   }) {
     this.outputSpecification = output;
     this.tools = tools;
+    this.singleConsumer = mode === 'single-consumer';
 
     const telemetryDispatcher = createRestrictedTelemetryDispatcher<
       TOOLS,
@@ -2511,8 +2536,26 @@ class DefaultStreamTextResult<
    *
    * Note: this leads to buffering the stream content on the server.
    * However, the LLM results are expected to be small enough to not cause issues.
+   *
+   * When `singleConsumer` is enabled, tee()-based buffering is skipped
+   * entirely: the first caller receives `baseStream` directly, and any
+   * further attempt to read the stream (via `stream`, `textStream`,
+   * `consumeStream`, `partialOutputStream`, `elementStream`, or any of the
+   * final-result getters) throws, since there is nothing left to read from.
    */
   private teeStream() {
+    if (this.singleConsumer) {
+      if (this.streamConsumed) {
+        throw new AISDKError({
+          name: 'StreamConsumedError',
+          message:
+            "experimental_streamMode: 'single-consumer' supports reading " +
+            'the stream once; it has already been consumed.',
+        });
+      }
+      this.streamConsumed = true;
+      return this.baseStream;
+    }
     const [stream1, stream2] = this.baseStream.tee();
     this.baseStream = stream2;
     return stream1;


### PR DESCRIPTION
## Background

`streamText().textStream` (and every other stream/result accessor) routes through `teeStream()`, which calls `ReadableStream.tee()` to allow multiple independent readers. The source comment on `teeStream()` already notes this buffers stream content on the server and assumes LLM output is small enough not to matter.

That assumption breaks down for long-running/large-output streams. #16753 reports high memory p99 and memory-limit breaches in a 128 MB Cloudflare Worker when consuming `textStream` for long generations, caused by this buffering. The reporter had to bypass `streamText` internals entirely and read `doStream()` directly to avoid it.

## Summary

Adds an opt-in `experimental_streamMode: 'single-consumer'` option to `streamText()`. When set, `teeStream()` skips `ReadableStream.tee()` entirely and hands the internal `baseStream` directly to the first caller. Any second attempt to read the stream — via `textStream`, `stream`/`fullStream`, `consumeStream()`, `partialOutputStream`, `elementStream`, or a final-result getter (`usage`, `steps`, `finishReason`, etc.) — throws an `AISDKError`, since there's no buffered copy left for a second reader.

Reading a final-result getter *after* another consumer has already fully drained the stream still works, since the result promises are already resolved by that point — the restriction only applies to reading the underlying stream a second time.

## Contributor Credit

Thanks to @matthew-gizmo for the original report and reproduction in #16753.

## End-to-End Verification

- Ran the full `stream-text.test.ts` suite (408 existing tests) — all pass unmodified.
- Added 4 new tests covering: `textStream` consumption in single-consumer mode, reading a single final-result getter, throwing on a second consumer access before the first drains, and throwing synchronously on a direct double-access of `stream`.
- `tsc --build` and `ultracite check` (repo lint/format) both pass clean.
- Have **not** independently measured the actual memory/p99 improvement under load — this PR only verifies functional correctness of the new code path, not the memory characteristics that motivated #16753. Would appreciate maintainer input on whether that's expected before merge, or acceptable to validate separately.

## Future Work

- `partialOutputStream` and `elementStream` go through the same `teeStream()` path and should behave the same way in single-consumer mode, but aren't covered by dedicated tests yet.
- Possible follow-up: measure actual memory/p99 impact in a Worker-like environment to confirm this resolves the original report's numbers, not just the API shape.

## Related Issues

Fixes #16753