### PR TITLE
fix(ai): chunk/step timeout timers no longer count tool execution time

### DIFF
--- a/.changeset/silent-cars-float.md
+++ b/.changeset/silent-cars-float.md
@@ -1,0 +1,13 @@
+---
+"ai": patch
+---
+
+fix(timeout): chunk/step timers no longer count tool execution time
+
+`timeout.chunkMs` and `timeout.stepMs` are documented bounds for streaming
+idle time and model generation respectively. In practice both timers remained
+armed during tool execution, so a tool that runs longer than `chunkMs` or
+`stepMs` would abort a healthy request — even though model chunks arrived
+instantly. This fix clears both timers when the model call ends
+(`model-call-end`), so they measure model activity only. `timeout.toolMs`
+already exists to bound individual tool executions.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -17243,6 +17243,163 @@ describe('streamText', () => {
 
       await result.consumeStream();
     });
+
+    it('should not abort on chunk timeout during tool execution when model chunks arrive instantly', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const toolDone = new DelayedPromise<void>();
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: '{ "value": "test" }',
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => {
+              await toolDone.promise;
+              return 'tool result';
+            },
+          }),
+        },
+        prompt: 'test-input',
+        timeout: { chunkMs: 50 },
+        onError: () => {},
+      });
+
+      const consumePromise = result.consumeStream();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      toolDone.resolve(undefined);
+
+      await consumePromise;
+
+      expect(receivedAbortSignal?.aborted).toBe(false);
+    });
+
+    it('should not abort on step timeout during tool execution when model finishes quickly', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const toolDone = new DelayedPromise<void>();
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: '{ "value": "test" }',
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => {
+              await toolDone.promise;
+              return 'tool result';
+            },
+          }),
+        },
+        prompt: 'test-input',
+        timeout: { stepMs: 50 },
+        onError: () => {},
+      });
+
+      const consumePromise = result.consumeStream();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      toolDone.resolve(undefined);
+
+      await consumePromise;
+
+      expect(receivedAbortSignal?.aborted).toBe(false);
+    });
+
+    it('should still abort on chunk timeout when model never emits chunks', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const modelHang = new DelayedPromise<void>();
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: new ReadableStream({
+                async start(controller) {
+                  controller.enqueue({
+                    type: 'text-start',
+                    id: '1',
+                  });
+                  controller.enqueue({
+                    type: 'text-delta',
+                    id: '1',
+                    delta: 'Hello',
+                  });
+
+                  await modelHang.promise;
+
+                  controller.enqueue({
+                    type: 'text-end',
+                    id: '1',
+                  });
+                  controller.enqueue({
+                    type: 'finish',
+                    finishReason: { unified: 'stop', raw: 'stop' },
+                    usage: testUsage,
+                  });
+                  controller.close();
+                },
+              }),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { chunkMs: 50 },
+        onError: () => {},
+      });
+
+      const consumePromise = result.consumeStream();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      modelHang.resolve(undefined);
+
+      await consumePromise;
+
+      expect(receivedAbortSignal?.aborted).toBe(true);
+      expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
+    });
   });
 
   describe('tool callbacks', () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2171,6 +2171,13 @@ class DefaultStreamTextResult<
                     case 'model-call-end': {
                       hasReceivedTerminalChunk = true;
 
+                      // Clear chunk and step timeouts: model generation is
+                      // complete and tool execution (which may take arbitrary
+                      // time) should not count against these timers.
+                      // timeouts.toolMs already bounds individual tools.
+                      clearChunkTimeout();
+                      clearStepTimeout();
+
                       // Note: tool executions might not be finished yet when the finish event is emitted.
                       // store usage and finish reason for promises and onEnd callback:
                       stepUsage = chunk.usage;


### PR DESCRIPTION
## Background
`timeout.chunkMs` is documented as a streaming idle bound ("aborts if no new chunk is received within the specified duration"). In practice the chunk timer is reset in the transform over the `streamWithToolResults` pipeline and stays armed while tool executions run — it's only cleared after the step's tool outputs complete. Same for `stepMs`: it bounds model generation plus tool execution, even though `timeout.toolMs` already exists to bound individual tool executions.
For tool-loop agents with long-running tools (e.g., warehouse SQL, sandboxed code execution taking 2–5 minutes), this makes both knobs unusable. Any `chunkMs`/`stepMs` tight enough to catch a hung provider also kills healthy requests mid-tool.
The root cause is in the step transform: `model-call-end` is forwarded from `executeToolsFromStream` *before* tool execution begins, so the chunk timer gets armed, then tool execution blocks the pipeline, and the timer fires. The step timer is armed at step start and not cleared until the flush, which runs after all tool execution completes.
See the linked issue for a minimal reproduction.
## Summary
Clears both `chunkTimeout` and `stepTimeout` when `model-call-end` arrives in the step transform (~line 2171 of `stream-text.ts`). At that point model generation is complete and any pending tool execution should not count against these timers. The timers re-arm naturally — the chunk timer resets on chunks from the next model call, and the step timer gets a fresh `setAbortTimeout` when `streamStep()` recurses for the next step.
The fix is two idempotent `clearTimeout` calls using existing closure functions (`clearChunkTimeout`, `clearStepTimeout`), matching the established pattern used in the error path and flush handler.
## Contributor Credit
Credit to @yonatan-shorani for the detailed issue report, reproduction, and root cause analysis.
## End-to-End Verification
1. Ran a minimal reproduction matching the issue's example: model produces `tool-call` + `finish` instantly, tool blocks for a simulated long execution. With `chunkMs: 50` and `stepMs: 50`, the stream completes normally instead of aborting mid-tool.
2. Verified the hung-model case still works: model emits some chunks then hangs indefinitely — `chunkMs` still fires and aborts the stream correctly.
## Checklist
- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
## Related Issues
Fixes #17310.