### PR TITLE
fix(provider/google): surface Gemini responseId on stream and generate

### DIFF
--- a/.changeset/gemini-stream-response-id.md
+++ b/.changeset/gemini-stream-response-id.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): surface Gemini `responseId` as `response-metadata` (stream) and `response.id` (generate)

--- a/examples/ai-functions/src/stream-text/google/response-id.ts
+++ b/examples/ai-functions/src/stream-text/google/response-id.ts
@@ -1,0 +1,46 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+/**
+ * Demonstrates that the Google provider surfaces the provider response id on the
+ * stream path.
+ *
+ * Gemini returns `responseId` in the response body and repeats it in every
+ * streaming chunk. The provider now parses it and emits a `response-metadata`
+ * chunk (once, as soon as it appears), so:
+ *   - `result.response.id` is the real provider `responseId`, and
+ *   - downstream consumers that read the `response-metadata` id (e.g. the AI
+ *     Gateway) capture it too.
+ *
+ * Before the fix `result.response.id` was an SDK-generated `aitxt-…` fallback
+ * and no `response-metadata` chunk was emitted. Run with rawChunks on to compare
+ * against the raw payload.
+ */
+run(async () => {
+  const result = streamText({
+    model: google('gemini-2.5-flash'),
+    prompt: 'Reply with only the word: ok',
+    include: { rawChunks: true },
+  });
+
+  const rawResponseIds = new Set<string>();
+  for await (const chunk of result.stream) {
+    if (chunk.type === 'raw') {
+      const raw = chunk.rawValue as { responseId?: string };
+      if (raw?.responseId) rawResponseIds.add(raw.responseId);
+    }
+  }
+
+  const response = await result.response;
+  const rawId = [...rawResponseIds][0];
+
+  console.log();
+  console.log('=== provider response id on the stream path ===');
+  console.log('result.response.id       :', response.id);
+  console.log('responseId in raw chunks :', rawId);
+  console.log(
+    'match                    :',
+    response.id === rawId ? 'YES ✅' : 'NO ❌',
+  );
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-response-id.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-response-id.ts
@@ -1,0 +1,37 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+/**
+ * Vertex variant of ./response-id.ts. google-vertex reuses GoogleLanguageModel,
+ * so the same stream fix applies: the provider emits a `response-metadata` chunk
+ * carrying Gemini's `responseId`, so `result.response.id` is the real provider
+ * response id on the stream path (previously an SDK-generated fallback).
+ */
+run(async () => {
+  const result = streamText({
+    model: googleVertex('gemini-2.5-flash'),
+    prompt: 'Reply with only the word: ok',
+    include: { rawChunks: true },
+  });
+
+  const rawResponseIds = new Set<string>();
+  for await (const chunk of result.stream) {
+    if (chunk.type === 'raw') {
+      const raw = chunk.rawValue as { responseId?: string };
+      if (raw?.responseId) rawResponseIds.add(raw.responseId);
+    }
+  }
+
+  const response = await result.response;
+  const rawId = [...rawResponseIds][0];
+
+  console.log();
+  console.log('=== provider response id on the stream path (vertex) ===');
+  console.log('result.response.id       :', response.id);
+  console.log('responseId in raw chunks :', rawId);
+  console.log(
+    'match                    :',
+    response.id === rawId ? 'YES ✅' : 'NO ❌',
+  );
+});

--- a/packages/google/src/__snapshots__/google-language-model.test.ts.snap
+++ b/packages/google/src/__snapshots__/google-language-model.test.ts.snap
@@ -114,6 +114,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "content-length": "580",
       "content-type": "application/json",
     },
+    "id": "DniLab2dFPeSxN8PpqXY4Ag",
   },
   "usage": {
     "inputTokens": {
@@ -258,6 +259,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "content-length": "549",
       "content-type": "application/json",
     },
+    "id": "Un6LacrVMcjUxs0PmJfWoQc",
   },
   "usage": {
     "inputTokens": {
@@ -454,6 +456,7 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
       "content-length": "583",
       "content-type": "application/json",
     },
+    "id": "m36LaZGyCLz1xs0PtNSB-QU",
   },
   "usage": {
     "inputTokens": {
@@ -602,6 +605,7 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
       "content-length": "581",
       "content-type": "application/json",
     },
+    "id": "JniLacKqGqH0xs0P0O776As",
   },
   "usage": {
     "inputTokens": {
@@ -637,6 +641,10 @@ exports[`doStream > reasoning > should stream reasoning and text parts 1`] = `
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": "dX6LadKVC7SZ28oPr9yJoQs",
+    "type": "response-metadata",
   },
   {
     "id": "0",
@@ -735,6 +743,10 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
     "warnings": [],
   },
   {
+    "id": "M3iLaY-AI7zTxN8P3Piw4Qg",
+    "type": "response-metadata",
+  },
+  {
     "id": "0",
     "providerMetadata": undefined,
     "type": "text-start",
@@ -829,6 +841,10 @@ exports[`doStream > streaming-tool-call-arguments > should stream partial functi
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": "dqHOab6xGLzWodAPkPuViA4",
+    "type": "response-metadata",
   },
   {
     "id": "test-id",
@@ -1021,6 +1037,10 @@ exports[`doStream > streaming-tool-call-arguments-nested > should stream nested 
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": "tjXVaYaxFISTq8YP_MWiyAo",
+    "type": "response-metadata",
   },
   {
     "id": "test-id",
@@ -1482,6 +1502,10 @@ exports[`doStream > text > should stream text deltas 1`] = `
     "warnings": [],
   },
   {
+    "id": "bH6LaZW8Fp_3nsEPqtaSwQ4",
+    "type": "response-metadata",
+  },
+  {
     "id": "0",
     "providerMetadata": undefined,
     "type": "text-start",
@@ -1576,6 +1600,10 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": "b36LacjwM668nsEP2tbsgQQ",
+    "type": "response-metadata",
   },
   {
     "id": "test-id",
@@ -1679,6 +1707,10 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": "QHiLaa6LBrb8vdIPoNztsAg",
+    "type": "response-metadata",
   },
   {
     "id": "test-id",

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -715,7 +715,7 @@ describe('doGenerate', () => {
         modelId: response?.modelId,
       }).toMatchInlineSnapshot(`
         {
-          "id": undefined,
+          "id": "Un6LacrVMcjUxs0PmJfWoQc",
           "modelId": undefined,
           "timestamp": undefined,
         }
@@ -4423,6 +4423,23 @@ describe('doStream', () => {
       const chunks = await convertReadableStreamToArray(stream);
 
       expect(chunks.filter(chunk => chunk.type === 'raw')).toHaveLength(0);
+    });
+
+    it('should emit response-metadata with the provider responseId', async () => {
+      // Gemini repeats `responseId` on every chunk; the provider emits a single
+      // response-metadata part carrying it (see google-text.chunks.txt fixture).
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const responseMetadata = (
+        await convertReadableStreamToArray(stream)
+      ).filter(chunk => chunk.type === 'response-metadata');
+
+      expect(responseMetadata).toEqual([
+        { type: 'response-metadata', id: 'bH6LaZW8Fp_3nsEPqtaSwQ4' },
+      ]);
     });
 
     it('should expose the raw response headers', async () => {

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -567,7 +567,8 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       } satisfies GoogleProviderMetadata),
       request: { body: args },
       response: {
-        // TODO timestamp, model id, id
+        // TODO timestamp, model id
+        id: response.responseId ?? undefined,
         headers: responseHeaders,
         body: rawResponse,
       },
@@ -613,6 +614,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;
+    let hasEmittedResponseMetadata = false;
 
     // Track active blocks to group consecutive parts of same type
     let currentTextBlockId: string | null = null;
@@ -690,6 +692,18 @@ export class GoogleLanguageModel implements LanguageModelV4 {
             }
 
             const value = chunk.value;
+
+            // Emit the provider response id as soon as it appears. Gemini
+            // includes `responseId` on every chunk, so emitting early — rather
+            // than at finish — means the id is captured even if the stream is
+            // aborted or errors mid-way.
+            if (!hasEmittedResponseMetadata && value.responseId != null) {
+              hasEmittedResponseMetadata = true;
+              controller.enqueue({
+                type: 'response-metadata',
+                id: value.responseId,
+              });
+            }
 
             const usageMetadata = value.usageMetadata;
 
@@ -1527,6 +1541,7 @@ export const getUrlContextMetadataSchema = () =>
 const responseSchema = lazySchema(() =>
   zodSchema(
     z.object({
+      responseId: z.string().nullish(),
       candidates: z.array(
         z.object({
           content: getContentSchema().nullish().or(z.object({}).strict()),
@@ -1573,6 +1588,7 @@ export type UsageMetadataSchema = NonNullable<
 const chunkSchema = lazySchema(() =>
   zodSchema(
     z.object({
+      responseId: z.string().nullish(),
       candidates: z
         .array(
           z.object({

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -693,10 +693,6 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
             const value = chunk.value;
 
-            // Emit the provider response id as soon as it appears. Gemini
-            // includes `responseId` on every chunk, so emitting early — rather
-            // than at finish — means the id is captured even if the stream is
-            // aborted or errors mid-way.
             if (!hasEmittedResponseMetadata && value.responseId != null) {
               hasEmittedResponseMetadata = true;
               controller.enqueue({


### PR DESCRIPTION
## Background

Gemini returns a `responseId` in its response body (documented as *"Output only. responseId is used to identify each response. It is the encoding of the eventId."*) and repeats it in every streaming chunk. The Google provider was dropping it:

- `doStream` emitted no `response-metadata` chunk, so `result.response.id` fell back to an SDK-generated id, and consumers that read the provider response id off the stream (e.g. Vercel AI Gateway) captured nothing.
- `doGenerate` left `response.id` unset (the `// TODO … id`), exposing the id only via the raw `response.body.responseId`.

Every other provider surfaces its response id through `response.id` (generate) and a `response-metadata` chunk (stream); this brings Google in line.

## Changes

`packages/google/src/google-language-model.ts`:
- Parse `responseId` into both the response schema (generate) and chunk schema (stream).
- **Stream:** emit `{ type: 'response-metadata', id: responseId }` **once, as soon as it appears**. Emitting early rather than at `finish`/`flush` means the id is captured even if the stream is aborted or errors mid-way (Gemini includes it on every chunk).
- **Generate:** set `response.id` from `responseId`.

Applies to `@ai-sdk/google-vertex` too, which reuses `GoogleLanguageModel`.

## Verification

Against the real APIs (`examples/ai-functions/src/stream-text/google/{response-id,vertex-response-id}.ts`), `result.response.id` now equals the raw-chunk `responseId` on the stream path for both `google` and `googleVertex` (previously an `aitxt-…` fallback).

Tests: 173 pass. Added a `doStream` test asserting the emitted `response-metadata` id; the existing `doGenerate` "additional response information" test now asserts the populated `response.id` (was `undefined`). Snapshots updated for the new `response-metadata` stream part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)