### PR TITLE
test(ai): reproduce provider option loss when combining tool messages

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1094,6 +1094,105 @@ describe('convertToLanguageModelPrompt', () => {
         ]
       `);
     });
+
+    it('should preserve provider options when combining tool messages', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId1',
+                  toolName: 'toolName',
+                  input: {},
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId2',
+                  toolName: 'toolName',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId1',
+                  output: { type: 'text', value: 'result1' },
+                  providerOptions: {
+                    test: {
+                      cacheControl: 'part',
+                      partOnly: true,
+                    },
+                  },
+                },
+              ],
+              providerOptions: {
+                test: {
+                  cacheControl: 'first-message',
+                  messageOnly: true,
+                },
+              },
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId2',
+                  output: { type: 'text', value: 'result2' },
+                },
+              ],
+              providerOptions: {
+                test: {
+                  cacheControl: 'second-message',
+                },
+              },
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      expect(result.at(-1)).toEqual({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId1',
+            output: { type: 'text', value: 'result1' },
+            providerOptions: {
+              test: {
+                cacheControl: 'part',
+                messageOnly: true,
+                partOnly: true,
+              },
+            },
+          },
+          {
+            type: 'tool-result',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId2',
+            output: { type: 'text', value: 'result2' },
+            providerOptions: undefined,
+          },
+        ],
+        providerOptions: {
+          test: {
+            cacheControl: 'second-message',
+          },
+        },
+      });
+    });
   });
 
   describe('custom download function', () => {


### PR DESCRIPTION
## Summary

- adds a focused regression test for #17507
- demonstrates that combining consecutive tool messages retains the first message's `providerOptions`, drops the second message's options, and moves the first options to the wrong content boundary
- covers precedence between message-level and existing part-level provider options

This is a reproduction-only draft PR. It is intentionally failing and is not intended to merge as-is. It can be paired with an implementation or used as a focused test fixture by maintainers and automated workflows.

## Reproduction

```bash
cd packages/ai
pnpm exec vitest --config vitest.node.config.js --run src/prompt/convert-to-language-model-prompt.test.ts
```

Current result: exactly one failing test, `should preserve provider options when combining tool messages`. The failure shows the second message's options are absent and the first message's options remain at the combined message level.

## Test plan

- [x] Focused test fails on current `main` with the expected provider-option diff
- [x] Test file reports no TypeScript errors
- [ ] Test will pass once #17507 is fixed

Related: #17507

Made with [Cursor](https://cursor.com)