### PR TITLE
fix(ai): preserve providerOptions when combining consecutive tool messages

### DIFF
--- a/.changeset/slimy-snakes-juggle.md
+++ b/.changeset/slimy-snakes-juggle.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): preserve providerOptions when combining consecutive tool messages

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1094,6 +1094,110 @@ describe('convertToLanguageModelPrompt', () => {
         ]
       `);
     });
+
+    it('should preserve provider options when combining tool messages', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId1',
+                  toolName: 'toolName',
+                  input: {},
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId2',
+                  toolName: 'toolName',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId1',
+                  output: { type: 'text', value: 'result1' },
+                  providerOptions: {
+                    test: {
+                      cacheControl: 'part',
+                      partOnly: true,
+                    },
+                  },
+                },
+              ],
+              providerOptions: {
+                test: {
+                  cacheControl: 'first-message',
+                  messageOnly: true,
+                },
+              },
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId2',
+                  output: { type: 'text', value: 'result2' },
+                },
+              ],
+              providerOptions: {
+                test: {
+                  cacheControl: 'second-message',
+                },
+              },
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      expect(result.at(-1)).toEqual({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId1',
+            output: { type: 'text', value: 'result1' },
+            providerOptions: {
+              test: {
+                cacheControl: 'part',
+                messageOnly: true,
+                partOnly: true,
+              },
+            },
+          },
+          {
+            type: 'tool-result',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId2',
+            output: { type: 'text', value: 'result2' },
+            providerOptions: {
+              test: {
+                cacheControl: 'second-message',
+              },
+            },
+          },
+        ],
+        providerOptions: {
+          test: {
+            cacheControl: 'first-message',
+            messageOnly: true,
+          },
+        },
+      });
+    });
   });
 
   describe('custom download function', () => {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -99,11 +99,43 @@ export async function convertToLanguageModelPrompt({
   ];
 
   // combine consecutive tool messages into a single tool message
-  const combinedMessages = [];
+  const combinedMessages: typeof messages = [];
   for (const message of messages) {
     if (message.role !== 'tool') {
       combinedMessages.push(message);
       continue;
+    }
+
+    // Propagate message-level providerOptions to the last content part
+    // so they are not lost when tool messages are coalesced.
+    const messageProviderOptions = message.providerOptions;
+    if (
+      messageProviderOptions != null &&
+      message.content.length > 0
+    ) {
+      const lastPart = message.content[message.content.length - 1];
+      if (lastPart.providerOptions == null) {
+        // @ts-expect-error - mutating the part is safe here;
+        // the content array is freshly created per message
+        lastPart.providerOptions = messageProviderOptions;
+      } else {
+        // Merge: part-level keys take precedence over message-level keys
+        // within each provider's options object.
+        const merged: Record<string, Record<string, unknown>> = {
+          ...messageProviderOptions,
+        };
+        for (const [provider, options] of Object.entries(
+          lastPart.providerOptions,
+        )) {
+          if (merged[provider] != null) {
+            merged[provider] = { ...merged[provider], ...options };
+          } else {
+            merged[provider] = options;
+          }
+        }
+        // @ts-expect-error - reconstructing providerOptions shape
+        lastPart.providerOptions = merged;
+      }
     }
 
     const lastCombinedMessage = combinedMessages.at(-1);


### PR DESCRIPTION
### Description

```markdown
When consecutive tool messages are coalesced, only the first message's providerOptions survived — subsequent messages' options were silently dropped. This broke Anthropic prompt caching, which relies on message-level cache breakpoints landing on the correct tool-result block.

Propagate each tool message's providerOptions to its last content part before coalescing. When the part already carries its own options, they are deep-merged with part-level keys taking precedence.

Fixes #17507.

## Background

When consecutive tool messages are combined in the prompt converter, only the first message's `providerOptions` survived — subsequent messages' options were silently dropped. For Anthropic prompt caching, message-level cache control applies to the message's final tool-result block. Combining messages therefore moved the first cache breakpoint to the wrong result and removed subsequent breakpoints entirely.

The coalescing behavior was introduced in #8541. Related provider-option loss reports include #5473, #5942, and #15185, but none cover this specific path.

## Summary

Added a pre-pass on tool messages before coalescing: each message's `providerOptions` are propagated to its last content part. If the part already carries its own options, they are deep-merged — part-level keys take precedence over message-level keys within each provider's options object. This preserves every original message's options at their correct boundary without altering the coalescing algorithm itself.

## Contributor Credit

- @ayoubkachkach for the issue report (#17507) and reproduction test (#17508)

## End-to-End Verification

1. Run the targeted test file:
   ```
   cd packages/ai
   pnpm exec vitest --config vitest.node.config.js --run src/prompt/convert-to-language-model-prompt.test.ts
   ```
2. The new test `should preserve provider options when combining tool messages` reproduces the exact scenario: two consecutive tool messages with distinct `providerOptions`, one with an overlapping part-level option.
3. All existing tests in the file continue to pass with no regressions.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17507.