### PR TITLE
fix(provider-utils): update eventsource-parser to ^3.0.8 to avoid O(N\u00b2) parse time (#14619)

### DIFF
--- a/.changeset/fix-mcp-parse-performance.md
+++ b/.changeset/fix-mcp-parse-performance.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+fix(provider-utils): update eventsource-parser to ^3.0.8 to avoid O(N²) parse time on large SSE events

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -46,7 +46,7 @@
     "@ai-sdk/provider": "workspace:*",
     "@standard-schema/spec": "^1.1.0",
     "@workflow/serde": "4.1.0",
-    "eventsource-parser": "^3.0.6"
+    "eventsource-parser": "^3.0.8"
   },
   "devDependencies": {
     "@types/node": "20.17.24",


### PR DESCRIPTION
Closes #14619

## Root cause
eventsource-parser 3.0.6 has O(N²) parse time on large SSE responses - upgrade to 3.0.8 fixes

## Fix
[
  "Update eventsource-parser from 3.0.6 to ^3.0.8"
]

## Validation
[
  "pnpm install && pnpm test"
]
