### PR TITLE
reproduction: providerOptions are lost when consecutive tool messages are

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17507,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17507-tool-message-provider-options.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #17507 reproduced: consecutive tool-message providerOptions were not preserved at their original tool-result boundaries."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts
+++ b/examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts
@@ -1,0 +1,136 @@
+import { generateText } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+
+const failureSignal =
+  'Issue #17507 reproduced: consecutive tool-message providerOptions were not preserved at their original tool-result boundaries.';
+
+const usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 1,
+    text: 1,
+    reasoning: undefined,
+  },
+};
+
+async function main() {
+  const model = new MockLanguageModelV4({
+    doGenerate: {
+      content: [{ type: 'text', text: 'ok' }],
+      finishReason: { unified: 'stop', raw: 'stop' },
+      usage,
+      warnings: [],
+    },
+  });
+
+  await generateText({
+    model,
+    maxRetries: 0,
+    messages: [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'toolCallId1',
+            toolName: 'toolName',
+            input: {},
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'toolCallId2',
+            toolName: 'toolName',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId1',
+            output: { type: 'text', value: 'result1' },
+            providerOptions: {
+              test: {
+                cacheControl: 'part',
+                partOnly: true,
+              },
+            },
+          },
+        ],
+        providerOptions: {
+          test: {
+            cacheControl: 'first-message',
+            messageOnly: true,
+          },
+        },
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId2',
+            output: { type: 'text', value: 'result2' },
+          },
+        ],
+        providerOptions: {
+          test: {
+            cacheControl: 'second-message',
+          },
+        },
+      },
+    ],
+  });
+
+  const toolMessages = model.doGenerateCalls[0].prompt.filter(
+    message => message.role === 'tool',
+  );
+  const combinedToolMessage = toolMessages[0];
+
+  const expected = {
+    toolMessageCount: 1,
+    firstResultProviderOptions: {
+      test: {
+        cacheControl: 'part',
+        messageOnly: true,
+        partOnly: true,
+      },
+    },
+    combinedMessageProviderOptions: {
+      test: {
+        cacheControl: 'second-message',
+      },
+    },
+  };
+
+  const actual = {
+    toolMessageCount: toolMessages.length,
+    firstResultProviderOptions:
+      combinedToolMessage?.content[0]?.providerOptions,
+    combinedMessageProviderOptions: combinedToolMessage?.providerOptions,
+  };
+
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${failureSignal}\n${JSON.stringify({ expected, actual }, null, 2)}`,
+    );
+  }
+
+  console.log(
+    'Issue #17507 is not reproduced: all providerOptions remained at the expected tool-result boundaries.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

providerOptions are lost when consecutive tool messages are combined

## Reproduction

- On `main` at commit `6cd7c74acf0d7ec84dd58a841fc0e20970d6f2e8` (`ai@7.0.31`), two consecutive tool messages were combined, but the combined message retained only the first message's `providerOptions`; the second message's options were dropped.
- The first tool result retained its existing part-level options but did not inherit the first message's non-conflicting options, confirming that the original provider-option boundary was lost.
- Expected behavior is to associate the first message's options with its final tool-result part while preserving part-level precedence, then retain the second message's options for the combined message's final result.
- `examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts` reproduces the loss through the public `generateText` path and captures the provider-facing prompt with a V4 mock model.
- For Anthropic, message-level cache control is applied to the final tool-result part, so this behavior moves the first cache breakpoint to the second result and removes the second breakpoint.

## Relevant Documentation

- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://ai-sdk.dev/cookbook/node/dynamic-prompt-caching
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching

## Related Issues

Reproduces #17507