### PR TITLE
[v5.0] reproduction: Gemini may return multiple codeExecutionResult per executableCode part

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 11485,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/google-multiple-code-execution-results.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts",
+    "packages/google/src/__fixtures__/google-code-execution-multiple-results.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Tool call undefined not found."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts
+++ b/examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts
@@ -1,0 +1,41 @@
+import { readFile } from 'node:fs/promises';
+import { createGoogleGenerativeAI } from '../../../../packages/google/dist/index.mjs';
+import { generateText } from '../../../../packages/ai/dist/index.mjs';
+
+async function main() {
+  const recordedResponse = await readFile(
+    new URL(
+      '../../../../packages/google/src/__fixtures__/google-code-execution-multiple-results.json',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  const google = createGoogleGenerativeAI({
+    apiKey: 'test-api-key',
+    generateId: () => 'code-execution-call',
+    fetch: async () =>
+      new Response(recordedResponse, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  });
+
+  await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      code_execution: google.tools.codeExecution({}),
+    },
+    prompt:
+      "use code execution to execute the following code snippet:\nprint('ok')\nprint(1/0)",
+  });
+
+  throw new Error(
+    'Expected generateText to reject the recorded response with multiple code execution results.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/__fixtures__/google-code-execution-multiple-results.json
+++ b/packages/google/src/__fixtures__/google-code-execution-multiple-results.json
@@ -1,0 +1,56 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "executableCode": {
+              "language": "PYTHON",
+              "code": "print('ok')\nprint(1/0)"
+            },
+            "thoughtSignature": "EjQKMgFyyNp8VRG2uDen0QENDjUJEy6ZQlvEGUhI8VcgTgNaspEC3M5Cao6lhYRGpmCcClR1"
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_OK",
+              "output": "ok\n"
+            }
+          },
+          {
+            "codeExecutionResult": {
+              "outcome": "OUTCOME_FAILED",
+              "output": "division by zero\nTraceback (most recent call last):\n  File \"/usr/bin/entry/entry_point\", line 109, in _run_python\n    exec(code, exec_scope)  # pylint: disable=exec-used\n    ^^^^^^^^^^^^^^^^^^^^^^\n  File \"<string>\", line 2, in <module>\nZeroDivisionError: division by zero\n"
+            }
+          },
+          {
+            "text": "The code execution resulted in the following output:\n\n```\nok\n```\n\nFollowed by an error:\n\n```python\nZeroDivisionError: division by zero\n```",
+            "thoughtSignature": "EjQKMgFyyNp8EcK2k/joUmmIxJlqtIvdJP/1F+ziwsCn9P4uyk2ZNeBiYz2Um4GXD4IEGlE9"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 23,
+    "candidatesTokenCount": 35,
+    "totalTokenCount": 347,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 23
+      }
+    ],
+    "toolUsePromptTokenCount": 289,
+    "toolUsePromptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 289
+      }
+    ]
+  },
+  "modelVersion": "gemini-3-flash-preview",
+  "responseId": "x7hVadT9OdKT_uMP792-mAc"
+}

--- a/packages/google/src/google-generative-ai-language-model.issue-11485.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.issue-11485.test.ts
@@ -1,0 +1,91 @@
+import type {
+  LanguageModelV2Prompt,
+  LanguageModelV2ProviderDefinedTool,
+} from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { createGoogleGenerativeAI } from './google-provider';
+
+const recordedResponse = readFileSync(
+  new URL(
+    './__fixtures__/google-code-execution-multiple-results.json',
+    import.meta.url,
+  ),
+  'utf8',
+);
+const parsedRecordedResponse = JSON.parse(recordedResponse);
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: "use code execution to execute the following code snippet:\nprint('ok')\nprint(1/0)",
+      },
+    ],
+  },
+];
+
+function createProvider(
+  responseBody: string,
+  contentType = 'application/json',
+) {
+  return createGoogleGenerativeAI({
+    apiKey: 'test-api-key',
+    generateId: () => 'code-execution-call',
+    fetch: async () =>
+      new Response(responseBody, {
+        status: 200,
+        headers: { 'content-type': contentType },
+      }),
+  });
+}
+
+describe('issue #11485', () => {
+  it('associates every generated code execution result with its executable code', async () => {
+    const provider = createProvider(recordedResponse);
+    const { content } = await provider
+      .languageModel('gemini-3-flash-preview')
+      .doGenerate({
+        prompt,
+        tools: [
+          provider.tools.codeExecution(
+            {},
+          ) as LanguageModelV2ProviderDefinedTool,
+        ],
+      });
+
+    expect(
+      content
+        .filter(part => part.type === 'tool-result')
+        .map(part => part.toolCallId),
+    ).toEqual(['code-execution-call', 'code-execution-call']);
+  });
+
+  it('emits every streamed code execution result for its executable code', async () => {
+    const provider = createProvider(
+      `data: ${JSON.stringify(parsedRecordedResponse)}\n\n`,
+      'text/event-stream',
+    );
+    const { stream } = await provider
+      .languageModel('gemini-3-flash-preview')
+      .doStream({
+        prompt,
+        tools: [
+          provider.tools.codeExecution(
+            {},
+          ) as LanguageModelV2ProviderDefinedTool,
+        ],
+      });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    expect(
+      events
+        .filter(event => event.type === 'tool-result')
+        .map(event => event.toolCallId),
+    ).toEqual(['code-execution-call', 'code-execution-call']);
+  });
+});


### PR DESCRIPTION
## Bug

Gemini may return multiple codeExecutionResult per executableCode part

## Reproduction

- `examples/ai-functions/src/reproduction/google-multiple-code-execution-results.ts`, enabled by `examples/ai-functions/package.json`, replays the response and makes `generateText` throw `Tool call undefined not found.` instead of returning both code-execution results.
- `packages/google/src/__fixtures__/google-code-execution-multiple-results.json` records the reported Gemini response containing one `executableCode` followed by two `codeExecutionResult` parts.
- `packages/google/src/google-generative-ai-language-model.issue-11485.test.ts` observes generated result IDs `["code-execution-call", undefined]` instead of both results referencing the call, and observes streaming emit only one of the two expected results.
- `packages/ai/package.json` and `packages/google/package.json` identify the release-v5 versions as `ai` 5.0.216 and `@ai-sdk/google` 2.0.82, where the bug remains present.
- The exact live Gemini request on July 20, 2026 was blocked by HTTP 403 `PERMISSION_DENIED` due to an unregistered caller identity; the reproduction therefore uses the issue's recorded provider response.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/code-execution
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview

## Related Issues

Reproduces #11485