### PR TITLE
reproduction: Duplicate toolCallId across steps causes readUIMessageStream to overwrite

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17347,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17347-duplicate-tool-call-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #17347 reproduced: expected 2 tool parts across steps, received 1"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts
@@ -1,0 +1,96 @@
+import { readUIMessageStream, type UIMessageChunk } from 'ai';
+
+async function main() {
+  const chunks: UIMessageChunk[] = [
+    { type: 'start', messageId: 'message-1' },
+    { type: 'start-step' },
+    {
+      type: 'tool-input-available',
+      toolCallId: 'call_0',
+      toolName: 'recordStep',
+      input: { step: 1 },
+      providerMetadata: { openai: { itemId: 'fc_step_1' } },
+    },
+    {
+      type: 'tool-output-available',
+      toolCallId: 'call_0',
+      output: { recorded: 1 },
+    },
+    { type: 'finish-step' },
+    { type: 'start-step' },
+    {
+      type: 'tool-input-available',
+      toolCallId: 'call_0',
+      toolName: 'recordStep',
+      input: { step: 2 },
+      providerMetadata: { openai: { itemId: 'fc_step_2' } },
+    },
+    {
+      type: 'tool-output-available',
+      toolCallId: 'call_0',
+      output: { recorded: 2 },
+    },
+    { type: 'finish-step' },
+    { type: 'finish' },
+  ];
+
+  const stream = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  let finalMessage;
+  for await (const message of readUIMessageStream({ stream })) {
+    finalMessage = message;
+  }
+
+  if (finalMessage == null) {
+    throw new Error('Issue #17347 reproduction failed to produce a UIMessage');
+  }
+
+  const toolParts = finalMessage.parts.filter(
+    part => part.type.startsWith('tool-') || part.type === 'dynamic-tool',
+  );
+
+  console.log(JSON.stringify(toolParts, null, 2));
+
+  if (toolParts.length !== 2) {
+    throw new Error(
+      `Issue #17347 reproduced: expected 2 tool parts across steps, received ${toolParts.length}`,
+    );
+  }
+
+  const inputs = toolParts.map(part => ('input' in part ? part.input : null));
+  const outputs = toolParts.map(part =>
+    'output' in part ? part.output : null,
+  );
+  const itemIds = toolParts.map(part =>
+    'callProviderMetadata' in part
+      ? part.callProviderMetadata?.openai?.itemId
+      : undefined,
+  );
+  const toolCallIds = toolParts.map(part =>
+    'toolCallId' in part ? part.toolCallId : undefined,
+  );
+
+  if (
+    JSON.stringify(inputs) !== JSON.stringify([{ step: 1 }, { step: 2 }]) ||
+    JSON.stringify(outputs) !==
+      JSON.stringify([{ recorded: 1 }, { recorded: 2 }]) ||
+    JSON.stringify(itemIds) !== JSON.stringify(['fc_step_1', 'fc_step_2']) ||
+    JSON.stringify(toolCallIds) !== JSON.stringify(['call_0', 'call_0'])
+  ) {
+    throw new Error(
+      'Issue #17347 reproduced: tool parts did not preserve both step payloads and provider protocol IDs',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Duplicate toolCallId across steps causes readUIMessageStream to overwrite earlier tool parts

## Reproduction

- Issue #17347 reproduces on the current `ai@7.0.31` checkout, so the behavior remains present after the reported `ai@7.0.29` version.
- The reproduction at `examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts` expected two tool parts but received one containing only step 2's input, output, and `fc_step_2` provider item ID.
- `packages/ai/src/ui/process-ui-message-stream.ts` locates tool parts by `toolCallId` across the entire message, causing the second step's `call_0` chunks to update the first step's part.
- The credential-free reproduction directly evaluates the final UI aggregation failure; it does not independently rerun the reported live Bedrock tool executions.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/read-ui-message-stream
- https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html

## Related Issues

Reproduces #17347