### PR TITLE
[v5.0] fix: prevent newer fields on known UI message chunks from breaking older clients

### DIFF
--- a/.changeset/friendly-streams-relax.md
+++ b/.changeset/friendly-streams-relax.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Allow UI message chunks to include fields added by newer server versions.

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.test.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.test.ts
@@ -1,0 +1,88 @@
+import { TypeValidationError } from '@ai-sdk/provider';
+import { parseJsonEventStream, validateTypes } from '@ai-sdk/provider-utils';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { uiMessageChunkSchema, type UIMessageChunk } from './ui-message-chunks';
+
+function createEventStream(value: unknown): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(value)}\n\n`));
+      controller.close();
+    },
+  });
+}
+
+describe('uiMessageChunkSchema', () => {
+  it('returns UI message chunks', async () => {
+    const chunk = await validateTypes({
+      schema: uiMessageChunkSchema,
+      value: {
+        type: 'text-delta',
+        delta: 'Hello, world!',
+        id: '123',
+      },
+    });
+
+    expectTypeOf(chunk).toEqualTypeOf<UIMessageChunk>();
+  });
+
+  it('accepts known chunks with fields added by newer servers', async () => {
+    const chunk = {
+      type: 'tool-output-available',
+      toolCallId: 'call-123',
+      output: { ok: true },
+      optionalFieldFromNewerServer: {
+        addedIn: 'future-ai-sdk-version',
+      },
+    };
+
+    expect(
+      await convertReadableStreamToArray(
+        parseJsonEventStream({
+          stream: createEventStream(chunk),
+          schema: uiMessageChunkSchema,
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "rawValue": {
+            "optionalFieldFromNewerServer": {
+              "addedIn": "future-ai-sdk-version",
+            },
+            "output": {
+              "ok": true,
+            },
+            "toolCallId": "call-123",
+            "type": "tool-output-available",
+          },
+          "success": true,
+          "value": {
+            "optionalFieldFromNewerServer": {
+              "addedIn": "future-ai-sdk-version",
+            },
+            "output": {
+              "ok": true,
+            },
+            "toolCallId": "call-123",
+            "type": "tool-output-available",
+          },
+        },
+      ]
+    `);
+  });
+
+  it('rejects chunk types unknown to the client', async () => {
+    await expect(
+      validateTypes({
+        schema: uiMessageChunkSchema,
+        value: {
+          type: 'future-control-chunk',
+        },
+      }),
+    ).rejects.toBeInstanceOf(TypeValidationError);
+  });
+});

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.test.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.test.ts
@@ -1,8 +1,8 @@
 import { TypeValidationError } from '@ai-sdk/provider';
 import { parseJsonEventStream, validateTypes } from '@ai-sdk/provider-utils';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
-import { describe, expect, expectTypeOf, it } from 'vitest';
-import { uiMessageChunkSchema, type UIMessageChunk } from './ui-message-chunks';
+import { describe, expect, it } from 'vitest';
+import { uiMessageChunkSchema } from './ui-message-chunks';
 
 function createEventStream(value: unknown): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -16,19 +16,6 @@ function createEventStream(value: unknown): ReadableStream<Uint8Array> {
 }
 
 describe('uiMessageChunkSchema', () => {
-  it('returns UI message chunks', async () => {
-    const chunk = await validateTypes({
-      schema: uiMessageChunkSchema,
-      value: {
-        type: 'text-delta',
-        delta: 'Hello, world!',
-        id: '123',
-      },
-    });
-
-    expectTypeOf(chunk).toEqualTypeOf<UIMessageChunk>();
-  });
-
   it('accepts known chunks with fields added by newer servers', async () => {
     const chunk = {
       type: 'tool-output-available',

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -13,42 +13,52 @@ import type {
 import type { ValueOf } from '../util/value-of';
 import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
 
+<<<<<<< HEAD
 export const uiMessageChunkSchema = lazyValidator(() =>
   zodSchema(
+=======
+const toolMetadataSchema: z.ZodType<JSONObject> = z.record(
+  z.string(),
+  jsonValueSchema.optional(),
+);
+
+export const uiMessageChunkSchema = lazySchema(() =>
+  zodSchema<UIMessageChunk>(
+>>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
     z.union([
-      z.strictObject({
+      z.looseObject({
         type: z.literal('text-start'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('text-delta'),
         id: z.string(),
         delta: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('text-end'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('error'),
         errorText: z.string(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('tool-input-start'),
         toolCallId: z.string(),
         toolName: z.string(),
         providerExecuted: z.boolean().optional(),
         dynamic: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('tool-input-delta'),
         toolCallId: z.string(),
         inputTextDelta: z.string(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('tool-input-available'),
         toolCallId: z.string(),
         toolName: z.string(),
@@ -57,7 +67,7 @@ export const uiMessageChunkSchema = lazyValidator(() =>
         providerMetadata: providerMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('tool-input-error'),
         toolCallId: z.string(),
         toolName: z.string(),
@@ -66,8 +76,27 @@ export const uiMessageChunkSchema = lazyValidator(() =>
         providerMetadata: providerMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         errorText: z.string(),
+<<<<<<< HEAD
+=======
+        title: z.string().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
+        type: z.literal('tool-approval-request'),
+        approvalId: z.string(),
+        toolCallId: z.string(),
+        isAutomatic: z.boolean().optional(),
+        signature: z.string().optional(),
+      }),
+      z.looseObject({
+        type: z.literal('tool-approval-response'),
+        approvalId: z.string(),
+        approved: z.boolean(),
+        reason: z.string().optional(),
+        providerExecuted: z.boolean().optional(),
+        providerMetadata: providerMetadataSchema.optional(),
+>>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
+      }),
+      z.looseObject({
         type: z.literal('tool-output-available'),
         toolCallId: z.string(),
         output: z.unknown(),
@@ -75,37 +104,54 @@ export const uiMessageChunkSchema = lazyValidator(() =>
         dynamic: z.boolean().optional(),
         preliminary: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('tool-output-error'),
         toolCallId: z.string(),
         errorText: z.string(),
         providerExecuted: z.boolean().optional(),
         dynamic: z.boolean().optional(),
       }),
+<<<<<<< HEAD
       z.strictObject({
+=======
+      z.looseObject({
+        type: z.literal('tool-output-denied'),
+        toolCallId: z.string(),
+      }),
+      z.looseObject({
+>>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
         type: z.literal('reasoning-start'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('reasoning-delta'),
         id: z.string(),
         delta: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('reasoning-end'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
+<<<<<<< HEAD
       z.strictObject({
+=======
+      z.looseObject({
+        type: z.literal('custom'),
+        kind: z.string().transform(value => value as `${string}.${string}`),
+        providerMetadata: providerMetadataSchema.optional(),
+      }),
+      z.looseObject({
+>>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
         type: z.literal('source-url'),
         sourceId: z.string(),
         url: z.string(),
         title: z.string().optional(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('source-document'),
         sourceId: z.string(),
         mediaType: z.string(),
@@ -113,13 +159,23 @@ export const uiMessageChunkSchema = lazyValidator(() =>
         filename: z.string().optional(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('file'),
         url: z.string(),
         mediaType: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
+<<<<<<< HEAD
       z.strictObject({
+=======
+      z.looseObject({
+        type: z.literal('reasoning-file'),
+        url: z.string(),
+        mediaType: z.string(),
+        providerMetadata: providerMetadataSchema.optional(),
+      }),
+      z.looseObject({
+>>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
         type: z.custom<`data-${string}`>(
           (value): value is `data-${string}` =>
             typeof value === 'string' && value.startsWith('data-'),
@@ -129,18 +185,18 @@ export const uiMessageChunkSchema = lazyValidator(() =>
         data: z.unknown(),
         transient: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('start-step'),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('finish-step'),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('start'),
         messageId: z.string().optional(),
         messageMetadata: z.unknown().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('finish'),
         finishReason: z
           .enum([
@@ -155,10 +211,10 @@ export const uiMessageChunkSchema = lazyValidator(() =>
           .optional(),
         messageMetadata: z.unknown().optional(),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('abort'),
       }),
-      z.strictObject({
+      z.looseObject({
         type: z.literal('message-metadata'),
         messageMetadata: z.unknown(),
       }),

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -13,18 +13,8 @@ import type {
 import type { ValueOf } from '../util/value-of';
 import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
 
-<<<<<<< HEAD
 export const uiMessageChunkSchema = lazyValidator(() =>
-  zodSchema(
-=======
-const toolMetadataSchema: z.ZodType<JSONObject> = z.record(
-  z.string(),
-  jsonValueSchema.optional(),
-);
-
-export const uiMessageChunkSchema = lazySchema(() =>
   zodSchema<UIMessageChunk>(
->>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
     z.union([
       z.looseObject({
         type: z.literal('text-start'),
@@ -76,25 +66,6 @@ export const uiMessageChunkSchema = lazySchema(() =>
         providerMetadata: providerMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         errorText: z.string(),
-<<<<<<< HEAD
-=======
-        title: z.string().optional(),
-      }),
-      z.looseObject({
-        type: z.literal('tool-approval-request'),
-        approvalId: z.string(),
-        toolCallId: z.string(),
-        isAutomatic: z.boolean().optional(),
-        signature: z.string().optional(),
-      }),
-      z.looseObject({
-        type: z.literal('tool-approval-response'),
-        approvalId: z.string(),
-        approved: z.boolean(),
-        reason: z.string().optional(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
->>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
       }),
       z.looseObject({
         type: z.literal('tool-output-available'),
@@ -111,15 +82,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         providerExecuted: z.boolean().optional(),
         dynamic: z.boolean().optional(),
       }),
-<<<<<<< HEAD
-      z.strictObject({
-=======
       z.looseObject({
-        type: z.literal('tool-output-denied'),
-        toolCallId: z.string(),
-      }),
-      z.looseObject({
->>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
         type: z.literal('reasoning-start'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
@@ -135,16 +98,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-<<<<<<< HEAD
-      z.strictObject({
-=======
       z.looseObject({
-        type: z.literal('custom'),
-        kind: z.string().transform(value => value as `${string}.${string}`),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.looseObject({
->>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
         type: z.literal('source-url'),
         sourceId: z.string(),
         url: z.string(),
@@ -165,17 +119,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         mediaType: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-<<<<<<< HEAD
-      z.strictObject({
-=======
       z.looseObject({
-        type: z.literal('reasoning-file'),
-        url: z.string(),
-        mediaType: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.looseObject({
->>>>>>> e35bcae87 (fix: prevent newer fields on known UI message chunks from breaking older clients (#17010))
         type: z.custom<`data-${string}`>(
           (value): value is `data-${string}` =>
             typeof value === 'string' && value.startsWith('data-'),


### PR DESCRIPTION
## Background

Cached clients use older UI message chunk schemas and previously threw `AI_TypeValidationError` when newer servers added optional top-level fields such as `providerMetadata` or `toolMetadata` to otherwise known chunk types.

## Summary

Changed all 28 UI message chunk schema variants from strict to loose Zod objects, accepting and preserving additional top-level fields while retaining validation of known fields, known discriminants, and the existing public `UIMessageChunk` type. Unknown chunk types remain rejected.

## Testing

Integrated the existing type assertion into the runtime schema test, added an inline-snapshot regression that parses an SSE chunk and verifies a newer-server field is accepted and preserved, and added coverage confirming unknown chunk types remain rejected. Focused Node and Edge suites each passed 3 tests, and the full repository test suite passed.

## End-to-end Validation

- `pnpm exec tsx --eval "<UI message SSE probe>"` successfully parsed and preserved an additional field on a known `tool-output-available` event without producing `AI_TypeValidationError`.

## Related Issues

Fixes #13733

Backport of #17010

Co-authored-by: pablodecm <6707437+pablodecm@users.noreply.github.com>
Co-authored-by: svenmuennich <1932115+svenmuennich@users.noreply.github.com>