### PR TITLE
reproduction: @ai-sdk/amazon-bedrock: ARN model IDs containing / application inference

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17523,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17523-bedrock-arn-model-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17523_REPRODUCED: generateText received HTTP 200 UnknownOperationException as Invalid JSON response; streamText returned empty text with finish reason other"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts
@@ -1,0 +1,96 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { APICallError } from '@ai-sdk/provider';
+import { generateText, streamText } from 'ai';
+
+const modelId =
+  'arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0';
+
+async function hasReportedRoutingBehavior(modelId: string) {
+  const baseUrl = 'https://bedrock-runtime.eu-west-1.amazonaws.com/model';
+  const request = {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  };
+
+  const [encodedResponse, unencodedResponse] = await Promise.all([
+    fetch(`${baseUrl}/${encodeURIComponent(modelId)}/converse`, request),
+    fetch(`${baseUrl}/${modelId}/converse`, request),
+  ]);
+  const [encodedBody, unencodedBody] = await Promise.all([
+    encodedResponse.text(),
+    unencodedResponse.text(),
+  ]);
+
+  return (
+    encodedResponse.status === 403 &&
+    encodedBody.includes('Authorization header is missing') &&
+    unencodedResponse.status === 200 &&
+    unencodedBody.includes('UnknownOperationException')
+  );
+}
+
+async function main() {
+  const [applicationProfileRoutingFailure, foundationModelRoutingFailure] =
+    await Promise.all([
+      hasReportedRoutingBehavior(
+        'arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abcdefghijkl',
+      ),
+      hasReportedRoutingBehavior(
+        'arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-lite-v1:0',
+      ),
+    ]);
+
+  if (!applicationProfileRoutingFailure || !foundationModelRoutingFailure) {
+    throw new Error('Bedrock routing comparison did not match issue #17523');
+  }
+
+  const bedrock = createAmazonBedrock({ region: 'eu-west-1' });
+
+  let generateFailureObserved = false;
+
+  try {
+    await generateText({
+      model: bedrock(modelId),
+      prompt: 'Say hello',
+      maxOutputTokens: 10,
+    });
+  } catch (error) {
+    generateFailureObserved =
+      APICallError.isInstance(error) &&
+      error.message === 'Invalid JSON response' &&
+      error.statusCode === 200 &&
+      error.responseBody?.includes('UnknownOperationException') === true;
+
+    if (!generateFailureObserved) {
+      throw error;
+    }
+  }
+
+  const streamResult = streamText({
+    model: bedrock(modelId),
+    prompt: 'Say hello',
+    maxOutputTokens: 10,
+  });
+  const [streamedText, streamFinishReason] = await Promise.all([
+    streamResult.text,
+    streamResult.finishReason,
+  ]);
+
+  const streamFailureObserved =
+    streamedText === '' && streamFinishReason === 'other';
+
+  if (generateFailureObserved && streamFailureObserved) {
+    throw new Error(
+      'ISSUE_17523_REPRODUCED: generateText received HTTP 200 UnknownOperationException as Invalid JSON response; streamText returned empty text with finish reason other',
+    );
+  }
+
+  console.log({
+    generateFailureObserved,
+    streamedText,
+    streamFinishReason,
+  });
+}
+
+main();

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse-stream.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse-stream.chunks.txt
@@ -1,0 +1,7 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"Hello"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"! How can I assist you"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" today? If"}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"stopReason":"max_tokens"}}
+{"metadata":{"metrics":{"latencyMs":317},"usage":{"inputTokens":2,"outputTokens":10,"serverToolUsage":{},"totalTokens":12}}}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse.json
@@ -1,0 +1,22 @@
+{
+  "metrics": {
+    "latencyMs": 352
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "Hello! How can I assist you today? If"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "max_tokens",
+  "usage": {
+    "inputTokens": 2,
+    "outputTokens": 10,
+    "serverToolUsage": {},
+    "totalTokens": 12
+  }
+}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.json
@@ -1,0 +1,6 @@
+{
+  "Output": {
+    "__type": "com.amazon.coral.service#UnknownOperationException"
+  },
+  "Version": "1.0"
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -280,6 +280,82 @@ describe('request URL', () => {
       expect.any(Object),
     );
   });
+
+  describe('ARN model IDs containing a slash', () => {
+    const inferenceProfileArn =
+      'arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0';
+    const encodedInferenceProfileArn = encodeURIComponent(inferenceProfileArn);
+    const unknownOperationResponse = JSON.stringify(
+      JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/issue-17523-unknown-operation.json',
+          'utf8',
+        ),
+      ),
+    );
+    const converseResponse = fs.readFileSync(
+      'src/__fixtures__/issue-17523-converse.json',
+      'utf8',
+    );
+    const converseStreamResponse = fs.readFileSync(
+      'src/__fixtures__/issue-17523-converse-stream.chunks.txt',
+      'utf8',
+    );
+
+    function createInferenceProfileModel() {
+      return new AmazonBedrockChatLanguageModel(inferenceProfileArn, {
+        baseUrl: () => baseUrl,
+        headers: {},
+        fetch: async input => {
+          const url = input.toString();
+          const isEncodedRoute = url.includes(encodedInferenceProfileArn);
+
+          return new Response(
+            isEncodedRoute
+              ? url.endsWith('/converse-stream')
+                ? converseStreamResponse
+                : converseResponse
+              : unknownOperationResponse,
+            {
+              status: 200,
+              headers: {
+                'content-type': isEncodedRoute
+                  ? url.endsWith('/converse-stream')
+                    ? 'application/vnd.amazon.eventstream'
+                    : 'application/json'
+                  : 'application/json',
+              },
+            },
+          );
+        },
+        generateId: () => 'test-id',
+      });
+    }
+
+    it('should generate text through the encoded Converse route', async () => {
+      const result = await createInferenceProfileModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toContainEqual({
+        type: 'text',
+        text: 'Hello! How can I assist you today? If',
+      });
+    });
+
+    it('should stream text through the encoded Converse route', async () => {
+      const { stream } = await createInferenceProfileModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toContainEqual({
+        type: 'text-delta',
+        id: '0',
+        delta: 'Hello',
+      });
+    });
+  });
 });
 
 describe('doStream', () => {


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: ARN model IDs containing `/` (application inference profiles, foundation-model ARNs) break the Converse API since 4.0.137 (regression from #17410)

## Reproduction

- AWS documents foundation-model and inference-profile ARNs as valid `modelId` values for Converse and ConverseStream.
- Live Bedrock checks for application-inference-profile and foundation-model ARNs returned HTTP 403 authentication errors with `%2F` encoded, but HTTP 200 `UnknownOperationException` responses with literal `/` path separators.
- Against a valid Nova Lite inference-profile ARN, the fully encoded signed Converse request returned assistant text, while `@ai-sdk/amazon-bedrock@5.0.24` surfaced `generateText` as `Invalid JSON response` and made `streamText` return empty text with finish reason `other`.
- `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts` decodes `%2F` for ARN model IDs, causing the malformed Converse routes.
- `examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts` reproduces both user-visible failures against live Bedrock.
- `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts` and the `packages/amazon-bedrock/src/__fixtures__/issue-17523-*` live-response fixtures assert that encoded ARN routes should generate and stream assistant text; both assertions fail on the target branch.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html

## Related Issues

Reproduces #17523