### PR TITLE
chore(ai): bump main bundle size limit to 650 KB

### DIFF
--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 640 * 1024;
+const LIMIT = 650 * 1024;
 
 interface BundleResult {
   size: number;


### PR DESCRIPTION
## Background

The AI package bundle-size CI check currently allows up to 640 KB.

## Summary

Increase the main AI package bundle-size limit from 640 KB to 650 KB.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request