### PR TITLE
chore: update workflow to run every 6 hours

### DIFF
--- a/.github/workflows/reconcile-merge-labels.yml
+++ b/.github/workflows/reconcile-merge-labels.yml
@@ -8,7 +8,7 @@ name: Reconcile Merge Labels
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Background

instead of 24 runs, the workflow is better off running every 6 hours (4 times)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)