### PR TITLE
[v5.0] reproduction: AI Gateway Anthropic Messages streaming: messagestart always reports

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "issueId": 17326,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17326.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-17326.ts",
+    "packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt",
+    "packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt",
+    "packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.txt"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17326 REPRODUCED: message_start usage is 0/0 for anthropic/claude-haiku-4.5 while terminal usage is non-zero"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-17326.ts
+++ b/examples/ai-functions/src/reproduction/issue-17326.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs/promises';
+
+type MessageStart = {
+  type: 'message_start';
+  message: {
+    model: string;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+    };
+  };
+};
+
+type MessageDelta = {
+  type: 'message_delta';
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+};
+
+function readEvent<T>(stream: string, eventType: string): T {
+  const block = stream
+    .split('\n\n')
+    .find(block => block.startsWith(`event: ${eventType}\n`));
+
+  if (block == null) {
+    throw new Error(`Missing ${eventType} event`);
+  }
+
+  return JSON.parse(block.slice(block.indexOf('data: ') + 6)) as T;
+}
+
+async function readFixture(filename: string) {
+  return fs.readFile(
+    new URL(
+      `../../../../packages/gateway/src/__fixtures__/${filename}`,
+      import.meta.url,
+    ),
+    'utf8',
+  );
+}
+
+async function main() {
+  const failures: string[] = [];
+
+  for (const filename of [
+    'issue-17326-xai-grok-4.5.chunks.txt',
+    'issue-17326-anthropic-claude-haiku-4.5.chunks.txt',
+  ]) {
+    const stream = await readFixture(filename);
+    const start = readEvent<MessageStart>(stream, 'message_start');
+    const delta = readEvent<MessageDelta>(stream, 'message_delta');
+    const { model, usage: startUsage } = start.message;
+    const finalUsage = delta.usage;
+
+    console.log(
+      `${model}: message_start=${startUsage.input_tokens}/${startUsage.output_tokens}, message_delta=${finalUsage.input_tokens}/${finalUsage.output_tokens}`,
+    );
+
+    if (
+      startUsage.input_tokens === 0 &&
+      startUsage.output_tokens === 0 &&
+      (finalUsage.input_tokens > 0 || finalUsage.output_tokens > 0)
+    ) {
+      failures.push(
+        `message_start usage is 0/0 for ${model} while terminal usage is non-zero`,
+      );
+    }
+  }
+
+  const countTokensResponse = await readFixture(
+    'issue-17326-xai-grok-4.5-count-tokens.txt',
+  );
+  const countTokensStatus = Number(
+    countTokensResponse.match(/HTTP_STATUS:(\d+)/)?.[1],
+  );
+  console.log(`xai/grok-4.5 count_tokens status=${countTokensStatus}`);
+
+  if (countTokensStatus === 404) {
+    failures.push('count_tokens returns 404 for xai/grok-4.5');
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`ISSUE #17326 REPRODUCED: ${failure}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt
+++ b/packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt
@@ -1,0 +1,20 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"gen_01KY072SFM28CY5VDQSH2AXQ6W","type":"message","role":"assistant","content":[],"model":"anthropic/claude-haiku-4.5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hey"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":13,"output_tokens":5,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"provider_metadata":{"anthropic":{"usage":{"input_tokens":13,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"},"cacheCreationInputTokens":0,"stopSequence":null,"iterations":null,"container":null,"contextManagement":null},"gateway":{"routing":{"originalModelId":"anthropic/claude-haiku-4.5","resolvedProvider":"anthropic","fallbacksAvailable":["bedrock","vertexAnthropic"],"planningReasoning":"System credentials planned for: anthropic, bedrock, vertexAnthropic. Total execution order: anthropic(system) → bedrock(system) → vertexAnthropic(system)","canonicalSlug":"anthropic/claude-haiku-4.5","finalProvider":"anthropic","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"anthropic/claude-haiku-4.5","success":true,"providerAttemptCount":1,"providerAttempts":[{"provider":"anthropic","credentialType":"system","success":true,"startTime":1784566343175,"endTime":1784566344020,"providerRequestId":"req_011CdDf2vemNmq2YNzsdsMoC","statusCode":200,"providerResponseId":"msg_011CdDf2w7YjtM12i29bmLhs"}]}],"totalProviderAttemptCount":1},"cost":"0.000038","marketCost":"0.000038","surchargeCost":"0.0001","gatewayCost":"0.000138","inferenceCost":"0.000038","inputInferenceCost":"0.000013","outputInferenceCost":"0.000025","providerAllowlistCost":"0.0001","generationId":"gen_01KY072SFM28CY5VDQSH2AXQ6W"}}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.txt
+++ b/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.txt
@@ -1,0 +1,2 @@
+HTTP_STATUS:404
+{"type":"error","error":{"type":"not_found_error","message":"model: xai/grok-4.5"},"request_id":"req_011CdDf2YFt1ADAXE9QNLbRK"}

--- a/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt
+++ b/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt
@@ -1,0 +1,59 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"gen_01KY072DWTJ0Y6V6W8YCXYA7NQ","type":"message","role":"assistant","content":[],"model":"xai/grok-4.5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" user"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" said"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" \""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Say"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" hi"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" in"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" one"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" word"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":".\""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hi"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":84,"output_tokens":32,"cache_read_input_tokens":128},"provider_metadata":{"gateway":{"routing":{"originalModelId":"xai/grok-4.5","resolvedProvider":"xai","fallbacksAvailable":[],"planningReasoning":"System credentials planned for: xai. Total execution order: xai(system)","canonicalSlug":"xai/grok-4.5","finalProvider":"xai","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"xai/grok-4.5","success":true,"providerAttemptCount":1,"providerAttempts":[{"provider":"xai","credentialType":"system","success":true,"startTime":1784566331314,"endTime":1784566332710,"providerRequestId":"69fffaae-bba0-9b66-8166-e6dfc03a92cd","statusCode":200,"providerResponseId":"69fffaae-bba0-9b66-8166-e6dfc03a92cd","inferenceEndpoint":{"slug":"global","scope":"global"}}]}],"totalProviderAttemptCount":1},"cost":"0.0003984","marketCost":"0.0003984","surchargeCost":"0.0001","gatewayCost":"0.0004984","inferenceCost":"0.0003984","inputInferenceCost":"0.0002064","outputInferenceCost":"0.000192","providerAllowlistCost":"0.0001","generationId":"gen_01KY072DWTJ0Y6V6W8YCXYA7NQ"}}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/packages/gateway/src/issue-17326.test.ts
+++ b/packages/gateway/src/issue-17326.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+type MessageStart = {
+  type: 'message_start';
+  message: {
+    model: string;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+    };
+  };
+};
+
+type MessageDelta = {
+  type: 'message_delta';
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+};
+
+function readFixture(filename: string) {
+  return fs.readFileSync(`src/__fixtures__/${filename}`, 'utf8');
+}
+
+function readEvent<T>(stream: string, eventType: string): T {
+  const block = stream
+    .split('\n\n')
+    .find(block => block.startsWith(`event: ${eventType}\n`));
+
+  if (block == null) {
+    throw new Error(`Missing ${eventType} event`);
+  }
+
+  return JSON.parse(block.slice(block.indexOf('data: ') + 6)) as T;
+}
+
+describe('issue #17326', () => {
+  it.each([
+    ['xai/grok-4.5', 'issue-17326-xai-grok-4.5.chunks.txt', 84, 32],
+    [
+      'anthropic/claude-haiku-4.5',
+      'issue-17326-anthropic-claude-haiku-4.5.chunks.txt',
+      13,
+      5,
+    ],
+  ])(
+    'reports real usage in message_start for %s',
+    (_model, filename, expectedInputTokens, expectedOutputTokens) => {
+      const stream = readFixture(filename);
+      const start = readEvent<MessageStart>(stream, 'message_start');
+      const delta = readEvent<MessageDelta>(stream, 'message_delta');
+
+      expect(delta.usage).toMatchObject({
+        input_tokens: expectedInputTokens,
+        output_tokens: expectedOutputTokens,
+      });
+      expect(start.message.usage.input_tokens).toBeGreaterThan(0);
+      expect(start.message.usage.output_tokens).toBeGreaterThan(0);
+    },
+  );
+
+  it('does not route count_tokens for xai/grok-4.5 to an Anthropic model lookup', () => {
+    const response = readFixture('issue-17326-xai-grok-4.5-count-tokens.txt');
+    const status = Number(response.match(/HTTP_STATUS:(\d+)/)?.[1]);
+
+    expect(status).toBe(200);
+    expect(response).toContain('"input_tokens"');
+  });
+});


### PR DESCRIPTION
## Bug

[AI Gateway] Anthropic Messages streaming: `message_start` always reports `usage: 0/0`, breaking Claude Code per-message cost/usage tracking

## Reproduction

- Live AI Gateway streams for `xai/grok-4.5` and `anthropic/claude-haiku-4.5` emitted `message_start` usage of `0/0`, while terminal usage was `84/32` and `13/5` respectively; clients snapshotting the initial event therefore record zero usage instead of the available token counts.
- Live `POST /v1/messages/count_tokens` for `xai/grok-4.5` returned HTTP 404 with Anthropic's `not_found_error`, rather than handling the gateway-supported non-Anthropic model.
- Live responses are recorded in `packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt`, `packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt`, and `packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.txt`.
- `packages/gateway/src/issue-17326.test.ts` asserts nonzero initial usage and successful token counting; all three assertions fail against the recorded responses.
- `examples/ai-functions/src/reproduction/issue-17326.ts` provides the required runnable reproduction and reports all three observed failures.

## Relevant Documentation

- https://platform.claude.com/docs/en/build-with-claude/streaming
- https://platform.claude.com/docs/en/api/messages/count_tokens
- https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api
- https://vercel.com/docs/ai-gateway/coding-agents/claude-code

## Related Issues

Reproduces #17326