### PR TITLE
[v6.0] reproduction: AI Gateway Anthropic Messages streaming: messagestart always reports

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17326,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17326-ai-gateway-anthropic-usage.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17326-ai-gateway-anthropic-usage.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17326: message_start usage is zero while terminal usage is non-zero for anthropic/claude-haiku-4.5"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17326-ai-gateway-anthropic-usage.ts
+++ b/examples/ai-functions/src/reproduction/issue-17326-ai-gateway-anthropic-usage.ts
@@ -1,0 +1,170 @@
+type Usage = {
+  input_tokens?: number;
+  output_tokens?: number;
+};
+
+type StreamObservation = {
+  model: string;
+  startUsage: Usage;
+  finalUsage: Usage;
+};
+
+const gatewayBaseUrl = 'https://ai-gateway.vercel.sh';
+
+function parseSseData(body: string): Array<Record<string, unknown>> {
+  return body
+    .split('\n')
+    .filter(line => line.startsWith('data: '))
+    .map(line => JSON.parse(line.slice('data: '.length)));
+}
+
+function readUsage(value: unknown, location: string): Usage {
+  if (value == null || typeof value !== 'object') {
+    throw new Error(`Missing usage at ${location}`);
+  }
+
+  const usage = value as Usage;
+  if (
+    typeof usage.input_tokens !== 'number' ||
+    typeof usage.output_tokens !== 'number'
+  ) {
+    throw new Error(`Invalid usage at ${location}`);
+  }
+
+  return usage;
+}
+
+async function observeStream({
+  apiKey,
+  model,
+}: {
+  apiKey: string;
+  model: string;
+}): Promise<StreamObservation> {
+  const response = await fetch(`${gatewayBaseUrl}/v1/messages`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 32,
+      stream: true,
+      messages: [{ role: 'user', content: 'Say hi in one word.' }],
+    }),
+    signal: AbortSignal.timeout(90_000),
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Gateway stream request for ${model} failed with HTTP ${response.status}: ${body}`,
+    );
+  }
+
+  const events = parseSseData(body);
+  const messageStart = events.find(event => event.type === 'message_start');
+  const messageDelta = events.find(event => event.type === 'message_delta');
+
+  if (messageStart == null || messageDelta == null) {
+    throw new Error(`Gateway stream for ${model} omitted required events`);
+  }
+
+  const message = messageStart.message;
+  if (message == null || typeof message !== 'object') {
+    throw new Error(`Gateway stream for ${model} has no start message`);
+  }
+
+  return {
+    model,
+    startUsage: readUsage(
+      (message as Record<string, unknown>).usage,
+      `${model} message_start`,
+    ),
+    finalUsage: readUsage(messageDelta.usage, `${model} message_delta`),
+  };
+}
+
+async function observeCountTokens({
+  apiKey,
+}: {
+  apiKey: string;
+}): Promise<{ status: number; body: string }> {
+  const response = await fetch(`${gatewayBaseUrl}/v1/messages/count_tokens`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'xai/grok-4.5',
+      messages: [{ role: 'user', content: 'hi' }],
+    }),
+    signal: AbortSignal.timeout(90_000),
+  });
+
+  return { status: response.status, body: await response.text() };
+}
+
+function hasZeroStartAndPositiveFinal({
+  startUsage,
+  finalUsage,
+}: StreamObservation): boolean {
+  return (
+    startUsage.input_tokens === 0 &&
+    startUsage.output_tokens === 0 &&
+    (finalUsage.input_tokens ?? 0) > 0 &&
+    (finalUsage.output_tokens ?? 0) > 0
+  );
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.AI_GATEWAY_API_KEY;
+  if (apiKey == null || apiKey.length === 0) {
+    throw new Error('AI_GATEWAY_API_KEY is required');
+  }
+
+  const observations = await Promise.all([
+    observeStream({ apiKey, model: 'anthropic/claude-haiku-4.5' }),
+    observeStream({ apiKey, model: 'xai/grok-4.5' }),
+  ]);
+  const countTokens = await observeCountTokens({ apiKey });
+
+  const failures: string[] = [];
+
+  for (const observation of observations) {
+    console.log(
+      `${observation.model}: message_start=${observation.startUsage.input_tokens}/${observation.startUsage.output_tokens}, message_delta=${observation.finalUsage.input_tokens}/${observation.finalUsage.output_tokens}`,
+    );
+
+    if (hasZeroStartAndPositiveFinal(observation)) {
+      failures.push(
+        `ISSUE #17326: message_start usage is zero while terminal usage is non-zero for ${observation.model}`,
+      );
+    }
+  }
+
+  console.log(
+    `xai/grok-4.5 count_tokens: HTTP ${countTokens.status} ${countTokens.body}`,
+  );
+  if (
+    countTokens.status === 404 &&
+    countTokens.body.includes('"type":"not_found_error"')
+  ) {
+    failures.push(
+      'ISSUE #17326: count_tokens returns Anthropic not_found_error for xai/grok-4.5',
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Error(failures.join('\n'));
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt
+++ b/packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt
@@ -1,0 +1,18 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"gen_01KY071V9GQK1EBS343E5TY39W","type":"message","role":"assistant","content":[],"model":"anthropic/claude-haiku-4.5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":13,"output_tokens":5,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"provider_metadata":{"anthropic":{"usage":{"input_tokens":13,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"},"cacheCreationInputTokens":0,"stopSequence":null,"iterations":null,"container":null,"contextManagement":null},"gateway":{"routing":{"originalModelId":"anthropic/claude-haiku-4.5","resolvedProvider":"anthropic","fallbacksAvailable":["bedrock","vertexAnthropic"],"planningReasoning":"System credentials planned for: anthropic, bedrock, vertexAnthropic. Total execution order: anthropic(system) → bedrock(system) → vertexAnthropic(system)","canonicalSlug":"anthropic/claude-haiku-4.5","finalProvider":"anthropic","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"anthropic/claude-haiku-4.5","success":true,"providerAttemptCount":1,"providerAttempts":[{"provider":"anthropic","credentialType":"system","success":true,"startTime":1784566312266,"endTime":1784566313406,"providerRequestId":"req_011CdDezezPBA3RrCN8Xq7br","statusCode":200,"providerResponseId":"msg_011CdDezfabrxd78pL4BYfV3"}]}],"totalProviderAttemptCount":1},"cost":"0.000038","marketCost":"0.000038","surchargeCost":"0.0001","gatewayCost":"0.000138","inferenceCost":"0.000038","inputInferenceCost":"0.000013","outputInferenceCost":"0.000025","providerAllowlistCost":"0.0001","generationId":"gen_01KY071V9GQK1EBS343E5TY39W"}}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.json
+++ b/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.json
@@ -1,0 +1,11 @@
+{
+  "status": 404,
+  "body": {
+    "type": "error",
+    "error": {
+      "type": "not_found_error",
+      "message": "model: xai/grok-4.5"
+    },
+    "request_id": "req_011CdDf17cmN9XAGMfqbsSBn"
+  }
+}

--- a/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt
+++ b/packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt
@@ -1,0 +1,60 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"gen_01KY071N0WCYNCDGM7C24J29GY","type":"message","role":"assistant","content":[],"model":"xai/grok-4.5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" user"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" said"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" \""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Say"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" hi"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" in"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" one"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" word"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":".\""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hi"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":84,"output_tokens":30,"cache_read_input_tokens":128},"provider_metadata":{"gateway":{"routing":{"originalModelId":"xai/grok-4.5","resolvedProvider":"xai","fallbacksAvailable":[],"planningReasoning":"System credentials planned for: xai. Total execution order: xai(system)","canonicalSlug":"xai/grok-4.5","finalProvider":"xai","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"xai/grok-4.5","success":true,"providerAttemptCount":1,"providerAttempts":[{"provider":"xai","credentialType":"system","success":true,"startTime":1784566305840,"endTime":1784566307018,"providerRequestId":"d6a032b9-98e2-9ffc-bc8c-4dc7ef59d5ab","statusCode":200,"providerResponseId":"d6a032b9-98e2-9ffc-bc8c-4dc7ef59d5ab","inferenceEndpoint":{"slug":"global","scope":"global"}}]}],"totalProviderAttemptCount":1},"cost":"0.0003864","marketCost":"0.0003864","surchargeCost":"0.0001","gatewayCost":"0.0004864","inferenceCost":"0.0003864","inputInferenceCost":"0.0002064","outputInferenceCost":"0.00018","providerAllowlistCost":"0.0001","generationId":"gen_01KY071N0WCYNCDGM7C24J29GY"}}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/packages/gateway/src/anthropic-compatibility.issue-17326.test.ts
+++ b/packages/gateway/src/anthropic-compatibility.issue-17326.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+type Usage = {
+  input_tokens: number;
+  output_tokens: number;
+};
+
+function readStreamFixture(filename: string): {
+  startUsage: Usage;
+  finalUsage: Usage;
+} {
+  const body = fs.readFileSync(`src/__fixtures__/${filename}`, 'utf8');
+  const events = body
+    .split('\n')
+    .filter(line => line.startsWith('data: '))
+    .map(line => JSON.parse(line.slice('data: '.length)));
+
+  const messageStart = events.find(event => event.type === 'message_start');
+  const messageDelta = events.find(event => event.type === 'message_delta');
+
+  return {
+    startUsage: messageStart.message.usage,
+    finalUsage: messageDelta.usage,
+  };
+}
+
+describe('AI Gateway Anthropic compatibility issue #17326', () => {
+  it.each([
+    'issue-17326-anthropic-claude-haiku-4.5.chunks.txt',
+    'issue-17326-xai-grok-4.5.chunks.txt',
+  ])('reports usable input tokens in message_start for %s', filename => {
+    const { startUsage, finalUsage } = readStreamFixture(filename);
+
+    expect(finalUsage.input_tokens).toBeGreaterThan(0);
+    expect(startUsage.input_tokens).toBeGreaterThan(0);
+  });
+
+  it('does not proxy a non-Anthropic model to Anthropic count_tokens', () => {
+    const fixture = JSON.parse(
+      fs.readFileSync(
+        'src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.json',
+        'utf8',
+      ),
+    );
+
+    expect(fixture.status).not.toBe(404);
+    expect(fixture.body.error?.type).not.toBe('not_found_error');
+  });
+});


### PR DESCRIPTION
## Bug

[AI Gateway] Anthropic Messages streaming: `message_start` always reports `usage: 0/0`, breaking Claude Code per-message cost/usage tracking

## Reproduction

- Live AI Gateway requests reproduced zeroed `message_start` usage for both reported models: `anthropic/claude-haiku-4.5` returned `0/0` before terminal usage `13/5`, and `xai/grok-4.5` returned `0/0` before terminal usage `84/30`; clients snapshotting the initial event therefore record zero instead of usable per-message token accounting.
- The live `xai/grok-4.5` `/v1/messages/count_tokens` request reproduced HTTP 404 with Anthropic `not_found_error`, rather than handling the non-Anthropic model through the resolved provider or a defined compatibility response.
- `examples/ai-functions/src/reproduction/issue-17326-ai-gateway-anthropic-usage.ts` reproduces both streaming failures and the token-counting failure against the live Gateway.
- Live responses were recorded in `packages/gateway/src/__fixtures__/issue-17326-anthropic-claude-haiku-4.5.chunks.txt`, `packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5.chunks.txt`, and `packages/gateway/src/__fixtures__/issue-17326-xai-grok-4.5-count-tokens.json`.
- `packages/gateway/src/anthropic-compatibility.issue-17326.test.ts` asserts positive initial usage and non-Anthropic token-count handling against the recorded responses.

## Relevant Documentation

- https://vercel.com/docs/ai-gateway/coding-agents/claude-code
- https://vercel.com/docs/ai-gateway/sdks-and-apis
- https://platform.claude.com/docs/en/build-with-claude/streaming
- https://platform.claude.com/docs/en/api/messages/count_tokens

## Related Issues

Reproduces #17326