### PR TITLE
docs: fix example link on human-in-the-loop docs

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -348,6 +348,6 @@ const result = streamText({
 
 ## Full Example
 
-To see this code in action, check out the [`next-openai` example](https://github.com/vercel/ai/tree/main/examples/next-openai) in the AI SDK repository. Navigate to the `/test-tool-approval` page and associated route handler.
+To see tool approval in action, check out the [`/chat/tool-approval` page](https://github.com/vercel/ai/blob/main/examples/ai-e2e-next/app/chat/tool-approval/page.tsx) and its [route handler](https://github.com/vercel/ai/blob/main/examples/ai-e2e-next/app/api/chat/tool-approval/route.ts) in the `ai-e2e-next` example.
 
 For more details on tool execution approval, see the [Tool Execution Approval](/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval) and [Chatbot Tool Usage](/docs/ai-sdk-ui/chatbot-tool-usage#tool-execution-approval) documentation.


### PR DESCRIPTION
## Background

human-in-the-loop docs still pointed to `next-openai` example which doesn't exist anymore.

## Summary

updated docs to point to the right place in `ai-e2e-next`

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/14705

these PRs are also out of date:

Closes https://github.com/vercel/ai/pull/16638
Closes https://github.com/vercel/ai/pull/15578
Closes https://github.com/vercel/ai/pull/14736
Closes https://github.com/vercel/ai/pull/15014