### PR TITLE
docs: fix outdated `parameters` instead of `inputSchema` in tool calling

### DIFF
--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -114,7 +114,7 @@ import { dataPartsSchema, metadataSchema } from '@util/schemas';
 const tools = {
   weather: tool({
     description: 'Get weather information',
-    parameters: z.object({
+    inputSchema: z.object({
       location: z.string(),
       units: z.enum(['celsius', 'fahrenheit']),
     }),

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -238,7 +238,7 @@ export async function POST(request) {
     tools: {
       displayWeather: {
         description: 'Display the weather for a location',
-        parameters: z.object({
+        inputSchema: z.object({
           latitude: z.number(),
           longitude: z.number(),
         }),

--- a/content/docs/07-reference/01-ai-sdk-core/32-validate-ui-messages.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/32-validate-ui-messages.mdx
@@ -55,7 +55,7 @@ const dataSchemas = {
 const tools = {
   weather: tool({
     description: 'Get weather info',
-    parameters: z.object({
+    inputSchema: z.object({
       location: z.string(),
     }),
     execute: async ({ location }) => `Weather in ${location}: sunny`,

--- a/content/docs/07-reference/01-ai-sdk-core/33-safe-validate-ui-messages.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/33-safe-validate-ui-messages.mdx
@@ -61,7 +61,7 @@ const dataSchemas = {
 const tools = {
   weather: tool({
     description: 'Get weather info',
-    parameters: z.object({
+    inputSchema: z.object({
       location: z.string(),
     }),
     execute: async ({ location }) => `Weather in ${location}: sunny`,

--- a/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
@@ -121,7 +121,7 @@ const result = await generateText({
     calculate: calculateTool,
     finalAnswer: {
       description: 'Provide the final answer to the user',
-      parameters: z.object({
+      inputSchema: z.object({
         answer: z.string(),
       }),
       execute: async ({ answer }) => answer,

--- a/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
@@ -237,7 +237,7 @@ import { z } from 'zod';
 
 const weatherTool = tool({
   description: 'Get the current weather',
-  parameters: z.object({
+  inputSchema: z.object({
     location: z.string().describe('The city and state'),
   }),
   execute: async ({ location }) => {

--- a/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
+++ b/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
@@ -25,7 +25,7 @@ You have two options for handling tool results:
 const tools = {
   weather: tool({
     description: 'Get the weather in a location',
-    parameters: z.object({
+    inputSchema: z.object({
       location: z
         .string()
         .describe('The city and state, e.g. "San Francisco, CA"'),

--- a/content/docs/09-troubleshooting/13-repeated-assistant-messages.mdx
+++ b/content/docs/09-troubleshooting/13-repeated-assistant-messages.mdx
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
     tools: {
       weather: {
         description: 'Get the weather for a location',
-        parameters: z.object({
+        inputSchema: z.object({
           location: z.string(),
         }),
         execute: async ({ location }) => {
@@ -54,7 +54,7 @@ export async function POST(req: Request) {
     tools: {
       weather: {
         description: 'Get the weather for a location',
-        parameters: z.object({
+        inputSchema: z.object({
           location: z.string(),
         }),
         execute: async ({ location }) => {

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -511,7 +511,7 @@ const { text } = await generateText({
   tools: {
     getWeather: tool({
       description: 'Get the current weather for a location',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The location to get weather for'),
       }),
       execute: async ({ location }) => {

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -150,7 +150,7 @@ const { text } = await generateText({
   tools: {
     weather: tool({
       description: 'Get the weather in a location',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The location to get the weather for'),
       }),
       execute: async ({ location }) => ({

--- a/content/providers/03-observability/braintrust.mdx
+++ b/content/providers/03-observability/braintrust.mdx
@@ -117,13 +117,13 @@ async function main() {
     tools: {
       listOrders: tool({
         description: 'list all orders',
-        parameters: z.object({ userId: z.string() }),
+        inputSchema: z.object({ userId: z.string() }),
         execute: async ({ userId }) =>
           `User ${userId} has the following orders: 1`,
       }),
       viewTrackingInformation: tool({
         description: 'view tracking information for a specific order',
-        parameters: z.object({ orderId: z.string() }),
+        inputSchema: z.object({ orderId: z.string() }),
         execute: async ({ orderId }) =>
           `Here is the tracking information for ${orderId}`,
       }),

--- a/content/providers/05-community-providers/01-custom-providers.mdx
+++ b/content/providers/05-community-providers/01-custom-providers.mdx
@@ -330,7 +330,7 @@ type LanguageModelV4FunctionTool = {
   type: 'function';
   name: string;
   description?: string;
-  parameters: JSONSchema7; // Full JSON Schema support
+  inputSchema: JSONSchema7; // Full JSON Schema support
 };
 ```
 

--- a/content/providers/05-community-providers/26-mcp-sampling.mdx
+++ b/content/providers/05-community-providers/26-mcp-sampling.mdx
@@ -365,7 +365,7 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
       tools: {
         getWeather: {
           description: 'Get the weather for a location',
-          parameters: z.object({
+          inputSchema: z.object({
             city: z.string().describe('The city name'),
           }),
           execute: async ({ city }) => {

--- a/content/providers/05-community-providers/27-mem0.mdx
+++ b/content/providers/05-community-providers/27-mem0.mdx
@@ -184,7 +184,7 @@ const result = await generateText({
   tools: {
     weather: tool({
       description: 'Get the weather in a location',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The location to get the weather for'),
       }),
       execute: async ({ location }) => ({

--- a/content/providers/05-community-providers/35-react-native-apple.mdx
+++ b/content/providers/05-community-providers/35-react-native-apple.mdx
@@ -122,7 +122,7 @@ import { z } from 'zod';
 
 const getWeather = tool({
   description: 'Get current weather information',
-  parameters: z.object({
+  inputSchema: z.object({
     city: z.string().describe('The city name'),
   }),
   execute: async ({ city }) => {

--- a/content/providers/05-community-providers/49-cencori.mdx
+++ b/content/providers/05-community-providers/49-cencori.mdx
@@ -120,7 +120,7 @@ const { text, toolCalls } = await generateText({
   tools: {
     getWeather: tool({
       description: 'Get the weather for a location',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The city and state'),
       }),
       execute: async ({ location }) => {

--- a/packages/alibaba/README.md
+++ b/packages/alibaba/README.md
@@ -94,7 +94,7 @@ const { text } = await generateText({
   tools: {
     weather: tool({
       description: 'Get the weather in a location',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The location to get the weather for'),
       }),
       execute: async ({ location }) => ({


### PR DESCRIPTION
## Background

ai sdk renamed `parameters` to `inputSchema` for tool definitions, but a number of docs were never updated

## Summary

updated docs to use `inputSchema`

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
