### PR TITLE
[v5.0] reproduction: could not reproduce @ai-sdk/amazon-bedrock: ARN model IDs containing / application inference

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ai-sdk/amazon-bedrock": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts
@@ -1,0 +1,129 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { APICallError } from '@ai-sdk/provider';
+import { generateText, streamText } from 'ai';
+
+const region = 'eu-west-1';
+const liveModelId =
+  'arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0';
+
+async function getRoutingResult(modelId: string) {
+  const baseUrl = `https://bedrock-runtime.${region}.amazonaws.com/model`;
+  const request = {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  };
+
+  const [encodedResponse, unencodedResponse] = await Promise.all([
+    fetch(`${baseUrl}/${encodeURIComponent(modelId)}/converse`, request),
+    fetch(`${baseUrl}/${modelId}/converse`, request),
+  ]);
+  const [encodedBody, unencodedBody] = await Promise.all([
+    encodedResponse.text(),
+    unencodedResponse.text(),
+  ]);
+
+  return {
+    encodedStatus: encodedResponse.status,
+    encodedBody,
+    unencodedStatus: unencodedResponse.status,
+    unencodedBody,
+  };
+}
+
+async function main() {
+  const [applicationProfileRouting, foundationModelRouting] = await Promise.all(
+    [
+      getRoutingResult(
+        'arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abcdefghijkl',
+      ),
+      getRoutingResult(
+        'arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-lite-v1:0',
+      ),
+    ],
+  );
+
+  const requestedUrls: string[] = [];
+  const bedrock = createAmazonBedrock({
+    region,
+    fetch: async (input, init) => {
+      requestedUrls.push(input.toString());
+      return fetch(input, init);
+    },
+  });
+
+  let generateError: unknown;
+  let generatedText = '';
+
+  try {
+    generatedText = (
+      await generateText({
+        model: bedrock(liveModelId),
+        prompt: 'Say hello',
+        maxOutputTokens: 10,
+      })
+    ).text;
+  } catch (error) {
+    generateError = error;
+  }
+
+  const streamResult = streamText({
+    model: bedrock(liveModelId),
+    prompt: 'Say hello',
+    maxOutputTokens: 10,
+  });
+  const [streamedText, streamFinishReason] = await Promise.all([
+    streamResult.text,
+    streamResult.finishReason,
+  ]);
+
+  const generateFailureObserved =
+    APICallError.isInstance(generateError) &&
+    generateError.message === 'Invalid JSON response' &&
+    generateError.statusCode === 200 &&
+    generateError.responseBody?.includes('UnknownOperationException') === true;
+  const streamFailureObserved =
+    streamedText === '' && streamFinishReason === 'other';
+
+  if (generateFailureObserved && streamFailureObserved) {
+    throw new Error(
+      'ISSUE_17523_REPRODUCED: generateText received HTTP 200 UnknownOperationException as Invalid JSON response; streamText returned empty text with finish reason other',
+    );
+  }
+
+  if (generateError != null) {
+    throw generateError;
+  }
+
+  if (generatedText === '' || streamedText === '') {
+    throw new Error(
+      'Bedrock ARN invocation completed without the reported error but returned empty assistant text',
+    );
+  }
+
+  if (
+    requestedUrls.length !== 2 ||
+    requestedUrls.some(url => !url.includes('%2F'))
+  ) {
+    throw new Error('SDK requests did not retain encoded ARN slashes');
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        applicationProfileRouting,
+        foundationModelRouting,
+        sdk: {
+          generatedText,
+          streamedText,
+          streamFinishReason,
+          requestedUrls,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main();

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse-stream.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse-stream.chunks.txt
@@ -1,0 +1,7 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"Hello"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"! How can I assist you"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" today? If"}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"stopReason":"max_tokens"}}
+{"metadata":{"metrics":{"latencyMs":317},"usage":{"inputTokens":2,"outputTokens":10,"totalTokens":12}}}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-converse.json
@@ -1,0 +1,21 @@
+{
+  "metrics": {
+    "latencyMs": 352
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "Hello! How can I assist you today? If"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "max_tokens",
+  "usage": {
+    "inputTokens": 2,
+    "outputTokens": 10,
+    "totalTokens": 12
+  }
+}

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.issue-17523.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.issue-17523.test.ts
@@ -1,0 +1,100 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+vi.mock('./bedrock-event-stream-response-handler', () => ({
+  createBedrockEventStreamResponseHandler:
+    () =>
+    async ({ response }: { response: Response }) => {
+      const chunks = (await response.text())
+        .split('\n')
+        .filter(Boolean)
+        .map(chunk => {
+          const value = JSON.parse(chunk);
+          return { success: true, value, rawValue: value };
+        });
+
+      return {
+        responseHeaders: Object.fromEntries(response.headers),
+        value: new ReadableStream({
+          start(controller) {
+            for (const chunk of chunks) {
+              controller.enqueue(chunk);
+            }
+            controller.close();
+          },
+        }),
+      };
+    },
+}));
+
+const prompt: LanguageModelV2Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Say hello' }] },
+];
+const baseUrl = 'https://bedrock-runtime.eu-west-1.amazonaws.com';
+const modelId =
+  'arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0';
+const encodedModelId = encodeURIComponent(modelId);
+
+describe('issue #17523', () => {
+  it('generates and streams text with ARN slashes encoded', async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith('/converse')) {
+        return new Response(
+          fs.readFileSync('src/__fixtures__/issue-17523-converse.json', 'utf8'),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      }
+
+      return new Response(
+        fs.readFileSync(
+          'src/__fixtures__/issue-17523-converse-stream.chunks.txt',
+          'utf8',
+        ),
+      );
+    });
+    const model = new BedrockChatLanguageModel(modelId, {
+      baseUrl: () => baseUrl,
+      headers: {},
+      fetch,
+      generateId: () => 'test-id',
+    });
+
+    const generated = await model.doGenerate({ prompt });
+    const streamed = await model.doStream({
+      prompt,
+      includeRawChunks: false,
+    });
+    const streamParts = await convertReadableStreamToArray(streamed.stream);
+
+    expect(generated.content).toContainEqual({
+      type: 'text',
+      text: 'Hello! How can I assist you today? If',
+    });
+    expect(streamParts).toContainEqual({
+      type: 'text-delta',
+      id: '0',
+      delta: 'Hello',
+    });
+    expect(streamParts).toContainEqual(
+      expect.objectContaining({
+        type: 'finish',
+        finishReason: 'length',
+      }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      `${baseUrl}/model/${encodedModelId}/converse`,
+      expect.any(Object),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      `${baseUrl}/model/${encodedModelId}/converse-stream`,
+      expect.any(Object),
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/amazon-bedrock':
+        specifier: workspace:*
+        version: link:../../packages/amazon-bedrock
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../../packages/provider
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19630,7 +19652,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19644,13 +19666,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19658,22 +19680,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19683,7 +19705,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19713,7 +19735,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24963,7 +24985,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -27396,7 +27418,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -29439,7 +29461,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30208,7 +30230,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30305,7 +30327,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33789,7 +33811,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33817,7 +33839,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34896,7 +34918,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36436,7 +36458,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -36840,7 +36862,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:
@@ -37393,7 +37415,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37830,7 +37852,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -38497,6 +38519,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -38699,7 +38730,7 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   ts-node@10.9.2(@types/node@20.17.24)(typescript@5.4.5):
     dependencies:
@@ -40029,12 +40060,44 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: ARN model IDs containing `/` (application inference profiles, foundation-model ARNs) break the Converse API since 4.0.137 (regression from #17410)

## Reproduction

- The live reproduction at `examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts` could not reproduce the primary failure: `generateText` and `streamText` both returned assistant text, with streaming finishing as `length` rather than empty text with finish reason `other`.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.ts` on `release-v5.0` uses plain `encodeURIComponent(modelId)`, and both observed SDK requests retained `%2F`; the reported slash-decoding regression is not present in this target branch's `@ai-sdk/amazon-bedrock@3.0.107` source.
- Unsigned live checks confirmed the secondary routing premise for both application-inference-profile and foundation-model ARNs: encoded slashes reached authentication with HTTP 403, while literal slashes returned HTTP 200 `UnknownOperationException`.
- Live response artifacts were recorded in `packages/amazon-bedrock/src/__fixtures__/issue-17523-converse.json` and `packages/amazon-bedrock/src/__fixtures__/issue-17523-converse-stream.chunks.txt`.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.issue-17523.test.ts` verifies successful generation, streaming, and percent-encoded ARN request URLs using the recorded fixtures; `examples/ai-functions/package.json` and `pnpm-lock.yaml` provide the runnable reproduction workspace.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html

## Related Issues

Could not reproduce #17523