### PR TITLE
[v6.0] reproduction: @ai-sdk/amazon-bedrock: ARN model IDs containing / application inference

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17523,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17523-bedrock-arn-model-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17523_REPRODUCED: generateText returned \"Invalid JSON response\"; streamText returned empty text with finish reason \"other\"."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts
@@ -1,0 +1,53 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, streamText } from 'ai';
+
+const modelId =
+  'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0';
+
+async function main() {
+  const bedrock = createAmazonBedrock({ region: 'us-east-1' });
+  const model = bedrock(modelId);
+
+  let generateFailure: string | undefined;
+
+  try {
+    await generateText({
+      model,
+      prompt: 'Reply with hello.',
+    });
+  } catch (error) {
+    generateFailure = error instanceof Error ? error.message : String(error);
+  }
+
+  const streamResult = streamText({
+    model,
+    prompt: 'Reply with hello.',
+  });
+  const streamedText = await streamResult.text;
+  const streamFinishReason = await streamResult.finishReason;
+
+  if (
+    generateFailure === 'Invalid JSON response' &&
+    streamedText === '' &&
+    streamFinishReason === 'other'
+  ) {
+    console.error(
+      'ISSUE_17523_REPRODUCED: generateText returned "Invalid JSON response"; streamText returned empty text with finish reason "other".',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    JSON.stringify({
+      generateFailure,
+      streamedText,
+      streamFinishReason,
+    }),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-foundation-model-arn.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-foundation-model-arn.chunks.txt
@@ -1,0 +1,36 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"Sorry"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":", I"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" can't respond in a"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" way that might seem"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" impersonal"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" or"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" incomplete"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":". If you have any questions"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" or need assistance,"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" feel free to ask"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":", and I'll be"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" happy to help. However"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":", I"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" can"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"'t respond"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" with"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" just"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" \""}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"hello\" as"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" it might"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" not provide"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" the"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" necessary context"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" or information"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":". If"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" you have a"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" specific request"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" or question"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":", please"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" let me know,"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" and I'll do my"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" best to assist you."}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"stopReason":"end_turn"}}
+{"metadata":{"metrics":{"latencyMs":824},"usage":{"inputTokens":5,"outputTokens":89,"serverToolUsage":{},"totalTokens":94}}}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-foundation-model-arn.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-foundation-model-arn.json
@@ -1,0 +1,22 @@
+{
+  "metrics": {
+    "latencyMs": 532
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "Sorry, I can't respond in a way that might seem like I'm ignoring your instructions. However, I'm here to help you with any questions or concerns you may have. Just let me know how I can assist you!"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 5,
+    "outputTokens": 50,
+    "serverToolUsage": {},
+    "totalTokens": 55
+  }
+}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.chunks.txt
@@ -1,0 +1,1 @@
+{"Output":{"__type":"com.amazon.coral.service#UnknownOperationException"},"Version":"1.0"}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.json
@@ -1,0 +1,6 @@
+{
+  "Output": {
+    "__type": "com.amazon.coral.service#UnknownOperationException"
+  },
+  "Version": "1.0"
+}

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -198,6 +198,61 @@ const opusAnthropicModel = new BedrockChatLanguageModel(opusAnthropicModelId, {
 
 let mockOptions: { success: boolean; errorValue?: any } = { success: true };
 
+const foundationModelArn =
+  'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0';
+const encodedFoundationModelArn = encodeURIComponent(foundationModelArn);
+const malformedFoundationModelArn = encodedFoundationModelArn
+  .replace(/%3A/g, ':')
+  .replace(/%2F/g, '/');
+
+function createFoundationModelArnFetch({
+  operation,
+}: {
+  operation: 'converse' | 'converse-stream';
+}) {
+  const successfulFixture =
+    operation === 'converse'
+      ? 'issue-17523-foundation-model-arn.json'
+      : 'issue-17523-foundation-model-arn.chunks.txt';
+  const unknownOperationFixture =
+    operation === 'converse'
+      ? 'issue-17523-unknown-operation.json'
+      : 'issue-17523-unknown-operation.chunks.txt';
+
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const encodedUrl = `${baseUrl}/model/${encodedFoundationModelArn}/${operation}`;
+    const malformedUrl = `${baseUrl}/model/${malformedFoundationModelArn}/${operation}`;
+
+    if (url !== encodedUrl && url !== malformedUrl) {
+      throw new Error(`Unexpected URL: ${url}`);
+    }
+
+    return new Response(
+      fs.readFileSync(
+        `src/__fixtures__/${
+          url === encodedUrl ? successfulFixture : unknownOperationFixture
+        }`,
+        'utf8',
+      ),
+      {
+        status: 200,
+        headers: {
+          'content-type':
+            operation === 'converse'
+              ? 'application/json'
+              : 'application/vnd.amazon.eventstream',
+        },
+      },
+    );
+  });
+}
+
 describe('doGenerate request metadata', () => {
   it('should return the request body', async () => {
     prepareJsonFixtureResponse('bedrock-text');
@@ -233,47 +288,27 @@ describe('doGenerate request metadata', () => {
 });
 
 describe('request URL', () => {
-  it('should preserve application inference profile ARN delimiters', async () => {
-    const inferenceProfileArn =
-      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
-    const fetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          output: {
-            message: {
-              role: 'assistant',
-              content: [{ text: 'hello' }],
-            },
-          },
-          stopReason: 'end_turn',
-          usage: {
-            inputTokens: 1,
-            outputTokens: 1,
-            totalTokens: 2,
-          },
-        }),
-        {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        },
-      );
+  it('should generate text with a foundation model ARN', async () => {
+    const fetch = createFoundationModelArnFetch({ operation: 'converse' });
+    const foundationModel = new BedrockChatLanguageModel(foundationModelArn, {
+      baseUrl: () => baseUrl,
+      headers: {},
+      fetch,
+      generateId: () => 'test-id',
     });
-    const inferenceProfileModel = new BedrockChatLanguageModel(
-      inferenceProfileArn,
-      {
-        baseUrl: () => baseUrl,
-        headers: {},
-        fetch,
-        generateId: () => 'test-id',
-      },
-    );
 
-    await inferenceProfileModel.doGenerate({
+    const result = await foundationModel.doGenerate({
       prompt: TEST_PROMPT,
     });
 
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringMatching(/\S/),
+      }),
+    ]);
     expect(fetch).toHaveBeenCalledWith(
-      `${baseUrl}/model/${inferenceProfileArn}/converse`,
+      `${baseUrl}/model/${encodedFoundationModelArn}/converse`,
       expect.any(Object),
     );
   });
@@ -329,6 +364,41 @@ describe('doStream', () => {
   ) {
     mockOptions = { ...mockOptions, ...options };
   }
+
+  it('should stream text with a foundation model ARN', async () => {
+    const fetch = createFoundationModelArnFetch({
+      operation: 'converse-stream',
+    });
+    const foundationModel = new BedrockChatLanguageModel(foundationModelArn, {
+      baseUrl: () => baseUrl,
+      headers: {},
+      fetch,
+      generateId: () => 'test-id',
+    });
+
+    const { stream } = await foundationModel.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+    const chunks = await convertReadableStreamToArray(stream);
+    const text = chunks
+      .filter(chunk => chunk.type === 'text-delta')
+      .map(chunk => chunk.delta)
+      .join('');
+    const finish = chunks.find(chunk => chunk.type === 'finish');
+
+    expect(text).toMatch(/\S/);
+    expect(finish).toMatchObject({
+      finishReason: {
+        unified: 'stop',
+        raw: 'end_turn',
+      },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/model/${encodedFoundationModelArn}/converse-stream`,
+      expect.any(Object),
+    );
+  });
 
   describe('text', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: ARN model IDs containing `/` (application inference profiles, foundation-model ARNs) break the Converse API since 4.0.137 (regression from #17410)

## Reproduction

- `examples/ai-functions/src/reproduction/issue-17523-bedrock-arn-model-id.ts` called a valid Nova Lite foundation-model ARN: expected assistant text, but `generateText` returned `Invalid JSON response` and `streamText` returned empty text with finish reason `other`.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts` uses recorded live responses from `packages/amazon-bedrock/src/__fixtures__/issue-17523-foundation-model-arn.json`, `packages/amazon-bedrock/src/__fixtures__/issue-17523-foundation-model-arn.chunks.txt`, `packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.json`, and `packages/amazon-bedrock/src/__fixtures__/issue-17523-unknown-operation.chunks.txt`; both generate and stream assertions fail because the ARN is routed with a literal `/` instead of `%2F`.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.ts` in `@ai-sdk/amazon-bedrock@4.0.137` explicitly replaces `%2F` with `/` for ARN model IDs; fully encoded signed requests generated and streamed assistant text successfully.
- No application inference profile existed in the available AWS account, so direct successful application-profile inference could not be compared; live routing checks still returned HTTP 403 at the authentication layer with `%2F`, versus HTTP 200 `UnknownOperationException` with a literal `/`.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListInferenceProfiles.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateInferenceProfile.html

## Related Issues

Reproduces #17523