### PR TITLE
[v6.0] fix: Amazon Bedrock Converse requests fail for ARN model IDs containing slashes

### DIFF
--- a/.changeset/strong-cats-smile.md
+++ b/.changeset/strong-cats-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): encode slashes in ARN model IDs for Converse requests

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -275,21 +275,13 @@ describe('request URL', () => {
             totalTokens: 2,
           },
         },
-<<<<<<< HEAD:packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
-      );
-    });
-    const inferenceProfileModel = new BedrockChatLanguageModel(
-      inferenceProfileArn,
-      {
-=======
       },
     ]
       .map(chunk => JSON.stringify(chunk))
       .join('\n');
 
     function createInferenceProfileModel() {
-      return new AmazonBedrockChatLanguageModel(inferenceProfileArn, {
->>>>>>> ce56626a76 (fix: Amazon Bedrock Converse requests fail for ARN model IDs containing slashes (#17525)):packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+      return new BedrockChatLanguageModel(inferenceProfileArn, {
         baseUrl: () => baseUrl,
         headers: {},
         fetch: async input => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -233,49 +233,164 @@ describe('doGenerate request metadata', () => {
 });
 
 describe('request URL', () => {
-  it('should preserve application inference profile ARN delimiters', async () => {
+  describe('ARN model IDs containing a slash', () => {
     const inferenceProfileArn =
-      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
-    const fetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          output: {
-            message: {
-              role: 'assistant',
-              content: [{ text: 'hello' }],
-            },
-          },
-          stopReason: 'end_turn',
+      'arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0';
+    const encodedInferenceProfileArn = encodeURIComponent(inferenceProfileArn);
+    const unknownOperationResponse = JSON.stringify({
+      Output: {
+        __type: 'com.amazon.coral.service#UnknownOperationException',
+      },
+      Version: '1.0',
+    });
+    const converseResponse = JSON.stringify({
+      output: {
+        message: {
+          role: 'assistant',
+          content: [{ text: 'Hello!' }],
+        },
+      },
+      stopReason: 'end_turn',
+      usage: {
+        inputTokens: 1,
+        outputTokens: 1,
+        totalTokens: 2,
+      },
+    });
+    const converseStreamResponse = [
+      { messageStart: { role: 'assistant' } },
+      {
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { text: 'Hello!' },
+        },
+      },
+      { contentBlockStop: { contentBlockIndex: 0 } },
+      { messageStop: { stopReason: 'end_turn' } },
+      {
+        metadata: {
           usage: {
             inputTokens: 1,
             outputTokens: 1,
             totalTokens: 2,
           },
-        }),
-        {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
         },
+<<<<<<< HEAD:packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
       );
     });
     const inferenceProfileModel = new BedrockChatLanguageModel(
       inferenceProfileArn,
       {
+=======
+      },
+    ]
+      .map(chunk => JSON.stringify(chunk))
+      .join('\n');
+
+    function createInferenceProfileModel() {
+      return new AmazonBedrockChatLanguageModel(inferenceProfileArn, {
+>>>>>>> ce56626a76 (fix: Amazon Bedrock Converse requests fail for ARN model IDs containing slashes (#17525)):packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
         baseUrl: () => baseUrl,
         headers: {},
-        fetch,
-        generateId: () => 'test-id',
-      },
-    );
+        fetch: async input => {
+          const url = input.toString();
+          const isEncodedRoute = url.includes(encodedInferenceProfileArn);
 
-    await inferenceProfileModel.doGenerate({
-      prompt: TEST_PROMPT,
+          return new Response(
+            isEncodedRoute
+              ? url.endsWith('/converse-stream')
+                ? converseStreamResponse
+                : converseResponse
+              : unknownOperationResponse,
+            {
+              status: 200,
+              headers: {
+                'content-type':
+                  isEncodedRoute && url.endsWith('/converse-stream')
+                    ? 'application/vnd.amazon.eventstream'
+                    : 'application/json',
+              },
+            },
+          );
+        },
+        generateId: () => 'test-id',
+      });
+    }
+
+    it('should generate text through the encoded Converse route', async () => {
+      const result = await createInferenceProfileModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "text": "Hello!",
+            "type": "text",
+          },
+        ]
+      `);
     });
 
-    expect(fetch).toHaveBeenCalledWith(
-      `${baseUrl}/model/${inferenceProfileArn}/converse`,
-      expect.any(Object),
-    );
+    it('should stream text through the encoded Converse route', async () => {
+      const { stream } = await createInferenceProfileModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": undefined,
+            "modelId": "arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0",
+            "timestamp": undefined,
+            "type": "response-metadata",
+          },
+          {
+            "id": "0",
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello!",
+            "id": "0",
+            "type": "text-delta",
+          },
+          {
+            "id": "0",
+            "type": "text-end",
+          },
+          {
+            "finishReason": {
+              "raw": "end_turn",
+              "unified": "stop",
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": {
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "noCache": 1,
+                "total": 1,
+              },
+              "outputTokens": {
+                "reasoning": undefined,
+                "text": 1,
+                "total": 1,
+              },
+              "raw": {
+                "inputTokens": 1,
+                "outputTokens": 1,
+                "totalTokens": 2,
+              },
+            },
+          },
+        ]
+      `);
+    });
   });
 });
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -1041,10 +1041,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = modelId.startsWith('arn:')
-      ? encodeURIComponent(modelId).replace(/%3A/g, ':').replace(/%2F/g, '/')
-      : encodeURIComponent(modelId);
-    return `${this.config.baseUrl()}/model/${encodedModelId}`;
+    return `${this.config.baseUrl()}/model/${encodeURIComponent(modelId)}`;
   }
 }
 


### PR DESCRIPTION
## Background

Amazon Bedrock Converse generation failed and streaming returned empty text when ARN model IDs contained `/`.

## Root Cause

The chat model URL builder decoded `%2F` in ARN model IDs, splitting the model ID across URL path segments and causing Bedrock to return an UnknownOperationException; route-sensitive regression tests confirmed the malformed path.

## Summary

Restored full percent-encoding of model IDs when constructing Amazon Bedrock Converse and ConverseStream URLs.

## Testing

Updated the existing chat language model tests with route-sensitive generate and stream coverage using inline snapshots, and added a patch changeset.

## End-to-end Validation

- `pnpm -C packages/amazon-bedrock build && pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17523-bedrock-arn-model-id.ts` — live Bedrock generation and streaming succeeded with the inference-profile ARN, returning assistant text and finish reason `length`.

## Related Issues

Fixes #17523

Closes #17524

Backport of #17525

Co-authored-by: PaulBanusIAD <120463976+PaulBanusIAD@users.noreply.github.com>