### PR TITLE
reproduction: @ai-sdk/amazon-bedrock: native structured output forwards unsupported maxItems

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17197,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17197-bedrock-max-items.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "For 'array' type, property 'maxItems' is not supported"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts
+++ b/examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts
@@ -1,0 +1,92 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { APICallError, generateText, Output } from 'ai';
+import { z } from 'zod';
+
+const modelId = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const providerErrorSignal =
+  "For 'array' type, property 'maxItems' is not supported";
+
+async function main() {
+  let requestBody: unknown;
+
+  const amazonBedrock = createAmazonBedrock({
+    region: 'us-east-1',
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBody = JSON.parse(init.body);
+      }
+      return fetch(input, init);
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model: amazonBedrock(modelId),
+      output: Output.object({
+        schema: z.object({
+          labels: z
+            .array(
+              z.object({
+                label: z.string(),
+                explanation: z.string(),
+              }),
+            )
+            .max(3),
+        }),
+      }),
+      prompt:
+        'Return three short labels for the seasons, each with a one-sentence explanation.',
+      maxOutputTokens: 256,
+      maxRetries: 0,
+    });
+
+    console.log(
+      JSON.stringify(
+        {
+          modelId,
+          expected:
+            'Bedrock accepts the structured-output request while AI SDK retains local max(3) validation.',
+          output: result.output,
+          requestBody: result.request.body,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    const details = APICallError.isInstance(error)
+      ? {
+          name: error.name,
+          message: error.message,
+          statusCode: error.statusCode,
+          responseBody: error.responseBody,
+          requestBody,
+        }
+      : {
+          name: error instanceof Error ? error.name : typeof error,
+          message: error instanceof Error ? error.message : String(error),
+          requestBody,
+        };
+
+    console.error(JSON.stringify(details, null, 2));
+
+    if (
+      APICallError.isInstance(error) &&
+      error.statusCode === 400 &&
+      `${error.message}\n${error.responseBody ?? ''}`.includes(
+        providerErrorSignal,
+      )
+    ) {
+      throw new Error(
+        `Reproduced issue #17197: Bedrock rejected Output.object() because output_config.format.schema contains unsupported maxItems.`,
+      );
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17197-max-items-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17197-max-items-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "The model returned the following errors: output_config.format.schema: For 'array' type, property 'maxItems' is not supported"
+}

--- a/packages/amazon-bedrock/src/issue-17197.test.ts
+++ b/packages/amazon-bedrock/src/issue-17197.test.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
+
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const modelId = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const liveErrorFixture = JSON.parse(
+  fs.readFileSync('src/__fixtures__/issue-17197-max-items-error.json', 'utf8'),
+);
+
+describe('issue #17197', () => {
+  it('does not send maxItems to Bedrock native structured output', async () => {
+    const model = new AmazonBedrockChatLanguageModel(modelId, {
+      baseUrl: () => baseUrl,
+      headers: {},
+      generateId: () => 'test-id',
+      fetch: async (_input, init) => {
+        const requestBody = JSON.parse(String(init?.body));
+        const schema =
+          requestBody.additionalModelRequestFields?.output_config?.format
+            ?.schema;
+
+        if (JSON.stringify(schema).includes('"maxItems"')) {
+          return new Response(JSON.stringify(liveErrorFixture), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        return new Response(
+          JSON.stringify({
+            output: {
+              message: {
+                role: 'assistant',
+                content: [
+                  {
+                    text: JSON.stringify({
+                      labels: [
+                        { label: 'Spring', explanation: 'A mild season.' },
+                        { label: 'Summer', explanation: 'A warm season.' },
+                        { label: 'Autumn', explanation: 'A cool season.' },
+                      ],
+                    }),
+                  },
+                ],
+              },
+            },
+            stopReason: 'end_turn',
+            usage: {
+              inputTokens: 10,
+              outputTokens: 20,
+              totalTokens: 30,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      },
+    });
+
+    await expect(
+      model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Generate three labels.' }],
+          },
+        ],
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              labels: {
+                type: 'array',
+                maxItems: 3,
+                items: {
+                  type: 'object',
+                  properties: {
+                    label: { type: 'string' },
+                    explanation: { type: 'string' },
+                  },
+                  required: ['label', 'explanation'],
+                  additionalProperties: false,
+                },
+              },
+            },
+            required: ['labels'],
+            additionalProperties: false,
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      content: [{ type: 'text' }],
+    });
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: native structured output forwards unsupported maxItems

## Reproduction

- Live `Output.object()` generation with `us.anthropic.claude-sonnet-4-5-20250929-v1:0` failed with HTTP 400 because Bedrock rejected `maxItems` in `output_config.format.schema`, so no structured object was generated.
- The captured request confirms `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts` forwards the Zod-derived `maxItems: 3` constraint without Bedrock-specific normalization; expected behavior is to omit the unsupported provider constraint while retaining local output validation.
- The bug persists on main with `ai@7.0.32` and `@ai-sdk/amazon-bedrock@5.0.25`, so upgrading from the reported versions does not resolve it.
- `examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts` contains the runnable live-provider reproduction and produced the reported Bedrock rejection.
- `packages/amazon-bedrock/src/__fixtures__/issue-17197-max-items-error.json` records the live Bedrock error response, and `packages/amazon-bedrock/src/issue-17197.test.ts` is a provider regression test that fails when the unsupported keyword is forwarded.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
- https://platform.claude.com/docs/en/build-with-claude/structured-outputs

## Related Issues

Reproduces #17197