### PR TITLE
[v6.0] reproduction: @ai-sdk/amazon-bedrock: native structured output forwards unsupported maxItems

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17197,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17197-bedrock-max-items.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "output_config.format.schema: For 'array' type, property 'maxItems' is not supported"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts
+++ b/examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts
@@ -1,0 +1,45 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const bedrock = createAmazonBedrock({ region: 'us-east-1' });
+
+  try {
+    const result = await generateText({
+      model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      output: Output.object({
+        schema: z.object({
+          labels: z
+            .array(
+              z.object({
+                label: z.string(),
+                explanation: z.string(),
+              }),
+            )
+            .max(3),
+        }),
+      }),
+      prompt: 'Generate two concise labels for a customer support request.',
+    });
+
+    console.log(JSON.stringify(result.output));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      message.includes(
+        "output_config.format.schema: For 'array' type, property 'maxItems' is not supported",
+      )
+    ) {
+      console.error(
+        'ISSUE_17197_REPRODUCED: Bedrock rejected Output.object() because maxItems is unsupported',
+      );
+    }
+
+    throw error;
+  }
+}
+
+main();

--- a/packages/amazon-bedrock/src/__fixtures__/issue-17197-max-items-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-17197-max-items-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "The model returned the following errors: output_config.format.schema: For 'array' type, property 'maxItems' is not supported"
+}

--- a/packages/amazon-bedrock/src/issue-17197.test.ts
+++ b/packages/amazon-bedrock/src/issue-17197.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+const errorFixture = JSON.parse(
+  fs.readFileSync('src/__fixtures__/issue-17197-max-items-error.json', 'utf8'),
+);
+
+describe('issue #17197', () => {
+  it('generates structured output when the local schema contains maxItems', async () => {
+    const model = new BedrockChatLanguageModel(
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: {},
+        generateId: () => 'test-id',
+        fetch: async (_input, init) => {
+          const requestBody = JSON.parse(String(init?.body));
+          const labelsSchema =
+            requestBody.additionalModelRequestFields.output_config.format.schema
+              .properties.labels;
+
+          if (labelsSchema.maxItems != null) {
+            return new Response(JSON.stringify(errorFixture), {
+              status: 400,
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+
+          return Response.json({
+            metrics: { latencyMs: 1 },
+            output: {
+              message: {
+                content: [
+                  {
+                    text: JSON.stringify({
+                      labels: [
+                        {
+                          label: 'billing',
+                          explanation: 'The request concerns an invoice.',
+                        },
+                      ],
+                    }),
+                  },
+                ],
+                role: 'assistant',
+              },
+            },
+            stopReason: 'end_turn',
+            usage: {
+              inputTokens: 10,
+              outputTokens: 10,
+              totalTokens: 20,
+            },
+          });
+        },
+      },
+    );
+
+    await expect(
+      model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Generate a support label.' }],
+          },
+        ],
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    label: { type: 'string' },
+                    explanation: { type: 'string' },
+                  },
+                  required: ['label', 'explanation'],
+                  additionalProperties: false,
+                },
+                maxItems: 3,
+              },
+            },
+            required: ['labels'],
+            additionalProperties: false,
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: expect.stringContaining('"labels"'),
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock: native structured output forwards unsupported maxItems

## Reproduction

- Live `Output.object()` generation on `release-v6.0` with `ai@6.0.231`, `@ai-sdk/amazon-bedrock@4.0.137`, and `us.anthropic.claude-sonnet-4-5-20250929-v1:0` failed with HTTP 400, so no structured object was generated.
- The request forwarded the Zod-derived `maxItems: 3` constraint under `output_config.format.schema`, which Bedrock rejected as unsupported.
- Expected behavior is to omit unsupported constraints from the provider schema while retaining the original `.max(3)` constraint for local `Output.object()` validation.
- `@ai-sdk/amazon-bedrock@4.0.124` used the JSON tool fallback without thinking, while the `4.0.135` backport enabled native structured output for Claude Sonnet 4.5; the current target branch therefore reproduces the regression.
- `examples/ai-functions/src/reproduction/issue-17197-bedrock-max-items.ts` contains the runnable live-provider reproduction.
- `packages/amazon-bedrock/src/__fixtures__/issue-17197-max-items-error.json` records the live Bedrock error, and `packages/amazon-bedrock/src/issue-17197.test.ts` reproduces the provider failure using that response.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
- https://platform.claude.com/docs/en/build-with-claude/structured-outputs

## Related Issues

Reproduces #17197