### PR TITLE
feat(tools-registry): add unirate

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -584,4 +584,34 @@ console.log(result.text);`,
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },
+  {
+    slug: 'unirate',
+    name: 'UniRate',
+    description:
+      'Currency exchange, conversion, currency listing, and VAT-rate tools backed by the UniRate API (593+ fiat, crypto, and commodity instruments, with a free tier). Lets a model fetch live exchange rates, convert amounts between currencies, list supported currencies, and look up country VAT rates.',
+    packageName: '@unirate/ai-sdk',
+    tags: ['currency', 'exchange-rates', 'forex', 'vat', 'fintech'],
+    apiKeyEnvName: 'UNIRATE_API_KEY',
+    installCommand: {
+      pnpm: 'pnpm add @unirate/ai-sdk',
+      npm: 'npm install @unirate/ai-sdk',
+      yarn: 'yarn add @unirate/ai-sdk',
+      bun: 'bun add @unirate/ai-sdk',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { createUniRateTools } from '@unirate/ai-sdk';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5-mini',
+  prompt: "Convert 250 USD to JPY, then tell me Germany's VAT rate.",
+  tools: createUniRateTools({ apiKey: process.env.UNIRATE_API_KEY }),
+  stopWhen: isStepCount(5),
+});
+
+console.log(text);`,
+    docsUrl: 'https://github.com/UniRate-API/ai-sdk-unirate#readme',
+    apiKeyUrl: 'https://unirateapi.com',
+    websiteUrl: 'https://unirateapi.com',
+    npmUrl: 'https://www.npmjs.com/package/@unirate/ai-sdk',
+  },
 ];


### PR DESCRIPTION
Adds **UniRate** to the AI SDK tools registry.

`@unirate/ai-sdk` provides ready-made `tool()` definitions for currency exchange, conversion, currency listing, and VAT-rate lookup, backed by the [UniRate API](https://unirateapi.com) (593+ fiat, crypto, and commodity instruments, with a free tier).

### Prerequisites (per the contributing guide)
- **Published to npm:** [`@unirate/ai-sdk`](https://www.npmjs.com/package/@unirate/ai-sdk) (v0.1.0, published with provenance)
- **Documented:** usage instructions in the [README](https://github.com/UniRate-API/ai-sdk-unirate#readme)
- **Tested with the AI SDK:** 60 unit tests; `ai` + `zod` are peer deps (compatible with AI SDK **v4 and v5**), zero runtime deps

### Tools provided
| Tool | Description |
|---|---|
| `unirate_exchange` | Convert an amount from one currency to another at the current rate |
| `unirate_rate` | Current rate for a pair, or all rates from a base currency |
| `unirate_currencies` | List every supported currency code |
| `unirate_vat` | VAT rate for a country (ISO-3166 alpha-2), or all countries |

`createUniRateTools({ apiKey })` returns the full record to pass straight to `generateText` / `streamText`; individual factories (`createExchangeTool`, etc.) are exported for subsets.

Only `content/tools-registry/registry.ts` is touched. The `codeExample` follows the current registry pattern (`isStepCount` + string model id).
