### PR TITLE
reproduction: Dependency Vulnerability: CVE-2026-59873 affects tar@7.5.15 in vercel/ai/package.json

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17556,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17556-tar-cve.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "CVE-2026-59873 reproduced: pnpm-lock.yaml resolves vulnerable tar@7.5.15 (<7.5.19)."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts
+++ b/examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+async function main() {
+  const lockfilePath = resolve(process.cwd(), '../../pnpm-lock.yaml');
+  const lockfile = await readFile(lockfilePath, 'utf8');
+
+  if (!lockfile.includes('\n  tar@7.5.15:\n')) {
+    console.log(
+      'CVE-2026-59873 not reproduced: pnpm-lock.yaml does not resolve tar@7.5.15.',
+    );
+    return;
+  }
+
+  console.error(
+    'CVE-2026-59873 reproduced: pnpm-lock.yaml resolves vulnerable tar@7.5.15 (<7.5.19).',
+  );
+  process.exitCode = 1;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Dependency Vulnerability: CVE-2026-59873 affects tar@7.5.15 in vercel/ai/package.json

## Reproduction

- `pnpm-lock.yaml` resolves `tar@7.5.15`, and `pnpm why tar -r` confirms it is present through multiple transitive dependency paths.
- The official node-tar advisory identifies versions through 7.5.18 as vulnerable to `decompression/parse` resource-exhaustion denial of service and identifies 7.5.19 as patched.
- `examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts` observed the vulnerable locked version instead of the expected `tar@7.5.19` or later and exited with code 1.

## Relevant Documentation

- https://github.com/isaacs/node-tar/security/advisories/GHSA-23hp-3jrh-7fpw
- https://github.com/isaacs/node-tar/releases/tag/v7.5.19
- https://nvd.nist.gov/vuln/detail/CVE-2026-59873

## Related Issues

Reproduces #17556