### PR TITLE
feat: add a per-step first-content timeout for streaming generations

### DIFF
--- a/.changeset/tidy-ducks-stream.md
+++ b/.changeset/tidy-ducks-stream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add per-step first content timeout for streaming generations

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -142,7 +142,8 @@ You can specify the timeout either as a number (milliseconds) or as an object wi
 
 - `totalMs`: The total timeout for the entire call including all steps.
 - `stepMs`: The timeout for each individual step (LLM call). This is useful for multi-step generations where you want to limit the time spent on each step independently.
-- `chunkMs`: The timeout between stream chunks (streaming only). The call will abort if no new chunk is received within this duration. This is useful for detecting stalled streams.
+- `firstChunkMs`: The timeout until the first content-bearing output of each step (streaming only). Text deltas, reasoning deltas, tool-input deltas, generated files, and tool calls satisfy the timeout. Response metadata, stream starts, empty deltas, raw chunks, and transport activity do not satisfy or reset it.
+- `chunkMs`: The timeout between content-bearing output chunks after output has started (streaming only). Non-content chunks do not reset it. This is useful for detecting streams that stall after generation begins.
 - `toolMs`: The default timeout for all tool executions. If a tool takes longer, it aborts and returns a tool-error so the model can respond or retry.
 - `tools`: Per-tool timeout overrides using `{toolName}Ms` keys (e.g. `weatherMs`, `slowApiMs`). Takes precedence over `toolMs`. Tool names are type-checked for autocomplete.
 
@@ -195,7 +196,19 @@ const result = await generateText({
 const result = streamText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
-  timeout: { chunkMs: 5000 }, // abort if no chunk received for 5 seconds
+  timeout: { chunkMs: 5000 }, // abort if content stalls for 5 seconds
+});
+```
+
+#### Example: First-content timeout for streaming (streamText only)
+
+```ts
+const result = streamText({
+  model: __MODEL__,
+  prompt: 'Invent a new holiday and describe its traditions.',
+  timeout: {
+    firstChunkMs: 10000, // 10 seconds for first content in each step
+  },
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -477,10 +477,10 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number; toolMs?: number; tools?: { [toolName]Ms?: number } }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, chunkMs, toolMs, and/or tools properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call). chunkMs sets the timeout between stream chunks - the call will abort if no new chunk is received within this duration. toolMs sets the default timeout for all tool executions. tools sets per-tool timeout overrides using the pattern {toolName}Ms (e.g. weatherMs, slowApiMs) that take precedence over toolMs - tool names are type-checked for autocomplete. If a tool takes longer than its timeout, it aborts and returns a tool-error so the model can respond or retry. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, chunkMs, toolMs, and/or tools properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call). firstChunkMs sets the timeout until the first content-bearing output in each step; metadata, stream starts, empty deltas, raw chunks, and transport activity do not satisfy it. chunkMs sets the timeout between content-bearing output chunks after output has started; non-content chunks do not reset it. toolMs sets the default timeout for all tool executions. tools sets per-tool timeout overrides using the pattern {toolName}Ms (e.g. weatherMs, slowApiMs) that take precedence over toolMs - tool names are type-checked for autocomplete. If a tool takes longer than its timeout, it aborts and returns a tool-error so the model can respond or retry. Can be used alongside abortSignal.',
     },
     {
       name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -246,7 +246,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
               description: 'Timeout configuration for the generation.',
             },
             {
@@ -360,7 +360,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'timeout',
-              type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number } | undefined',
+              type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
               description: 'Timeout configuration for the generation.',
             },
             {
@@ -712,10 +712,10 @@ const result = await agent.generate({
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, and/or chunkMs properties. firstChunkMs limits the wait for the first content-bearing output in each model-call step. chunkMs limits gaps between later content-bearing output chunks. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',
@@ -828,10 +828,10 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, and/or chunkMs properties. firstChunkMs limits the wait for the first content-bearing output in each model-call step. chunkMs limits gaps between later content-bearing output chunks. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -247,7 +247,8 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             {
               name: 'timeout',
               type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
-              description: 'Timeout configuration for the generation.',
+              description:
+                'Timeout configuration for the generation. firstChunkMs and chunkMs are only enforced by stream().',
             },
             {
               name: 'headers',
@@ -361,7 +362,8 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             {
               name: 'timeout',
               type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number } | undefined',
-              description: 'Timeout configuration for the generation.',
+              description:
+                'Timeout configuration for the generation. firstChunkMs and chunkMs are only enforced by stream().',
             },
             {
               name: 'headers',
@@ -715,7 +717,7 @@ const result = await agent.generate({
       type: 'number | { totalMs?: number; stepMs?: number; firstChunkMs?: number; chunkMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, and/or chunkMs properties. firstChunkMs limits the wait for the first content-bearing output in each model-call step. chunkMs limits gaps between later content-bearing output chunks. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, firstChunkMs, and/or chunkMs properties. firstChunkMs and chunkMs have no effect on generate(); they are streaming-only and are enforced by stream(). Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_sandbox',

--- a/examples/ai-functions/src/stream-text/mock/timeout-first-chunk.ts
+++ b/examples/ai-functions/src/stream-text/mock/timeout-first-chunk.ts
@@ -1,0 +1,67 @@
+import { streamText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: new MockLanguageModelV3({
+      doStream: async ({ abortSignal }) => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'response-metadata',
+              id: 'response-1',
+            });
+            controller.enqueue({ type: 'text-start', id: 'text-1' });
+
+            const outputTimeout = setTimeout(() => {
+              controller.enqueue({
+                type: 'text-delta',
+                id: 'text-1',
+                delta: 'The first content arrived before the deadline.',
+              });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              controller.enqueue({
+                type: 'finish',
+                finishReason: { raw: undefined, unified: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 3,
+                    noCache: 3,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: {
+                    total: 8,
+                    text: 8,
+                    reasoning: undefined,
+                  },
+                },
+              });
+              controller.close();
+            }, 100);
+
+            abortSignal?.addEventListener(
+              'abort',
+              () => {
+                clearTimeout(outputTimeout);
+                controller.error(abortSignal.reason);
+              },
+              { once: true },
+            );
+          },
+        }),
+      }),
+    }),
+    prompt: 'Write one sentence.',
+    timeout: {
+      firstChunkMs: 1000,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+});

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -70,7 +70,8 @@ export type AgentCallParameters<
     abortSignal?: AbortSignal;
 
     /**
-     * Timeout in milliseconds. Can be specified as a number or as an object with `totalMs`.
+     * Timeout in milliseconds. Can be specified as a number or as an object
+     * with total, per-step, first-content, inter-content, and tool timeouts.
      */
     timeout?: TimeoutConfiguration<TOOLS>;
 

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -72,6 +72,8 @@ export type AgentCallParameters<
     /**
      * Timeout in milliseconds. Can be specified as a number or as an object
      * with total, per-step, first-content, inter-content, and tool timeouts.
+     * First-content and inter-content timeouts are only enforced by streaming
+     * calls.
      */
     timeout?: TimeoutConfiguration<TOOLS>;
 

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -56,7 +56,8 @@ export type GenerateTextStartEvent<
 
   /**
    * Timeout configuration for the generation.
-   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs, toolMs, and per-tool overrides via tools.
+   * Can be a number (milliseconds) or an object with totalMs, stepMs,
+   * firstChunkMs (streaming only), chunkMs, toolMs, and per-tool overrides via tools.
    */
   readonly timeout: TimeoutConfiguration<TOOLS> | undefined;
 

--- a/packages/ai/src/generate-text/stream-text-timeout.test.ts
+++ b/packages/ai/src/generate-text/stream-text-timeout.test.ts
@@ -1,0 +1,353 @@
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import { DelayedPromise } from '@ai-sdk/provider-utils';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { isStepCount } from './stop-condition';
+import { streamText } from './stream-text';
+
+const testUsage: LanguageModelV4Usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+describe('streamText first chunk timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should abort when only non-output chunks arrive before firstChunkMs', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    let textError: unknown;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-1',
+                });
+                controller.enqueue({ type: 'text-start', id: '1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: '1',
+                  delta: '',
+                });
+                controller.enqueue({ type: 'reasoning-start', id: '2' });
+                controller.enqueue({
+                  type: 'reasoning-delta',
+                  id: '2',
+                  delta: '',
+                });
+                controller.enqueue({
+                  type: 'tool-input-start',
+                  id: 'call-1',
+                  toolName: 'tool1',
+                });
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: 'call-1',
+                  delta: '',
+                });
+                controller.enqueue({ type: 'raw', rawValue: ': ping' });
+
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      onError: () => {},
+    });
+
+    const handledTextPromise = Promise.resolve(result.text).catch(error => {
+      textError = error;
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await handledTextPromise;
+
+    expect(receivedAbortSignal?.aborted).toBe(true);
+    expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
+    expect((receivedAbortSignal?.reason as Error)?.message).toBe(
+      'First chunk timeout of 50ms exceeded',
+    );
+    expect(textError).toHaveProperty('name', 'TimeoutError');
+  });
+
+  const outputCases: Array<{
+    name: string;
+    chunks: LanguageModelV4StreamPart[];
+  }> = [
+    {
+      name: 'text delta',
+      chunks: [
+        { type: 'text-start', id: '1' },
+        { type: 'text-delta', id: '1', delta: 'Hello' },
+      ],
+    },
+    {
+      name: 'reasoning delta',
+      chunks: [
+        { type: 'reasoning-start', id: '1' },
+        { type: 'reasoning-delta', id: '1', delta: 'Thinking' },
+      ],
+    },
+    {
+      name: 'tool input delta',
+      chunks: [
+        { type: 'tool-input-start', id: 'call-1', toolName: 'tool1' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"value":' },
+      ],
+    },
+    {
+      name: 'file',
+      chunks: [
+        {
+          type: 'file',
+          data: { type: 'data', data: 'Hello World' },
+          mediaType: 'text/plain',
+        },
+      ],
+    },
+    {
+      name: 'reasoning file',
+      chunks: [
+        {
+          type: 'reasoning-file',
+          data: { type: 'data', data: 'Thinking' },
+          mediaType: 'text/plain',
+        },
+      ],
+    },
+    {
+      name: 'tool call',
+      chunks: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: '{"value":"test"}',
+        },
+      ],
+    },
+  ];
+
+  for (const { name, chunks } of outputCases) {
+    it(`should disarm firstChunkMs before forwarding the first ${name}`, async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const finishStream = new DelayedPromise<void>();
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+
+            return {
+              stream: new ReadableStream({
+                start(controller) {
+                  for (const chunk of chunks) {
+                    controller.enqueue(chunk);
+                  }
+
+                  finishStream.promise.then(() => {
+                    controller.enqueue({
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: testUsage,
+                    });
+                    controller.close();
+                  });
+                },
+              }),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { firstChunkMs: 50 },
+        onError: () => {},
+      });
+
+      const consumePromise = result.consumeStream();
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(receivedAbortSignal?.aborted).toBe(false);
+
+      finishStream.resolve(undefined);
+      await consumePromise;
+    });
+  }
+
+  it('should re-arm firstChunkMs for each model-call step', async () => {
+    const receivedAbortSignals: AbortSignal[] = [];
+    const secondStepStarted = new DelayedPromise<void>();
+    let stepCount = 0;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignals.push(abortSignal!);
+          stepCount++;
+
+          if (stepCount === 1) {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: '{"value":"test"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: {
+                    unified: 'tool-calls',
+                    raw: 'tool-calls',
+                  },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          }
+
+          secondStepStarted.resolve(undefined);
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-2',
+                });
+                controller.enqueue({ type: 'text-start', id: '2' });
+
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+              },
+            }),
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          inputSchema: z.object({ value: z.string() }),
+          execute: async () => 'tool result',
+        },
+      },
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      stopWhen: isStepCount(2),
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+
+    await secondStepStarted.promise;
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(stepCount).toBe(2);
+    expect(receivedAbortSignals[1].aborted).toBe(true);
+    expect((receivedAbortSignals[1].reason as Error).name).toBe('TimeoutError');
+
+    await consumePromise;
+  });
+});
+
+describe('streamText chunk timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not reset chunkMs for non-output chunks', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'text-start', id: '1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: '1',
+                  delta: 'Hello',
+                });
+
+                setTimeout(() => {
+                  controller.enqueue({
+                    type: 'response-metadata',
+                    id: 'response-1',
+                  });
+                }, 20);
+                setTimeout(() => {
+                  controller.enqueue({ type: 'raw', rawValue: ': ping' });
+                }, 40);
+
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => controller.error(abortSignal.reason),
+                  { once: true },
+                );
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { chunkMs: 50 },
+      onError: () => {},
+    });
+
+    const consumePromise = result.consumeStream();
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(receivedAbortSignal?.aborted).toBe(true);
+    expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
+
+    await consumePromise;
+  });
+});

--- a/packages/ai/src/generate-text/stream-text-timeout.test.ts
+++ b/packages/ai/src/generate-text/stream-text-timeout.test.ts
@@ -286,6 +286,83 @@ describe('streamText first chunk timeout', () => {
 
     await consumePromise;
   });
+
+  it('should clear firstChunkMs when the provider stream errors', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+    const providerError = new Error('simulated provider stream error');
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.error(providerError);
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+    });
+
+    const textPromise = result.text;
+
+    await result.consumeStream();
+    await expect(textPromise).rejects.toThrow(providerError);
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+  });
+
+  it('should clear firstChunkMs when the registered step stream is cancelled', async () => {
+    let receivedAbortSignal: AbortSignal | undefined;
+
+    const result = streamText({
+      model: new MockLanguageModelV4({
+        doStream: async ({ abortSignal }) => {
+          receivedAbortSignal = abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'response-1',
+                });
+              },
+            }),
+          };
+        },
+      }),
+      prompt: 'test-input',
+      timeout: { firstChunkMs: 50 },
+      experimental_transform: ({ stopStream }) =>
+        new TransformStream({
+          transform(chunk, controller) {
+            if (chunk.type === 'start-step') {
+              stopStream();
+            }
+            controller.enqueue(chunk);
+          },
+        }),
+    });
+
+    await result.consumeStream();
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(receivedAbortSignal?.aborted).toBe(false);
+  });
 });
 
 describe('streamText chunk timeout', () => {

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -22,6 +22,16 @@ import type { ResponseMessage } from './response-message';
 import type { StepResult } from './step-result';
 
 describe('streamText types', () => {
+  describe('timeout', () => {
+    it('should accept a first chunk timeout', () => {
+      streamText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        timeout: { firstChunkMs: 1000 },
+      });
+    });
+  });
+
   describe('onEnd', () => {
     it('should expose end event properties', () => {
       streamText({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -958,6 +958,10 @@ class DefaultStreamTextResult<
 
   private readonly addStream: (
     stream: ReadableStream<TextStreamPart<TOOLS>>,
+    callbacks?: {
+      onError?: (error: unknown) => void;
+      onCancel?: () => void;
+    },
   ) => void;
 
   private readonly closeStream: () => void;
@@ -1862,11 +1866,16 @@ class DefaultStreamTextResult<
           clearChunkTimeout();
         }
 
+        function cleanupStepTimeouts() {
+          abortSignal?.removeEventListener('abort', cleanupStepTimeouts);
+          clearStepTimeouts();
+        }
+
         // The step's stream is registered lazily and consumed long after this
         // function returns, so its timers must stay armed past setup. When the
         // merged abort signal fires, drop all step-scoped timers so none
         // outlives the step.
-        abortSignal?.addEventListener('abort', clearStepTimeouts, {
+        abortSignal?.addEventListener('abort', cleanupStepTimeouts, {
           once: true,
         });
 
@@ -2287,11 +2296,7 @@ class DefaultStreamTextResult<
                       }),
                     });
 
-                    abortSignal?.removeEventListener(
-                      'abort',
-                      clearStepTimeouts,
-                    );
-                    clearStepTimeouts();
+                    cleanupStepTimeouts();
                     self.closeStream();
                     return;
                   }
@@ -2372,8 +2377,7 @@ class DefaultStreamTextResult<
                   }
 
                   // Clear this step's timeouts before the next step is started.
-                  abortSignal?.removeEventListener('abort', clearStepTimeouts);
-                  clearStepTimeouts();
+                  cleanupStepTimeouts();
 
                   if (
                     // Continue if:
@@ -2418,12 +2422,15 @@ class DefaultStreamTextResult<
                 },
               }),
             ),
+            {
+              onError: cleanupStepTimeouts,
+              onCancel: cleanupStepTimeouts,
+            },
           );
         } catch (error) {
           // Setup failed before the stream was registered, so neither the
           // stream's flush nor an abort will clear the timers — clear them here.
-          abortSignal?.removeEventListener('abort', clearStepTimeouts);
-          clearStepTimeouts();
+          cleanupStepTimeouts();
           throw error;
         }
       }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -34,6 +34,7 @@ import { prepareTools } from '../prompt/prepare-tools';
 import type { Prompt } from '../prompt/prompt';
 import {
   getChunkTimeoutMs,
+  getFirstChunkTimeoutMs,
   getStepTimeoutMs,
   getTotalTimeoutMs,
   type RequestOptions,
@@ -157,28 +158,29 @@ const originalGenerateCallId = createIdGenerator({
   size: 24,
 });
 
-// chunk types that count as model output; used to distinguish empty
-// incomplete streams from incomplete streams with partial results.
-// exhaustive so that new chunk types must be classified explicitly:
+// Chunk types that contain semantic model output. This classification is used
+// for first-content and inter-content timeouts as well as to distinguish empty
+// incomplete streams from incomplete streams with partial results. It is
+// exhaustive so that new chunk types must be classified explicitly.
 const isOutputChunkType = {
   file: true,
-  custom: true,
-  source: true,
-  'text-start': true,
-  'text-end': true,
+  custom: false,
+  source: false,
+  'text-start': false,
+  'text-end': false,
   'text-delta': true,
-  'reasoning-start': true,
-  'reasoning-end': true,
+  'reasoning-start': false,
+  'reasoning-end': false,
   'reasoning-delta': true,
   'reasoning-file': true,
-  'tool-input-start': true,
-  'tool-input-end': true,
+  'tool-input-start': false,
+  'tool-input-end': false,
   'tool-input-delta': true,
-  'tool-approval-request': true,
-  'tool-approval-response': true,
+  'tool-approval-request': false,
+  'tool-approval-response': false,
   'tool-call': true,
-  'tool-result': true,
-  'tool-error': true,
+  'tool-result': false,
+  'tool-error': false,
   'tool-execution-end': false,
   'model-call-start': false,
   'model-call-response-metadata': false,
@@ -186,6 +188,26 @@ const isOutputChunkType = {
   error: false,
   raw: false,
 } as const satisfies Record<ExecuteToolsStreamPart['type'], boolean>;
+
+function isOutputChunk(chunk: ExecuteToolsStreamPart): boolean {
+  if (!isOutputChunkType[chunk.type]) {
+    return false;
+  }
+
+  switch (chunk.type) {
+    case 'text-delta':
+    case 'reasoning-delta':
+      return chunk.text.length > 0;
+    case 'tool-input-delta':
+      return chunk.delta.length > 0;
+    case 'file':
+    case 'reasoning-file':
+    case 'tool-call':
+      return true;
+    default:
+      return false;
+  }
+}
 
 export type StreamTextInclude = {
   /**
@@ -716,9 +738,12 @@ export function streamText<
   }): StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
+  const firstChunkTimeoutMs = getFirstChunkTimeoutMs(timeout);
   const chunkTimeoutMs = getChunkTimeoutMs(timeout);
   const stepAbortController =
     stepTimeoutMs != null ? new AbortController() : undefined;
+  const firstChunkAbortController =
+    firstChunkTimeoutMs != null ? new AbortController() : undefined;
   const chunkAbortController =
     chunkTimeoutMs != null ? new AbortController() : undefined;
   const resolvedOnStart = onStart ?? experimental_onStart;
@@ -742,10 +767,13 @@ export function streamText<
       abortSignal,
       totalTimeoutMs,
       stepAbortController?.signal,
+      firstChunkAbortController?.signal,
       chunkAbortController?.signal,
     ),
     stepTimeoutMs,
     stepAbortController,
+    firstChunkTimeoutMs,
+    firstChunkAbortController,
     chunkTimeoutMs,
     chunkAbortController,
     instructions,
@@ -951,6 +979,8 @@ class DefaultStreamTextResult<
     abortSignal,
     stepTimeoutMs,
     stepAbortController,
+    firstChunkTimeoutMs,
+    firstChunkAbortController,
     chunkTimeoutMs,
     chunkAbortController,
     instructions,
@@ -1000,6 +1030,8 @@ class DefaultStreamTextResult<
     abortSignal: AbortSignal | undefined;
     stepTimeoutMs: number | undefined;
     stepAbortController: AbortController | undefined;
+    firstChunkTimeoutMs: number | undefined;
+    firstChunkAbortController: AbortController | undefined;
     chunkTimeoutMs: number | undefined;
     chunkAbortController: AbortController | undefined;
     toolsContext: InferToolSetContext<TOOLS>;
@@ -1771,7 +1803,32 @@ class DefaultStreamTextResult<
           timeoutMs: stepTimeoutMs,
         });
 
-        // Set up chunk timeout tracking (will be reset on each chunk)
+        // The first-content timeout is armed when the provider response stream
+        // starts and is cleared by the first semantic output chunk.
+        let firstChunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
+          undefined;
+
+        function startFirstChunkTimeout() {
+          if (abortSignal?.aborted) {
+            return;
+          }
+
+          firstChunkTimeoutId = setAbortTimeout({
+            abortController: firstChunkAbortController,
+            label: 'First chunk',
+            timeoutMs: firstChunkTimeoutMs,
+          });
+        }
+
+        function clearFirstChunkTimeout() {
+          if (firstChunkTimeoutId != null) {
+            clearTimeout(firstChunkTimeoutId);
+            firstChunkTimeoutId = undefined;
+          }
+        }
+
+        // Chunk timeout tracking starts after semantic output begins and is
+        // reset only by subsequent semantic output chunks.
         let chunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
           undefined;
 
@@ -1799,12 +1856,19 @@ class DefaultStreamTextResult<
           }
         }
 
+        function clearStepTimeouts() {
+          clearStepTimeout();
+          clearFirstChunkTimeout();
+          clearChunkTimeout();
+        }
+
         // The step's stream is registered lazily and consumed long after this
-        // function returns, so the step timer must stay armed past setup. When
-        // the merged abort signal fires (any step/chunk/total timeout or caller
-        // abort), drop both step-scoped timers so neither outlives the step.
-        abortSignal?.addEventListener('abort', clearStepTimeout);
-        abortSignal?.addEventListener('abort', clearChunkTimeout);
+        // function returns, so its timers must stay armed past setup. When the
+        // merged abort signal fires, drop all step-scoped timers so none
+        // outlives the step.
+        abortSignal?.addEventListener('abort', clearStepTimeouts, {
+          once: true,
+        });
 
         try {
           stepFinish = new DelayedPromise<void>();
@@ -1967,6 +2031,8 @@ class DefaultStreamTextResult<
             ),
           );
 
+          startFirstChunkTimeout();
+
           const streamAfterToolCallbackInvocation =
             invokeToolCallbacksFromStream({
               stream: languageModelStream,
@@ -2076,8 +2142,6 @@ class DefaultStreamTextResult<
                 TextStreamPart<TOOLS>
               >({
                 async transform(chunk, controller): Promise<void> {
-                  resetChunkTimeout();
-
                   if (chunk.type === 'model-call-start') {
                     warnings = chunk.warnings;
                     return; // stream start chunks are sent immediately and do not count as first chunk
@@ -2096,8 +2160,14 @@ class DefaultStreamTextResult<
 
                   const chunkType = chunk.type;
 
-                  if (isOutputChunkType[chunkType]) {
+                  if (isOutputChunk(chunk)) {
+                    if (!hasReceivedOutputChunk) {
+                      // Clear before forwarding the first output so a timeout
+                      // cannot race with already-visible generated content.
+                      clearFirstChunkTimeout();
+                    }
                     hasReceivedOutputChunk = true;
+                    resetChunkTimeout();
                   }
 
                   switch (chunkType) {
@@ -2217,8 +2287,11 @@ class DefaultStreamTextResult<
                       }),
                     });
 
-                    clearStepTimeout();
-                    clearChunkTimeout();
+                    abortSignal?.removeEventListener(
+                      'abort',
+                      clearStepTimeouts,
+                    );
+                    clearStepTimeouts();
                     self.closeStream();
                     return;
                   }
@@ -2298,9 +2371,9 @@ class DefaultStreamTextResult<
                     }
                   }
 
-                  // Clear the step and chunk timeouts before the next step is started
-                  clearStepTimeout();
-                  clearChunkTimeout();
+                  // Clear this step's timeouts before the next step is started.
+                  abortSignal?.removeEventListener('abort', clearStepTimeouts);
+                  clearStepTimeouts();
 
                   if (
                     // Continue if:
@@ -2349,8 +2422,8 @@ class DefaultStreamTextResult<
         } catch (error) {
           // Setup failed before the stream was registered, so neither the
           // stream's flush nor an abort will clear the timers — clear them here.
-          clearStepTimeout();
-          clearChunkTimeout();
+          abortSignal?.removeEventListener('abort', clearStepTimeouts);
+          clearStepTimeouts();
           throw error;
         }
       }

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -10,6 +10,7 @@ export type CallSettings = LanguageModelCallOptions &
 export {
   getTotalTimeoutMs,
   getStepTimeoutMs,
+  getFirstChunkTimeoutMs,
   getChunkTimeoutMs,
   getToolTimeoutMs,
 } from './request-options';

--- a/packages/ai/src/prompt/prepare-language-model-call-options.test.ts
+++ b/packages/ai/src/prompt/prepare-language-model-call-options.test.ts
@@ -4,6 +4,7 @@ import {
   getToolTimeoutMs,
   getTotalTimeoutMs,
   getStepTimeoutMs,
+  getFirstChunkTimeoutMs,
   getChunkTimeoutMs,
 } from './request-options';
 import { describe, it, expect } from 'vitest';
@@ -265,6 +266,20 @@ describe('timeout helpers (from request-options)', () => {
 
     it('should return stepMs from an object', () => {
       expect(getStepTimeoutMs({ stepMs: 3000 })).toBe(3000);
+    });
+  });
+
+  describe('getFirstChunkTimeoutMs', () => {
+    it('should return undefined when timeout is undefined', () => {
+      expect(getFirstChunkTimeoutMs(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when timeout is a number', () => {
+      expect(getFirstChunkTimeoutMs(5000)).toBeUndefined();
+    });
+
+    it('should return firstChunkMs from an object', () => {
+      expect(getFirstChunkTimeoutMs({ firstChunkMs: 1500 })).toBe(1500);
     });
   });
 

--- a/packages/ai/src/prompt/request-options.ts
+++ b/packages/ai/src/prompt/request-options.ts
@@ -5,7 +5,8 @@ import type { ToolSet } from '@ai-sdk/provider-utils';
  * - A number representing milliseconds
  * - An object with `totalMs` property for the total timeout in milliseconds
  * - An object with `stepMs` property for the timeout of each step in milliseconds
- * - An object with `chunkMs` property for the timeout between stream chunks (streaming only)
+ * - An object with `firstChunkMs` property for the timeout until the first content chunk of each step (streaming only)
+ * - An object with `chunkMs` property for the timeout between content chunks (streaming only)
  * - An object with `toolMs` property for the default timeout for all tool executions
  * - An object with `tools` property for per-tool timeout overrides using `{toolName}Ms` keys
  */
@@ -14,6 +15,7 @@ export type TimeoutConfiguration<TOOLS extends ToolSet> =
   | {
       totalMs?: number;
       stepMs?: number;
+      firstChunkMs?: number;
       chunkMs?: number;
       toolMs?: number;
       tools?: Partial<Record<`${keyof TOOLS & string}Ms`, number>>;
@@ -53,8 +55,24 @@ export function getStepTimeoutMs(
 }
 
 /**
+ * Extracts the first chunk timeout value in milliseconds from a TimeoutConfiguration.
+ * This timeout is for streaming only - it aborts if no content chunk is received within the specified duration.
+ *
+ * @param timeout - The timeout configuration.
+ * @returns The first chunk timeout in milliseconds, or undefined if no first chunk timeout is configured.
+ */
+export function getFirstChunkTimeoutMs(
+  timeout: TimeoutConfiguration<any> | undefined,
+): number | undefined {
+  if (timeout == null || typeof timeout === 'number') {
+    return undefined;
+  }
+  return timeout.firstChunkMs;
+}
+
+/**
  * Extracts the chunk timeout value in milliseconds from a TimeoutConfiguration.
- * This timeout is for streaming only - it aborts if no new chunk is received within the specified duration.
+ * This timeout is for streaming only - it aborts if no new content chunk is received within the specified duration.
  *
  * @param timeout - The timeout configuration.
  * @returns The chunk timeout in milliseconds, or undefined if no chunk timeout is configured.

--- a/packages/ai/src/util/create-stitchable-stream.test.ts
+++ b/packages/ai/src/util/create-stitchable-stream.test.ts
@@ -132,6 +132,28 @@ describe('createStitchableStream', () => {
         'Test error',
       );
     });
+
+    it('should call the inner stream error callback', async () => {
+      const { stream, addStream } = createStitchableStream<number>();
+      let receivedError: unknown;
+      const error = new Error('Test error');
+
+      addStream(
+        new ReadableStream({
+          start(controller) {
+            controller.error(error);
+          },
+        }),
+        {
+          onError(error) {
+            receivedError = error;
+          },
+        },
+      );
+
+      await expect(convertReadableStreamToArray(stream)).rejects.toThrow(error);
+      expect(receivedError).toBe(error);
+    });
   });
 
   describe('cancellation & closing', () => {
@@ -168,6 +190,28 @@ describe('createStitchableStream', () => {
 
       expect(stream1Cancelled).toBe(true);
       expect(stream2Cancelled).toBe(true);
+    });
+
+    it('should call the inner stream cancellation callbacks', async () => {
+      const { stream, addStream } = createStitchableStream<number>();
+      let stream1CallbackCalled = false;
+      let stream2CallbackCalled = false;
+
+      addStream(new ReadableStream(), {
+        onCancel() {
+          stream1CallbackCalled = true;
+        },
+      });
+      addStream(new ReadableStream(), {
+        onCancel() {
+          stream2CallbackCalled = true;
+        },
+      });
+
+      await stream.cancel();
+
+      expect(stream1CallbackCalled).toBe(true);
+      expect(stream2CallbackCalled).toBe(true);
     });
 
     it('should throw an error when adding a stream after closing', async () => {

--- a/packages/ai/src/util/create-stitchable-stream.ts
+++ b/packages/ai/src/util/create-stitchable-stream.ts
@@ -8,11 +8,21 @@ import { createResolvablePromise } from './create-resolvable-promise';
  */
 export function createStitchableStream<T>(): {
   stream: ReadableStream<T>;
-  addStream: (innerStream: ReadableStream<T>) => void;
+  addStream: (
+    innerStream: ReadableStream<T>,
+    callbacks?: {
+      onError?: (error: unknown) => void;
+      onCancel?: () => void;
+    },
+  ) => void;
   close: () => void;
   terminate: () => void;
 } {
-  let innerStreamReaders: ReadableStreamDefaultReader<T>[] = [];
+  let innerStreams: Array<{
+    reader: ReadableStreamDefaultReader<T>;
+    onError?: (error: unknown) => void;
+    onCancel?: () => void;
+  }> = [];
   let controller: ReadableStreamDefaultController<T> | null = null;
   let isClosed = false;
   let waitForNewStream = createResolvablePromise<void>();
@@ -21,34 +31,39 @@ export function createStitchableStream<T>(): {
     isClosed = true;
     waitForNewStream.resolve();
 
-    innerStreamReaders.forEach(reader => reader.cancel());
-    innerStreamReaders = [];
+    innerStreams.forEach(({ reader, onCancel }) => {
+      onCancel?.();
+      reader.cancel();
+    });
+    innerStreams = [];
     controller?.close();
   };
 
   const processPull = async () => {
     // Case 1: Outer stream is closed and no more inner streams
-    if (isClosed && innerStreamReaders.length === 0) {
+    if (isClosed && innerStreams.length === 0) {
       controller?.close();
       return;
     }
 
     // Case 2: No inner streams available, but outer stream is open
     // wait for a new inner stream to be added or the outer stream to close
-    if (innerStreamReaders.length === 0) {
+    if (innerStreams.length === 0) {
       waitForNewStream = createResolvablePromise<void>();
       await waitForNewStream.promise;
       return await processPull();
     }
 
+    const currentStream = innerStreams[0];
+
     try {
-      const { value, done } = await innerStreamReaders[0].read();
+      const { value, done } = await currentStream.reader.read();
 
       if (done) {
         // Case 3: Current inner stream is done
-        innerStreamReaders.shift(); // Remove the finished stream
+        innerStreams.shift(); // Remove the finished stream
 
-        if (innerStreamReaders.length === 0 && isClosed) {
+        if (innerStreams.length === 0 && isClosed) {
           // when closed and no more inner streams, stop pulling
           controller?.close();
         } else {
@@ -61,8 +76,9 @@ export function createStitchableStream<T>(): {
       }
     } catch (error) {
       // Case 5: Current inner stream throws an error
+      currentStream.onError?.(error);
       controller?.error(error);
-      innerStreamReaders.shift(); // Remove the errored stream
+      innerStreams.shift(); // Remove the errored stream
       terminate(); // we have errored, terminate all streams
     }
   };
@@ -74,19 +90,29 @@ export function createStitchableStream<T>(): {
       },
       pull: processPull,
       async cancel() {
-        for (const reader of innerStreamReaders) {
+        for (const { reader, onCancel } of innerStreams) {
+          onCancel?.();
           await reader.cancel();
         }
-        innerStreamReaders = [];
+        innerStreams = [];
         isClosed = true;
       },
     }),
-    addStream: (innerStream: ReadableStream<T>) => {
+    addStream: (
+      innerStream: ReadableStream<T>,
+      callbacks?: {
+        onError?: (error: unknown) => void;
+        onCancel?: () => void;
+      },
+    ) => {
       if (isClosed) {
         throw new Error('Cannot add inner stream: outer stream is closed');
       }
 
-      innerStreamReaders.push(innerStream.getReader());
+      innerStreams.push({
+        reader: innerStream.getReader(),
+        ...callbacks,
+      });
       waitForNewStream.resolve();
     },
 
@@ -98,7 +124,7 @@ export function createStitchableStream<T>(): {
       isClosed = true;
       waitForNewStream.resolve();
 
-      if (innerStreamReaders.length === 0) {
+      if (innerStreams.length === 0) {
         controller?.close();
       }
     },


### PR DESCRIPTION
## Background

Streaming transports can remain active through headers, metadata, keep-alives, empty deltas, or raw bytes without producing model content. Consumers need an SDK-level semantic deadline for the first content-bearing output of every streaming model-call step.

## Summary

Adds optional timeout.firstChunkMs configuration and extraction. streamText arms a dedicated timeout for every model-call response stream, merges its abort signal into the provider call, and disarms it before forwarding the first non-empty text, reasoning, or tool-input delta, generated file, reasoning file, or tool call. Non-content activity does not affect firstChunkMs, and chunkMs now starts and resets only on semantic output. Step timers and abort listeners are cleaned up on completion, abort, setup failure, provider stream error, and cancellation, including through stitchable-stream lifecycle callbacks.

## Testing

Adds Node and Edge runtime coverage for non-content activity, empty deltas, every qualifying output category, timeout identity, pre-forward disarming, multi-step re-arming, semantic chunkMs behavior, provider errors, cancellation, and timer cleanup. Also adds stitchable-stream lifecycle tests, timeout extraction tests, and compile-time public API coverage.

## End-to-end Validation

- Ran the provider-independent firstChunkMs streamText example with delayed initial content; it completed successfully and emitted `The first content arrived before the deadline.`

## Documentation

Updates timeout settings, the streamText reference, and ToolLoopAgent documentation with firstChunkMs semantics, qualifying output, ignored non-content activity, and content-based chunkMs behavior. ToolLoopAgent now explicitly identifies firstChunkMs and chunkMs as streaming-only. Adds a runnable mock-provider example and an ai patch changeset.

## Related Issues

Fixes #17315

Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>