### PR TITLE
[v6.0] reproduction: Dependency Vulnerability: CVE-2026-59873 affects tar@7.5.15 in vercel/ai/package.json

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17556,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17556-tar-cve.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "CVE-2026-59873 reproduced: pnpm-lock.yaml resolves vulnerable tar versions 6.2.1, 7.4.3, 7.5.9; expected tar@7.5.19 or later."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts
+++ b/examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts
@@ -1,0 +1,51 @@
+import { readFile } from 'node:fs/promises';
+
+const patchedVersion = [7, 5, 19] as const;
+
+function isVulnerable(version: string): boolean {
+  const parts = version.split('.').map(Number);
+
+  for (let index = 0; index < patchedVersion.length; index++) {
+    const difference = parts[index] - patchedVersion[index];
+
+    if (difference !== 0) {
+      return difference < 0;
+    }
+  }
+
+  return false;
+}
+
+async function main() {
+  const lockfile = await readFile(
+    new URL('../../../../pnpm-lock.yaml', import.meta.url),
+    'utf8',
+  );
+  const versions = [
+    ...new Set(
+      Array.from(
+        lockfile.matchAll(/^ {2}tar@(\d+\.\d+\.\d+):$/gm),
+        match => match[1],
+      ),
+    ),
+  ].sort((left, right) =>
+    left.localeCompare(right, undefined, { numeric: true }),
+  );
+  const vulnerableVersions = versions.filter(isVulnerable);
+
+  if (vulnerableVersions.length > 0) {
+    throw new Error(
+      `CVE-2026-59873 reproduced: pnpm-lock.yaml resolves vulnerable tar versions ${vulnerableVersions.join(
+        ', ',
+      )}; expected tar@7.5.19 or later.`,
+    );
+  }
+
+  console.log(
+    `CVE-2026-59873 not reproduced: all locked tar versions are patched (${versions.join(
+      ', ',
+    )}).`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Bug

Dependency Vulnerability: CVE-2026-59873 affects tar@7.5.15 in vercel/ai/package.json

## Reproduction

- The official node-tar advisory marks versions through 7.5.18 as vulnerable to `decompression/parse` resource-exhaustion DoS and identifies 7.5.19 as patched.
- The target `release-v6.0` lockfile does not contain the reported tar@7.5.15; `pnpm-lock.yaml` instead resolves tar@6.2.1, tar@7.4.3, and tar@7.5.9, all within the affected range.
- The vulnerable versions are transitive dependencies of repository example and build tooling; root `package.json` does not directly declare tar.
- `examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts` expected every locked tar version to be patched, observed the three vulnerable versions, and exited with code 1.
- Code paths that use these dependencies to extract attacker-controlled archives can exhaust disk and CPU resources.

## Relevant Documentation

- https://github.com/isaacs/node-tar/security/advisories/GHSA-23hp-3jrh-7fpw
- https://github.com/isaacs/node-tar/releases/tag/v7.5.19
- https://nvd.nist.gov/vuln/detail/CVE-2026-59873

## Related Issues

Reproduces #17556