### PR TITLE
[v5.0] reproduction: Dependency Vulnerability: CVE-2026-59873 affects tar@7.5.15 in vercel/ai/package.json

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17556,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17556-tar-cve.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "CVE-2026-59873: pnpm-lock.yaml resolves vulnerable tar versions: 6.2.1, 7.5.9; expected tar@7.5.19 or later."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts
+++ b/examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const patchedVersion = [7, 5, 19] as const;
+
+function isOlderThanPatched(version: string): boolean {
+  const parts = version.split('.').map(part => Number.parseInt(part, 10));
+
+  for (let index = 0; index < patchedVersion.length; index++) {
+    const part = parts[index] ?? 0;
+    const patchedPart = patchedVersion[index];
+
+    if (part !== patchedPart) {
+      return part < patchedPart;
+    }
+  }
+
+  return false;
+}
+
+async function main() {
+  const lockfilePath = resolve(process.cwd(), '../../pnpm-lock.yaml');
+  const lockfile = await readFile(lockfilePath, 'utf8');
+  const versions = [
+    ...new Set(
+      [...lockfile.matchAll(/^ {2}tar@([^:]+):$/gm)].map(match => match[1]),
+    ),
+  ].sort((left, right) =>
+    left.localeCompare(right, undefined, { numeric: true }),
+  );
+
+  if (versions.length === 0) {
+    throw new Error(
+      'Expected pnpm-lock.yaml to resolve at least one tar version.',
+    );
+  }
+
+  const vulnerableVersions = versions.filter(isOlderThanPatched);
+
+  if (vulnerableVersions.length > 0) {
+    throw new Error(
+      `CVE-2026-59873: pnpm-lock.yaml resolves vulnerable tar versions: ${vulnerableVersions.join(
+        ', ',
+      )}; expected tar@7.5.19 or later.`,
+    );
+  }
+
+  console.log(
+    `pnpm-lock.yaml resolves only patched tar versions: ${versions.join(', ')}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Dependency Vulnerability: CVE-2026-59873 affects tar@7.5.15 in vercel/ai/package.json

## Reproduction

- On `release-v5.0`, `pnpm-lock.yaml` resolves `tar@6.2.1` and `tar@7.5.9`, rather than the reported `tar@7.5.15`; both are within the advisory's affected range of versions through 7.5.18.
- The vulnerable transitive dependencies expose archive extraction consumers to CVE-2026-59873 resource-exhaustion denial of service; the expected resolution is `tar@7.5.19` or later.
- `examples/ai-functions/src/reproduction/issue-17556-tar-cve.ts`, supported by `examples/ai-functions/package.json`, observed both vulnerable versions and exited with code 1 instead of confirming a patched dependency tree.

## Relevant Documentation

- https://github.com/isaacs/node-tar/security/advisories/GHSA-23hp-3jrh-7fpw
- https://github.com/isaacs/node-tar/releases/tag/v7.5.19
- https://nvd.nist.gov/vuln/detail/CVE-2026-59873

## Related Issues

Reproduces #17556