### PR TITLE
[v6.0] fix(anthropic): warn when jsonTool disables parallel tool use

### DIFF
--- a/.changeset/lucky-tools-warn.md
+++ b/.changeset/lucky-tools-warn.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+fix(provider/anthropic): warn when parallel tool use is requested with JSON tool structured output

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -362,6 +362,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           providerOptions: {
             anthropic: {
               structuredOutputMode: 'jsonTool',
+              disableParallelToolUse: false,
             } satisfies AnthropicLanguageModelOptions,
           },
           responseFormat: {
@@ -420,6 +421,18 @@ describe('AnthropicMessagesLanguageModel', () => {
             ],
           }
         `);
+      });
+
+      it('should warn when parallel tool use is requested', () => {
+        expect(result.warnings).toEqual([
+          {
+            type: 'unsupported',
+            feature: 'providerOptions.anthropic.disableParallelToolUse',
+            details:
+              '`disableParallelToolUse: false` is ignored when using the JSON response tool. ' +
+              'Parallel tool use is disabled to ensure a single coherent JSON tool call.',
+          },
+        ]);
       });
 
       it('should return the json response', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -334,6 +334,19 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
           }
         : undefined;
 
+    if (
+      jsonResponseTool != null &&
+      anthropicOptions?.disableParallelToolUse === false
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'providerOptions.anthropic.disableParallelToolUse',
+        details:
+          '`disableParallelToolUse: false` is ignored when using the JSON response tool. ' +
+          'Parallel tool use is disabled to ensure a single coherent JSON tool call.',
+      });
+    }
+
     const contextManagement = anthropicOptions?.contextManagement;
 
     // Create a shared cache control validator to track breakpoints across tools and messages


### PR DESCRIPTION
## Background

The Anthropic provider ignores the `disableParallelToolUse: false` setting when `structuredOutputMode: 'jsonTool'` is set.

```
providerOptions: {
  anthropic: {
    structuredOutputMode: 'jsonTool',
    disableParallelToolUse: false,
  },
}
```

## Summary

Add an unsupported-option warning when parallel tool use is explicitly requested with the Anthropic JSON response tool, cover the behavior with a regression test, and add a patch changeset for `@ai-sdk/anthropic`.

## Testing

Passed the complete Anthropic provider test suite in Node and Edge environments (446 tests each), `pnpm check`, `pnpm type-check:full`, the Anthropic package build, and `git diff --check`.

## Related Issues

Fixes #15652

Backport of #17560