### PR TITLE
reproduction: Bug @ai-sdk/amazon-bedrock: normalizeToolCallId truncation causes duplicate tool-call IDs

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 16182,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/amazon-bedrock-mistral-duplicate-tool-call-ids.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/amazon-bedrock-mistral-duplicate-tool-call-ids.ts",
+    "packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-mistral-duplicate-tool-call-ids-error.json",
+    "packages/amazon-bedrock/src/amazon-bedrock-mistral-duplicate-tool-call-ids.reproduction.test.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_16182_REPRODUCED: Bedrock rejected duplicate normalized toolUseId tooluseAc."
+  }
+}

--- a/examples/ai-functions/src/reproduction/amazon-bedrock-mistral-duplicate-tool-call-ids.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-mistral-duplicate-tool-call-ids.ts
@@ -1,0 +1,96 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, tool, type ModelMessage } from 'ai';
+import { z } from 'zod';
+
+const firstToolCallId = 'tooluse_Ac1Xq9ZklmNoPq';
+const secondToolCallId = 'tooluse_Ac2Yt7WrstUvWx';
+let observedRequestBody = '';
+let observedResponseBody = '';
+let observedResponseStatus = 0;
+const amazonBedrock = createAmazonBedrock({
+  region: 'us-east-1',
+  fetch: async (input, init) => {
+    observedRequestBody = String(init?.body ?? '');
+    const response = await fetch(input, init);
+    observedResponseStatus = response.status;
+    observedResponseBody = await response.clone().text();
+    return response;
+  },
+});
+
+const messages: ModelMessage[] = [
+  {
+    role: 'user',
+    content: 'Look up both values.',
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: firstToolCallId,
+        toolName: 'lookup',
+        input: { value: 'first' },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: secondToolCallId,
+        toolName: 'lookup',
+        input: { value: 'second' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: firstToolCallId,
+        toolName: 'lookup',
+        output: { type: 'text', value: 'first result' },
+      },
+      {
+        type: 'tool-result',
+        toolCallId: secondToolCallId,
+        toolName: 'lookup',
+        output: { type: 'text', value: 'second result' },
+      },
+    ],
+  },
+];
+
+async function main() {
+  try {
+    await generateText({
+      model: amazonBedrock('mistral.ministral-3-8b-instruct'),
+      messages,
+      tools: {
+        lookup: tool({
+          inputSchema: z.object({ value: z.string() }),
+        }),
+      },
+      maxOutputTokens: 16,
+    });
+
+    throw new Error(
+      'Expected Bedrock to reject duplicate normalized toolUseId values, but the request succeeded.',
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('duplicate Ids') && message.includes('tooluseAc')) {
+      console.error(
+        `CAPTURED_REQUEST: ${observedRequestBody}\nCAPTURED_RESPONSE_STATUS: ${observedResponseStatus}\nCAPTURED_RESPONSE: ${observedResponseBody}`,
+      );
+      console.error(
+        `ISSUE_16182_REPRODUCED: Bedrock rejected duplicate normalized toolUseId tooluseAc. ${message}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+}
+
+main();

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-mistral-duplicate-tool-call-ids-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-mistral-duplicate-tool-call-ids-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "The toolUse blocks at messages.2.content contain duplicate Ids: tooluseAc"
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-mistral-duplicate-tool-call-ids.reproduction.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-mistral-duplicate-tool-call-ids.reproduction.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
+
+const firstToolCallId = 'tooluse_Ac1Xq9ZklmNoPq';
+const secondToolCallId = 'tooluse_Ac2Yt7WrstUvWx';
+
+const prompt: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Look up both values.' }],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: firstToolCallId,
+        toolName: 'lookup',
+        input: { value: 'first' },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: secondToolCallId,
+        toolName: 'lookup',
+        input: { value: 'second' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: firstToolCallId,
+        toolName: 'lookup',
+        output: { type: 'text', value: 'first result' },
+      },
+      {
+        type: 'tool-result',
+        toolCallId: secondToolCallId,
+        toolName: 'lookup',
+        output: { type: 'text', value: 'second result' },
+      },
+    ],
+  },
+];
+
+const recordedBedrockError = JSON.parse(
+  fs.readFileSync(
+    'src/__fixtures__/amazon-bedrock-mistral-duplicate-tool-call-ids-error.json',
+    'utf8',
+  ),
+);
+
+describe('issue #16182 reproduction', () => {
+  it('keeps distinct tool calls distinct when replaying Mistral history', async () => {
+    const model = new AmazonBedrockChatLanguageModel(
+      'mistral.ministral-3-8b-instruct',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: {},
+        generateId: () => 'test-id',
+        fetch: async (_input, init) => {
+          const requestBody = JSON.parse(String(init?.body));
+          const toolUseIds = requestBody.messages[1].content.map(
+            (part: { toolUse: { toolUseId: string } }) =>
+              part.toolUse.toolUseId,
+          );
+          const hasDuplicateToolUseIds =
+            new Set(toolUseIds).size !== toolUseIds.length;
+
+          if (hasDuplicateToolUseIds) {
+            return new Response(JSON.stringify(recordedBedrockError), {
+              status: 400,
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+
+          return Response.json({
+            output: {
+              message: {
+                role: 'assistant',
+                content: [{ text: 'Both values were processed.' }],
+              },
+            },
+            stopReason: 'end_turn',
+            usage: {
+              inputTokens: 1,
+              outputTokens: 1,
+              totalTokens: 2,
+            },
+          });
+        },
+      },
+    );
+
+    const result = await model.doGenerate({
+      prompt,
+      tools: [
+        {
+          type: 'function',
+          name: 'lookup',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Both values were processed.' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Bug

[Bug] @ai-sdk/amazon-bedrock: normalizeToolCallId truncation causes duplicate tool-call IDs (Bedrock ValidationException) for Mistral models

## Reproduction

- `packages/amazon-bedrock/src/normalize-tool-call-id.ts` in `@ai-sdk/amazon-bedrock` 5.0.25 still strips non-alphanumeric characters and uses `slice(0, 9)`, leaving only two variable characters after the `tooluse` prefix.
- `examples/ai-functions/src/reproduction/amazon-bedrock-mistral-duplicate-tool-call-ids.ts` sent two distinct IDs through the public API; both became `tooluseAc`, and live Bedrock returned HTTP 400 instead of continuing the conversation with distinct IDs.
- `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-mistral-duplicate-tool-call-ids-error.json` records the live Bedrock duplicate-ID response.
- `packages/amazon-bedrock/src/amazon-bedrock-mistral-duplicate-tool-call-ids.reproduction.test.ts` replays the recorded response and fails because the generated request contains duplicate tool-use IDs.
- Although `normalizeToolCallId` is not publicly exported by `packages/amazon-bedrock/src/index.ts`, the reported user-visible failure reproduces through `generateText` with the public provider API.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-mistral-ai-ministral-3-8b.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
- https://docs.mistral.ai/resources/cookbooks/concept-deep-dive-tokenization-tool_calling

## Related Issues

Reproduces #16182