### PR TITLE
feat: support opt-in smoothing for streamed tool inputs

### DIFF
--- a/.changeset/smooth-tool-input-streams.md
+++ b/.changeset/smooth-tool-input-streams.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add opt-in tool input smoothing to `smoothStream`

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -547,8 +547,13 @@ for await (const part of result.stream) {
 You can use the `experimental_transform` option to transform the stream.
 This is useful for e.g. filtering, changing, or smoothing the text stream.
 
-The transformations are applied before the callbacks are invoked and the promises are resolved.
-If you e.g. have a transformation that changes all text to uppercase, the `onEnd` callback will receive the transformed text.
+The transformations are applied before stream output callbacks such as
+`onChunk` and `onEnd` are invoked and before result promises are resolved. If
+you e.g. have a transformation that changes all text to uppercase, the `onEnd`
+callback will receive the transformed text. Tool lifecycle callbacks such as
+`onInputStart`, `onInputDelta`, and `onInputAvailable`, as well as tool
+execution, are driven by the normalized provider stream before transformations
+are applied.
 
 #### Smoothing streams
 

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -553,7 +553,8 @@ If you e.g. have a transformation that changes all text to uppercase, the `onEnd
 #### Smoothing streams
 
 The AI SDK Core provides a [`smoothStream` function](/docs/reference/ai-sdk-core/smooth-stream) that
-can be used to smooth out text and reasoning streaming.
+can be used to smooth out text and reasoning streaming. You can separately opt
+in to smoothing streamed tool inputs with `toolInputSmoothing`.
 
 ```tsx highlight="6"
 import { smoothStream, streamText } from 'ai';
@@ -562,6 +563,17 @@ const result = streamText({
   model,
   prompt,
   experimental_transform: smoothStream(),
+});
+```
+
+```tsx highlight="6-8"
+const result = streamText({
+  model,
+  prompt,
+  tools,
+  experimental_transform: smoothStream({
+    toolInputSmoothing: {},
+  }),
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -101,9 +101,13 @@ preserved.
 <Note>
   Smoothing can only subdivide tool input deltas after the provider sends them.
   It cannot make a provider start streaming tool input earlier. Delaying many
-  small chunks also delays tool input callbacks, completed tool calls, tool
-  execution, and stream completion. Adjust `delayInMs` or the tool input
-  chunking strategy for large inputs.
+  small chunks delays downstream `fullStream`, `onChunk`, UI message stream
+  events, and stream completion. Tool `onInputStart`, `onInputDelta`,
+  `onInputAvailable`, and execution run before stream transformations. In
+  particular, `onInputDelta` retains the provider's original chunking rather
+  than receiving smoothed chunks, and completed tool calls or execution can
+  occur while smoothed output events are still being delivered. Adjust
+  `delayInMs` or the tool input chunking strategy for large inputs.
 </Note>
 
 <Note>

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -1,6 +1,6 @@
 ---
 title: smoothStream
-description: Stream transformer for smoothing text and reasoning output
+description: Stream transformer for smoothing text, reasoning, and tool input output
 ---
 
 # `smoothStream()`
@@ -8,7 +8,8 @@ description: Stream transformer for smoothing text and reasoning output
 `smoothStream` is a utility function that creates a TransformStream
 for the `streamText` `transform` option
 to smooth out text and reasoning streaming by buffering and releasing complete chunks with configurable delays.
-This creates a more natural reading experience when streaming text and reasoning responses.
+It can also opt in to smoothing streamed tool inputs.
+This creates a more natural experience when displaying streaming model output.
 
 ```ts highlight={"6-9"}
 import { smoothStream, streamText } from 'ai';
@@ -47,8 +48,69 @@ const result = streamText({
       description:
         'Controls how text and reasoning content is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom callback or RegExp pattern for custom chunking.',
     },
+    {
+      name: 'toolInputSmoothing',
+      type: '{ chunking?: "character" | RegExp | ChunkDetector; include?: ReadonlyArray<string>; exclude?: ReadonlyArray<string> }',
+      isOptional: true,
+      description:
+        'Opts in to smoothing tool input deltas. Tool inputs are streamed character by character by default. Use include to smooth only selected tools and exclude to opt selected tools out. exclude takes precedence over include.',
+    },
   ]}
 />
+
+### Smoothing tool inputs
+
+Tool input smoothing is disabled by default. Enable it with
+`toolInputSmoothing`. The default `character` chunking emits one Unicode code
+point at a time and works with partial JSON that is not valid until the tool
+call is complete.
+
+```ts highlight={"10-13"}
+import { smoothStream, streamText } from 'ai';
+
+const result = streamText({
+  model,
+  prompt: 'Check the weather in London.',
+  tools: {
+    weather,
+    uploadFile,
+  },
+  experimental_transform: smoothStream({
+    toolInputSmoothing: {
+      exclude: ['uploadFile'],
+    },
+  }),
+});
+```
+
+Use a regular expression or custom chunk detector when character-by-character
+streaming is too fine-grained:
+
+```ts
+smoothStream({
+  toolInputSmoothing: {
+    chunking: /[:,}\]]/,
+  },
+});
+```
+
+The emitted `tool-input-delta` strings always concatenate to the original
+provider input. `tool-input-start` and `tool-input-end` lifecycle events are
+preserved.
+
+<Note>
+  Smoothing can only subdivide tool input deltas after the provider sends them.
+  It cannot make a provider start streaming tool input earlier. Delaying many
+  small chunks also delays tool input callbacks, completed tool calls, tool
+  execution, and stream completion. Adjust `delayInMs` or the tool input
+  chunking strategy for large inputs.
+</Note>
+
+<Note>
+  Partial tool input is untrusted and may be invalid JSON. Enabling smoothing
+  can expose it to rendering, logging, and callbacks in more events before the
+  complete tool input is validated.
+</Note>
 
 #### Word chunking caveats with non-latin languages
 
@@ -139,7 +201,7 @@ smoothStream({
 
 Returns a `TransformStream` that:
 
-- Buffers incoming text and reasoning chunks
+- Buffers incoming text, reasoning, and enabled tool input chunks
 - Releases content when the chunking pattern is encountered
 - Adds configurable delays between chunks for smooth output
-- Passes through non-text/reasoning chunks (like tool calls, step-finish events) immediately
+- Passes through other chunks (like tool calls and step-finish events) immediately

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -198,7 +198,7 @@ It also contains the following helper functions:
     },
     {
       title: 'smoothStream()',
-      description: 'Smooths text and reasoning streaming output.',
+      description: 'Smooths text, reasoning, and tool input streaming output.',
       href: '/docs/reference/ai-sdk-core/smooth-stream',
     },
     {

--- a/examples/ai-functions/src/stream-text/smooth/tool-input.ts
+++ b/examples/ai-functions/src/stream-text/smooth/tool-input.ts
@@ -1,0 +1,82 @@
+import { simulateReadableStream, smoothStream, streamText, tool } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            {
+              type: 'tool-input-start',
+              id: 'call-1',
+              toolName: 'weather',
+            },
+            {
+              type: 'tool-input-delta',
+              id: 'call-1',
+              delta: '{"city":"London"}',
+            },
+            { type: 'tool-input-end', id: 'call-1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'weather',
+              input: '{"city":"London"}',
+            },
+            {
+              type: 'finish',
+              finishReason: { raw: undefined, unified: 'tool-calls' },
+              usage: {
+                inputTokens: {
+                  total: 3,
+                  noCache: 3,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 10,
+                  text: 10,
+                  reasoning: undefined,
+                },
+              },
+            },
+          ],
+        }),
+      }),
+    }),
+    prompt: 'Check the weather in London.',
+    tools: {
+      weather: tool({
+        inputSchema: z.object({
+          city: z.string(),
+        }),
+      }),
+    },
+    experimental_transform: smoothStream({
+      delayInMs: 25,
+      toolInputSmoothing: {},
+    }),
+  });
+
+  const toolInputDeltas: string[] = [];
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'tool-input-delta') {
+      toolInputDeltas.push(part.delta);
+      process.stdout.write(part.delta);
+    }
+  }
+
+  console.log();
+
+  if (
+    toolInputDeltas.length === 0 ||
+    toolInputDeltas.some(delta => [...delta].length !== 1) ||
+    toolInputDeltas.join('') !== '{"city":"London"}'
+  ) {
+    throw new Error('Expected character-by-character tool input deltas.');
+  }
+});

--- a/packages/ai/src/generate-text/smooth-stream.test-d.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test-d.ts
@@ -1,0 +1,73 @@
+import { tool } from '@ai-sdk/provider-utils';
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { smoothStream } from './smooth-stream';
+import { streamText } from './stream-text';
+
+const tools = {
+  weather: tool({
+    inputSchema: z.object({ city: z.string() }),
+  }),
+  upload: tool({
+    inputSchema: z.object({ data: z.string() }),
+  }),
+};
+
+describe('smoothStream types', () => {
+  it('accepts tool input smoothing in streamText', () => {
+    const result = streamText({
+      model: new MockLanguageModelV4(),
+      prompt: 'Test',
+      tools,
+      experimental_transform: smoothStream({
+        toolInputSmoothing: {
+          chunking: 'character',
+          include: ['weather'],
+          exclude: ['upload'],
+        },
+      }),
+    });
+
+    expectTypeOf(result).toBeObject();
+  });
+
+  it('accepts custom tool input chunk detectors', () => {
+    smoothStream<typeof tools>({
+      toolInputSmoothing: {
+        chunking: buffer => buffer.match(/^.{1,5}/)?.[0],
+      },
+    });
+
+    smoothStream<typeof tools>({
+      toolInputSmoothing: {
+        chunking: /[:,]/,
+      },
+    });
+  });
+
+  it('restricts tool selection to tool names', () => {
+    smoothStream<typeof tools>({
+      toolInputSmoothing: {
+        // @ts-expect-error unknownTool is not part of the tool set
+        include: ['unknownTool'],
+      },
+    });
+
+    smoothStream<typeof tools>({
+      toolInputSmoothing: {
+        // @ts-expect-error unknownTool is not part of the tool set
+        exclude: ['unknownTool'],
+      },
+    });
+  });
+
+  it('rejects text chunking strategies for tool inputs', () => {
+    smoothStream<typeof tools>({
+      toolInputSmoothing: {
+        // @ts-expect-error tool inputs support character, RegExp, or ChunkDetector chunking
+        chunking: 'word',
+      },
+    });
+  });
+});

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -2098,4 +2098,279 @@ describe('smoothStream', () => {
       `);
     });
   });
+
+  describe('tool input smoothing', () => {
+    const noOpDelay = async () => {};
+
+    it('should reject invalid tool input chunking strategies', () => {
+      expect(() =>
+        smoothStream({
+          toolInputSmoothing: {
+            chunking: 'word' as any,
+          },
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[AI_InvalidArgumentError: Chunking must be "character", a RegExp, or a ChunkDetector function. Received: word]`,
+      );
+    });
+
+    it('should smooth tool input by Unicode code point when enabled', async () => {
+      const delays: Array<number | null> = [];
+      const input = '{"city":"London 🌧️"}';
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: input,
+          providerMetadata: {
+            testProvider: { signature: 'test-signature' },
+          },
+        },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 5,
+          toolInputSmoothing: {},
+          _internal: {
+            delay: async delayInMs => {
+              delays.push(delayInMs);
+            },
+          },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      const inputDeltas = events.filter(
+        (
+          event,
+        ): event is Extract<
+          TextStreamPart<ToolSet>,
+          { type: 'tool-input-delta' }
+        > => event.type === 'tool-input-delta',
+      );
+
+      expect(inputDeltas).toEqual(
+        [...input].map((delta, index, chunks) => ({
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta,
+          ...(index === chunks.length - 1
+            ? {
+                providerMetadata: {
+                  testProvider: { signature: 'test-signature' },
+                },
+              }
+            : {}),
+        })),
+      );
+      expect(inputDeltas.map(({ delta }) => delta).join('')).toBe(input);
+      expect(delays).toEqual([...input].map(() => 5));
+      expect(events.at(0)).toEqual({
+        type: 'tool-input-start',
+        id: 'call-1',
+        toolName: 'weather',
+      });
+      expect(events.at(-1)).toEqual({
+        type: 'tool-input-end',
+        id: 'call-1',
+      });
+    });
+
+    it('should combine provider deltas with custom tool input chunking', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city":' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '"Lon' },
+        { type: 'tool-input-delta', id: 'call-1', delta: 'don"' },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /[:,]/,
+          },
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toEqual([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city":' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '"London"' },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]);
+      expect(
+        events
+          .filter(event => event.type === 'tool-input-delta')
+          .map(event => event.delta)
+          .join(''),
+      ).toBe('{"city":"London"');
+    });
+
+    it('should preserve empty tool input deltas with provider metadata', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"}' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '',
+          providerMetadata: {
+            testProvider: { signature: 'test-signature' },
+          },
+        },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {},
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events.at(-2)).toEqual({
+        type: 'tool-input-delta',
+        id: 'call-1',
+        delta: '',
+        providerMetadata: {
+          testProvider: { signature: 'test-signature' },
+        },
+      });
+      expect(events.at(-1)).toEqual({
+        type: 'tool-input-end',
+        id: 'call-1',
+      });
+    });
+
+    it('should include and exclude individual tools', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"}' },
+        { type: 'tool-input-end', id: 'call-1' },
+        { type: 'tool-input-start', id: 'call-2', toolName: 'upload' },
+        { type: 'tool-input-delta', id: 'call-2', delta: '{"data":"abc"}' },
+        { type: 'tool-input-end', id: 'call-2' },
+        { type: 'tool-input-start', id: 'call-3', toolName: 'search' },
+        { type: 'tool-input-delta', id: 'call-3', delta: '{"query":"AI"}' },
+        { type: 'tool-input-end', id: 'call-3' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {
+            include: ['weather', 'upload'],
+            exclude: ['upload'],
+          },
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events.filter(event => event.type === 'tool-input-delta')).toEqual(
+        [
+          ...[...'{"city":"Rome"}'].map(delta => ({
+            type: 'tool-input-delta',
+            id: 'call-1',
+            delta,
+          })),
+          { type: 'tool-input-delta', id: 'call-2', delta: '{"data":"abc"}' },
+          { type: 'tool-input-delta', id: 'call-3', delta: '{"query":"AI"}' },
+        ],
+      );
+    });
+
+    it('should preserve ordering for interleaved tool inputs', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-start', id: 'call-2', toolName: 'search' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city"' },
+        { type: 'tool-input-delta', id: 'call-2', delta: '{"query"' },
+        { type: 'tool-input-delta', id: 'call-1', delta: ':"Rome"}' },
+        { type: 'tool-input-end', id: 'call-1' },
+        { type: 'tool-input-delta', id: 'call-2', delta: ':"AI"}' },
+        { type: 'tool-input-end', id: 'call-2' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /:/,
+          },
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toEqual([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-start', id: 'call-2', toolName: 'search' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city"' },
+        { type: 'tool-input-delta', id: 'call-2', delta: '{"query"' },
+        { type: 'tool-input-delta', id: 'call-1', delta: ':' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '"Rome"}' },
+        { type: 'tool-input-end', id: 'call-1' },
+        { type: 'tool-input-delta', id: 'call-2', delta: ':' },
+        { type: 'tool-input-delta', id: 'call-2', delta: '"AI"}' },
+        { type: 'tool-input-end', id: 'call-2' },
+      ]);
+    });
+
+    it.each([
+      { type: 'error' as const, error: new Error('test error') },
+      { type: 'abort' as const, reason: 'test abort' },
+    ])(
+      'should flush pending tool input before $type chunks',
+      async finalChunk => {
+        const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+          finalChunk,
+        ]).pipeThrough(
+          smoothStream({
+            delayInMs: null,
+            toolInputSmoothing: {
+              chunking: /,missing,/,
+            },
+            _internal: { delay: noOpDelay },
+          })({ tools: {} }),
+        );
+
+        await consumeStream(stream);
+
+        expect(events).toEqual([
+          { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+          { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+          finalChunk,
+        ]);
+      },
+    );
+
+    it('should flush pending tool input when the stream closes', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /,missing,/,
+          },
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toEqual([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Rome"' },
+      ]);
+    });
+  });
 });

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -2211,6 +2211,115 @@ describe('smoothStream', () => {
       ).toBe('{"city":"London"');
     });
 
+    it('should support a custom tool input chunk detector', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '{"city":"London"}',
+        },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: buffer =>
+              buffer.length >= 4 ? buffer.slice(0, 4) : null,
+          },
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events.filter(event => event.type === 'tool-input-delta')).toEqual(
+        ['{"ci', 'ty":', '"Lon', 'don"', '}'].map(delta => ({
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta,
+        })),
+      );
+    });
+
+    it('should pass zero delay to the delay function', async () => {
+      const delays: Array<number | null> = [];
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        { type: 'tool-input-delta', id: 'call-1', delta: '{}' },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 0,
+          toolInputSmoothing: {},
+          _internal: {
+            delay: async delayInMs => {
+              delays.push(delayInMs);
+            },
+          },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(delays).toEqual([0, 0]);
+    });
+
+    it('should preserve metadata from multiple provider deltas in order', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '{"city"',
+          providerMetadata: {
+            testProvider: { signature: 'first' },
+          },
+        },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: ':"Rome"}',
+          providerMetadata: {
+            testProvider: { signature: 'second' },
+          },
+        },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: null,
+          toolInputSmoothing: {
+            chunking: /:/,
+          },
+          _internal: { delay: noOpDelay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toEqual([
+        { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '{"city"',
+          providerMetadata: {
+            testProvider: { signature: 'first' },
+          },
+        },
+        { type: 'tool-input-delta', id: 'call-1', delta: ':' },
+        {
+          type: 'tool-input-delta',
+          id: 'call-1',
+          delta: '"Rome"}',
+          providerMetadata: {
+            testProvider: { signature: 'second' },
+          },
+        },
+        { type: 'tool-input-end', id: 'call-1' },
+      ]);
+    });
+
     it('should preserve empty tool input deltas with provider metadata', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'tool-input-start', id: 'call-1', toolName: 'weather' },

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -10,6 +10,8 @@ const CHUNKING_REGEXPS = {
   line: /\n+/m,
 };
 
+type TextChunking = 'word' | 'line' | RegExp | ChunkDetector | Intl.Segmenter;
+
 /**
  * Detects the first chunk in a buffer.
  *
@@ -19,32 +21,15 @@ const CHUNKING_REGEXPS = {
  */
 export type ChunkDetector = (buffer: string) => string | undefined | null;
 
-/**
- * Smooths text and reasoning streaming output.
- *
- * @param delayInMs - The delay in milliseconds between each chunk. Defaults to 10ms. Can be set to `null` to skip the delay.
- * @param chunking - Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, provide a custom RegExp pattern for custom chunking, provide an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom ChunkDetector function.
- *
- * @returns A transform stream that smooths text streaming output.
- */
-export function smoothStream<TOOLS extends ToolSet>({
-  delayInMs = 10,
-  chunking = 'word',
-  _internal: { delay = originalDelay } = {},
+function createChunkDetector({
+  chunking,
+  argument,
+  validChunkingDescription,
 }: {
-  delayInMs?: number | null;
-  chunking?: 'word' | 'line' | RegExp | ChunkDetector | Intl.Segmenter;
-  /**
-   * Internal. For test use only. May change without notice.
-   */
-  _internal?: {
-    delay?: (delayInMs: number | null) => Promise<void>;
-  };
-} = {}): (options: {
-  tools: TOOLS;
-}) => TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>> {
-  let detectChunk: ChunkDetector;
-
+  chunking: TextChunking;
+  argument: string;
+  validChunkingDescription: string;
+}): ChunkDetector {
   // Check if chunking is an Intl.Segmenter (duck-typing for segment method)
   if (
     chunking != null &&
@@ -53,14 +38,16 @@ export function smoothStream<TOOLS extends ToolSet>({
     typeof chunking.segment === 'function'
   ) {
     const segmenter = chunking as Intl.Segmenter;
-    detectChunk = (buffer: string) => {
+    return (buffer: string) => {
       if (buffer.length === 0) return null;
       const iterator = segmenter.segment(buffer)[Symbol.iterator]();
       const first = iterator.next().value;
       return first?.segment || null;
     };
-  } else if (typeof chunking === 'function') {
-    detectChunk = buffer => {
+  }
+
+  if (typeof chunking === 'function') {
+    return buffer => {
       const match = chunking(buffer);
 
       if (match == null) {
@@ -79,37 +66,132 @@ export function smoothStream<TOOLS extends ToolSet>({
 
       return match;
     };
-  } else {
-    const chunkingRegex =
-      typeof chunking === 'string'
-        ? CHUNKING_REGEXPS[chunking]
-        : chunking instanceof RegExp
-          ? chunking
-          : undefined;
+  }
 
-    if (chunkingRegex == null) {
-      throw new InvalidArgumentError({
-        argument: 'chunking',
-        message: `Chunking must be "word", "line", a RegExp, an Intl.Segmenter, or a ChunkDetector function. Received: ${chunking}`,
-      });
+  const chunkingRegex =
+    typeof chunking === 'string'
+      ? CHUNKING_REGEXPS[chunking]
+      : chunking instanceof RegExp
+        ? chunking
+        : undefined;
+
+  if (chunkingRegex == null) {
+    throw new InvalidArgumentError({
+      argument,
+      message: `Chunking must be ${validChunkingDescription}. Received: ${chunking}`,
+    });
+  }
+
+  return buffer => {
+    const match = chunkingRegex.exec(buffer);
+
+    if (!match) {
+      return null;
     }
 
-    detectChunk = buffer => {
-      const match = chunkingRegex.exec(buffer);
+    const detectedChunk = buffer.slice(0, match.index) + match[0];
+    if (detectedChunk.length === 0) {
+      throw new Error(`Chunking pattern must match a non-empty string.`);
+    }
 
-      if (!match) {
-        return null;
-      }
+    return detectedChunk;
+  };
+}
 
-      return buffer.slice(0, match.index) + match?.[0];
-    };
+/**
+ * Smooths text, reasoning, and optionally tool input streaming output.
+ *
+ * @param delayInMs - The delay in milliseconds between each chunk. Defaults to 10ms. Can be set to `null` to skip the delay.
+ * @param chunking - Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, provide a custom RegExp pattern for custom chunking, provide an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom ChunkDetector function.
+ * @param toolInputSmoothing - Opt-in configuration for smoothing tool input deltas. Tool inputs are streamed character by character by default. Use `include` or `exclude` to control smoothing for individual tools.
+ *
+ * @returns A transform stream that smooths streaming output.
+ */
+export function smoothStream<TOOLS extends ToolSet>({
+  delayInMs = 10,
+  chunking = 'word',
+  toolInputSmoothing,
+  _internal: { delay = originalDelay } = {},
+}: {
+  delayInMs?: number | null;
+  chunking?: TextChunking;
+  toolInputSmoothing?: {
+    /**
+     * Controls how tool input JSON is chunked.
+     *
+     * @default 'character'
+     */
+    chunking?: 'character' | RegExp | ChunkDetector;
+    /**
+     * Only smooth tool inputs for these tools.
+     */
+    include?: ReadonlyArray<keyof TOOLS & string>;
+    /**
+     * Do not smooth tool inputs for these tools.
+     *
+     * `exclude` takes precedence over `include`.
+     */
+    exclude?: ReadonlyArray<keyof TOOLS & string>;
+  };
+  /**
+   * Internal. For test use only. May change without notice.
+   */
+  _internal?: {
+    delay?: (delayInMs: number | null) => Promise<void>;
+  };
+} = {}): (options: {
+  tools: TOOLS;
+}) => TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>> {
+  const detectChunk = createChunkDetector({
+    chunking,
+    argument: 'chunking',
+    validChunkingDescription:
+      '"word", "line", a RegExp, an Intl.Segmenter, or a ChunkDetector function',
+  });
+
+  const toolInputChunking = toolInputSmoothing?.chunking;
+  if (
+    toolInputSmoothing != null &&
+    toolInputChunking !== undefined &&
+    toolInputChunking !== 'character' &&
+    !(toolInputChunking instanceof RegExp) &&
+    typeof toolInputChunking !== 'function'
+  ) {
+    throw new InvalidArgumentError({
+      argument: 'toolInputSmoothing.chunking',
+      message: `Chunking must be "character", a RegExp, or a ChunkDetector function. Received: ${toolInputChunking}`,
+    });
   }
+
+  const detectToolInputChunk =
+    toolInputSmoothing == null
+      ? undefined
+      : toolInputChunking == null || toolInputChunking === 'character'
+        ? (buffer: string) => {
+            const codePoint = buffer.codePointAt(0);
+            return codePoint == null ? null : String.fromCodePoint(codePoint);
+          }
+        : createChunkDetector({
+            chunking: toolInputChunking,
+            argument: 'toolInputSmoothing.chunking',
+            validChunkingDescription:
+              '"character", a RegExp, or a ChunkDetector function',
+          });
 
   return () => {
     let buffer = '';
     let id = '';
     let type: 'text-delta' | 'reasoning-delta' | undefined = undefined;
     let providerMetadata: SharedV4ProviderMetadata | undefined = undefined;
+    let activeToolInputId: string | undefined;
+    const toolInputStates = new Map<
+      string,
+      {
+        buffer: string;
+        providerMetadata: SharedV4ProviderMetadata | undefined;
+        smooth: boolean;
+      }
+    >();
 
     function flushBuffer(
       controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
@@ -126,37 +208,179 @@ export function smoothStream<TOOLS extends ToolSet>({
       }
     }
 
+    function flushToolInputBuffer(
+      id: string,
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      const state = toolInputStates.get(id);
+
+      if (state != null && state.buffer.length > 0) {
+        controller.enqueue({
+          type: 'tool-input-delta',
+          id,
+          delta: state.buffer,
+          ...(state.providerMetadata != null
+            ? { providerMetadata: state.providerMetadata }
+            : {}),
+        });
+        state.buffer = '';
+        state.providerMetadata = undefined;
+      }
+    }
+
+    function flushActiveToolInputBuffer(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      if (activeToolInputId != null) {
+        flushToolInputBuffer(activeToolInputId, controller);
+        activeToolInputId = undefined;
+      }
+    }
+
+    function flushAllBuffers(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      flushBuffer(controller);
+      flushActiveToolInputBuffer(controller);
+
+      // Normally only the active tool input has buffered content. Iterating
+      // over all states also preserves input from malformed or truncated
+      // interleaved streams.
+      for (const toolInputId of toolInputStates.keys()) {
+        flushToolInputBuffer(toolInputId, controller);
+      }
+    }
+
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async transform(chunk, controller) {
-        // Handle non-smoothable chunks: flush buffer and pass through
-        if (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') {
+        if (chunk.type === 'text-delta' || chunk.type === 'reasoning-delta') {
+          flushActiveToolInputBuffer(controller);
+
+          // Flush buffer when type or id changes
+          if ((chunk.type !== type || chunk.id !== id) && buffer.length > 0) {
+            flushBuffer(controller);
+          }
+
+          buffer += chunk.text;
+          id = chunk.id;
+          type = chunk.type;
+
+          // Preserve providerMetadata (e.g., Anthropic thinking signatures)
+          if (chunk.providerMetadata != null) {
+            providerMetadata = chunk.providerMetadata;
+          }
+
+          let match;
+
+          while ((match = detectChunk(buffer)) != null) {
+            controller.enqueue({ type, text: match, id });
+            buffer = buffer.slice(match.length);
+
+            await delay(delayInMs);
+          }
+          return;
+        }
+
+        if (chunk.type === 'tool-input-start') {
           flushBuffer(controller);
+          flushActiveToolInputBuffer(controller);
+
+          const { include, exclude } = toolInputSmoothing ?? {};
+          toolInputStates.set(chunk.id, {
+            buffer: '',
+            providerMetadata: undefined,
+            smooth:
+              detectToolInputChunk != null &&
+              (include == null || include.includes(chunk.toolName)) &&
+              (exclude == null || !exclude.includes(chunk.toolName)),
+          });
+
           controller.enqueue(chunk);
           return;
         }
 
-        // Flush buffer when type or id changes
-        if ((chunk.type !== type || chunk.id !== id) && buffer.length > 0) {
+        if (chunk.type === 'tool-input-delta') {
           flushBuffer(controller);
+
+          const state = toolInputStates.get(chunk.id);
+          if (state == null || !state.smooth || detectToolInputChunk == null) {
+            flushActiveToolInputBuffer(controller);
+            controller.enqueue(chunk);
+            return;
+          }
+
+          if (activeToolInputId != null && activeToolInputId !== chunk.id) {
+            flushActiveToolInputBuffer(controller);
+          }
+          activeToolInputId = chunk.id;
+
+          if (chunk.delta.length === 0) {
+            flushToolInputBuffer(chunk.id, controller);
+            activeToolInputId = undefined;
+            controller.enqueue(chunk);
+            return;
+          }
+
+          if (
+            chunk.providerMetadata != null &&
+            state.providerMetadata != null &&
+            state.buffer.length > 0
+          ) {
+            // Keep metadata from separate provider deltas ordered and
+            // observable instead of overwriting it while buffering.
+            flushToolInputBuffer(chunk.id, controller);
+          }
+
+          state.buffer += chunk.delta;
+          if (chunk.providerMetadata != null) {
+            state.providerMetadata = chunk.providerMetadata;
+          }
+
+          let match;
+
+          while ((match = detectToolInputChunk(state.buffer)) != null) {
+            const isLastBufferedChunk = match.length === state.buffer.length;
+            controller.enqueue({
+              type: 'tool-input-delta',
+              id: chunk.id,
+              delta: match,
+              ...(isLastBufferedChunk && state.providerMetadata != null
+                ? { providerMetadata: state.providerMetadata }
+                : {}),
+            });
+            state.buffer = state.buffer.slice(match.length);
+
+            if (isLastBufferedChunk) {
+              state.providerMetadata = undefined;
+            }
+
+            await delay(delayInMs);
+          }
+          return;
         }
 
-        buffer += chunk.text;
-        id = chunk.id;
-        type = chunk.type;
+        if (chunk.type === 'tool-input-end') {
+          flushBuffer(controller);
 
-        // Preserve providerMetadata (e.g., Anthropic thinking signatures)
-        if (chunk.providerMetadata != null) {
-          providerMetadata = chunk.providerMetadata;
+          if (activeToolInputId != null && activeToolInputId !== chunk.id) {
+            flushActiveToolInputBuffer(controller);
+          }
+
+          flushToolInputBuffer(chunk.id, controller);
+          if (activeToolInputId === chunk.id) {
+            activeToolInputId = undefined;
+          }
+          toolInputStates.delete(chunk.id);
+          controller.enqueue(chunk);
+          return;
         }
 
-        let match;
-
-        while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
-          buffer = buffer.slice(match.length);
-
-          await delay(delayInMs);
-        }
+        // Handle non-smoothable chunks: flush buffers and pass through.
+        flushAllBuffers(controller);
+        controller.enqueue(chunk);
+      },
+      flush(controller) {
+        flushAllBuffers(controller);
       },
     });
   };

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -54,6 +54,7 @@ import {
 } from '../types/usage';
 import type { StepResult } from './step-result';
 import { isLoopFinished, isStepCount } from './stop-condition';
+import { smoothStream } from './smooth-stream';
 import { streamText } from './stream-text';
 import type { StreamTextResult, TextStreamPart } from './stream-text-result';
 import type {
@@ -464,6 +465,135 @@ const modelWithReasoningFiles = new MockLanguageModelV4({
 
 describe('streamText', () => {
   let logWarningsSpy: ReturnType<typeof vitest.spyOn>;
+
+  it('should retain provider chunking for tool input callbacks while smoothing output callbacks', async () => {
+    const input = '{"value":"test"}';
+    const callbackDeltas: string[] = [];
+    const outputDeltas: string[] = [];
+    const lifecycle: string[] = [];
+
+    const result = streamText({
+      model: createTestModel({
+        stream: convertArrayToReadableStream([
+          { type: 'tool-input-start', id: 'call-1', toolName: 'tool1' },
+          { type: 'tool-input-delta', id: 'call-1', delta: input },
+          { type: 'tool-input-end', id: 'call-1' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'tool1',
+            input,
+          },
+          {
+            type: 'finish',
+            finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+            usage: testUsage,
+          },
+        ]),
+      }),
+      tools: {
+        tool1: tool({
+          inputSchema: z.object({ value: z.string() }),
+          onInputStart: () => {
+            lifecycle.push('onInputStart');
+          },
+          onInputDelta: ({ inputTextDelta }) => {
+            callbackDeltas.push(inputTextDelta);
+            lifecycle.push('onInputDelta');
+          },
+          onInputAvailable: () => {
+            lifecycle.push('onInputAvailable');
+          },
+          execute: async () => {
+            lifecycle.push('execute');
+            return 'result';
+          },
+        }),
+      },
+      prompt: 'test-input',
+      experimental_transform: smoothStream({
+        delayInMs: null,
+        toolInputSmoothing: {},
+      }),
+      onChunk: ({ chunk }) => {
+        if (chunk.type === 'tool-input-delta') {
+          outputDeltas.push(chunk.delta);
+          lifecycle.push(`onChunk:${chunk.delta}`);
+        }
+      },
+    });
+
+    await result.consumeStream();
+
+    expect(callbackDeltas).toEqual([input]);
+    expect(outputDeltas).toEqual([...input]);
+    expect(lifecycle.slice(0, 2)).toEqual(['onInputStart', 'onInputDelta']);
+
+    const lastOutputDeltaIndex = lifecycle.lastIndexOf(
+      `onChunk:${[...input].at(-1)}`,
+    );
+    const inputAvailableIndex = lifecycle.indexOf('onInputAvailable');
+    const executeIndex = lifecycle.indexOf('execute');
+
+    expect(inputAvailableIndex).toBeGreaterThan(
+      lifecycle.indexOf('onInputDelta'),
+    );
+    expect(executeIndex).toBeGreaterThan(inputAvailableIndex);
+    expect(inputAvailableIndex).toBeLessThan(lastOutputDeltaIndex);
+    expect(executeIndex).toBeLessThan(lastOutputDeltaIndex);
+  });
+
+  it('should expose smoothed tool input deltas to the UI message stream', async () => {
+    const input = '{"value":"test"}';
+    const result = streamText({
+      model: createTestModel({
+        stream: convertArrayToReadableStream([
+          { type: 'tool-input-start', id: 'call-1', toolName: 'tool1' },
+          { type: 'tool-input-delta', id: 'call-1', delta: input },
+          { type: 'tool-input-end', id: 'call-1' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'tool1',
+            input,
+          },
+          {
+            type: 'finish',
+            finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+            usage: testUsage,
+          },
+        ]),
+      }),
+      tools: {
+        tool1: tool({
+          inputSchema: z.object({ value: z.string() }),
+        }),
+      },
+      prompt: 'test-input',
+      experimental_transform: smoothStream({
+        delayInMs: null,
+        toolInputSmoothing: {},
+      }),
+    });
+
+    const chunks = await convertReadableStreamToArray(
+      result.toUIMessageStream(),
+    );
+
+    expect(chunks.filter(chunk => chunk.type === 'tool-input-delta')).toEqual(
+      [...input].map(inputTextDelta => ({
+        type: 'tool-input-delta',
+        toolCallId: 'call-1',
+        inputTextDelta,
+      })),
+    );
+    expect(chunks).toContainEqual({
+      type: 'tool-input-available',
+      toolCallId: 'call-1',
+      toolName: 'tool1',
+      input: { value: 'test' },
+    });
+  });
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });


### PR DESCRIPTION
## Background

Tool input fragments can arrive in visually abrupt provider-sized bursts even when text and reasoning output use smoothStream. Consumers need an opt-in, provider-independent way to rechunk those fragments, selectively enable it per tool, and understand its lifecycle and performance boundaries.

## Summary

Extends smoothStream with optional toolInputSmoothing configuration supporting Unicode character, RegExp, or custom detector chunking; typed include and exclude tool selection with exclusion precedence; independent buffering for interleaved calls; metadata preservation; lifecycle ordering; and flushing at end, error, abort, and truncated-stream boundaries. Existing behavior remains unchanged unless enabled. Tool lifecycle callbacks and execution remain upstream of transformations and retain provider timing and chunking.

## Testing

Covers character and custom chunking, Unicode, inclusion and exclusion, interleaving, empty and multiple metadata-bearing provider deltas, zero and null delays, errors, aborts, truncated streams, callback and execution ordering, UI message conversion, and public option types. Focused suites passed with 46 smoothStream tests and the two new streamText integrations; the complete repository test suite also passed.

## End-to-end Validation

- The provider-independent `stream-text/smooth/tool-input` example ran successfully against the built workspace package and verified character-sized deltas reconstruct the original JSON.

## Documentation

Updates the smoothStream reference, generating-text guide, and API index with configuration, defaults, selection precedence, lifecycle behavior, callback boundaries, performance implications, and partial-input safety guidance. Adds a runnable provider-independent example and an ai patch changeset.

## Related Issues

Fixes #7720

Co-authored-by: Shinchan3102 <106232138+Shinchan3102@users.noreply.github.com>