### PR TITLE
[v6.0] reproduction: Duplicate toolCallId across steps causes readUIMessageStream to overwrite

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17347,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17347-duplicate-tool-call-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17347 REPRODUCED: expected 2 tool parts across 2 steps, received 1."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts
@@ -1,0 +1,96 @@
+import {
+  isToolOrDynamicToolUIPart,
+  readUIMessageStream,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai';
+
+async function main() {
+  const chunks: UIMessageChunk[] = [
+    { type: 'start', messageId: 'message-1' },
+    { type: 'start-step' },
+    {
+      type: 'tool-input-available',
+      toolCallId: 'call_0',
+      toolName: 'recordStep',
+      input: { step: 1 },
+      providerMetadata: { openai: { itemId: 'fc_step_1' } },
+    },
+    {
+      type: 'tool-output-available',
+      toolCallId: 'call_0',
+      output: { recorded: 1 },
+    },
+    { type: 'finish-step' },
+    { type: 'start-step' },
+    {
+      type: 'tool-input-available',
+      toolCallId: 'call_0',
+      toolName: 'recordStep',
+      input: { step: 2 },
+      providerMetadata: { openai: { itemId: 'fc_step_2' } },
+    },
+    {
+      type: 'tool-output-available',
+      toolCallId: 'call_0',
+      output: { recorded: 2 },
+    },
+    { type: 'finish-step' },
+    { type: 'finish' },
+  ];
+
+  const stream = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  let finalMessage: UIMessage | undefined;
+  for await (const message of readUIMessageStream({ stream })) {
+    finalMessage = message;
+  }
+
+  if (finalMessage == null) {
+    throw new Error('No final UI message was produced.');
+  }
+
+  const toolParts = finalMessage.parts.filter(isToolOrDynamicToolUIPart);
+
+  if (toolParts.length !== 2) {
+    console.error(
+      `ISSUE #17347 REPRODUCED: expected 2 tool parts across 2 steps, received ${toolParts.length}.`,
+    );
+    console.error(JSON.stringify(toolParts, null, 2));
+    process.exitCode = 1;
+    return;
+  }
+
+  const itemIds = toolParts.map(
+    part => part.callProviderMetadata?.openai?.itemId,
+  );
+
+  if (
+    toolParts.some(part => part.toolCallId !== 'call_0') ||
+    itemIds[0] !== 'fc_step_1' ||
+    itemIds[1] !== 'fc_step_2'
+  ) {
+    console.error(
+      'Unexpected tool-part identity or provider metadata after aggregation.',
+    );
+    console.error(JSON.stringify(toolParts, null, 2));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    'Issue not reproduced: both tool parts were preserved with unchanged provider protocol IDs.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Duplicate toolCallId across steps causes readUIMessageStream to overwrite earlier tool parts

## Reproduction

- On `release-v6.0` with `ai@6.0.231`, `examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts` expected two tool parts but received one.
- The surviving part contains step 2's input, output, and `fc_step_2` item ID; step 1 and `fc_step_1` were overwritten.
- `packages/ai/src/ui/process-ui-message-stream.ts` searches the entire message for an existing part with the same `toolCallId`, conflating `call_0` across steps.
- The credential-free reproduction validates UI aggregation and unchanged expected `toolCallId` values, but does not independently rerun the live Bedrock executions or provider round trip.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/read-ui-message-stream
- https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html

## Related Issues

Reproduces #17347