### PR TITLE
[v6.0] reproduction: providerOptions are lost when consecutive tool messages are

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17507,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17507-tool-message-provider-options.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #17507: consecutive tool messages lost providerOptions from the second message."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts
+++ b/examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts
@@ -1,0 +1,152 @@
+import type { LanguageModelV3, LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { generateText, type ModelMessage } from 'ai';
+
+const firstMessageProviderOptions = {
+  anthropic: { cacheControl: { type: 'ephemeral' } },
+  test: {
+    conflict: 'message',
+    firstMessageOnly: true,
+  },
+};
+
+const firstPartProviderOptions = {
+  test: {
+    conflict: 'part',
+  },
+};
+
+const secondMessageProviderOptions = {
+  anthropic: { cacheControl: { type: 'ephemeral' } },
+  test: {
+    secondMessageOnly: true,
+  },
+};
+
+async function main() {
+  let providerPrompt: LanguageModelV3Prompt | undefined;
+
+  const model = {
+    specificationVersion: 'v3',
+    provider: 'reproduction',
+    modelId: 'issue-17507',
+    supportedUrls: {},
+    async doGenerate({ prompt }) {
+      providerPrompt = prompt;
+
+      return {
+        content: [{ type: 'text' as const, text: 'ok' }],
+        finishReason: { unified: 'stop' as const, raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 0,
+            noCache: 0,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 0,
+            text: 0,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      };
+    },
+    async doStream() {
+      throw new Error('doStream is not used by this reproduction.');
+    },
+  } satisfies LanguageModelV3;
+
+  const messages: ModelMessage[] = [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool-1',
+          input: {},
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'tool-2',
+          input: {},
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      providerOptions: firstMessageProviderOptions,
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'tool-1',
+          output: { type: 'text', value: 'first result' },
+          providerOptions: firstPartProviderOptions,
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      providerOptions: secondMessageProviderOptions,
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-2',
+          toolName: 'tool-2',
+          output: { type: 'text', value: 'second result' },
+        },
+      ],
+    },
+  ];
+
+  await generateText({ model, messages });
+
+  const toolMessages =
+    providerPrompt?.filter(message => message.role === 'tool') ?? [];
+  const combinedToolMessage = toolMessages[0];
+  const observed = {
+    toolMessageCount: toolMessages.length,
+    combinedMessageProviderOptions: combinedToolMessage?.providerOptions,
+    firstResultProviderOptions:
+      combinedToolMessage?.content[0]?.providerOptions,
+    secondResultProviderOptions:
+      combinedToolMessage?.content[1]?.providerOptions,
+  };
+  const expected = {
+    toolMessageCount: 1,
+    combinedMessageProviderOptions: secondMessageProviderOptions,
+    firstResultProviderOptions: {
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+      test: {
+        conflict: 'part',
+        firstMessageOnly: true,
+      },
+    },
+    secondResultProviderOptions: undefined,
+  };
+
+  console.log(JSON.stringify({ observed, expected }, null, 2));
+
+  if (
+    JSON.stringify(observed.combinedMessageProviderOptions) !==
+    JSON.stringify(secondMessageProviderOptions)
+  ) {
+    throw new Error(
+      'Reproduced issue #17507: consecutive tool messages lost providerOptions from the second message.',
+    );
+  }
+
+  if (JSON.stringify(observed) !== JSON.stringify(expected)) {
+    throw new Error(
+      'Consecutive tool messages did not preserve providerOptions at their original message boundaries with part-level precedence.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

providerOptions are lost when consecutive tool messages are combined

## Reproduction

- On `release-v6.0` with `ai@6.0.231`, consecutive tool messages were coalesced, but the provider-facing prompt retained only the first message's `providerOptions`; the second message's options were silently lost.
- The first tool-result part retained its conflicting part-level option but failed to inherit the first message's non-conflicting options, so the original message boundary was not preserved.
- `examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts` reproduces the bug through public `generateText`; correct behavior would retain the second message's options on the combined message and merge the first message's options into its final result with part-level precedence.
- Losing valid message-level options can remove or relocate Anthropic explicit prompt-cache breakpoints.

## Relevant Documentation

- https://ai-sdk.dev/docs/foundations/prompts
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
- https://ai-sdk.dev/cookbook/node/dynamic-prompt-caching
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching

## Related Issues

Reproduces #17507