### PR TITLE
[v5.0] reproduction: could not reproduce OpenAI o3 model throws "Invalid schema for function"

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-7082-openai-o3-optional-tool-parameters.ts
+++ b/examples/ai-functions/src/reproduction/issue-7082-openai-o3-optional-tool-parameters.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { createOpenAI } from '../../../../packages/openai/dist/index.mjs';
+import {
+  APICallError,
+  generateText,
+  tool,
+} from '../../../../packages/ai/dist/index.mjs';
+import { z } from '../../../ai-core/node_modules/zod/index.js';
+
+const fixturePath =
+  '../../packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json';
+
+const requests: Array<Record<string, any>> = [];
+const responses: Array<unknown> = [];
+
+const openai = createOpenAI({
+  fetch: async (url, init) => {
+    requests.push(JSON.parse(init?.body as string));
+
+    const response = await fetch(url, init);
+    const responseText = await response.clone().text();
+
+    try {
+      responses.push(JSON.parse(responseText));
+    } catch {
+      responses.push(responseText);
+    }
+
+    return response;
+  },
+});
+
+const semanticScholarSearch = tool({
+  description: 'Search academic papers using Semantic Scholar API.',
+  inputSchema: z.object({
+    query: z
+      .string()
+      .describe(
+        'The text to search for. Convert the question to a sensible search query.',
+      ),
+    limit: z
+      .number()
+      .int()
+      .optional()
+      .describe('The maximum number of results to return. Min 5, max 100.'),
+    offset: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe('The pagination offset.'),
+    year: z
+      .number()
+      .int()
+      .optional()
+      .describe('Restrict results to this publication year.'),
+  }),
+});
+
+async function generate(strictJsonSchema?: boolean) {
+  return generateText({
+    model: openai('o3'),
+    maxOutputTokens: 1000,
+    tools: {
+      semantic_scholar_search: semanticScholarSearch,
+    },
+    toolChoice: {
+      type: 'tool',
+      toolName: 'semantic_scholar_search',
+    },
+    prompt: 'Search for papers about machine learning.',
+    ...(strictJsonSchema == null
+      ? {}
+      : {
+          providerOptions: {
+            openai: { strictJsonSchema },
+          },
+        }),
+  });
+}
+
+async function main() {
+  const result = await generate();
+
+  const defaultRequestTool = requests[0]?.tools?.[0];
+  assert.equal(defaultRequestTool?.name, 'semantic_scholar_search');
+  assert.equal(defaultRequestTool?.strict, false);
+  assert.deepEqual(defaultRequestTool?.parameters?.required, ['query']);
+  assert.deepEqual(Object.keys(defaultRequestTool?.parameters?.properties), [
+    'query',
+    'limit',
+    'offset',
+    'year',
+  ]);
+
+  assert.equal(result.toolCalls.length, 1);
+  assert.equal(result.toolCalls[0]?.toolName, 'semantic_scholar_search');
+  assert.equal(typeof result.toolCalls[0]?.input.query, 'string');
+
+  try {
+    await fs.writeFile(
+      fixturePath,
+      `${JSON.stringify(responses[0], null, 2)}\n`,
+      {
+        encoding: 'utf8',
+        flag: 'wx',
+      },
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      throw error;
+    }
+  }
+
+  let strictError: unknown;
+  try {
+    await generate(true);
+  } catch (error) {
+    strictError = error;
+  }
+
+  assert.ok(
+    APICallError.isInstance(strictError),
+    'strictJsonSchema: true should reject this non-strict schema',
+  );
+  assert.match(
+    strictError.responseBody ?? strictError.message,
+    /Missing 'limit'/,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        defaultRequest: {
+          strict: defaultRequestTool.strict,
+          required: defaultRequestTool.parameters.required,
+        },
+        toolCall: result.toolCalls[0],
+        strictTrueError: strictError.responseBody,
+        fixturePath,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json
+++ b/packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json
@@ -1,0 +1,132 @@
+{
+  "id": "resp_0895dc792e938f60006a5f4529ee1081a0b5a67da472db790f",
+  "object": "response",
+  "created_at": 1784628521,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1784628523,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": 1000,
+  "max_tool_calls": null,
+  "model": "o3-2025-04-16",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0895dc792e938f60006a5f452a7ee481a0b093e9723ada4e68",
+      "type": "reasoning",
+      "content": [],
+      "encrypted_content": "gAAAAABqX0UrJ9GrP9frBP-xn8lwYZ49nUTByi1_rWTj0iOgjyqA0D04Psz4trnLehtTAMTcBB85589LQWqWbr6_Sc9LaMm0ZCFmjc6Jkj6bi1RxjzVzZrRgD3lB121FmfFirxdh7KKLJq4sAjhPV3BI8zzrcbkHAspNMj1vVsqwxvBvr6U0PL3KchiyuUov3nEP40lDbc4wee2zENWGAq5rASP8LwnbQ5fnKhrsivJUKxchNNlkEkaQoK_oK8QnD5_yhTKa0Il9xBB5pNePcuCJLMjuLsr5p7OL4lMTJ1Q-dRebEeiSHMOr77ZGtW7h4cxhG5_6ECXKx8qRhR4nU2tg6De4d8fERsK1R6D8oRoip_Jd8eFM3wlIAx7vKq3WCwL0Ies2radhfp3d0wvrNHzaqkqLFTquH4YAFQk_bV5iIEt5mxx1-BlZR3go6i5cUN9CgPEUCZuje1yU9v-Z7yxTMVLiEnEy53XKKD-U2EkM3MZ5CbrixrJgzOqmRxZa0xpmUi0E3VxZJVcP2rC5XStzexT0YJQKCfYG5ZLHF4IkT9XvtQzrnnfgfHDTTr4ujzHNHGZAEdh1mhWXWBWnE_Ty-yMYgwIokPEoVbV2j-hVJxa05V4bPWYJihcxvwRRrP0DvrDG3dVEHmMEp1V_xaXgt9-bfi_AM2UDXyUzGRiUAOJnXxgX06qmjbET8WIXq5ntB1AMaP4y5P7A8jzASlWqf5XbfevlnlxEZOQmUFpCtX34wCbzTN_sA92MraLFF6AM3ULmVAYa9Vr7mEg-0MyJyOyNAVipv3m1TG1uAU-llXswJpwALiruTtIfG4ppmu4Ni3gh12fkrTydbxAwDN7xDan-eK5yzhb_DOzmwpIy5rwPmrQA48xc_cYMPNnyRxCIgiBcpLMU9gazf1hESrt-wupCbylF7Bgk8S0QkX28wHKpu4g61qcEOjqBFIihS5r7qgodMTmU2xLpNNKC_KJXSLbCQOqkcLZIE52laBj9QEJbvSkSHxwghOYkyTa0RAvm0S2iwovHvLXOexUdItznUYe8DIk4MfGds7-jHuRL-UX6HO8ip_4OlXjzBK2hW9S5Q5r3E1AcuYaBwUocHxCFeCEJJyDQGKzBUkkmWjjCvI2QNFxralbtHdBrkzS70ZbkjklOND-pFpFcMF-zkn04EPYi9raK2DHTogunde4MwtH2m9RFGhvIbpQlDgcrTUXMYouna3MdF5LCRnYuzv5yP9ytZR40ZrYOD1VEegpWamyQdIj4K7gcsxV_z7W-XueY01mfbtmgUAhbj18ajh4IoS0LENFezWjucNmgh5wDSGJ6vOiDGVoyuNxPgplni3gxPt5EuYeIjr66lDt98FI7spGmK_bgGRbMyDVFfmxzpU1x3xiZhQQ=",
+      "summary": []
+    },
+    {
+      "id": "fc_0895dc792e938f60006a5f452b6ae081a09491832f50a63901",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"query\":\"machine learning\",\"limit\":10}",
+      "call_id": "call_sllqlMEFqHePsbF1dDko4Pdq",
+      "name": "semantic_scholar_search"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "mode": "standard",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": {
+    "type": "function",
+    "name": "semantic_scholar_search"
+  },
+  "tool_usage": {
+    "image_gen": {
+      "input_tokens": 0,
+      "input_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "output_tokens": 0,
+      "output_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "total_tokens": 0
+    },
+    "web_search": {
+      "num_requests": 0
+    }
+  },
+  "tools": [
+    {
+      "type": "function",
+      "description": "Search academic papers using Semantic Scholar API.",
+      "name": "semantic_scholar_search",
+      "output_schema": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The text to search for. Convert the question to a sensible search query."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "The maximum number of results to return. Min 5, max 100."
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The pagination offset."
+          },
+          "year": {
+            "type": "integer",
+            "description": "Restrict results to this publication year."
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "strict": false
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 114,
+    "input_tokens_details": {
+      "cache_write_tokens": 0,
+      "cached_tokens": 0
+    },
+    "output_tokens": 99,
+    "output_tokens_details": {
+      "reasoning_tokens": 64
+    },
+    "total_tokens": 213
+  },
+  "user": null,
+  "metadata": {}
+}

--- a/packages/openai/src/responses/issue-7082.test.ts
+++ b/packages/openai/src/responses/issue-7082.test.ts
@@ -1,0 +1,119 @@
+import type {
+  LanguageModelV2FunctionTool,
+  LanguageModelV2Prompt,
+} from '@ai-sdk/provider';
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { OpenAIResponsesLanguageModel } from './openai-responses-language-model';
+
+const server = createTestServer({
+  'https://api.openai.com/v1/responses': {
+    response: {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json',
+          'utf8',
+        ),
+      ),
+    },
+  },
+});
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Search for papers about machine learning.',
+      },
+    ],
+  },
+];
+
+const semanticScholarSearch: LanguageModelV2FunctionTool = {
+  type: 'function',
+  name: 'semantic_scholar_search',
+  description: 'Search academic papers using Semantic Scholar API.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description:
+          'The text to search for. Convert the question to a sensible search query.',
+      },
+      limit: {
+        type: 'integer',
+        description: 'The maximum number of results to return. Min 5, max 100.',
+      },
+      offset: {
+        type: 'integer',
+        minimum: 0,
+        description: 'The pagination offset.',
+      },
+      year: {
+        type: 'integer',
+        description: 'Restrict results to this publication year.',
+      },
+    },
+    required: ['query'],
+    additionalProperties: false,
+    $schema: 'http://json-schema.org/draft-07/schema#',
+  },
+};
+
+it('accepts an o3 tool with optional parameters when strictJsonSchema defaults to false', async () => {
+  const model = new OpenAIResponsesLanguageModel('o3', {
+    provider: 'openai.responses',
+    url: ({ path }) => `https://api.openai.com/v1${path}`,
+    headers: () => ({ Authorization: 'Bearer APIKEY' }),
+    generateId: mockId(),
+    fileIdPrefixes: ['file-'],
+  });
+
+  const result = await model.doGenerate({
+    prompt,
+    tools: [semanticScholarSearch],
+    toolChoice: {
+      type: 'tool',
+      toolName: 'semantic_scholar_search',
+    },
+    maxOutputTokens: 1000,
+  });
+
+  expect(await server.calls[0].requestBodyJson).toMatchObject({
+    model: 'o3',
+    tools: [
+      {
+        type: 'function',
+        name: 'semantic_scholar_search',
+        strict: false,
+        parameters: {
+          required: ['query'],
+          properties: {
+            query: { type: 'string' },
+            limit: { type: 'integer' },
+            offset: { type: 'integer' },
+            year: { type: 'integer' },
+          },
+        },
+      },
+    ],
+  });
+  expect(result.content).toContainEqual({
+    type: 'tool-call',
+    toolCallId: 'call_sllqlMEFqHePsbF1dDko4Pdq',
+    toolName: 'semantic_scholar_search',
+    input: '{"query":"machine learning","limit":10}',
+    providerMetadata: {
+      openai: {
+        itemId: 'fc_0895dc792e938f60006a5f452b6ae081a09491832f50a63901',
+      },
+    },
+  });
+  expect(result.finishReason).toBe('tool-calls');
+});


### PR DESCRIPTION
## Bug

OpenAI o3 model throws "Invalid schema for function" error when optional parameters are not included in 'required' array

## Reproduction

- Target `release-v5.0` uses `ai` 5.0.217 and `@ai-sdk/openai` 2.0.114; the issue reported AI SDK 4.3.16 and OpenAI provider 1.3.22.
- `examples/ai-functions/src/reproduction/issue-7082-openai-o3-optional-tool-parameters.ts` completed a live `o3` request successfully: only `query` was required, `strict` was `false`, and OpenAI returned the requested tool call instead of the reported schema-validation error.
- Enabling `strictJsonSchema: true` produced the reported `Missing 'limit'` error, consistent with OpenAI's documented requirement that strict schemas mark every property as required; AI SDK 5 defaults this option to `false`.
- `packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json` records the completed live `o3-2025-04-16` response.
- `packages/openai/src/responses/issue-7082.test.ts` verifies the non-strict request schema and successful tool-call parsing from the live fixture.
- On the target branch, aligning to AI SDK 5 packages and leaving `strictJsonSchema` disabled avoids the reported failure without product-code changes.

## Relevant Documentation

- https://developers.openai.com/api/docs/guides/function-calling
- https://developers.openai.com/api/docs/models/o3
- https://ai-sdk.dev/v5/docs/migration-guides/migration-guide-5-0

## Related Issues

Could not reproduce #7082