### PR TITLE
[v6.0] reproduction: could not reproduce OpenAI o3 model throws "Invalid schema for function"

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-7082-openai-o3-optional-tool-parameters.ts
+++ b/examples/ai-functions/src/reproduction/issue-7082-openai-o3-optional-tool-parameters.ts
@@ -1,0 +1,153 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+
+type CapturedCall = {
+  requestBody?: Record<string, any>;
+  responseBody?: Record<string, any>;
+};
+
+const modelId = process.env.ISSUE_7082_MODEL ?? 'o3';
+const schemaVariant = process.env.ISSUE_7082_SCHEMA_VARIANT ?? 'optional';
+
+function createSearchTool(strict?: boolean) {
+  const limit = z.number().int();
+  const limitSchema =
+    schemaVariant === 'default'
+      ? limit.default(10)
+      : schemaVariant === 'nullish'
+        ? limit.nullish()
+        : schemaVariant === 'nullable'
+          ? limit.nullable()
+          : limit.optional();
+
+  return tool({
+    description: 'Search academic papers using Semantic Scholar API.',
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe(
+          'The text to search for. Convert the question to a sensible search query.',
+        ),
+      limit: limitSchema.describe(
+        'The maximum number of results to return. Min 5, max 100.',
+      ),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('The pagination offset.'),
+      year: z
+        .number()
+        .int()
+        .optional()
+        .describe('The publication year, formatted as YYYY.'),
+    }),
+    ...(strict == null ? {} : { strict }),
+  });
+}
+
+async function callModel(strict?: boolean) {
+  const calls: CapturedCall[] = [];
+  const openai = createOpenAI({
+    fetch: async (input, init) => {
+      const call: CapturedCall = {
+        requestBody:
+          typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.responseBody = await response
+        .clone()
+        .json()
+        .catch(() => undefined);
+      return response;
+    },
+  });
+
+  const result = await generateText({
+    model: openai(modelId),
+    prompt: 'Search for papers about machine learning.',
+    tools: {
+      semantic_scholar_search: createSearchTool(strict),
+    },
+    toolChoice: {
+      type: 'tool',
+      toolName: 'semantic_scholar_search',
+    },
+  });
+
+  return { calls, result };
+}
+
+async function main() {
+  let defaultRun: Awaited<ReturnType<typeof callModel>>;
+
+  try {
+    defaultRun = await callModel();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      `ISSUE_7082_REPRODUCED: ${modelId} rejected optional tool parameters by default: ${message}`,
+    );
+    throw error;
+  }
+
+  const defaultRequestTool = defaultRun.calls[0]?.requestBody?.tools?.[0];
+  assert.deepEqual(
+    defaultRequestTool?.parameters?.required,
+    schemaVariant === 'nullable' ? ['query', 'limit'] : ['query'],
+  );
+  assert.equal('strict' in defaultRequestTool, false);
+  assert.equal(
+    defaultRun.result.toolCalls[0]?.toolName,
+    'semantic_scholar_search',
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        defaultRun: {
+          modelId,
+          schemaVariant,
+          requestTool: defaultRequestTool,
+          toolCall: defaultRun.result.toolCalls[0],
+          responseStatus: defaultRun.calls[0]?.responseBody?.status,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (process.env.ISSUE_7082_DEFAULT_ONLY === '1') {
+    return;
+  }
+
+  const flexibleRun = await callModel(false);
+  const flexibleRequestTool = flexibleRun.calls[0]?.requestBody?.tools?.[0];
+  assert.equal(flexibleRequestTool?.strict, false);
+  assert.equal(
+    flexibleRun.result.toolCalls[0]?.toolName,
+    'semantic_scholar_search',
+  );
+  console.log(
+    `strictFalseRun: accepted: ${JSON.stringify(flexibleRun.result.toolCalls[0]?.input)}`,
+  );
+
+  try {
+    await callModel(true);
+    console.log('strictRun: accepted');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`strictRun: rejected: ${message}`);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json
+++ b/packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json
@@ -1,0 +1,130 @@
+{
+  "id": "resp_0d742adaa831b789006a5f45306dbc81a0b3e4830424e1c682",
+  "object": "response",
+  "created_at": 1784628528,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1784628531,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "o3-2025-04-16",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0d742adaa831b789006a5f4531387481a08e8bb2e23a707ded",
+      "type": "reasoning",
+      "content": [],
+      "encrypted_content": "[redacted]",
+      "summary": []
+    },
+    {
+      "id": "fc_0d742adaa831b789006a5f453311d881a08b119d7d4a5da176",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"query\":\"machine learning\",\"limit\":10,\"offset\":0,\"year\":0}",
+      "call_id": "call_TXveU5dZ1lW6uhMbjhUIE9Gq",
+      "name": "semantic_scholar_search"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "mode": "standard",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": {
+    "type": "function",
+    "name": "semantic_scholar_search"
+  },
+  "tool_usage": {
+    "image_gen": {
+      "input_tokens": 0,
+      "input_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "output_tokens": 0,
+      "output_tokens_details": {
+        "image_tokens": 0,
+        "text_tokens": 0
+      },
+      "total_tokens": 0
+    },
+    "web_search": {
+      "num_requests": 0
+    }
+  },
+  "tools": [
+    {
+      "type": "function",
+      "description": "Search academic papers using Semantic Scholar API.",
+      "name": "semantic_scholar_search",
+      "output_schema": null,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The text to search for. Convert the question to a sensible search query."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "The maximum number of results to return. Min 5, max 100."
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The pagination offset."
+          },
+          "year": {
+            "type": "integer",
+            "description": "The publication year, formatted as YYYY."
+          }
+        },
+        "required": ["query", "limit", "offset", "year"],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 114,
+    "input_tokens_details": {
+      "cache_write_tokens": 0,
+      "cached_tokens": 0
+    },
+    "output_tokens": 284,
+    "output_tokens_details": {
+      "reasoning_tokens": 192
+    },
+    "total_tokens": 398
+  },
+  "user": null,
+  "metadata": {}
+}

--- a/packages/openai/src/responses/issue-7082.test.ts
+++ b/packages/openai/src/responses/issue-7082.test.ts
@@ -1,0 +1,77 @@
+import { mockId } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { OpenAIResponsesLanguageModel } from './openai-responses-language-model';
+
+const server = createTestServer({
+  'https://api.openai.com/v1/responses': {},
+});
+
+it('accepts an o3 tool schema with optional properties when strict is omitted', async () => {
+  server.urls['https://api.openai.com/v1/responses'].response = {
+    type: 'json-value',
+    body: JSON.parse(
+      fs.readFileSync(
+        'src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json',
+        'utf8',
+      ),
+    ),
+  };
+
+  const model = new OpenAIResponsesLanguageModel('o3', {
+    provider: 'openai.responses',
+    url: ({ path }) => `https://api.openai.com/v1${path}`,
+    headers: () => ({ Authorization: 'Bearer APIKEY' }),
+    generateId: mockId(),
+  });
+
+  const result = await model.doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Search for papers about machine learning.' },
+        ],
+      },
+    ],
+    tools: [
+      {
+        type: 'function',
+        name: 'semantic_scholar_search',
+        description: 'Search academic papers using Semantic Scholar API.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            limit: { type: 'integer' },
+            offset: { type: 'integer', minimum: 0 },
+            year: { type: 'integer' },
+          },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    toolChoice: {
+      type: 'tool',
+      toolName: 'semantic_scholar_search',
+    },
+  });
+
+  const requestBody = await server.calls[0].requestBodyJson;
+  expect(requestBody.tools[0].parameters.required).toEqual(['query']);
+  expect(requestBody.tools[0]).not.toHaveProperty('strict');
+
+  const toolCall = result.content.find(part => part.type === 'tool-call');
+  expect(toolCall).toMatchObject({
+    type: 'tool-call',
+    toolName: 'semantic_scholar_search',
+  });
+  expect(JSON.parse(toolCall!.input)).toEqual({
+    query: 'machine learning',
+    limit: 10,
+    offset: 0,
+    year: 0,
+  });
+});


### PR DESCRIPTION
## Bug

OpenAI o3 model throws "Invalid schema for function" error when optional parameters are not included in 'required' array

## Reproduction

- On `release-v6.0`, using `ai` 6.0.231 and `@ai-sdk/openai` 3.0.86, the live `o3` request completed and produced the requested tool call; the expected `Missing 'limit'` exception did not occur.
- The request retained only `query` in `required` and omitted the tool-level `strict` field; explicitly setting `strict: false` also succeeded, while opt-in `strict: true` produced the documented schema rejection.
- Live comparison calls also succeeded with `o3-mini`, `o4-mini`, and `gpt-4o-mini`; the reported `.default()`, `.nullish()`, and `.nullable()` variants succeeded with `gpt-4o-mini`.
- The reported versions, `ai` 4.3.16 and `@ai-sdk/openai` 1.3.22, differ from the aligned AI SDK 6 packages on the target branch; upgrading and leaving per-tool strict mode omitted or false resolves the reported outcome without product-code changes.
- `examples/ai-functions/src/reproduction/issue-7082-openai-o3-optional-tool-parameters.ts` contains the runnable live reproduction and `model/schema` comparisons.
- `packages/openai/src/responses/__fixtures__/issue-7082-o3-optional-tool-parameters.json` records the successful live `o3` response, and `packages/openai/src/responses/issue-7082.test.ts` verifies the flexible request schema and resulting tool call.

## Relevant Documentation

- https://developers.openai.com/api/docs/guides/function-calling
- https://developers.openai.com/api/docs/models/o3
- https://ai-sdk.dev/providers/ai-sdk-providers/openai
- https://ai-sdk.dev/docs/migration-guides/migration-guide-6-0

## Related Issues

Could not reproduce #7082