### PR TITLE
docs(devtools): document the `include` opt-in for raw request/response bodies

### DIFF
--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -101,7 +101,26 @@ DevTools captures the following information from your AI SDK calls:
 - **Input parameters and prompts**: View the complete input sent to your LLM
 - **Output content and tool calls**: Inspect generated text and tool invocations
 - **Token usage and timing**: Monitor resource consumption and performance
-- **Raw provider data**: Access complete request and response payloads
+- **Raw provider data**: Access complete request and response payloads (opt-in, see below)
+
+### Raw request and response bodies
+
+Since AI SDK 7, `generateText` and `streamText` exclude request bodies from step results by default, and `generateText` also excludes response bodies. As a result, raw request and response payloads do not appear in DevTools unless you opt in with the `include` option:
+
+```ts
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello!',
+  include: {
+    requestBody: true,
+    responseBody: true,
+  },
+});
+```
+
+For `streamText`, only `requestBody` is available. See the [AI SDK 7 migration guide](/docs/migration-guides/migration-guide-7-0#request-and-response-bodies-are-excluded-by-default) for details.
 
 ### Runs and steps
 


### PR DESCRIPTION
## Background

Since AI SDK 7, `generateText` and `streamText` exclude request bodies from step
results by default, and `generateText` also excludes response bodies (see the
[v7 migration guide](https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0#request-and-response-bodies-are-excluded-by-default)).

The DevTools page still stated that DevTools captures "Raw provider data: Access
complete request and response payloads", without mentioning that this now
requires opting in via `include`. As reported in #17579, this cost a user an hour
of debugging after upgrading to v7, because raw payloads silently stopped
appearing in the DevTools viewer.

## Summary

- Marked the "Raw provider data" bullet in the **Captured data** section as opt-in
- Added a **Raw request and response bodies** subsection explaining the v7 default,
  with a code example showing `include: { requestBody: true, responseBody: true }`
- Noted that `streamText` only supports `requestBody`, and linked the relevant
  migration guide section

Docs-only change; no changeset added.

## Contributor Credit

- @rovo89 reported the issue and identified the missing documentation (#17579)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17579
