### PR TITLE
[v5.0] reproduction: Amazon Bedrock toolResult in user message

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 7034,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-7034.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-7034.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_7034_REPRODUCED: User messages cannot contain reasoning content"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/examples/ai-functions/src/reproduction/issue-7034.ts
+++ b/examples/ai-functions/src/reproduction/issue-7034.ts
@@ -1,0 +1,154 @@
+import { createAmazonBedrock } from '../../../../packages/amazon-bedrock/dist/index.mjs';
+import {
+  APICallError,
+  extractReasoningMiddleware,
+  generateText,
+  jsonSchema,
+  tool,
+  wrapLanguageModel,
+} from '../../../../packages/ai/dist/index.mjs';
+import { MockLanguageModelV2 } from '../../../../packages/ai/dist/test/index.mjs';
+
+const modelId =
+  process.env.ISSUE_7034_MODEL_ID ??
+  'us.anthropic.claude-3-haiku-20240307-v1:0';
+const toolCallId = 'tooluse_issue_7034';
+
+async function main() {
+  const resetPassword = tool({
+    description: 'Reset a user password.',
+    inputSchema: jsonSchema<{
+      username: string;
+      password: string;
+    }>({
+      type: 'object',
+      properties: {
+        username: { type: 'string' },
+        password: { type: 'string' },
+      },
+      required: ['username', 'password'],
+      additionalProperties: false,
+    }),
+  });
+
+  const middlewareResult = await generateText({
+    model: wrapLanguageModel({
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          content: [
+            {
+              type: 'text',
+              text: '<reasoning>I should call reset_password.</reasoning>\n',
+            },
+            {
+              type: 'tool-call',
+              toolCallId,
+              toolName: 'reset_password',
+              input: JSON.stringify({ username: 'adam', password: 'blah' }),
+            },
+          ],
+          finishReason: 'tool-calls',
+          usage: {
+            inputTokens: 10,
+            outputTokens: 10,
+            totalTokens: 20,
+          },
+          warnings: [],
+        }),
+      }),
+      middleware: extractReasoningMiddleware({ tagName: 'reasoning' }),
+    }),
+    prompt:
+      'Can you change my password? My username is "adam" and the new password is "blah".',
+    tools: { reset_password: resetPassword },
+  });
+
+  const unsignedReasoning = middlewareResult.content.find(
+    part => part.type === 'reasoning',
+  );
+  if (
+    unsignedReasoning?.type !== 'reasoning' ||
+    unsignedReasoning.providerMetadata != null
+  ) {
+    throw new Error(
+      'Setup failed: extractReasoningMiddleware did not produce unsigned reasoning.',
+    );
+  }
+
+  let capturedRequest: unknown;
+  const bedrock = createAmazonBedrock({
+    region: process.env.AWS_REGION ?? 'us-east-1',
+    fetch: async (url, init) => {
+      if (typeof init?.body === 'string') {
+        capturedRequest = JSON.parse(init.body);
+      }
+      return fetch(url, init);
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model: bedrock(modelId),
+      maxRetries: 0,
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Can you change my password? My username is "adam" and the new password is "blah".',
+        },
+        {
+          role: 'assistant',
+          content: middlewareResult.content,
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId,
+              toolName: 'reset_password',
+              output: {
+                type: 'text',
+                value:
+                  '{"success":false,"message":"Password reset failed: Password must be at least 8 characters long","username":"adam","password":"blah"}',
+              },
+            },
+          ],
+        },
+      ],
+      tools: { reset_password: resetPassword },
+    });
+
+    console.log('ISSUE_7034_NOT_REPRODUCED');
+    console.log(result.text);
+  } catch (error) {
+    if (APICallError.isInstance(error)) {
+      const responseBody = error.responseBody ?? error.message;
+      console.error(JSON.stringify(capturedRequest, null, 2));
+      console.error(responseBody);
+
+      if (
+        responseBody.includes('User messages cannot contain reasoning content')
+      ) {
+        console.error(
+          'ISSUE_7034_REPRODUCED: User messages cannot contain reasoning content',
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      if ([401, 402, 403, 429].includes(error.statusCode ?? 0)) {
+        console.error(`ISSUE_7034_BLOCKED: HTTP ${error.statusCode}`);
+        process.exitCode = 2;
+        return;
+      }
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 2;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-7034-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-7034-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "User messages cannot contain reasoning content. Please remove the reasoning content and try again."
+}

--- a/packages/amazon-bedrock/src/issue-7034.test.ts
+++ b/packages/amazon-bedrock/src/issue-7034.test.ts
@@ -1,0 +1,126 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+const modelId = 'us.anthropic.claude-3-haiku-20240307-v1:0';
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const generateUrl = `${baseUrl}/model/${encodeURIComponent(modelId)}/converse`;
+
+const fixture = fs.readFileSync(
+  'src/__fixtures__/issue-7034-error.json',
+  'utf8',
+);
+
+const server = createTestServer({
+  [generateUrl]: {
+    response: {
+      type: 'error',
+      status: 400,
+      body: fixture,
+    },
+  },
+});
+
+const model = new BedrockChatLanguageModel(modelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: injectFetchHeaders({ 'x-amz-auth': 'test-auth' }),
+  generateId: () => 'test-id',
+});
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Can you change my password? My username is "adam".',
+      },
+    ],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'reasoning',
+        text: 'I should call reset_password.',
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'tooluse_issue_7034',
+        toolName: 'reset_password',
+        input: { username: 'adam', password: 'blah' },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'tooluse_issue_7034',
+        toolName: 'reset_password',
+        output: {
+          type: 'text',
+          value:
+            '{"success":false,"message":"Password must be at least 8 characters long"}',
+        },
+      },
+    ],
+  },
+];
+
+it('continues after an extractReasoningMiddleware tool result', async () => {
+  try {
+    await model.doGenerate({
+      prompt,
+      tools: [
+        {
+          type: 'function',
+          name: 'reset_password',
+          description: 'Reset a user password.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              username: { type: 'string' },
+              password: { type: 'string' },
+            },
+            required: ['username', 'password'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+  } catch (error) {
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.messages).toMatchObject([
+      { role: 'user' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            reasoningContent: {
+              reasoningText: { text: 'I should call reset_password.' },
+            },
+          },
+          { toolUse: { toolUseId: 'tooluse_issue_7034' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ toolResult: { toolUseId: 'tooluse_issue_7034' } }],
+      },
+    ]);
+
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('User messages cannot contain reasoning content')) {
+      throw new Error(`ISSUE_7034_REPRODUCED: ${message}`);
+    }
+
+    throw error;
+  }
+});


### PR DESCRIPTION
## Bug

Amazon Bedrock `toolResult` in `user` message

## Reproduction

- On `release-v5.0` with `@ai-sdk/amazon-bedrock@3.0.107` and `ai@5.0.217`, the live Bedrock continuation was expected to process the tool result but returned “User messages cannot contain reasoning content.”
- `examples/ai-functions/src/reproduction/issue-7034.ts` uses `extractReasoningMiddleware`, sends its unsigned reasoning with a tool call and result to `us.anthropic.claude-3-haiku-20240307-v1:0`, and exits 1 after reproducing the reported failure.
- The captured request placed `toolResult` in a Bedrock `user` message as documented and included unsigned `reasoningContent` in the preceding assistant message.
- `packages/amazon-bedrock/src/__fixtures__/issue-7034-error.json` records the live HTTP 400 response; `packages/amazon-bedrock/src/issue-7034.test.ts` replays it and fails on the primary reported behavior.
- `examples/ai-functions/package.json` makes the required reproduction command runnable in this branch, where `examples/ai-functions` was previously absent.
- The reporter did not provide the exact model ID or middleware tag configuration, so the live reproduction used the supported Claude 3 Haiku substitute identified in the prior investigation.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-client-side.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Message.html
- https://ai-sdk.dev/docs/reference/ai-sdk-core/extract-reasoning-middleware

## Related Issues

Reproduces #7034