### PR TITLE
[v6.0] reproduction: could not reproduce Amazon Bedrock toolResult in user message

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-7034.ts
+++ b/examples/ai-functions/src/reproduction/issue-7034.ts
@@ -1,0 +1,176 @@
+import 'dotenv/config';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  extractReasoningMiddleware,
+  generateText,
+  tool,
+  wrapLanguageModel,
+  type ModelMessage,
+} from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+const resetPassword = tool({
+  description: 'Reset a user password.',
+  inputSchema: z.object({
+    username: z.string(),
+    password: z.string(),
+  }),
+  execute: async ({ username, password }) => ({
+    success: false,
+    message:
+      'Password reset failed: Password must be at least 8 characters long',
+    username,
+    password,
+  }),
+});
+
+async function main() {
+  const initialMessage: ModelMessage = {
+    role: 'user',
+    content:
+      'Can you change my password? My username is "adam" and the new password I want is "blah"',
+  };
+
+  // Recreate the unsigned reasoning plus tool-result history produced when
+  // extractReasoningMiddleware processes XML-tagged model text.
+  const firstTurn = await generateText({
+    model: wrapLanguageModel({
+      model: new MockLanguageModelV3({
+        doGenerate: {
+          content: [
+            {
+              type: 'text',
+              text: [
+                '<think>',
+                'The user requested a password reset, so I should call the reset_password tool.',
+                '</think>',
+              ].join(''),
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tooluse_issue7034',
+              toolName: 'reset_password',
+              input: JSON.stringify({ username: 'adam', password: 'blah' }),
+            },
+          ],
+          finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+          usage: {
+            inputTokens: {
+              total: 10,
+              noCache: 10,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+            outputTokens: {
+              total: 20,
+              text: 20,
+              reasoning: 15,
+            },
+          },
+          warnings: [],
+        },
+      }),
+      middleware: extractReasoningMiddleware({ tagName: 'think' }),
+    }),
+    tools: { reset_password: resetPassword },
+    messages: [initialMessage],
+  });
+
+  const generatedMessages = firstTurn.response.messages;
+  const assistantMessage = generatedMessages.find(
+    message => message.role === 'assistant',
+  );
+  const toolMessage = generatedMessages.find(
+    message => message.role === 'tool',
+  );
+
+  if (
+    assistantMessage == null ||
+    typeof assistantMessage.content === 'string' ||
+    !assistantMessage.content.some(part => part.type === 'reasoning')
+  ) {
+    throw new Error(
+      'SETUP_FAILURE: extractReasoningMiddleware did not produce reasoning content',
+    );
+  }
+
+  if (
+    toolMessage == null ||
+    !toolMessage.content.some(part => part.type === 'tool-result')
+  ) {
+    throw new Error('SETUP_FAILURE: the tool result message was not produced');
+  }
+
+  let requestBody: Record<string, unknown> | undefined;
+  const bedrock = createAmazonBedrock({
+    region: 'us-east-1',
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBody = JSON.parse(init.body) as Record<string, unknown>;
+      }
+      return globalThis.fetch(input, init);
+    },
+  });
+
+  const result = await generateText({
+    model: bedrock('us.anthropic.claude-3-haiku-20240307-v1:0'),
+    tools: { reset_password: resetPassword },
+    messages: [initialMessage, ...generatedMessages],
+    maxOutputTokens: 100,
+  });
+
+  const bedrockMessages = requestBody?.messages;
+  if (!Array.isArray(bedrockMessages)) {
+    throw new Error(
+      'SETUP_FAILURE: Bedrock request messages were not captured',
+    );
+  }
+
+  const requestContainsReasoning = bedrockMessages.some(
+    message =>
+      typeof message === 'object' &&
+      message != null &&
+      Array.isArray((message as { content?: unknown }).content) &&
+      (message as { content: unknown[] }).content.some(
+        part =>
+          typeof part === 'object' &&
+          part != null &&
+          'reasoningContent' in part,
+      ),
+  );
+
+  const requestContainsUserToolResult = bedrockMessages.some(
+    message =>
+      typeof message === 'object' &&
+      message != null &&
+      (message as { role?: unknown }).role === 'user' &&
+      Array.isArray((message as { content?: unknown }).content) &&
+      (message as { content: unknown[] }).content.some(
+        part =>
+          typeof part === 'object' && part != null && 'toolResult' in part,
+      ),
+  );
+
+  if (requestContainsReasoning) {
+    throw new Error(
+      'ISSUE_7034_REPRODUCED: Bedrock request replayed unsigned reasoning content',
+    );
+  }
+
+  if (!requestContainsUserToolResult) {
+    throw new Error(
+      'SETUP_FAILURE: Bedrock request did not contain the expected user-role toolResult',
+    );
+  }
+
+  console.log('LIVE_BEDROCK_CALL_SUCCEEDED');
+  console.log('UNSIGNED_REASONING_OMITTED');
+  console.log('USER_TOOL_RESULT_PRESERVED');
+  console.log(`MODEL_RESPONSE_PRESENT=${result.text.length > 0}`);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-7034-tool-result-continuation.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-7034-tool-result-continuation.json
@@ -1,0 +1,22 @@
+{
+  "metrics": {
+    "latencyMs": 599
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "The password you requested, \"blah\", is not long enough. Password policies typically require passwords to be at least 8 characters long. Please try again with a longer password."
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 500,
+    "outputTokens": 41,
+    "serverToolUsage": {},
+    "totalTokens": 541
+  }
+}

--- a/packages/amazon-bedrock/src/issue-7034.test.ts
+++ b/packages/amazon-bedrock/src/issue-7034.test.ts
@@ -1,0 +1,138 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+const modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const generateUrl = `${baseUrl}/model/${encodeURIComponent(modelId)}/converse`;
+
+const server = createTestServer({
+  [generateUrl]: {},
+});
+
+const model = new BedrockChatLanguageModel(modelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: injectFetchHeaders({ 'x-amz-auth': 'test-auth' }),
+  generateId: () => 'test-id',
+});
+
+describe('issue #7034', () => {
+  beforeEach(() => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/issue-7034-tool-result-continuation.json',
+          'utf8',
+        ),
+      ),
+    };
+  });
+
+  it('omits unsigned reasoning and accepts the user-role tool result', async () => {
+    const result = await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Reset the password for adam to blah.',
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'I should call the reset_password tool.',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tooluse_issue7034',
+              toolName: 'reset_password',
+              input: { username: 'adam', password: 'blah' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'tooluse_issue7034',
+              toolName: 'reset_password',
+              output: {
+                type: 'text',
+                value:
+                  '{"success":false,"message":"Password reset failed: Password must be at least 8 characters long"}',
+              },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: 'function',
+          name: 'reset_password',
+          description: 'Reset a user password.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              username: { type: 'string' },
+              password: { type: 'string' },
+            },
+            required: ['username', 'password'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: expect.stringContaining('not long enough'),
+      },
+    ]);
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Reset the password for adam to blah.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'tooluse_issue7034',
+                name: 'reset_password',
+                input: { username: 'adam', password: 'blah' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'tooluse_issue7034',
+                content: [
+                  {
+                    text: '{"success":false,"message":"Password reset failed: Password must be at least 8 characters long"}',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Bug

Amazon Bedrock `toolResult` in `user` message

## Reproduction

- `examples/ai-functions/src/reproduction/issue-7034.ts` recreated unsigned reasoning from `extractReasoningMiddleware`, executed the reported password-reset tool, and completed a live Bedrock continuation without the expected `AI_APICallError` on `ai@6.0.231` and `@ai-sdk/amazon-bedrock@4.0.137`.
- The captured request omitted unsigned `reasoningContent` while preserving `toolResult` in a `user` message; AWS documents the user-role tool-result message as the correct Converse format.
- `packages/amazon-bedrock/src/__fixtures__/issue-7034-tool-result-continuation.json` records the successful live response, and `packages/amazon-bedrock/src/issue-7034.test.ts` verifies the corresponding request and response behavior.
- `packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts` intentionally omits unsigned reasoning, and `packages/amazon-bedrock/CHANGELOG.md` records that fix in version 4.0.104; aligning with the release-v6 package line removes the reported failure without product-code changes.
- The reporter did not provide the exact model ID, middleware tag configuration, or call code, so the live check used the supported substitute `us.anthropic.claude-3-haiku-20240307-v1:0`; the exact original scenario could not be evaluated.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-client-side.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html
- https://ai-sdk.dev/docs/reference/ai-sdk-core/extract-reasoning-middleware

## Related Issues

Could not reproduce #7034