### PR TITLE
docs: clarify how to retain raw request and response bodies in DevTools

### DIFF
--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -101,7 +101,22 @@ DevTools captures the following information from your AI SDK calls:
 - **Input parameters and prompts**: View the complete input sent to your LLM
 - **Output content and tool calls**: Inspect generated text and tool invocations
 - **Token usage and timing**: Monitor resource consumption and performance
-- **Raw provider data**: Access complete request and response payloads
+- **Raw provider data**: Access provider request and response payloads when body retention is enabled
+
+Telemetry is enabled automatically, but AI SDK 7 excludes raw request and response bodies from step results by default. To make them available to DevTools for `generateText`, enable body retention on the call:
+
+```ts highlight="4-7"
+const result = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello!',
+  include: {
+    requestBody: true,
+    responseBody: true,
+  },
+});
+```
+
+`ToolLoopAgent` accepts the same `include` setting in its constructor. For `streamText` and `ToolLoopAgent.stream()`, only the request body can be retained; use `include: { requestBody: true }`.
 
 ### Runs and steps
 
@@ -129,6 +144,6 @@ DevTools stores all AI interactions locally in plain text files, including:
 - User prompts and messages
 - LLM responses
 - Tool call arguments and results
-- API request and response data
+- API request and response data when body retention is enabled
 
 **Only use DevTools in local development environments.** Do not enable DevTools in production or when handling sensitive data.


### PR DESCRIPTION
## Background

## Scope and interpretation

Issue #17579 reports that the hosted DevTools page promises access to complete raw provider request and response payloads without explaining that AI SDK 7 excludes those bodies by default. The maintainer comment classifies this as a documentation problem and repeats the proposed `include` configuration. I evaluated that interpretation while separately verifying the configuration for non-streaming and streaming calls.

## Verified behavior

- `content/docs/03-ai-sdk-core/65-devtools.mdx` described raw provider data as complete request and response payloads, but supplied no body-retention configuration.
- `GenerateTextInclude` in `packages/ai/src/generate-text/generate-text.ts` exposes `requestBody` and `responseBody`, both defaulting to `false`. The implementation resolves omitted values to `false` before creating step results.
- Tests in `packages/ai/src/generate-text/generate-text.test.ts` verify that request bodies are absent by default and retained with `include.requestBody: true`, while response bodies are retained with `include.responseBody: true`.
- `DevToolsTelemetry` in `packages/devtools/src/integration.ts` stores raw data directly from `stepResult.request.body` and `stepResult.response.body`. Therefore, bodies excluded from AI SDK step results cannot appear in DevTools. `packages/devtools/src/integration.test.ts` verifies that these fields become DevTools raw request and response data when present.
- The issue's proposed `{ requestBody: true, responseBody: true }` configuration is correct for `generateText`. It is not valid as universal guidance for streaming: `StreamTextInclude` in `packages/ai/src/generate-text/stream-text.ts` has `requestBody`, `requestMessages`, and `rawChunks`, but no `responseBody`. Its request body also defaults to excluded.
- `ToolLoopAgent` accepts the combined include settings through `ToolLoopAgentSettings` in `packages/ai/src/agent/tool-loop-agent-settings.ts` and forwards them to its underlying generation or streaming call. Consequently, `ToolLoopAgent.generate()` can retain request and response bodies, while `ToolLoopAgent.stream()` can retain only the request body.

## Existing documentation audit

The behavior was already documented in migration and API-reference material: `content/docs/08-migration-guides/23-migration-guide-7-0.mdx` explains the AI SDK 7 default change and distinguishes `generateText` from `streamText`; the `include` entries in `content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx`, `02-stream-text.mdx`, and `16-tool-loop-agent.mdx` document the supported fields. However, the DevTools page did not connect those retention settings to its raw-data feature. The telemetry page explains integration registration but does not address DevTools body retention. `packages/devtools/README.md` contains only a high-level raw-provider-data feature list, so the detailed hosted DevTools page remains the appropriate source of truth for this setup guidance.

## Decision

The report is valid. Registering `DevToolsTelemetry` enables telemetry automatically, but it does not override AI SDK 7's body-retention defaults. Readers could therefore follow the DevTools setup successfully while still seeing no raw bodies. Adding the exact `generateText` configuration and the streaming limitation directly beside the raw-data claim resolves that reader problem without duplicating the migration guide or changing product behavior.

## Summary

Updated `content/docs/03-ai-sdk-core/65-devtools.mdx` to state that raw bodies require retention, show `include: { requestBody: true, responseBody: true }` for `generateText`, explain the `ToolLoopAgent` and streaming behavior, and qualify the related security guidance.

## Testing

`pnpm validate:docs` validated all 500 MDX property tables; `pnpm check` completed with zero warnings or errors; `pnpm type-check:full` completed successfully. No runtime unit tests were run because the change only modifies MDX documentation.

## Related Issues

Fixes #17579

Co-authored-by: rovo89 <1573299+rovo89@users.noreply.github.com>