### PR TITLE
reproduction: problemtic default value of maxtokens for unknown models

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17588,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17588 REPRODUCED: unknown Anthropic model silently received max_tokens=4096"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts
+++ b/examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts
@@ -1,0 +1,66 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const failureSignal =
+  'ISSUE #17588 REPRODUCED: unknown Anthropic model silently received max_tokens=4096';
+
+async function main() {
+  let requestBody: { max_tokens?: number; model?: string } | undefined;
+
+  const anthropic = createAnthropic({
+    apiKey: 'reproduction-api-key',
+    fetch: async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body));
+
+      return new Response(
+        JSON.stringify({
+          id: 'msg_reproduction',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-future-6',
+          content: [{ type: 'text', text: 'Synthetic successful response.' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 4,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    },
+  });
+
+  const result = await generateText({
+    model: anthropic('claude-future-6'),
+    prompt: 'Generate a response that may require more than 4096 tokens.',
+  });
+
+  const warnings = result.warnings ?? [];
+  const hasUnknownModelWarning = warnings.some(warning => {
+    const warningText = JSON.stringify(warning).toLowerCase();
+    return (
+      warningText.includes('unknown') ||
+      warningText.includes('max_tokens') ||
+      warningText.includes('maxoutputtokens')
+    );
+  });
+
+  if (requestBody?.max_tokens === 4096 && !hasUnknownModelWarning) {
+    console.error(failureSignal);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Issue not reproduced: request=${JSON.stringify(requestBody)}, warnings=${JSON.stringify(warnings)}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

problemtic default value of `max_tokens` for unknown models

## Reproduction

- On `main`, `@ai-sdk/anthropic` 4.0.16 still sends `"max_tokens":4096` for the unknown model `claude-future-6` when `maxOutputTokens` is omitted.
- The generated call returns no warning about the unknown model or implicit token limit; Anthropic documents `max_tokens` as the absolute generation maximum, so this silently caps otherwise longer responses.
- `packages/anthropic/src/anthropic-language-model.ts` assigns unknown models a 4096-token fallback and uses it as the request limit.
- The reproduction at `examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts` expects an unknown model not to receive a silent 4096-token cap and observed the reported silent fallback.

## Relevant Documentation

- https://platform.claude.com/docs/en/api/messages/create
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic

## Related Issues

Reproduces #17588