### PR TITLE
[v6.0] fix: prevent Bedrock native structured output from forwarding unsupported JSON Schema constraints

### DIFF
--- a/.changeset/calm-beds-sanitize.md
+++ b/.changeset/calm-beds-sanitize.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/anthropic": patch
+---
+
+fix(amazon-bedrock): sanitize unsupported JSON Schema constraints in native Anthropic structured output

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -4721,9 +4721,11 @@ describe('doGenerate', () => {
         type: 'json_schema',
         schema: {
           type: 'object',
+          additionalProperties: false,
           properties: {
             recipe: {
               type: 'object',
+              additionalProperties: false,
               properties: {
                 name: { type: 'string' },
                 ingredients: { type: 'array', items: { type: 'string' } },
@@ -4780,6 +4782,7 @@ describe('doGenerate', () => {
         type: 'json_schema',
         schema: {
           type: 'object',
+          additionalProperties: false,
           properties: {
             name: { type: 'string' },
           },
@@ -4896,6 +4899,7 @@ describe('doGenerate', () => {
       {
         "format": {
           "schema": {
+            "additionalProperties": false,
             "properties": {
               "name": {
                 "type": "string",
@@ -4908,6 +4912,63 @@ describe('doGenerate', () => {
           },
           "type": "json_schema",
         },
+      }
+    `);
+  });
+
+  it('should sanitize unsupported JSON schema keywords for native structured output', async () => {
+    server.urls[newerAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            content: [{ text: '{"labels":["Spring","Summer","Autumn"]}' }],
+            role: 'assistant',
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'end_turn',
+      },
+    };
+
+    await newerAnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            labels: {
+              type: 'array',
+              maxItems: 3,
+              items: { type: 'string' },
+            },
+          },
+          required: ['labels'],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.additionalModelRequestFields.output_config.format.schema)
+      .toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "labels": {
+            "description": "max items: 3.",
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "labels",
+        ],
+        "type": "object",
       }
     `);
   });

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -24,13 +24,7 @@ import {
   type ParseResult,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
-<<<<<<< HEAD:packages/amazon-bedrock/src/bedrock-chat-language-model.ts
-=======
-import {
-  getModelCapabilities,
-  sanitizeJsonSchema,
-} from '@ai-sdk/anthropic/internal';
->>>>>>> b72fc7ce0a (fix: prevent Bedrock native structured output from forwarding unsupported JSON Schema constraints (#17558)):packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+import { sanitizeJsonSchema } from '@ai-sdk/anthropic/internal';
 import { z } from 'zod/v4';
 import {
   BEDROCK_STOP_REASONS,

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -24,6 +24,13 @@ import {
   type ParseResult,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
+<<<<<<< HEAD:packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+=======
+import {
+  getModelCapabilities,
+  sanitizeJsonSchema,
+} from '@ai-sdk/anthropic/internal';
+>>>>>>> b72fc7ce0a (fix: prevent Bedrock native structured output from forwarding unsupported JSON Schema constraints (#17558)):packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
 import { z } from 'zod/v4';
 import {
   BEDROCK_STOP_REASONS,
@@ -316,7 +323,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
           ...bedrockOptions.additionalModelRequestFields?.output_config,
           format: {
             type: 'json_schema',
-            schema: responseFormat!.schema,
+            schema: sanitizeJsonSchema(responseFormat!.schema!),
           },
         },
       };

--- a/packages/anthropic/src/internal/index.ts
+++ b/packages/anthropic/src/internal/index.ts
@@ -2,3 +2,8 @@ export { AnthropicMessagesLanguageModel } from '../anthropic-messages-language-m
 export { anthropicTools } from '../anthropic-tools';
 export type { AnthropicMessagesModelId } from '../anthropic-messages-options';
 export { prepareTools } from '../anthropic-prepare-tools';
+<<<<<<< HEAD
+=======
+export { sanitizeJsonSchema } from '../sanitize-json-schema';
+export { AnthropicSkills } from '../skills/anthropic-skills';
+>>>>>>> b72fc7ce0a (fix: prevent Bedrock native structured output from forwarding unsupported JSON Schema constraints (#17558))

--- a/packages/anthropic/src/internal/index.ts
+++ b/packages/anthropic/src/internal/index.ts
@@ -2,8 +2,4 @@ export { AnthropicMessagesLanguageModel } from '../anthropic-messages-language-m
 export { anthropicTools } from '../anthropic-tools';
 export type { AnthropicMessagesModelId } from '../anthropic-messages-options';
 export { prepareTools } from '../anthropic-prepare-tools';
-<<<<<<< HEAD
-=======
 export { sanitizeJsonSchema } from '../sanitize-json-schema';
-export { AnthropicSkills } from '../skills/anthropic-skills';
->>>>>>> b72fc7ce0a (fix: prevent Bedrock native structured output from forwarding unsupported JSON Schema constraints (#17558))


### PR DESCRIPTION
## Background

Bedrock rejected native structured-output requests containing Zod-derived maxItems constraints with HTTP 400, preventing structured objects from being generated.

## Root Cause

The Bedrock chat model forwarded responseFormat.schema directly into output_config.format.schema, bypassing the Anthropic schema sanitizer; the live request confirmed maxItems was forwarded and triggered Bedrock's rejection.

## Summary

Exported the existing Anthropic schema sanitizer internally and applied it when constructing Bedrock Anthropic native structured-output requests.

## Testing

Added an inline-snapshot regression test to the existing Bedrock chat language model test verifying maxItems is removed and retained as a descriptive constraint.

## End-to-end Validation

- `cd examples/ai-functions && pnpm tsx -e "<live Output.object() probe>"` generated a valid three-label object with Claude Sonnet 4.5 through Bedrock; the captured request reported `maxItemsForwarded: false`.

## Related Issues

Fixes #17197

Closes #17554

Backport of #17558

Co-authored-by: ex0ns <1064129+ex0ns@users.noreply.github.com>