### PR TITLE
[v6.0] fix: preserve provider options across consecutive tool messages

### DIFF
--- a/.changeset/tender-tools-remember.md
+++ b/.changeset/tender-tools-remember.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Preserve provider options when combining consecutive tool messages.

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -969,7 +969,6 @@ describe('convertToLanguageModelPrompt', () => {
     it('should preserve provider options at tool message boundaries when combining consecutive tool messages', async () => {
       const result = await convertToLanguageModelPrompt({
         prompt: {
-          instructions: undefined,
           messages: [
             {
               role: 'assistant',

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -965,6 +965,137 @@ describe('convertToLanguageModelPrompt', () => {
         ]
       `);
     });
+
+    it('should preserve provider options at tool message boundaries when combining consecutive tool messages', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          instructions: undefined,
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId1',
+                  toolName: 'toolName',
+                  input: {},
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'toolCallId2',
+                  toolName: 'toolName',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId1',
+                  output: { type: 'text', value: 'result1' },
+                  providerOptions: {
+                    test: {
+                      cacheControl: 'part',
+                      partOnly: true,
+                    },
+                  },
+                },
+              ],
+              providerOptions: {
+                test: {
+                  cacheControl: 'first-message',
+                  messageOnly: true,
+                },
+              },
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolName: 'toolName',
+                  toolCallId: 'toolCallId2',
+                  output: { type: 'text', value: 'result2' },
+                },
+              ],
+              providerOptions: {
+                test: {
+                  cacheControl: 'second-message',
+                },
+              },
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "input": {},
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "toolCallId1",
+                "toolName": "toolName",
+                "type": "tool-call",
+              },
+              {
+                "input": {},
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "toolCallId2",
+                "toolName": "toolName",
+                "type": "tool-call",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "result1",
+                },
+                "providerOptions": {
+                  "test": {
+                    "cacheControl": "part",
+                    "messageOnly": true,
+                    "partOnly": true,
+                  },
+                },
+                "toolCallId": "toolCallId1",
+                "toolName": "toolName",
+                "type": "tool-result",
+              },
+              {
+                "output": {
+                  "type": "text",
+                  "value": "result2",
+                },
+                "providerOptions": undefined,
+                "toolCallId": "toolCallId2",
+                "toolName": "toolName",
+                "type": "tool-result",
+              },
+            ],
+            "providerOptions": {
+              "test": {
+                "cacheControl": "second-message",
+              },
+            },
+            "role": "tool",
+          },
+        ]
+      `);
+    });
   });
 
   describe('custom download function', () => {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -25,10 +25,17 @@ import {
   createDefaultDownloadFunction,
   type DownloadFunction,
 } from '../util/download/download-function';
+<<<<<<< HEAD
 import {
   convertDataContentToBase64String,
   convertToLanguageModelV3DataContent,
 } from './data-content';
+=======
+import { mergeObjects } from '../util/merge-objects';
+import { convertToLanguageModelV4FilePart } from './file-part-data';
+import { logWarnings } from '../logger/log-warnings';
+import type { Warning } from '../types/warning';
+>>>>>>> 33647d7d29 (fix: preserve provider options across consecutive tool messages (#17577))
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import type { StandardizedPrompt } from './standardize-prompt';
 import { asArray } from '../util/as-array';
@@ -106,7 +113,19 @@ export async function convertToLanguageModelPrompt({
 
     const lastCombinedMessage = combinedMessages.at(-1);
     if (lastCombinedMessage?.role === 'tool') {
+      const lastContentPart = lastCombinedMessage.content.at(-1);
+      if (
+        lastContentPart != null &&
+        lastCombinedMessage.providerOptions != null
+      ) {
+        lastContentPart.providerOptions = mergeObjects(
+          lastCombinedMessage.providerOptions,
+          lastContentPart.providerOptions,
+        );
+      }
+
       lastCombinedMessage.content.push(...message.content);
+      lastCombinedMessage.providerOptions = message.providerOptions;
     } else {
       combinedMessages.push(message);
     }

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -25,17 +25,11 @@ import {
   createDefaultDownloadFunction,
   type DownloadFunction,
 } from '../util/download/download-function';
-<<<<<<< HEAD
+import { mergeObjects } from '../util/merge-objects';
 import {
   convertDataContentToBase64String,
   convertToLanguageModelV3DataContent,
 } from './data-content';
-=======
-import { mergeObjects } from '../util/merge-objects';
-import { convertToLanguageModelV4FilePart } from './file-part-data';
-import { logWarnings } from '../logger/log-warnings';
-import type { Warning } from '../types/warning';
->>>>>>> 33647d7d29 (fix: preserve provider options across consecutive tool messages (#17577))
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import type { StandardizedPrompt } from './standardize-prompt';
 import { asArray } from '../util/as-array';


### PR DESCRIPTION
## Background

Consecutive tool messages silently lost later message-level provider options, causing provider behavior such as Anthropic cache breakpoints to be applied to the wrong tool results.

## Root Cause

The prompt converter appended consecutive tool-message content while retaining only the first message's providerOptions. The public generateText reproduction confirmed that the first options remained on the combined message and the second options disappeared.

## Summary

Before combining tool messages, the converter now merges the previous message's provider options into its final content part with part-level precedence, then retains the incoming message's options on the combined message.

## Testing

Added an inline-snapshot regression test covering message-boundary preservation, part-level precedence, and retention of the final tool message's provider options.

## End-to-end Validation

- `pnpm -C packages/ai build && git show a8203a7f:examples/ai-functions/src/reproduction/issue-17507-tool-message-provider-options.ts | pnpm -C examples/ai-functions exec tsx -` — the public generateText reproduction exited successfully and confirmed all provider options remained at their expected tool-result boundaries.

## Related Issues

Fixes #17507

Closes #17516

Backport of #17577

Co-authored-by: ayoubkachkach <16275973+ayoubkachkach@users.noreply.github.com>