### PR TITLE
[v5.0] reproduction: Duplicate toolCallId across steps causes readUIMessageStream to overwrite

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17347,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17347-duplicate-tool-call-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17347_REPRODUCED: Expected 2 tool parts, received 1; the repeated response-scoped toolCallId overwrote the earlier step."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions-reproductions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts
@@ -1,0 +1,107 @@
+import {
+  readUIMessageStream,
+  type UIMessage,
+  type UIMessageChunk,
+} from '../../../../packages/ai/src';
+
+async function main() {
+  const chunks = [
+    { type: 'start', messageId: 'message-1' },
+    { type: 'start-step' },
+    {
+      type: 'tool-input-available',
+      toolCallId: 'call_0',
+      toolName: 'recordStep',
+      input: { step: 1 },
+      providerMetadata: { openai: { itemId: 'fc_step_1' } },
+    },
+    {
+      type: 'tool-output-available',
+      toolCallId: 'call_0',
+      output: { recorded: 1 },
+    },
+    { type: 'finish-step' },
+    { type: 'start-step' },
+    {
+      type: 'tool-input-available',
+      toolCallId: 'call_0',
+      toolName: 'recordStep',
+      input: { step: 2 },
+      providerMetadata: { openai: { itemId: 'fc_step_2' } },
+    },
+    {
+      type: 'tool-output-available',
+      toolCallId: 'call_0',
+      output: { recorded: 2 },
+    },
+    { type: 'finish-step' },
+    { type: 'finish' },
+  ] satisfies UIMessageChunk[];
+
+  const stream = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  let finalMessage: UIMessage | undefined;
+  for await (const message of readUIMessageStream({ stream })) {
+    finalMessage = message;
+  }
+
+  if (finalMessage == null) {
+    throw new Error('No final UIMessage was produced.');
+  }
+
+  const toolParts = finalMessage.parts.filter(
+    part => part.type.startsWith('tool-') || part.type === 'dynamic-tool',
+  );
+
+  console.log(JSON.stringify(toolParts, null, 2));
+
+  if (toolParts.length !== 2) {
+    throw new Error(
+      `ISSUE_17347_REPRODUCED: Expected 2 tool parts, received ${toolParts.length}; the repeated response-scoped toolCallId overwrote the earlier step.`,
+    );
+  }
+
+  const expectedParts = [
+    {
+      toolCallId: 'call_0',
+      input: { step: 1 },
+      output: { recorded: 1 },
+      itemId: 'fc_step_1',
+    },
+    {
+      toolCallId: 'call_0',
+      input: { step: 2 },
+      output: { recorded: 2 },
+      itemId: 'fc_step_2',
+    },
+  ];
+
+  for (const [index, part] of toolParts.entries()) {
+    const expected = expectedParts[index];
+    if (
+      part.toolCallId !== expected.toolCallId ||
+      JSON.stringify(part.input) !== JSON.stringify(expected.input) ||
+      !('output' in part) ||
+      JSON.stringify(part.output) !== JSON.stringify(expected.output) ||
+      part.callProviderMetadata?.openai?.itemId !== expected.itemId
+    ) {
+      throw new Error(
+        `Tool part ${index + 1} did not preserve its step-local input, output, provider item ID, and original toolCallId.`,
+      );
+    }
+  }
+
+  console.log('PASS: both step-local tool parts were preserved.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

Duplicate toolCallId across steps causes readUIMessageStream to overwrite earlier tool parts

## Reproduction

- The `release-v5.0` target contains `ai@5.0.217`; `readUIMessageStream` and the required multi-step tool chunks are available in `packages/ai/src/ui-message-stream/`.
- The reproduction in `examples/ai-functions/src/reproduction/issue-17347-duplicate-tool-call-id.ts`, supported by `examples/ai-functions/package.json`, expected two step-local tool parts but received only one.
- The surviving part contained step 2's input, output, and `fc_step_2` provider item ID; step 1 and `fc_step_1` were overwritten while the original `call_0` remained unchanged.
- `packages/ai/src/ui/process-ui-message-stream.ts` searches all message parts by `toolCallId`, causing the second step's `call_0` chunks to mutate the first step's part.
- The credential-free reproduction confirms the final UI aggregation failure but does not independently rerun the live Bedrock executions or provider round trip.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/read-ui-message-stream
- https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html

## Related Issues

Reproduces #17347