### PR TITLE
[v6.0] fix: preserve tool parts when tool call IDs repeat across steps

### DIFF
--- a/.changeset/quiet-tools-repeat.md
+++ b/.changeset/quiet-tools-repeat.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): preserve tool parts when tool call IDs repeat across steps

--- a/packages/ai/src/ui-message-stream/read-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/read-ui-message-stream.test.ts
@@ -102,6 +102,70 @@ describe('readUIMessageStream', () => {
       `);
   });
 
+  it('should preserve tool parts when tool call ids repeat across steps', async () => {
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call-0',
+        toolName: 'recordStep',
+        input: { step: 1 },
+        providerMetadata: { openai: { itemId: 'fc-step-1' } },
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-0',
+        output: { recorded: 1 },
+      },
+      { type: 'finish-step' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call-0',
+        toolName: 'recordStep',
+        input: { step: 2 },
+        providerMetadata: { openai: { itemId: 'fc-step-2' } },
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-0',
+        output: { recorded: 2 },
+      },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ]);
+
+    const messages = await convertAsyncIterableToArray(
+      readUIMessageStream({ stream }),
+    );
+    const toolParts = messages
+      .at(-1)!
+      .parts.filter(
+        part => part.type.startsWith('tool-') || part.type === 'dynamic-tool',
+      );
+
+    expect(toolParts).toHaveLength(2);
+    expect(toolParts).toMatchObject([
+      {
+        type: 'tool-recordStep',
+        toolCallId: 'call-0',
+        state: 'output-available',
+        input: { step: 1 },
+        output: { recorded: 1 },
+        callProviderMetadata: { openai: { itemId: 'fc-step-1' } },
+      },
+      {
+        type: 'tool-recordStep',
+        toolCallId: 'call-0',
+        state: 'output-available',
+        input: { step: 2 },
+        output: { recorded: 2 },
+        callProviderMetadata: { openai: { itemId: 'fc-step-2' } },
+      },
+    ]);
+  });
+
   it('should throw an error when encountering an error UI stream part', async () => {
     const stream = createUIMessageStream([
       { type: 'start', messageId: 'msg-123' },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -104,12 +104,42 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
     new TransformStream<UIMessageChunk, InferUIMessageChunk<UI_MESSAGE>>({
       async transform(chunk, controller) {
         await runUpdateMessageJob(async ({ state, write }) => {
-          function getToolInvocation(toolCallId: string) {
-            const toolInvocations = state.message.parts.filter(isToolUIPart);
+          function getCurrentStepParts() {
+            const parts = state.message.parts;
+            let currentStepStartIndex = parts.length - 1;
 
-            const toolInvocation = toolInvocations.find(
+            while (
+              currentStepStartIndex >= 0 &&
+              parts[currentStepStartIndex].type !== 'step-start'
+            ) {
+              currentStepStartIndex--;
+            }
+
+            return parts.slice(currentStepStartIndex + 1);
+          }
+
+          function getCurrentStepToolInvocations() {
+            return getCurrentStepParts().filter(isToolUIPart);
+          }
+
+          function getToolInvocation(toolCallId: string) {
+            const toolInvocations = getCurrentStepToolInvocations();
+
+            let toolInvocation = toolInvocations.find(
               invocation => invocation.toolCallId === toolCallId,
             );
+
+            if (toolInvocation == null) {
+              const parts = state.message.parts;
+
+              for (let i = parts.length - 1; i >= 0; i--) {
+                const part = parts[i];
+                if (isToolUIPart(part) && part.toolCallId === toolCallId) {
+                  toolInvocation = part;
+                  break;
+                }
+              }
+            }
 
             if (toolInvocation == null) {
               throw new UIMessageStreamError({
@@ -159,12 +189,15 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerMetadata?: ProviderMetadata;
                 }
             ),
+            existingPart?: ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
           ) {
-            const part = state.message.parts.find(
-              part =>
-                isStaticToolUIPart(part) &&
-                part.toolCallId === options.toolCallId,
-            ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined;
+            const part =
+              existingPart ??
+              (getCurrentStepParts().find(
+                part =>
+                  isStaticToolUIPart(part) &&
+                  part.toolCallId === options.toolCallId,
+              ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined);
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -266,12 +299,15 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerMetadata?: ProviderMetadata;
                 }
             ),
+            existingPart?: DynamicToolUIPart,
           ) {
-            const part = state.message.parts.find(
-              part =>
-                part.type === 'dynamic-tool' &&
-                part.toolCallId === options.toolCallId,
-            ) as DynamicToolUIPart | undefined;
+            const part =
+              existingPart ??
+              (getCurrentStepParts().find(
+                part =>
+                  part.type === 'dynamic-tool' &&
+                  part.toolCallId === options.toolCallId,
+              ) as DynamicToolUIPart | undefined);
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -510,7 +546,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'tool-input-start': {
               const toolInvocations =
-                state.message.parts.filter(isStaticToolUIPart);
+                getCurrentStepParts().filter(isStaticToolUIPart);
 
               // add the partial tool call to the map
               state.partialToolCalls[chunk.toolCallId] = {
@@ -635,7 +671,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               // When a part already exists for this toolCallId (e.g. from
               // tool-input-start), honour its type so we update in place
               // instead of creating a duplicate with a mismatched type.
-              const existingPart = state.message.parts
+              const existingPart = getCurrentStepParts()
                 .filter(isToolUIPart)
                 .find(p => p.toolCallId === chunk.toolCallId);
               const isDynamic =
@@ -696,31 +732,37 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               const toolInvocation = getToolInvocation(chunk.toolCallId);
 
               if (toolInvocation.type === 'dynamic-tool') {
-                updateDynamicToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: toolInvocation.toolName,
-                  state: 'output-available',
-                  input: (toolInvocation as any).input,
-                  output: chunk.output,
-                  preliminary: chunk.preliminary,
-                  providerExecuted: chunk.providerExecuted,
-                  providerMetadata: chunk.providerMetadata,
-                  title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
-                });
+                updateDynamicToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: toolInvocation.toolName,
+                    state: 'output-available',
+                    input: (toolInvocation as any).input,
+                    output: chunk.output,
+                    preliminary: chunk.preliminary,
+                    providerExecuted: chunk.providerExecuted,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation,
+                );
               } else {
-                updateToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: getStaticToolName(toolInvocation),
-                  state: 'output-available',
-                  input: (toolInvocation as any).input,
-                  output: chunk.output,
-                  providerExecuted: chunk.providerExecuted,
-                  preliminary: chunk.preliminary,
-                  providerMetadata: chunk.providerMetadata,
-                  title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
-                });
+                updateToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: getStaticToolName(toolInvocation),
+                    state: 'output-available',
+                    input: (toolInvocation as any).input,
+                    output: chunk.output,
+                    providerExecuted: chunk.providerExecuted,
+                    preliminary: chunk.preliminary,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
+                );
               }
 
               write();
@@ -731,30 +773,36 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               const toolInvocation = getToolInvocation(chunk.toolCallId);
 
               if (toolInvocation.type === 'dynamic-tool') {
-                updateDynamicToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: toolInvocation.toolName,
-                  state: 'output-error',
-                  input: (toolInvocation as any).input,
-                  errorText: chunk.errorText,
-                  providerExecuted: chunk.providerExecuted,
-                  providerMetadata: chunk.providerMetadata,
-                  title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
-                });
+                updateDynamicToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: toolInvocation.toolName,
+                    state: 'output-error',
+                    input: (toolInvocation as any).input,
+                    errorText: chunk.errorText,
+                    providerExecuted: chunk.providerExecuted,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation,
+                );
               } else {
-                updateToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: getStaticToolName(toolInvocation),
-                  state: 'output-error',
-                  input: (toolInvocation as any).input,
-                  rawInput: (toolInvocation as any).rawInput,
-                  errorText: chunk.errorText,
-                  providerExecuted: chunk.providerExecuted,
-                  providerMetadata: chunk.providerMetadata,
-                  title: toolInvocation.title,
-                  toolMetadata: toolInvocation.toolMetadata,
-                });
+                updateToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: getStaticToolName(toolInvocation),
+                    state: 'output-error',
+                    input: (toolInvocation as any).input,
+                    rawInput: (toolInvocation as any).rawInput,
+                    errorText: chunk.errorText,
+                    providerExecuted: chunk.providerExecuted,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
+                );
               }
 
               write();


### PR DESCRIPTION
## Background

Repeated provider-scoped tool call IDs across model steps caused readUIMessageStream to overwrite an earlier tool part, leaving only the later step's input, output, and metadata.

## Root Cause

The UI stream reducer searched all message parts by toolCallId, so a later step reused and mutated the first matching part. The credential-free reproduction confirmed two step-local calls were aggregated into one part.

## Summary

Scoped tool input aggregation to the current step while retaining explicit fallback handling for outputs that complete previously existing tool calls. Removed reproduction artifacts and added an ai package patch changeset.

## Testing

Added a readUIMessageStream regression test asserting that repeated tool call IDs retain both steps' inputs, outputs, and provider metadata.

## End-to-end Validation

- `pnpm exec vitest --config vitest.node.config.js --run src/ui-message-stream/read-ui-message-stream.test.ts -t "should preserve tool parts when tool call ids repeat across steps"` — passed and preserved both tool parts.

## Related Issues

Fixes #17347

Closes #17519

Backport of #17586

Co-authored-by: wangliang1996 <36724800+wangliang1996@users.noreply.github.com>