### PR TITLE
[v5.0] fix: preserve tool parts when tool call IDs repeat across steps

### DIFF
--- a/.changeset/quiet-tools-repeat.md
+++ b/.changeset/quiet-tools-repeat.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): preserve tool parts when tool call IDs repeat across steps

--- a/packages/ai/src/ui-message-stream/read-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/read-ui-message-stream.test.ts
@@ -102,6 +102,70 @@ describe('readUIMessageStream', () => {
       `);
   });
 
+  it('should preserve tool parts when tool call ids repeat across steps', async () => {
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call-0',
+        toolName: 'recordStep',
+        input: { step: 1 },
+        providerMetadata: { openai: { itemId: 'fc-step-1' } },
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-0',
+        output: { recorded: 1 },
+      },
+      { type: 'finish-step' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call-0',
+        toolName: 'recordStep',
+        input: { step: 2 },
+        providerMetadata: { openai: { itemId: 'fc-step-2' } },
+      },
+      {
+        type: 'tool-output-available',
+        toolCallId: 'call-0',
+        output: { recorded: 2 },
+      },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ]);
+
+    const messages = await convertAsyncIterableToArray(
+      readUIMessageStream({ stream }),
+    );
+    const toolParts = messages
+      .at(-1)!
+      .parts.filter(
+        part => part.type.startsWith('tool-') || part.type === 'dynamic-tool',
+      );
+
+    expect(toolParts).toHaveLength(2);
+    expect(toolParts).toMatchObject([
+      {
+        type: 'tool-recordStep',
+        toolCallId: 'call-0',
+        state: 'output-available',
+        input: { step: 1 },
+        output: { recorded: 1 },
+        callProviderMetadata: { openai: { itemId: 'fc-step-1' } },
+      },
+      {
+        type: 'tool-recordStep',
+        toolCallId: 'call-0',
+        state: 'output-available',
+        input: { step: 2 },
+        output: { recorded: 2 },
+        callProviderMetadata: { openai: { itemId: 'fc-step-2' } },
+      },
+    ]);
+  });
+
   it('should throw an error when encountering an error UI stream part', async () => {
     const stream = createUIMessageStream([
       { type: 'start', messageId: 'msg-123' },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -126,11 +126,6 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             );
 
             if (toolInvocation == null) {
-<<<<<<< HEAD
-              throw new Error(
-                'tool-output-error must be preceded by a tool-input-available',
-              );
-=======
               const parts = state.message.parts;
 
               for (let i = parts.length - 1; i >= 0; i--) {
@@ -143,25 +138,37 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             if (toolInvocation == null) {
-              throw new UIMessageStreamError({
-                chunkType: 'tool-invocation',
-                chunkId: toolCallId,
-                message: `No tool invocation found for tool call ID "${toolCallId}".`,
-              });
->>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
+              throw new Error(
+                'tool-output-error must be preceded by a tool-input-available',
+              );
             }
 
             return toolInvocation;
           }
 
           function getDynamicToolInvocation(toolCallId: string) {
-            const toolInvocations = state.message.parts.filter(
+            const toolInvocations = getCurrentStepParts().filter(
               part => part.type === 'dynamic-tool',
             ) as DynamicToolUIPart[];
 
-            const toolInvocation = toolInvocations.find(
+            let toolInvocation = toolInvocations.find(
               invocation => invocation.toolCallId === toolCallId,
             );
+
+            if (toolInvocation == null) {
+              const parts = state.message.parts;
+
+              for (let i = parts.length - 1; i >= 0; i--) {
+                const part = parts[i];
+                if (
+                  part.type === 'dynamic-tool' &&
+                  part.toolCallId === toolCallId
+                ) {
+                  toolInvocation = part;
+                  break;
+                }
+              }
+            }
 
             if (toolInvocation == null) {
               throw new Error(
@@ -207,20 +214,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             ),
             existingPart?: ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
           ) {
-<<<<<<< HEAD
-            const part = state.message.parts.find(
-              part =>
-                isToolUIPart(part) && part.toolCallId === options.toolCallId,
-            ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined;
-=======
             const part =
               existingPart ??
               (getCurrentStepParts().find(
                 part =>
-                  isStaticToolUIPart(part) &&
-                  part.toolCallId === options.toolCallId,
+                  isToolUIPart(part) && part.toolCallId === options.toolCallId,
               ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined);
->>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -463,12 +462,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-start': {
-<<<<<<< HEAD
-              const toolInvocations = state.message.parts.filter(isToolUIPart);
-=======
               const toolInvocations =
-                getCurrentStepParts().filter(isStaticToolUIPart);
->>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
+                getCurrentStepParts().filter(isToolUIPart);
 
               // add the partial tool call to the map
               state.partialToolCalls[chunk.toolCallId] = {
@@ -565,22 +560,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-error': {
-<<<<<<< HEAD
               if (chunk.dynamic) {
-=======
-              // When a part already exists for this toolCallId (e.g. from
-              // tool-input-start), honour its type so we update in place
-              // instead of creating a duplicate with a mismatched type.
-              const existingPart = getCurrentStepParts()
-                .filter(isToolUIPart)
-                .find(p => p.toolCallId === chunk.toolCallId);
-              const isDynamic =
-                existingPart != null
-                  ? existingPart.type === 'dynamic-tool'
-                  : !!chunk.dynamic;
-
-              if (isDynamic) {
->>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: chunk.toolName,
@@ -613,29 +593,6 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   chunk.toolCallId,
                 );
 
-<<<<<<< HEAD
-                updateDynamicToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: toolInvocation.toolName,
-                  state: 'output-available',
-                  input: (toolInvocation as any).input,
-                  output: chunk.output,
-                  preliminary: chunk.preliminary,
-                });
-              } else {
-                const toolInvocation = getToolInvocation(chunk.toolCallId);
-
-                updateToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: getToolName(toolInvocation),
-                  state: 'output-available',
-                  input: (toolInvocation as any).input,
-                  output: chunk.output,
-                  providerExecuted: chunk.providerExecuted,
-                  preliminary: chunk.preliminary,
-                });
-=======
-              if (toolInvocation.type === 'dynamic-tool') {
                 updateDynamicToolPart(
                   {
                     toolCallId: chunk.toolCallId,
@@ -644,30 +601,24 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                     input: (toolInvocation as any).input,
                     output: chunk.output,
                     preliminary: chunk.preliminary,
-                    providerExecuted: chunk.providerExecuted,
-                    providerMetadata: chunk.providerMetadata,
-                    title: toolInvocation.title,
-                    toolMetadata: toolInvocation.toolMetadata,
                   },
                   toolInvocation,
                 );
               } else {
+                const toolInvocation = getToolInvocation(chunk.toolCallId);
+
                 updateToolPart(
                   {
                     toolCallId: chunk.toolCallId,
-                    toolName: getStaticToolName(toolInvocation),
+                    toolName: getToolName(toolInvocation),
                     state: 'output-available',
                     input: (toolInvocation as any).input,
                     output: chunk.output,
                     providerExecuted: chunk.providerExecuted,
                     preliminary: chunk.preliminary,
-                    providerMetadata: chunk.providerMetadata,
-                    title: toolInvocation.title,
-                    toolMetadata: toolInvocation.toolMetadata,
                   },
                   toolInvocation as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
                 );
->>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
               }
 
               write();
@@ -680,29 +631,6 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   chunk.toolCallId,
                 );
 
-<<<<<<< HEAD
-                updateDynamicToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: toolInvocation.toolName,
-                  state: 'output-error',
-                  input: (toolInvocation as any).input,
-                  errorText: chunk.errorText,
-                  providerExecuted: chunk.providerExecuted,
-                });
-              } else {
-                const toolInvocation = getToolInvocation(chunk.toolCallId);
-
-                updateToolPart({
-                  toolCallId: chunk.toolCallId,
-                  toolName: getToolName(toolInvocation),
-                  state: 'output-error',
-                  input: (toolInvocation as any).input,
-                  rawInput: (toolInvocation as any).rawInput,
-                  errorText: chunk.errorText,
-                  providerExecuted: chunk.providerExecuted,
-                });
-=======
-              if (toolInvocation.type === 'dynamic-tool') {
                 updateDynamicToolPart(
                   {
                     toolCallId: chunk.toolCallId,
@@ -711,29 +639,24 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                     input: (toolInvocation as any).input,
                     errorText: chunk.errorText,
                     providerExecuted: chunk.providerExecuted,
-                    providerMetadata: chunk.providerMetadata,
-                    title: toolInvocation.title,
-                    toolMetadata: toolInvocation.toolMetadata,
                   },
                   toolInvocation,
                 );
               } else {
+                const toolInvocation = getToolInvocation(chunk.toolCallId);
+
                 updateToolPart(
                   {
                     toolCallId: chunk.toolCallId,
-                    toolName: getStaticToolName(toolInvocation),
+                    toolName: getToolName(toolInvocation),
                     state: 'output-error',
                     input: (toolInvocation as any).input,
                     rawInput: (toolInvocation as any).rawInput,
                     errorText: chunk.errorText,
                     providerExecuted: chunk.providerExecuted,
-                    providerMetadata: chunk.providerMetadata,
-                    title: toolInvocation.title,
-                    toolMetadata: toolInvocation.toolMetadata,
                   },
                   toolInvocation as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
                 );
->>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
               }
 
               write();

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -100,17 +100,55 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
     new TransformStream<UIMessageChunk, InferUIMessageChunk<UI_MESSAGE>>({
       async transform(chunk, controller) {
         await runUpdateMessageJob(async ({ state, write }) => {
-          function getToolInvocation(toolCallId: string) {
-            const toolInvocations = state.message.parts.filter(isToolUIPart);
+          function getCurrentStepParts() {
+            const parts = state.message.parts;
+            let currentStepStartIndex = parts.length - 1;
 
-            const toolInvocation = toolInvocations.find(
+            while (
+              currentStepStartIndex >= 0 &&
+              parts[currentStepStartIndex].type !== 'step-start'
+            ) {
+              currentStepStartIndex--;
+            }
+
+            return parts.slice(currentStepStartIndex + 1);
+          }
+
+          function getCurrentStepToolInvocations() {
+            return getCurrentStepParts().filter(isToolUIPart);
+          }
+
+          function getToolInvocation(toolCallId: string) {
+            const toolInvocations = getCurrentStepToolInvocations();
+
+            let toolInvocation = toolInvocations.find(
               invocation => invocation.toolCallId === toolCallId,
             );
 
             if (toolInvocation == null) {
+<<<<<<< HEAD
               throw new Error(
                 'tool-output-error must be preceded by a tool-input-available',
               );
+=======
+              const parts = state.message.parts;
+
+              for (let i = parts.length - 1; i >= 0; i--) {
+                const part = parts[i];
+                if (isToolUIPart(part) && part.toolCallId === toolCallId) {
+                  toolInvocation = part;
+                  break;
+                }
+              }
+            }
+
+            if (toolInvocation == null) {
+              throw new UIMessageStreamError({
+                chunkType: 'tool-invocation',
+                chunkId: toolCallId,
+                message: `No tool invocation found for tool call ID "${toolCallId}".`,
+              });
+>>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
             }
 
             return toolInvocation;
@@ -167,11 +205,22 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerMetadata?: ProviderMetadata;
                 }
             ),
+            existingPart?: ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
           ) {
+<<<<<<< HEAD
             const part = state.message.parts.find(
               part =>
                 isToolUIPart(part) && part.toolCallId === options.toolCallId,
             ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined;
+=======
+            const part =
+              existingPart ??
+              (getCurrentStepParts().find(
+                part =>
+                  isStaticToolUIPart(part) &&
+                  part.toolCallId === options.toolCallId,
+              ) as ToolUIPart<InferUIMessageTools<UI_MESSAGE>> | undefined);
+>>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -240,12 +289,15 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerMetadata?: ProviderMetadata;
                 }
             ),
+            existingPart?: DynamicToolUIPart,
           ) {
-            const part = state.message.parts.find(
-              part =>
-                part.type === 'dynamic-tool' &&
-                part.toolCallId === options.toolCallId,
-            ) as DynamicToolUIPart | undefined;
+            const part =
+              existingPart ??
+              (getCurrentStepParts().find(
+                part =>
+                  part.type === 'dynamic-tool' &&
+                  part.toolCallId === options.toolCallId,
+              ) as DynamicToolUIPart | undefined);
 
             const anyOptions = options as any;
             const anyPart = part as any;
@@ -411,7 +463,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-start': {
+<<<<<<< HEAD
               const toolInvocations = state.message.parts.filter(isToolUIPart);
+=======
+              const toolInvocations =
+                getCurrentStepParts().filter(isStaticToolUIPart);
+>>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
 
               // add the partial tool call to the map
               state.partialToolCalls[chunk.toolCallId] = {
@@ -508,7 +565,22 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-error': {
+<<<<<<< HEAD
               if (chunk.dynamic) {
+=======
+              // When a part already exists for this toolCallId (e.g. from
+              // tool-input-start), honour its type so we update in place
+              // instead of creating a duplicate with a mismatched type.
+              const existingPart = getCurrentStepParts()
+                .filter(isToolUIPart)
+                .find(p => p.toolCallId === chunk.toolCallId);
+              const isDynamic =
+                existingPart != null
+                  ? existingPart.type === 'dynamic-tool'
+                  : !!chunk.dynamic;
+
+              if (isDynamic) {
+>>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: chunk.toolName,
@@ -541,6 +613,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   chunk.toolCallId,
                 );
 
+<<<<<<< HEAD
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: toolInvocation.toolName,
@@ -561,6 +634,40 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   preliminary: chunk.preliminary,
                 });
+=======
+              if (toolInvocation.type === 'dynamic-tool') {
+                updateDynamicToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: toolInvocation.toolName,
+                    state: 'output-available',
+                    input: (toolInvocation as any).input,
+                    output: chunk.output,
+                    preliminary: chunk.preliminary,
+                    providerExecuted: chunk.providerExecuted,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation,
+                );
+              } else {
+                updateToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: getStaticToolName(toolInvocation),
+                    state: 'output-available',
+                    input: (toolInvocation as any).input,
+                    output: chunk.output,
+                    providerExecuted: chunk.providerExecuted,
+                    preliminary: chunk.preliminary,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
+                );
+>>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
               }
 
               write();
@@ -573,6 +680,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   chunk.toolCallId,
                 );
 
+<<<<<<< HEAD
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: toolInvocation.toolName,
@@ -593,6 +701,39 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   errorText: chunk.errorText,
                   providerExecuted: chunk.providerExecuted,
                 });
+=======
+              if (toolInvocation.type === 'dynamic-tool') {
+                updateDynamicToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: toolInvocation.toolName,
+                    state: 'output-error',
+                    input: (toolInvocation as any).input,
+                    errorText: chunk.errorText,
+                    providerExecuted: chunk.providerExecuted,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation,
+                );
+              } else {
+                updateToolPart(
+                  {
+                    toolCallId: chunk.toolCallId,
+                    toolName: getStaticToolName(toolInvocation),
+                    state: 'output-error',
+                    input: (toolInvocation as any).input,
+                    rawInput: (toolInvocation as any).rawInput,
+                    errorText: chunk.errorText,
+                    providerExecuted: chunk.providerExecuted,
+                    providerMetadata: chunk.providerMetadata,
+                    title: toolInvocation.title,
+                    toolMetadata: toolInvocation.toolMetadata,
+                  },
+                  toolInvocation as ToolUIPart<InferUIMessageTools<UI_MESSAGE>>,
+                );
+>>>>>>> e808fa5ec2 (fix: preserve tool parts when tool call IDs repeat across steps (#17586))
               }
 
               write();


### PR DESCRIPTION
## Background

Repeated provider-scoped tool call IDs across model steps caused readUIMessageStream to overwrite an earlier tool part, leaving only the later step's input, output, and metadata.

## Root Cause

The UI stream reducer searched all message parts by toolCallId, so a later step reused and mutated the first matching part. The credential-free reproduction confirmed two step-local calls were aggregated into one part.

## Summary

Scoped tool input aggregation to the current step while retaining explicit fallback handling for outputs that complete previously existing tool calls. Removed reproduction artifacts and added an ai package patch changeset.

## Testing

Added a readUIMessageStream regression test asserting that repeated tool call IDs retain both steps' inputs, outputs, and provider metadata.

## End-to-end Validation

- `pnpm exec vitest --config vitest.node.config.js --run src/ui-message-stream/read-ui-message-stream.test.ts -t "should preserve tool parts when tool call ids repeat across steps"` — passed and preserved both tool parts.

## Related Issues

Fixes #17347

Closes #17519

Backport of #17586

Co-authored-by: wangliang1996 <36724800+wangliang1996@users.noreply.github.com>