### PR TITLE
reproduction: could not reproduce Getting outputTokens:0 for gemma model but it is

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12013-google-gemma-output-tokens.ts
+++ b/examples/ai-functions/src/reproduction/issue-12013-google-gemma-output-tokens.ts
@@ -1,0 +1,62 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+
+async function stream(modelId: string) {
+  const result = streamText({
+    model: google(modelId),
+    prompt: 'Reply with exactly the word hello.',
+    maxOutputTokens: 128,
+    include: {
+      rawChunks: true,
+    },
+  });
+
+  const rawUsageMetadata: unknown[] = [];
+  const errors: unknown[] = [];
+
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'raw') {
+      const rawValue = chunk.rawValue;
+      if (
+        typeof rawValue === 'object' &&
+        rawValue != null &&
+        'usageMetadata' in rawValue
+      ) {
+        rawUsageMetadata.push(rawValue.usageMetadata);
+      }
+    } else if (chunk.type === 'error') {
+      errors.push(chunk.error);
+    }
+  }
+
+  return {
+    modelId,
+    text: await result.text,
+    usage: await result.usage,
+    rawUsageMetadata,
+    errors,
+  };
+}
+
+async function main() {
+  const gemmaModelId = process.argv[2] ?? 'gemma-3-12b-it';
+  const gemma = await stream(gemmaModelId);
+  const gemini = await stream('gemini-2.5-flash');
+
+  console.log(JSON.stringify({ gemma, gemini }, null, 2));
+
+  if (gemma.errors.length > 0 || gemini.errors.length > 0) {
+    throw new Error('Provider stream returned an error.');
+  }
+
+  if (gemma.text.length > 0 && gemma.usage.outputTokens === 0) {
+    throw new Error(
+      `Reproduced issue #12013: ${gemmaModelId} streamed non-empty text but AI SDK reported outputTokens: 0.`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Getting outputTokens:0 for gemma model but it is working correctly for gemini model

## Reproduction

- The reported user impact is misleading usage accounting: a non-empty streamed response should not report `outputTokens: 0` when the output count is unavailable.
- The exact `gemma-3-12b-it` scenario could not be evaluated because the live Gemini API returned HTTP 404 and the current Models API no longer lists that model.
- The officially supported replacement `gemma-4-26b-a4b-it` streamed `hello` and reported 62 output tokens; its final raw metadata included `candidatesTokenCount: 1`, so the primary failure did not occur.
- Main currently uses `@ai-sdk/google` 4.0.20 and `ai` 7.0.33; migrating to the currently supported Gemma 4 model avoids the reported behavior without product-code changes.
- `packages/google/src/convert-google-usage.ts` still converts a missing `candidatesTokenCount` to zero, but current supported Gemma responses supplied the field before stream completion.
- `examples/ai-functions/src/reproduction/issue-12013-google-gemma-output-tokens.ts` compares Gemma with Gemini and fails if Gemma produces non-empty text while reporting zero output tokens.

## Relevant Documentation

- https://ai.google.dev/api/generate-content
- https://ai.google.dev/api/models
- https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api
- https://ai.google.dev/gemini-api/docs/changelog

## Related Issues

Could not reproduce #12013