### PR TITLE
[v6.0] reproduction: problemtic default value of maxtokens for unknown models

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17588,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17588_REPRODUCED: unknown model silently received max_tokens=4096 with no warning"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts
+++ b/examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts
@@ -1,0 +1,87 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const modelId = 'claude-mythos-5';
+const requestBodies: Array<Record<string, unknown>> = [];
+
+const anthropic = createAnthropic({
+  apiKey: 'test-key',
+  fetch: async (_input, init) => {
+    requestBodies.push(JSON.parse(String(init?.body)));
+
+    return new Response(
+      JSON.stringify({
+        id: 'msg_issue_17588',
+        type: 'message',
+        role: 'assistant',
+        model: modelId,
+        content: [{ type: 'text', text: 'OK' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+        },
+      }),
+      {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      },
+    );
+  },
+});
+
+async function main() {
+  const implicitResult = await generateText({
+    model: anthropic(modelId),
+    prompt: 'Reply with exactly OK.',
+    maxRetries: 0,
+  });
+
+  const explicitResult = await generateText({
+    model: anthropic(modelId),
+    prompt: 'Reply with exactly OK.',
+    maxOutputTokens: 128_000,
+    maxRetries: 0,
+  });
+
+  const implicitMaxTokens = requestBodies[0]?.max_tokens;
+  const explicitMaxTokens = requestBodies[1]?.max_tokens;
+  const implicitWarnings = implicitResult.warnings ?? [];
+  const explicitWarnings = explicitResult.warnings ?? [];
+
+  console.log(
+    JSON.stringify(
+      {
+        modelId,
+        implicitMaxTokens,
+        implicitWarnings,
+        explicitMaxTokens,
+        explicitWarnings,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (explicitMaxTokens !== 128_000) {
+    throw new Error(
+      `Comparison failed: explicit maxOutputTokens became ${String(explicitMaxTokens)}`,
+    );
+  }
+
+  if (implicitMaxTokens === 4096 && implicitWarnings.length === 0) {
+    throw new Error(
+      'ISSUE_17588_REPRODUCED: unknown model silently received max_tokens=4096 with no warning',
+    );
+  }
+
+  console.log(
+    'Issue not reproduced: the unknown model was not silently capped at 4096.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

problemtic default value of `max_tokens` for unknown models

## Reproduction

- On `ai` 6.0.232 and `@ai-sdk/anthropic` 3.0.99, the documented 128k-output model `claude-mythos-5` is treated as unknown and silently receives `"max_tokens":4096`.
- `packages/anthropic/src/anthropic-messages-language-model.ts` supplies unknown models with the 4096 fallback, sends it as `max_tokens`, and emits no warning when `maxOutputTokens` is omitted.
- `examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts` observed the implicit 4096 cap and an empty warnings array; expected behavior is to disclose or avoid the implicit cap.
- Setting `maxOutputTokens: 128000` explicitly sent 128000, confirming the reported configuration workaround but not resolving the silent default.
- A live `claude-mythos-5` request returned HTTP 404 for the configured Anthropic account, so an actual response exceeding 4096 tokens was not measured; the reported SDK request and warning behavior was directly reproduced through the custom-fetch technique from the issue.

## Relevant Documentation

- https://platform.claude.com/docs/en/api/messages/create
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic

## Related Issues

Reproduces #17588