### PR TITLE
[v5.0] reproduction: problemtic default value of maxtokens for unknown models

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17588,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #17588 reproduced: unknown Anthropic model silently received max_tokens=4096"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts
+++ b/examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts
@@ -1,0 +1,89 @@
+import { createAnthropic } from '../../../../packages/anthropic/src';
+import { generateText } from '../../../../packages/ai/src/generate-text';
+
+type RequestBody = {
+  max_tokens?: number;
+  model?: string;
+};
+
+function createResponse(model: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'msg_issue_17588',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+      model,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
+async function runCall(maxOutputTokens?: number) {
+  const requestBodies: RequestBody[] = [];
+  const modelId = 'claude-fable-6';
+  const anthropic = createAnthropic({
+    apiKey: 'test-api-key',
+    fetch: async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)) as RequestBody);
+      return createResponse(modelId);
+    },
+  });
+
+  const result = await generateText({
+    model: anthropic(modelId),
+    messages: [{ role: 'user', content: '' }],
+    maxOutputTokens,
+  });
+
+  if (requestBodies.length !== 1) {
+    throw new Error(`Expected one request, received ${requestBodies.length}.`);
+  }
+
+  return {
+    body: requestBodies[0],
+    warnings: result.warnings ?? [],
+  };
+}
+
+async function main() {
+  const implicit = await runCall();
+  const explicit = await runCall(8192);
+
+  console.log(
+    JSON.stringify(
+      {
+        implicit,
+        explicit,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (explicit.body.max_tokens !== 8192) {
+    throw new Error(
+      `Expected explicit maxOutputTokens=8192 to send max_tokens=8192, received ${String(explicit.body.max_tokens)}.`,
+    );
+  }
+
+  if (implicit.body.max_tokens === 4096 && implicit.warnings.length === 0) {
+    throw new Error(
+      'Issue #17588 reproduced: unknown Anthropic model silently received max_tokens=4096',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

problemtic default value of `max_tokens` for unknown models

## Reproduction

- On `release-v5.0` (`ai` 5.0.217 and `@ai-sdk/anthropic` 2.0.88), the unknown model `claude-fable-6` silently received `"max_tokens":4096` with an empty warnings array.
- Setting `maxOutputTokens: 8192` sent `"max_tokens":8192`, confirming explicit configuration avoids the implicit cap but does not address the silent default.
- `packages/anthropic/src/anthropic-messages-language-model.ts` supplies a 4096-token fallback for unknown models and uses it when `maxOutputTokens` is omitted.
- The reproduction in `examples/ai-functions/src/reproduction/issue-17588-anthropic-unknown-model-max-tokens.ts`, supported by `examples/ai-functions/package.json`, expected unknown models not to receive an undocumented silent 4096-token cap and observed the reported behavior.

## Relevant Documentation

- https://platform.claude.com/docs/en/api/messages/create
- https://ai-sdk.dev/providers/ai-sdk-providers/anthropic

## Related Issues

Reproduces #17588