### PR TITLE
[v6.0] reproduction: could not reproduce Getting outputTokens:0 for gemma model but it is

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-12013-google-gemma-output-tokens.ts
+++ b/examples/ai-functions/src/reproduction/issue-12013-google-gemma-output-tokens.ts
@@ -1,0 +1,100 @@
+import { google } from '@ai-sdk/google';
+import { APICallError, streamText } from 'ai';
+
+const reportedGemmaModel = 'gemma-3-12b-it';
+const currentGemmaModel = 'gemma-4-26b-a4b-it';
+const comparisonGeminiModel = 'gemini-2.5-flash';
+
+type Observation = {
+  model: string;
+  text: string;
+  usage: Awaited<ReturnType<typeof streamText>['usage']>;
+  usageMetadata: unknown;
+  rawUsageMetadata: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function observe(model: string): Promise<Observation> {
+  const result = streamText({
+    model: google(model),
+    maxOutputTokens: 256,
+    prompt: 'Reply with exactly: hello',
+    includeRawChunks: true,
+    onError: () => {},
+  });
+
+  let text = '';
+  let rawUsageMetadata: unknown;
+
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'text-delta') {
+      text += chunk.text;
+    } else if (chunk.type === 'raw' && isRecord(chunk.rawValue)) {
+      rawUsageMetadata = chunk.rawValue.usageMetadata ?? rawUsageMetadata;
+    } else if (chunk.type === 'error') {
+      throw chunk.error;
+    }
+  }
+
+  const [usage, providerMetadata] = await Promise.all([
+    result.usage,
+    result.providerMetadata,
+  ]);
+
+  return {
+    model,
+    text,
+    usage,
+    usageMetadata: providerMetadata?.google?.usageMetadata,
+    rawUsageMetadata,
+  };
+}
+
+function assertNoZeroOutputTokens(observation: Observation) {
+  if (observation.text.length > 0 && observation.usage.outputTokens === 0) {
+    throw new Error(
+      `Reproduced issue #12013: ${observation.model} streamed non-empty text but reported outputTokens: 0.`,
+    );
+  }
+}
+
+async function main() {
+  let reportedModelUnavailable = false;
+  let gemmaObservation: Observation;
+
+  try {
+    gemmaObservation = await observe(reportedGemmaModel);
+  } catch (error) {
+    if (APICallError.isInstance(error) && error.statusCode === 404) {
+      reportedModelUnavailable = true;
+      gemmaObservation = await observe(currentGemmaModel);
+    } else {
+      throw error;
+    }
+  }
+
+  const geminiObservation = await observe(comparisonGeminiModel);
+
+  console.log(
+    JSON.stringify(
+      {
+        reportedModelUnavailable,
+        gemma: gemmaObservation,
+        gemini: geminiObservation,
+      },
+      null,
+      2,
+    ),
+  );
+
+  assertNoZeroOutputTokens(gemmaObservation);
+  assertNoZeroOutputTokens(geminiObservation);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Getting outputTokens:0 for gemma model but it is working correctly for gemini model

## Reproduction

- The reported impact is misleading usage accounting: non-empty streamed text should not report `outputTokens: 0` when output-token data is unavailable.
- The live API returned HTTP 404 for the exact `gemma-3-12b-it` model, so that historical model scenario could not be evaluated.
- `examples/ai-functions/src/reproduction/issue-12013-google-gemma-output-tokens.ts` tested the documented `gemma-4-26b-a4b-it` replacement; it streamed `hello`, reported 121 output tokens, and included `candidatesTokenCount: 1`, so the expected issue behavior did not occur.
- The Gemini comparison streamed `hello`, reported 17 output tokens, and included `candidatesTokenCount: 1`.
- `packages/google/src/convert-google-generative-ai-usage.ts` still converts a missing `candidatesTokenCount` to zero, but the supported live Gemma response supplied that field.
- The target branch uses `ai` 6.0.232 and `@ai-sdk/google` 3.0.97; using the currently documented Gemma 4 model avoids the reported outcome without product-code changes.

## Relevant Documentation

- https://ai.google.dev/api/generate-content
- https://ai.google.dev/api/models
- https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api
- https://ai.google.dev/gemini-api/docs/changelog

## Related Issues

Could not reproduce #12013