### PR TITLE
reproduction: @ai-sdk/langchain: convertUserContent emits OpenAI-specific imageurl blocks instead of

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11943,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11943-langchain-image-content-block.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #11943: image inputs emit OpenAI-specific image_url blocks instead of LangChain canonical image ContentBlocks"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts
+++ b/examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts
@@ -1,0 +1,102 @@
+import { convertModelMessages } from '@ai-sdk/langchain';
+import type { ModelMessage } from 'ai';
+import { isDeepStrictEqual } from 'node:util';
+
+async function main() {
+  const urlImageMessage: ModelMessage = {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Describe this image.' },
+      {
+        type: 'image',
+        image: new URL('https://example.com/image.jpg'),
+      },
+    ],
+  };
+
+  const binaryImageMessage: ModelMessage = {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Describe this image.' },
+      {
+        type: 'image',
+        image: new Uint8Array([1, 2, 3]),
+        mediaType: 'image/png',
+      },
+    ],
+  };
+
+  const nonImageFileMessage: ModelMessage = {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Summarize this file.' },
+      {
+        type: 'file',
+        data: { type: 'data', data: 'JVBERi0xLjQK' },
+        mediaType: 'application/pdf',
+      },
+    ],
+  };
+
+  const [urlImage] = convertModelMessages([urlImageMessage]);
+  const [binaryImage] = convertModelMessages([binaryImageMessage]);
+  const [nonImageFile] = convertModelMessages([nonImageFileMessage]);
+
+  const actual = {
+    urlImage: urlImage.content,
+    binaryImage: binaryImage.content,
+    nonImageFile: nonImageFile.content,
+  };
+
+  const expected = {
+    urlImage: [
+      { type: 'text', text: 'Describe this image.' },
+      { type: 'image', url: 'https://example.com/image.jpg' },
+    ],
+    binaryImage: [
+      { type: 'text', text: 'Describe this image.' },
+      { type: 'image', data: 'AQID', mimeType: 'image/png' },
+    ],
+    nonImageFile: [
+      { type: 'text', text: 'Summarize this file.' },
+      {
+        type: 'file',
+        data: 'JVBERi0xLjQK',
+        mimeType: 'application/pdf',
+        filename: 'file.pdf',
+      },
+    ],
+  };
+
+  const urlImageIsCanonical = isDeepStrictEqual(
+    actual.urlImage,
+    expected.urlImage,
+  );
+  const binaryImageIsCanonical = isDeepStrictEqual(
+    actual.binaryImage,
+    expected.binaryImage,
+  );
+  const nonImageFileIsCanonical = isDeepStrictEqual(
+    actual.nonImageFile,
+    expected.nonImageFile,
+  );
+
+  console.log(JSON.stringify({ expected, actual }, null, 2));
+
+  if (!urlImageIsCanonical || !binaryImageIsCanonical) {
+    throw new Error(
+      'Reproduced issue #11943: image inputs emit OpenAI-specific image_url blocks instead of LangChain canonical image ContentBlocks',
+    );
+  }
+
+  if (!nonImageFileIsCanonical) {
+    throw new Error(
+      'Comparison failed: non-image files did not emit the expected LangChain canonical file ContentBlock',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

@ai-sdk/langchain: convertUserContent emits OpenAI-specific image_url blocks instead of LangChain image ContentBlock

## Reproduction

- `packages/langchain/src/utils.ts` converts URL and binary image inputs into OpenAI-specific `image_url` blocks despite the installed LangChain 1.x types supporting canonical image blocks.
- `examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts` observed `image_url` for both URL and base64 image inputs instead of the expected flat `image` blocks.
- The same reproduction emitted a non-image PDF as a canonical flat `file` block, confirming the reported image-only inconsistency.

## Relevant Documentation

- https://docs.langchain.com/oss/javascript/langchain/messages
- https://docs.langchain.com/oss/javascript/migrate/langchain-v1
- https://reference.langchain.com/javascript/langchain-core/messages

## Related Issues

Reproduces #11943