### PR TITLE
reproduction: Gemini 3 parallel function calls: converter injects skipthoughtsignaturevalidator

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 16298,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts",
+    "packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #16298 reproduced: valid parallel Gemini 3 tool calls triggered the skip_thought_signature_validator warning."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts
+++ b/examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts
@@ -1,0 +1,186 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type {
+  LanguageModelV4Prompt,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { createGateway, stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+import {
+  convertToGoogleMessages,
+  SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+} from '../../../../packages/google/src/convert-to-google-messages';
+
+const failureSignal =
+  'Issue #16298 reproduced: valid parallel Gemini 3 tool calls triggered the skip_thought_signature_validator warning.';
+
+type Fixture = {
+  model: string;
+  prompt: string;
+  warnings: SharedV4Warning[];
+  toolCalls: Array<{
+    stepIndex: number;
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    providerMetadata: SharedV4ProviderMetadata | null;
+  }>;
+};
+
+function readThoughtSignature(
+  providerMetadata: Fixture['toolCalls'][number]['providerMetadata'],
+): string | undefined {
+  for (const namespace of ['google', 'vertex', 'googleVertex']) {
+    const thoughtSignature = providerMetadata?.[namespace]?.thoughtSignature;
+    if (typeof thoughtSignature === 'string') {
+      return thoughtSignature;
+    }
+  }
+}
+
+async function runLive() {
+  const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY! });
+  const prompt =
+    'Use get_weather for Paris and Tokyo in parallel in one assistant step, then summarize both weather results.';
+
+  const result = streamText({
+    model: gateway('google/gemini-3.1-flash-lite'),
+    abortSignal: AbortSignal.timeout(60_000),
+    stopWhen: stepCountIs(3),
+    providerOptions: {
+      gateway: {
+        order: ['vertex'],
+        only: ['vertex'],
+      } satisfies GatewayProviderOptions,
+    },
+    tools: {
+      get_weather: tool({
+        description: 'Get the current weather for a city.',
+        inputSchema: z.object({ city: z.string() }),
+        execute: async ({ city }) => ({
+          city,
+          tempC: city === 'Tokyo' ? 24 : 21,
+          conditions: 'sunny',
+        }),
+      }),
+    },
+    prompt,
+  });
+
+  for await (const _ of result.textStream) {
+    // Drain all steps so the replay warning is available.
+  }
+
+  const fixture: Fixture = {
+    model: 'google/gemini-3.1-flash-lite',
+    prompt,
+    warnings: (await result.warnings) ?? [],
+    toolCalls: (await result.steps).flatMap((step, stepIndex) =>
+      step.content
+        .filter(part => part.type === 'tool-call')
+        .map(part => ({
+          stepIndex,
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input: part.input,
+          providerMetadata:
+            (part.providerMetadata as Fixture['toolCalls'][number]['providerMetadata']) ??
+            null,
+        })),
+    ),
+  };
+
+  console.log(JSON.stringify(fixture, null, 2));
+
+  const hasSignedCall = fixture.toolCalls.some(
+    call => readThoughtSignature(call.providerMetadata) != null,
+  );
+  const hasUnsignedCall = fixture.toolCalls.some(
+    call => readThoughtSignature(call.providerMetadata) == null,
+  );
+  const hasWarning = fixture.warnings.some(
+    warning =>
+      warning.type === 'other' &&
+      warning.message.includes(SKIP_THOUGHT_SIGNATURE_VALIDATOR),
+  );
+
+  if (hasSignedCall && hasUnsignedCall && hasWarning) {
+    throw new Error(failureSignal);
+  }
+}
+
+async function replayFixture() {
+  const fixturePath = fileURLToPath(
+    new URL(
+      '../../../../packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json',
+      import.meta.url,
+    ),
+  );
+  const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as Fixture;
+  const warnings: SharedV4Warning[] = [];
+
+  const prompt: LanguageModelV4Prompt = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: fixture.prompt }],
+    },
+    {
+      role: 'assistant',
+      content: fixture.toolCalls.map(call => ({
+        type: 'tool-call' as const,
+        toolCallId: call.toolCallId,
+        toolName: call.toolName,
+        input: call.input,
+        providerOptions: call.providerMetadata ?? undefined,
+      })),
+    },
+  ];
+
+  const converted = convertToGoogleMessages(prompt, {
+    isGemini3Model: true,
+    providerOptionsNames: ['googleVertex', 'vertex'],
+    onWarning: warning => warnings.push(warning),
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        recordedWarnings: fixture.warnings,
+        replayWarnings: warnings,
+        convertedToolCallParts: converted.contents[1].parts,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const hasWarning = warnings.some(
+    warning =>
+      warning.type === 'other' &&
+      warning.message.includes(SKIP_THOUGHT_SIGNATURE_VALIDATOR),
+  );
+  const hasInjectedSentinel = converted.contents[1].parts.some(
+    part =>
+      'thoughtSignature' in part &&
+      part.thoughtSignature === SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+  );
+
+  if (hasWarning && hasInjectedSentinel) {
+    throw new Error(failureSignal);
+  }
+}
+
+async function main() {
+  if (process.env.LIVE_PROVIDER === '1') {
+    await runLive();
+  } else {
+    await replayFixture();
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json
+++ b/packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json
@@ -1,0 +1,39 @@
+{
+  "capturedAt": "2026-07-21",
+  "provider": "Vercel AI Gateway routed only to Vertex AI",
+  "model": "google/gemini-3.1-flash-lite",
+  "prompt": "Use get_weather for Paris and Tokyo in parallel in one assistant step, then summarize both weather results.",
+  "warnings": [
+    {
+      "type": "other",
+      "message": "Replayed 1 `functionCall` part(s) for a Gemini 3 model without a `thoughtSignature` (tools: `get_weather`). Injected the documented `skip_thought_signature_validator` sentinel to keep the request from failing with HTTP 400. The likely cause is application code that drops `providerOptions.google.thoughtSignature` when persisting or serializing assistant tool-call messages. See https://ai.google.dev/gemini-api/docs/thought-signatures."
+    }
+  ],
+  "toolCalls": [
+    {
+      "stepIndex": 0,
+      "toolCallId": "lpndqlku",
+      "toolName": "get_weather",
+      "input": {
+        "city": "Paris"
+      },
+      "providerMetadata": {
+        "googleVertex": {
+          "thoughtSignature": "AY89a19YsnFp7FOSIejJDV9XuMU996D+ZaDJiD6L9EEi+Lh+VGTEGqM3Lip3DPI7QzY="
+        },
+        "vertex": {
+          "thoughtSignature": "AY89a19YsnFp7FOSIejJDV9XuMU996D+ZaDJiD6L9EEi+Lh+VGTEGqM3Lip3DPI7QzY="
+        }
+      }
+    },
+    {
+      "stepIndex": 0,
+      "toolCallId": "m6rogicj",
+      "toolName": "get_weather",
+      "input": {
+        "city": "Tokyo"
+      },
+      "providerMetadata": null
+    }
+  ]
+}

--- a/packages/google/src/issue-16298-gemini3-parallel-tool-calls.test.ts
+++ b/packages/google/src/issue-16298-gemini3-parallel-tool-calls.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import type {
+  LanguageModelV4Prompt,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import {
+  convertToGoogleMessages,
+  SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+} from './convert-to-google-messages';
+
+type Fixture = {
+  prompt: string;
+  toolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    providerMetadata: SharedV4ProviderMetadata | null;
+  }>;
+};
+
+describe('issue #16298: Gemini 3 parallel tool-call thought signatures', () => {
+  it('does not warn or inject a sentinel when the first parallel call is signed', () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          './__fixtures__/issue-16298-gemini3-parallel-tool-calls.json',
+          import.meta.url,
+        ),
+        'utf8',
+      ),
+    ) as Fixture;
+    const warnings: SharedV4Warning[] = [];
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: fixture.prompt }],
+      },
+      {
+        role: 'assistant',
+        content: fixture.toolCalls.map(call => ({
+          type: 'tool-call' as const,
+          toolCallId: call.toolCallId,
+          toolName: call.toolName,
+          input: call.input,
+          providerOptions: call.providerMetadata ?? undefined,
+        })),
+      },
+    ];
+
+    const result = convertToGoogleMessages(prompt, {
+      isGemini3Model: true,
+      providerOptionsNames: ['googleVertex', 'vertex'],
+      onWarning: warning => warnings.push(warning),
+    });
+
+    expect(warnings).toEqual([]);
+    expect(result.contents[1].parts).not.toContainEqual(
+      expect.objectContaining({
+        thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Bug

Gemini 3 parallel function calls: converter injects `skip_thought_signature_validator` + warns every turn (only the first parallel call is signed)

## Reproduction

- Google documents that only the first function call in a Gemini 3 parallel batch carries a thought signature; subsequent unsigned calls are valid.
- On July 21, 2026, a live AI Gateway request routed to Vertex returned two parallel calls: the first was signed, the second had `providerMetadata: null`, and the automatic multi-step replay emitted the misleading `skip_thought_signature_validator` warning without application persistence or serialization.
- The replay confirmed `packages/google/src/convert-to-google-messages.ts` injects the sentinel into the valid unsigned second call and attributes the missing signature to application code.
- `examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts` deterministically reproduces the warning and sentinel injection from the recorded live response.
- The live response is recorded in `packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json`, and `packages/google/src/issue-16298-gemini3-parallel-tool-calls.test.ts` is a failing provider regression test for the expected no-warning behavior.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
- https://ai.google.dev/gemini-api/docs/generate-content/gemini-3
- https://vercel.com/ai-gateway/models/gemini-3.1-flash-lite/providers
- https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway

## Related Issues

Reproduces #16298