### PR TITLE
reproduction: could not reproduce LangChain Package - Multimodal conversion not working

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11435-langchain-multimodal.ts
+++ b/examples/ai-functions/src/reproduction/issue-11435-langchain-multimodal.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { convertModelMessages } from '@ai-sdk/langchain';
+import type { ModelMessage } from 'ai';
+
+async function main() {
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Inspect these attachments.' },
+        {
+          type: 'image',
+          image: new URL('https://example.com/image.png'),
+          mediaType: 'image/png',
+        },
+        {
+          type: 'file',
+          data: new URL('https://example.com/document.pdf'),
+          mediaType: 'application/pdf',
+          filename: 'document.pdf',
+        },
+      ],
+    },
+  ];
+
+  const [message] = convertModelMessages(messages);
+
+  assert.deepEqual(
+    message.content,
+    [
+      { type: 'text', text: 'Inspect these attachments.' },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/image.png' },
+      },
+      {
+        type: 'file',
+        url: 'https://example.com/document.pdf',
+        mimeType: 'application/pdf',
+        filename: 'document.pdf',
+      },
+    ],
+    'Issue #11435 reproduced: image or file content was dropped during LangChain conversion.',
+  );
+
+  console.log(
+    'Issue #11435 not reproduced: image and file content were preserved.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

LangChain Package - Multimodal conversion not working

## Reproduction

- The reported user-visible bug is that image and file attachments disappear when AI SDK user messages are converted to LangChain messages; current `main` preserves both attachment types.
- The reproduction at `examples/ai-functions/src/reproduction/issue-11435-langchain-multimodal.ts` converted text, image, and PDF parts and observed all three in the resulting LangChain message instead of the reported text-only output.
- `packages/langchain/package.json` is version 3.0.33, while `packages/langchain/CHANGELOG.md` records the multimodal conversion fix in version 2.0.23; the issue reported version 2.0.3.
- Upgrading `@ai-sdk/langchain` from 2.0.3 to 2.0.23 or later resolves the reported behavior without additional product-code changes.

## Relevant Documentation

- https://docs.langchain.com/oss/javascript/langchain/messages
- https://ai-sdk.dev/docs/reference/ai-sdk-core/model-message

## Related Issues

Could not reproduce #11435