### PR TITLE
reproduction: Bedrock client doesn't support alternate URLs for non-standard

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11197,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11197-bedrock-nonstandard-region.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #11197: region us-iso-east-1 resolved Bedrock Runtime to https://bedrock-runtime.us-iso-east-1.amazonaws.com instead of https://bedrock-runtime.us-iso-east-1.c2s.ic.gov and ignored AWS_ENDPOINT_URL_BEDROCK_RUNTIME."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts
+++ b/examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts
@@ -1,0 +1,58 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+
+const region = 'us-iso-east-1';
+const expectedBaseURL = `https://bedrock-runtime.${region}.c2s.ic.gov`;
+const incorrectBaseURL = `https://bedrock-runtime.${region}.amazonaws.com`;
+
+function getRequestUrl(error: unknown): string | undefined {
+  if (error != null && typeof error === 'object' && 'url' in error) {
+    const url = error.url;
+    return typeof url === 'string' ? url : undefined;
+  }
+
+  return undefined;
+}
+
+async function main() {
+  const previousEndpointOverride = process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+
+  try {
+    process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME = expectedBaseURL;
+
+    await generateText({
+      model: createAmazonBedrock({ region })(
+        'anthropic.claude-3-haiku-20240307-v1:0',
+      ),
+      prompt: 'Reply with OK.',
+      maxOutputTokens: 2,
+      maxRetries: 0,
+      abortSignal: AbortSignal.timeout(5_000),
+    });
+  } catch (error) {
+    const requestUrl = getRequestUrl(error);
+
+    if (requestUrl?.startsWith(incorrectBaseURL)) {
+      throw new Error(
+        `Reproduced issue #11197: region ${region} resolved Bedrock Runtime to ${incorrectBaseURL} instead of ${expectedBaseURL} and ignored AWS_ENDPOINT_URL_BEDROCK_RUNTIME.`,
+      );
+    }
+
+    throw error;
+  } finally {
+    if (previousEndpointOverride == null) {
+      delete process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+    } else {
+      process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME = previousEndpointOverride;
+    }
+  }
+
+  console.log(
+    `Bedrock Runtime request succeeded through the expected endpoint ${expectedBaseURL}.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts
@@ -121,6 +121,19 @@ describe('AmazonBedrockProvider', () => {
       expect(constructorCall[1].baseUrl()).toBe('https://custom.url');
     });
 
+    it('should resolve the Bedrock Runtime endpoint for an AWS ISO region', () => {
+      const provider = createAmazonBedrock({
+        region: 'us-iso-east-1',
+      });
+
+      provider('anthropic.claude-v2');
+
+      const constructorCall = AmazonBedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe(
+        'https://bedrock-runtime.us-iso-east-1.c2s.ic.gov',
+      );
+    });
+
     it('should accept a credentialProvider in options', () => {
       const mockCredentialProvider = vi.fn().mockResolvedValue({
         accessKeyId: 'dynamic-access-key',


### PR DESCRIPTION
## Bug

Bedrock client doesn't support alternate URLs for non-standard AWS Regions.

## Reproduction

- On `@ai-sdk/amazon-bedrock` 5.0.26, `us-iso-east-1` resolves to the invalid `bedrock-runtime.us-iso-east-1.amazonaws.com` host instead of AWS's documented `bedrock-runtime.us-iso-east-1.c2s.ic.gov` host.
- `examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts` observed the incorrect outgoing URL and showed that `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` was ignored; the expected behavior was automatic non-standard-region resolution or use of the service-specific override.
- `packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts` now contains a focused regression test that expected the ISO endpoint and received the hard-coded `amazonaws.com` endpoint.
- `packages/amazon-bedrock/src/amazon-bedrock-provider.ts` constructs both Runtime and Agent Runtime endpoints with `amazonaws.com` and applies the same `baseURL` option to both services, confirming the override conflict described in the comment.
- The package does not expose Bedrock control-plane operations, so the comment's exact Bedrock control-plane versus Bedrock Runtime call pair could not be exercised; the analogous Runtime versus Agent Runtime configuration conflict is present in source.
- The sandbox proxy prevented an AWS service response and returned a tunneling error, but the client-selected request URL was captured before that blocker and directly reproduced the reported endpoint-resolution failure.

## Relevant Documentation

- https://github.com/aws/aws-sdk-js-v3/blob/a0bd362cca53a59918a8b55ed12dcda421edc9b5/codegen/sdk-codegen/aws-models/bedrock-runtime.json
- https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html
- https://docs.aws.amazon.com/sdkref/latest/guide/ss-endpoints-table.html
- https://docs.aws.amazon.com/general/latest/gr/bedrock.html

## Related Issues

Reproduces #11197