### PR TITLE
[v6.0] reproduction: could not reproduce needsApproval tools not returning a toolresult block

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10980-tool-approval-results.ts
+++ b/examples/ai-functions/src/reproduction/issue-10980-tool-approval-results.ts
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict';
+import {
+  convertToModelMessages,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+  streamText,
+  tool,
+  type ModelMessage,
+  type UIMessage,
+} from 'ai';
+import { convertArrayToReadableStream, MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+const toolCallId = 'tooluse_issue_10980';
+const approvalId = 'approval_issue_10980';
+
+function createApprovalMessage(approved: boolean): UIMessage {
+  return {
+    id: `assistant-${approved ? 'approved' : 'denied'}`,
+    role: 'assistant',
+    parts: [
+      { type: 'step-start' },
+      {
+        type: 'tool-update_current_theme_tokens',
+        toolCallId,
+        state: 'approval-responded',
+        input: {
+          operations: [{ token: 'primary', value: '#000000' }],
+          reasoning: 'Apply the requested theme change',
+        },
+        approval: {
+          id: approvalId,
+          approved,
+          reason: approved ? 'Apply the change' : 'Reject the change',
+        },
+      },
+    ],
+  };
+}
+
+function createPendingApprovalMessage(): UIMessage {
+  return {
+    id: 'assistant-pending',
+    role: 'assistant',
+    parts: [
+      { type: 'step-start' },
+      {
+        type: 'tool-update_current_theme_tokens',
+        toolCallId,
+        state: 'approval-requested',
+        input: {
+          operations: [{ token: 'primary', value: '#000000' }],
+          reasoning: 'Apply the requested theme change',
+        },
+        approval: { id: approvalId },
+      },
+    ],
+  };
+}
+
+function createModel() {
+  return new MockLanguageModelV3({
+    provider: 'anthropic-compatible-mock',
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'continued' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: { raw: undefined, unified: 'stop' },
+          usage: {
+            inputTokens: {
+              total: 10,
+              noCache: 10,
+              cacheRead: undefined,
+              cacheWrite: undefined,
+            },
+            outputTokens: {
+              total: 1,
+              text: 1,
+              reasoning: undefined,
+            },
+          },
+        },
+      ]),
+    }),
+  });
+}
+
+function countParts(
+  messages: ModelMessage[],
+  type: 'tool-call' | 'tool-result',
+): number {
+  return messages.reduce((count, message) => {
+    if (typeof message.content === 'string') {
+      return count;
+    }
+
+    return count + message.content.filter(part => part.type === type).length;
+  }, 0);
+}
+
+function getToolCallIds(
+  messages: ModelMessage[],
+  type: 'tool-call' | 'tool-result',
+): string[] {
+  const ids: string[] = [];
+
+  for (const message of messages) {
+    if (typeof message.content === 'string') {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === type) {
+        ids.push(part.toolCallId);
+      }
+    }
+  }
+
+  return ids;
+}
+
+async function runApprovalCase(approved: boolean) {
+  let executionCount = 0;
+  const uiMessages: UIMessage[] = [
+    {
+      id: 'user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Update the theme tokens.' }],
+    },
+    createApprovalMessage(approved),
+  ];
+
+  assert.equal(
+    lastAssistantMessageIsCompleteWithApprovalResponses({
+      messages: uiMessages,
+    }),
+    true,
+    'the configured sendAutomaticallyWhen predicate should resume the chat',
+  );
+
+  const messages = await convertToModelMessages(uiMessages);
+  const model = createModel();
+  const tools = {
+    update_current_theme_tokens: tool({
+      inputSchema: z.object({
+        operations: z.array(z.object({ token: z.string(), value: z.string() })),
+        reasoning: z.string(),
+      }),
+      needsApproval: true,
+      execute: async input => {
+        executionCount++;
+        return {
+          success: true,
+          applied: input.operations.length,
+        };
+      },
+    }),
+  };
+
+  const result = streamText({ model, messages, tools });
+  await result.consumeStream();
+
+  assert.equal(
+    model.doStreamCalls.length,
+    1,
+    'the model should be called once',
+  );
+  const providerPrompt = model.doStreamCalls[0].prompt;
+  assert.equal(
+    countParts(providerPrompt, 'tool-call'),
+    1,
+    'the provider prompt should contain the original tool call',
+  );
+  assert.equal(
+    countParts(providerPrompt, 'tool-result'),
+    1,
+    'the provider prompt should contain one matching terminal tool result',
+  );
+  assert.deepEqual(
+    getToolCallIds(providerPrompt, 'tool-result'),
+    getToolCallIds(providerPrompt, 'tool-call'),
+    'the terminal tool result should match the original tool call ID',
+  );
+
+  if (approved) {
+    assert.equal(executionCount, 1, 'an approved tool should execute once');
+  } else {
+    assert.equal(executionCount, 0, 'a denied tool should not execute');
+  }
+
+  return { executionCount, providerPrompt };
+}
+
+async function main() {
+  const approved = await runApprovalCase(true);
+  const denied = await runApprovalCase(false);
+
+  const pendingMessages = await convertToModelMessages(
+    [createPendingApprovalMessage()],
+    { ignoreIncompleteToolCalls: true },
+  );
+  const pendingToolCalls = countParts(pendingMessages, 'tool-call');
+  const pendingToolResults = countParts(pendingMessages, 'tool-result');
+
+  assert.equal(
+    pendingToolCalls,
+    1,
+    'the current incomplete-tool filter still retains approval-requested calls',
+  );
+  assert.equal(pendingToolResults, 0);
+
+  console.log(
+    JSON.stringify(
+      {
+        approved: {
+          executionCount: approved.executionCount,
+          toolCalls: countParts(approved.providerPrompt, 'tool-call'),
+          toolResults: countParts(approved.providerPrompt, 'tool-result'),
+        },
+        denied: {
+          executionCount: denied.executionCount,
+          toolCalls: countParts(denied.providerPrompt, 'tool-call'),
+          toolResults: countParts(denied.providerPrompt, 'tool-result'),
+        },
+        automaticResumePredicate: true,
+        pendingApprovalConversion: {
+          toolCalls: pendingToolCalls,
+          toolResults: pendingToolResults,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

needsApproval tools not returning a tool_result block

## Reproduction

- On target `ai@6.0.232`, `examples/ai-functions/src/reproduction/issue-10980-tool-approval-results.ts` did not produce the expected orphaned tool call after approval or denial.
- The approved path executed the tool exactly once and supplied one result whose `toolCallId` matched the provider-facing tool call.
- The denied path never executed the tool and supplied one matching terminal denial result.
- `lastAssistantMessageIsCompleteWithApprovalResponses` returned `true`, so the documented `sendAutomaticallyWhen` configuration did not require manual message submission.
- The secondary conversion issue remains: `ignoreIncompleteToolCalls: true` retained a pending `approval-requested` call without a result, but this did not cause the reported post-response failure.
- The report cited an unspecified beta and later `ai@6.0.97`; the working target setup uses aligned v6 workspace packages at `ai@6.0.232`.
- The exact live Bedrock model was not called; the final provider-facing prompt was captured with a `LanguageModelV3` test model.

## Relevant Documentation

- https://ai-sdk.dev/cookbook/next/human-in-the-loop
- https://ai-sdk.dev/docs/troubleshooting/missing-tool-results-error
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html

## Related Issues

Could not reproduce #10980