### PR TITLE
[v6.0] fix: surface the implicit output token limit for unknown Anthropic models

### DIFF
--- a/.changeset/tidy-ants-warn.md
+++ b/.changeset/tidy-ants-warn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Warn when an unknown model uses the default 4096 max output token limit.

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -279,6 +279,17 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       isKnownModel,
     } = getModelCapabilities(this.modelId);
 
+    if (!isKnownModel && maxOutputTokens == null) {
+      warnings.push({
+        type: 'compatibility',
+        feature: 'maxOutputTokens',
+        details:
+          `The model "${this.modelId}" is unknown. ` +
+          `The max output tokens have been limited to ${maxOutputTokensForModel}. ` +
+          `Set maxOutputTokens explicitly to override this limit.`,
+      });
+    }
+
     if (rejectsSamplingParameters) {
       if (temperature != null) {
         warnings.push({

--- a/packages/anthropic/src/anthropic-unknown-model-max-output-tokens.test.ts
+++ b/packages/anthropic/src/anthropic-unknown-model-max-output-tokens.test.ts
@@ -1,0 +1,64 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+describe('unknown model max output tokens', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+
+  const model = createAnthropic({ apiKey: 'test-api-key' })('future-model');
+
+  beforeEach(() => {
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'json-value',
+      body: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        model: 'future-model',
+        content: [{ type: 'text', text: 'Hello!' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    };
+  });
+
+  it('should warn when using the default max output token limit', async () => {
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      model: 'future-model',
+      max_tokens: 4096,
+    });
+    expect(warnings).toEqual([
+      {
+        type: 'compatibility',
+        feature: 'maxOutputTokens',
+        details:
+          'The model "future-model" is unknown. The max output tokens have been limited to 4096. Set maxOutputTokens explicitly to override this limit.',
+      },
+    ]);
+  });
+
+  it('should not warn when max output tokens are provided', async () => {
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      maxOutputTokens: 123456,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      model: 'future-model',
+      max_tokens: 123456,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/anthropic/src/anthropic-unknown-model-max-output-tokens.test.ts
+++ b/packages/anthropic/src/anthropic-unknown-model-max-output-tokens.test.ts
@@ -1,9 +1,9 @@
-import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createAnthropic } from './anthropic-provider';
 
-const TEST_PROMPT: LanguageModelV4Prompt = [
+const TEST_PROMPT: LanguageModelV3Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 


### PR DESCRIPTION
## Background

Unknown Anthropic models silently received a 4096-token output limit when maxOutputTokens was omitted, making unexpected response truncation difficult to diagnose.

## Root Cause

getModelCapabilities returned a 4096 fallback with isKnownModel false, and getArgs used that fallback as max_tokens without adding a provider warning. The reproduction confirmed a 4096 request limit and an empty warnings array.

## Bugfix Guidance

```
address the issue the following way:

raise a warning when the model is unknown and state in the warning that output tokens have been limited to 4096
```

## Summary

Added a compatibility warning identifying the unknown model, stating that output tokens were limited to 4096, and recommending an explicit maxOutputTokens value. Existing request behavior remains unchanged.

## Testing

Added regression tests verifying that unknown models receive the warning with the 4096 fallback and that explicitly setting maxOutputTokens suppresses it. Added a patch changeset for @ai-sdk/anthropic.

## End-to-end Validation

- `pnpm -C packages/anthropic build && pnpm -C examples/ai-functions exec tsx -e '…'` built the published package and exercised generateText with a synthetic unknown model; the request contained `max_tokens: 4096` and the returned and logged warning stated that output tokens were limited to 4096.

## Related Issues

Fixes #17588

Closes #17596

Backport of #17611

Co-authored-by: plutonium-94 <47095613+plutonium-94@users.noreply.github.com>