### PR TITLE
[v6.0] reproduction: @ai-sdk/langchain: convertUserContent emits OpenAI-specific imageurl blocks instead of

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11943,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11943-langchain-image-content-block.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #11943: @ai-sdk/langchain emitted OpenAI image_url blocks instead of canonical LangChain image blocks."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts
+++ b/examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts
@@ -1,0 +1,102 @@
+import type { UserContent } from 'ai';
+
+async function main() {
+  const { convertUserContent } = await import(
+    new URL('../../../../packages/langchain/src/utils.ts', import.meta.url).href
+  );
+
+  const urlMessage = convertUserContent([
+    { type: 'text', text: 'Describe this image.' },
+    { type: 'image', image: 'https://example.com/image.jpg' },
+  ] satisfies UserContent);
+
+  const binaryMessage = convertUserContent([
+    { type: 'text', text: 'Describe this image.' },
+    {
+      type: 'image',
+      image: new Uint8Array([1, 2, 3]),
+      mediaType: 'image/png',
+    },
+  ] satisfies UserContent);
+
+  const pdfMessage = convertUserContent([
+    { type: 'text', text: 'Summarize this document.' },
+    {
+      type: 'file',
+      data: 'https://example.com/document.pdf',
+      mediaType: 'application/pdf',
+    },
+  ] satisfies UserContent);
+
+  const urlImageBlock = urlMessage.content[1];
+  const binaryImageBlock = binaryMessage.content[1];
+  const pdfFileBlock = pdfMessage.content[1];
+
+  console.log(
+    JSON.stringify(
+      {
+        urlImageBlock,
+        binaryImageBlock,
+        pdfFileBlock,
+        urlMessageOutputVersion:
+          urlMessage.response_metadata.output_version ?? null,
+        normalizedUrlContentBlocks: urlMessage.contentBlocks,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const emittedOpenAIUrlBlock =
+    typeof urlImageBlock === 'object' &&
+    urlImageBlock != null &&
+    urlImageBlock.type === 'image_url';
+  const emittedOpenAIBinaryBlock =
+    typeof binaryImageBlock === 'object' &&
+    binaryImageBlock != null &&
+    binaryImageBlock.type === 'image_url';
+  const emittedCanonicalPdfBlock =
+    typeof pdfFileBlock === 'object' &&
+    pdfFileBlock != null &&
+    pdfFileBlock.type === 'file';
+
+  if (
+    emittedOpenAIUrlBlock &&
+    emittedOpenAIBinaryBlock &&
+    emittedCanonicalPdfBlock
+  ) {
+    throw new Error(
+      'Reproduced issue #11943: @ai-sdk/langchain emitted OpenAI image_url blocks instead of canonical LangChain image blocks.',
+    );
+  }
+
+  if (!emittedCanonicalPdfBlock) {
+    throw new Error(
+      'Expected the non-image PDF input to use a canonical LangChain file block.',
+    );
+  }
+
+  const expectedUrlBlock = {
+    type: 'image',
+    url: 'https://example.com/image.jpg',
+  };
+  const expectedBinaryBlock = {
+    type: 'image',
+    data: 'AQID',
+    mimeType: 'image/png',
+  };
+
+  if (
+    JSON.stringify(urlImageBlock) !== JSON.stringify(expectedUrlBlock) ||
+    JSON.stringify(binaryImageBlock) !== JSON.stringify(expectedBinaryBlock)
+  ) {
+    throw new Error(
+      'Image inputs did not use the expected canonical LangChain image block shapes.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

@ai-sdk/langchain: convertUserContent emits OpenAI-specific image_url blocks instead of LangChain image ContentBlock

## Reproduction

- `packages/langchain/src/utils.ts` hard-codes OpenAI `image_url` serialization despite `packages/langchain/package.json` requiring LangChain 1.x and `pnpm-lock.yaml` resolving `@langchain/core` 1.1.29, which supports canonical image blocks.
- `examples/ai-functions/src/reproduction/issue-11943-langchain-image-content-block.ts` observed URL and binary images in raw message content as `image_url`; expected canonical `image` blocks with `url` or `data` plus `mimeType`.
- The reproduction emitted the non-image PDF as a canonical flat `file` block, confirming the reported image-only inconsistency.
- The converted multimodal message lacked LangChain's `output_version: "v1"` marker because it was constructed through `content`, although LangChain's getter lazily normalized the URL image in `contentBlocks`.

## Relevant Documentation

- https://docs.langchain.com/oss/javascript/langchain/messages
- https://docs.langchain.com/oss/javascript/migrate/langchain-v1
- https://reference.langchain.com/javascript/langchain-core/messages

## Related Issues

Reproduces #11943