### PR TITLE
[v6.0] reproduction: could not reproduce LangChain Package - Multimodal conversion not working

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11435-langchain-multimodal.ts
+++ b/examples/ai-functions/src/reproduction/issue-11435-langchain-multimodal.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { convertModelMessages } from '../../../../packages/langchain/dist/index.mjs';
+import type { ModelMessage } from 'ai';
+
+async function main() {
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe the attachments.' },
+        {
+          type: 'image',
+          image: new URL('https://example.com/image.png'),
+        },
+        {
+          type: 'file',
+          data: new URL('https://example.com/report.pdf'),
+          mediaType: 'application/pdf',
+          filename: 'report.pdf',
+        },
+      ],
+    },
+  ];
+
+  const [convertedMessage] = convertModelMessages(messages);
+
+  assert.deepStrictEqual(
+    convertedMessage.content,
+    [
+      { type: 'text', text: 'Describe the attachments.' },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/image.png' },
+      },
+      {
+        type: 'file',
+        url: 'https://example.com/report.pdf',
+        mimeType: 'application/pdf',
+        filename: 'report.pdf',
+      },
+    ],
+    'Issue #11435 reproduced: image or file content was dropped during LangChain conversion.',
+  );
+
+  console.log(
+    JSON.stringify({
+      messageType: convertedMessage.getType(),
+      content: convertedMessage.content,
+    }),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

LangChain Package - Multimodal conversion not working

## Reproduction

- The reported user-visible failure is that image and file attachments disappear during conversion to a LangChain `HumanMessage`; the target branch preserved both attachments.
- `examples/ai-functions/src/reproduction/issue-11435-langchain-multimodal.ts` converted mixed text, image, and PDF content into three corresponding LangChain content blocks, rather than the reported text-only output.
- `packages/langchain/package.json` identifies the tested target-branch package as version 2.0.241.
- `packages/langchain/CHANGELOG.md` records the multimodal `convertUserContent` fix in version 2.0.23, while the issue reported version 2.0.3; upgrading to 2.0.23 or later addresses the reported behavior.

## Relevant Documentation

- https://docs.langchain.com/oss/javascript/langchain/messages
- https://ai-sdk.dev/docs/reference/ai-sdk-core/model-message

## Related Issues

Could not reproduce #11435