### PR TITLE
[v6.0] reproduction: could not reproduce LLM passing escaped double quotes in tool arguments

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11719-anthropic-quoted-tool-input.ts
+++ b/examples/ai-functions/src/reproduction/issue-11719-anthropic-quoted-tool-input.ts
@@ -1,0 +1,151 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+const quotedQuestion = '"What should I do next after this run?"';
+const expectedDescription =
+  `Today you post every run to Strava, but Strava does not answer the question: ${quotedQuestion}. ` +
+  'It is a great log, but it is not adaptive.';
+
+const Task = z.object({
+  id: z.number().optional(),
+  description: z.string(),
+  type: z.enum(['feature', 'bug']),
+  passes: z.boolean(),
+});
+
+const WebsiteUpdateInput = z.object({
+  tasks: z.array(Task),
+  assets: z.array(z.string()).optional(),
+  website_path: z.string(),
+});
+
+type WebsiteUpdateInput = z.infer<typeof WebsiteUpdateInput>;
+
+const prompt = `Call website_update exactly once with:
+- website_path: /home/user/pace-landing
+- one feature task with passes false
+- the task description exactly as written between <description> tags:
+<description>${expectedDescription}</description>
+Do not replace the double quotes around the question with single quotes or remove them.`;
+
+const capturedResponses: Array<Promise<{ stream: boolean; text: string }>> = [];
+
+const anthropic = createAnthropic({
+  fetch: async (url, options) => {
+    const requestBody = JSON.parse(String(options?.body)) as {
+      stream?: boolean;
+    };
+    const response = await fetch(url, options);
+    const clonedResponse = response.clone();
+
+    capturedResponses.push(
+      clonedResponse.text().then(text => ({
+        stream: requestBody.stream === true,
+        text,
+      })),
+    );
+
+    return response;
+  },
+});
+
+function assertExecutedInput(
+  method: 'generateText' | 'streamText',
+  inputs: WebsiteUpdateInput[],
+) {
+  if (inputs.length !== 1) {
+    throw new Error(
+      `${method}: expected website_update execute to run once, ran ${inputs.length} times`,
+    );
+  }
+
+  const description = inputs[0].tasks[0]?.description;
+  if (description !== expectedDescription) {
+    throw new Error(
+      `${method}: quoted task description did not reach execute intact: ${JSON.stringify(description)}`,
+    );
+  }
+
+  console.log(
+    `${method}: execute received quoted question intact: ${quotedQuestion}`,
+  );
+}
+
+function createWebsiteUpdateTool(executedInputs: WebsiteUpdateInput[]) {
+  return tool({
+    description: 'Update a website by executing the supplied task list.',
+    inputSchema: WebsiteUpdateInput,
+    execute: async input => {
+      executedInputs.push(input);
+      return { updated: true };
+    },
+  });
+}
+
+async function runGenerateText() {
+  const executedInputs: WebsiteUpdateInput[] = [];
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    maxOutputTokens: 2048,
+    tools: {
+      website_update: createWebsiteUpdateTool(executedInputs),
+    },
+    toolChoice: { type: 'tool', toolName: 'website_update' },
+    prompt,
+  });
+
+  const invalidCall = result.toolCalls.find(toolCall => toolCall.invalid);
+  if (invalidCall != null) {
+    throw new Error(
+      `generateText: invalid tool input: ${JSON.stringify(invalidCall.input)}`,
+    );
+  }
+
+  assertExecutedInput('generateText', executedInputs);
+}
+
+async function runStreamText() {
+  const executedInputs: WebsiteUpdateInput[] = [];
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    maxOutputTokens: 2048,
+    tools: {
+      website_update: createWebsiteUpdateTool(executedInputs),
+    },
+    toolChoice: { type: 'tool', toolName: 'website_update' },
+    prompt,
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'error') {
+      throw part.error;
+    }
+    if (part.type === 'tool-call' && part.invalid) {
+      throw new Error(
+        `streamText: invalid tool input: ${JSON.stringify(part.input)}`,
+      );
+    }
+  }
+
+  assertExecutedInput('streamText', executedInputs);
+}
+
+async function main() {
+  await runGenerateText();
+  await runStreamText();
+
+  for (const response of await Promise.all(capturedResponses)) {
+    console.log(
+      response.stream
+        ? '--- LIVE ANTHROPIC STREAM RESPONSE ---'
+        : '--- LIVE ANTHROPIC GENERATE RESPONSE ---',
+    );
+    console.log(response.text);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-11719-quoted-tool-input.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-11719-quoted-tool-input.chunks.txt
@@ -1,0 +1,18 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011CdFVpY8ZSiJdMWvbXZUUC","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":912,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard","inference_geo":"not_available"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Cr31vcGoeeRgi3Eo5Ds8qN","name":"website_update","input":{},"caller":{"type":"direct"}}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"website_path\": \"/home/user"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"/pace-landing"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\", \"tasks\": [{\"description\": \"Today you post"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" every run to Strava, but"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" Strava does not answer the question"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":": \\\"What should I do next after"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" this run?\\\". It is a great"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" log, but it is not adaptive.\","}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" \"type\": \"feature\", \"passes"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\": false}]"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}
+{"type":"content_block_stop","index":0}
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":912,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":118}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-11719-quoted-tool-input.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-11719-quoted-tool-input.json
@@ -1,0 +1,41 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CdFVpN6K4ZeYJpQWnJE41",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_01JKBd25gEfr9ZpVvn8quK2v",
+      "name": "website_update",
+      "input": {
+        "website_path": "/home/user/pace-landing",
+        "tasks": [
+          {
+            "description": "Today you post every run to Strava, but Strava does not answer the question: \"What should I do next after this run?\". It is a great log, but it is not adaptive.",
+            "type": "feature",
+            "passes": false
+          }
+        ]
+      },
+      "caller": {
+        "type": "direct"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 912,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 118,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/anthropic-issue-11719.test.ts
+++ b/packages/anthropic/src/anthropic-issue-11719.test.ts
@@ -1,0 +1,113 @@
+import type {
+  LanguageModelV3FunctionTool,
+  LanguageModelV3Prompt,
+  LanguageModelV3ToolCall,
+} from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const prompt: LanguageModelV3Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Call website_update.' }],
+  },
+];
+
+const tools: LanguageModelV3FunctionTool[] = [
+  {
+    type: 'function',
+    name: 'website_update',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        website_path: { type: 'string' },
+        tasks: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              description: { type: 'string' },
+              type: { type: 'string', enum: ['feature', 'bug'] },
+              passes: { type: 'boolean' },
+            },
+            required: ['description', 'type', 'passes'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['website_path', 'tasks'],
+      additionalProperties: false,
+    },
+  },
+];
+
+const expectedDescription =
+  'Today you post every run to Strava, but Strava does not answer the question: "What should I do next after this run?". It is a great log, but it is not adaptive.';
+
+function assertQuotedDescription(toolCall: LanguageModelV3ToolCall) {
+  const input = JSON.parse(toolCall.input) as {
+    tasks: Array<{ description: string }>;
+  };
+
+  expect(input.tasks[0]?.description).toBe(expectedDescription);
+}
+
+describe('issue #11719 quoted tool input', () => {
+  const server = createTestServer({
+    'https://api.anthropic.com/v1/messages': {},
+  });
+  const model = createAnthropic({ apiKey: 'test-api-key' })(
+    'claude-sonnet-4-5',
+  );
+
+  it('preserves an escaped quoted question in a generated tool call', async () => {
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/anthropic-issue-11719-quoted-tool-input.json',
+          'utf8',
+        ),
+      ),
+    };
+
+    const result = await model.doGenerate({ prompt, tools });
+    const toolCall = result.content.find(
+      part => part.type === 'tool-call',
+    ) as LanguageModelV3ToolCall;
+
+    assertQuotedDescription(toolCall);
+  });
+
+  it('preserves an escaped quoted question across streamed input deltas', async () => {
+    const chunks = fs
+      .readFileSync(
+        'src/__fixtures__/anthropic-issue-11719-quoted-tool-input.chunks.txt',
+        'utf8',
+      )
+      .trimEnd()
+      .split('\n')
+      .map(line => `data: ${line}\n\n`);
+    chunks.push('data: [DONE]\n\n');
+
+    server.urls['https://api.anthropic.com/v1/messages'].response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+
+    const result = await model.doStream({ prompt, tools });
+    const parts = await convertReadableStreamToArray(result.stream);
+    const toolCall = parts.find(
+      part => part.type === 'tool-call',
+    ) as LanguageModelV3ToolCall;
+
+    assertQuotedDescription(toolCall);
+  });
+});


### PR DESCRIPTION
## Bug

LLM passing escaped double quotes in tool arguments result in error

## Reproduction

- The expected outcome is that a nested task description containing `"What should I do next after this run?"` reaches the tool's `execute`; the reported outcome was invalid JSON and no execution.
- Live `claude-sonnet-4-5` calls on `release-v6.0` with AI SDK `6.0.233` preserved the quoted question and executed the tool successfully with both `generateText` and `streamText`.
- `examples/ai-functions/src/reproduction/issue-11719-anthropic-quoted-tool-input.ts` contains the runnable live reproduction; the reported parsing failure was not observed.
- Live responses are recorded in `packages/anthropic/src/__fixtures__/anthropic-issue-11719-quoted-tool-input.json` and `packages/anthropic/src/__fixtures__/anthropic-issue-11719-quoted-tool-input.chunks.txt`.
- `packages/anthropic/src/anthropic-issue-11719.test.ts` confirms that both buffered and streamed live response fixtures retain the escaped quotation marks.
- The issue's standalone template literal is invalid JSON because JavaScript consumes `\"`, leaving unescaped quotation marks before `JSON.parse` runs.
- The exact production scenario could not be matched because the issue does not identify its model, AI SDK version, runtime, or provider configuration.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/fine-grained-tool-streaming

## Related Issues

Could not reproduce #11719